### PR TITLE
Enhance HfArgumentParser functionality and ease of use

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -20,7 +20,7 @@ from copy import copy
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, NewType, Optional, Tuple, Union, get_type_hints
+from typing import Any, Callable, Dict, Iterable, Literal, NewType, Optional, Tuple, Union, get_type_hints
 
 import yaml
 
@@ -41,6 +41,55 @@ def string_to_bool(v):
         raise ArgumentTypeError(
             f"Truthy value expected: got {v} but expected one of yes/no, true/false, t/f, y/n, 1/0 (case insensitive)."
         )
+
+
+def HfArg(
+    *,
+    aliases: Union[str, list[str]] = None,
+    help: str = None,
+    default: Any = dataclasses.MISSING,
+    default_factory: Callable[[], Any] = dataclasses.MISSING,
+    metadata: dict = None,
+    **kwargs,
+):
+    """
+    Argument helper enabling a concise syntax to create dataclass fields for parsing with HfArgumentParser.
+
+    Example comparing the use of `HfArg` and `dataclasses.field`:
+    ```
+    @dataclass
+    class Args:
+        regular_arg: str = dataclasses.field(default="Huggingface", metadata={"aliases"=["--example", "-e"], "help"="This syntax could be better!"})
+        hf_arg: str = HfArg(default="Huggingface", aliases=["--example", "-e"], help="What a nice syntax!")
+    ```
+
+    Args:
+        aliases:
+            Single string or list of strings of aliases to pass on to argparse, e.g. `aliases=["--example", "-e"]`
+        help:
+            Help string to pass on to argparse that can be displayed with --help.
+        default:
+            Default value. If not default or default_factory is specified, the argument is required.
+        default_factory:
+            The default_factory is a 0-argument function called to initialize a field's value.
+            It is useful to provide default values for mutable types, e.g. lists: `default_factory=list`
+        metadata:
+            Further metadata to pass on to `dataclasses.field`.
+        kwargs:
+            (Optional) Passed on to `dataclasses.field`.
+
+    Returns:
+        A `dataclasses.field` with the desired properties.
+    """
+    if metadata is None:
+        # Important, don't use as default param in function signature because dict is mutable and shared across function calls
+        metadata = dict()
+    if aliases is not None:
+        metadata["aliases"] = aliases
+    if help is not None:
+        metadata["help"] = help
+
+    return dataclasses.field(metadata=metadata, default=default, default_factory=default_factory, **kwargs)
 
 
 class HfArgumentParser(ArgumentParser):
@@ -84,6 +133,10 @@ class HfArgumentParser(ArgumentParser):
                 "`typing.get_type_hints` method by default"
             )
 
