### PR TITLE
[Whisper Tokenizer] Make more user-friendly

### DIFF
--- a/docs/source/en/model_doc/whisper.mdx
+++ b/docs/source/en/model_doc/whisper.mdx
@@ -38,6 +38,7 @@ The original code can be found [here](https://github.com/openai/whisper).
 ## WhisperTokenizer
 
 [[autodoc]] WhisperTokenizer
+    - set_prefix_tokens
     - build_inputs_with_special_tokens
     - get_special_tokens_mask
     - create_token_type_ids_from_sequences

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -70,7 +70,7 @@ class WhisperProcessor(ProcessorMixin):
             forced_decoder_tokens += f"<|{task}|>"
 
         forced_decoder_tokens += "<|notimestamps|>" if no_timestamps else ""
-        ids = self.tokenizer.encode(forced_decoder_tokens)
+        ids = self.tokenizer.encode(forced_decoder_tokens, add_special_tokens=False)
         forced_decoder_ids = [(rank + 1, token) for rank, token in enumerate(ids)]
         return forced_decoder_ids
 

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -362,7 +362,11 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return word
 
     @property
-    def prefix_tokens(self):
+    def prefix_tokens(self, language=None, task=None, predict_timestamps=None):
+        self.language = language if language is not None else self.language
+        self.task = task if task is not None else self.task
+        self.predict_timestamps = predict_timestamps if predict_timestamps is not None else self.predict_timestamps
+
         all_special_ids = self.all_special_ids
         bos_token_id = all_special_ids[-106]
         translate_token_id = all_special_ids[-6]

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -241,10 +241,10 @@ class WhisperTokenizer(PreTrainedTokenizer):
             The language of the transcription text. The corresponding language id token is appended to the start of the
             sequence in multilingual speech recognition and speech translation tasks, e.g. for Spanish the token
             `<|es|>` is appended to the start of sequence.
-        predict_timestamps (`bool`, *optional*, defaults to `False`):
-            Whether to omit the `<|notimestamps|>` token at the start of the sequence.
         task (`str`, *optional*, defaults to `None`):
             Task identifier to append at the start of sequence (if any).
+        predict_timestamps (`bool`, *optional*, defaults to `False`):
+            Whether to omit the `<|notimestamps|>` token at the start of the sequence.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -264,8 +264,8 @@ class WhisperTokenizer(PreTrainedTokenizer):
         pad_token=None,
         add_prefix_space=False,
         language=None,
-        predict_timestamps=False,
         task=None,
+        predict_timestamps=False,
         **kwargs
     ):
 
@@ -306,8 +306,8 @@ class WhisperTokenizer(PreTrainedTokenizer):
         self.pat = re.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")
 
         self.language = language
-        self.predict_timestamps = predict_timestamps
         self.task = task
+        self.predict_timestamps = predict_timestamps
 
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -237,9 +237,10 @@ class WhisperTokenizer(PreTrainedTokenizer):
         add_prefix_space (`bool`, *optional*, defaults to `False`):
             Whether or not to add an initial space to the input. This allows to treat the leading word just as any
             other word.
-        land_id (`str`, *optional*, defaults to `None`):
-            The language identifier for transcription labels. Appended to the start of the sequence in multilingual
-            speech recognition and speech translation tasks.
+        language (`str`, *optional*, defaults to `None`):
+            The language of the transcription text. The corresponding language id token is appended to the start of the
+            sequence in multilingual speech recognition and speech translation tasks, e.g. for Spanish the token
+            `<|es|>` is appended to the start of sequence.
         predict_timestamps (`bool`, *optional*, defaults to `False`):
             Whether to omit the `<|notimestamps|>` token at the start of the sequence.
         task (`str`, *optional*, defaults to `None`):
@@ -264,7 +265,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         eos_token="<|endoftext|>",
         pad_token=None,
         add_prefix_space=False,
-        lang_id=None,
+        language=None,
         predict_timestamps=False,
         task=None,
         multilingual=False,
@@ -307,7 +308,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         # Should have added re.IGNORECASE so BPE merges can happen for capitalized versions of contractions
         self.pat = re.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")
 
-        self.language = lang_id
+        self.language = language
         self.predict_timestamps = predict_timestamps
         self.task = task
         self.multilingual = multilingual
@@ -383,14 +384,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
             if task not in TASK_IDS:
                 raise ValueError(f"Unsupported task: {task}. Task should be in: {TASK_IDS}")
 
