### PR TITLE
object-detection instead of object_detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Many tasks have a pre-trained `pipeline` ready to go, in NLP but also in compute
 >>> image = Image.open(image_data)
 
 # Allocate a pipeline for object detection
->>> object_detector = pipeline('object_detection')
+>>> object_detector = pipeline('object-detection')
 >>> object_detector(image)
 [{'score': 0.9982201457023621,
   'label': 'remote',


### PR DESCRIPTION
The Object detection Sample in the README.md does not work out of the box,
as it tries to initialize a pipeline `object_detection` however it is called `object-detection`

Not sure if this is intended such that a new user has to overcome a minimal sanity check?! 🤣 

@sgugger