### PR TITLE
Fix doctest for MarkupLM

### DIFF
--- a/docs/source/en/model_doc/markuplm.mdx
+++ b/docs/source/en/model_doc/markuplm.mdx
@@ -95,10 +95,8 @@ This is the simplest case, in which the processor will use the feature extractor
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-
 ...  <h1>Welcome</h1>
 ...  <p>Here is my website.</p>
-
 ...  </body>
 ...  </html>"""
 
@@ -165,10 +163,8 @@ processor will use the feature extractor to get all nodes and xpaths, and create
 ...  <title>Hello world</title>
 ...  </head>
 ...  <body>
-
 ...  <h1>Welcome</h1>
 ...  <p>My name is Niels.</p>
-
 ...  </body>
 ...  </html>"""
 


### PR DESCRIPTION
# What does this PR do?

The CI complains
```
UNEXPECTED EXCEPTION: SyntaxError('EOF while scanning triple-quoted string literal', ('<doctest markuplm.mdx[2]>', 7, 96, 'html_string = """\n <!DOCTYPE html>\n <html>\n <head>\n <title>Hello world</title>\n </head>\n <body>\n'))
```
due to the lack of `...` in some empty lines. But `make style` will remove those `...` after I add it to those lines.

So I just removed those empty lines to pass the doctest.