### PR TITLE
Generate: add generation config class

### DIFF
--- a/docs/source/en/main_classes/text_generation.mdx
+++ b/docs/source/en/main_classes/text_generation.mdx
@@ -18,6 +18,14 @@ Each framework has a generate method for auto-regressive text generation impleme
 - TensorFlow [`~generation.TFGenerationMixin.generate`] is implemented in [`~generation.TFGenerationMixin`].
 - Flax/JAX [`~generation.FlaxGenerationMixin.generate`] is implemented in [`~generation.FlaxGenerationMixin`].
 
+{/* TODO: add a brief description of GenerationConfig (with examples) when it becomes usable with generate */}
+
+## GenerationConfig
+
+[[autodoc]] generation.GenerationConfig
+	- from_pretrained
+	- save_pretrained
+
 ## GenerationMixin
 
 [[autodoc]] generation.GenerationMixin

--- a/docs/source/en/main_classes/text_generation.mdx
+++ b/docs/source/en/main_classes/text_generation.mdx
@@ -18,7 +18,7 @@ Each framework has a generate method for auto-regressive text generation impleme
 - TensorFlow [`~generation.TFGenerationMixin.generate`] is implemented in [`~generation.TFGenerationMixin`].
 - Flax/JAX [`~generation.FlaxGenerationMixin.generate`] is implemented in [`~generation.FlaxGenerationMixin`].
 
