### PR TITLE
Revert `keys_to_ignore` for M2M100

### DIFF
--- a/src/transformers/models/m2m_100/modeling_m2m_100.py
+++ b/src/transformers/models/m2m_100/modeling_m2m_100.py
@@ -1128,7 +1128,14 @@ class M2M100Decoder(M2M100PreTrainedModel):
     M2M_100_START_DOCSTRING,
 )
 class M2M100Model(M2M100PreTrainedModel):
-    _keys_to_ignore_on_load_missing = ["encoder.embed_tokens.weight", "decoder.embed_tokens.weight"]
+    _keys_to_ignore_on_load_missing = [
+        "encoder.embed_tokens.weight",
+        "decoder.embed_tokens.weight",
+        "encoder.embed_positions.weights",
+        "encoder.embed_positions.bias",
+        "decoder.embed_positions.weights",
+        "decoder.embed_positions.bias",
+    ]
 
     def __init__(self, config: M2M100Config):
         super().__init__(config)
@@ -1248,6 +1255,10 @@ class M2M100ForConditionalGeneration(M2M100PreTrainedModel):
         r"lm_head.weight",
         r"encoder.embed_tokens.weight",
         r"decoder.embed_tokens.weight",
+        r"encoder.embed_positions.weights",
+        r"encoder.embed_positions.bias",
+        r"decoder.embed_positions.weights",
+        r"decoder.embed_positions.bias",
     ]
 
     def __init__(self, config: M2M100Config):


### PR DESCRIPTION
# What does this PR do?

This PR reverts a change that has been made on `M2M100Model` , to reproduce you can run: 
```
import torch
from transformers import AutoModelForSeq2SeqLM, AutoTokenizer

src_lang = "eng_Latn"
tgt_lang = "spa_Latn"

model_id = "facebook/nllb-200-3.3B"

tokenizer = AutoTokenizer.from_pretrained(model_id, src_lang=src_lang)
model = AutoModelForSeq2SeqLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map="auto")
```
on `main`, users get: 
```
│ /home/younes_huggingface_co/debug_issues/code/transformers/src/transformers/modeling_utils.py:24 │
│ 59 in _load_pretrained_model                                                                     │
│                                                                                                  │
│   2456 │   │   │   for key in missing_keys:                                                      │
│   2457 │   │   │   │   if key.startswith(prefix):                                                │
│   2458 │   │   │   │   │   key = ".".join(key.split(".")[1:])                                    │
│ ❱ 2459 │   │   │   │   param = model_state_dict[key]                                             │
│   2460 │   │   │   │   if param.device == torch.device("meta"):                                  │
│   2461 │   │   │   │   │   if not load_in_8bit:                                                  │
│   2462 │   │   │   │   │   │   set_module_tensor_to_device(model, key, "cpu", torch.empty(*para  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'encoder.embed_positions.weights'
```

cc @Narsil 