### PR TITLE
docs: Replace awkward `timm` link with the expected one

### DIFF
--- a/docs/source/en/custom_models.mdx
+++ b/docs/source/en/custom_models.mdx
@@ -21,7 +21,7 @@ with the community (with the code it relies on) so that anyone can use it, even 
 Transformers library.
 
 We will illustrate all of this on a ResNet model, by wrapping the ResNet class of the
-[timm library](https://github.com/rwightman/pytorch-image-models/tree/master/timm) into a [`PreTrainedModel`].
+[timm library](https://github.com/rwightman/pytorch-image-models) into a [`PreTrainedModel`].
 
 ## Writing a custom configuration
 

--- a/docs/source/es/custom_models.mdx
+++ b/docs/source/es/custom_models.mdx
@@ -21,7 +21,7 @@ cómo escribir un modelo personalizado y su configuración para que pueda usarse
 con la comunidad (con el código en el que se basa) para que cualquiera pueda usarlo, incluso si no está presente en la biblioteca 
 🤗 Transformers.
 
-Ilustraremos todo esto con un modelo ResNet, envolviendo la clase ResNet de la [biblioteca timm](https://github.com/rwightman/pytorch-image-models/tree/master/timm) en un [`PreTrainedModel`].
+Ilustraremos todo esto con un modelo ResNet, envolviendo la clase ResNet de la [biblioteca timm](https://github.com/rwightman/pytorch-image-models) en un [`PreTrainedModel`].
 
 ## Escribir una configuración personalizada
 

--- a/docs/source/it/custom_models.mdx
+++ b/docs/source/it/custom_models.mdx
@@ -21,7 +21,7 @@ Transformers, e come condividerlo con la community (assieme al relativo codice) 
 se non presente nella libreria 🤗 Transformers.
 
 Illustriamo tutto questo su un modello ResNet, avvolgendo la classe ResNet della 
-[libreria timm](https://github.com/rwightman/pytorch-image-models/tree/master/timm) in un [`PreTrainedModel`].
+[libreria timm](https://github.com/rwightman/pytorch-image-models) in un [`PreTrainedModel`].
 
 ## Scrivere una configurazione personalizzata
 Prima di iniziare a lavorare al modello, scriviamone la configurazione. La configurazione di un modello è un oggetto

--- a/docs/source/pt/custom_models.mdx
+++ b/docs/source/pt/custom_models.mdx
@@ -20,7 +20,7 @@ como escrever um modelo customizado e sua configuração para que possa ser usad
 com a comunidade (com o código em que se baseia) para que qualquer pessoa possa usá-lo, mesmo se não estiver presente na biblioteca 🤗 Transformers.
 
 Ilustraremos tudo isso em um modelo ResNet, envolvendo a classe ResNet do
-[biblioteca timm](https://github.com/rwightman/pytorch-image-models/tree/master/timm) em um [`PreTrainedModel`].
+[biblioteca timm](https://github.com/rwightman/pytorch-image-models) em um [`PreTrainedModel`].
 
 ## Escrevendo uma configuração customizada
 


### PR DESCRIPTION
# What does this PR do?

Replace https://github.com/rwightman/pytorch-image-models/tree/master/timm with https://github.com/rwightman/pytorch-image-models. 

## Reasoning
1. The URL has the hardcoded `master` branch, despite the `timm` being branch being renamed to `main` nowadays.
2. The URL points to the `timm` folder for some reason, when linking to the root, i.e. where a README is visible, is much more sensible.

## Before submitting
- [x] This PR fixes a typo or improves the docs

## Who can review?

Documentation: @sgugger

---

I just keep running into small issues here and there! More than happy to help fix them, though.

- Tom Aarsen