### PR TITLE
Run some TF Whisper tests in subprocesses to avoid GPU OOM

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1675,7 +1675,20 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None):
     return decorator
 
 
-def run_test_in_subprocess(test_case, target_func, inputs, timeout):
+def run_test_in_subprocess(test_case, target_func, inputs=None, timeout=600):
+    """
+    To run a test in a subprocess. In particular, this can avoid (GPU) memory issue.
+
+    Args:
+        test_case (`unittest.TestCase`):
+            The test that will run `target_func`.
+        target_func (`Callable`):
+            The function implementing the actual testing logic.
+        inputs (`dict`, *optional*, defaults to `None`):
+            The inputs that will be passed to `target_func` through an (input) queue.
+        timeout (`int`, *optional*, defaults to 600):
+            The timeout (in seconds) that will be passed to the input and output queues.
+    """
 
     start_methohd = "spawn"
     ctx = multiprocessing.get_context(start_methohd)
@@ -1683,7 +1696,7 @@ def run_test_in_subprocess(test_case, target_func, inputs, timeout):
     input_queue = ctx.Queue(1)
     output_queue = ctx.JoinableQueue(1)
 
-    # We can't send `self` to the child, otherwise hanging forever.
+    # We can't send `unittest.TestCase` to the child, otherwise we get issues regarding pickle.
     input_queue.put(inputs, timeout=timeout)
 
     process = ctx.Process(target=target_func, args=(input_queue, output_queue, timeout))

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -643,38 +643,38 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
     try:
         _inputs = in_queue.get(timeout=timeout)
 
-        set_seed(0)
-        processor = WhisperProcessor.from_pretrained("openai/whisper-large")
-        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
-
-        input_speech = _load_datasamples(4)
-        input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
-        generated_ids = model.generate(input_features, max_length=20)
-
-        # fmt: off
-        EXPECTED_LOGITS = tf.convert_to_tensor(
-            [
-                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
-                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
-                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
-                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
-            ]
-        )
-        # fmt: on
-
-        unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
-
-        # fmt: off
-        EXPECTED_TRANSCRIPT = [
-            ' Mr. Quilter is the apostle of the middle classes and we are glad to',
-            " Nor is Mr. Quilter's manner less interesting than his matter.",
-            " He tells us that at this festive season of the year, with Christmas and roast beef",
-            " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
-        ]
-        # fmt: on
-
-        transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
-        unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
+    #     set_seed(0)
+    #     processor = WhisperProcessor.from_pretrained("openai/whisper-large")
+    #     model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
+    #
+    #     input_speech = _load_datasamples(4)
+    #     input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
+    #     generated_ids = model.generate(input_features, max_length=20)
+    #
+    #     # fmt: off
+    #     EXPECTED_LOGITS = tf.convert_to_tensor(
+    #         [
+    #             [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
+    #             [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
+    #             [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
+    #             [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
+    #         ]
+    #     )
+    #     # fmt: on
+    #
+    #     unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
+    #
+    #     # fmt: off
+    #     EXPECTED_TRANSCRIPT = [
+    #         ' Mr. Quilter is the apostle of the middle classes and we are glad to',
+    #         " Nor is Mr. Quilter's manner less interesting than his matter.",
+    #         " He tells us that at this festive season of the year, with Christmas and roast beef",
+    #         " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
+    #     ]
+    #     # fmt: on
+    #
+    #     transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
+    #     unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
     except Exception:
         error = f"{traceback.format_exc()}"
 
@@ -924,7 +924,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
     @slow
     def test_large_batched_generation(self):
         timeout = os.environ.get("PYTEST_TIMEOUT", 120)
-        run_test_in_subprocess(test_case=self, inputs=None, target_func=_test_large_batched_generation, timeout=timeout)
+        run_test_in_subprocess(test_case=self, target_func=_test_large_batched_generation, inputs=None, timeout=timeout)
 
     @slow
     def test_tiny_en_batched_generation(self):

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -644,8 +644,8 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
         _inputs = in_queue.get(timeout=timeout)
 
         set_seed(0)
-        processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
-        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+        processor = WhisperProcessor.from_pretrained("openai/whisper-large")
+        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
 
         input_speech = _load_datasamples(4)
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
@@ -662,7 +662,7 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
         )
         # fmt: on
 
