### PR TITLE
[WHISPER] Update documentation of processor and nits in forward example

### DIFF
--- a/src/transformers/models/whisper/modeling_tf_whisper.py
+++ b/src/transformers/models/whisper/modeling_tf_whisper.py
@@ -1288,7 +1288,7 @@ class TFWhisperForConditionalGeneration(TFWhisperPreTrainedModel, TFCausalLangua
 
         >>> transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> transcription
-        ' Mr. Quilter is the apostle of the middle classes, and we are glad to'
+        ' Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1178,7 +1178,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
 
         >>> transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> transcription
-        ' Mr. Quilter is the apostle of the middle classes, and we are glad to'
+        ' Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -76,11 +76,9 @@ class WhisperProcessor(ProcessorMixin):
 
     def __call__(self, *args, **kwargs):
         """
-        When used in normal mode, this method forwards all its arguments to WhisperFeatureExtractor's
-        [`~WhisperFeatureExtractor.__call__`] and returns its output. If used in the context
-        [`~WhisperProcessor.as_target_processor`] this method forwards all its arguments to WhisperTokenizer's
-        [`~WhisperTokenizer.__call__`]. Please refer to the doctsring of the above two methods for more information.
-
+        Forwards the `audio` argument to WhisperFeatureExtractor's [`~WhisperFeatureExtractor.__call__`] and the `text`
+        argument to [`~WhisperTokenizer.__call__`]. Please refer to the doctsring of the above two methods for more
+        information.
         """
         # For backward compatibility
         if self._in_target_context_manager:


### PR DESCRIPTION
# What does this PR do?

Fixes #19672

With respect to #19672, the `__call__` method of the `WhisperProcessor` was updated. 
The doctest were also not passing with the new `max_length`, see #19670 and #19668 
@ydshieh 