### PR TITLE
Add object detection + segmentation transforms

### DIFF
--- a/docs/source/en/internal/image_processing_utils.mdx
+++ b/docs/source/en/internal/image_processing_utils.mdx
@@ -21,7 +21,15 @@ Most of those are only useful if you are studying the code of the image processo
 
 [[autodoc]] image_transforms.center_crop
 
+[[autodoc]] image_transforms.center_to_corners_format
+
+[[autodoc]] image_transforms.corners_to_center_format
+
+[[autodoc]] image_transforms.id_to_rgb
+
 [[autodoc]] image_transforms.normalize
+
+[[autodoc]] image_transforms.rgb_to_id
 
 [[autodoc]] image_transforms.rescale
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -449,8 +449,7 @@ def _center_to_corners_format_tf(bboxes_center: "tf.Tensor") -> "tf.Tensor":
 # 2 functions below inspired by https://github.com/facebookresearch/detr/blob/master/util/box_ops.py
 def center_to_corners_format(bboxes_center: TensorType) -> TensorType:
     """
-    Converts bounding boxes from center format (center_x, center_y, width, height) to corners format (x_0, y_1, x_1,
-    y_1).
+    Converts bounding boxes from center format (center_x, center_y, width, height) to corners format `(left, top, right, bottom)`.
     """
     # Function is used during model forward pass, so we use the input framework if possible, without
     # converting to numpy

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -171,8 +171,6 @@ def get_resize_output_image_size(
             If `size` is an int and `default_to_square` is `True`, then image will be resized to (size, size). If
             `size` is an int and `default_to_square` is `False`, then smaller edge of the image will be matched to this
             number. i.e, if height > width, then image will be rescaled to (size * height / width, size).
-        resample (`int`, *optional*, defaults to `PIL.Image.BILINEAR`):
-            The filter to user for resampling.
         default_to_square (`bool`, *optional*, defaults to `True`):
             How to convert `size` when it is a single int. If set to `True`, the `size` will be converted to a square
             (`size`,`size`). If set to `False`, will replicate

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -461,7 +461,7 @@ def center_to_corners_format(bboxes_center: TensorType) -> TensorType:
     """
     Converts bounding boxes from center format to corners format.
 
-    center format: contains the coordinate for the center of the box and its the width, height dimensions
+    center format: contains the coordinate for the center of the box and its width, height dimensions
         (center_x, center_y, width, height)
     corners format: contains the coodinates for the top-left and bottom-right corners of the box
         (top_left_x, top_left_y, bottom_right_x, bottom_right_y)

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -36,9 +36,13 @@ if is_vision_available():
 
     from transformers.image_transforms import (
         center_crop,
+        center_to_corners_format,
+        corners_to_center_format,
         get_resize_output_image_size,
+        id_to_rgb,
         normalize,
         resize,
+        rgb_to_id,
         to_channel_dimension_format,
         to_pil_image,
     )
@@ -178,6 +182,11 @@ class ImageTransformsTester(unittest.TestCase):
     def test_normalize(self):
         image = np.random.randint(0, 256, (224, 224, 3)) / 255
 
+        # Test that exception is raised if inputs are incorrect
+        # Not a numpy array image
+        with self.assertRaises(ValueError):
+            normalize(5, 5, 5)
+
         # Number of mean values != number of channels
         with self.assertRaises(ValueError):
             normalize(image, mean=(0.5, 0.6), std=1)
@@ -219,3 +228,64 @@ class ImageTransformsTester(unittest.TestCase):
         self.assertIsInstance(cropped_image, np.ndarray)
         self.assertEqual(cropped_image.shape, (300, 260, 3))
         self.assertTrue(np.allclose(cropped_image, expected_image))
+
+    def test_center_to_corners_format(self):
+        bbox_center = np.array([[10, 20, 4, 8], [15, 16, 3, 4]])
+        expected = np.array([[8, 16, 12, 24], [13.5, 14, 16.5, 18]])
+        self.assertTrue(np.allclose(center_to_corners_format(bbox_center), expected))
+
+        # Check that the function and inverse function are inverse of each other
+        self.assertTrue(np.allclose(corners_to_center_format(center_to_corners_format(bbox_center)), bbox_center))
+
+    def test_corners_to_center_format(self):
+        bbox_corners = np.array([[8, 16, 12, 24], [13.5, 14, 16.5, 18]])
+        expected = np.array([[10, 20, 4, 8], [15, 16, 3, 4]])
+        self.assertTrue(np.allclose(corners_to_center_format(bbox_corners), expected))
+
+        # Check that the function and inverse function are inverse of each other
+        self.assertTrue(np.allclose(center_to_corners_format(corners_to_center_format(bbox_corners)), bbox_corners))
+
+    def test_rgb_to_id(self):
+        # test list input
+        rgb = [125, 4, 255]
+        self.assertEqual(rgb_to_id(rgb), 16712829)
+
+        # test numpy array input
+        color = np.array(
+            [
+                [
+                    [213, 54, 165],
+                    [88, 207, 39],
+                    [156, 108, 128],
+                ],
+                [
+                    [183, 194, 46],
+                    [137, 58, 88],
+                    [114, 131, 233],
+                ],
+            ]
+        )
+        expected = np.array([[10827477, 2608984, 8416412], [3064503, 5782153, 15303538]])
+        self.assertTrue(np.allclose(rgb_to_id(color), expected))
+
+    def test_id_to_rgb(self):
+        # test int input
+        self.assertEqual(id_to_rgb(16712829), [125, 4, 255])
+
+        # test array input
+        id_array = np.array([[10827477, 2608984, 8416412], [3064503, 5782153, 15303538]])
+        color = np.array(
+            [
+                [
+                    [213, 54, 165],
+                    [88, 207, 39],
+                    [156, 108, 128],
+                ],
+                [
+                    [183, 194, 46],
+                    [137, 58, 88],
+                    [114, 131, 233],
+                ],
+            ]
+        )
+        self.assertTrue(np.allclose(id_to_rgb(id_array), color))


### PR DESCRIPTION
# What does this PR do?

Adds logic for processing bounding boxes and some additional transforms (`rgb_to_id`, `id_to_rgb`) needed for DETR. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