-        if multilingual:
-            task = task or "transcribe"
-            language = language or "en"
-        else:
-            task = None
-            language = None
-
-        bos_sequence = []
+        bos_sequence = [bos_token_id]
         if language is not None:
             bos_sequence.append(bos_token_id + 1 + langs.index(language))
         if task is not None:

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -245,8 +245,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
             Whether to omit the `<|notimestamps|>` token at the start of the sequence.
         task (`str`, *optional*, defaults to `None`):
             Task identifier to append at the start of sequence (if any).
-        multilingual (`bool`, *optional*, defaults to `False`):
-            Whether to tokenize text for multilingual speech recognition or speech translation tasks.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -268,7 +266,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
         language=None,
         predict_timestamps=False,
         task=None,
-        multilingual=False,
         **kwargs
     ):
 
@@ -311,7 +308,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
         self.language = language
         self.predict_timestamps = predict_timestamps
         self.task = task
-        self.multilingual = multilingual
 
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
@@ -365,7 +361,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         self.cache[token] = word
         return word
 
-    def set_bos_sequence(self, language=None, task=None, predict_timestamps=False, multilingual=False):
+    def set_bos_sequence(self, language=None, task=None, predict_timestamps=False):
         all_special_ids = self.all_special_ids
         bos_token_id = all_special_ids[-106]
         translate_token_id = all_special_ids[-6]
@@ -398,7 +394,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return self.set_bos_sequence(
             language=self.language,
             task=self.task,
-            multilingual=self.multilingual,
             predict_timestamps=self.predict_timestamps,
         )
 

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -365,11 +365,11 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return word
 
     def set_bos_sequence(self, language=None, task=None, predict_timestamps=False, multilingual=False):
-        all_special_ids: List[int] = self.all_special_ids
-        bos_token_id: int = all_special_ids[1]
-        translate_token_id: int = all_special_ids[-6]
-        transcribe_token_id: int = all_special_ids[-5]
-        notimestamps_token_id: int = all_special_ids[-1]
+        all_special_ids = self.all_special_ids
+        bos_token_id = all_special_ids[-106]
+        translate_token_id = all_special_ids[-6]
+        transcribe_token_id = all_special_ids[-5]
+        notimestamps_token_id = all_special_ids[-1]
         langs = tuple(LANGUAGES.keys())
 
         if language is not None:

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -237,13 +237,13 @@ class WhisperTokenizer(PreTrainedTokenizer):
         add_prefix_space (`bool`, *optional*, defaults to `False`):
             Whether or not to add an initial space to the input. This allows to treat the leading word just as any
             other word.
-        language (`str`, *optional*, defaults to `None`):
+        language (`str`, *optional*):
             The language of the transcription text. The corresponding language id token is appended to the start of the
             sequence for multilingual speech recognition and speech translation tasks, e.g. for Spanish the token
-            `<|es|>` is appended to the start of sequence. This should be used for multilingual fine-tuning only.
-        task (`str`, *optional*, defaults to `None`):
+            `"<|es|>"` is appended to the start of sequence. This should be used for multilingual fine-tuning only.
+        task (`str`, *optional*):
             Task identifier to append at the start of sequence (if any). This should be used for mulitlingual
