### PR TITLE
Fix somehow incorrect model - tokenizer mapping in tokenization testing

### DIFF
--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -120,8 +120,9 @@ def merge_model_tokenizer_mappings(
             tokenizer = tokenizer_mapping[configuration][0]
             tokenizer_fast = tokenizer_mapping[configuration][1]
 
-            if configuration.__name__.startswith(tokenizer.__name__.replace("Tokenizer", "")):
-                model_tokenizer_mapping.update({tokenizer: (configuration, model)})
+            if tokenizer is not None:
+                if configuration.__name__.startswith(tokenizer.__name__.replace("Tokenizer", "")):
+                    model_tokenizer_mapping.update({tokenizer: (configuration, model)})
             if tokenizer_fast is not None:
                 if configuration.__name__.startswith(tokenizer_fast.__name__.replace("TokenizerFast", "")):
                     model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -122,7 +122,8 @@ def merge_model_tokenizer_mappings(
 
             model_tokenizer_mapping.update({tokenizer: (configuration, model)})
             if tokenizer_fast is not None:
-                model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})
+                if configuration.__name__.startswith(tokenizer_fast.__name__.replace("TokenizerFast")):
+                    model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})
 
     return model_tokenizer_mapping
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -120,7 +120,8 @@ def merge_model_tokenizer_mappings(
             tokenizer = tokenizer_mapping[configuration][0]
             tokenizer_fast = tokenizer_mapping[configuration][1]
 
-            model_tokenizer_mapping.update({tokenizer: (configuration, model)})
+            if configuration.__name__.startswith(tokenizer.__name__.replace("Tokenizer", "")):
+                model_tokenizer_mapping.update({tokenizer: (configuration, model)})
             if tokenizer_fast is not None:
                 if configuration.__name__.startswith(tokenizer_fast.__name__.replace("TokenizerFast", "")):
                     model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -122,7 +122,7 @@ def merge_model_tokenizer_mappings(
 
             model_tokenizer_mapping.update({tokenizer: (configuration, model)})
             if tokenizer_fast is not None:
-                if configuration.__name__.startswith(tokenizer_fast.__name__.replace("TokenizerFast")):
+                if configuration.__name__.startswith(tokenizer_fast.__name__.replace("TokenizerFast", "")):
                     model_tokenizer_mapping.update({tokenizer_fast: (configuration, model)})
 
     return model_tokenizer_mapping


### PR DESCRIPTION
# What does this PR do?

In this method
https://github.com/huggingface/transformers/blob/371337a95b5d82cc9376c2595ed2022a5eb2ee6e/tests/test_tokenization_common.py#L107

we update the mapping whenever we find a tokenizer/model found for a configuration
```
tokenizer[_fast]: (configuration, model)
```

However, **multiple models could share the same tokenizer class**, and, for example, we get `LiLT` (recently added) model for the tokenizer class `LayoutLMv3Tokenizer`. Some tests like the following fails
```bash
tests/models/layoutlmv3/test_tokenization_layoutlmv3.py::LayoutLMv3TokenizationTest::test_torch_encode_plus_sent_to_model
(line 1130)  TypeError: forward() got an unexpected keyword argument 'pixel_values'
```
as the model used for `LayoutLMv3TokenizationTest` is `LiLT` model instead of `LayoutLMv3Model`.

1. This is somehow undesirable, and we would prefer to test the original/canonical mode/tokenizer pair.
2. This PR adds some condition to ensure the desired property in 1.
3. We can probably extend the test to test each possible pair of `(model_1, tokenizer)`, `(model_2, tokenizer)`, ...etc. But I would leave this in another PR.