-        # unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
+        unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
 
         # fmt: off
         EXPECTED_TRANSCRIPT = [
@@ -674,7 +674,7 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
         # fmt: on
 
         transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
-        # unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
+        unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
     except Exception:
         error = f"{traceback.format_exc()}"
 
@@ -923,7 +923,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
 
     @slow
     def test_large_batched_generation(self):
-        timeout = os.environ.get("PYTEST_TIMEOUT", 120)
+        timeout = os.environ.get("PYTEST_TIMEOUT", 600)
         run_test_in_subprocess(test_case=self, target_func=_test_large_batched_generation, inputs=None, timeout=timeout)
 
     @slow

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -644,8 +644,8 @@ def child(in_queue, out_queue):
         _inputs = in_queue.get(timeout=30)
 
         set_seed(0)
-        processor = WhisperProcessor.from_pretrained("openai/whisper-base")
-        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-base")
+        processor = WhisperProcessor.from_pretrained("openai/whisper-large")
+        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
 
         input_speech = _load_datasamples(4)
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
@@ -662,7 +662,7 @@ def child(in_queue, out_queue):
         )
         # fmt: on
 
-        ## unittest.TestCase.assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
+        unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
 
         # fmt: off
         EXPECTED_TRANSCRIPT = [
@@ -674,7 +674,7 @@ def child(in_queue, out_queue):
         # fmt: on
 
         transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
-        ## unittest.TestCase.assertListEqual(transcript, EXPECTED_TRANSCRIPT)
+        unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
     except Exception:
         error = f"{traceback.format_exc()}"
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -770,17 +770,17 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
 
         input_speech = _load_datasamples(4)
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
-        generated_ids_1 = model.generate(input_features[0:2], max_length=15)
-        generated_ids_2 = model.generate(input_features[2:4], max_length=15)
+        generated_ids_1 = model.generate(input_features[0:2], max_length=20)
+        generated_ids_2 = model.generate(input_features[2:4], max_length=20)
         generated_ids = np.concatenate([generated_ids_1, generated_ids_2])
 
         # fmt: off
         EXPECTED_LOGITS = tf.convert_to_tensor(
             [
-                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359],
-                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813],
-                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11],
-                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307]
+                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
+                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
+                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
+                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
             ]
         )
         # fmt: on
@@ -789,10 +789,10 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
 
         # fmt: off
         EXPECTED_TRANSCRIPT = [
-            " Mr. Quilter is the apostle of the middle classes",
-            " Nor is Mr. Quilter's manner less interesting than",
-            " He tells us that at this festive season of the year,",
-            " He has grave doubts whether Sir Frederick Layton's work is"
+            ' Mr. Quilter is the apostle of the middle classes and we are glad to',
+            " Nor is Mr. Quilter's manner less interesting than his matter.",
+            " He tells us that at this festive season of the year, with Christmas and roast beef",
+            " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
         ]
         # fmt: on
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -718,6 +718,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         self.assertTrue(np.allclose(logits[0, 0, :30], EXPECTED_LOGITS, atol=1e-4))
 
     @slow
+    @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
     def test_large_logits_librispeech(self):
         set_seed(0)
 
@@ -815,6 +816,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         self.assertEqual(transcript_xla, EXPECTED_TRANSCRIPT)
 
     @slow
+    @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
     def test_large_generation(self):
         set_seed(0)
         processor = WhisperProcessor.from_pretrained("openai/whisper-large")
@@ -831,6 +833,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
 
     @slow
+    @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
     def test_large_generation_multilingual(self):
         set_seed(0)
         processor = WhisperProcessor.from_pretrained("openai/whisper-large")
@@ -867,6 +870,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
 
     @slow
+    @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
     def test_large_batched_generation(self):
         set_seed(0)
         processor = WhisperProcessor.from_pretrained("openai/whisper-large")

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -639,8 +639,8 @@ def _load_datasamples(num_samples):
 def child(in_queue, out_queue):
 
     set_seed(0)