+        aliases = kwargs.pop("aliases", [])
+        if isinstance(aliases, str):
+            aliases = [aliases]
+
         origin_type = getattr(field.type, "__origin__", field.type)
         if origin_type is Union:
             if str not in field.type.__args__ and (
@@ -108,9 +161,14 @@ class HfArgumentParser(ArgumentParser):
         # A variable to store kwargs for a boolean field, if needed
         # so that we can init a `no_*` complement argument (see below)
         bool_kwargs = {}
-        if isinstance(field.type, type) and issubclass(field.type, Enum):
-            kwargs["choices"] = [x.value for x in field.type]
-            kwargs["type"] = type(kwargs["choices"][0])
+        if origin_type is Literal or isinstance(field.type, type) and issubclass(field.type, Enum):
+            if origin_type is Literal:
+                kwargs["choices"] = field.type.__args__
+            else:
+                kwargs["choices"] = [x.value for x in field.type]
+            # This allows mixed types between the choices
+            str_to_choice = {str(choice): choice for choice in kwargs["choices"]}
+            kwargs["type"] = lambda arg: str_to_choice.get(arg, arg)
             if field.default is not dataclasses.MISSING:
                 kwargs["default"] = field.default
             else:
@@ -146,7 +204,7 @@ class HfArgumentParser(ArgumentParser):
                 kwargs["default"] = field.default_factory()
             else:
                 kwargs["required"] = True
-        parser.add_argument(field_name, **kwargs)
+        parser.add_argument(field_name, *aliases, **kwargs)
 
         # Add a complement `no_*` argument for a boolean field AFTER the initial field has already been added.
         # Order is important for arguments with the same destination!
@@ -178,7 +236,12 @@ class HfArgumentParser(ArgumentParser):
             self._parse_dataclass_field(parser, field)
 
     def parse_args_into_dataclasses(
-        self, args=None, return_remaining_strings=False, look_for_args_file=True, args_filename=None
+        self,
+        args=None,
+        return_remaining_strings=False,
+        look_for_args_file=True,
+        args_filename=None,
+        args_file_flag=None,
     ) -> Tuple[DataClass, ...]:
         """
         Parse command-line args into instances of the specified dataclass types.
@@ -196,6 +259,9 @@ class HfArgumentParser(ArgumentParser):
                 process, and will append its potential content to the command line args.
             args_filename:
                 If not None, will uses this file instead of the ".args" file specified in the previous argument.
+            args_file_flag:
+                If not None, will look for a file in the command-line args specified with this flag.
+                The flag can be specified multiple times and precedence is determined by the order (last one wins).
 
         Returns:
             Tuple consisting of:
@@ -205,17 +271,37 @@ class HfArgumentParser(ArgumentParser):
                   after initialization.
                 - The potential list of remaining argument strings. (same as argparse.ArgumentParser.parse_known_args)
         """
-        if args_filename or (look_for_args_file and len(sys.argv)):
-            if args_filename:
-                args_file = Path(args_filename)
-            else:
-                args_file = Path(sys.argv[0]).with_suffix(".args")
 
-            if args_file.exists():
-                fargs = args_file.read_text().split()
-                args = fargs + args if args is not None else fargs + sys.argv[1:]
-                # in case of duplicate arguments the first one has precedence
-                # so we append rather than prepend.
+        if args_file_flag or args_filename or (look_for_args_file and len(sys.argv)):
+            args_files = []
+
+            if args_filename:
+                args_files.append(Path(args_filename))
+            elif look_for_args_file and len(sys.argv):
+                args_files.append(Path(sys.argv[0]).with_suffix(".args"))
+
+            # args files specified via command line flag should overwrite default args files so we add them last
+            if args_file_flag:
+                # Create special parser just to extract the args_file_flag values
+                args_file_parser = ArgumentParser()
+                args_file_parser.add_argument(args_file_flag, type=str, action="append")
+
+                # Use only remaining args for further parsing (remove the args_file_flag)
+                cfg, args = args_file_parser.parse_known_args(args=args)
+                cmd_args_file_paths = vars(cfg).get(args_file_flag.lstrip("-"), None)
+
+                if cmd_args_file_paths:
+                    args_files.extend([Path(p) for p in cmd_args_file_paths])
+
+            file_args = []
+            for args_file in args_files:
+                # TODO: print warning if file does not exist?
+                if args_file.exists():
+                    file_args += args_file.read_text().split()
+
+            # in case of duplicate arguments the last one has precedence
+            # args specified via the command line should overwrite args from files, so we add them last
+            args = file_args + args if args is not None else file_args + sys.argv[1:]
         namespace, remaining_args = self.parse_known_args(args=args)
         outputs = []
         for dtype in self.dataclass_types:

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -16,7 +16,6 @@ import dataclasses
 import json
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError
-from ast import Call
 from copy import copy
 from enum import Enum
 from inspect import isclass

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -54,7 +54,8 @@ def string_to_bool(v):
 
 def make_choice_type_function(choices: list) -> Callable[[str], Any]:
     """
-    Creates a mapping function from each choices string representation to the actual value. Used to support multiple value types for a single argument.
+    Creates a mapping function from each choices string representation to the actual value. Used to support multiple
+    value types for a single argument.
 
     Args:
         choices (list): List of choices.
@@ -86,11 +87,17 @@ def HfArg(
     ```
 
     Args:
-        aliases (Union[str, List[str]], optional): Single string or list of strings of aliases to pass on to argparse, e.g. `aliases=["--example", "-e"]`. Defaults to None.
+        aliases (Union[str, List[str]], optional):
+            Single string or list of strings of aliases to pass on to argparse, e.g. `aliases=["--example", "-e"]`.
+            Defaults to None.
         help (str, optional): Help string to pass on to argparse that can be displayed with --help. Defaults to None.
-        default (Any, optional): Default value for the argument. If not default or default_factory is specified, the argument is required. Defaults to dataclasses.MISSING.
-        default_factory (Callable[[], Any], optional): The default_factory is a 0-argument function called to initialize a field's value. It is useful to provide
-            default values for mutable types, e.g. lists: `default_factory=list`. Mutually exclusive with `default=`. Defaults to dataclasses.MISSING.
+        default (Any, optional):
+            Default value for the argument. If not default or default_factory is specified, the argument is required.
+            Defaults to dataclasses.MISSING.
+        default_factory (Callable[[], Any], optional):
+            The default_factory is a 0-argument function called to initialize a field's value. It is useful to provide
+            default values for mutable types, e.g. lists: `default_factory=list`. Mutually exclusive with `default=`.
+            Defaults to dataclasses.MISSING.
         metadata (dict, optional): Further metadata to pass on to `dataclasses.field`. Defaults to None.
 
     Returns:

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -20,9 +20,21 @@ from copy import copy
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Literal, NewType, Optional, Tuple, Union, get_type_hints
+from typing import Any, Callable, Dict, Iterable, List, NewType, Optional, Tuple, Union, get_type_hints
 
 import yaml
+
+
+try:
+    # For Python versions <3.8, Literal is not in typing: https://peps.python.org/pep-0586/
+    from typing import Literal
+except ImportError:
+    try:
+        # For Python 3.7
+        from typing_extensions import Literal
+    except ImportError:
+        # On older Python versions, we cannot use Literal
+        Literal = "LiteralNotAvailable"
 
 
 DataClass = NewType("DataClass", Any)
@@ -45,7 +57,7 @@ def string_to_bool(v):
 
 def HfArg(
     *,
-    aliases: Union[str, list[str]] = None,
+    aliases: Union[str, List[str]] = None,
     help: str = None,
     default: Any = dataclasses.MISSING,
     default_factory: Callable[[], Any] = dataclasses.MISSING,
@@ -53,13 +65,13 @@ def HfArg(
     **kwargs,
 ):
     """
-    Argument helper enabling a concise syntax to create dataclass fields for parsing with HfArgumentParser.
+    Argument helper enabling a concise syntax to create dataclass fields for parsing with `HfArgumentParser`.
 
     Example comparing the use of `HfArg` and `dataclasses.field`:
     ```
     @dataclass
     class Args:
-        regular_arg: str = dataclasses.field(default="Huggingface", metadata={"aliases"=["--example", "-e"], "help"="This syntax could be better!"})
+        regular_arg: str = dataclasses.field(default="Huggingface", metadata={"aliases": ["--example", "-e"], "help": "This syntax could be better!"})
         hf_arg: str = HfArg(default="Huggingface", aliases=["--example", "-e"], help="What a nice syntax!")
     ```
 
@@ -83,7 +95,7 @@ def HfArg(
     """
     if metadata is None:
         # Important, don't use as default param in function signature because dict is mutable and shared across function calls
-        metadata = dict()
+        metadata = {}
     if aliases is not None:
         metadata["aliases"] = aliases
     if help is not None:
@@ -295,7 +307,6 @@ class HfArgumentParser(ArgumentParser):
 
             file_args = []
             for args_file in args_files:
-                # TODO: print warning if file does not exist?
                 if args_file.exists():
                     file_args += args_file.read_text().split()
 

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -32,12 +32,8 @@ try:
     # For Python versions <3.8, Literal is not in typing: https://peps.python.org/pep-0586/
     from typing import Literal
 except ImportError:
-    try:
-        # For Python 3.7
-        from typing_extensions import Literal
-    except ImportError:
-        # On older Python versions, we cannot use Literal
-        Literal = None
+    # For Python 3.7
+    from typing_extensions import Literal
 
 
 def list_field(default=None, metadata=None):
@@ -224,10 +220,6 @@ class HfArgumentParserTest(unittest.TestCase):
         self.assertEqual(enum_ex.foo, MixedTypeEnum.fourtytwo)
 
     def test_with_literal(self):
-        # In Python 3.6, we don't have Literal
-        if Literal is None:
-            return
-
         @dataclass
         class LiteralExample:
             foo: Literal["titi", "toto", 42] = "toto"

--- a/tests/utils/test_hf_argparser.py
+++ b/tests/utils/test_hf_argparser.py
@@ -25,7 +25,19 @@ from typing import List, Optional
 
 import yaml
 from transformers import HfArgumentParser, TrainingArguments
-from transformers.hf_argparser import string_to_bool
+from transformers.hf_argparser import make_choice_type_function, string_to_bool
+
+
+try:
+    # For Python versions <3.8, Literal is not in typing: https://peps.python.org/pep-0586/
+    from typing import Literal
+except ImportError:
+    try:
+        # For Python 3.7
+        from typing_extensions import Literal
+    except ImportError:
+        # On older Python versions, we cannot use Literal
+        Literal = None
 
 
 def list_field(default=None, metadata=None):
@@ -58,12 +70,26 @@ class BasicEnum(Enum):
     toto = "toto"
 
 
+class MixedTypeEnum(Enum):
+    titi = "titi"
+    toto = "toto"
+    fourtytwo = 42
+
+
 @dataclass
 class EnumExample:
     foo: BasicEnum = "toto"
 
     def __post_init__(self):
         self.foo = BasicEnum(self.foo)
+
+
+@dataclass
+class MixedTypeEnumExample:
+    foo: MixedTypeEnum = "toto"
+
+    def __post_init__(self):
+        self.foo = MixedTypeEnum(self.foo)
 
 
 @dataclass
@@ -111,6 +137,14 @@ class HfArgumentParserTest(unittest.TestCase):
         for x, y in zip(a._actions, b._actions):
             xx = {k: v for k, v in vars(x).items() if k != "container"}
             yy = {k: v for k, v in vars(y).items() if k != "container"}
+
+            # Choices with mixed type have custom function as "type"
+            # So we need to compare results directly for equality
+            if xx.get("choices", None) and yy.get("choices", None):
+                for expected_choice in yy["choices"] + xx["choices"]:
+                    self.assertEqual(xx["type"](expected_choice), yy["type"](expected_choice))
+                del xx["type"], yy["type"]
+
             self.assertEqual(xx, yy)
 
     def test_basic(self):
@@ -163,21 +197,60 @@ class HfArgumentParserTest(unittest.TestCase):
         self.assertEqual(args, Namespace(foo=False, baz=False, opt=False))
 
     def test_with_enum(self):
-        parser = HfArgumentParser(EnumExample)
+        parser = HfArgumentParser(MixedTypeEnumExample)
 
         expected = argparse.ArgumentParser()
-        expected.add_argument("--foo", default="toto", choices=["titi", "toto"], type=str)
+        expected.add_argument(
+            "--foo",
+            default="toto",
+            choices=["titi", "toto", 42],
+            type=make_choice_type_function(["titi", "toto", 42]),
+        )
         self.argparsersEqual(parser, expected)
 
         args = parser.parse_args([])
         self.assertEqual(args.foo, "toto")
         enum_ex = parser.parse_args_into_dataclasses([])[0]
-        self.assertEqual(enum_ex.foo, BasicEnum.toto)
+        self.assertEqual(enum_ex.foo, MixedTypeEnum.toto)
 
         args = parser.parse_args(["--foo", "titi"])
         self.assertEqual(args.foo, "titi")
         enum_ex = parser.parse_args_into_dataclasses(["--foo", "titi"])[0]
-        self.assertEqual(enum_ex.foo, BasicEnum.titi)
+        self.assertEqual(enum_ex.foo, MixedTypeEnum.titi)
+
+        args = parser.parse_args(["--foo", "42"])
+        self.assertEqual(args.foo, 42)
+        enum_ex = parser.parse_args_into_dataclasses(["--foo", "42"])[0]
+        self.assertEqual(enum_ex.foo, MixedTypeEnum.fourtytwo)
+
+    def test_with_literal(self):
+        # In Python 3.6, we don't have Literal
+        if Literal is None:
+            return
+
+        @dataclass
+        class LiteralExample:
+            foo: Literal["titi", "toto", 42] = "toto"
+
+        parser = HfArgumentParser(LiteralExample)
+
+        expected = argparse.ArgumentParser()
+        expected.add_argument(
+            "--foo",
+            default="toto",
+            choices=("titi", "toto", 42),
+            type=make_choice_type_function(["titi", "toto", 42]),
+        )
+        self.argparsersEqual(parser, expected)
+
+        args = parser.parse_args([])
+        self.assertEqual(args.foo, "toto")
+
+        args = parser.parse_args(["--foo", "titi"])
+        self.assertEqual(args.foo, "titi")
+
+        args = parser.parse_args(["--foo", "42"])
+        self.assertEqual(args.foo, 42)
 
     def test_with_list(self):
         parser = HfArgumentParser(ListExample)
@@ -222,7 +295,12 @@ class HfArgumentParserTest(unittest.TestCase):
         expected = argparse.ArgumentParser()
         expected.add_argument("--required_list", nargs="+", type=int, required=True)
         expected.add_argument("--required_str", type=str, required=True)
-        expected.add_argument("--required_enum", type=str, choices=["titi", "toto"], required=True)
+        expected.add_argument(
+            "--required_enum",
+            type=make_choice_type_function(["titi", "toto"]),
+            choices=["titi", "toto"],
+            required=True,
+        )
         self.argparsersEqual(parser, expected)
 
     def test_with_string_literal_annotation(self):
@@ -230,7 +308,12 @@ class HfArgumentParserTest(unittest.TestCase):
 
         expected = argparse.ArgumentParser()
         expected.add_argument("--foo", type=int, required=True)
-        expected.add_argument("--required_enum", type=str, choices=["titi", "toto"], required=True)
+        expected.add_argument(
+            "--required_enum",
+            type=make_choice_type_function(["titi", "toto"]),
+            choices=["titi", "toto"],
+            required=True,
+        )
         expected.add_argument("--opt", type=string_to_bool, default=None)
         expected.add_argument("--baz", default="toto", type=str, help="help message")
         expected.add_argument("--foo_str", nargs="+", default=["Hallo", "Bonjour", "Hello"], type=str)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

I have enhanced the `HfArgumentParser` for my own work and decided to contribute my changes back to `transformers`.

The changes are:
- Allow aliases for command line flags to be created (by providing `aliases` inside the metadata dict)
- Enable specification of one or multiple config files via a customizable command line flag (e.g. `--cfg ./path/to/basic-config.txt --cfg ./path/to/special.txt`). For my own use, I set the customizable command line flag to `"--cfg"` by default. I omitted this here to keep 100% backwards compatibility but a sensible default might make sense as well.
- Enable use of the `Literal` type for easy ad-hoc specification of choices without the need to define an `Enum` (inspired by [typed-argument-parser](https://github.com/swansonk14/typed-argument-parser)):
```python
@dataclass
class Args:
    literal_arg: Literal["the meaning of life", 42, "hitchhiking"] = 42
```
- Allow use of mixed types for `Enum` similar to `Literal`
- Created `HfArg` helper for a more concise syntax when creating data class fields:
```python
@dataclass
class Args:
    field_arg: int = field(default=42, metadata={"aliases": ["--arg", "-a"], "help": "This is a bit verbose."})
    hf_arg: int = HfArg(default=42, aliases=["--arg", "-a"], help="This is more concise.")
```



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
@sgugger