### PR TITLE
Fix arg names for our models

### DIFF
--- a/src/transformers/models/esm/modeling_esmfold.py
+++ b/src/transformers/models/esm/modeling_esmfold.py
@@ -2249,7 +2249,6 @@ class EsmForProteinFolding(EsmPreTrainedModel):
         self,
         seqs: Union[str, List[str]],
         residx=None,
-        with_mask: Optional[torch.Tensor] = None,
     ):
         if type(seqs) is str:
             lst = [seqs]
@@ -2280,9 +2279,7 @@ class EsmForProteinFolding(EsmPreTrainedModel):
         return self.forward(
             aatype,
             mask,
-            mask_aa=with_mask is not None,
-            masking_pattern=with_mask,
-            residx=residx,
+            position_ids=residx,
         )
 
     @staticmethod

--- a/src/transformers/models/esm/modeling_esmfold.py
+++ b/src/transformers/models/esm/modeling_esmfold.py
@@ -2248,7 +2248,7 @@ class EsmForProteinFolding(EsmPreTrainedModel):
     def infer(
         self,
         seqs: Union[str, List[str]],
-        residx=None,
+        position_ids=None,
     ):
         if type(seqs) is str:
             lst = [seqs]
@@ -2271,15 +2271,15 @@ class EsmForProteinFolding(EsmPreTrainedModel):
             ]
         )  # B=1 x L
         mask = collate_dense_tensors([aatype.new_ones(len(seq)) for seq in lst])
-        residx = (
-            torch.arange(aatype.shape[1], device=device).expand(len(lst), -1) if residx is None else residx.to(device)
+        position_ids = (
+            torch.arange(aatype.shape[1], device=device).expand(len(lst), -1) if position_ids is None else position_ids.to(device)
         )
-        if residx.ndim == 1:
-            residx = residx.unsqueeze(0)
+        if position_ids.ndim == 1:
+            position_ids = position_ids.unsqueeze(0)
         return self.forward(
             aatype,
             mask,
-            position_ids=residx,
+            position_ids=position_ids,
         )
 
     @staticmethod

--- a/src/transformers/models/esm/modeling_esmfold.py
+++ b/src/transformers/models/esm/modeling_esmfold.py
@@ -2272,7 +2272,9 @@ class EsmForProteinFolding(EsmPreTrainedModel):
         )  # B=1 x L
         mask = collate_dense_tensors([aatype.new_ones(len(seq)) for seq in lst])
         position_ids = (
-            torch.arange(aatype.shape[1], device=device).expand(len(lst), -1) if position_ids is None else position_ids.to(device)
+            torch.arange(aatype.shape[1], device=device).expand(len(lst), -1)
+            if position_ids is None
+            else position_ids.to(device)
         )
         if position_ids.ndim == 1:
             position_ids = position_ids.unsqueeze(0)


### PR DESCRIPTION
Some arg names on the `infer` method for `ESMFold` don't fit our port, and this PR updates/removes them.

In future these methods will probably be moved to the tokenizer/processor but this quick fix will at least get them working for now!

Fixes #20120