### PR TITLE
Make DummyObject more robust

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -986,9 +986,9 @@ class DummyObject(type):
     `requires_backend` each time a user tries to access any method of that class.
     """
 
-    def __getattr__(cls, key):
+    def __getattribute__(cls, key):
         if key.startswith("_"):
-            return super().__getattr__(cls, key)
+            return super().__getattribute__(key)
         requires_backends(cls, cls._backends)
 
 


### PR DESCRIPTION
# What does this PR do?

Use `__getattribute__`  instead of `__getattr__` in `DummyObject` to track the attribute access. Compared to `__getattr__` (invoked only if the attribute is missing), `__getattribute__` is invoked for every access, hence more robust.

Fixes #20127 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 