### PR TITLE
Support Roberta on `accelerate`

### DIFF
--- a/src/transformers/models/lilt/modeling_lilt.py
+++ b/src/transformers/models/lilt/modeling_lilt.py
@@ -588,6 +588,7 @@ class LiltPreTrainedModel(PreTrainedModel):
     config_class = LiltConfig
     base_model_prefix = "lilt"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["LiltLayer", "LiltLayoutEmbeddings"]
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -584,6 +584,7 @@ class RobertaPreTrainedModel(PreTrainedModel):
     config_class = RobertaConfig
     base_model_prefix = "roberta"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["RobertaLayer"]
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):

--- a/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -586,6 +586,7 @@ class XLMRobertaPreTrainedModel(PreTrainedModel):
     config_class = XLMRobertaConfig
     base_model_prefix = "roberta"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["XLMRobertaLayer"]
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):

--- a/tests/models/lilt/test_modeling_lilt.py
+++ b/tests/models/lilt/test_modeling_lilt.py
@@ -14,10 +14,19 @@
 # limitations under the License.
 
 
+import tempfile
 import unittest
 
 from transformers import LiltConfig, is_torch_available
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.testing_utils import (
+    is_accelerate_available,
+    require_accelerate,
+    require_torch,
+    require_torch_gpu,
+    require_torch_multi_gpu,
+    slow,
+    torch_device,
+)
 
 from ...generation.test_generation_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -34,6 +43,9 @@ if is_torch_available():
         LiltModel,
     )
     from transformers.models.lilt.modeling_lilt import LILT_PRETRAINED_MODEL_ARCHIVE_LIST
+
+if is_accelerate_available():
+    from accelerate.utils import compute_module_sizes
 
 
 class LiltModelTester:
@@ -263,6 +275,172 @@ class LiltModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
         for model_name in LILT_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             model = LiltModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
+
+    @require_accelerate
+    @require_torch_multi_gpu
+    def test_model_parallelism(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            torch.manual_seed(0)
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            # We test several splits of sizes to make sure it works.
+            max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents]
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                for max_size in max_gpu_sizes:
+                    max_memory = {0: max_size, 1: model_size * 2, "cpu": model_size * 2}
+
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+
+                    # Making sure part of the model will actually end up offloaded
+                    self.assertSetEqual(set(new_model.hf_device_map.values()), {0, 1})
+
+                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+
+                    torch.manual_seed(0)
+                    new_output = new_model(**inputs_dict_model_class)
+
+                    # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                    # the final logits but only the intermediate attentions for all layers
+                    if ignore_lm_head:
+                        for i in range(len(base_output["attentions"])):
+                            self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                    else:
+                        self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+
+    @require_accelerate
+    @require_torch_gpu
+    def test_disk_offload(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+            torch.manual_seed(0)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            max_size = int(self.model_split_percents[0] * model_size)
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                max_memory = {0: max_size, "cpu": max_size}
+                with self.assertRaises(ValueError):
+                    # This errors out cause it's missing an offload folder
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+
+                new_model = model_class.from_pretrained(
+                    tmp_dir, device_map="auto", max_memory=max_memory, offload_folder=tmp_dir
+                )
+
+                self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+                torch.manual_seed(0)
+                new_output = new_model(**inputs_dict_model_class)
+
+                # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                # the final logits but only the intermediate attentions for all layers
+                if ignore_lm_head:
+                    for i in range(len(base_output["attentions"])):
+                        self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                else:
+                    self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+
+    @require_accelerate
+    @require_torch_gpu
+    def test_cpu_offload(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            torch.manual_seed(0)
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            # We test several splits of sizes to make sure it works.
+            max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents]
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                for max_size in max_gpu_sizes:
+                    max_memory = {0: max_size, "cpu": model_size * 2}
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    # Making sure part of the model will actually end up offloaded
+                    self.assertSetEqual(set(new_model.hf_device_map.values()), {0, "cpu"})
+
+                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+
+                    torch.manual_seed(0)
+                    new_output = new_model(**inputs_dict_model_class)
+
+                    # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                    # the final logits but only the intermediate attentions for all layers
+                    if ignore_lm_head:
+                        for i in range(len(base_output["attentions"])):
+                            self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                    else:
+                        self.assertTrue(torch.allclose(base_output[0], new_output[0]))
 
 
 @require_torch

--- a/tests/models/roberta/test_modeling_roberta.py
+++ b/tests/models/roberta/test_modeling_roberta.py
@@ -14,11 +14,21 @@
 # limitations under the License.
 
 
+import tempfile
 import unittest
 from copy import deepcopy
 
 from transformers import RobertaConfig, is_torch_available
-from transformers.testing_utils import TestCasePlus, require_torch, slow, torch_device
+from transformers.testing_utils import (
+    TestCasePlus,
+    is_accelerate_available,
+    require_accelerate,
+    require_torch,
+    require_torch_gpu,
+    require_torch_multi_gpu,
+    slow,
+    torch_device,
+)
 
 from ...generation.test_generation_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -42,6 +52,9 @@ if is_torch_available():
         RobertaEmbeddings,
         create_position_ids_from_input_ids,
     )
+
+if is_accelerate_available():
+    from accelerate.utils import compute_module_sizes
 
 ROBERTA_TINY = "sshleifer/tiny-distilroberta-base"
 
@@ -482,6 +495,172 @@ class RobertaModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
         position_ids = embeddings.create_position_ids_from_inputs_embeds(inputs_embeds)
         self.assertEqual(position_ids.shape, expected_positions.shape)
         self.assertTrue(torch.all(torch.eq(position_ids, expected_positions)))
