### PR TITLE
Image transforms add center crop

### DIFF
--- a/docs/source/en/internal/image_processing_utils.mdx
+++ b/docs/source/en/internal/image_processing_utils.mdx
@@ -19,6 +19,8 @@ Most of those are only useful if you are studying the code of the image processo
 
 ## Image Transformations
 
+[[autodoc]] image_transforms.center_crop
+
 [[autodoc]] image_transforms.normalize
 
 [[autodoc]] image_transforms.rescale

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -335,8 +335,8 @@ def center_crop(
             The target size for the cropped image.
         data_format (`str` or `ChannelDimension`, *optional*):
             The channel dimension format for the output image. Can be one of:
-                    - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
-                    - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
+                - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
+                - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
             If unset, will use the inferred format of the input image.
         return_numpy (`bool`, *optional*):
             Whether or not to return the cropped image as a numpy array. Used for backwards compatibility with the
@@ -372,10 +372,12 @@ def center_crop(
     orig_height, orig_width = get_image_size(image)
     crop_height, crop_width = size
 
+    # In case size is odd, (image_shape[0] + size[0]) // 2 won't give the proper result.
     top = (orig_height - crop_height) // 2
-    bottom = top + crop_height  # In case size is odd, (image_shape[0] + size[0]) // 2 won't give the proper result.
+    bottom = top + crop_height
+    # In case size is odd, (image_shape[1] + size[1]) // 2 won't give the proper result.
     left = (orig_width - crop_width) // 2
-    right = left + crop_width  # In case size is odd, (image_shape[1] + size[1]) // 2 won't give the proper result.
+    right = left + crop_width
 
     # Check if cropped area is within image boundaries
     if top >= 0 and bottom <= orig_height and left >= 0 and right <= orig_width:

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -322,6 +322,7 @@ def center_crop(
     image: np.ndarray,
     size: Tuple[int, int],
     data_format: Optional[Union[str, ChannelDimension]] = None,
+    return_numpy: Optional[bool] = None
 ) -> np.ndarray:
     """
     Crops the `image` to the specified `size` using a center crop. Note that if the image is too small to be cropped to
@@ -337,7 +338,12 @@ def center_crop(
                     - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
                     - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
             If `None`, will use the inferred format of the input image.
-
+        return_numpy (`bool`, *optional*):
+            Whether or not to return the cropped image as a numpy array. Used for backwards compatibility with the
+            previous ImageFeatureExtractionMixin method.
+                - `None` (default): will return the same type as the input image.
+                - `True`: will return a numpy array.
+                - `False`: will return a `PIL.Image.Image` object.
     Returns:
         `np.ndarray`: The cropped image.
     """
@@ -347,6 +353,9 @@ def center_crop(
             FutureWarning,
         )
         image = to_numpy_array(image)
+        return_numpy = False if return_numpy is None else return_numpy
+    else:
+        return_numpy = True if return_numpy is None else return_numpy
 
     if not isinstance(image, np.ndarray):
         raise ValueError(f"Input image must be of type np.ndarray, got {type(image)}")
@@ -394,4 +403,8 @@ def center_crop(
 
     new_image = new_image[..., max(0, top) : min(new_height, bottom), max(0, left) : min(new_width, right)]
     new_image = to_channel_dimension_format(new_image, output_data_format)
+
+    if not return_numpy:
+        new_image = to_pil_image(new_image)
+
     return new_image

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -316,3 +316,82 @@ def normalize(
 
     image = to_channel_dimension_format(image, data_format) if data_format is not None else image
     return image
+
+
+def center_crop(
+    image: np.ndarray,
+    size: Tuple[int, int],
+    data_format: Optional[Union[str, ChannelDimension]] = None,
+) -> np.ndarray:
+    """
+    Crops the `image` to the specified `size` using a center crop. Note that if the image is too small to be cropped to
+    the size given, it will be padded (so the returned result will always be of size `size`).
+
+    Args:
+        image (`np.ndarray`):
+            The image to crop.
+        size (`Tuple[int, int]`):
+            The target size for the cropped image.
+        data_format (`str` or `ChannelDimension`, *optional*):
+            The channel dimension format for the output image. Can be one of:
+                    - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
+                    - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
+            If `None`, will use the inferred format of the input image.
+
+    Returns:
+        `np.ndarray`: The cropped image.
+    """
+    if isinstance(image, PIL.Image.Image):
+        warnings.warn(
+            "PIL.Image.Image inputs are deprecated and will be removed in v4.26.0. Please use numpy arrays instead.",
+            FutureWarning,
+        )
+        image = to_numpy_array(image)
+
+    if not isinstance(image, np.ndarray):
+        raise ValueError(f"Input image must be of type np.ndarray, got {type(image)}")
+
+    if not isinstance(size, Iterable) or len(size) != 2:
+        raise ValueError("size must have 2 elements representing the height and width of the output image")
+
+    input_data_format = infer_channel_dimension_format(image)
+    output_data_format = data_format if data_format is not None else input_data_format
+
+    # We perform the crop in (C, H, W) format and then convert to the output format
+    image = to_channel_dimension_format(image, ChannelDimension.FIRST)
+
+    orig_height, orig_width = get_image_size(image)
+    crop_height, crop_width = size
+
+    top = (orig_height - crop_height) // 2
+    bottom = top + crop_height  # In case size is odd, (image_shape[0] + size[0]) // 2 won't give the proper result.
+    left = (orig_width - crop_width) // 2
+    right = left + crop_width  # In case size is odd, (image_shape[1] + size[1]) // 2 won't give the proper result.
+
+    # Check if cropped area is within image boundaries
+    if top >= 0 and bottom <= orig_height and left >= 0 and right <= orig_width:
+        image = image[..., top:bottom, left:right]
+        image = to_channel_dimension_format(image, output_data_format)
+        return image
+
+    # Otherwise, we may need to pad if the image is too small. Oh joy...
+    new_height = max(crop_height, orig_height)
+    new_width = max(crop_width, orig_width)
+    new_shape = image.shape[:-2] + (new_height, new_width)
+    new_image = np.zeros_like(image, shape=new_shape)
+
+    # If the image is too small, pad it with zeros
+    top_pad = (new_height - orig_height) // 2
+    bottom_pad = top_pad + orig_height
+    left_pad = (new_width - orig_width) // 2
+    right_pad = left_pad + orig_width
+    new_image[..., top_pad:bottom_pad, left_pad:right_pad] = image
+
+    top += top_pad
+    bottom += top_pad
+    left += left_pad
+    right += left_pad
+
+    new_image = new_image[..., max(0, top) : min(new_height, bottom), max(0, left) : min(new_width, right)]
+    new_image = to_channel_dimension_format(new_image, output_data_format)
+    return new_image

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -337,7 +337,7 @@ def center_crop(
             The channel dimension format for the output image. Can be one of:
                     - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
                     - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
-            If `None`, will use the inferred format of the input image.
+            If unset, will use the inferred format of the input image.
         return_numpy (`bool`, *optional*):
             Whether or not to return the cropped image as a numpy array. Used for backwards compatibility with the
             previous ImageFeatureExtractionMixin method.

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -341,7 +341,7 @@ def center_crop(
         return_numpy (`bool`, *optional*):
             Whether or not to return the cropped image as a numpy array. Used for backwards compatibility with the
             previous ImageFeatureExtractionMixin method.
-                - `None` (default): will return the same type as the input image.
+                - Unset: will return the same type as the input image.
                 - `True`: will return a numpy array.
                 - `False`: will return a `PIL.Image.Image` object.
     Returns:

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -322,7 +322,7 @@ def center_crop(
     image: np.ndarray,
     size: Tuple[int, int],
     data_format: Optional[Union[str, ChannelDimension]] = None,
-    return_numpy: Optional[bool] = None
+    return_numpy: Optional[bool] = None,
 ) -> np.ndarray:
     """
     Crops the `image` to the specified `size` using a center crop. Note that if the image is too small to be cropped to


### PR DESCRIPTION
# What does this PR do?

Adds `center_crop` to the image transforms library, to be used in the future image processors. Performs equivalent processing as done in the `ImageFeatureExtractionMixin`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
