### PR TITLE
Cached sin and cos matrices for rotary at GPT-J model initialization for faster generation

### DIFF
--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -125,8 +125,8 @@ class GPTJAttention(nn.Module):
             self.rotary_dim = config.rotary_dim
 
         sin, cos = fixed_pos_embedding(x=torch.zeros(1, 1, self.rotary_dim), seq_len=max_positions)
-        self.register_buffer("sin", sin)
-        self.register_buffer("cos", cos)
+        self.register_buffer("sin", sin, persistent=False)
+        self.register_buffer("cos", cos, persistent=False)
 
     def _split_heads(self, tensor, num_attention_heads, attn_head_size, rotary):
         """


### PR DESCRIPTION
# What does this PR do?

Makes generations faster by caching sincos matrices for rotary for the max sequence length at model initialisation so it won't be done every other forward.

around ~%15 percent speedup overall
Tested on A100-SXM4-80GB
Benchmarks:
1 token forward average runtime out of 100 iterations with cached sin cos:
0.023421470640283642s

1 token forward average runtime out of 100 iterations without cached sin cos:
0.02738137301433869s

10 generations with 1 token context and 40 tokens generated without sincos caching:
1.410405054409057s

10 generations with 1 token context and 40 tokens generated with sincos caching:
1.2199230638332665s

Test script:
```
torch.manual_seed(123)
input_ids = torch.randint(0, 100, (1, 1)).cuda().long()

iterations = 11
with torch.no_grad():
    for i in range(iterations):
        if i == 1:
            #start counting time after tier 1 due to pytorch warming up
            t = time.perf_counter()
        outputs = model.generate(input_ids, max_length=input_ids.shape[-1] + 50, min_length=input_ids.shape[-1] + 50, do_sample=True, use_cache=True)
        #outputs = model.forward(input_ids)
print((time.perf_counter() - t) / (iterations - 1))
```

Models:
- GPT-J

