### PR TITLE
[PoC] Add resources to each model's doc page

### DIFF
--- a/docs/source/en/model_doc/vit.mdx
+++ b/docs/source/en/model_doc/vit.mdx
@@ -95,6 +95,7 @@ PyTorch:
 - [Blog](https://huggingface.co/blog/fine-tune-vit): Fine-Tune ViT for Image Classification with 🤗 Transformers. 
 
 TensorFlow:
+
 - [`TFViTForImageClassification`] is supported by the [example scripts](https://github.com/huggingface/transformers/tree/main/examples/pytorch/image-classification) and [example notebooks](https://github.com/huggingface/notebooks/tree/main/examples).
 - [Blog](https://www.philschmid.de/image-classification-huggingface-transformers-keras): Image Classification with Hugging Face Transformers and `Keras`. 
 - [Blog](Deploying TensorFlow Vision Models in Hugging Face with TF Serving) Deploying TensorFlow Vision Models in Hugging Face with TF Serving.
@@ -102,6 +103,7 @@ TensorFlow:
 - [Blog](https://huggingface.co/blog/deploy-vertex-ai): Deploying 🤗 ViT on Vertex AI.
 
 Optimum:
+
 - [Blog](https://www.philschmid.de/optimizing-vision-transformer): Accelerate Vision Transformer (ViT) with Quantization using Optimum.
 
 ## ViTConfig

--- a/docs/source/en/model_doc/vit.mdx
+++ b/docs/source/en/model_doc/vit.mdx
@@ -34,7 +34,6 @@ substantially fewer computational resources to train.*
 
 Tips:
 
-- Demo notebooks regarding inference as well as fine-tuning ViT on custom data can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/VisionTransformer).
 - To feed images to the Transformer encoder, each image is split into a sequence of fixed-size non-overlapping patches,
   which are then linearly embedded. A [CLS] token is added to serve as representation of an entire image, which can be
   used for classification. The authors also add absolute position embeddings, and feed the resulting sequence of
@@ -86,6 +85,24 @@ found [here](https://github.com/google-research/vision_transformer).
 Note that we converted the weights from Ross Wightman's [timm library](https://github.com/rwightman/pytorch-image-models), who already converted the weights from JAX to PyTorch. Credits
 go to him!
 
+## Resources
+
+PyTorch:
+
+- [`ViTForImageClassification`] is supported by the official [image classification scripts](https://github.com/huggingface/transformers/tree/main/examples/pytorch/image-classification) and [notebooks](https://github.com/huggingface/notebooks/tree/main/examples).
+- Demo notebooks regarding inference as well as fine-tuning ViT on custom data can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/VisionTransformer).
+- [`ViTForMaskedImageModeling`] is supported by the official [image pretraining script](https://github.com/huggingface/transformers/tree/main/examples/pytorch/image-pretraining).
+- [Blog](https://huggingface.co/blog/fine-tune-vit): Fine-Tune ViT for Image Classification with 🤗 Transformers. 
+
+TensorFlow:
+- [`TFViTForImageClassification`] is supported by the [example scripts](https://github.com/huggingface/transformers/tree/main/examples/pytorch/image-classification) and [example notebooks](https://github.com/huggingface/notebooks/tree/main/examples).
+- [Blog](https://www.philschmid.de/image-classification-huggingface-transformers-keras): Image Classification with Hugging Face Transformers and `Keras`. 
+- [Blog](Deploying TensorFlow Vision Models in Hugging Face with TF Serving) Deploying TensorFlow Vision Models in Hugging Face with TF Serving.
+- [Blog](https://huggingface.co/blog/deploy-tfserving-kubernetes): Deploying 🤗 ViT on Kubernetes with TF Serving.
+- [Blog](https://huggingface.co/blog/deploy-vertex-ai): Deploying 🤗 ViT on Vertex AI.
+
+Optimum:
+- [Blog](https://www.philschmid.de/optimizing-vision-transformer): Accelerate Vision Transformer (ViT) with Quantization using Optimum.
 
 ## ViTConfig
 

--- a/src/transformers/models/vit/modeling_vit.py
+++ b/src/transformers/models/vit/modeling_vit.py
@@ -722,7 +722,8 @@ class ViTForMaskedImageModeling(ViTPreTrainedModel):
 @add_start_docstrings(
     """
     ViT Model transformer with an image classification head on top (a linear layer on top of the final hidden state of
-    the [CLS] token) e.g. for ImageNet.
+    the [CLS] token) e.g. for ImageNet. Check the [image classification
+    task](https://huggingface.co/tasks/image-classification) for more info.
 
     <Tip>
 


### PR DESCRIPTION
# What does this PR do?

This PR is a small PoC to add resources (notebooks, scripts, blogs, etc.) to each model's doc page.

Ideally (not sure if it's possible), but it'd be great if we could (partially) automate this.

The idea being that, if a new model is added to the FOR_IMAGE_CLASSIFICATION_MAPPING for instance, the doc page automatically will add a link to the image classification notebooks and scripts. Not sure if this is possible, cc @sgugger.