### PR TITLE
Fix generate_dummy_inputs for ImageGPTOnnxConfig

### DIFF
--- a/src/transformers/models/imagegpt/configuration_imagegpt.py
+++ b/src/transformers/models/imagegpt/configuration_imagegpt.py
@@ -197,6 +197,6 @@ class ImageGPTOnnxConfig(OnnxConfig):
         """
 
         input_image = self._generate_dummy_images(batch_size, num_channels, image_height, image_width)
-        inputs = dict(preprocessor(input_image, framework))
+        inputs = dict(preprocessor(images=input_image, return_tensors=framework))
 
         return inputs


### PR DESCRIPTION
# What does this PR do?

`ImageGPT` ONNX tests fail with

```bash
TypeError: __call__() takes 2 positional arguments but 3 were given
```

This is due to the way of calling `preprocessor(input_image, framework)` is not working with the changes introduced in Image Process PR #19796.

This PR updates the calling way by using keyword arguments.
