### PR TITLE
 [Doctest] Add `configuration_speech_to_text.py`

### DIFF
--- a/src/transformers/models/speech_to_text/configuration_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/configuration_speech_to_text.py
@@ -100,12 +100,12 @@ class Speech2TextConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import Speech2TextModel, Speech2TextConfig
+    >>> from transformers import Speech2TextConfig, Speech2TextModel
 
     >>> # Initializing a Speech2Text s2t_transformer_s style configuration
     >>> configuration = Speech2TextConfig()
 
-    >>> # Initializing a model from the s2t_transformer_s style configuration
+    >>> # Initializing a model (with random weights) from the s2t_transformer_s style configuration
     >>> model = Speech2TextModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -121,6 +121,7 @@ src/transformers/models/sew/modeling_sew.py
 src/transformers/models/sew_d/configuration_sew_d.py
 src/transformers/models/sew_d/modeling_sew_d.py
 src/transformers/models/speech_encoder_decoder/modeling_speech_encoder_decoder.py
+src/transformers/models/speech_to_text/configuration_speech_to_text.py
 src/transformers/models/speech_to_text/modeling_speech_to_text.py
 src/transformers/models/speech_to_text_2/modeling_speech_to_text_2.py
 src/transformers/models/segformer/modeling_tf_segformer.py


### PR DESCRIPTION
Add `configuration_speech_to_text.py` to `utils/documentation_tests.txt` for doctest.

Based on issue #19487

@ydshieh could you please check it?
Thanks :)