### PR TITLE
[Doctests] Add `configuration_detr.py`

### DIFF
--- a/src/transformers/models/detr/configuration_detr.py
+++ b/src/transformers/models/detr/configuration_detr.py
@@ -113,12 +113,12 @@ class DetrConfig(PretrainedConfig):
     Examples:
 
     ```python
-    >>> from transformers import DetrModel, DetrConfig
+    >>> from transformers import DetrConfig, DetrModel
 
     >>> # Initializing a DETR facebook/detr-resnet-50 style configuration
     >>> configuration = DetrConfig()
 
-    >>> # Initializing a model from the facebook/detr-resnet-50 style configuration
+    >>> # Initializing a model (with random weights) from the facebook/detr-resnet-50 style configuration
     >>> model = DetrModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -55,6 +55,7 @@ src/transformers/models/deformable_detr/modeling_deformable_detr.py
 src/transformers/models/deit/configuration_deit.py
 src/transformers/models/deit/modeling_deit.py
 src/transformers/models/deit/modeling_tf_deit.py
+src/transformers/models/detr/configuration_detr.py
 src/transformers/models/detr/modeling_detr.py
 src/transformers/models/distilbert/configuration_distilbert.py
 src/transformers/models/dpt/modeling_dpt.py


### PR DESCRIPTION
Add `configuration_detr.py` to `utils/documentation_tests.txt` for doctest.

Based on issue https://github.com/huggingface/transformers/issues/19487

@ydshieh could you please check it?
Thank you :)