### PR TITLE
Fix pipeline predict transform methods

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -836,13 +836,13 @@ class Pipeline(_ScikitCompat):
         """
         Scikit / Keras interface to transformers' pipelines. This method will forward to __call__().
         """
-        return self(X=X)
+        return self(X)
 
     def predict(self, X):
         """
         Scikit / Keras interface to transformers' pipelines. This method will forward to __call__().
         """
-        return self(X=X)
+        return self(X)
 
     @contextmanager
     def device_placement(self):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -303,6 +303,18 @@ def require_torch_or_tf(test_case):
     )
 
 
+def require_torch_and_tf(test_case):
+    """
+    Decorator marking a test that requires PyTorch and TensorFlow.
+
+    These tests are skipped when either PyTorch or TensorFlow is not installed.
+
+    """
+    return unittest.skipUnless(is_torch_available() and is_tf_available(), "test requires PyTorch and TensorFlow")(
+        test_case
+    )
+
+
 def require_intel_extension_for_pytorch(test_case):
     """
     Decorator marking a test that requires Intel Extension for PyTorch.

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -303,18 +303,6 @@ def require_torch_or_tf(test_case):
     )
 
 
-def require_torch_and_tf(test_case):
-    """
-    Decorator marking a test that requires PyTorch and TensorFlow.
-
-    These tests are skipped when either PyTorch or TensorFlow is not installed.
-
-    """
-    return unittest.skipUnless(is_torch_available() and is_tf_available(), "test requires PyTorch and TensorFlow")(
-        test_case
-    )
-
-
 def require_intel_extension_for_pytorch(test_case):
     """
     Decorator marking a test that requires Intel Extension for PyTorch.

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -29,7 +29,6 @@ from unittest import skipIf
 import numpy as np
 
 from huggingface_hub import HfFolder, Repository, delete_repo, set_access_token
-from parameterized import parameterized
 from requests.exceptions import HTTPError
 from transformers import (
     FEATURE_EXTRACTOR_MAPPING,
@@ -55,7 +54,6 @@ from transformers.testing_utils import (
     require_tensorflow_probability,
     require_tf,
     require_torch,
-    require_torch_and_tf,
     require_torch_or_tf,
     slow,
 )
@@ -425,26 +423,49 @@ class CommonPipelineTest(unittest.TestCase):
         self.assertEqual(len(outputs), 20)
 
 
-@require_torch_and_tf
 class PipelineScikitCompatTest(unittest.TestCase):
-    @parameterized.expand([("pt",), ("tf",)])
-    def test_pipeline_predict(self, framework):
+    @require_torch
+    def test_pipeline_predict_pt(self):
         data = ["This is a test"]
 
         text_classifier = pipeline(
-            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework=framework
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework="pt"
         )
 
         expected_output = [{"label": ANY(str), "score": ANY(float)}]
         actual_output = text_classifier.predict(data)
         self.assertEqual(expected_output, actual_output)
 
-    @parameterized.expand([("pt",), ("tf",)])
-    def test_pipeline_transform(self, framework):
+    @require_tf
+    def test_pipeline_predict_tf(self):
         data = ["This is a test"]
 
         text_classifier = pipeline(
-            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework=framework
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework="tf"
+        )
+
+        expected_output = [{"label": ANY(str), "score": ANY(float)}]
+        actual_output = text_classifier.predict(data)
+        self.assertEqual(expected_output, actual_output)
+
+    @require_torch
+    def test_pipeline_transform_pt(self):
+        data = ["This is a test"]
+
+        text_classifier = pipeline(
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework="pt"
+        )
+
+        expected_output = [{"label": ANY(str), "score": ANY(float)}]
+        actual_output = text_classifier.transform(data)
+        self.assertEqual(expected_output, actual_output)
+
+    @require_tf
+    def test_pipeline_transform_tf(self):
+        data = ["This is a test"]
+
+        text_classifier = pipeline(
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework="tf"
         )
 
         expected_output = [{"label": ANY(str), "score": ANY(float)}]

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -29,6 +29,7 @@ from unittest import skipIf
 import numpy as np
 
 from huggingface_hub import HfFolder, Repository, delete_repo, set_access_token
+from parameterized import parameterized
 from requests.exceptions import HTTPError
 from transformers import (
     FEATURE_EXTRACTOR_MAPPING,
@@ -54,6 +55,7 @@ from transformers.testing_utils import (
     require_tensorflow_probability,
     require_tf,
     require_torch,
+    require_torch_and_tf,
     require_torch_or_tf,
     slow,
 )
@@ -421,6 +423,33 @@ class CommonPipelineTest(unittest.TestCase):
         # instead of the expected tensor.
         outputs = text_classifier(["This is great !"] * 20, batch_size=32)
         self.assertEqual(len(outputs), 20)
+
+
+@require_torch_and_tf
+class PipelineScikitCompatTest(unittest.TestCase):
+    @parameterized.expand([("pt",), ("tf",)])
+    def test_pipeline_predict(self, framework):
+        data = ["This is a test"]
+
+        text_classifier = pipeline(
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework=framework
+        )
+
+        expected_output = [{"label": ANY(str), "score": ANY(float)}]
+        actual_output = text_classifier.predict(data)
+        self.assertEqual(expected_output, actual_output)
+
+    @parameterized.expand([("pt",), ("tf",)])
+    def test_pipeline_transform(self, framework):
+        data = ["This is a test"]
+
+        text_classifier = pipeline(
+            task="text-classification", model="hf-internal-testing/tiny-random-distilbert", framework=framework
+        )
+
+        expected_output = [{"label": ANY(str), "score": ANY(float)}]
+        actual_output = text_classifier.transform(data)
+        self.assertEqual(expected_output, actual_output)
 
 
 class PipelinePadTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

This PR fixes pipeline's predict and transform methods which are wrapper around ` __call__` of pipeline class. `__call__ `requires one positional argument, However these wrapper methods pass the incoming argument as a keyword argument to `__call__` method which leads to failure. Hence in this commit the keyword argument is modified to positional argument and basic tests are added to make sure this does not break again in future.


Fixes #19289


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik @Narsil 