### PR TITLE
Specify TF framework explicitly in more pipeline tests

### DIFF
--- a/tests/pipelines/test_pipelines_image_classification.py
+++ b/tests/pipelines/test_pipelines_image_classification.py
@@ -140,7 +140,7 @@ class ImageClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_tf
     def test_small_model_tf(self):
         small_model = "hf-internal-testing/tiny-random-vit"
-        image_classifier = pipeline("image-classification", model=small_model)
+        image_classifier = pipeline("image-classification", model=small_model, framework="tf")
 
         outputs = image_classifier("http://images.cocodataset.org/val2017/000000039769.jpg")
         self.assertEqual(

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -154,7 +154,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
     @slow
     @require_tf
     def test_large_model_tf(self):
-        pipe = pipeline("image-to-text", model="ydshieh/vit-gpt2-coco-en")
+        pipe = pipeline("image-to-text", model="ydshieh/vit-gpt2-coco-en", framework="tf")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
 
         outputs = pipe(image)


### PR DESCRIPTION
# What does this PR do?

It seems these 2 are the remaining ones, and no test failure due to the change in this PR.