### PR TITLE
PT <-> TF for composite models

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -15,6 +15,8 @@
 """ Classes to support TF Encoder-Decoder architectures"""
 
 
+import gc
+import os
 import tempfile
 import warnings
 from typing import Optional

--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -291,24 +291,6 @@ class TFEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLoss):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         r"""
-        Initializing *TFEncoderDecoderModel* from a pytorch checkpoint is not supported currently.
-
-        If there are only pytorch checkpoints for a particular encoder-decoder model, a workaround is:
-
-        ```python
-        >>> # a workaround to load from pytorch checkpoint
-        >>> from transformers import EncoderDecoderModel, TFEncoderDecoderModel
-
-        >>> _model = EncoderDecoderModel.from_pretrained("patrickvonplaten/bert2bert-cnn_dailymail-fp16")
-        >>> _model.encoder.save_pretrained("./encoder")
-        >>> _model.decoder.save_pretrained("./decoder")
-        >>> model = TFEncoderDecoderModel.from_encoder_decoder_pretrained(
-        ...     "./encoder", "./decoder", encoder_from_pt=True, decoder_from_pt=True
-        ... )
-        >>> # This is only for copying some specific attributes of this particular model.
-        >>> model.config = _model.config
-        ```
-
         Example:
 
         ```python
@@ -319,12 +301,42 @@ class TFEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLoss):
 
         from_pt = kwargs.pop("from_pt", False)
         if from_pt:
-            raise ValueError(
-                "Initializing `TFEncoderDecoderModel` from a pytorch checkpoint is not supported currently. Use a"
-                " tensorflow checkpoint instead. If only the pytorch checkpoints are available, create the encoder and"
-                " decoder models separately, and use them to initialize `TFEncoderDecoderModel`. Check"
-                " `TFEncoderDecoderModel.from_encoder_decoder_pretrained()` for more details."
-            )
+            import torch
+
+            from transformers import EncoderDecoderModel
+
+            # a workaround to load from pytorch checkpoint
+            _model = EncoderDecoderModel.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
+            config = _model.config
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                encoder_dir = os.path.join(tmpdirname, "encoder")
+                decoder_dir = os.path.join(tmpdirname, "decoder")
+                _model.encoder.save_pretrained(encoder_dir)
+                _model.decoder.save_pretrained(decoder_dir)
+
+                if hasattr(_model, "enc_to_dec_proj"):
+                    enc_to_dec_proj_kernel = tf.transpose(
+                        tf.constant(_model.enc_to_dec_proj.weight.detach().to("cpu").numpy()), perm=(1, 0)
+                    )
+                    enc_to_dec_proj_bias = tf.constant(_model.enc_to_dec_proj.bias.detach().to("cpu").numpy())
+
+                del _model
+                gc.collect()
+                torch.cuda.empty_cache()
+
+                model = TFEncoderDecoderModel.from_encoder_decoder_pretrained(
+                    encoder_dir, decoder_dir, encoder_from_pt=True, decoder_from_pt=True
+                )
+                # This is only for copying some specific attributes of this particular model.
+                model.config = config
+
+                if hasattr(model, "enc_to_dec_proj"):
+                    model(model.dummy_inputs)
+                    model.enc_to_dec_proj.kernel.assign(enc_to_dec_proj_kernel)
+                    model.enc_to_dec_proj.bias.assign(enc_to_dec_proj_bias)
+
+                return model
 
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 

--- a/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
@@ -476,6 +476,7 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
             encoder = TFAutoModel.from_pretrained(encoder_pretrained_model_name_or_path, *model_args, **kwargs_encoder)
 
             # Necessary to make `save_pretrained -> from_pretrained` work correctly for the converted PT -> TF model.
+            # See https://github.com/huggingface/transformers/pull/14016#issuecomment-944046313
             if kwargs_encoder.get("from_pt", None):
                 del kwargs_encoder["from_pt"]
                 with tempfile.TemporaryDirectory() as tmp_dirname:
@@ -518,6 +519,7 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
             decoder = TFAutoModelForCausalLM.from_pretrained(decoder_pretrained_model_name_or_path, **kwargs_decoder)
 
             # Necessary to make `save_pretrained -> from_pretrained` work correctly for the converted PT -> TF model.
+            # See https://github.com/huggingface/transformers/pull/14016#issuecomment-944046313
             if kwargs_decoder.get("from_pt", None):
                 del kwargs_decoder["from_pt"]
                 with tempfile.TemporaryDirectory() as tmp_dirname:

--- a/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
@@ -294,22 +294,6 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         r"""
-        Initializing `TFVisionEncoderDecoderModel` from a pytorch checkpoint is not supported currently.
-
-        If there are only pytorch checkpoints for a particular encoder-decoder model, a workaround is:
-
-        ```python
-        >>> # a workaround to load from pytorch checkpoint
-        >>> _model = VisionEncoderDecoderModel.from_pretrained("ydshieh/vit-gpt2-coco-en")
-        >>> _model.encoder.save_pretrained("./encoder")
-        >>> _model.decoder.save_pretrained("./decoder")
-        >>> model = TFVisionEncoderDecoderModel.from_encoder_decoder_pretrained(
-        ...     "./encoder", "./decoder", encoder_from_pt=True, decoder_from_pt=True
-        ... )
-        >>> # This is only for copying some specific attributes of this particular model.
-        >>> model.config = _model.config
-        ```
-
         Example:
 
         ```python

--- a/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
@@ -337,12 +337,28 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
 
         from_pt = kwargs.pop("from_pt", False)
         if from_pt:
-            raise ValueError(
-                "Initializing `TFVisionEncoderDecoderModel` from a pytorch checkpoint is not supported currently. Use"
-                " a tensorflow checkpoint instead. If only the pytorch checkpoints are available, create the encoder"
-                " and decoder models separately, and use them to initialize `TFVisionEncoderDecoderModel`. Check"
-                " `TFVisionEncoderDecoderModel.from_encoder_decoder_pretrained()` for more details."
-            )
+            import os
+            import tempfile
+            from transformers import VisionEncoderDecoderModel
+
+            # a workaround to load from pytorch checkpoint
+            _model = VisionEncoderDecoderModel.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                encoder_dir = os.path.join(tmpdirname, "encoder")
+                decoder_dir = os.path.join(tmpdirname, "decoder")
+                _model.encoder.save_pretrained(encoder_dir)
+                _model.decoder.save_pretrained(decoder_dir)
+                model = TFVisionEncoderDecoderModel.from_encoder_decoder_pretrained(encoder_dir, decoder_dir, encoder_from_pt=True, decoder_from_pt=True)
+                # This is only for copying some specific attributes of this particular model.
+                model.config = _model.config
+
+                if hasattr(_model, "enc_to_dec_proj"):
+                    model(model.dummy_inputs)
+                    model.enc_to_dec_proj.kernel.assign(tf.transpose(tf.constant(_model.enc_to_dec_proj.weight.detach().to("cpu").numpy()), perm=(1, 0)))
+                    model.enc_to_dec_proj.bias.assign(tf.constant(_model.enc_to_dec_proj.bias.detach().to("cpu").numpy()))
+
+                return model
 
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 

--- a/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_tf_vision_encoder_decoder.py
@@ -15,6 +15,7 @@
 """ Classes to support TF Vision-Encoder-Text-Decoder architectures"""
 
 
+import os
 import tempfile
 import warnings
 from typing import Optional
@@ -321,9 +322,6 @@ class TFVisionEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLos
 
         from_pt = kwargs.pop("from_pt", False)
         if from_pt:
-            import os
-            import tempfile
-
             from transformers import VisionEncoderDecoderModel
 
             # a workaround to load from pytorch checkpoint

--- a/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
@@ -240,35 +240,29 @@ class VisionEncoderDecoderModel(PreTrainedModel):
         return self.decoder.set_output_embeddings(new_embeddings)
 
     @classmethod
-    def from_pretrained(cls, *args, **kwargs):
-        # At the moment fast initialization is not supported for composite models
-        if kwargs.get("_fast_init", False):
-            logger.warning(
-                "Fast initialization is currently not supported for VisionEncoderDecoderModel. "
-                "Falling back to slow initialization..."
-            )
-        kwargs["_fast_init"] = False
-        return super().from_pretrained(*args, **kwargs)
-
-    @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         r"""
-        >>> from transformers import VisionEncoderDecoderModel, ViTFeatureExtractor, GPT2Tokenizer >>> from PIL import
-        Image >>> import requests
+        Example:
 
-        >>> feature_extractor = ViTFeatureExtractor.from_pretrained("ydshieh/vit-gpt2-coco-en") >>> decoder_tokenizer =
-        GPT2Tokenizer.from_pretrained("ydshieh/vit-gpt2-coco-en") >>> model =
-        VisionEncoderDecoderModel.from_pretrained("ydshieh/vit-gpt2-coco-en")
+        ```python
+        >>> from transformers import VisionEncoderDecoderModel, ViTFeatureExtractor, GPT2Tokenizer
+        >>> from PIL import Image
+        >>> import requests
 
