### PR TITLE
Show installed libraries and their versions in CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,9 @@ jobs:
                   key: v0.5-code_quality-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
+            - run:
+                name: Show installed libraries and their versions
+                command: pip freeze
             - run: black --check --preview examples tests src utils
             - run: isort --check-only examples tests src utils
             - run: python utils/custom_init_isort.py --check_only
@@ -145,6 +148,9 @@ jobs:
                   key: v0.5-repository_consistency-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
+            - run:
+                name: Show installed libraries and their versions
+                command: pip freeze
             - run: python utils/check_copies.py
             - run: python utils/check_table.py
             - run: python utils/check_dummies.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,9 @@ jobs:
                       - '~/.cache/pip'
             - run:
                 name: Show installed libraries and their versions
-                command: pip freeze
+                command: pip freeze | tee installed.txt
+            - store_artifacts:
+                  path: ~/transformers/installed.txt
             - run: black --check --preview examples tests src utils
             - run: isort --check-only examples tests src utils
             - run: python utils/custom_init_isort.py --check_only
@@ -150,7 +152,9 @@ jobs:
                       - '~/.cache/pip'
             - run:
                 name: Show installed libraries and their versions
-                command: pip freeze
+                command: pip freeze | tee installed.txt
+            - store_artifacts:
+                  path: ~/transformers/installed.txt
             - run: python utils/check_copies.py
             - run: python utils/check_table.py
             - run: python utils/check_dummies.py

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -91,6 +91,7 @@ class CircleCIJob:
                 }
             }
         )
+        steps.append({"run": {"name": "Show installed libraries and their versions", "command": "pip freeze"}})
 
         all_options = {**COMMON_PYTEST_OPTIONS, **self.pytest_options}
         pytest_flags = [f"--{key}={value}" if value is not None else f"-{key}" for key, value in all_options.items()]

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -91,7 +91,8 @@ class CircleCIJob:
                 }
             }
         )
-        steps.append({"run": {"name": "Show installed libraries and their versions", "command": "pip freeze"}})
+        steps.append({"run": {"name": "Show installed libraries and their versions", "command": "pip freeze | tee installed.txt"}})
+        steps.append({"store_artifacts": {"path": "~/transformers/installed.txt"}})
 
         all_options = {**COMMON_PYTEST_OPTIONS, **self.pytest_options}
         pytest_flags = [f"--{key}={value}" if value is not None else f"-{key}" for key, value in all_options.items()]

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -878,6 +878,7 @@ class BertModel(BertPreTrainedModel):
 
     def __init__(self, config, add_pooling_layer=True):
         super().__init__(config)
+        self.x = 1
         self.config = config
 
         self.embeddings = BertEmbeddings(config)

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -878,7 +878,6 @@ class BertModel(BertPreTrainedModel):
 
     def __init__(self, config, add_pooling_layer=True):
         super().__init__(config)
-        self.x = 1
         self.config = config
 
         self.embeddings = BertEmbeddings(config)


### PR DESCRIPTION
# What does this PR do?

Whenever there is a need to check
  - if the versions of install libraries change
  - and/or find out which ones change

it is not super easy to get this information.

This PR adds `pip freeze | tee installed.txt` to
  - show the results
  - save to a file
  - and upload as an artifact.

It makes the access to this information easier, and potentially make the process to **get the difference** between previous/current runs easier too.

Example run job (and the artifact): [here](https://app.circleci.com/pipelines/github/huggingface/transformers/50778/workflows/cf542f91-cc42-4942-bac8-100436555dda/jobs/606945)

I plan to do the same for GH actions jobs, but maybe in another PR :-)