### PR TITLE
Let inputs of fast tokenizers be tuples as well as lists

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -412,7 +412,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         verbose: bool = True,
     ) -> BatchEncoding:
 
-        if not isinstance(batch_text_or_text_pairs, list):
+        if not isinstance(batch_text_or_text_pairs, (tuple, list)):
             raise TypeError(f"batch_text_or_text_pairs has to be a list (got {type(batch_text_or_text_pairs)})")
 
         # Set the truncation and padding strategy and restore the initial configuration

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -413,7 +413,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
     ) -> BatchEncoding:
 
         if not isinstance(batch_text_or_text_pairs, (tuple, list)):
-            raise TypeError(f"batch_text_or_text_pairs has to be a list (got {type(batch_text_or_text_pairs)})")
+            raise TypeError(f"batch_text_or_text_pairs has to be a list or a tuple (got {type(batch_text_or_text_pairs)})")
 
         # Set the truncation and padding strategy and restore the initial configuration
         self.set_truncation_and_padding(

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -413,7 +413,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
     ) -> BatchEncoding:
 
         if not isinstance(batch_text_or_text_pairs, (tuple, list)):
-            raise TypeError(f"batch_text_or_text_pairs has to be a list or a tuple (got {type(batch_text_or_text_pairs)})")
+            raise TypeError(
+                f"batch_text_or_text_pairs has to be a list or a tuple (got {type(batch_text_or_text_pairs)})"
+            )
 
         # Set the truncation and padding strategy and restore the initial configuration
         self.set_truncation_and_padding(


### PR DESCRIPTION
# What does this PR do?

Fixes #19882
Not sure if this was an oversight when introducing fast tokenizers or if there is a real reason for not accepting tuples as well as list here (which is the case everywhere else from a quick search). We'll see if the CI picks something failing but it looks like it fixes the issue.