### PR TITLE
Add `accelerate` support for `ESM`

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -638,6 +638,7 @@ class EsmPreTrainedModel(PreTrainedModel):
 
     config_class = EsmConfig
     base_model_prefix = "esm"
+    _no_split_modules = ["EsmLayer"]
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):


### PR DESCRIPTION
# What does this PR do?

This PR adds `accelerate` support for `ESM` models, so that the largest `ESM` models (15B params) can be loaded in 8-bit, therefore easing accessibility for large protein models. This also introduces the first protein model that can be loaded in 8bit.
```
# pip install accelerate bitsandbytes
from transformers import AutoModel

model = AutoModel.from_pretrained("acebook/esm2_t48_15B_UR50D", device_map="auto", load_in_8bit=True)
```

cc @sgugger @Rocketknight1 

slow tests pass