### PR TITLE
transformers.data.metrics: replace mention of 🤗 Datasets in DEPRECATION_WARNING with 🤗 Evaluate

### DIFF
--- a/src/transformers/data/metrics/__init__.py
+++ b/src/transformers/data/metrics/__init__.py
@@ -26,7 +26,7 @@ if is_sklearn_available():
 
 
 DEPRECATION_WARNING = (
-    "This metric will be removed from the library soon, metrics should be handled with the 🤗 Datasets "
+    "This metric will be removed from the library soon, metrics should be handled with the 🤗 Evaluate "
     "library. You can have a look at this example script for pointers: "
     "https://github.com/huggingface/transformers/blob/main/examples/pytorch/text-classification/run_glue.py"
 )


### PR DESCRIPTION
# What does this PR do?

Changes DEPRECATION_WARNING in `src/transformers/data/metrics/__init__.py` to point to 🤗 Evaluate for metrics functionality instead of 🤗 Datasets, whose metrics functionality has been deprecated and moved to 🤗 Evaluate since the metrics in this file were deprecated in 🤗 Transformers


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 
@albertvillanova 