### PR TITLE
Use TF framework

### DIFF
--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -56,7 +56,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
 
     @require_tf
     def test_small_model_tf(self):
-        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2")
+        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2", framework="tf")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
 
         outputs = pipe(image)
@@ -64,7 +64,12 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             outputs,
             [
                 {
-                    "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
+                    "generated_text": (
+                        " intermedi intermedi intermedi intermedi intermedi "
+                        "explorer explorer explorer explorer explorer explorer "
+                        "explorer medicine medicine medicine medicine medicine "
+                        "medicine medicine"
+                    )
                 },
             ],
         )
@@ -75,13 +80,23 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             [
                 [
                     {
-                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
-                    }
+                        "generated_text": (
+                            " intermedi intermedi intermedi intermedi intermedi "
+                            "explorer explorer explorer explorer explorer explorer "
+                            "explorer medicine medicine medicine medicine medicine "
+                            "medicine medicine"
+                        )
+                    },
                 ],
                 [
                     {
-                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
-                    }
+                        "generated_text": (
+                            " intermedi intermedi intermedi intermedi intermedi "
+                            "explorer explorer explorer explorer explorer explorer "
+                            "explorer medicine medicine medicine medicine medicine "
+                            "medicine medicine"
+                        )
+                    },
                 ],
             ],
         )


### PR DESCRIPTION
# What does this PR do?

This PR specifies `framework="tf"` for `ImageToTextPipelineTests.test_small_model_tf`.

--------

The pipeline tests are run in 3 docker environment: only PT, only TF, both PT/TF installation.

In the last case (`PT/TF installed`), the loaded models in tests like `test_small_model_tf` are in fact **PT models**, as we didn't specify the framework when creating the pipelines.

This is particularly confusing during debugging - especially when a model will produce diff. outputs between PT/TF models.
In such case, the same test will fail either in TF-only env. or in PT/TF env.

(One example is PR #19565, where I got the expected values from PT/TF env., and it failed on CI for TF-only env.)

**TODO**:
- Same change to other TF pipeline tests
- Investigate why we get diff. outputs between PT/TF models for `ImageToTextPipelineTests.test_small_model_tf`.


