### PR TITLE
support `t5` for `text-generation` pipeline

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2264,7 +2264,8 @@ class GenerationMixin:
             )
 
         # keep track of which sequences are already finished
-        unfinished_sequences = input_ids.new(input_ids.shape[0]).fill_(1)
+        # unfinished_sequences = input_ids.new(input_ids.shape[0]).fill_(1)
+        unfinished_sequences = torch.ones_like(input_ids[:, 0])
 
         this_peer_finished = False  # used by synced_gpus only
         while True:


### PR DESCRIPTION
# What does this PR do?

A tentative to support `T5` for `text-generation` pipeline. I don't really expect this PR to get merged as it is very hacky and IMO not a good idea to support `T5` for `text-generation` but I would love to have some insights on what we can potentially do to support `text-generation` pipeline for `T5`

Probably the fix would be also to implement `T5ForCausalLM` but not sure if this makes sense!