### PR TITLE
Add pillow to layoutlmv3 example requirements.txt

### DIFF
--- a/examples/research_projects/layoutlmv3/requirements.txt
+++ b/examples/research_projects/layoutlmv3/requirements.txt
@@ -1,2 +1,3 @@
 datasets
 seqeval
+pillow


### PR DESCRIPTION
Adds required pillow / PIL library to the layoutlmv3 training example, as it´s used to load the images during training.

@sgugger, @patil-suraj
tagging you as i don´t know who is reponsible for that example.