### PR TITLE
Fix a typo in the preprocessing tutorial

### DIFF
--- a/docs/source/en/preprocessing.mdx
+++ b/docs/source/en/preprocessing.mdx
@@ -383,7 +383,7 @@ For computer vision tasks, it is common to add some type of data augmentation to
 4. Now when you access the image, you'll notice the feature extractor has added `pixel_values`. You can pass your processed dataset to the model now!
 
 ```py
->>> dataset[0]["image"]
+>>> dataset[0]
 {'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=384x512 at 0x7F1A7B0630D0>,
  'label': 6,
  'pixel_values': tensor([[[ 0.0353,  0.0745,  0.1216,  ..., -0.9922, -0.9922, -0.9922],


### PR DESCRIPTION
# What does this PR do?

Fixed a typo in transformers [tutorials > preprocess](https://huggingface.co/docs/transformers/preprocessing). Currently the code and its output does not match. Please see last two cells from this [colab notebook](https://colab.research.google.com/drive/18WjgFPtQu4n8k6qAWtpsjVwDmICDrcfD#scrollTo=4LsMdS8plf-K); `dataset[0]["image"]` is a PIL image, not a dictionary as present in the current version of the tutorial. It should be `dataset[0]`.

(Please ignore the change at line 490, Github is showing the wrong diff. There's no actual changes.)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).