### PR TITLE
Update `OnnxConfig.generate_dummy_inputs` to check `ImageProcessingMixin`

### DIFF
--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -380,6 +380,11 @@ class OnnxConfig(ABC):
             batch_size = compute_effective_axis_dimension(batch_size, fixed_dimension=OnnxConfig.default_fixed_batch)
             dummy_input = self._generate_dummy_images(batch_size, num_channels, image_height, image_width)
             return dict(preprocessor(images=dummy_input, return_tensors=framework))
+        elif isinstance(preprocessor, FeatureExtractionMixin) and preprocessor.model_input_names[0] == "pixel_values":
+            # If dynamic axis (-1) we forward with a fixed dimension of 2 samples to avoid optimizations made by ONNX
+            batch_size = compute_effective_axis_dimension(batch_size, fixed_dimension=OnnxConfig.default_fixed_batch)
+            dummy_input = self._generate_dummy_images(batch_size, num_channels, image_height, image_width)
+            return dict(preprocessor(images=dummy_input, return_tensors=framework))
         elif (
             isinstance(preprocessor, FeatureExtractionMixin) and preprocessor.model_input_names[0] == "input_features"
         ):

--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -279,7 +279,7 @@ class OnnxConfig(ABC):
 
     def generate_dummy_inputs(
         self,
-        preprocessor: Union["PreTrainedTokenizerBase", "FeatureExtractionMixin"],
+        preprocessor: Union["PreTrainedTokenizerBase", "FeatureExtractionMixin", "ImageProcessingMixin"],
         batch_size: int = -1,
         seq_length: int = -1,
         num_choices: int = -1,
@@ -297,7 +297,7 @@ class OnnxConfig(ABC):
         Generate inputs to provide to the ONNX exporter for the specific framework
 
         Args:
-            preprocessor: ([`PreTrainedTokenizerBase`] or [`FeatureExtractionMixin`]):
+            preprocessor: ([`PreTrainedTokenizerBase`], [`FeatureExtractionMixin`], or [`ImageProcessingMixin`]):
                 The preprocessor associated with this model configuration.
             batch_size (`int`, *optional*, defaults to -1):
                 The batch size to export the model for (-1 means dynamic axis).


### PR DESCRIPTION
# What does this PR do?

As we have a new class `ImageProcessingMixin`, the method `OnnxConfig.generate_dummy_inputs` needs to check this case, otherwise it can't find a if/else branch to create dummy inputs.

See 
https://github.com/huggingface/transformers/blob/7ec1dc8817a99d16e6f9e0ab94ce4027ef74b72d/src/transformers/onnx/config.py#L371

Current failing error is:

```bash
AssertionError: beit, default -> Unable to generate dummy inputs for the model. Please provide a tokenizer or a preprocessor.
```
