### PR TITLE
Fix `run_clip.py`

### DIFF
--- a/examples/pytorch/contrastive-image-text/run_clip.py
+++ b/examples/pytorch/contrastive-image-text/run_clip.py
@@ -198,7 +198,8 @@ class Transform(torch.nn.Module):
             Normalize(mean, std),
         )
 
-    def forward(self, x: Image) -> torch.Tensor:
+    def forward(self, x) -> torch.Tensor:
+        """`x` should be an instance of `PIL.Image.Image`"""
         with torch.no_grad():
             x = self.transforms(x)
         return x


### PR DESCRIPTION
# What does this PR do?

The type annotation for `Transform.forward` (in `run_clip.py`) never work when I tried several torch/pillow versions.
This forward is compiled by `torch.jit`.

With the current type annotation `x: Image`, we get error
```bash
RuntimeError: 
Unknown type name 'Image':
```

With `x: Image.Image`, error is
```bash
NotSupportedError: Compiled functions can't take variable number of arguments or use keyword-only arguments with defaults:
  File "/home/huggingface/miniconda3/envs/py38/lib/python3.8/site-packages/PIL/Image.py", line 550
    def __exit__(self, *args):
                       ~~~~~ <--- HERE
        if hasattr(self, "fp") and getattr(self, "_exclusive_fp", False):
            if getattr(self, "_fp", False):
'__torch__.PIL.Image.Image' is being compiled since it was called from 'Transform.forward'

```