### PR TITLE
[Doctest] - Fixing doctest `configuration_pegasus_x.py`

### DIFF
--- a/src/transformers/models/pegasus_x/configuration_pegasus_x.py
+++ b/src/transformers/models/pegasus_x/configuration_pegasus_x.py
@@ -94,12 +94,12 @@ class PegasusXConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import PegasusXModel, PegasusXConfig
+    >>> from transformers import PegasusXConfig, PegasusXModel
 
     >>> # Initializing a PEGASUS google/pegasus-x-large style configuration
     >>> configuration = PegasusXConfig()
 
-    >>> # Initializing a model from the google/pegasus-x-large style configuration
+    >>> # Initializing a model (with random weights) from the google/pegasus-x-large style configuration
     >>> model = PegasusXModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -91,6 +91,7 @@ src/transformers/models/opt/modeling_tf_opt.py
 src/transformers/models/owlvit/modeling_owlvit.py
 src/transformers/models/pegasus/configuration_pegasus.py
 src/transformers/models/pegasus/modeling_pegasus.py
+src/transformers/models/pegasus_x/configuration_pegasus_x.py
 src/transformers/models/perceiver/modeling_perceiver.py
 src/transformers/models/plbart/modeling_plbart.py
 src/transformers/models/poolformer/modeling_poolformer.py


### PR DESCRIPTION
# What does this PR do?
Fixes #19487 
Added (with random weights) in `configuration_pegasus_x.py`.
Added `configuration_pegasus_x.py` in `documentation_tests.txt`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ydshieh 
