### PR TITLE
Update ESM checkpoints to point to `facebook/`

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -42,13 +42,13 @@ from .configuration_esm import EsmConfig
 
 logger = logging.get_logger(__name__)
 
-_CHECKPOINT_FOR_DOC = "Rocketknight1/esm2_t6_8M_UR50D"
+_CHECKPOINT_FOR_DOC = "facebook/esm2_t6_8M_UR50D"
 _CONFIG_FOR_DOC = "EsmConfig"
 _TOKENIZER_FOR_DOC = "EsmTokenizer"
 
 ESM_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "Rocketknight1/esm2_t6_8M_UR50D",
-    "Rocketknight1/esm2_t12_35M_UR50D",
+    "facebook/esm2_t6_8M_UR50D",
+    "facebook/esm2_t12_35M_UR50D",
     # This is not a complete list of all ESM models!
     # See all ESM models at https://huggingface.co/models?filter=esm
 ]

--- a/src/transformers/models/esm/modeling_tf_esm.py
+++ b/src/transformers/models/esm/modeling_tf_esm.py
@@ -47,13 +47,13 @@ from .configuration_esm import EsmConfig
 
 logger = logging.get_logger(__name__)
 
-_CHECKPOINT_FOR_DOC = "Rocketknight1/esm2_t6_8M_UR50D"
+_CHECKPOINT_FOR_DOC = "facebook/esm2_t6_8M_UR50D"
 _CONFIG_FOR_DOC = "EsmConfig"
 _TOKENIZER_FOR_DOC = "EsmTokenizer"
 
 TF_ESM_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "Rocketknight1/esm2_t6_8M_UR50D",
-    "Rocketknight1/esm2_t12_35M_UR50D",
+    "facebook/esm2_t6_8M_UR50D",
+    "facebook/esm2_t12_35M_UR50D",
     # This is not a complete list of all ESM models!
     # See all ESM models at https://huggingface.co/models?filter=esm
 ]

--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -27,12 +27,8 @@ VOCAB_FILES_NAMES = {"vocab_file": "vocab.txt"}
 
 PRETRAINED_VOCAB_FILES_MAP = {
     "vocab_file": {
-        "facebook/esm2_t6_8M_UR50D": (
-            "https://huggingface.co/facebook/esm2_t6_8M_UR50D/resolve/main/vocab.txt"
-        ),
-        "facebook/esm2_t12_35M_UR50D": (
-            "https://huggingface.co/facebook/esm2_t12_35M_UR50D/resolve/main/vocab.txt"
-        ),
+        "facebook/esm2_t6_8M_UR50D": "https://huggingface.co/facebook/esm2_t6_8M_UR50D/resolve/main/vocab.txt",
+        "facebook/esm2_t12_35M_UR50D": "https://huggingface.co/facebook/esm2_t12_35M_UR50D/resolve/main/vocab.txt",
     },
 }
 

--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -27,18 +27,18 @@ VOCAB_FILES_NAMES = {"vocab_file": "vocab.txt"}
 
 PRETRAINED_VOCAB_FILES_MAP = {
     "vocab_file": {
-        "Rocketknight1/esm2_t6_8M_UR50D": (
-            "https://huggingface.co/Rocketknight1/esm2_t6_8M_UR50D/resolve/main/vocab.txt"
+        "facebook/esm2_t6_8M_UR50D": (
+            "https://huggingface.co/facebook/esm2_t6_8M_UR50D/resolve/main/vocab.txt"
         ),
-        "Rocketknight1/esm2_t12_35M_UR50D": (
-            "https://huggingface.co/Rocketknight1/esm2_t12_35M_UR50D/resolve/main/vocab.txt"
+        "facebook/esm2_t12_35M_UR50D": (
+            "https://huggingface.co/facebook/esm2_t12_35M_UR50D/resolve/main/vocab.txt"
         ),
     },
 }
 
 PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
-    "Rocketknight1/esm2_t6_8M_UR50D": 1024,
-    "Rocketknight1/esm2_t12_35M_UR50D": 1024,
+    "facebook/esm2_t6_8M_UR50D": 1024,
+    "facebook/esm2_t12_35M_UR50D": 1024,
 }
 
 


### PR DESCRIPTION
ESM checkpoints were initially uploaded to my account, but have now been moved to the correct location. This PR updates all references to point to their new home under `facebook/`