### PR TITLE
Fix MaskformerFeatureExtractor

### DIFF
--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -482,9 +482,9 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         # Get unique ids (class or instance ids based on input)
         all_labels = np.unique(segmentation_map)
 
-        # Drop background label if applicable
-        if self.reduce_labels:
-            all_labels = all_labels[all_labels != 0]
+        # Remove ignored region
+        if self.ignore_index is not None:
+            all_labels = all_labels[all_labels != self.ignore_index]
 
         # Generate a binary mask for each object instance
         binary_masks = [(segmentation_map == i) for i in all_labels]

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -479,8 +479,6 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         segmentation_map: "np.ndarray",
         instance_id_to_semantic_id: Optional[Dict[int, int]] = None,
     ):
-        print("Segmentation map:", segmentation_map)
-        
         # Reduce labels, if requested
         if self.reduce_labels:
             if self.ignore_index is None:
@@ -492,13 +490,9 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         # Get unique ids (class ids, segment ids or instance ids based on input)
         all_labels = np.unique(segmentation_map)
 
-        print("Unique labels:", all_labels)
-
         # Remove ignored label
         if self.ignore_index is not None:
             all_labels = all_labels[all_labels != self.ignore_index]
-
-        print("All labels:", all_labels)
 
         # Generate a binary mask for each object instance
         binary_masks = [(segmentation_map == i) for i in all_labels]
@@ -509,7 +503,6 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             labels = np.zeros(all_labels.shape[0])
 
             for label in all_labels:
-                print("Label:", label)
                 class_id = instance_id_to_semantic_id[label + 1 if self.reduce_labels else label]
                 labels[all_labels == label] = class_id - 1 if self.reduce_labels else class_id
         else:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -504,7 +504,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
             for label in all_labels:
                 class_id = instance_id_to_semantic_id[label + 1 if self.reduce_labels else label]
-                labels[all_labels == label] = class_id
+                labels[all_labels == label] = class_id - 1 if self.reduce_labels else class_id
         else:
             labels = all_labels
 

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -494,6 +494,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         if self.ignore_index is not None:
             all_labels = all_labels[all_labels != self.ignore_index]
 
+        print("All labels:", all_labels)
+
         # Generate a binary mask for each object instance
         binary_masks = [(segmentation_map == i) for i in all_labels]
         binary_masks = np.stack(binary_masks, axis=0)  # (num_labels, height, width)
@@ -503,6 +505,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             labels = np.zeros(all_labels.shape[0])
 
             for label in all_labels:
+                print("Label:", label)
                 class_id = instance_id_to_semantic_id[label + 1 if self.reduce_labels else label]
                 labels[all_labels == label] = class_id - 1 if self.reduce_labels else class_id
         else:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -226,7 +226,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             ImageNet std.
         ignore_index (`int`, *optional*):
             Label to be assigned to background pixels in segmentation maps. If provided, segmentation map pixels
-            denoted with 0 (background) will be replaced with `ignore_index`.
+            denoted with 0 (background) will be replaced with `ignore_index`. The ignore index of the loss function of
+            the model should then correspond to this ignore index.
         reduce_labels (`bool`, *optional*, defaults to `False`):
             Whether or not to decrement all label values of segmentation maps by 1. Usually used for datasets where 0
             is used for background, and background itself is not included in all classes of a dataset (e.g. ADE20k).
@@ -376,7 +377,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
                 A mapping between instance/segment ids and semantic category ids. If passed, `segmentation_maps` is
                 treated as an instance or panoptic segmentation map where each pixel represents an instance or segment
                 id. Can be provided as a single dictionary with a global / dataset-level mapping or as a list of
-                dictionaries (one per image), to map instance ids in each image separately.
+                dictionaries (one per image), to map instance ids in each image separately. Note that this assumes a
+                mapping before reduction of labels.
 
             return_tensors (`str` or [`~file_utils.TensorType`], *optional*):
                 If set, will return tensors instead of NumPy arrays. If set to `'pt'`, return PyTorch `torch.Tensor`
@@ -579,7 +581,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
                 A mapping between instance/segment ids and semantic category ids. If passed, `segmentation_maps` is
                 treated as an instance or panoptic segmentation map where each pixel represents an instance or segment
                 id. Can be provided as a single dictionary with a global / dataset-level mapping or as a list of
-                dictionaries (one per image), to map instance ids in each image separately.
+                dictionaries (one per image), to map instance ids in each image separately. Note that this assumes a
+                mapping before reduction of labels.
 
             return_tensors (`str` or [`~file_utils.TensorType`], *optional*):
                 If set, will return tensors instead of NumPy arrays. If set to `'pt'`, return PyTorch `torch.Tensor`

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -492,6 +492,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
         # Convert instance ids to class ids
         if instance_id_to_semantic_id is not None:
+            print("All labels:", all_labels)
             labels = np.zeros(all_labels.shape[0])
 
             for label in all_labels:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -479,6 +479,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
         segmentation_map: "np.ndarray",
         instance_id_to_semantic_id: Optional[Dict[int, int]] = None,
     ):
+        print("Segmentation map:", segmentation_map)
+        
         # Reduce labels, if requested
         if self.reduce_labels:
             if self.ignore_index is None:
@@ -489,6 +491,8 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
         # Get unique ids (class ids, segment ids or instance ids based on input)
         all_labels = np.unique(segmentation_map)
+
+        print("Unique labels:", all_labels)
 
         # Remove ignored label
         if self.ignore_index is not None:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -492,7 +492,6 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
 
         # Convert instance ids to class ids
         if instance_id_to_semantic_id is not None:
