### PR TITLE
[SegFormer] Add support for segmentation masks with one label

### DIFF
--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -819,7 +819,7 @@ class SegformerForSemanticSegmentation(SegformerPreTrainedModel):
                 loss = loss_fct(upsampled_logits.squeeze(1), labels.float())
                 loss = (loss * valid_mask).mean()
             else:
-                raise ValueError("Number of labels should be >=0: {}".format(self.config.num_labels))
+                raise ValueError(f"Number of labels should be >=0: {self.config.num_labels}")
 
         if not return_dict:
             if output_hidden_states:

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -813,11 +813,13 @@ class SegformerForSemanticSegmentation(SegformerPreTrainedModel):
             if self.config.num_labels > 1:
                 loss_fct = CrossEntropyLoss(ignore_index=self.config.semantic_loss_ignore_index)
                 loss = loss_fct(upsampled_logits, labels)
-            else:
+            elif self.config.num_labels == 1:
                 valid_mask = ((labels >= 0) & (labels != self.config.semantic_loss_ignore_index)).float()
-                loss_fct = BCEWithLogitsLoss(redction="none")
-                loss = loss_fct(upsampled_logits, labels.float())
+                loss_fct = BCEWithLogitsLoss(reduction="none")
+                loss = loss_fct(upsampled_logits.squeeze(1), labels.float())
                 loss = (loss * valid_mask).mean()
+            else:
+                raise ValueError("Number of labels should be >=0: {}".format(self.config.num_labels))
 
         if not return_dict:
             if output_hidden_states:

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -806,15 +806,18 @@ class SegformerForSemanticSegmentation(SegformerPreTrainedModel):
 
         loss = None
         if labels is not None:
-            if not self.config.num_labels > 1:
-                raise ValueError("The number of labels should be greater than one")
-            else:
-                # upsample logits to the images' original size
-                upsampled_logits = nn.functional.interpolate(
-                    logits, size=labels.shape[-2:], mode="bilinear", align_corners=False
-                )
+            # upsample logits to the images' original size
+            upsampled_logits = nn.functional.interpolate(
+                logits, size=labels.shape[-2:], mode="bilinear", align_corners=False
+            )
+            if self.config.num_labels > 1:
                 loss_fct = CrossEntropyLoss(ignore_index=self.config.semantic_loss_ignore_index)
                 loss = loss_fct(upsampled_logits, labels)
+            else:
+                valid_mask = ((labels >= 0) & (labels != self.config.semantic_loss_ignore_index)).float()
+                loss_fct = BCEWithLogitsLoss(redction="none")
+                loss = loss_fct(upsampled_logits, labels.float())
+                loss = (loss * valid_mask).mean()
 
         if not return_dict:
             if output_hidden_states:

--- a/tests/models/segformer/test_modeling_segformer.py
+++ b/tests/models/segformer/test_modeling_segformer.py
@@ -140,6 +140,17 @@ class SegformerModelTester:
         self.parent.assertEqual(
             result.logits.shape, (self.batch_size, self.num_labels, self.image_size // 4, self.image_size // 4)
         )
+        self.parent.assertGreater(result.loss, 0.0)
+
+
+    def create_and_check_for_binary_image_segmentation(self, config, pixel_values, labels):
+        config.num_labels = 1
+        model = SegformerForSemanticSegmentation(config=config)
+        model.to(torch_device)
+        model.eval()
+        labels = torch.randint(0, 1, (self.batch_size, self.image_size, self.image_size)).to(torch_device)
+        result = model(pixel_values, labels=labels)
+        self.parent.assertGreater(result.loss, 0.0)
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
@@ -176,6 +187,10 @@ class SegformerModelTest(ModelTesterMixin, unittest.TestCase):
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_for_binary_image_segmentation(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_for_binary_image_segmentation(*config_and_inputs)
 
     def test_for_image_segmentation(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/segformer/test_modeling_segformer.py
+++ b/tests/models/segformer/test_modeling_segformer.py
@@ -142,7 +142,6 @@ class SegformerModelTester:
         )
         self.parent.assertGreater(result.loss, 0.0)
 
-
     def create_and_check_for_binary_image_segmentation(self, config, pixel_values, labels):
         config.num_labels = 1
         model = SegformerForSemanticSegmentation(config=config)


### PR DESCRIPTION
# What does this PR do?

This PR makes it possible to fine-tune SegFormer in case you have a mask containing only a single value, i.e. your mask could look like [[255, 0], [0, 255]]. In this case, config.num_labels = 1 and the ignore index is 255.

If this works fine, then we can add it to any other model supported by `AutoModelForSemanticSegmentation`.

