### PR TITLE
docs: Fixed variables in f-strings

### DIFF
--- a/docs/source/en/custom_models.mdx
+++ b/docs/source/en/custom_models.mdx
@@ -55,9 +55,9 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block}.")
+            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
-            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {block}.")
+            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 
         self.block_type = block_type
         self.layers = layers

--- a/docs/source/en/custom_models.mdx
+++ b/docs/source/en/custom_models.mdx
@@ -55,7 +55,7 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
+            raise ValueError(f"`block_type` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
             raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 

--- a/docs/source/en/custom_models.mdx
+++ b/docs/source/en/custom_models.mdx
@@ -146,6 +146,9 @@ class ResnetModel(PreTrainedModel):
 For the model that will classify images, we just change the forward method:
 
 ```py
+import torch
+
+
 class ResnetModelForImageClassification(PreTrainedModel):
     config_class = ResnetConfig
 

--- a/docs/source/es/custom_models.mdx
+++ b/docs/source/es/custom_models.mdx
@@ -145,6 +145,9 @@ class ResnetModel(PreTrainedModel):
 Para el modelo que clasificará las imágenes, solo cambiamos el método de avance (es decir, el método `forward`):
 
 ```py
+import torch
+
+
 class ResnetModelForImageClassification(PreTrainedModel):
     config_class = ResnetConfig
 

--- a/docs/source/es/custom_models.mdx
+++ b/docs/source/es/custom_models.mdx
@@ -55,9 +55,9 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block}.")
+            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
-            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {block}.")
+            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 
         self.block_type = block_type
         self.layers = layers

--- a/docs/source/es/custom_models.mdx
+++ b/docs/source/es/custom_models.mdx
@@ -55,7 +55,7 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
+            raise ValueError(f"`block_type` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
             raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 

--- a/docs/source/it/custom_models.mdx
+++ b/docs/source/it/custom_models.mdx
@@ -54,9 +54,9 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block}.")
+            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
-            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {block}.")
+            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 
         self.block_type = block_type
         self.layers = layers

--- a/docs/source/it/custom_models.mdx
+++ b/docs/source/it/custom_models.mdx
@@ -54,7 +54,7 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
+            raise ValueError(f"`block_type` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
             raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 

--- a/docs/source/it/custom_models.mdx
+++ b/docs/source/it/custom_models.mdx
@@ -146,6 +146,9 @@ class ResnetModel(PreTrainedModel):
 Per il modello che classificherà le immagini, cambiamo soltanto il metodo forward:
 
 ```py
+import torch
+
+
 class ResnetModelForImageClassification(PreTrainedModel):
     config_class = ResnetConfig
 

--- a/docs/source/pt/custom_models.mdx
+++ b/docs/source/pt/custom_models.mdx
@@ -54,9 +54,9 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block}.")
+            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
-            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {block}.")
+            raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 
         self.block_type = block_type
         self.layers = layers

--- a/docs/source/pt/custom_models.mdx
+++ b/docs/source/pt/custom_models.mdx
@@ -145,6 +145,9 @@ class ResnetModel(PreTrainedModel):
 Para o modelo que irá classificar as imagens, vamos apenas alterar o método forward:
 
 ```py
+import torch
+
+
 class ResnetModelForImageClassification(PreTrainedModel):
     config_class = ResnetConfig
 

--- a/docs/source/pt/custom_models.mdx
+++ b/docs/source/pt/custom_models.mdx
@@ -54,7 +54,7 @@ class ResnetConfig(PretrainedConfig):
         **kwargs,
     ):
         if block_type not in ["basic", "bottleneck"]:
-            raise ValueError(f"`block` must be 'basic' or bottleneck', got {block_type}.")
+            raise ValueError(f"`block_type` must be 'basic' or bottleneck', got {block_type}.")
         if stem_type not in ["", "deep", "deep-tiered"]:
             raise ValueError(f"`stem_type` must be '', 'deep' or 'deep-tiered', got {stem_type}.")
 


### PR DESCRIPTION
# What does this PR do?

Fixes unknown variables in some documentation code blocks' f-strings.

- [x] This PR fixes a typo or improves the docs

## In addition...
The following code block, which can be found at https://huggingface.co/docs/transformers/custom_models#writing-a-custom-model & [custom_models.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/custom_models.mdx), uses `torch` without `import torch` being performed in any prior docstring.

```python
class ResnetModelForImageClassification(PreTrainedModel):
    config_class = ResnetConfig

    def __init__(self, config):
        super().__init__(config)
        block_layer = BLOCK_MAPPING[config.block_type]
        self.model = ResNet(
            block_layer,
            config.layers,
            num_classes=config.num_classes,
            in_chans=config.input_channels,
            cardinality=config.cardinality,
            base_width=config.base_width,
            stem_width=config.stem_width,
            stem_type=config.stem_type,
            avg_down=config.avg_down,
        )

    def forward(self, tensor, labels=None):
        logits = self.model(tensor)
        if labels is not None:
            loss = torch.nn.cross_entropy(logits, labels)
            return {"loss": loss, "logits": logits}
        return {"logits": logits}
```
If preferred, I can add `import torch` in this code block in this PR, or make a new one for it.

## Who can review?

Documentation: @sgugger

- Tom Aarsen