### PR TITLE
Fix CTRL `test_torchscrip_xxx` CI by updating `_create_and_check_torchscript`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -670,6 +670,7 @@ class ModelTesterMixin:
                     )  # when traced model is checked, an error is produced due to name mangling
                 else:
                     main_input = inputs[main_input_name]
+                    model(main_input)
                     traced_model = torch.jit.trace(model, main_input)
             except RuntimeError:
                 self.fail("Couldn't trace module.")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -658,6 +658,7 @@ class ModelTesterMixin:
                     attention_mask = inputs["attention_mask"]
                     decoder_input_ids = inputs["decoder_input_ids"]
                     decoder_attention_mask = inputs["decoder_attention_mask"]
+                    model(main_input, attention_mask, decoder_input_ids, decoder_attention_mask)
                     traced_model = torch.jit.trace(
                         model, (main_input, attention_mask, decoder_input_ids, decoder_attention_mask)
                     )
@@ -665,6 +666,7 @@ class ModelTesterMixin:
                     input_ids = inputs["input_ids"]
                     bbox = inputs["bbox"]
                     image = inputs["image"].tensor
+                    model(input_ids, bbox, image)
                     traced_model = torch.jit.trace(
                         model, (input_ids, bbox, image), check_trace=False
                     )  # when traced model is checked, an error is produced due to name mangling


### PR DESCRIPTION
# What does this PR do?

Fix CTRL `test_torchscrip_xxx` CI by updating `_create_and_check_torchscript`. Before calling `torch.jit.trace`, we run the prepared inputs first.

### More context

The PR #19681 puts `pos_encoding` attribute to the correct device for CTRL model, but this could be only done safely in the `forward` method.

However, our current `torchscript` tests don't run the model with the prepared inputs before calling `torch.jit.trace`. And so we get the following error for `CTRL` after PR #19678:
```bash
(line 535)  torch.jit._trace.TracingCheckError: Tracing failed sanity checks!
...
...
Comparison exception: 	The values for attribute 'device' do not match: cpu != cuda:0.
``` 
See [CI report](https://github.com/huggingface/transformers/actions/runs/3286486761/jobs/5414682626)