-            fine-tuning, with `transcribe` for speech recognition and `translate` for speech translation.
+            fine-tuning, with `"transcribe"` for speech recognition and `"translate"` for speech translation.
         predict_timestamps (`bool`, *optional*, defaults to `False`):
             Whether to omit the `<|notimestamps|>` token at the start of the sequence.
     """

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -368,8 +368,10 @@ class WhisperTokenizer(PreTrainedTokenizer):
         update the prefix tokens as required when fine-tuning. Example:
 
         ```python
+        >>> # instantiate the tokenizer and set the prefix token to Spanish
         >>> tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="spanish")
-        >>> tokenizer.set_prefix_tokens(language="french")  # update the language prefix token
+        >>> # now switch the prefix token from Spanish to French
+        >>> tokenizer.set_prefix_tokens(language="french")
         ```
 
         Args:

--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -20,8 +20,13 @@ from transformers.testing_utils import slow
 from ...test_tokenization_common import TokenizerTesterMixin
 
 
-EN_CODE = 50258
-ES_CODE = 50256
+ES_CODE = 50262
+EN_CODE = 50259
+END_OF_TRANSCRIPT = 50257
+START_OF_TRANSCRIPT = 50258
+TRANSLATE = 50358
+TRANSCRIBE = 50359
+NOTIMESTAMPS = 50363
 
 
 class WhisperTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
@@ -101,13 +106,6 @@ class WhisperTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
 class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
     checkpoint_name = "openai/whisper-small.en"
 
-    transcript = (
-        "'<|startoftranscript|> <|en|> <|transcribe|> <|notimestamps|>  Nor is Mr. Quilters manner less interesting"
-        " than his matter.<|endoftext|>'"
-    )
-    clean_transcript = "  Nor is Mr. Quilters manner less interesting than his matter."
-    french_text = "Bonjour! Il me semble que Mrs Quilters n'était pas présente"
-
     @classmethod
     def setUpClass(cls):
         cls.tokenizer: WhisperTokenizer = WhisperTokenizer.from_pretrained(cls.checkpoint_name)
@@ -115,15 +113,15 @@ class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
 
     def test_tokenizer_equivalence(self):
         text = "다람쥐 헌 쳇바퀴에 타고파"
-        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="ko")
-        gpt2_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny.en")
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="korean")
+        monolingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny.en")
 
-        gpt2_tokens = gpt2_tokenizer.encode(text)
-        multilingual_tokens = multilingual_tokenizer.encode(text)
+        monolingual_tokens = monolingual_tokenizer.encode(text, add_special_tokens=False)
+        multilingual_tokens = multilingual_tokenizer.encode(text, add_special_tokens=False)
 
-        assert gpt2_tokenizer.decode(gpt2_tokens) == text
+        assert monolingual_tokenizer.decode(monolingual_tokens) == text
         assert multilingual_tokenizer.decode(multilingual_tokens) == text
-        assert len(gpt2_tokens) > len(multilingual_tokens)
+        assert len(monolingual_tokens) > len(multilingual_tokens)
 
         # fmt: off
         EXPECTED_ENG = [
@@ -138,35 +136,42 @@ class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
         ]
         # fmt: on
 
-        self.assertListEqual(gpt2_tokens, EXPECTED_ENG)
+        self.assertListEqual(monolingual_tokens, EXPECTED_ENG)
         self.assertListEqual(multilingual_tokens, EXPECTED_MULTI)
 
     def test_tokenizer_special(self):
-        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny.en")
-        text = "<|startoftranscript|>Hey! How are you feeling? J'ai l'impression que 郷さん est prêt<|endoftext|>"
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained(
+            "openai/whisper-tiny", language="english", task="transcribe"
+        )
+        text = "Hey! How are you feeling? J'ai l'impression que 郷さん est prêt"
 
         multilingual_tokens = multilingual_tokenizer.encode(text)
 
         # fmt: off
+        # format: <|startoftranscript|> <|lang-id|> <|task|> <|notimestamps|> ... transcription ids ... <|endoftext|>
         EXPECTED_MULTI = [
-            50257, 10814, 0, 1374, 389, 345, 4203, 30, 449, 6,
-            1872, 300, 6, 11011, 2234, 8358, 16268, 225, 115, 43357,
-            22174, 1556, 778, 25792, 83, 50256
+            START_OF_TRANSCRIPT, EN_CODE, TRANSCRIBE, NOTIMESTAMPS, 7057, 0, 1012, 366, 291,
+            2633, 30, 508, 6, 1301, 287, 6, 36107, 631, 220, 11178,
+            115, 15567, 871, 44393, END_OF_TRANSCRIPT
         ]
+        EXPECTED_SPECIAL_TEXT = (
+            "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>Hey! How are you feeling? "
+            "J'ai l'impression que 郷さん est prêt<|endoftext|>"
+        )
         # fmt: on
 
         self.assertListEqual(multilingual_tokens, EXPECTED_MULTI)
 
-        self.assertEqual(text, multilingual_tokenizer.decode(multilingual_tokens))
+        special_transcript = multilingual_tokenizer.decode(multilingual_tokens, skip_special_tokens=False)
+        self.assertEqual(special_transcript, EXPECTED_SPECIAL_TEXT)
 
         transcript = multilingual_tokenizer.decode(multilingual_tokens, skip_special_tokens=True)
-
-        EXPECTED_JAP = "Hey! How are you feeling? J'ai l'impression que 郷さん est prêt"
-        self.assertEqual(transcript, EXPECTED_JAP)
+        self.assertEqual(transcript, text)
 
     def test_vocab_size(self):
         self.assertEqual(self.tokenizer.vocab_size, 50257)
 
+    # Copied from transformers.tests.speech_to_test.test_tokenization_speech_to_text.py
     def test_tokenizer_decode_ignores_language_codes(self):
         self.assertIn(ES_CODE, self.tokenizer.all_special_ids)
         generated_ids = [ES_CODE, 4, 1601, 47, 7647, 2]
@@ -176,15 +181,26 @@ class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
         self.assertNotIn(self.tokenizer.eos_token, result)
 
     def test_batch_encoding(self):
-        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny.en")
-        batch = ["<|en|><|notimestamps|>", "<|en|><|notimestamps|>I am sure that"]
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained(
+            "openai/whisper-tiny", language="spanish", task="translate"
+        )
+        batch = ["El gato ", "El gato se sentó"]
         batch_output = multilingual_tokenizer.batch_encode_plus(batch, padding=True).input_ids
 
         # fmt: off
         EXPECTED_MULTI = [
-            [50258, 50362, 50256, 50256, 50256, 50256],
-            [50258, 50362, 40, 716, 1654, 326]
+            [START_OF_TRANSCRIPT, ES_CODE, TRANSLATE, NOTIMESTAMPS, 17356, 290, 2513, 220,
+             END_OF_TRANSCRIPT, END_OF_TRANSCRIPT, END_OF_TRANSCRIPT],
+            [START_OF_TRANSCRIPT, ES_CODE, TRANSLATE, NOTIMESTAMPS, 17356, 290, 2513, 369,
+             2279, 812, END_OF_TRANSCRIPT]
         ]
         # fmt: on
 
         self.assertListEqual(batch_output, EXPECTED_MULTI)
+
+    def test_batch_encoding_decoding(self):
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="spanish")
+        batch = ["hola güey", "que onda"]
+        batch_encoding = multilingual_tokenizer.batch_encode_plus(batch, padding=True).input_ids
+        transcription = multilingual_tokenizer.batch_decode(batch_encoding, skip_special_tokens=True)
+        self.assertListEqual(batch, transcription)

--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -33,6 +33,7 @@ class WhisperTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = WhisperTokenizer
     test_rust_tokenizer = False
     test_sentencepiece = False
+    test_seq2seq = False
 
     def setUp(self):
         super().setUp()

--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -199,6 +199,28 @@ class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
 
         self.assertListEqual(batch_output, EXPECTED_MULTI)
 
+    def test_set_prefix_tokens(self):
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained(
+            "openai/whisper-tiny", language="spanish", task="translate"
+        )
+
+        # change the language prefix token from Spanish to English
+        multilingual_tokenizer.set_prefix_tokens(language="english")
+
+        batch = ["the cat", "the cat sat"]
+        batch_output = multilingual_tokenizer.batch_encode_plus(batch, padding=True).input_ids
+
+        # fmt: off
+        EXPECTED_MULTI = [
+            [START_OF_TRANSCRIPT, EN_CODE, TRANSLATE, NOTIMESTAMPS, 3322, 3857,
+             END_OF_TRANSCRIPT, END_OF_TRANSCRIPT],
+            [START_OF_TRANSCRIPT, EN_CODE, TRANSLATE, NOTIMESTAMPS, 3322, 3857,
+             3227, END_OF_TRANSCRIPT]
+        ]
+        # fmt: on
+
+        self.assertListEqual(batch_output, EXPECTED_MULTI)
+
     def test_batch_encoding_decoding(self):
         multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="spanish")
         batch = ["hola güey", "que onda"]


### PR DESCRIPTION
# What does this PR do?

Fixes #19864.

In summary, the Whisper tokenizer is modified to prepend several tokens to the start-of-sequence:
- BOS token id (`<|startoftranscript|>`) -> consistent with other sequence-to-sequence models such as _BART_.
- Language token id (e.g. `<|es|>` for Spanish) -> set only when the tokenizer is instantiated with argument `language=X`. Otherwise omitted.
- Task token id (e.g. `<|translate|>` for speech translation) -> set only when the tokenizer is instantiated with argument `task=Y`. Otherwise omitted.
- No time stamps id (`<|notimestamps|>`)  ->set only when the tokenizer is instantiated with argument  `predict_timestamps=False`. For `predict_timestamps=True`, it is omitted.

In addition, it is modified to always append the end-of-sequence token to the end of the label sequence (`<|endoftext|>`).

The updated tokenizer behaves as follows:
```python
from transformers import WhisperTokenizer
tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny", language="english", task="transcribe", predict_timestamps=False)

input_ids = tokenizer("hey").input_ids

text_with_special = tokenizer.decode(input_ids, skip_special_tokens=False)
text = tokenizer.decode(input_ids, skip_special_tokens=True)

print("Input ids :", input_ids)
print("Text w/ special :", text_with_special)
print("Text :", text)
```
**Print Output:**
```
Input ids : [50258, 50259, 50359, 50363, 17230, 50257]
Text w/ special : <|startoftranscript|><|en|><|transcribe|><|notimestamps|>hey<|endoftext|>
Text : hey
```

The attention mask functionality of the Whisper tokenizer **is** retained (_c.f._ https://github.com/huggingface/transformers/issues/19864#issuecomment-1291799687).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
