### PR TITLE
Add `accelerate` support for M2M100

### DIFF
--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -532,6 +532,7 @@ class M2M100PreTrainedModel(PreTrainedModel):
     config_class = M2M100Config
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["M2M100Attention"]
 
     def _init_weights(self, module):
         std = self.config.init_std
@@ -693,10 +694,10 @@ class M2M100Encoder(M2M100PreTrainedModel):
         self.max_source_positions = config.max_position_embeddings
         self.embed_scale = math.sqrt(embed_dim) if config.scale_embedding else 1.0
 
+        self.embed_tokens = nn.Embedding(config.vocab_size, embed_dim, self.padding_idx)
+
         if embed_tokens is not None:
-            self.embed_tokens = embed_tokens
-        else:
-            self.embed_tokens = nn.Embedding(config.vocab_size, embed_dim, self.padding_idx)
+            self.embed_tokens.weight = embed_tokens.weight
 
         self.embed_positions = M2M100SinusoidalPositionalEmbedding(
             config.max_position_embeddings,
@@ -778,6 +779,8 @@ class M2M100Encoder(M2M100PreTrainedModel):
 
         embed_pos = self.embed_positions(input_ids, inputs_embeds)
 
+        if embed_pos.device != inputs_embeds.device:
+            embed_pos = embed_pos.to(inputs_embeds.device)
         hidden_states = inputs_embeds + embed_pos
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
 
@@ -868,10 +871,10 @@ class M2M100Decoder(M2M100PreTrainedModel):
         self.max_target_positions = config.max_position_embeddings
         self.embed_scale = math.sqrt(config.d_model) if config.scale_embedding else 1.0
 
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.d_model, self.padding_idx)
+
         if embed_tokens is not None:
-            self.embed_tokens = embed_tokens
-        else:
-            self.embed_tokens = nn.Embedding(config.vocab_size, config.d_model, self.padding_idx)
+            self.embed_tokens.weight = embed_tokens.weight
 
         self.embed_positions = M2M100SinusoidalPositionalEmbedding(
             config.max_position_embeddings,
@@ -1011,6 +1014,8 @@ class M2M100Decoder(M2M100PreTrainedModel):
         # embed positions
         positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length)
 
+        if positions.device != inputs_embeds.device:
+            positions = positions.to(inputs_embeds.device)
         hidden_states = inputs_embeds + positions
 
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)

--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -778,9 +778,8 @@ class M2M100Encoder(M2M100PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
 
         embed_pos = self.embed_positions(input_ids, inputs_embeds)
+        embed_pos = embed_pos.to(inputs_embeds.device)
 
-        if embed_pos.device != inputs_embeds.device:
-            embed_pos = embed_pos.to(inputs_embeds.device)
         hidden_states = inputs_embeds + embed_pos
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
 
@@ -1013,9 +1012,8 @@ class M2M100Decoder(M2M100PreTrainedModel):
 
         # embed positions
         positions = self.embed_positions(input_ids, inputs_embeds, past_key_values_length)
+        positions = positions.to(inputs_embeds.device)
 
-        if positions.device != inputs_embeds.device:
-            positions = positions.to(inputs_embeds.device)
         hidden_states = inputs_embeds + positions
 
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)


### PR DESCRIPTION
# What does this PR do?

This PR adds `accelerate` support to `M2M100`, therefore this enables loading NLLB models in 8-bit using `load_in_8bit=True`.

This might contain a breaking change but I am not sure. 
When initializing the model in the meta device using `accelerate` the module `self.shared` is intialized and set to the correct device using `set_tensor_to_device` thrice - since it is shared by 3 modules (base model, encoder, decoder) - so it somehow ends up being on the `meta` device. 
Therefore manually assigning a new module with the weights that correspond to the weights of the `shared` module should do the trick. But I am wondering if this is a breaking change since the `shared` module of the Encoder & Decoder won't be "shared" anymore. It should not be a problem at inference time, but can be problematic when training the model.

cc @sgugger 

Also I know T5 also supports `accelerate` and uses `shared` embeddings. The only difference I see from both implementations are the `_keys_to_ignore_on_load_missing` that contains the `shared` weights for `T5` and doesn't contain the shared weights for M2M100