### PR TITLE
[BNB] fix nasty `bnb` bug

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2351,7 +2351,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 load_in_8bit=load_in_8bit,
             )
 
-        cls.is_loaded_in_8bit = load_in_8bit
+        model.is_loaded_in_8bit = load_in_8bit
 
         # make sure token embedding weights are still tied if needed
         model.tie_weights()


### PR DESCRIPTION
# What does this PR do?

This PR fixes a very nasty bug that can be reproduced with the following script: 
```
from transformers import AutoModel

model_16bit = AutoModel.from_pretrained("bigscience/bloom-560m", device_map="auto", load_in_8bit=False)
model_8bit = AutoModel.from_pretrained("bigscience/bloom-560m", device_map="auto", load_in_8bit=True)

print(model_16bit.is_loaded_in_8bit)
>>> True
```
In fact we should assign the attribute `is_loaded_in_8bit` to the variable `model` instead of `cls`. Otherwise `is_loaded_in_8bit` will be overriden by the next model that is loaded in 8bit

@sgugger @ydshieh 