### PR TITLE
 [Doctest] Add `configuration_clip.py`

### DIFF
--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -285,6 +285,8 @@ class CLIPConfig(PretrainedConfig):
     >>> # Accessing the model configuration
     >>> configuration = model.config
 
+    >>> # We can also initialize a CLIPConfig from a CLIPTextConfig and a CLIPVisionConfig
+
     >>> # Initializing a CLIPText and CLIPVision configuration
     >>> config_text = CLIPTextConfig()
     >>> config_vision = CLIPVisionConfig()

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -80,12 +80,12 @@ class CLIPTextConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import CLIPTextModel, CLIPTextConfig
+    >>> from transformers import CLIPTextConfig, CLIPTextModel
 
-    >>> # Initializing a CLIPTextModel with openai/clip-vit-base-patch32 style configuration
+    >>> # Initializing a CLIPTextConfig with openai/clip-vit-base-patch32 style configuration
     >>> configuration = CLIPTextConfig()
 
-    >>> # Initializing a CLIPTextConfig from the openai/clip-vit-base-patch32 style configuration
+    >>> # Initializing a CLIPTextModel (with random weights) from the openai/clip-vit-base-patch32 style configuration
     >>> model = CLIPTextModel(configuration)
 
     >>> # Accessing the model configuration
@@ -186,12 +186,12 @@ class CLIPVisionConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import CLIPVisionModel, CLIPVisionConfig
+    >>> from transformers import CLIPVisionConfig, CLIPVisionModel
 
-    >>> # Initializing a CLIPVisionModel with openai/clip-vit-base-patch32 style configuration
+    >>> # Initializing a CLIPVisionConfig with openai/clip-vit-base-patch32 style configuration
     >>> configuration = CLIPVisionConfig()
 
-    >>> # Initializing a CLIPVisionModel model from the openai/clip-vit-base-patch32 style configuration
+    >>> # Initializing a CLIPVisionModel (with random weights) from the openai/clip-vit-base-patch32 style configuration
     >>> model = CLIPVisionModel(configuration)
 
     >>> # Accessing the model configuration

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -270,7 +270,21 @@ class CLIPConfig(PretrainedConfig):
             The inital value of the *logit_scale* paramter. Default is used as per the original CLIP implementation.
         kwargs (*optional*):
             Dictionary of keyword arguments.
-    """
+
+    Example:
+
+    ```python
+    >>> from transformers import CLIPConfig, CLIPModel
+
+    >>> # Initializing a CLIPConfig with openai/clip-vit-base-patch32 style configuration
+    >>> configuration = CLIPConfig()
+
+    >>> # Initializing a CLIPModel (with random weights) from the openai/clip-vit-base-patch32 style configuration
+    >>> model = CLIPModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
 
     model_type = "clip"
     is_composition = True

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -284,6 +284,12 @@ class CLIPConfig(PretrainedConfig):
 
     >>> # Accessing the model configuration
     >>> configuration = model.config
+
+    >>> # Initializing a CLIPText and CLIPVision configuration
+    >>> config_text = CLIPTextConfig()
+    >>> config_vision = CLIPVisionConfig()
+
+    >>> config = CLIPConfig.from_text_vision_configs(config_text, config_vision)
     ```"""
 
     model_type = "clip"

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -33,6 +33,7 @@ src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
 src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
 src/transformers/models/bloom/configuration_bloom.py
 src/transformers/models/canine/configuration_canine.py
+src/transformers/models/clip/configuration_clip.py
 src/transformers/models/codegen/configuration_codegen.py
 src/transformers/models/conditional_detr/modeling_conditional_detr.py
 src/transformers/models/convnext/modeling_convnext.py


### PR DESCRIPTION
Add `configuration_clip.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

Noticed the model initialization and config initialization lines were switched so made some additional changes to correct it.

@ydshieh could you please check if it's okay?
Thank you =)