-    processor = WhisperProcessor.from_pretrained("openai/whisper-large")
-    model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
+    processor = WhisperProcessor.from_pretrained("openai/whisper-base")
+    model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-base")
 
     input_speech = _load_datasamples(4)
     input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -770,15 +770,17 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
 
         input_speech = _load_datasamples(4)
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
-        generated_ids = model.generate(input_features, max_length=20)
+        generated_ids_1 = model.generate(input_features[0:2], max_length=15)
+        generated_ids_2 = model.generate(input_features[2:4], max_length=15)
+        generated_ids = np.concatenate([generated_ids_1, generated_ids_2])
 
         # fmt: off
         EXPECTED_LOGITS = tf.convert_to_tensor(
             [
-                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
-                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
-                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
-                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
+                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359],
+                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813],
+                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11],
+                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307]
             ]
         )
         # fmt: on
@@ -787,10 +789,10 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
 
         # fmt: off
         EXPECTED_TRANSCRIPT = [
-            ' Mr. Quilter is the apostle of the middle classes and we are glad to',
-            " Nor is Mr. Quilter's manner less interesting than his matter.",
-            " He tells us that at this festive season of the year, with Christmas and roast beef",
-            " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
+            " Mr. Quilter is the apostle of the middle classes",
+            " Nor is Mr. Quilter's manner less interesting than",
+            " He tells us that at this festive season of the year,",
+            " He has grave doubts whether Sir Frederick Layton's work is"
         ]
         # fmt: on
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -638,6 +638,8 @@ def _load_datasamples(num_samples):
 
 def child(in_queue, out_queue):
 
+    _inputs = in_queue.get(timeout=30)
+
     set_seed(0)
     processor = WhisperProcessor.from_pretrained("openai/whisper-base")
     model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-base")
@@ -645,6 +647,11 @@ def child(in_queue, out_queue):
     input_speech = _load_datasamples(4)
     input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
     generated_ids = model.generate(input_features, max_length=20)
+
+    error = "bye"
+    results = {"error": error}
+    out_queue.put(results, timeout=30)
+    out_queue.join()
 
     # # fmt: off
     # EXPECTED_LOGITS = tf.convert_to_tensor(

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -762,7 +762,7 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
 
     error = None
     try:
-        _inputs = in_queue.get(timeout=timeout)
+        _ = in_queue.get(timeout=timeout)
 
         set_seed(0)
         processor = WhisperProcessor.from_pretrained("openai/whisper-large")

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -924,7 +924,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
     @slow
     def test_large_batched_generation(self):
         timeout = os.environ.get("PYTEST_TIMEOUT", 120)
-        run_test_in_subprocess(inputs=None, target_func=_test_large_batched_generation, timeout=timeout)
+        run_test_in_subprocess(test_case=self, inputs=None, target_func=_test_large_batched_generation, timeout=timeout)
 
     @slow
     def test_tiny_en_batched_generation(self):

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -636,7 +636,7 @@ def _load_datasamples(num_samples):
     return [x["array"] for x in speech_samples]
 
 
-def child():
+def child(in_queue, out_queue):
 
     set_seed(0)
     processor = WhisperProcessor.from_pretrained("openai/whisper-large")

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -643,38 +643,38 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
     try:
         _inputs = in_queue.get(timeout=timeout)
 
