### PR TITLE
TF: sample generation compatible with XLA and dynamic batch sizes

### DIFF
--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -360,6 +360,7 @@ class TFGenerationMixin:
 
     @property
     def seed_generator(self):
+        warnings.warn("`seed_generator` is deprecated and will be removed in a future version.", UserWarning)
         if self._seed_generator is None:
             self._seed_generator = tf.random.Generator.from_non_deterministic_state()
         return self._seed_generator
@@ -1920,7 +1921,7 @@ class TFGenerationMixin:
         **model_kwargs,
     ) -> Tuple[tf.Tensor, Dict[str, Any]]:
         expanded_return_idx = tf.reshape(
-            tf.tile(tf.reshape(tf.range(input_ids.shape[0]), (-1, 1)), (1, expand_size)), (-1,)
+            tf.tile(tf.reshape(tf.range(tf.shape(input_ids)[0]), (-1, 1)), (1, expand_size)), (-1,)
         )
         input_ids = tf.gather(input_ids, expanded_return_idx, axis=0)
 
@@ -2624,7 +2625,7 @@ class TFGenerationMixin:
             if seed is not None:
                 sample_seed = seed
             else:
-                sample_seed = tf.cast(self.seed_generator.make_seeds(count=1)[:, 0], dtype=tf.int32)
+                sample_seed = tf.experimental.numpy.random.randint(tf.int32.min, tf.int32.max, (2,), dtype=tf.int32)
             next_tokens = tf.squeeze(
                 tf.random.stateless_categorical(
                     logits=next_tokens_scores, num_samples=1, seed=sample_seed, dtype=tf.int32


### PR DESCRIPTION
# What does this PR do?

Fixes #19747 (sample generation failing with XLA and dynamic batch sizes)

There were two distinct problems:
- `_expand_inputs_for_generation` was crashing when the input was a `TensorSpec` with dynamic batch size (used e.g. with tf.Serving). Fix: `tensor.shape` -> `tf.shape`
- Obtaining a new seed with `tf.random.Generator` is broken with `tf.function` for two distinct reasons: 1) the protection we added [here](https://github.com/huggingface/transformers/pull/18044/files) makes unseeded `sample` crash unless we call `sample` with eager execution first (see [here](https://www.tensorflow.org/api_docs/python/tf/random/set_global_generator) why); 2) TF 2.10 + XLA crashes on the line that instantiates it. Fix: replace TF-suggested method to generate seed with `tf.random.Generator` with `tf.experimental.numpy.random.randint`, since we were creating a Generator from a non-deterministic state anyways 🤷 Notes: the new `tf.experimental.numpy.random.randint` strategy seems to be slightly faster (23.5 ms -> 21.6 ms per generate call on a benchmark with XLA, nvidia 3090,  and `t5-small`) and is retrocompatible up to TF 2.4.0.