### PR TITLE
PoolformerImageProcessor defaults to match previous FE

### DIFF
--- a/src/transformers/models/poolformer/image_processing_poolformer.py
+++ b/src/transformers/models/poolformer/image_processing_poolformer.py
@@ -59,7 +59,7 @@ class PoolFormerImageProcessor(BaseImageProcessor):
         do_resize (`bool`, *optional*, defaults to `True`):
             Whether to resize the image's (height, width) dimensions to the specified `size`. Can be overridden by
             `do_resize` in the `preprocess` method.
-        size (`Dict[str, int]` *optional*, defaults to `{"shortest_edge": 256}`):
+        size (`Dict[str, int]` *optional*, defaults to `{"shortest_edge": 224}`):
             Size of the image after resizing. Can be overridden by `size` in the `preprocess` method. If crop_pct is
             unset:
             - size is `{"height": h, "width": w}`: the image is resized to `(h, w)`.
@@ -82,7 +82,7 @@ class PoolFormerImageProcessor(BaseImageProcessor):
             Whether to center crop the image. If the input size is smaller than `crop_size` along any edge, the image
             is padded with 0's and then center cropped. Can be overridden by `do_center_crop` in the `preprocess`
             method.
-        crop_size (`Dict[str, int]`, *optional*, defaults to `{"height": 256, "width": 256}`):
+        crop_size (`Dict[str, int]`, *optional*, defaults to `{"height": 224, "width": 224}`):
             Size of the image after applying center crop. Only has an effect if `do_center_crop` is set to `True`. Can
             be overridden by the `crop_size` parameter in the `preprocess` method.
         do_rescale (`bool`, *optional*, defaults to `True`):
@@ -120,9 +120,9 @@ class PoolFormerImageProcessor(BaseImageProcessor):
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
-        size = size if size is not None else {"shortest_edge": 256}
+        size = size if size is not None else {"shortest_edge": 224}
         size = get_size_dict(size, default_to_square=False)
-        crop_size = crop_size if crop_size is not None else {"height": 256, "width": 256}
+        crop_size = crop_size if crop_size is not None else {"height": 224, "width": 224}
         crop_size = get_size_dict(crop_size)
 
         self.do_resize = do_resize
@@ -184,10 +184,7 @@ class PoolFormerImageProcessor(BaseImageProcessor):
                 if size["height"] == size["width"]:
                     scale_size = int(math.floor(size["height"] / crop_pct))
                 else:
-                    scale_size = (
-                        int(math.floor(size["height"] / crop_pct)),
-                        int(math.floor(size["width"] / crop_pct)),
-                    )
+                    scale_size = (int(size["height"] / crop_pct), int(size["width"] / crop_pct))
             else:
                 raise ValueError("Invalid size for resize: {}".format(size))
 

--- a/src/transformers/models/poolformer/image_processing_poolformer.py
+++ b/src/transformers/models/poolformer/image_processing_poolformer.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Image processor class for PoolFormer."""
 
-import math
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -179,10 +178,10 @@ class PoolFormerImageProcessor(BaseImageProcessor):
             raise ValueError(f"size must contain 'height' and 'width' or 'shortest_edge' as keys. Got {size.keys()}")
         if crop_pct is not None:
             if "shortest_edge" in size:
-                scale_size = int(math.floor(size["shortest_edge"] / crop_pct))
+                scale_size = int(size["shortest_edge"] / crop_pct)
             elif "height" in size and "width" in size:
                 if size["height"] == size["width"]:
-                    scale_size = int(math.floor(size["height"] / crop_pct))
+                    scale_size = int(size["height"] / crop_pct)
                 else:
                     scale_size = (int(size["height"] / crop_pct), int(size["width"] / crop_pct))
             else:


### PR DESCRIPTION
# What does this PR do?

Output of PoolformerImageProcessor didn't exactly match previous feature extractor. Updates defaults and size calculation logic to match outputs. 

Running:
```
import torch
from transformers import PoolFormerFeatureExtractor, PoolFormerModel
from datasets import load_dataset
dataset = load_dataset("huggingface/cats-image")
image = dataset["test"]["image"][0]

feature_extractor = PoolFormerFeatureExtractor.from_pretrained("sail/poolformer_s12")
model = PoolFormerModel.from_pretrained("sail/poolformer_s12")

inputs = feature_extractor(image, return_tensors="pt")

with torch.no_grad():
    outputs = model(**inputs)

last_hidden_states = outputs.last_hidden_state
r = list(last_hidden_states.shape)
print(r)
```

Now outputs images of size `[1, 512, 7, 7]` - matching the output of the images before #19796 was merged in. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
