### PR TITLE
[Trainer] Fix model name in push_to_hub

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3444,7 +3444,8 @@ class Trainer:
         if not hasattr(self, "repo"):
             self.init_git_repo()
 
-        if self.args.should_save:
+        model_name = kwargs.pop("model_name", None)
+        if model_name is None and self.args.should_save:
             if self.args.hub_model_id is None:
                 model_name = Path(self.args.output_dir).name
             else:


### PR DESCRIPTION
# What does this PR do?

Trainer's `push_to_hub` fails if `model_name` is specified in the kwargs. 

The variable `model_name` is explicitly defined in the `push_to_hub` method:
https://github.com/huggingface/transformers/blob/d447c460b16626c656e4d7a9425f648fe69517b3/src/transformers/trainer.py#L3449

And then subsequently passed **alongside** the kwargs to the method `create_model_card`:
https://github.com/huggingface/transformers/blob/d447c460b16626c656e4d7a9425f648fe69517b3/src/transformers/trainer.py#L3471

This means if `model_name` is specified in the kwargs, it is passed **twice** to `create_model_card`, once from the variable and once from the kwargs, giving a `TypeError`:
```python
from transformers import Trainer, TrainingArguments, Wav2Vec2ForCTC

model = Wav2Vec2ForCTC.from_pretrained("hf-internal-testing/tiny-random-wav2vec2")
training_args = TrainingArguments(output_dir="dummy_dir_for_issue")
trainer = Trainer(args=training_args, model=model)
trainer.push_to_hub(model_name="pretty-model-name")
```

**Traceback**
```
File ~/transformers/src/transformers/trainer.py:3471, in Trainer.push_to_hub(self, commit_message, blocking, **kwargs)
   3469 # push separately the model card to be independant from the rest of the model
   3470 if self.args.should_save:
-> 3471     self.create_model_card(model_name=model_name, **kwargs)
   3472     try:
   3473         self.repo.push_to_hub(
   3474             commit_message="update model card README.md", blocking=blocking, auto_lfs_prune=True
   3475         )

TypeError: create_model_card() got multiple values for keyword argument 'model_name'
```

Fixes #20058.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