-{/* TODO: add a brief description of GenerationConfig (with examples) when it becomes usable with generate */}
+<!--- TODO: add a brief description of GenerationConfig (with examples) when it becomes usable with generate --->
 
 ## GenerationConfig
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -96,7 +96,7 @@ _import_structure = {
     "feature_extraction_sequence_utils": ["SequenceFeatureExtractor"],
     "feature_extraction_utils": ["BatchFeature", "FeatureExtractionMixin"],
     "file_utils": [],
-    "generation": [],
+    "generation": ["GenerationConfig"],
     "hf_argparser": ["HfArgumentParser"],
     "integrations": [
         "is_clearml_available",
@@ -3240,6 +3240,9 @@ if TYPE_CHECKING:
 
     # Feature Extractor
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
+
+    # Generation
+    from .generation import GenerationConfig
     from .hf_argparser import HfArgumentParser
 
     # Integrations

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -96,7 +96,7 @@ _import_structure = {
     "feature_extraction_sequence_utils": ["SequenceFeatureExtractor"],
     "feature_extraction_utils": ["BatchFeature", "FeatureExtractionMixin"],
     "file_utils": [],
-    "generation": [],
+    "generation": ["GenerationConfig"],
     "hf_argparser": ["HfArgumentParser"],
     "integrations": [
         "is_clearml_available",
@@ -3241,6 +3241,9 @@ if TYPE_CHECKING:
     # Feature Extractor
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
     from .hf_argparser import HfArgumentParser
+
+    # Generation
+    from .generation import GenerationConfig
 
     # Integrations
     from .integrations import (

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -96,7 +96,7 @@ _import_structure = {
     "feature_extraction_sequence_utils": ["SequenceFeatureExtractor"],
     "feature_extraction_utils": ["BatchFeature", "FeatureExtractionMixin"],
     "file_utils": [],
-    "generation": ["GenerationConfig"],
+    "generation": [],
     "hf_argparser": ["HfArgumentParser"],
     "integrations": [
         "is_clearml_available",
@@ -3241,9 +3241,6 @@ if TYPE_CHECKING:
     # Feature Extractor
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
     from .hf_argparser import HfArgumentParser
-
-    # Generation
-    from .generation import GenerationConfig
 
     # Integrations
     from .integrations import (

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -21,9 +21,7 @@ from typing import TYPE_CHECKING
 from ..utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_available, is_tf_available, is_torch_available
 
 
-_import_structure = {
-    "configuration_utils": ["GenerationConfig"]
-}
+_import_structure = {"configuration_utils": ["GenerationConfig"]}
 
 
 try:

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -21,7 +21,9 @@ from typing import TYPE_CHECKING
 from ..utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_available, is_tf_available, is_torch_available
 
 
-_import_structure = {}
+_import_structure = {
+    "configuration_utils": ["GenerationConfig"]
+}
 
 
 try:
@@ -149,6 +151,8 @@ else:
     ]
 
 if TYPE_CHECKING:
+    from .configuration_utils import GenerationConfig
+
     try:
         if not is_torch_available():
             raise OptionalDependencyNotAvailable()

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -226,9 +226,10 @@ class GenerationConfig(PushToHubMixin):
         # to facilitate the creation of multiple generation config files in the root directory of a model.
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         r"""
-        Args:
-        Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the:
+        Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the
         [`~GenerationConfig.from_pretrained`] class method.
+
+        Args:
             save_directory (`str` or `os.PathLike`):
                 Directory where the configuration JSON file will be saved (will be created if it does not exist).
             config_name (`str`, *optional*, defaults to `"generation_config.json"`):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -40,19 +40,19 @@ class GenerationConfig(PushToHubMixin):
 
     <Tip>
 
-    A configuration file can be loaded and saved to disk. Loading and using a generation configuration file does
+    A generation configuration file can be loaded and saved to disk. Loading and using a generation configuration file does
     **not** change a model configuration or weights. It only affects the model's behavior at generation time.
 
     </Tip>
 
     Arg:
-        max_length (`int`, *optional*, defaults to `20`):
+        max_length (`int`, *optional*, defaults to 20):
             The maximum length the generated tokens can have. Corresponds to the length of the input prompt +
             `max_new_tokens`. In general, prefer the use of `max_new_tokens`, which ignores the number of tokens in the
             prompt.
         max_new_tokens (`int`, *optional*):
             The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
-        min_length (`int`, *optional*, defaults to `0`):
+        min_length (`int`, *optional*, defaults to 0):
             The minimum length of the sequence to be generated.
         early_stopping (`bool`, *optional*, defaults to `False`):
             Whether to stop the beam search when at least `num_beams` sentences are finished per batch or not.
@@ -61,35 +61,35 @@ class GenerationConfig(PushToHubMixin):
             the current pass after allocated time has been passed.
         do_sample (`bool`, *optional*, defaults to `False`):
             Whether or not to use sampling ; use greedy decoding otherwise.
-        num_beams (`int`, *optional*, defaults to `1`):
+        num_beams (`int`, *optional*, defaults to 1):
             Number of beams for beam search. 1 means no beam search.
-        num_beam_groups (`int`, *optional*, defaults to `1`):
+        num_beam_groups (`int`, *optional*, defaults to 1):
             Number of groups to divide `num_beams` into in order to ensure diversity among different groups of beams.
             [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
         penalty_alpha (`float`, *optional*):
             The values balance the model confidence and the degeneration penalty in contrastive search decoding.
-        temperature (`float`, *optional*, defaults to `1.0`):
+        temperature (`float`, *optional*, defaults to 1.0):
             The value used to module the next token probabilities.
-        top_k (`int`, *optional*, defaults to `50`):
+        top_k (`int`, *optional*, defaults to 50):
             The number of highest probability vocabulary tokens to keep for top-k-filtering.
-        top_p (`float`, *optional*, defaults to `1.0`):
+        top_p (`float`, *optional*, defaults to 1.0):
             If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
             `top_p` or higher are kept for generation.
-        typical_p (`float`, *optional*, defaults to `1.0`):
+        typical_p (`float`, *optional*, defaults to 1.0):
             The amount of probability mass from the original distribution to be considered in typical decoding. If set
             to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
-        diversity_penalty (`float`, *optional*, defaults to `0.0`):
+        diversity_penalty (`float`, *optional*, defaults to 0.0):
             This value is subtracted from a beam's score if it generates a token same as any beam from other group at a
             particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.
-        repetition_penalty (`float`, *optional*, defaults to `1.0`):
+        repetition_penalty (`float`, *optional*, defaults to 1.0):
             The parameter for repetition penalty. 1.0 means no penalty. See [this
             paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
-        length_penalty (`float`, *optional*, defaults to `1.0`):
+        length_penalty (`float`, *optional*, defaults to 1.0):
             Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to
             the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log
             likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while
             `length_penalty` < 0.0 encourages shorter sequences.
-        no_repeat_ngram_size (`int`, *optional*, defaults to `0`):
+        no_repeat_ngram_size (`int`, *optional*, defaults to 0):
             If set to int > 0, all ngrams of that size can only occur once.
         bad_words_ids(`List[List[int]]`, *optional*):
             List of token ids that are not allowed to be generated. In order to get the token ids of the words that
@@ -130,7 +130,7 @@ class GenerationConfig(PushToHubMixin):
             A list of pairs of integers which indicates a mapping from generation indices to token indices that will be
             forced before sampling. For example, `[[1, 123]]` means the second generated token will always be a token
             of index 123.
-        num_return_sequences(`int`, *optional*, defaults to `1`):
+        num_return_sequences(`int`, *optional*, defaults to 1):
             The number of independently computed returned sequences for each element in the batch.
         output_attentions (`bool`, *optional*, defaults to `False`):
             Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
@@ -148,7 +148,7 @@ class GenerationConfig(PushToHubMixin):
             The id of the *beginning-of-sequence* token.
         eos_token_id (`int`, *optional*):
             The id of the *end-of-sequence* token.
-        encoder_no_repeat_ngram_size (`int`, *optional*, defaults to `0`):
+        encoder_no_repeat_ngram_size (`int`, *optional*, defaults to 0):
             If set to int > 0, all ngrams of that size that occur in the `encoder_input_ids` cannot occur in the
             `decoder_input_ids`.
         decoder_start_token_id (`int`, *optional*):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -14,12 +14,6 @@
 # limitations under the License.
 """ Generation configuration class and utilities."""
 
-# TODO -- Generation config wishlist before making it a public class, ordered:
-# - We can load a Generation Config from a Model Config (to make it compatible with all existing repos)
-# - `.generate()` inherits default values from generate config, instead of from model config
-# - Add doctests for loading, storing, and using with `.generate()`
-# - (bonus) Generate config validates its attributes at initialization time
-
 import copy
 import json
 import os

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -17,7 +17,7 @@
 import copy
 import json
 import os
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from .. import __version__
 from ..utils import (
@@ -217,7 +217,7 @@ class GenerationConfig(PushToHubMixin):
     def save_pretrained(
         self,
         save_directory: Union[str, os.PathLike],
-        config_name: str = GENERATION_CONFIG_NAME,
+        config_name: Optional[str] = None,
         push_to_hub: bool = False,
         **kwargs
     ):
@@ -225,7 +225,7 @@ class GenerationConfig(PushToHubMixin):
         # REVIEWERS: As discussed on Slack, this config file has an argument to specify the file name (`config_name`),
         # to facilitate the creation of multiple generation config files in the root directory of a model.
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        """
+        r"""
         Args:
         Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the:
         [`~GenerationConfig.from_pretrained`] class method.
@@ -240,6 +240,8 @@ class GenerationConfig(PushToHubMixin):
             kwargs:
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
+        config_name = config_name if config_name is not None else GENERATION_CONFIG_NAME
+
         if os.path.isfile(save_directory):
             raise AssertionError(f"Provided path ({save_directory}) should be a directory, not a file")
 
@@ -267,7 +269,7 @@ class GenerationConfig(PushToHubMixin):
 
     @classmethod
     def from_pretrained(
-        cls, pretrained_model_name: Union[str, os.PathLike], config_name: str = GENERATION_CONFIG_NAME, **kwargs
+        cls, pretrained_model_name: Union[str, os.PathLike], config_name: Optional[str] = None, **kwargs
     ) -> "GenerationConfig":
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # REVIEWERS: Contrarily to the model config, the first argument is a folder (as opposed to a folder OR a
@@ -350,6 +352,8 @@ class GenerationConfig(PushToHubMixin):
         assert unused_kwargs == {"foo": False}
         ```"""
         # TODO: convert the examples above to doctest when we have public examples on the hub
+        config_name = config_name if config_name is not None else GENERATION_CONFIG_NAME
+
         cache_dir = kwargs.pop("cache_dir", None)
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1,0 +1,319 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Generation configuration class and utilities."""
+
+import os
+import json
+import copy
+from typing import Any, Dict, Union
+from .. import __version__
+from ..utils import PushToHubMixin, logging, GENERATION_CONFIG_NAME
+
+logger = logging.get_logger(__name__)
+
+
+class GenerationConfig(PushToHubMixin):
+    r"""
+    Class that holds a configuration for a generation task.
+    <Tip>
+    A configuration file can be loaded and saved to disk. Loading the configuration file and using this file to
+    initialize a model does **not** change its configuration or weights. It only affects the model's behavior at
+    generation time.
+    </Tip>
+    Arg:
+        max_length (`int`, *optional*, defaults to `20`):
+            The maximum length the generated tokens can have. Corresponds to the length of the input prompt +
+            `max_new_tokens`. In general, prefer the use of `max_new_tokens`, which ignores the number of tokens in
+            the prompt.
+        max_new_tokens (`int`, *optional*):
+            The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
+        min_length (`int`, *optional*, defaults to `0`):
+            The minimum length of the sequence to be generated.
+        early_stopping (`bool`, *optional*, defaults to `False`):
+            Whether to stop the beam search when at least `num_beams` sentences are finished per batch or not.
+        max_time(`float`, *optional*):
+            The maximum amount of time you allow the computation to run for in seconds. generation will still
+            finish the current pass after allocated time has been passed.
+        do_sample (`bool`, *optional*, defaults to `False`):
+            Whether or not to use sampling ; use greedy decoding otherwise.
+        num_beams (`int`, *optional*, defaults to `1`):
+            Number of beams for beam search. 1 means no beam search.
+        num_beam_groups (`int`, *optional*, defaults to `1`):
+            Number of groups to divide `num_beams` into in order to ensure diversity among different groups of
+            beams. [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
+        penalty_alpha (`float`, *optional*):
+            The values balance the model confidence and the degeneration penalty in contrastive search decoding.
+        temperature (`float`, *optional*, defaults to `1.0`):
+            The value used to module the next token probabilities.
+        top_k (`int`, *optional*, defaults to `50`):
+            The number of highest probability vocabulary tokens to keep for top-k-filtering.
+        top_p (`float`, *optional*, defaults to `1.0`):
+            If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
+            `top_p` or higher are kept for generation.
+        typical_p (`float`, *optional*, defaults to `1.0`):
+            The amount of probability mass from the original distribution to be considered in typical decoding. If
+            set to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+        diversity_penalty (`float`, *optional*, defaults to `0.0`):
+            This value is subtracted from a beam's score if it generates a token same as any beam from other group
+            at a particular time. Note that `diversity_penalty` is only effective if `group beam search` is
+            enabled.
+        repetition_penalty (`float`, *optional*, defaults to `1.0`):
+            The parameter for repetition penalty. 1.0 means no penalty. See [this
+            paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
+        length_penalty (`float`, *optional*, defaults to `1.0`):
+            Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent
+            to the sequence length, which in turn is used to divide the score of the sequence. Since the score is
+            the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences,
+            while `length_penalty` < 0.0 encourages shorter sequences.
+        no_repeat_ngram_size (`int`, *optional*, defaults to `0`):
+            If set to int > 0, all ngrams of that size can only occur once.
+        bad_words_ids(`List[List[int]]`, *optional*):
+            List of token ids that are not allowed to be generated. In order to get the token ids of the words that
+            should not appear in the generated text, use `tokenizer(bad_words, add_prefix_space=True,
+            add_special_tokens=False).input_ids`.
+        force_words_ids(`List[List[int]]` or `List[List[List[int]]]`, *optional*):
+            List of token ids that must be generated. If given a `List[List[int]]`, this is treated as a simple
+            list of words that must be included, the opposite to `bad_words_ids`. If given `List[List[List[int]]]`,
+            this triggers a [disjunctive constraint](https://github.com/huggingface/transformers/issues/14081),
+            where one can allow different forms of each word.
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should use the past last key/values attentions (if applicable to the model) to
+            speed up decoding.
+        renormalize_logits (`bool`, *optional*, defaults to `False`):
+            Whether to renormalize the logits after applying all the logits processors or warpers (including the
+            custom ones). It's highly recommended to set this flag to `True` as the search algorithms suppose the
+            score logits are normalized but some logit processors or warpers break the normalization.
+        forced_bos_token_id (`int`, *optional*, defaults to `model.config.forced_bos_token_id`):
+            The id of the token to force as the first generated token after the `decoder_start_token_id`. Useful
+            for multilingual models like [mBART](../model_doc/mbart) where the first generated token needs to be
+            the target language token.
+        forced_eos_token_id (`int`, *optional*, defaults to `model.config.forced_eos_token_id`):
+            The id of the token to force as the last generated token when `max_length` is reached.
+        remove_invalid_values (`bool`, *optional*, defaults to `model.config.remove_invalid_values`):
+            Whether to remove possible *nan* and *inf* outputs of the model to prevent the generation method to
+            crash. Note that using `remove_invalid_values` can slow down generation.
+        exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
+            This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
+            generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates
+            where penalty starts and `decay_factor` represents the factor of exponential decay
+        suppress_tokens  (`List[int]`, *optional*):
+            A list of tokens that will be supressed at generation. The `SupressTokens` logit processor will set
+            their log probs to `-inf` so that they are not sampled.
+        begin_suppress_tokens  (`List[int]`, *optional*):
+            A list of tokens that will be supressed at the begining of the generation. The `SupressBeginTokens`
+            logit processor will set their log probs to `-inf` so that they are not sampled.
+        forced_decoder_ids (`List[List[int]]`, *optional*):
+            A list of pairs of integers which indicates a mapping from generation indices to token indices that
+            will be forced before sampling. For example, `[[1, 123]]` means the second generated token will always
+            be a token of index 123.
+        num_return_sequences(`int`, *optional*, defaults to `1`):
+            The number of independently computed returned sequences for each element in the batch.
+        output_attentions (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+            returned tensors for more details.
+        output_hidden_states (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
+            for more details.
+        output_scores (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the prediction scores. See `scores` under returned tensors for more details.
+        return_dict_in_generate (`bool`, *optional*, defaults to `False`):
+            Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        pad_token_id (`int`, *optional*):
+            The id of the *padding* token.
+        bos_token_id (`int`, *optional*):
+            The id of the *beginning-of-sequence* token.
+        eos_token_id (`int`, *optional*):
+            The id of the *end-of-sequence* token.
+        encoder_no_repeat_ngram_size (`int`, *optional*, defaults to `0`):
+            If set to int > 0, all ngrams of that size that occur in the `encoder_input_ids` cannot occur in the
+            `decoder_input_ids`.
+        decoder_start_token_id (`int`, *optional*):
+            If an encoder-decoder model starts decoding with a different token than *bos*, the id of that token.
+        generation_kwargs:
+            Additional generation kwargs will be forwarded to the `generate` function of the model. Kwargs that are not
+            present in `generate`'s signature will be used in the model forward pass.
+    """
+
+    def __init__(self, **kwargs):
+        # Parameters that control the length of the output
+        self.max_length = kwargs.pop("max_length", 20)
+        self.max_new_tokens = kwargs.pop("max_new_tokens", None)
+        self.min_length = kwargs.pop("min_length", 0)
+        self.early_stopping = kwargs.pop("early_stopping", False)
+        self.max_time = kwargs.pop("max_time", None)
+
+        # Parameters that control the generation strategy used
+        self.do_sample = kwargs.pop("do_sample", False)
+        self.num_beams = kwargs.pop("num_beams", 1)
+        self.num_beam_groups = kwargs.pop("num_beam_groups", 1)
+        self.penalty_alpha = kwargs.pop("penalty_alpha", None)
+
+        # Parameters for manipulation of the model output logits
+        self.temperature = kwargs.pop("temperature", 1.0)
+        self.top_k = kwargs.pop("top_k", 50)
+        self.top_p = kwargs.pop("top_p", 1.0)
+        self.typical_p = kwargs.pop("typical_p", 1.0)
+        self.diversity_penalty = kwargs.pop("diversity_penalty", 0.0)
+        self.repetition_penalty = kwargs.pop("repetition_penalty", 1.0)
+        self.length_penalty = kwargs.pop("length_penalty", 1.0)
+        self.no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 0)
+        self.bad_words_ids = kwargs.pop("bad_words_ids", None)
+        self.force_word_ids = kwargs.pop("force_word_ids", None)
+        self.forced_bos_token_id = kwargs.pop("forced_bos_token_id", None)
+        self.forced_eos_token_id = kwargs.pop("forced_eos_token_id", None)
+        self.remove_invalid_values = kwargs.pop("remove_invalid_values", False)
+        self.exponential_decay_length_penalty = kwargs.pop("exponential_decay_length_penalty", None)
+        self.suppress_tokens = kwargs.pop("suppress_tokens", None)
+        self.begin_suppress_tokens = kwargs.pop("begin_suppress_tokens", None)
+        self.forced_decoder_ids = kwargs.pop("forced_decoder_ids", None)
+
+        # Parameters that define the output of `generate`
+        self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
+        self.output_attentions = kwargs.pop("output_attentions", False)
+        self.output_hidden_states = kwargs.pop("output_hidden_states", False)
+        self.output_scores = kwargs.pop("output_scores", False)
+        self.return_dict_in_generate = kwargs.pop("return_dict_in_generate", False)
+
+        # Special tokens
+        self.pad_token_id = kwargs.pop("pad_token_id", None)
+        self.bos_token_id = kwargs.pop("bos_token_id", None)
+        self.eos_token_id = kwargs.pop("eos_token_id", None)
+
+        # Encoder-decoder generation parameters
+        self.encoder_no_repeat_ngram_size = kwargs.pop("encoder_no_repeat_ngram_size", 0)
+        self.decoder_start_token_id = kwargs.pop("decoder_start_token_id", None)
+
+        # Wild card
+        self.generation_kwargs = kwargs.pop("generation_kwargs", {})
+
+        # The remaining attributes do not parametrize `.generate()`, but are used by the the hub interface.
+        # Name or path to the pretrained checkpoint
+        self._name_or_path = str(kwargs.pop("name_or_path", ""))
+        # Config hash
+        self._commit_hash = kwargs.pop("_commit_hash", None)
+        # Drop the transformers version info
+        self.transformers_version = kwargs.pop("transformers_version", None)
+
+    def to_diff_dict(self) -> Dict[str, Any]:
+        """
+        Removes all attributes from config which correspond to the default config attributes for better readability and
+        serializes to a Python dictionary.
+
+        Returns:
+            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance,
+        """
+        config_dict = self.to_dict()
+
+        # get the default config dict
+        default_config_dict = GenerationConfig().to_dict()
+
+        serializable_config_dict = {}
+
+        # only serialize values that differ from the default config
+        for key, value in config_dict.items():
+            if (
+                key not in default_config_dict
+                or key == "transformers_version"
+                or value != default_config_dict[key]
+            ):
+                serializable_config_dict[key] = value
+
+        return serializable_config_dict
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes this instance to a Python dictionary.
+
+        Returns:
+            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
+        """
+        output = copy.deepcopy(self.__dict__)
+        if "_commit_hash" in output:
+            del output["_commit_hash"]
+
+        # Transformers version when serializing this file
+        output["transformers_version"] = __version__
+
+        return output
+
+    def to_json_string(self, use_diff: bool = True) -> str:
+        """
+        Serializes this instance to a JSON string.
+
+        Args:
+            use_diff (`bool`, *optional*, defaults to `True`):
+                If set to `True`, only the difference between the config instance and the default `GenerationConfig()`
+                is serialized to JSON string.
+
+        Returns:
+            `str`: String containing all the attributes that make up this configuration instance in JSON format.
+        """
+        # REVIEWERS: maybe we want to store everything that's non-None (and not just the diff)?
+        if use_diff is True:
+            config_dict = self.to_diff_dict()
+        else:
+            config_dict = self.to_dict()
+        return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
+
+    def to_json_file(self, json_file_path: Union[str, os.PathLike], use_diff: bool = True):
+        """
+        Save this instance to a JSON file.
+
+        Args:
+            json_file_path (`str` or `os.PathLike`):
+                Path to the JSON file in which this configuration instance's parameters will be saved.
+            use_diff (`bool`, *optional*, defaults to `True`):
+                If set to `True`, only the difference between the config instance and the default `GenerationConfig()`
+                is serialized to JSON file.
+        """
+        with open(json_file_path, "w", encoding="utf-8") as writer:
+            writer.write(self.to_json_string(use_diff=use_diff))
+
+    def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):
+        """
+        Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the
+        [`~GenerationConfig.from_pretrained`] class method.
+        Args:
+            save_directory (`str` or `os.PathLike`):
+                Directory where the configuration JSON file will be saved (will be created if it does not exist).
+            push_to_hub (`bool`, *optional*, defaults to `False`):
+                Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
+                repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
+                namespace).
+            kwargs:
+                Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
+        """
+        if os.path.isfile(save_directory):
+            raise AssertionError(f"Provided path ({save_directory}) should be a directory, not a file")
+
+        os.makedirs(save_directory, exist_ok=True)
+
+        if push_to_hub:
+            commit_message = kwargs.pop("commit_message", None)
+            repo_id = kwargs.pop("repo_id", save_directory.split(os.path.sep)[-1])
+            repo_id, token = self._create_repo(repo_id, **kwargs)
+            files_timestamps = self._get_files_timestamps(save_directory)
+
+        # If we save using the predefined names, we can load using `from_pretrained`
+        # REVIEWERS: maybe add arg to specify filename and store all files in a folder?
+        output_config_file = os.path.join(save_directory, GENERATION_CONFIG_NAME)
+
+        self.to_json_file(output_config_file, use_diff=True)
+        logger.info(f"Configuration saved in {output_config_file}")
+
+        if push_to_hub:
+            self._upload_modified_files(
+                save_directory, repo_id, files_timestamps, commit_message=commit_message, token=token
+            )

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -14,12 +14,28 @@
 # limitations under the License.
 """ Generation configuration class and utilities."""
 
-import os
-import json
+# TODO -- Generation config wishlist before making it a public class, ordered:
+# - We can load a Generation Config from a Model Config (to make it compatible with all existing repos)
+# - `.generate()` inherits default values from generate config, instead of from model config
+# - Add doctests for loading, storing, and using with `.generate()`
+# - (bonus) Generate config validates its attributes at initialization time
+
 import copy
+import json
+import os
 from typing import Any, Dict, Union
+
 from .. import __version__
-from ..utils import cached_file, extract_commit_hash, download_url, is_remote_url, PushToHubMixin, logging, GENERATION_CONFIG_NAME
+from ..utils import (
+    GENERATION_CONFIG_NAME,
+    PushToHubMixin,
+    cached_file,
+    download_url,
+    extract_commit_hash,
+    is_remote_url,
+    logging,
+)
+
 
 logger = logging.get_logger(__name__)
 
@@ -27,16 +43,19 @@ logger = logging.get_logger(__name__)
 class GenerationConfig(PushToHubMixin):
     r"""
     Class that holds a configuration for a generation task.
+
     <Tip>
-    A configuration file can be loaded and saved to disk. Loading the configuration file and using this file to
-    initialize a model does **not** change its configuration or weights. It only affects the model's behavior at
-    generation time.
+
+    A configuration file can be loaded and saved to disk. Loading and using a generation configuration file does
+    **not** change a model configuration or weights. It only affects the model's behavior at generation time.
+
     </Tip>
+
     Arg:
         max_length (`int`, *optional*, defaults to `20`):
             The maximum length the generated tokens can have. Corresponds to the length of the input prompt +
-            `max_new_tokens`. In general, prefer the use of `max_new_tokens`, which ignores the number of tokens in
-            the prompt.
+            `max_new_tokens`. In general, prefer the use of `max_new_tokens`, which ignores the number of tokens in the
+            prompt.
         max_new_tokens (`int`, *optional*):
             The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
         min_length (`int`, *optional*, defaults to `0`):
@@ -44,15 +63,15 @@ class GenerationConfig(PushToHubMixin):
         early_stopping (`bool`, *optional*, defaults to `False`):
             Whether to stop the beam search when at least `num_beams` sentences are finished per batch or not.
         max_time(`float`, *optional*):
-            The maximum amount of time you allow the computation to run for in seconds. generation will still
-            finish the current pass after allocated time has been passed.
+            The maximum amount of time you allow the computation to run for in seconds. generation will still finish
+            the current pass after allocated time has been passed.
         do_sample (`bool`, *optional*, defaults to `False`):
             Whether or not to use sampling ; use greedy decoding otherwise.
         num_beams (`int`, *optional*, defaults to `1`):
             Number of beams for beam search. 1 means no beam search.
         num_beam_groups (`int`, *optional*, defaults to `1`):
-            Number of groups to divide `num_beams` into in order to ensure diversity among different groups of
-            beams. [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
+            Number of groups to divide `num_beams` into in order to ensure diversity among different groups of beams.
+            [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
         penalty_alpha (`float`, *optional*):
             The values balance the model confidence and the degeneration penalty in contrastive search decoding.
         temperature (`float`, *optional*, defaults to `1.0`):
@@ -63,20 +82,19 @@ class GenerationConfig(PushToHubMixin):
             If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
             `top_p` or higher are kept for generation.
         typical_p (`float`, *optional*, defaults to `1.0`):
-            The amount of probability mass from the original distribution to be considered in typical decoding. If
-            set to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+            The amount of probability mass from the original distribution to be considered in typical decoding. If set
+            to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         diversity_penalty (`float`, *optional*, defaults to `0.0`):
-            This value is subtracted from a beam's score if it generates a token same as any beam from other group
-            at a particular time. Note that `diversity_penalty` is only effective if `group beam search` is
-            enabled.
+            This value is subtracted from a beam's score if it generates a token same as any beam from other group at a
+            particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.
         repetition_penalty (`float`, *optional*, defaults to `1.0`):
             The parameter for repetition penalty. 1.0 means no penalty. See [this
             paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
         length_penalty (`float`, *optional*, defaults to `1.0`):
-            Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent
-            to the sequence length, which in turn is used to divide the score of the sequence. Since the score is
-            the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences,
-            while `length_penalty` < 0.0 encourages shorter sequences.
+            Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to
+            the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log
+            likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while
+            `length_penalty` < 0.0 encourages shorter sequences.
         no_repeat_ngram_size (`int`, *optional*, defaults to `0`):
             If set to int > 0, all ngrams of that size can only occur once.
         bad_words_ids(`List[List[int]]`, *optional*):
@@ -84,48 +102,48 @@ class GenerationConfig(PushToHubMixin):
             should not appear in the generated text, use `tokenizer(bad_words, add_prefix_space=True,
             add_special_tokens=False).input_ids`.
         force_words_ids(`List[List[int]]` or `List[List[List[int]]]`, *optional*):
-            List of token ids that must be generated. If given a `List[List[int]]`, this is treated as a simple
-            list of words that must be included, the opposite to `bad_words_ids`. If given `List[List[List[int]]]`,
-            this triggers a [disjunctive constraint](https://github.com/huggingface/transformers/issues/14081),
-            where one can allow different forms of each word.
+            List of token ids that must be generated. If given a `List[List[int]]`, this is treated as a simple list of
+            words that must be included, the opposite to `bad_words_ids`. If given `List[List[List[int]]]`, this
+            triggers a [disjunctive constraint](https://github.com/huggingface/transformers/issues/14081), where one
+            can allow different forms of each word.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should use the past last key/values attentions (if applicable to the model) to
             speed up decoding.
         renormalize_logits (`bool`, *optional*, defaults to `False`):
-            Whether to renormalize the logits after applying all the logits processors or warpers (including the
-            custom ones). It's highly recommended to set this flag to `True` as the search algorithms suppose the
-            score logits are normalized but some logit processors or warpers break the normalization.
+            Whether to renormalize the logits after applying all the logits processors or warpers (including the custom
+            ones). It's highly recommended to set this flag to `True` as the search algorithms suppose the score logits
+            are normalized but some logit processors or warpers break the normalization.
         forced_bos_token_id (`int`, *optional*, defaults to `model.config.forced_bos_token_id`):
-            The id of the token to force as the first generated token after the `decoder_start_token_id`. Useful
-            for multilingual models like [mBART](../model_doc/mbart) where the first generated token needs to be
-            the target language token.
+            The id of the token to force as the first generated token after the `decoder_start_token_id`. Useful for
+            multilingual models like [mBART](../model_doc/mbart) where the first generated token needs to be the target
+            language token.
         forced_eos_token_id (`int`, *optional*, defaults to `model.config.forced_eos_token_id`):
             The id of the token to force as the last generated token when `max_length` is reached.
         remove_invalid_values (`bool`, *optional*, defaults to `model.config.remove_invalid_values`):
-            Whether to remove possible *nan* and *inf* outputs of the model to prevent the generation method to
-            crash. Note that using `remove_invalid_values` can slow down generation.
+            Whether to remove possible *nan* and *inf* outputs of the model to prevent the generation method to crash.
+            Note that using `remove_invalid_values` can slow down generation.
         exponential_decay_length_penalty (`tuple(int, float)`, *optional*):
             This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been
-            generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates
-            where penalty starts and `decay_factor` represents the factor of exponential decay
+            generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where
+            penalty starts and `decay_factor` represents the factor of exponential decay
         suppress_tokens  (`List[int]`, *optional*):
-            A list of tokens that will be supressed at generation. The `SupressTokens` logit processor will set
-            their log probs to `-inf` so that they are not sampled.
+            A list of tokens that will be supressed at generation. The `SupressTokens` logit processor will set their
+            log probs to `-inf` so that they are not sampled.
         begin_suppress_tokens  (`List[int]`, *optional*):
-            A list of tokens that will be supressed at the begining of the generation. The `SupressBeginTokens`
-            logit processor will set their log probs to `-inf` so that they are not sampled.
+            A list of tokens that will be supressed at the begining of the generation. The `SupressBeginTokens` logit
+            processor will set their log probs to `-inf` so that they are not sampled.
         forced_decoder_ids (`List[List[int]]`, *optional*):
-            A list of pairs of integers which indicates a mapping from generation indices to token indices that
-            will be forced before sampling. For example, `[[1, 123]]` means the second generated token will always
-            be a token of index 123.
+            A list of pairs of integers which indicates a mapping from generation indices to token indices that will be
+            forced before sampling. For example, `[[1, 123]]` means the second generated token will always be a token
+            of index 123.
         num_return_sequences(`int`, *optional*, defaults to `1`):
             The number of independently computed returned sequences for each element in the batch.
         output_attentions (`bool`, *optional*, defaults to `False`):
-            Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-            returned tensors for more details.
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
+            tensors for more details.
         output_hidden_states (`bool`, *optional*, defaults to `False`):
-            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
-            for more details.
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
+            more details.
         output_scores (`bool`, *optional*, defaults to `False`):
             Whether or not to return the prediction scores. See `scores` under returned tensors for more details.
         return_dict_in_generate (`bool`, *optional*, defaults to `False`):
@@ -179,39 +197,44 @@ class GenerationConfig(PushToHubMixin):
         self.begin_suppress_tokens = kwargs.pop("begin_suppress_tokens", None)
         self.forced_decoder_ids = kwargs.pop("forced_decoder_ids", None)
 
-        # Parameters that define the output of `generate`
+        # Parameters that define the output variables of `generate`
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.output_hidden_states = kwargs.pop("output_hidden_states", False)
         self.output_scores = kwargs.pop("output_scores", False)
         self.return_dict_in_generate = kwargs.pop("return_dict_in_generate", False)
 
-        # Special tokens
+        # Special tokens that can be used at generation time
         self.pad_token_id = kwargs.pop("pad_token_id", None)
         self.bos_token_id = kwargs.pop("bos_token_id", None)
         self.eos_token_id = kwargs.pop("eos_token_id", None)
 
-        # Encoder-decoder generation parameters
+        # Generation parameters exclusive to encoder-decoder models
         self.encoder_no_repeat_ngram_size = kwargs.pop("encoder_no_repeat_ngram_size", 0)
         self.decoder_start_token_id = kwargs.pop("decoder_start_token_id", None)
 
         # Wild card
         self.generation_kwargs = kwargs.pop("generation_kwargs", {})
 
-        # The remaining attributes do not parametrize `.generate()`, but are used by the the hub interface.
-        self._name_or_path = str(kwargs.pop("name_or_path", ""))
+        # The remaining attributes do not parametrize `.generate()`, but are informative and/or used by the the hub interface.
         self._commit_hash = kwargs.pop("_commit_hash", None)
         self.transformers_version = kwargs.pop("transformers_version", None)
 
-    def save_pretrained(self, save_directory: Union[str, os.PathLike], config_name: str = GENERATION_CONFIG_NAME, push_to_hub: bool = False, **kwargs):
+    def save_pretrained(
+        self,
+        save_directory: Union[str, os.PathLike],
+        config_name: str = GENERATION_CONFIG_NAME,
+        push_to_hub: bool = False,
+        **kwargs
+    ):
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # REVIEWERS: As discussed on Slack, this config file has an argument to specify the file name, to facilitate
-        # the creation of multiple generation config files in the root directory of a model.
+        # REVIEWERS: As discussed on Slack, this config file has an argument to specify the file name (`config_name`),
+        # to facilitate the creation of multiple generation config files in the root directory of a model.
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         """
-        Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the
-        [`~GenerationConfig.from_pretrained`] class method.
         Args:
+        Save a generation configuration object to the directory `save_directory`, so that it can be re-loaded using the:
+        [`~GenerationConfig.from_pretrained`] class method.
             save_directory (`str` or `os.PathLike`):
                 Directory where the configuration JSON file will be saved (will be created if it does not exist).
             config_name (`str`, *optional*, defaults to `"generation_config.json"`):
@@ -235,6 +258,11 @@ class GenerationConfig(PushToHubMixin):
             files_timestamps = self._get_files_timestamps(save_directory)
 
         output_config_file = os.path.join(save_directory, config_name)
+
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # REVIEWERS: maybe we want to store all generation attributes that are non-None (and not just the diff)?
+        # That seems more robust against future changes.
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         self.to_json_file(output_config_file, use_diff=True)
         logger.info(f"Configuration saved in {output_config_file}")
 
@@ -244,13 +272,15 @@ class GenerationConfig(PushToHubMixin):
             )
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name: Union[str, os.PathLike], config_name: str = GENERATION_CONFIG_NAME, **kwargs) -> "GenerationConfig":
+    def from_pretrained(
+        cls, pretrained_model_name: Union[str, os.PathLike], config_name: str = GENERATION_CONFIG_NAME, **kwargs
+    ) -> "GenerationConfig":
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # REVIEWERS: Contrarily to the model config, the first argument is a folder (as opposed to a folder OR a
         # file). This is because saving the generation config expects two arguments as well: the folder and the file
         # name.
 
-        # I think maintaing consistency with the save function is more important than with other config classes.
+        # I think maintaing consistency with its save function is more important than with other config classes.
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         r"""
         Instantiate a [`GenerationConfig`] from a generation configuration file.
@@ -463,11 +493,7 @@ class GenerationConfig(PushToHubMixin):
 
         # only serialize values that differ from the default config
         for key, value in config_dict.items():
-            if (
-                key not in default_config_dict
-                or key == "transformers_version"
-                or value != default_config_dict[key]
-            ):
+            if key not in default_config_dict or key == "transformers_version" or value != default_config_dict[key]:
                 serializable_config_dict[key] = value
 
         return serializable_config_dict
@@ -500,9 +526,6 @@ class GenerationConfig(PushToHubMixin):
         Returns:
             `str`: String containing all the attributes that make up this configuration instance in JSON format.
         """
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # REVIEWERS: maybe we want to store all generation attributes that are non-None (and not just the diff)?
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         if use_diff is True:
             config_dict = self.to_diff_dict()
         else:

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -177,6 +177,7 @@ SAFE_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
 CONFIG_NAME = "config.json"
 FEATURE_EXTRACTOR_NAME = "preprocessor_config.json"
 IMAGE_PROCESSOR_NAME = FEATURE_EXTRACTOR_NAME
+GENERATION_CONFIG_NAME = "generation_config.json"
 MODEL_CARD_NAME = "modelcard.json"
 
 SENTENCEPIECE_UNDERLINE = "▁"

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a clone of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+from parameterized import parameterized
+
+from transformers.generation import GenerationConfig
+from transformers.utils import GENERATION_CONFIG_NAME
+
+
+class LogitsProcessorTest(unittest.TestCase):
+    @parameterized.expand([(GENERATION_CONFIG_NAME,), ("foo.json",)])
+    def test_save_load_config(self, config_name):
+        config = GenerationConfig(
+            do_sample=True,
+            temperature=0.7,
+            length_penalty=1.0,
+            bad_words_ids=[[1, 2, 3], [4, 5]],
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config.save_pretrained(tmp_dir, config_name=config_name)
+            loaded_config = GenerationConfig.from_pretrained(tmp_dir, config_name=config_name)
+
+        # Checks parameters that were specified
+        self.assertEqual(loaded_config.do_sample, True)
+        self.assertEqual(loaded_config.temperature, 0.7)
+        self.assertEqual(loaded_config.length_penalty, 1.0)
+        self.assertEqual(loaded_config.bad_words_ids, [[1, 2, 3], [4, 5]])
+
+        # Checks parameters that were not specified (defaults)
+        self.assertEqual(loaded_config.top_k, 50)
+        self.assertEqual(loaded_config.max_length, 20)
+        self.assertEqual(loaded_config.max_time, None)

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -15,8 +15,8 @@
 
 import tempfile
 import unittest
-from parameterized import parameterized
 
+from parameterized import parameterized
 from transformers.generation import GenerationConfig
 from transformers.utils import GENERATION_CONFIG_NAME
 

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -18,11 +18,10 @@ import unittest
 
 from parameterized import parameterized
 from transformers.generation import GenerationConfig
-from transformers.utils import GENERATION_CONFIG_NAME
 
 
 class LogitsProcessorTest(unittest.TestCase):
-    @parameterized.expand([(GENERATION_CONFIG_NAME,), ("foo.json",)])
+    @parameterized.expand([(None,), ("foo.json",)])
     def test_save_load_config(self, config_name):
         config = GenerationConfig(
             do_sample=True,

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -12,8 +12,9 @@ docs/source/en/model_doc/byt5.mdx
 docs/source/en/model_doc/tapex.mdx
 docs/source/en/model_doc/donut.mdx
 docs/source/en/model_doc/encoder-decoder.mdx
-src/transformers/generation/utils.py
+src/transformers/generation/configuration_utils.py
 src/transformers/generation/tf_utils.py
+src/transformers/generation/utils.py
 src/transformers/models/albert/configuration_albert.py
 src/transformers/models/albert/modeling_albert.py
 src/transformers/models/albert/modeling_tf_albert.py


### PR DESCRIPTION
# What does this PR do?

Adds the class that handles generation configurations. From this class, we can then start working on the interaction with other parts of the Hugging Face 🤗 ecosystem. See https://github.com/huggingface/transformers/issues/18655 for the original plan, which matches this implementation.

Throughout the PR, there are a few very visible comments where your input would be appreciated to establish solid base functionality.

The expected follow-up tasks are:
1. We can load a Generation Config from a Model Config (to make it compatible with all existing repos)
2. `.generate()` inherits default values from generate config, instead of from model config. Add an argument to pass a generation configuration.
3. Add doctests for loading, storing, and using with `.generate()`
4. The top 100 models with generate compatibility get a PR with the corresponding generation confg file(s). At least 1 has multiple generation config files, to be used as an example.
5. (bonus) Generate config validates its attributes at initialization time
6. (bonus) Pipelines make automatic use of the appropriate generation config file
7. (bonus) Ensure that advanced functionality (e.g. models like RAG and Trainer) operates well with the generation config file