### PR TITLE
Fix OOM in config doctest

### DIFF
--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -78,10 +78,10 @@ class GPTNeoXConfig(PretrainedConfig):
     >>> configuration = GPTNeoXConfig()
 
     >>> # Initializing a model (with random weights) from the gpt-neox-20b style configuration
-    >>> model = GPTNeoXModel(configuration)
+    >>> model = GPTNeoXModel(configuration)  # doctest: +SKIP
 
     >>> # Accessing the model configuration
-    >>> configuration = model.config
+    >>> configuration = model.config  # doctest: +SKIP
     ```"""
     model_type = "gpt_neox"
 


### PR DESCRIPTION
# What does this PR do?

This model is too large to be tested (OOM).
```python
    >>> # Initializing a model (with random weights) from the gpt-neox-20b style configuration
    >>> model = GPTNeoXModel(configuration)  # doctest: +SKIP
```