### PR TITLE
[DPR] fix unexpected "pooler" keys

### DIFF
--- a/src/transformers/models/dpr/modeling_dpr.py
+++ b/src/transformers/models/dpr/modeling_dpr.py
@@ -299,6 +299,7 @@ class DPRPretrainedContextEncoder(DPRPreTrainedModel):
     load_tf_weights = None
     base_model_prefix = "ctx_encoder"
     _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
 
 class DPRPretrainedQuestionEncoder(DPRPreTrainedModel):
@@ -311,6 +312,7 @@ class DPRPretrainedQuestionEncoder(DPRPreTrainedModel):
     load_tf_weights = None
     base_model_prefix = "question_encoder"
     _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_unexpected = [r"pooler"]
 
 
 class DPRPretrainedReader(DPRPreTrainedModel):


### PR DESCRIPTION
# What does this PR do?
Fixes #19111, by adding  [r"pooler"] to the list of ignored unexpected keys for both the `DPRPretrainedContextEncoder` and `DPRPretrainedQuestionEncoder`. 