### PR TITLE
Fixing Spelling Error in Testing Documentation - Issue #20194

### DIFF
--- a/docs/source/en/testing.mdx
+++ b/docs/source/en/testing.mdx
@@ -178,7 +178,7 @@ pytest -k "test and ada" tests/test_optimization.py
 ```
 ### Run documentation tests 
 
-In order to test whether the documentation examples are correct, you should checkt that the `doctests` are passing. 
+In order to test whether the documentation examples are correct, you should check that the `doctests` are passing. 
 As an example, let's use [`WhisperModel.forward`'s docstring](https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/modeling_whisper.py#L1017-L1035): 
 
 ```python 


### PR DESCRIPTION
# What does this PR do?
This PR fixes a spelling error in the testing documentation. Changes "checkt" to "check".

Fixes #20194

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
