### PR TITLE
Document BLOOM lm_logits original training behavior

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -329,7 +329,7 @@ class BloomAttention(nn.Module):
         input_dtype = attention_scores.dtype
         # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
         # compute softmax in fp32, the same as the fused kernel during training
-        # https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/09a35f53abac96903fee50787426b7ee5f63fc62/megatron/fused_kernels/scaled_upper_triang_masked_softmax_cuda.cu#L52)
+        # https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/09a35f53abac96903fee50787426b7ee5f63fc62/megatron/fused_kernels/scaled_upper_triang_masked_softmax_cuda.cu#L52
         if input_dtype == torch.float16 or input_dtype == torch.bfloat16:
             attention_scores = attention_scores.to(torch.float)
         attn_weights = torch.masked_fill(attention_scores, attention_mask, torch.finfo(attention_scores.dtype).min)

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -844,6 +844,8 @@ class BloomForCausalLM(BloomPreTrainedModel):
             Labels for language modeling. Note that the labels **are shifted** inside the model, i.e. you can set
             `labels = input_ids` Indices are selected in `[-100, 0, ..., config.vocab_size]` All labels set to `-100`
             are ignored (masked), the loss is only computed for labels in `[0, ..., config.vocab_size]`
+
+            Note: the original softmax is computed in fp32 during training ([see](https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/09a35f53abac96903fee50787426b7ee5f63fc62/megatron/model/gpt_model.py#L289-L29)). To replicate the same behavior as training, make sure to cast lm_logits to fp32 before computing CrossEntropyLoss when using fp16/bf16.
         """
         if deprecated_arguments.pop("position_ids", False) is not False:
             # `position_ids` could have been `torch.Tensor` or `None` so defaulting pop to `False` allows to detect if users were passing explicitly `None`

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -328,7 +328,9 @@ class BloomAttention(nn.Module):
         # cast attention scores to fp32, compute scaled softmax and cast back to initial dtype - [batch_size, num_heads, q_length, kv_length]
         input_dtype = attention_scores.dtype
         # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
-        if input_dtype == torch.float16:
+        # compute softmax in fp32, the same as the fused kernel during training
+        # https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/09a35f53abac96903fee50787426b7ee5f63fc62/megatron/fused_kernels/scaled_upper_triang_masked_softmax_cuda.cu#L52)
+        if input_dtype == torch.float16 or input_dtype == torch.bfloat16:
             attention_scores = attention_scores.to(torch.float)
         attn_weights = torch.masked_fill(attention_scores, attention_mask, torch.finfo(attention_scores.dtype).min)
         attention_probs = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(input_dtype)

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -873,6 +873,11 @@ class BloomForCausalLM(BloomPreTrainedModel):
         hidden_states = transformer_outputs[0]
 
         lm_logits = self.lm_head(hidden_states)
+        input_dtype = lm_logits.dtype
+        # compute softmax in fp32, the same as training
+        # https://github.com/bigscience-workshop/Megatron-DeepSpeed/blob/09a35f53abac96903fee50787426b7ee5f63fc62/megatron/model/gpt_model.py#L289-L291
+        if input_dtype == torch.float16 or input_dtype == torch.bfloat16:
+            lm_logits = lm_logits.float()
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
# What does this PR do?

~Compute softmax of Bloom in fp32 during half percision~

Document BLOOM lm_logits original training behavior

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@thomasw21 @stas00 @TevenLeScao