### PR TITLE
[Doctest] Add `configuration_wavlm.py`

### DIFF
--- a/src/transformers/models/wavlm/configuration_wavlm.py
+++ b/src/transformers/models/wavlm/configuration_wavlm.py
@@ -180,7 +180,7 @@ class WavLMConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import WavLMModel, WavLMConfig
+    >>> from transformers import WavLMConfig, WavLMModel
 
     >>> # Initializing a WavLM facebook/wavlm-base-960h style configuration
     >>> configuration = WavLMConfig()

--- a/src/transformers/models/wavlm/configuration_wavlm.py
+++ b/src/transformers/models/wavlm/configuration_wavlm.py
@@ -185,7 +185,7 @@ class WavLMConfig(PretrainedConfig):
     >>> # Initializing a WavLM facebook/wavlm-base-960h style configuration
     >>> configuration = WavLMConfig()
 
-    >>> # Initializing a model from the facebook/wavlm-base-960h style configuration
+    >>> # Initializing a model (with random weights) from the facebook/wavlm-base-960h style configuration
     >>> model = WavLMModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -154,6 +154,7 @@ src/transformers/models/wav2vec2/tokenization_wav2vec2.py
 src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
 src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
 src/transformers/models/wav2vec2_with_lm/processing_wav2vec2_with_lm.py
+src/transformers/models/wavlm/configuration_wavlm.py
 src/transformers/models/wavlm/modeling_wavlm.py
 src/transformers/models/whisper/configuration_whisper.py
 src/transformers/models/whisper/modeling_whisper.py


### PR DESCRIPTION
Add configuration_wav2vec2_conformer.py to utils/documentation_tests.txt for doctest.

Based on issue: [19487](https://github.com/huggingface/transformers/issues/19487)


@ydshieh Could you please take a look? Thank you very much for your kind support!