### PR TITLE
 [Doctest] Add `configuration_trocr.py`

### DIFF
--- a/src/transformers/models/trocr/configuration_trocr.py
+++ b/src/transformers/models/trocr/configuration_trocr.py
@@ -82,12 +82,12 @@ class TrOCRConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import TrOCRForCausalLM, TrOCRConfig
+    >>> from transformers import TrOCRConfig, TrOCRForCausalLM
 
     >>> # Initializing a TrOCR-base style configuration
     >>> configuration = TrOCRConfig()
 
-    >>> # Initializing a model from the TrOCR-base style configuration
+    >>> # Initializing a model (with random weights) from the TrOCR-base style configuration
     >>> model = TrOCRForCausalLM(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -112,6 +112,7 @@ src/transformers/models/swinv2/configuration_swinv2.py
 src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
 src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
 src/transformers/models/trajectory_transformer/configuration_trajectory_transformer.py
+src/transformers/models/trocr/configuration_trocr.py
 src/transformers/models/trocr/modeling_trocr.py
 src/transformers/models/unispeech/configuration_unispeech.py
 src/transformers/models/unispeech/modeling_unispeech.py


### PR DESCRIPTION
* trocr Config for doctest

* ran make style

# What does this PR do?

Add `configuration_trocr.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you please take a look at it?
Thanks =)