### PR TITLE
Quick fix for `test_torch_fx` under torch 1.13

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -59,7 +59,10 @@ logger = logging.get_logger(__name__)
 _IS_IN_DEBUG_MODE = os.environ.get("FX_DEBUG_MODE", "").upper() in ENV_VARS_TRUE_VALUES
 
 
-DEVICE = "cpu"
+DEVICE = "meta"
+if "PYTEST_CURRENT_TEST" in os.environ:
+    # We are running under pytest, act accordingly...
+    DEVICE = "cpu"
 
 
 def _generate_supported_model_class_names(

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -21,6 +21,7 @@ import math
 import operator
 import os
 import random
+import sys
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
@@ -60,7 +61,7 @@ _IS_IN_DEBUG_MODE = os.environ.get("FX_DEBUG_MODE", "").upper() in ENV_VARS_TRUE
 
 
 DEVICE = "meta"
-if "PYTEST_CURRENT_TEST" in os.environ:
+if "pytest" in sys.modules:
     # We are running under pytest, act accordingly...
     DEVICE = "cpu"
 


### PR DESCRIPTION
# What does this PR do?

Quick fix for `test_torch_fx` under torch 1.13.

Since `torch 1.13`, using `meta` device gives some noisy tensors, which breaks `test_torch_fx`.
@michaelbenayoun is more qualified than me to explain this more clearly.

This PR changes the device to "cpu" if `fx.py` is used in the testing. 

running all `test_torch_fx_*` tests:
  -  with "**meta**": 1m33s
  - with "**cpu**": 1m45s

So the speed-up of using `meta` is tiny , and we can just use `cpu`.

However,

**Questions**:
  - It looks like `fx.py` is only used in the testing (at least in `transformers`)?
  - Is this module in `optimum`?
    - If so:
      -  is it used only in testing?
      -  is it used for large real models?