### PR TITLE
Update `ImageToTextPipelineTests.test_small_model_tf`

### DIFF
--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -64,12 +64,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             outputs,
             [
                 {
-                    "generated_text": (
-                        " intermedi intermedi intermedi intermedi intermedi "
-                        "explorer explorer explorer explorer explorer explorer "
-                        "explorer medicine medicine medicine medicine medicine "
-                        "medicine medicine"
-                    )
+                    "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
                 },
             ],
         )
@@ -80,23 +75,13 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
             [
                 [
                     {
-                        "generated_text": (
-                            " intermedi intermedi intermedi intermedi intermedi "
-                            "explorer explorer explorer explorer explorer explorer "
-                            "explorer medicine medicine medicine medicine medicine "
-                            "medicine medicine"
-                        )
-                    },
+                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
+                    }
                 ],
                 [
                     {
-                        "generated_text": (
-                            " intermedi intermedi intermedi intermedi intermedi "
-                            "explorer explorer explorer explorer explorer explorer "
-                            "explorer medicine medicine medicine medicine medicine "
-                            "medicine medicine"
-                        )
-                    },
+                        "generated_text": "growthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthgrowthGOGO"
+                    }
                 ],
             ],
         )

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -56,7 +56,9 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
 
     @require_tf
     def test_small_model_tf(self):
-        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2", framework="tf")
+        from transformers import TFVisionEncoderDecoderModel
+        model = TFVisionEncoderDecoderModel.from_pretrained("hf-internal-testing/tiny-random-vit-gpt2", from_pt=True)
+        pipe = pipeline("image-to-text", model=model, framework="tf")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
 
         outputs = pipe(image)

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -56,7 +56,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
 
     @require_tf
     def test_small_model_tf(self):
-        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2")
+        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2", framework="tf")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
 
         outputs = pipe(image)

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -56,9 +56,7 @@ class ImageToTextPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta
 
     @require_tf
     def test_small_model_tf(self):
-        from transformers import TFVisionEncoderDecoderModel
-        model = TFVisionEncoderDecoderModel.from_pretrained("hf-internal-testing/tiny-random-vit-gpt2", from_pt=True)
-        pipe = pipeline("image-to-text", model=model, framework="tf")
+        pipe = pipeline("image-to-text", model="hf-internal-testing/tiny-random-vit-gpt2")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
 
         outputs = pipe(image)


### PR DESCRIPTION
# What does this PR do?

After PR #19732, I uploaded the correctly converted TF model to the Hub repo [hf-internal-testing/tiny-random-vit-gpt2](https://huggingface.co/hf-internal-testing/tiny-random-vit-gpt2/tree/main)

This PR updates the expected values accordingly, which is the same values as for `test_small_model_pt`.