### PR TITLE
TF: future proof our keras imports

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -217,8 +217,9 @@ def load_pytorch_state_dict_in_tf2_model(
 ):
     """Load a pytorch state_dict in a TF 2.0 model."""
     import tensorflow as tf
+    from packaging.version import parse
 
-    if tf.__version__ >= "2.11.0":
+    if parse(tf.__version__) >= parse("2.11.0"):
         from keras import backend as K
     else:
         from tensorflow.python.keras import backend as K

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -216,7 +216,12 @@ def load_pytorch_state_dict_in_tf2_model(
     tf_model, pt_state_dict, tf_inputs=None, allow_missing_keys=False, output_loading_info=False
 ):
     """Load a pytorch state_dict in a TF 2.0 model."""
-    from tensorflow.python.keras import backend as K
+    import tensorflow as tf
+
+    if tf.__version__ >= "2.11.0":
+        from keras import backend as K
+    else:
+        from tensorflow.python.keras import backend as K
 
     if tf_inputs is None:
         tf_inputs = tf_model.dummy_inputs

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -30,13 +30,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 import h5py
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.engine import data_adapter
-from tensorflow.python.keras.engine.keras_tensor import KerasTensor
-from tensorflow.python.keras.saving import hdf5_format
 
 from huggingface_hub import Repository, list_repo_files
-from keras.saving.hdf5_format import save_attributes_to_hdf5_group
 from transformers.utils.hub import convert_file_size_to_int, get_checkpoint_shard_files
 
 from . import DataCollatorWithPadding, DefaultDataCollator
@@ -66,6 +61,18 @@ from .utils import (
     requires_backends,
     working_or_temp_dir,
 )
+
+
+if tf.__version__ >= "2.11.0":
+    from keras import backend as K
+    from keras.engine import data_adapter
+    from keras.engine.keras_tensor import KerasTensor
+    from keras.saving.legacy import hdf5_format
+else:
+    from tensorflow.python.keras import backend as K
+    from tensorflow.python.keras.engine import data_adapter
+    from tensorflow.python.keras.engine.keras_tensor import KerasTensor
+    from tensorflow.python.keras.saving import hdf5_format
 
 
 if is_safetensors_available():
@@ -2310,7 +2317,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                         )
                         param_dset[:] = layer.numpy()
                         layers.append(layer_name.encode("utf8"))
-                    save_attributes_to_hdf5_group(shard_file, "layer_names", layers)
+                    hdf5_format.save_attributes_to_hdf5_group(shard_file, "layer_names", layers)
 
         if push_to_hub:
             self._upload_modified_files(

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 import h5py
 import numpy as np
 import tensorflow as tf
+from packaging.version import parse
 
 from huggingface_hub import Repository, list_repo_files
 from transformers.utils.hub import convert_file_size_to_int, get_checkpoint_shard_files
@@ -63,7 +64,7 @@ from .utils import (
 )
 
 
-if tf.__version__ >= "2.11.0":
+if parse(tf.__version__) >= parse("2.11.0"):
     from keras import backend as K
     from keras.engine import data_adapter
     from keras.engine.keras_tensor import KerasTensor


### PR DESCRIPTION
# What does this PR do?

On the release notes for [TF 2.11](https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0), we can read:

```
tensorflow/python/keras code is a legacy copy of Keras since the TensorFlow v2.7 release, and 
will be deleted in the v2.12 release. Please remove any import of tensorflow.python.keras and 
use the public API with `from tensorflow import keras` or `import tensorflow as tf; tf.keras`.
```

On top of that, `hdf5_format` was moved from `keras.saving` to `keras.saving.legacy` in v2.11 (this one is not in the patch notes). 

This PR prepares us for v2.11 and beyond, while keeping retrocompatibility through gated imports.

Note: I've tested the v2.11 imports locally :) (the CI is running against v2.10)