### PR TITLE
Update reqs to include min gather_for_metrics Accelerate version

### DIFF
--- a/examples/pytorch/image-classification/requirements.txt
+++ b/examples/pytorch/image-classification/requirements.txt
@@ -1,3 +1,4 @@
+accelerate>=0.12.0
 torch>=1.5.0
 torchvision>=0.6.0
 datasets>=1.17.0

--- a/examples/pytorch/language-modeling/requirements.txt
+++ b/examples/pytorch/language-modeling/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 torch >= 1.3
 datasets >= 1.8.0
 sentencepiece != 0.1.92

--- a/examples/pytorch/multiple-choice/requirements.txt
+++ b/examples/pytorch/multiple-choice/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 sentencepiece != 0.1.92
 protobuf
 torch >= 1.3

--- a/examples/pytorch/question-answering/requirements.txt
+++ b/examples/pytorch/question-answering/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 datasets >= 1.8.0
 torch >= 1.3.0
 evaluate

--- a/examples/pytorch/speech-pretraining/requirements.txt
+++ b/examples/pytorch/speech-pretraining/requirements.txt
@@ -1,5 +1,5 @@
 datasets >= 1.12.0
 torch >= 1.5
 torchaudio
-accelerate >= 0.5.0
+accelerate >= 0.12.0
 librosa

--- a/examples/pytorch/summarization/requirements.txt
+++ b/examples/pytorch/summarization/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/examples/pytorch/text-classification/requirements.txt
+++ b/examples/pytorch/text-classification/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 scipy

--- a/examples/pytorch/token-classification/requirements.txt
+++ b/examples/pytorch/token-classification/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 seqeval
 datasets >= 1.8.0
 torch >= 1.3

--- a/examples/pytorch/translation/requirements.txt
+++ b/examples/pytorch/translation/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+accelerate >= 0.12.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf


### PR DESCRIPTION
# What does this PR do?
Update all the PyTorch examples using `accelerate` and `gather_for_metrics` to include a minimum accelerate version of 0.12.0 since this introduced `gather_for_metrics`


Related to https://github.com/huggingface/accelerate/issues/854

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 
