### PR TITLE
[Doctest] Add `configuration_poolformer.py`

### DIFF
--- a/src/transformers/models/poolformer/configuration_poolformer.py
+++ b/src/transformers/models/poolformer/configuration_poolformer.py
@@ -74,12 +74,12 @@ class PoolFormerConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import PoolFormerModel, PoolFormerConfig
+    >>> from transformers import PoolFormerConfig, PoolFormerModel
 
     >>> # Initializing a PoolFormer sail/poolformer_s12 style configuration
     >>> configuration = PoolFormerConfig()
 
-    >>> # Initializing a model from the sail/poolformer_s12 style configuration
+    >>> # Initializing a model (with random weights) from the sail/poolformer_s12 style configuration
     >>> model = PoolFormerModel(configuration)
 
     >>> # Accessing the model configuration

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -105,6 +105,7 @@ src/transformers/models/pegasus/modeling_pegasus.py
 src/transformers/models/pegasus_x/configuration_pegasus_x.py
 src/transformers/models/perceiver/modeling_perceiver.py
 src/transformers/models/plbart/modeling_plbart.py
+src/transformers/models/poolformer/configuration_poolformer.py
 src/transformers/models/poolformer/modeling_poolformer.py
 src/transformers/models/realm/configuration_realm.py
 src/transformers/models/reformer/configuration_reformer.py


### PR DESCRIPTION
# What does this PR do?

Add `configuration_poolformer.py` to `utils/documentation_tests.txt` for doctest.

Based on issue https://github.com/huggingface/transformers/issues/19487

@sgugger could you please take a look at it?

Thanks =)