### PR TITLE
Fix ONNX tests for ONNX Runtime v1.13.1

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -435,6 +435,7 @@ def quantize(onnx_model_path: Path) -> Path:
     Returns: The Path generated for the quantized
     """
     import onnx
+    import onnxruntime
     from onnx.onnx_pb import ModelProto
     from onnxruntime.quantization import QuantizationMode
     from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
@@ -454,19 +455,38 @@ def quantize(onnx_model_path: Path) -> Path:
     copy_model.CopyFrom(onnx_model)
 
     # Construct quantizer
-    quantizer = ONNXQuantizer(
-        model=copy_model,
-        per_channel=False,
-        reduce_range=False,
-        mode=QuantizationMode.IntegerOps,
-        static=False,
-        weight_qType=True,
-        activation_qType=False,
-        tensors_range=None,
-        nodes_to_quantize=None,
-        nodes_to_exclude=None,
-        op_types_to_quantize=list(IntegerOpsRegistry),
-    )
+    # onnxruntime renamed input_qType to activation_qType in v1.13.1, so we
+    # check the onnxruntime version to ensure backward compatibility.
+    # See also: https://github.com/microsoft/onnxruntime/pull/12873
+    ort_version = parse(onnxruntime.__version__)
+    if ort_version < parse("1.13.1"):
+        quantizer = ONNXQuantizer(
+            model=copy_model,
+            per_channel=False,
+            reduce_range=False,
+            mode=QuantizationMode.IntegerOps,
+            static=False,
+            weight_qType=True,
+            input_qType=False,
+            tensors_range=None,
+            nodes_to_quantize=None,
+            nodes_to_exclude=None,
+            op_types_to_quantize=list(IntegerOpsRegistry),
+        )
+    else:
+        quantizer = ONNXQuantizer(
+            model=copy_model,
+            per_channel=False,
+            reduce_range=False,
+            mode=QuantizationMode.IntegerOps,
+            static=False,
+            weight_qType=True,
+            activation_qType=False,
+            tensors_range=None,
+            nodes_to_quantize=None,
+            nodes_to_exclude=None,
+            op_types_to_quantize=list(IntegerOpsRegistry),
+        )
 
     # Quantize and export
     quantizer.quantize_model()

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -458,8 +458,7 @@ def quantize(onnx_model_path: Path) -> Path:
     # onnxruntime renamed input_qType to activation_qType in v1.13.1, so we
     # check the onnxruntime version to ensure backward compatibility.
     # See also: https://github.com/microsoft/onnxruntime/pull/12873
-    ort_version = parse(onnxruntime.__version__)
-    if ort_version < parse("1.13.1"):
+    if parse(onnxruntime.__version__) < parse("1.13.1"):
         quantizer = ONNXQuantizer(
             model=copy_model,
             per_channel=False,

--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -461,7 +461,7 @@ def quantize(onnx_model_path: Path) -> Path:
         mode=QuantizationMode.IntegerOps,
         static=False,
         weight_qType=True,
-        input_qType=False,
+        activation_qType=False,
         tensors_range=None,
         nodes_to_quantize=None,
         nodes_to_exclude=None,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes the slow tests for ONNX in `test_onnx.py` which were failing due `input_qType` being renamed by `activation_qType` in `onnxruntime` v1.13.1

With this fix, the follow passes:

```
RUN_SLOW=1 pytest tests/onnx/test_onnx.py
```
