### PR TITLE
Pin torch to < 1.13 temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ _deps = [
     "timeout-decorator",
     "timm",
     "tokenizers>=0.11.1,!=0.11.3,<0.14",
-    "torch>=1.7,!=1.12.0",
+    "torch>=1.7,!=1.12.0,<1.13.0",
     "torchaudio",
     "pyctcdecode>=0.4.0",
     "tqdm>=4.27",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -69,7 +69,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",
     "tokenizers": "tokenizers>=0.11.1,!=0.11.3,<0.14",
-    "torch": "torch>=1.7,!=1.12.0",
+    "torch": "torch>=1.7,!=1.12.0,<1.13.0",
     "torchaudio": "torchaudio",
     "pyctcdecode": "pyctcdecode>=0.4.0",
     "tqdm": "tqdm>=4.27",


### PR DESCRIPTION
# What does this PR do?

Pin torch to < 1.13 temporarily, as it causes strange failures (segmentation fault) on CircleCI.

Evidence could be found

with torch 1.12.1 
https://app.circleci.com/pipelines/github/huggingface/transformers/50619/workflows/5b665ba2-5f45-4b61-9e08-de6c8a2349cd

with torch 1.13.0
https://app.circleci.com/pipelines/github/huggingface/transformers/50621/workflows/8a137f60-2e66-48fd-aeb6-1a8d49369d4c