+
+    @require_accelerate
+    @require_torch_multi_gpu
+    def test_model_parallelism(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            torch.manual_seed(0)
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            # We test several splits of sizes to make sure it works.
+            max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents]
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                for max_size in max_gpu_sizes:
+                    max_memory = {0: max_size, 1: model_size * 2, "cpu": model_size * 2}
+
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+
+                    # Making sure part of the model will actually end up offloaded
+                    self.assertSetEqual(set(new_model.hf_device_map.values()), {0, 1})
+
+                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+
+                    torch.manual_seed(0)
+                    new_output = new_model(**inputs_dict_model_class)
+
+                    # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                    # the final logits but only the intermediate attentions for all layers
+                    if ignore_lm_head:
+                        for i in range(len(base_output["attentions"])):
+                            self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                    else:
+                        self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+
+    @require_accelerate
+    @require_torch_gpu
+    def test_disk_offload(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+            torch.manual_seed(0)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            max_size = int(self.model_split_percents[0] * model_size)
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                max_memory = {0: max_size, "cpu": max_size}
+                with self.assertRaises(ValueError):
+                    # This errors out cause it's missing an offload folder
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+
+                new_model = model_class.from_pretrained(
+                    tmp_dir, device_map="auto", max_memory=max_memory, offload_folder=tmp_dir
+                )
+
+                self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+                torch.manual_seed(0)
+                new_output = new_model(**inputs_dict_model_class)
+
+                # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                # the final logits but only the intermediate attentions for all layers
+                if ignore_lm_head:
+                    for i in range(len(base_output["attentions"])):
+                        self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                else:
+                    self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+
+    @require_accelerate
+    @require_torch_gpu
+    def test_cpu_offload(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class._no_split_modules is None:
+                continue
+
+            inputs_dict_model_class = self._prepare_for_class(inputs_dict, model_class)
+
+            model = model_class(config).eval()
+            model = model.to(torch_device)
+
+            ignore_lm_head = (
+                hasattr(model, "lm_head")
+                and hasattr(model, "_keys_to_ignore_on_load_missing")
+                and hasattr(model, "_keys_to_ignore_on_save")
+            )
+            if ignore_lm_head:
+                ignore_lm_head = (
+                    ignore_lm_head
+                    if any("lm_head" in keys for keys in model._keys_to_ignore_on_load_missing)
+                    else not ignore_lm_head
+                )
+                inputs_dict_model_class["output_attentions"] = True
+
+            torch.manual_seed(0)
+            base_output = model(**inputs_dict_model_class)
+
+            model_size = compute_module_sizes(model)[""]
+            # We test several splits of sizes to make sure it works.
+            max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents]
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model.cpu().save_pretrained(tmp_dir)
+
+                for max_size in max_gpu_sizes:
+                    max_memory = {0: max_size, "cpu": model_size * 2}
+                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    # Making sure part of the model will actually end up offloaded
+                    self.assertSetEqual(set(new_model.hf_device_map.values()), {0, "cpu"})
+
+                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+
+                    torch.manual_seed(0)
+                    new_output = new_model(**inputs_dict_model_class)
+
+                    # Since the `lm_head.decoder.weight` is in `_keys_to_ignore_on_save` we don't check
+                    # the final logits but only the intermediate attentions for all layers
+                    if ignore_lm_head:
+                        for i in range(len(base_output["attentions"])):
+                            self.assertTrue(torch.allclose(base_output["attentions"][i], new_output["attentions"][i]))
+                    else:
+                        self.assertTrue(torch.allclose(base_output[0], new_output[0]))
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

This PR adds `Roberta` model family support with `accelerate` ! This aims to support `int8` quantization for these models.
Before merging I have notice few nits that I need to fix and discuss! I am unsure whether these fixes should be here or in `accelerate`.

1- If the model has the attribute `_keys_to_ignore_on_save`, it seems that it does not get properly initialized by `accelerate` (but I might be missing something here). AFAIK all models that has `accelerate` support for now, has at most the attribute `_keys_to_ignore_on_load_missing` but not `_keys_to_ignore_on_save`. Therefore [when the base model gets saved in the `accelerate` test](https://github.com/younesbelkada/transformers/blob/aefea27619b43cbb3e518ea972009e525676dc8d/tests/models/roberta/test_modeling_roberta.py#L587), these parameters does not get saved in the state_dict. I had to come up with a modification in the `_load_pretrained_model` function to randomly initialize these parameters since they're ignored by the `_load_state_dict_into_meta_model`. This post processing trick happens [here](https://github.com/younesbelkada/transformers/blob/aefea27619b43cbb3e518ea972009e525676dc8d/src/transformers/modeling_utils.py#L2598). 
2- Therefore I had to change the `accelerate` tests. Since the parameters that are assigned in the `_keys_to_ignore_on_save` are initialized randomly, I propose to check the logits compatibility between the base model and the accelerate model only for the attention outputs and not the `lm_head` output. These modifications happens [here](https://github.com/younesbelkada/transformers/blob/aefea27619b43cbb3e518ea972009e525676dc8d/tests/models/roberta/test_modeling_roberta.py#L569) - maybe this modification could happen in the super class?
3- Last nit: in the `accelerate` tests, it is better to not override the variable `inputs_dict` since inside the main loop, we can switch from a `xxxForMultipleChoice` to a `xxxForQuestionAnswering` model. Therefore, this variable does not get modified by the class function `_prepare_for_class` since it [gets modified only if the model is a `MODEL_FOR_MULTIPLE_CHOICE` model.](https://github.com/younesbelkada/transformers/blob/aefea27619b43cbb3e518ea972009e525676dc8d/tests/test_modeling_common.py#L165-L173) and not reset to the correct `inputs_dict` afterwards.

Need also to fix the slow test for `lilt` model where I am having `ValueError: embeddings.position_ids doesn't have any device set.`

cc @sgugger  
