### PR TITLE
Pin TensorFlow as new release breaks `pip install transformers["all"]`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ _deps = [
     "librosa",
     "starlette",
     "tensorflow-cpu>=2.3",
-    "tensorflow>=2.4",
+    "tensorflow>=2.4,<2.10",
     "tensorflow-text",
     "tf2onnx",
     "timeout-decorator",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -63,7 +63,7 @@ deps = {
     "librosa": "librosa",
     "starlette": "starlette",
     "tensorflow-cpu": "tensorflow-cpu>=2.3",
-    "tensorflow": "tensorflow>=2.4",
+    "tensorflow": "tensorflow>=2.4,<2.10",
     "tensorflow-text": "tensorflow-text",
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",


### PR DESCRIPTION
# What does this PR do?

This PR pins TensorFlow for now, as it seems there is no version of `tensorflow-text` compatible with it.