### PR TITLE
[Doctest] Add `wav2vec2_conformer.py`

### DIFF
--- a/src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
@@ -193,12 +193,12 @@ class Wav2Vec2ConformerConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import Wav2Vec2ConformerModel, Wav2Vec2ConformerConfig
+    >>> from transformers import Wav2Vec2ConformerConfig, Wav2Vec2ConformerModel
 
     >>> # Initializing a Wav2Vec2Conformer facebook/wav2vec2-conformer-rel-pos-large style configuration
     >>> configuration = Wav2Vec2ConformerConfig()
 
-    >>> # Initializing a model from the facebook/wav2vec2-conformer-rel-pos-large style configuration
+    >>> # Initializing a model (with random weights) from the facebook/wav2vec2-conformer-rel-pos-large style configuration
     >>> model = Wav2Vec2ConformerModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -147,6 +147,7 @@ src/transformers/models/visual_bert/configuration_visual_bert.py
 src/transformers/models/wav2vec2/configuration_wav2vec2.py
 src/transformers/models/wav2vec2/modeling_wav2vec2.py
 src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
 src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
 src/transformers/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.py
 src/transformers/models/wavlm/modeling_wavlm.py


### PR DESCRIPTION
Add `configuration_wav2vec2_conformer.py` to `utils/documentation_tests.txt` for doctest.

Based on issue: [19487](https://github.com/huggingface/transformers/issues/19487)

@ydshieh could you please check it? If it is ok for you I can keep working on the "wav2vec2" ones!
Thank you very much for your support :)