### PR TITLE
Fix ESM LM head test

### DIFF
--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -285,7 +285,7 @@ class EsmModelIntegrationTest(TestCasePlus):
             self.assertEqual(output.shape, expected_shape)
 
             expected_slice = torch.tensor(
-                [[[15.0973, -6.6406, -1.1351], [-0.2209, -9.9622, 4.2109], [-1.6055, -10.0023, 1.5914]]]
+                [[[8.9215, -10.5898,  -6.4671], [-6.3967, -13.9114,  -1.1212], [-7.7812, -13.9516,  -3.7406]]]
             )
             self.assertTrue(torch.allclose(output[:, :3, :3], expected_slice, atol=1e-4))
 

--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -285,7 +285,7 @@ class EsmModelIntegrationTest(TestCasePlus):
             self.assertEqual(output.shape, expected_shape)
 
             expected_slice = torch.tensor(
-                [[[8.9215, -10.5898,  -6.4671], [-6.3967, -13.9114,  -1.1212], [-7.7812, -13.9516,  -3.7406]]]
+                [[[8.9215, -10.5898, -6.4671], [-6.3967, -13.9114, -1.1212], [-7.7812, -13.9516, -3.7406]]]
             )
             self.assertTrue(torch.allclose(output[:, :3, :3], expected_slice, atol=1e-4))
 


### PR DESCRIPTION
The original ESM-2 checkpoints had a bug that meant the LM head bias was not saved correctly. Now this has been fixed, we need to update our LM test as well.

cc @ydshieh