### PR TITLE
Add missing tokenizer tests - RemBert

### DIFF
--- a/tests/models/rembert/test_tokenization_rembert.py
+++ b/tests/models/rembert/test_tokenization_rembert.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2018 HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import RemBertTokenizer, RemBertTokenizerFast
+from transformers.testing_utils import require_tokenizers
+from transformers.utils import is_torch_available
+
+from ...test_tokenization_common import TokenizerTesterMixin
+
+
+FRAMEWORK = "pt" if is_torch_available() else "tf"
+
+
+@require_tokenizers
+class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+
+    tokenizer_class = RemBertTokenizer
+    rust_tokenizer_class = RemBertTokenizerFast
+    test_rust_tokenizer = True
+    test_sentencepiece = True
+
+    def setUp(self):
+        super().setUp()
+
+        tokenizer = RemBertTokenizer.from_pretrained("google/rembert")
+        tokenizer.save_pretrained(self.tmpdirname)
+
+    def test_convert_token_and_id(self):
+        """Test ``_convert_token_to_id`` and ``_convert_id_to_token``."""
+        token = "[PAD]"
+        token_id = 0
+
+        self.assertEqual(self.get_tokenizer()._convert_token_to_id(token), token_id)
+        self.assertEqual(self.get_tokenizer()._convert_id_to_token(token_id), token)
+
+    def test_get_vocab(self):
+        vocab_keys = list(self.get_tokenizer().get_vocab().keys())
+
+        self.assertEqual(vocab_keys[0], "[PAD]")
+        self.assertEqual(vocab_keys[1], "</s>")
+        self.assertEqual(vocab_keys[-1], "ઞ")
+        self.assertEqual(len(vocab_keys), 250300)
+
+    def test_vocab_size(self):
+        self.assertEqual(self.get_tokenizer().vocab_size, 250300)
+
+    def test_rust_and_python_bpe_tokenizers(self):
+        tokenizer = RemBertTokenizer.from_pretrained("google/rembert")
+        tokenizer.save_pretrained(self.tmpdirname)
+        rust_tokenizer = RemBertTokenizerFast.from_pretrained(self.tmpdirname)
+
+        sequence = "Hi I am new at huggingface."
+
+        ids = tokenizer.encode(sequence)
+        rust_ids = rust_tokenizer.encode(sequence)
+        self.assertListEqual(ids, rust_ids)
+
+        ids = tokenizer.encode(sequence, add_special_tokens=False)
+        rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
+        self.assertListEqual(ids, rust_ids)
+
+        tokens = tokenizer.convert_ids_to_tokens(ids)
+        rust_tokens = rust_tokenizer.tokenize(sequence)
+        self.assertListEqual(tokens, rust_tokens)
+
+    def test_rust_and_python_full_tokenizers(self):
+        if not self.test_rust_tokenizer:
+            return
+
+        tokenizer = self.get_tokenizer()
+        rust_tokenizer = self.get_rust_tokenizer()
+
+        sequence = "Hi I am new at huggingface."
+
+        tokens = tokenizer.tokenize(sequence)
+        rust_tokens = rust_tokenizer.tokenize(sequence)
+        self.assertListEqual(tokens, rust_tokens)
+
+        ids = tokenizer.encode(sequence, add_special_tokens=False)
+        rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
+        self.assertListEqual(ids, rust_ids)
+
+        rust_tokenizer = self.get_rust_tokenizer()
+        ids = tokenizer.encode(sequence)
+        rust_ids = rust_tokenizer.encode(sequence)
+        self.assertListEqual(ids, rust_ids)
+
+    def test_training_new_tokenizer(self):
+        pass
+
+    def test_training_new_tokenizer_with_special_tokens_change(self):
+        pass
+
+    def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):
+        pass

--- a/tests/models/rembert/test_tokenization_rembert.py
+++ b/tests/models/rembert/test_tokenization_rembert.py
@@ -15,17 +15,18 @@
 
 import unittest
 
-from transformers import RemBertTokenizer, RemBertTokenizerFast
-from transformers.testing_utils import require_tokenizers
-from transformers.utils import is_torch_available
+from transformers.models.rembert.tokenization_rembert import RemBertTokenizer
+from transformers.models.rembert.tokenization_rembert_fast import RemBertTokenizerFast
 
+from transformers.testing_utils import get_tests_dir, is_torch_available, require_sentencepiece
 from ...test_tokenization_common import TokenizerTesterMixin
 
 
+SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
+
 FRAMEWORK = "pt" if is_torch_available() else "tf"
 
-
-@require_tokenizers
+@require_sentencepiece
 class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     tokenizer_class = RemBertTokenizer
@@ -36,7 +37,8 @@ class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        tokenizer = RemBertTokenizer.from_pretrained("google/rembert")
+        # We have a SentencePiece fixture for testing
+        tokenizer = RemBertTokenizer(SAMPLE_VOCAB)
         tokenizer.save_pretrained(self.tmpdirname)
 
     def test_convert_token_and_id(self):
@@ -56,7 +58,7 @@ class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(len(vocab_keys), 250300)
 
     def test_vocab_size(self):
-        self.assertEqual(self.get_tokenizer().vocab_size, 250300)
+        self.assertEqual(self.get_tokenizer().vocab_size, 1_000)
 
     def test_rust_and_python_full_tokenizers(self):
         if not self.test_rust_tokenizer:

--- a/tests/models/rembert/test_tokenization_rembert.py
+++ b/tests/models/rembert/test_tokenization_rembert.py
@@ -58,25 +58,6 @@ class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_vocab_size(self):
         self.assertEqual(self.get_tokenizer().vocab_size, 250300)
 
-    def test_rust_and_python_bpe_tokenizers(self):
-        tokenizer = RemBertTokenizer.from_pretrained("google/rembert")
-        tokenizer.save_pretrained(self.tmpdirname)
-        rust_tokenizer = RemBertTokenizerFast.from_pretrained(self.tmpdirname)
-
-        sequence = "Hi I am new at huggingface."
-
-        ids = tokenizer.encode(sequence)
-        rust_ids = rust_tokenizer.encode(sequence)
-        self.assertListEqual(ids, rust_ids)
-
-        ids = tokenizer.encode(sequence, add_special_tokens=False)
-        rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
-        self.assertListEqual(ids, rust_ids)
-
-        tokens = tokenizer.convert_ids_to_tokens(ids)
-        rust_tokens = rust_tokenizer.tokenize(sequence)
-        self.assertListEqual(tokens, rust_tokens)
-
     def test_rust_and_python_full_tokenizers(self):
         if not self.test_rust_tokenizer:
             return


### PR DESCRIPTION
# What does this PR do?
Fixes : #16627
Added tokenizer tests for Rembert. I took reference from test_tokenization_camembert.py

@SaulLu @LysandreJik