### PR TITLE
Update Special Language Tokens for PLBART

### DIFF
--- a/src/transformers/models/plbart/modeling_plbart.py
+++ b/src/transformers/models/plbart/modeling_plbart.py
@@ -1050,6 +1050,7 @@ class PLBartDecoder(PLBartPreTrainedModel):
             past_key_value = past_key_values[idx] if past_key_values is not None else None
 
             if self.gradient_checkpointing and self.training:
+
                 if use_cache:
                     logger.warning(
                         "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
@@ -1074,6 +1075,7 @@ class PLBartDecoder(PLBartPreTrainedModel):
                     None,
                 )
             else:
+
                 layer_outputs = decoder_layer(
                     hidden_states,
                     attention_mask=attention_mask,

--- a/src/transformers/models/plbart/modeling_plbart.py
+++ b/src/transformers/models/plbart/modeling_plbart.py
@@ -1050,7 +1050,6 @@ class PLBartDecoder(PLBartPreTrainedModel):
             past_key_value = past_key_values[idx] if past_key_values is not None else None
 
             if self.gradient_checkpointing and self.training:
-
                 if use_cache:
                     logger.warning(
                         "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
@@ -1075,7 +1074,6 @@ class PLBartDecoder(PLBartPreTrainedModel):
                     None,
                 )
             else:
-
                 layer_outputs = decoder_layer(
                     hidden_states,
                     attention_mask=attention_mask,

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -88,9 +88,10 @@ PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
 }
 
 FAIRSEQ_LANGUAGE_CODES = {
-    "base": ["java", "python", "en_XX"],
-    "multi": ["java", "python", "en_XX", "javascript", "php", "ruby", "go"],
+    "base": ["__java__", "__python__", "__en_XX__"],
+    "multi": ["__java__", "__python__", "__en_XX__", "__javascript__", "__php__", "__ruby__", "__go__"],
 }
+
 
 
 class PLBartTokenizer(PreTrainedTokenizer):

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -93,7 +93,6 @@ FAIRSEQ_LANGUAGE_CODES = {
 }
 
 
-
 class PLBartTokenizer(PreTrainedTokenizer):
     """
     Construct an PLBART tokenizer.

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -390,7 +390,7 @@ class PLBartTokenizer(PreTrainedTokenizer):
         self.src_lang = self._convert_lang_code_special_format(src_lang)
         self.tgt_lang = self._convert_lang_code_special_format(tgt_lang)
         inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
-        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        tgt_lang_id = self.convert_tokens_to_ids(self.tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs
 

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -387,9 +387,8 @@ class PLBartTokenizer(PreTrainedTokenizer):
         """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
-        src_lang = self._convert_lang_code_special_format(src_lang)
-        tgt_lang = self._convert_lang_code_special_format(tgt_lang)
-        self.src_lang = src_lang
+        self.src_lang = self._convert_lang_code_special_format(src_lang)
+        self.tgt_lang = self._convert_lang_code_special_format(tgt_lang)
         inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
         tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
         inputs["forced_bos_token_id"] = tgt_lang_id

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -448,11 +448,8 @@ class PLBartTokenizer(PreTrainedTokenizer):
         tgt_lang: str = "python",
         **kwargs,
     ) -> BatchEncoding:
-        src_lang = self._convert_lang_code_special_format(src_lang)
-        tgt_lang = self._convert_lang_code_special_format(tgt_lang)
-
-        self.src_lang = src_lang
-        self.tgt_lang = tgt_lang
+        self.src_lang = self._convert_lang_code_special_format(src_lang)
+        self.tgt_lang = self._convert_lang_code_special_format(tgt_lang)
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
     def _switch_to_input_mode(self):

--- a/src/transformers/models/plbart/tokenization_plbart.py
+++ b/src/transformers/models/plbart/tokenization_plbart.py
@@ -92,6 +92,16 @@ FAIRSEQ_LANGUAGE_CODES = {
     "multi": ["__java__", "__python__", "__en_XX__", "__javascript__", "__php__", "__ruby__", "__go__"],
 }
 
