### PR TITLE
Skip 2 tests in `VisionTextDualEncoderProcessorTest`

### DIFF
--- a/tests/models/vision_text_dual_encoder/test_processor_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_processor_vision_text_dual_encoder.py
@@ -76,6 +76,8 @@ class VisionTextDualEncoderProcessorTest(unittest.TestCase):
 
         return image_inputs
 
+    # TODO (Amy): fix me
+    @unittest.skip("An issue introduced in PR #19796 will be fixed by `AutoImageProcessor`")
     def test_save_load_pretrained_default(self):
         tokenizer = self.get_tokenizer()
         feature_extractor = self.get_feature_extractor()
@@ -91,6 +93,8 @@ class VisionTextDualEncoderProcessorTest(unittest.TestCase):
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor.to_json_string())
         self.assertIsInstance(processor.feature_extractor, ViTFeatureExtractor)
 
+    # TODO (Amy): fix me
+    @unittest.skip("An issue introduced in PR #19796 will be fixed by `AutoImageProcessor`")
     def test_save_load_pretrained_additional_features(self):
         processor = VisionTextDualEncoderProcessor(
             tokenizer=self.get_tokenizer(), feature_extractor=self.get_feature_extractor()


### PR DESCRIPTION
# What does this PR do?

These 2 tests in `VisionTextDualEncoderProcessorTest` will be fixed when we add the new `AutoImageProcessor`.

Current error is

```bash
AttributeError: 'NoneType' object has no attribute 'from_dict
```