### PR TITLE
Fix device in longformer onnx path

### DIFF
--- a/src/transformers/models/led/modeling_led.py
+++ b/src/transformers/models/led/modeling_led.py
@@ -425,7 +425,7 @@ class LEDEncoderSelfAttention(nn.Module):
             hidden_states.size(2),
         ]
 
-        overlapping_chunks = torch.empty(chunk_size)
+        overlapping_chunks = torch.empty(chunk_size, device=hidden_states.device)
         for chunk in range(chunk_size[1]):
             overlapping_chunks[:, chunk, :, :] = hidden_states[
                 :, chunk * window_overlap : chunk * window_overlap + 2 * window_overlap, :

--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -796,7 +796,7 @@ class LongformerSelfAttention(nn.Module):
             hidden_states.size(2),
         ]
 
-        overlapping_chunks = torch.empty(chunk_size)
+        overlapping_chunks = torch.empty(chunk_size, device=hidden_states.device)
         for chunk in range(chunk_size[1]):
             overlapping_chunks[:, chunk, :, :] = hidden_states[
                 :, chunk * window_overlap : chunk * window_overlap + 2 * window_overlap, :


### PR DESCRIPTION
# What does this PR do?

Longformer has a custom path in its `_chunk()` method, in order to be tracable (to some extent) + exportable to ONNX. https://github.com/huggingface/transformers/pull/20292 fixed a bug where this special path was always registering a non-general case:

https://github.com/huggingface/transformers/blob/9ef46659da45f6b605873ca59124d03976990b33/src/transformers/models/longformer/modeling_longformer.py#L785-L787

It seems that the `else` path that should be taken in the export was actually never tested, and notably never tested on GPU. This PR fixes a device assignment.

The test `RUN_SLOW=1 python -m pytest -v tests/onnx/test_onnx_v2.py::OnnxExportTestCaseV2::test_pytorch_export_on_cuda_102_longformer_token_classification` is now running fine.

## Who can review?

@lewtun @ydshieh 