-    #     set_seed(0)
-    #     processor = WhisperProcessor.from_pretrained("openai/whisper-large")
-    #     model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
-    #
-    #     input_speech = _load_datasamples(4)
-    #     input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
-    #     generated_ids = model.generate(input_features, max_length=20)
-    #
-    #     # fmt: off
-    #     EXPECTED_LOGITS = tf.convert_to_tensor(
-    #         [
-    #             [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
-    #             [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
-    #             [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
-    #             [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
-    #         ]
-    #     )
-    #     # fmt: on
-    #
-    #     unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
-    #
-    #     # fmt: off
-    #     EXPECTED_TRANSCRIPT = [
-    #         ' Mr. Quilter is the apostle of the middle classes and we are glad to',
-    #         " Nor is Mr. Quilter's manner less interesting than his matter.",
-    #         " He tells us that at this festive season of the year, with Christmas and roast beef",
-    #         " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
-    #     ]
-    #     # fmt: on
-    #
-    #     transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
-    #     unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
+        set_seed(0)
+        processor = WhisperProcessor.from_pretrained("openai/whisper-tine")
+        model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+
+        input_speech = _load_datasamples(4)
+        input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="tf").input_features
+        generated_ids = model.generate(input_features, max_length=20)
+
+        # fmt: off
+        EXPECTED_LOGITS = tf.convert_to_tensor(
+            [
+                [50258, 50358, 50363, 2221, 13, 2326, 388, 391, 307, 264, 50244, 295, 264, 2808, 5359, 293, 321, 366, 5404, 281],
+                [50258, 50358, 50363, 6966, 307, 2221, 13, 2326, 388, 391, 311, 9060, 1570, 1880, 813, 702, 1871, 13, 50257, 50257],
+                [50258, 50358, 50363, 634, 5112, 505, 300, 412, 341, 42729, 3196, 295, 264, 1064, 11, 365, 5272, 293, 12904, 9256],
+                [50258, 50358, 50363, 634, 575, 12525, 22618, 1968, 6144, 35617, 20084, 1756, 311, 589, 307, 534, 10281, 934, 439, 11]
+            ]
+        )
+        # fmt: on
+
+        # unittest.TestCase().assertTrue(np.allclose(generated_ids, EXPECTED_LOGITS))
+
+        # fmt: off
+        EXPECTED_TRANSCRIPT = [
+            ' Mr. Quilter is the apostle of the middle classes and we are glad to',
+            " Nor is Mr. Quilter's manner less interesting than his matter.",
+            " He tells us that at this festive season of the year, with Christmas and roast beef",
+            " He has grave doubts whether Sir Frederick Layton's work is really Greek after all,"
+        ]
+        # fmt: on
+
+        transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
+        # unittest.TestCase().assertListEqual(transcript, EXPECTED_TRANSCRIPT)
     except Exception:
         error = f"{traceback.format_exc()}"
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -910,7 +910,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
 
     @slow
-    @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
+    # @unittest.skip(reason="TF uses almost all GPU and won't release it, causing some PT tests GPU OOM.")
     def test_large_batched_generation(self):
 
         start_methohd = "spawn"

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -679,7 +679,7 @@ def child(in_queue, out_queue):
         error = f"{traceback.format_exc()}"
 
     results = {"error": error}
-    out_queue.put(results, timeout=30)
+    out_queue.put(results, timeout=120)
     out_queue.join()
 
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -940,7 +940,7 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         # Kill the child process if we can't get outputs from it in time: otherwise, the hanging subprocess prevents
         # the test to exit properly.
         try:
-            results = output_queue.get(timeout=30)
+            results = output_queue.get(timeout=120)
             output_queue.task_done()
         except Exception as e:
             process.terminate()

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -644,7 +644,7 @@ def _test_large_batched_generation(in_queue, out_queue, timeout):
         _inputs = in_queue.get(timeout=timeout)
 
         set_seed(0)
-        processor = WhisperProcessor.from_pretrained("openai/whisper-tine")
+        processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
         model = TFWhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
 
         input_speech = _load_datasamples(4)

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -637,7 +637,7 @@ def _load_datasamples(num_samples):
     return [x["array"] for x in speech_samples]
 
 
-def child(in_queue, out_queue):
+def _test_large_batched_generation(in_queue, out_queue):
 
     error = None
     try:
@@ -932,10 +932,11 @@ class TFWhisperModelIntegrationTests(unittest.TestCase):
         output_queue = ctx.JoinableQueue(1)
 
         # We can't send `self` to the child, otherwise hanging forever.
+        # No input to be sent here.
         _inputs = None
         input_queue.put(_inputs, timeout=30)
 
-        process = ctx.Process(target=child, args=(input_queue, output_queue))
+        process = ctx.Process(target=_test_large_batched_generation, args=(input_queue, output_queue))
         process.start()
         # Kill the child process if we can't get outputs from it in time: otherwise, the hanging subprocess prevents
         # the test to exit properly.


### PR DESCRIPTION
# What does this PR do?

Run some TF Whisper tests in subprocesses to avoid GPU OOM (in the PT tests, which run after the TF tests)

After TF loading `openai/whisper-large`, it takes almost all GPU and won't release it, causing some PT tests GPU OOM later.

Current failing CI report [here](https://github.com/huggingface/transformers/actions/runs/3278475639/jobs/5396961322)