### PR TITLE
Fix some doctests after PR 15775

### DIFF
--- a/docs/source/en/model_doc/speech_to_text.mdx
+++ b/docs/source/en/model_doc/speech_to_text.mdx
@@ -57,7 +57,7 @@ be installed as follows: `apt install libsndfile1-dev`
 >>> inputs = processor(ds[0]["audio"]["array"], sampling_rate=ds[0]["audio"]["sampling_rate"], return_tensors="pt")
 >>> generated_ids = model.generate(inputs["input_features"], attention_mask=inputs["attention_mask"])
 
->>> transcription = processor.batch_decode(generated_ids)
+>>> transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)
 >>> transcription
 ['mister quilter is the apostle of the middle classes and we are glad to welcome his gospel']
 ```
@@ -87,9 +87,9 @@ be installed as follows: `apt install libsndfile1-dev`
 ...     forced_bos_token_id=processor.tokenizer.lang_code_to_id["fr"],
 ... )
 
->>> translation = processor.batch_decode(generated_ids)
+>>> translation = processor.batch_decode(generated_ids, skip_special_tokens=True)
 >>> translation
-["<lang:fr> (Vidéo) Si M. Kilder est l'apossible des classes moyennes, et nous sommes heureux d'être accueillis dans son évangile."]
+["(Vidéo) Si M. Kilder est l'apossible des classes moyennes, et nous sommes heureux d'être accueillis dans son évangile."]
 ```
 
 See the [model hub](https://huggingface.co/models?filter=speech_to_text) to look for Speech2Text checkpoints.

--- a/docs/source/en/model_doc/t5.mdx
+++ b/docs/source/en/model_doc/t5.mdx
@@ -285,7 +285,7 @@ The predicted tokens will then be placed between the sentinel tokens.
 >>> sequence_ids = model.generate(input_ids)
 >>> sequences = tokenizer.batch_decode(sequence_ids)
 >>> sequences
-['<pad> <extra_id_0> park offers<extra_id_1> the<extra_id_2> park.</s>']
+['<pad><extra_id_0> park offers<extra_id_1> the<extra_id_2> park.</s>']
 ```
 
 

--- a/src/transformers/models/speech_to_text/modeling_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/modeling_speech_to_text.py
@@ -1334,7 +1334,7 @@ class Speech2TextForConditionalGeneration(Speech2TextPreTrainedModel):
 
         >>> generated_ids = model.generate(inputs=input_features)
 
-        >>> transcription = processor.batch_decode(generated_ids)[0]
+        >>> transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> transcription
         'mister quilter is the apostle of the middle classes and we are glad to welcome his gospel'
         ```"""

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -201,7 +201,7 @@ PT_QUESTION_ANSWERING_SAMPLE = r"""
     >>> answer_end_index = outputs.end_logits.argmax()
 
     >>> predict_answer_tokens = inputs.input_ids[0, answer_start_index : answer_end_index + 1]
-    >>> tokenizer.decode(predict_answer_tokens)
+    >>> tokenizer.decode(predict_answer_tokens, skip_special_tokens=True)
     {expected_output}
     ```
 


### PR DESCRIPTION
# What does this PR do?

After PR #15775, we need to either update some expected values or specify `skip_special_tokens=True`.

I am not very comfortable to use `skip_special_tokens=True` for `PT_QUESTION_ANSWERING_SAMPLE` in `doc.py`, as it might fail other tests. We will have to run the doctest manually to see if everything is fine.

(A lazy way is not to use this argument, but just to update the expected values)

#### update
I launched doctest [here](https://github.com/huggingface/transformers/actions/runs/3384706275). The tests with `ForQuestionAnswering` all pass, so we are good!