-        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg" >>> img = Image.open(requests.get(url,
-        stream=True).raw) >>> pixel_values = feature_extractor(images=img, return_tensors="pt").pixel_values # Batch
-        size 1
+        >>> feature_extractor = ViTFeatureExtractor.from_pretrained("ydshieh/vit-gpt2-coco-en")
+        >>> decoder_tokenizer = GPT2Tokenizer.from_pretrained("ydshieh/vit-gpt2-coco-en")
+        >>> model = VisionEncoderDecoderModel.from_pretrained("ydshieh/vit-gpt2-coco-en")
 
-        >>> output_ids = model.generate( ... pixel_values, max_length=16, num_beams=4, return_dict_in_generate=True ...
-        ).sequences
+        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        >>> img = Image.open(requests.get(url, stream=True).raw)
+        >>> pixel_values = feature_extractor(images=img, return_tensors="pt").pixel_values  # Batch size 1
 
-        >>> preds = decoder_tokenizer.batch_decode(output_ids, skip_special_tokens=True) >>> preds = [pred.strip() for
-        pred in preds]
+        >>> output_ids = model.generate(
+        ...     pixel_values, max_length=16, num_beams=4, return_dict_in_generate=True
+        ... ).sequences
+
+        >>> preds = decoder_tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+        >>> preds = [pred.strip() for pred in preds]
 
         >>> assert preds == ["a cat laying on top of a couch next to another cat"]
         ```"""
@@ -352,6 +346,14 @@ class VisionEncoderDecoderModel(PreTrainedModel):
                     model.enc_to_dec_proj.bias.data = torch.from_numpy(tf_model.enc_to_dec_proj.bias.numpy())
 
                 return model
+
+        # At the moment fast initialization is not supported for composite models
+        if kwargs.get("_fast_init", False):
+            logger.warning(
+                "Fast initialization is currently not supported for VisionEncoderDecoderModel. "
+                "Falling back to slow initialization..."
+            )
+        kwargs["_fast_init"] = False
 
         return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 

--- a/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
@@ -15,6 +15,8 @@
 """ Classes to support Vision-Encoder-Text-Decoder architectures"""
 
 
+import os
+import tempfile
 from typing import Optional
 
 import torch
@@ -269,9 +271,6 @@ class VisionEncoderDecoderModel(PreTrainedModel):
 
         from_tf = kwargs.pop("from_tf", False)
         if from_tf:
-            import os
-            import tempfile
-
             from transformers import TFVisionEncoderDecoderModel
 
             # a workaround to load from tensorflow checkpoint

--- a/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -532,7 +532,7 @@ class TFVisionEncoderDecoderMixin:
         diff = np.abs((a - b)).max()
         self.assertLessEqual(diff, tol, f"Difference between torch and tf is {diff} (>= {tol}).")
 
-    # @is_pt_tf_cross_test
+    @is_pt_tf_cross_test
     def test_pt_tf_model_equivalence(self):
 
         config_inputs_dict = self.prepare_config_and_inputs()

--- a/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -532,7 +532,7 @@ class TFVisionEncoderDecoderMixin:
         diff = np.abs((a - b)).max()
         self.assertLessEqual(diff, tol, f"Difference between torch and tf is {diff} (>= {tol}).")
 
-    @is_pt_tf_cross_test
+    # @is_pt_tf_cross_test
     def test_pt_tf_model_equivalence(self):
 
         config_inputs_dict = self.prepare_config_and_inputs()

--- a/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py
@@ -463,7 +463,6 @@ class TFVisionEncoderDecoderMixin:
         self.check_pt_tf_models(tf_model, pt_model, tf_inputs_dict)
 
     def check_pt_to_tf_equivalence(self, config, decoder_config, tf_inputs_dict):
-        """EncoderDecoderModel requires special way to cross load (PT -> TF)"""
 
         encoder_decoder_config = VisionEncoderDecoderConfig.from_encoder_decoder_configs(config, decoder_config)
         # Output all for aggressive testing
@@ -480,7 +479,6 @@ class TFVisionEncoderDecoderMixin:
         self.check_pt_tf_equivalence(tf_model, pt_model, tf_inputs_dict)
 
     def check_tf_to_pt_equivalence(self, config, decoder_config, tf_inputs_dict):
-        """EncoderDecoderModel requires special way to cross load (TF -> PT)"""
 
         encoder_decoder_config = VisionEncoderDecoderConfig.from_encoder_decoder_configs(config, decoder_config)
         # Output all for aggressive testing
@@ -488,37 +486,13 @@ class TFVisionEncoderDecoderMixin:
         # TODO: A generalizable way to determine this attribute
         encoder_decoder_config.output_attentions = True
 
-        # Using `_tf_model`, the test will fail, because the weight names in the encoder/decoder of `_tf_model` get
-        # extended before saving those components. For example, The name of `_tf_model.encoder.vit` is
-        # `[top model name]/encoder/vit`, but the name of `tf_model.encoder.vit` is `[top model name]/vit`. The
-        # [top model name] is handled (stripped) by the conversion method, and the former case gets extra `encoder`,
-        # which should not occur when we want to save the components along.
+        tf_model = TFVisionEncoderDecoderModel(encoder_decoder_config)
+        # Make sure model is built before saving
+        tf_model(**tf_inputs_dict)
 
-        # There was a (very) ugly potential fix, which wasn't integrated to `transformers`: see
-        #   https://github.com/huggingface/transformers/pull/13222/commits/dbb3c9de76eee235791d2064094654637c99f36d#r697304245
-        #   (the change in `src/transformers/modeling_tf_utils.py`)
-        _tf_model = TFVisionEncoderDecoderModel(encoder_decoder_config)
-        # Make sure model is built
-        _tf_model(**tf_inputs_dict)
-
-        # Using `tf_model` to pass the test.
-        encoder = _tf_model.encoder.__class__(encoder_decoder_config.encoder)
-        decoder = _tf_model.decoder.__class__(encoder_decoder_config.decoder)
-        # Make sure models are built
-        encoder(encoder.dummy_inputs)
-        decoder(decoder.dummy_inputs)
-        tf_model = TFVisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
-        tf_model.config = encoder_decoder_config
-
-        with tempfile.TemporaryDirectory() as encoder_tmp_dirname, tempfile.TemporaryDirectory() as decoder_tmp_dirname:
-
-            tf_model.encoder.save_pretrained(encoder_tmp_dirname)
-            tf_model.decoder.save_pretrained(decoder_tmp_dirname)
-            pt_model = VisionEncoderDecoderModel.from_encoder_decoder_pretrained(
-                encoder_tmp_dirname, decoder_tmp_dirname, encoder_from_tf=True, decoder_from_tf=True
-            )
-            # This is only for copying some specific attributes of this particular model.
-            pt_model.config = tf_model.config
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tf_model.save_pretrained(tmpdirname)
+            pt_model = VisionEncoderDecoderModel.from_pretrained(tmpdirname, from_tf=True)
 
         self.check_pt_tf_equivalence(tf_model, pt_model, tf_inputs_dict)
 
@@ -620,8 +594,7 @@ class TFVisionEncoderDecoderMixin:
         decoder_config.hidden_size = decoder_config.hidden_size * 2
         self.assertTrue(config.hidden_size != decoder_config.hidden_size)
         self.check_pt_to_tf_equivalence(config, decoder_config, tf_inputs_dict)
-        # This requires a change in `VisionEncoderDecoder.from_pretrained` to pass
-        # self.check_tf_to_pt_equivalence(config, decoder_config, tf_inputs_dict)
+        self.check_tf_to_pt_equivalence(config, decoder_config, tf_inputs_dict)
 
     @slow
     def test_real_model_save_load_from_pretrained(self):


### PR DESCRIPTION
# What does this PR do?

Make `from_pretrained` (cross loading PT/TF) available for composite models. Ensure `enc_to_dec_proj` layer is correctly loaded.

With this PR, we can get the PT/TF same output for the test in #19719

I will apply the same change to Text and Speech composite models if the current version is approved.