### PR TITLE
[WIP] Add a `get_token_embeddings_size` to `PreTrainedModel`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1222,7 +1222,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Use in conjunction with resize_token_embeddings to provide a baseline against which size changes can be 
         calculated. For example:
         
-        ```
+        ```python
         # add 1 new embedding
         current_embeddings_size = my_xformer.get_token_embeddings_size()
         new_embeddings_size = current_embeddings_size + 1

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1219,7 +1219,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         Return the current size of the input token embeddings matrix. 
         
-        Use in conjunction with resize_token_embeddings to provide a baseline against which size changes can be 
+        Use in conjunction with `resize_token_embeddings` to provide a baseline against which size changes can be 
         calculated. For example:
         
         ```python

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1215,10 +1215,31 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if hasattr(output_embeddings, "out_features") and hasattr(input_embeddings, "num_embeddings"):
             output_embeddings.out_features = input_embeddings.num_embeddings
 
+    def get_token_embeddings_size(self) -> int:
+        """
+        Return the current size of the input token embeddings matrix. 
+        
+        Use in conjunction with resize_token_embeddings to provide a baseline against which size changes can be 
+        calculated. For example:
+        
+        ```
+        # add 1 new embedding
+        current_embeddings_size = my_xformer.get_token_embeddings_size()
+        new_embeddings_size = current_embeddings_size + 1
+        my_xformer.resize_token_embeddings(new_embeddings_size)
+        ```
+        
+        Return:
+            `int`: The current size of the token embeddings matrix.
+        """
+        return self.get_input_embeddings().weight.size()[0]
+            
     def resize_token_embeddings(self, new_num_tokens: Optional[int] = None) -> nn.Embedding:
         """
-        Resizes input token embeddings matrix of the model if `new_num_tokens != config.vocab_size`.
-
+        Resizes input token embeddings matrix of the model if `new_num_tokens` does not correspond to the current size.
+        
+        Use `get_token_embeddings_size()` to retrieve the current size.
+        
         Takes care of tying weights embeddings afterwards if the model class has a `tie_weights()` method.
 
         Arguments:


### PR DESCRIPTION
Adds an intuitive and obvious method, `get_token_embeddings_size()`, to get the size of the current token embeddings on `PreTrainedModel`. This can be used to compute the new size when calling `resize_token_embeddings()`.

### Motivation

Current API design around the `resize_token_embeddings()` method requires doing the following to increase the size of the token embeddings by 1:

```python
# add 1 new embedding
current_embeddings = my_xformer.resize_token_embeddings(None)
new_embeddings_size = current_embeddings.num_embeddings + 1
my_xformer.resize_token_embeddings(new_embeddings_size)
```

This is counterintuitive and bleeds implementation details to the call site. It requires me to know
1. that calling a "resize" method with the argument `None` returns the object to be resized (which is not intuitive), and
2. that "size" means the property `num_embeddings` on the returned object (admittedly it's not difficult to guess, but it is still a *guess*, and is in fact an implementation detail that I shouldn't need to know).

# What does this PR do?

This PR enables instead the following:

```python
# add 1 new embedding
current_embeddings_size = my_xformer.get_token_embeddings_size()
new_embeddings_size = current_embeddings_size + 1
my_xformer.resize_token_embeddings(new_embeddings_size)
```

This provides an intuitively-named method to determine the current "size", and appropriately hides the implementation detail that "size" means the `num_embeddings` property on the object to be resized.

Fixes #20377 .


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [*] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [*] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. - #20377 .
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
