### PR TITLE
[Doctest] Add `configuration_electra.py`

### DIFF
--- a/src/transformers/models/electra/configuration_electra.py
+++ b/src/transformers/models/electra/configuration_electra.py
@@ -119,12 +119,12 @@ class ElectraConfig(PretrainedConfig):
     Examples:
 
     ```python
-    >>> from transformers import ElectraModel, ElectraConfig
+    >>> from transformers import ElectraConfig, ElectraModel
 
     >>> # Initializing a ELECTRA electra-base-uncased style configuration
     >>> configuration = ElectraConfig()
 
-    >>> # Initializing a model from the electra-base-uncased style configuration
+    >>> # Initializing a model (with random weights) from the electra-base-uncased style configuration
     >>> model = ElectraModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -60,6 +60,7 @@ src/transformers/models/detr/configuration_detr.py
 src/transformers/models/detr/modeling_detr.py
 src/transformers/models/distilbert/configuration_distilbert.py
 src/transformers/models/dpt/modeling_dpt.py
+src/transformers/models/electra/configuration_electra.py
 src/transformers/models/electra/modeling_electra.py
 src/transformers/models/electra/modeling_tf_electra.py
 src/transformers/models/ernie/configuration_ernie.py


### PR DESCRIPTION
# What does this PR do?

Add `configuration_electra.py` to `utils/documentation_tests.txt` for doctest.

Based on issue https://github.com/huggingface/transformers/issues/19487

@sgugger could you please take a look at it?

Thanks =)