### PR TITLE
Indicate better minimal version of PyTorch in big model inference

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1926,6 +1926,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if low_cpu_mem_usage:
             # low_cpu_mem_usage requires PyTorch >= 1.9 to have the meta device.
             require_version_core("torch>=1.9")
+            if device_map is not None:
+                # The max memory utils require PyTorch >= 1.11 to have torch.cuda.mem_get_info.
+                require_version_core("torch>=1.11")
 
             if is_deepspeed_zero3_enabled():
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

As pointed out in https://github.com/huggingface/accelerate/issues/880, the minimum version when using a `device_map` is not PyTorch 1.9 but PyTorch 1.11. This PR fixes that.