### PR TITLE
Enables torchrun for XLA-based accelerators

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1372,8 +1372,9 @@ class Trainer:
         if not training:
             return model
 
-        # add torchrun support for XLA, but currently DDP doesn't support XLA yet
-        if is_torch_tpu_available():
+        # Add torchrun support for XLA, but currently DDP doesn't work with torch.distributed XLA backend yet
+        # https://github.com/pytorch/pytorch/issues/79164
+        if is_torch_tpu_available() and os.environ.get("WORLD_SIZE"):
             return model
 
         # Distributed training (should be after apex fp16 initialization)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1372,6 +1372,10 @@ class Trainer:
         if not training:
             return model
 
+        # add torchrun support for XLA, but currently DDP doesn't support XLA yet
+        if is_torch_tpu_available():
+            return model
+
         # Distributed training (should be after apex fp16 initialization)
         if self.sharded_ddp is not None:
             # Sharded DDP!

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1372,11 +1372,6 @@ class Trainer:
         if not training:
             return model
 
-        # Add torchrun support for XLA, but currently DDP doesn't work with torch.distributed XLA backend yet
-        # https://github.com/pytorch/pytorch/issues/79164
-        if is_torch_tpu_available() and os.environ.get("WORLD_SIZE"):
-            return model
-
         # Distributed training (should be after apex fp16 initialization)
         if self.sharded_ddp is not None:
             # Sharded DDP!

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -53,14 +53,16 @@ from .utils import (
     torch_required,
 )
 
-
 if is_torch_available():
     import torch
     import torch.distributed as dist
 
 if is_torch_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
-
+    # torchrun support
+    import torch_xla.distributed.xla_backend
+    if os.environ.get("WORLD_SIZE"):
+        torch.distributed.init_process_group(backend="xla")
 
 if is_sagemaker_mp_enabled():
     import smdistributed.modelparallel.torch as smp

--- a/tests/trainer/test_trainer_distributed.py
+++ b/tests/trainer/test_trainer_distributed.py
@@ -21,6 +21,7 @@ from transformers.testing_utils import (
     execute_subprocess_async,
     get_torch_dist_unique_port,
     require_torch_multi_gpu,
+    require_torch_tpu,
 )
 from transformers.utils import logging
 
@@ -60,6 +61,22 @@ if is_torch_available():
                 return torch.tensor(0.0, device=input_ids.device), input_ids
             else:
                 return input_ids
+
+class TestTrainerDistributedXLA(TestCasePlus):
+    @require_torch_tpu
+    def test_trainer(self):
+
+        distributed_args = f"""
+            -m torch.distributed.launch
+            --nproc_per_node=2
+            --master_port={get_torch_dist_unique_port()}
+            {self.test_file_dir}/test_trainer_distributed.py
+        """.split()
+        output_dir = self.get_auto_remove_tmp_dir()
+        args = f"--output_dir {output_dir}".split()
+        cmd = [sys.executable] + distributed_args + args
+        execute_subprocess_async(cmd, env=self.get_env())
+        # successful return here == success - any errors would have caused an error in the sub-call
 
 
 class TestTrainerDistributed(TestCasePlus):


### PR DESCRIPTION
# What does this PR do?

This PR enables torchrun for XLA-based accelerators (TPU/NeuronCore) by using torch.distributed XLA backend. It is dependent on the torch/xla change https://github.com/pytorch/xla/pull/3609.

Example application is the AWS Neuron tutorial with HF Trainer that uses torchrun:

https://awsdocs-neuron.readthedocs-hosted.com/en/latest/frameworks/torch/torch-neuronx/tutorials/training/finetune_hftrainer.html

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger