### PR TITLE
fix convert longformer to onnx bug

### DIFF
--- a/src/transformers/models/longformer/configuration_longformer.py
+++ b/src/transformers/models/longformer/configuration_longformer.py
@@ -183,6 +183,7 @@ class LongformerOnnxConfig(OnnxConfig):
                 ("input_ids", dynamic_axis),
                 ("attention_mask", dynamic_axis),
                 ("global_attention_mask", dynamic_axis),
+                ("token_type_ids", dynamic_axis),
             ]
         )
 


### PR DESCRIPTION
class `LongformerOnnxConfig`
property `inputs`
miss one input `"token_type_ids"`


```shell
# before fix : onnx input node
name: "token_type_ids"
type {
  tensor_type {
    elem_type: 7
    shape {
      dim {
        dim_value: 2
      }
      dim {
        dim_value: 8
      }
    }
  }
}

# after fix : onnx input node
name: "token_type_ids"
type {
  tensor_type {
    elem_type: 7
    shape {
      dim {
        dim_param: "batch"
      }
      dim {
        dim_param: "sequence"
      }
    }
  }
}
```