### PR TITLE
[Doctest] Add `configuration_plbart.py`

### DIFF
--- a/src/transformers/models/plbart/configuration_plbart.py
+++ b/src/transformers/models/plbart/configuration_plbart.py
@@ -91,16 +91,17 @@ class PLBartConfig(PretrainedConfig):
     Example:
 
     ```python
-    >>> from transformers import PLBartModel, PLBartConfig
+    >>> from transformers import PLBartConfig, PLBartModel
 
     >>> # Initializing a PLBART uclanlp/plbart-base style configuration
     >>> configuration = PLBartConfig()
-    >>> # Initializing a model from the uclanlp/plbart-base style configuration
+
+    >>> # Initializing a model (with random weights) from the uclanlp/plbart-base style configuration
     >>> model = PLBartModel(configuration)
+
     >>> # Accessing the model configuration
     >>> configuration = model.config
     ```"""
-
     model_type = "plbart"
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {"num_attention_heads": "encoder_attention_heads", "hidden_size": "d_model"}

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -104,6 +104,7 @@ src/transformers/models/pegasus/configuration_pegasus.py
 src/transformers/models/pegasus/modeling_pegasus.py
 src/transformers/models/pegasus_x/configuration_pegasus_x.py
 src/transformers/models/perceiver/modeling_perceiver.py
+src/transformers/models/plbart/configuration_plbart.py
 src/transformers/models/plbart/modeling_plbart.py
 src/transformers/models/poolformer/modeling_poolformer.py
 src/transformers/models/realm/configuration_realm.py


### PR DESCRIPTION
# What does this PR do?

Add `configuration_plbart.py` to `utils/documentation_tests.txt` for doctest.

Additionally, I updated its doctest format to make it consistent with BERT.

Based on issue https://github.com/huggingface/transformers/issues/19487

@sgugger could you please take a look at it?

Thanks =)