+FAIRSEQ_LANGUAGE_CODES_MAP = {
+    "java": "__java__",
+    "python": "__python__",
+    "en_XX": "__en_XX__",
+    "javascript": "__javascript__",
+    "php": "__php__",
+    "ruby": "__ruby__",
+    "go": "__go__",
+}
+
 
 class PLBartTokenizer(PreTrainedTokenizer):
     """
@@ -202,6 +212,8 @@ class PLBartTokenizer(PreTrainedTokenizer):
             sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
+        src_lang = self._convert_lang_code_special_format(src_lang)
+        tgt_lang = self._convert_lang_code_special_format(tgt_lang)
 
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(str(vocab_file))
@@ -247,7 +259,7 @@ class PLBartTokenizer(PreTrainedTokenizer):
                 self.lang_code_to_id[self._src_lang] if self._src_lang is not None else self._src_lang
             )
         else:
-            self._src_lang = src_lang if src_lang is not None else "en_XX"
+            self._src_lang = src_lang if src_lang is not None else "__en_XX__"
             self.cur_lang_code_id = self.lang_code_to_id[self._src_lang]
 
         self.tgt_lang = tgt_lang
@@ -284,6 +296,7 @@ class PLBartTokenizer(PreTrainedTokenizer):
 
     @src_lang.setter
     def src_lang(self, new_src_lang: str) -> None:
+        new_src_lang = self._convert_lang_code_special_format(new_src_lang)
         self._src_lang = new_src_lang
         self.set_src_lang_special_tokens(self._src_lang)
 
@@ -374,6 +387,8 @@ class PLBartTokenizer(PreTrainedTokenizer):
         """Used by translation pipeline, to prepare inputs for the generate function"""
         if src_lang is None or tgt_lang is None:
             raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        src_lang = self._convert_lang_code_special_format(src_lang)
+        tgt_lang = self._convert_lang_code_special_format(tgt_lang)
         self.src_lang = src_lang
         inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
         tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
@@ -433,6 +448,9 @@ class PLBartTokenizer(PreTrainedTokenizer):
         tgt_lang: str = "python",
         **kwargs,
     ) -> BatchEncoding:
+        src_lang = self._convert_lang_code_special_format(src_lang)
+        tgt_lang = self._convert_lang_code_special_format(tgt_lang)
+
         self.src_lang = src_lang
         self.tgt_lang = tgt_lang
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
@@ -445,6 +463,7 @@ class PLBartTokenizer(PreTrainedTokenizer):
 
     def set_src_lang_special_tokens(self, src_lang) -> None:
         """Reset the special tokens to the source lang setting. No prefix and suffix=[eos, src_lang_code]."""
+        src_lang = self._convert_lang_code_special_format(src_lang)
         self.cur_lang_code = self.lang_code_to_id[src_lang] if src_lang is not None else None
         self.prefix_tokens = []
         if self.cur_lang_code is not None:
@@ -454,9 +473,16 @@ class PLBartTokenizer(PreTrainedTokenizer):
 
     def set_tgt_lang_special_tokens(self, lang: str) -> None:
         """Reset the special tokens to the target language setting. No prefix and suffix=[eos, tgt_lang_code]."""
+        lang = self._convert_lang_code_special_format(lang)
+
         self.cur_lang_code = self.lang_code_to_id[lang] if lang is not None else None
         self.prefix_tokens = []
         if self.cur_lang_code is not None:
             self.suffix_tokens = [self.eos_token_id, self.cur_lang_code]
         else:
             self.suffix_tokens = [self.eos_token_id]
+
+    def _convert_lang_code_special_format(self, lang: str) -> str:
+        """Convert Language Codes to format tokenizer uses if required"""
+        lang = FAIRSEQ_LANGUAGE_CODES_MAP[lang] if lang in FAIRSEQ_LANGUAGE_CODES_MAP.keys() else lang
+        return lang

--- a/tests/models/plbart/test_modeling_plbart.py
+++ b/tests/models/plbart/test_modeling_plbart.py
@@ -290,8 +290,7 @@ class PLBartModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
 
 
 def assert_tensors_close(a, b, atol=1e-12, prefix=""):
-    """If tensors have different shapes, different values or a and b are not both tensors, raise a nice Assertion error.
-    """
+    """If tensors have different shapes, different values or a and b are not both tensors, raise a nice Assertion error."""
     if a is None and b is None:
         return True
     try:

--- a/tests/models/plbart/test_modeling_plbart.py
+++ b/tests/models/plbart/test_modeling_plbart.py
@@ -290,7 +290,8 @@ class PLBartModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
 
 
 def assert_tensors_close(a, b, atol=1e-12, prefix=""):
-    """If tensors have different shapes, different values or a and b are not both tensors, raise a nice Assertion error."""
+    """If tensors have different shapes, different values or a and b are not both tensors, raise a nice Assertion error.
+    """
     if a is None and b is None:
         return True
     try:

--- a/tests/models/plbart/test_tokenization_plbart.py
+++ b/tests/models/plbart/test_tokenization_plbart.py
@@ -227,6 +227,7 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             code,
         )
 
+
 @require_torch
 @require_sentencepiece
 @require_tokenizers

--- a/tests/models/plbart/test_tokenization_plbart.py
+++ b/tests/models/plbart/test_tokenization_plbart.py
@@ -129,7 +129,15 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         end = tokenizer.vocab_size
         language_tokens = [tokenizer.convert_ids_to_tokens(x) for x in range(end - 4, end)]
 
-        self.assertListEqual(language_tokens, ["java", "python", "en_XX", "<mask>"])
+        self.assertListEqual(language_tokens, ["__java__", "__python__", "__en_XX__", "<mask>"])
+
+        code = "java.lang.Exception, python.lang.Exception"
+        self.assertEqual(
+            tokenizer.decode(
+                tokenizer([code])["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False
+            ),
+            code,
+        )
 
     def test_full_multi_tokenizer(self):
         tokenizer = PLBartTokenizer(SAMPLE_VOCAB, language_codes="multi", keep_accents=True)
@@ -208,7 +216,9 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         end = tokenizer.vocab_size
         language_tokens = [tokenizer.convert_ids_to_tokens(x) for x in range(end - 7, end)]
 
-        self.assertListEqual(language_tokens, ["java", "python", "en_XX", "javascript", "php", "ruby", "go"])
+        self.assertListEqual(
+            language_tokens, ["__java__", "__python__", "__en_XX__", "__javascript__", "__php__", "__ruby__", "__go__"]
+        )
 
 
 @require_torch
@@ -262,9 +272,9 @@ class PLBartPythonEnIntegrationTest(unittest.TestCase):
         return cls
 
     def check_language_codes(self):
-        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["java"], 50001)
-        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["python"], 50002)
-        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["en_XX"], 50003)
+        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["__java__"], 50001)
+        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["__python__"], 50002)
+        self.assertEqual(self.tokenizer.fairseq_tokens_to_ids["__en_XX__"], 50003)
 
     def test_python_en_tokenizer_batch_encode_plus(self):
         ids = self.tokenizer.batch_encode_plus(self.src_text).input_ids[0]
@@ -288,7 +298,7 @@ class PLBartPythonEnIntegrationTest(unittest.TestCase):
         self.assertEqual(len(ids), desired_max_length)
 
     def test_mask_token(self):
-        self.assertListEqual(self.tokenizer.convert_tokens_to_ids(["<mask>", "java"]), [50004, 50001])
+        self.assertListEqual(self.tokenizer.convert_tokens_to_ids(["<mask>", "__java__"]), [50004, 50001])
 
     def test_special_tokens_unaffacted_by_save_load(self):
         tmpdirname = tempfile.mkdtemp()

--- a/tests/models/plbart/test_tokenization_plbart.py
+++ b/tests/models/plbart/test_tokenization_plbart.py
@@ -132,10 +132,9 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(language_tokens, ["__java__", "__python__", "__en_XX__", "<mask>"])
 
         code = "java.lang.Exception, python.lang.Exception, javascript, php, ruby, go"
+        input_ids = tokenizer(code).input_ids
         self.assertEqual(
-            tokenizer.decode(
-                tokenizer([code])["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False
-            ),
+            tokenizer.decode(input_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False),
             code,
         )
 
@@ -220,10 +219,9 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             language_tokens, ["__java__", "__python__", "__en_XX__", "__javascript__", "__php__", "__ruby__", "__go__"]
         )
         code = "java.lang.Exception, python.lang.Exception, javascript, php, ruby, go"
+        input_ids = tokenizer(code).input_ids
         self.assertEqual(
-            tokenizer.decode(
-                tokenizer([code])["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False
-            ),
+            tokenizer.decode(input_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False),
             code,
         )
 

--- a/tests/models/plbart/test_tokenization_plbart.py
+++ b/tests/models/plbart/test_tokenization_plbart.py
@@ -131,7 +131,7 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.assertListEqual(language_tokens, ["__java__", "__python__", "__en_XX__", "<mask>"])
 
-        code = "java.lang.Exception, python.lang.Exception"
+        code = "java.lang.Exception, python.lang.Exception, javascript, php, ruby, go"
         self.assertEqual(
             tokenizer.decode(
                 tokenizer([code])["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False
@@ -219,7 +219,13 @@ class PLBartTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             language_tokens, ["__java__", "__python__", "__en_XX__", "__javascript__", "__php__", "__ruby__", "__go__"]
         )
-
+        code = "java.lang.Exception, python.lang.Exception, javascript, php, ruby, go"
+        self.assertEqual(
+            tokenizer.decode(
+                tokenizer([code])["input_ids"][0], skip_special_tokens=True, clean_up_tokenization_spaces=False
+            ),
+            code,
+        )
 
 @require_torch
 @require_sentencepiece


### PR DESCRIPTION
# What does this PR do?

This PR fixes the special tokens for PLBartTokenizer, raised in Issue #19505. Previously the tokenizer treats java, python etc. as special tokens, and removes them when decoding is performed.

@LysandreJik