### PR TITLE
 [Doctest] Add `configuration_speech_to_text_2.py`

### DIFF
--- a/src/transformers/models/speech_to_text_2/configuration_speech_to_text_2.py
+++ b/src/transformers/models/speech_to_text_2/configuration_speech_to_text_2.py
@@ -79,12 +79,12 @@ class Speech2Text2Config(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import Speech2Text2ForCausalLM, Speech2Text2Config
+    >>> from transformers import Speech2Text2Config, Speech2Text2ForCausalLM
 
     >>> # Initializing a Speech2Text2 s2t_transformer_s style configuration
     >>> configuration = Speech2Text2Config()
 
-    >>> # Initializing a model from the s2t_transformer_s style configuration
+    >>> # Initializing a model (with random weights) from the s2t_transformer_s style configuration
     >>> model = Speech2Text2ForCausalLM(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -122,6 +122,7 @@ src/transformers/models/sew_d/configuration_sew_d.py
 src/transformers/models/sew_d/modeling_sew_d.py
 src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
 src/transformers/models/speech_to_text/modeling_speech_to_text.py
+src/transformers/models/speech_to_text_2/configuration_speech_to_text_2.py
 src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
 src/transformers/models/segformer/modeling_tf_segformer.py
 src/transformers/models/swin/configuration_swin.py


### PR DESCRIPTION
Add `configuration_speech_to_text_2.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you please take a look at it?
Thanks :)