### PR TITLE
Fix cache version file creation

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -1115,6 +1115,7 @@ if cache_version < 1 and cache_is_not_empty:
             "message and we will do our best to help."
         )
 
+if cache_version < 1:
     try:
         os.makedirs(TRANSFORMERS_CACHE, exist_ok=True)
         with open(cache_version_file, "w") as f:


### PR DESCRIPTION
# What does this PR do?

As reported in #19738, the cache version file is never actually created on a new machine. This is because it was under a test a bit too restrictive (there needed to be cached files).
This PR should fix this.

Fixes #19738 