### PR TITLE
No conv bn folding in ipex to avoid warning

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1280,12 +1280,12 @@ class Trainer:
 
         if not training:
             model.eval()
-            model = ipex.optimize(model, dtype=dtype, level="O1")
+            model = ipex.optimize(model, dtype=dtype, level="O1", conv_bn_folding=False)
         else:
             if not model.training:
                 model.train()
             model, self.optimizer = ipex.optimize(
-                model, dtype=dtype, optimizer=self.optimizer, inplace=True, level="O1"
+                model, dtype=dtype, optimizer=self.optimizer, inplace=True, level="O1", conv_bn_folding=False
             )
 
         return model

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1280,6 +1280,7 @@ class Trainer:
 
         if not training:
             model.eval()
+            # conv_bn_folding is disabled as it fails in symbolic tracing, resulting in ipex warnings
             model = ipex.optimize(model, dtype=dtype, level="O1", conv_bn_folding=False)
         else:
             if not model.training:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1285,7 +1285,7 @@ class Trainer:
             if not model.training:
                 model.train()
             model, self.optimizer = ipex.optimize(
-                model, dtype=dtype, optimizer=self.optimizer, inplace=True, level="O1", conv_bn_folding=False
+                model, dtype=dtype, optimizer=self.optimizer, inplace=True, level="O1"
             )
 
         return model


### PR DESCRIPTION
# What does this PR do?

Removes attempting convolution-batchnorm folding from ipex optimization, as it always fails and throws a warning.
See https://github.com/intel/intel-extension-for-pytorch/issues/250

Most models won't even benefit from attempting, but note that even a model like ResNet fails due to checks like:
```
if num_channels != self.num_channels:
```

## Who can review?

- trainer: @sgugger
