### PR TITLE
[Doctest] Add `configuration_decision_transformer.py`

### DIFF
--- a/src/transformers/models/decision_transformer/configuration_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/configuration_decision_transformer.py
@@ -90,13 +90,13 @@ class DecisionTransformerConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import DecisionTransformerModel, DecisionTransformerConfig
+    >>> from transformers import DecisionTransformerConfig, DecisionTransformerModel
 
     >>> # Initializing a DecisionTransformer configuration
     >>> configuration = DecisionTransformerConfig()
 
-    >>> # Initializing a model from the configuration
-    >>> model = DecisionTransformerConfig(configuration)
+    >>> # Initializing a model (with random weights) from the configuration
+    >>> model = DecisionTransformerModel(configuration)
 
     >>> # Accessing the model configuration
     >>> configuration = model.config

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -51,6 +51,7 @@ src/transformers/models/data2vec/modeling_data2vec_audio.py
 src/transformers/models/data2vec/modeling_data2vec_vision.py
 src/transformers/models/deberta/modeling_deberta.py
 src/transformers/models/deberta_v2/modeling_deberta_v2.py
+src/transformers/models/decision_transformer/configuration_decision_transformer.py
 src/transformers/models/deformable_detr/modeling_deformable_detr.py
 src/transformers/models/deit/configuration_deit.py
 src/transformers/models/deit/modeling_deit.py


### PR DESCRIPTION
Add `configuration_decision_transformer.py` to `utils/documentation_tests.txt` for doctest.

Based on issue https://github.com/huggingface/transformers/issues/19487

@ydshieh could you please check it?
Thank you :)