### PR TITLE
Fix nightly runs

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -386,6 +386,7 @@ def create_circleci_config(folder=None):
     if len(jobs) > 0:
         config = {"version": "2.1"}
         config["parameters"] = {
+            # Only used to accept the parameters from the trigger
             "nightly": {"type": "boolean", "default": False},
             "tests_to_run": {"type": "string", "default": test_list},
         }

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -386,7 +386,7 @@ def create_circleci_config(folder=None):
     if len(jobs) > 0:
         config = {"version": "2.1"}
         config["parameters"] = {
-            "nightly": {"type": "bool", "default": False},
+            "nightly": {"type": "boolean", "default": False},
             "tests_to_run": {"type": "string", "default": test_list},
         }
         config["jobs"] = {j.job_name: j.to_dict() for j in jobs}

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -385,7 +385,10 @@ def create_circleci_config(folder=None):
 
     if len(jobs) > 0:
         config = {"version": "2.1"}
-        config["parameters"] = {"tests_to_run": {"type": "string", "default": test_list}}
+        config["parameters"] = {
+            "nightly": {"type": "bool", "default": False},
+            "tests_to_run": {"type": "string", "default": test_list},
+        }
         config["jobs"] = {j.job_name: j.to_dict() for j in jobs}
         config["workflows"] = {"version": 2, "run_tests": {"jobs": [j.job_name for j in jobs]}}
         with open(os.path.join(folder, "generated_config.yml"), "w") as f:


### PR DESCRIPTION
# What does this PR do?

The pipeline that runs the nightly tests exits with `Unexpected argument(s): nightly` instead of running all tests. I think we just need to add it in the custom config as an argument (unused) so circleCI doesn't complain anymore.

Manually triggered the tests on this branch with `nightly` at `true` and it ran all tests (see workflow nightly in the tests).