### PR TITLE
Fix checkpoint used in `VisualBertConfig` doc example

### DIFF
--- a/src/transformers/models/visual_bert/configuration_visual_bert.py
+++ b/src/transformers/models/visual_bert/configuration_visual_bert.py
@@ -99,7 +99,7 @@ class VisualBertConfig(PretrainedConfig):
     >>> from transformers import VisualBertConfig, VisualBertModel
 
     >>> # Initializing a VisualBERT visualbert-vqa-coco-pre style configuration
-    >>> configuration = VisualBertConfig.from_pretrained("visualbert-vqa-coco-pre")
+    >>> configuration = VisualBertConfig.from_pretrained("uclanlp/visualbert-vqa-coco-pre")
 
     >>> # Initializing a model (with random weights) from the visualbert-vqa-coco-pre style configuration
     >>> model = VisualBertModel(configuration)


### PR DESCRIPTION
# What does this PR do?

The checkpoint was wrong, and not cached during the review in the config doctest PR (as it was wrong all the time).