### PR TITLE
Use self._trial  to generate trial_name for Trainer.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1651,8 +1651,10 @@ class Trainer:
         self.callback_handler.optimizer = self.optimizer
         self.callback_handler.lr_scheduler = self.lr_scheduler
         self.callback_handler.train_dataloader = train_dataloader
-        if self.hp_name is not None and (trial or self._trial) is not None:
-            self.state.trial_name = self.hp_name(trial or self._trial)
+        if self.hp_name is not None and self._trial is not None:
+            # use self._trial because the SigOpt/Optuna hpo only call `_hp_search_setup(trial)` instead of passing trial
+            # parameter to Train when using DDP.
+            self.state.trial_name = self.hp_name(self._trial)
         if trial is not None:
             assignments = trial.assignments if self.hp_search_backend == HPSearchBackend.SIGOPT else trial
             self.state.trial_params = hp_params(assignments)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1651,7 +1651,7 @@ class Trainer:
         self.callback_handler.optimizer = self.optimizer
         self.callback_handler.lr_scheduler = self.lr_scheduler
         self.callback_handler.train_dataloader = train_dataloader
-        self.state.trial_name = self.hp_name(trial) if self.hp_name is not None else None
+        self.state.trial_name = self.hp_name(trial) if self.hp_name is not None and trial is not None else None
         if trial is not None:
             assignments = trial.assignments if self.hp_search_backend == HPSearchBackend.SIGOPT else trial
             self.state.trial_params = hp_params(assignments)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1651,7 +1651,8 @@ class Trainer:
         self.callback_handler.optimizer = self.optimizer
         self.callback_handler.lr_scheduler = self.lr_scheduler
         self.callback_handler.train_dataloader = train_dataloader
-        self.state.trial_name = self.hp_name(trial) if self.hp_name is not None and trial is not None else None
+        if self.hp_name is not None and (trial or self._trial) is not None:
+            self.state.trial_name = self.hp_name(trial or self._trial)
         if trial is not None:
             assignments = trial.assignments if self.hp_search_backend == HPSearchBackend.SIGOPT else trial
             self.state.trial_params = hp_params(assignments)


### PR DESCRIPTION
# What does this PR do?

Generate trial name unless the trial is not None, and use `(self._trial or trial)` to generate trial name. 
Because [currently the `optuna` backend give a None trial when using DDP and rank != 0](https://github.com/huggingface/transformers/blob/v4.23.1/src/transformers/integrations.py#L193)

Related code:
https://github.com/huggingface/transformers/blob/bd469c40659ce76c81f69c7726759d249b4aef49/src/transformers/integrations.py#L160-L208


Or maybe the documentation should be changed.

https://github.com/huggingface/transformers/blob/bd469c40659ce76c81f69c7726759d249b4aef49/src/transformers/trainer.py#L2318-L2319

Who can review: 

* Trainer: @sgugger  
* optuna HPO: @sywangyi
