### PR TITLE
[BNB] Throw `ValueError` when trying to cast or assign

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1667,10 +1667,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         return mem
 
     def to(self, *args, **kwargs):
-        r"""
-        Overrides the `.to` function from `nn.Module` to raise a ValueError if `8-bit` models are tried to be set on a
-        new device or `dtype`
-        """
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(
@@ -1682,10 +1678,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return super().to(*args, **kwargs)
 
     def half(self, *args):
-        r"""
-        Overrides the `.half` function from `nn.Module` to raise a ValueError if this method is called with `8-bit`
-        models.
-        """
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(
@@ -1697,10 +1689,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return super().half(*args)
 
     def float(self, *args):
-        r"""
-        Overrides the `.float` function from `nn.Module` to raise a ValueError if this method is called with `8-bit`
-        models.
-        """
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1666,6 +1666,51 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             mem = mem + mem_bufs
         return mem
 
+    def to(self, *args):
+        r"""
+        Overrides the `.to` function from `nn.Module` to raise a ValueError if `8-bit` models are tried to be set on a
+        new device or `dtype`
+        """
+        # Checks if the model has been loaded in 8-bit
+        if getattr(self, "is_loaded_in_8bit", False):
+            raise ValueError(
+                "You are assigning your `8-bit` model into a new device or casting it with a new `dtype`. Device and"
+                " `dtype` assignment is not supported for `8-bit` models. Please use the model as it is, since the"
+                " model has already been set to the correct devices and casted to the correct `dtype`."
+            )
+        else:
+            return super().to(*args)
+
+    def half(self, *args):
+        r"""
+        Overrides the `.half` function from `nn.Module` to raise a ValueError if this method is called with `8-bit`
+        models.
+        """
+        # Checks if the model has been loaded in 8-bit
+        if getattr(self, "is_loaded_in_8bit", False):
+            raise ValueError(
+                "You are calling `.half()` with your `8-bit` model."
+                " `.half()` is not supported for `8-bit` models. Please use the model as it is, since the"
+                " model has already been set to the correct devices and casted to the correct `dtype`."
+            )
+        else:
+            return super().half(*args)
+
+    def float(self, *args):
+        r"""
+        Overrides the `.float` function from `nn.Module` to raise a ValueError if this method is called with `8-bit`
+        models.
+        """
+        # Checks if the model has been loaded in 8-bit
+        if getattr(self, "is_loaded_in_8bit", False):
+            raise ValueError(
+                "You are calling `.float()` with your `8-bit` model."
+                " `.float()` is not supported for `8-bit` models. Please use the model as it is, since the"
+                " model has already been set to the correct devices and casted to the correct `dtype`."
+            )
+        else:
+            return super().float(*args)
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], *model_args, **kwargs):
         r"""
@@ -2351,7 +2396,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 load_in_8bit=load_in_8bit,
             )
 
-        cls.is_loaded_in_8bit = load_in_8bit
+        model.is_loaded_in_8bit = load_in_8bit
 
         # make sure token embedding weights are still tied if needed
         model.tie_weights()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1670,8 +1670,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(
-                "You are assigning your `8-bit` model into a new device or casting it with a new `dtype`. Device and"
-                " `dtype` assignment is not supported for `8-bit` models. Please use the model as it is, since the"
+                "`.to` is not supported for `8-bit` models. Please use the model as it is, since the"
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         else:
@@ -1681,9 +1680,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(
-                "You are calling `.half()` with your `8-bit` model."
-                " `.half()` is not supported for `8-bit` models. Please use the model as it is, since the"
-                " model has already been set to the correct devices and casted to the correct `dtype`."
+                "`.half()` is not supported for `8-bit` models. Please use the model as it is, since the"
+                " model has already been casted to the correct `dtype`."
             )
         else:
             return super().half(*args)
@@ -1692,9 +1690,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_loaded_in_8bit", False):
             raise ValueError(
-                "You are calling `.float()` with your `8-bit` model."
-                " `.float()` is not supported for `8-bit` models. Please use the model as it is, since the"
-                " model has already been set to the correct devices and casted to the correct `dtype`."
+                "`.float()` is not supported for `8-bit` models. Please use the model as it is, since the"
+                " model has already been casted to the correct `dtype`."
             )
         else:
             return super().float(*args)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1666,7 +1666,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             mem = mem + mem_bufs
         return mem
 
-    def to(self, *args):
+    def to(self, *args, **kwargs):
         r"""
         Overrides the `.to` function from `nn.Module` to raise a ValueError if `8-bit` models are tried to be set on a
         new device or `dtype`
@@ -1679,7 +1679,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         else:
-            return super().to(*args)
+            return super().to(*args, **kwargs)
 
     def half(self, *args):
         r"""

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -115,6 +115,46 @@ class MixedInt8Test(BaseMixedInt8Test):
         with self.assertWarns(UserWarning), tempfile.TemporaryDirectory() as tmpdirname:
             self.model_8bit.save_pretrained(tmpdirname)
 
+    def test_device_and_dtype_assignment(self):
+        r"""
+        Test whether trying to cast (or assigning a device to) a model after converting it in 8-bit will throw an error.
+        Checks also if other models are casted correctly.
+        """
+        with self.assertRaises(ValueError):
+            # Tries with `str`
+            self.model_8bit.to("cpu")
+
+        with self.assertRaises(ValueError):
+            # Tries with a `dtype``
+            self.model_8bit.to(torch.float16)
+
+        with self.assertRaises(ValueError):
+            # Tries with a `device`
+            self.model_8bit.to(torch.device("cuda:0"))
+
+        with self.assertRaises(ValueError):
+            # Tries with a `device`
+            self.model_8bit.float()
+
+        with self.assertRaises(ValueError):
+            # Tries with a `device`
+            self.model_8bit.half()
+
+        # Test if we did not break anything
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
+
+        self.model_fp16 = self.model_fp16.to(torch.float32)
+        _ = self.model_fp16.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
+
+        # Check this does not throw an error
+        _ = self.model_fp16.to("cpu")
+
+        # Check this does not throw an error
+        _ = self.model_fp16.half()
+
+        # Check this does not throw an error
+        _ = self.model_fp16.float()
+
 
 class MixedInt8ModelClassesTest(BaseMixedInt8Test):
     def setUp(self):


### PR DESCRIPTION
# What does this PR do?

I have seen several piece of code where users try to assign `8-bit` loaded models into a new device and/or `dtype` this PR aims to throw an error to the users that perform this.

Also added a set of slow tests

cc @sgugger @ydshieh 

Do not merge before #20408
