### PR TITLE
Downgrade log warning -> info

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -497,7 +497,7 @@ def get_size_dict(
     elif isinstance(size, (tuple, list)) and not height_width_order:
         size_dict = {"height": size[1], "width": size[0]}
 
-    logger.warning(
+    logger.info(
         "The size parameter should be a dictionary with keys ('height', 'width'), ('shortest_edge', 'longest_edge')"
         f" or ('shortest_edge',) got {size}. Setting as {size_dict}.",
     )


### PR DESCRIPTION
# What does this PR do?

Downgrades the logged messages about the size parameter being converted from int/tuple -> dict from warning to info. 

## Fixes

Addresses part of the issue raised in #20185 - where many downstream tasks would have multiple warning messages, potentially scaring the users and spamming their logs. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