-            print("All labels:", all_labels)
             labels = np.zeros(all_labels.shape[0])
 
             for label in all_labels:

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -487,7 +487,7 @@ class MaskFormerFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionM
             all_labels = all_labels[all_labels != 0]
 
         # Generate a binary mask for each object instance
-        binary_masks = [np.ma.masked_where(segmentation_map == i, segmentation_map) for i in all_labels]
+        binary_masks = [(segmentation_map == i) for i in all_labels]
         binary_masks = np.stack(binary_masks, axis=0)  # (num_labels, height, width)
 
         # Convert instance ids to class ids

--- a/tests/models/maskformer/test_feature_extraction_maskformer.py
+++ b/tests/models/maskformer/test_feature_extraction_maskformer.py
@@ -20,7 +20,7 @@ import numpy as np
 from datasets import load_dataset
 
 from huggingface_hub import hf_hub_download
-from transformers.testing_utils import require_torch, require_vision, slow
+from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_feature_extraction_common import FeatureExtractionSavingTestMixin, prepare_image_inputs
@@ -347,7 +347,6 @@ class MaskFormerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         common(is_instance_map=False, segmentation_type="pil")
         common(is_instance_map=True, segmentation_type="pil")
 
-    @slow
     def test_integration_instance_segmentation(self):
         # load 2 images and corresponding annotations from the hub
         repo_id = "nielsr/image-segmentation-toy-data"

--- a/tests/models/maskformer/test_feature_extraction_maskformer.py
+++ b/tests/models/maskformer/test_feature_extraction_maskformer.py
@@ -18,7 +18,8 @@ import unittest
 
 import numpy as np
 
-from transformers.testing_utils import require_torch, require_vision
+from huggingface_hub import hf_hub_download
+from transformers.testing_utils import require_torch, require_vision, slow
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_feature_extraction_common import FeatureExtractionSavingTestMixin, prepare_image_inputs
@@ -344,6 +345,67 @@ class MaskFormerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         common(is_instance_map=True)
         common(is_instance_map=False, segmentation_type="pil")
         common(is_instance_map=True, segmentation_type="pil")
+
+    @slow
+    def test_integration_instance_segmentation(self):
+        # load 2 images and corresponding annotations from the hub
+        repo_id = "nielsr/image-segmentation-toy-data"
+        image1 = Image.open(
+            hf_hub_download(repo_id=repo_id, filename="instance_segmentation_image_1.png", repo_type="dataset")
+        )
+        image2 = Image.open(
+            hf_hub_download(repo_id=repo_id, filename="instance_segmentation_image_2.png", repo_type="dataset")
+        )
+        annotation1 = Image.open(
+            hf_hub_download(repo_id=repo_id, filename="instance_segmentation_annotation_1.png", repo_type="dataset")
+        )
+        annotation2 = Image.open(
+            hf_hub_download(repo_id=repo_id, filename="instance_segmentation_annotation_2.png", repo_type="dataset")
+        )
+
+        # get instance segmentations and instance-to-segmentation mappings
+        def get_instance_segmentation_and_mapping(annotation):
+            instance_seg = np.array(annotation)[:, :, 1]
+            class_id_map = np.array(annotation)[:, :, 0]
+            class_labels = np.unique(class_id_map)
+
+            # create mapping between instance IDs and semantic category IDs
+            inst2class = {}
+            for label in class_labels:
+                instance_ids = np.unique(instance_seg[class_id_map == label])
+                inst2class.update({i: label for i in instance_ids})
+
+            return instance_seg, inst2class
+
+        instance_seg1, inst2class1 = get_instance_segmentation_and_mapping(annotation1)
+        instance_seg2, inst2class2 = get_instance_segmentation_and_mapping(annotation2)
+
+        # create a feature extractor
+        feature_extractor = MaskFormerFeatureExtractor(reduce_labels=True, ignore_index=255, size=(512, 512))
+
+        # prepare the images and annotations
+        inputs = feature_extractor(
+            [image1, image2],
+            [instance_seg1, instance_seg2],
+            instance_id_to_semantic_id=[inst2class1, inst2class2],
+            return_tensors="pt",
+        )
+
+        # verify the pixel values and pixel mask
+        self.assertEqual(inputs["pixel_values"].shape, (2, 3, 512, 512))
+        self.assertEqual(inputs["pixel_mask"].shape, (2, 512, 512))
+
+        # verify the class labels
+        self.assertEqual(len(inputs["class_labels"]), 2)
+        self.assertTrue(torch.allclose(inputs["class_labels"][0], torch.tensor([30, 55])))
+        self.assertTrue(torch.allclose(inputs["class_labels"][1], torch.tensor([4, 4, 23, 55])))
+
+        # verify the mask labels
+        self.assertEqual(len(inputs["mask_labels"]), 2)
+        self.assertEqual(inputs["mask_labels"][0].shape, (2, 512, 512))
+        self.assertTrue(inputs["mask_labels"][1].shape, (4, 512, 512))
+        self.assertEquals(inputs["mask_labels"][0].sum().item(), 41527.0)
+        self.assertEquals(inputs["mask_labels"][1].sum().item(), 26259.0)
 
     def test_binary_mask_to_rle(self):
         fake_binary_mask = np.zeros((20, 50))


### PR DESCRIPTION
# What does this PR do?

This PR fixes MaskFormer's feature extractor. 

PR #18997 introduced a bug which made the feature extractor create the same binary mask for all segments/instances in an image, hence making it impossible to fine-tune the model. This PR fixes it and makes sure the model can be properly fine-tuned on instance, semantic and panoptic segmentation datasets.

To do:

- [x] add tests