### PR TITLE
Update `max_diff` in `test_save_load_fast_init_to_base`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -398,8 +398,6 @@ class ModelTesterMixin:
                 model_slow_init = base_class_copy.from_pretrained(tmpdirname, _fast_init=False)
 
                 for key in model_fast_init.state_dict().keys():
-                    if random_key_to_del.endswith(key):
-                        continue
                     max_diff = torch.max(
                         torch.abs(model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key])
                     ).item()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -400,7 +400,9 @@ class ModelTesterMixin:
                 for key in model_fast_init.state_dict().keys():
                     if random_key_to_del.endswith(key):
                         continue
-                    max_diff = torch.max(torch.abs(model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key])).item()
+                    max_diff = torch.max(
+                        torch.abs(model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key])
+                    ).item()
                     self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
     def test_initialization(self):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -398,7 +398,9 @@ class ModelTesterMixin:
                 model_slow_init = base_class_copy.from_pretrained(tmpdirname, _fast_init=False)
 
                 for key in model_fast_init.state_dict().keys():
-                    max_diff = (model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key]).sum().item()
+                    if random_key_to_del.endswith(key):
+                        continue
+                    max_diff = torch.max(torch.abs(model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key])).item()
                     self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
     def test_initialization(self):


### PR DESCRIPTION
# What does this PR do?

This test seems flaky. After looking a bit deeper, I am not sure if we should expect to get the same (or very close) weights with/without `_fast_init` for the deleted key.
https://github.com/huggingface/transformers/blob/9ecb13d63a9524478656b2233e6fb4e9f15d3fbf/tests/test_modeling_common.py#L343
https://github.com/huggingface/transformers/blob/9ecb13d63a9524478656b2233e6fb4e9f15d3fbf/tests/test_modeling_common.py#L400

My intuition is that **the values for that deleted key could be different with 2 different init. methods.**

I also change the way of `max_diff` being calculated.