### PR TITLE
Speed up TF token classification postprocessing by converting complete tensors to numpy

### DIFF
--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -240,7 +240,7 @@ class TokenClassificationPipeline(Pipeline):
 
         if self.framework == "tf":
             input_ids = input_ids.numpy()
-            offset_mapping = offset_mapping.numpy()
+            offset_mapping = offset_mapping.numpy() if offset_mapping is not None else None
 
         pre_entities = self.gather_pre_entities(
             sentence, input_ids, scores, offset_mapping, special_tokens_mask, aggregation_strategy

--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -238,6 +238,10 @@ class TokenClassificationPipeline(Pipeline):
         shifted_exp = np.exp(logits - maxes)
         scores = shifted_exp / shifted_exp.sum(axis=-1, keepdims=True)
 
+        if self.framework == "tf":
+            input_ids = input_ids.numpy()
+            offset_mapping = offset_mapping.numpy()
+
         pre_entities = self.gather_pre_entities(
             sentence, input_ids, scores, offset_mapping, special_tokens_mask, aggregation_strategy
         )
@@ -276,9 +280,6 @@ class TokenClassificationPipeline(Pipeline):
                     if self.framework == "pt":
                         start_ind = start_ind.item()
                         end_ind = end_ind.item()
-                    else:
-                        start_ind = int(start_ind.numpy())
-                        end_ind = int(end_ind.numpy())
                 word_ref = sentence[start_ind:end_ind]
                 if getattr(self.tokenizer._tokenizer.model, "continuing_subword_prefix", None):
                     # This is a BPE, word aware tokenizer, there is a correct way


### PR DESCRIPTION
# What does this PR do?

The postprocessing of the token classification when using TensorFlow is not as fast as it could be. We discovered that with some experiments and profiling that showed that, in some settings, most time of the pipeline is spent in `gather_pre_entities`:

Before:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/37573274/198983453-8a34e7a8-6f67-4010-9509-359b4fb9bdf7.png">

After:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/37573274/198983760-1f27b4b3-6d55-4137-a22c-707992a11637.png">

This PR speeds it up by converting `input_ids` and `offset_mapping` to numpy before passing them to `gather_pre_entities`. Thereby, the tensor is moved to the appropriate device only once. Besides, it's also in line with the type annotation of `gather_pre_entities`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case: **n/a**
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation): **n/a**
- [ ] Did you write any new necessary tests? **n/a**


## Who can review?

Could you please review, @LysandreJik 😊
