### PR TITLE
Add deprecation warning when image FE instantiated

### DIFF
--- a/src/transformers/models/beit/feature_extraction_beit.py
+++ b/src/transformers/models/beit/feature_extraction_beit.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 """Feature extractor class for BEiT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_beit import BeitImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-BeitFeatureExtractor = BeitImageProcessor
+
+class BeitFeatureExtractor(BeitImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class BeitFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use BeitImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/beit/feature_extraction_beit.py
+++ b/src/transformers/models/beit/feature_extraction_beit.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class BeitFeatureExtractor(BeitImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class BeitFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class BeitFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use BeitImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/chinese_clip/feature_extraction_chinese_clip.py
+++ b/src/transformers/models/chinese_clip/feature_extraction_chinese_clip.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for Chinese-CLIP."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_chinese_clip import ChineseCLIPImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_chinese_clip import ChineseCLIPImageProcessor
 logger = logging.get_logger(__name__)
 
 
-ChineseCLIPFeatureExtractor = ChineseCLIPImageProcessor
+class ChineseCLIPFeatureExtractor(ChineseCLIPImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ChineseCLIPFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
+            " Please use ChineseCLIPImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/clip/feature_extraction_clip.py
+++ b/src/transformers/models/clip/feature_extraction_clip.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for CLIP."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_clip import CLIPImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_clip import CLIPImageProcessor
 logger = logging.get_logger(__name__)
 
 
-CLIPFeatureExtractor = CLIPImageProcessor
+class CLIPFeatureExtractor(CLIPImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class CLIPFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use CLIPImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/clip/feature_extraction_clip.py
+++ b/src/transformers/models/clip/feature_extraction_clip.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class CLIPFeatureExtractor(CLIPImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class CLIPFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class CLIPFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use CLIPImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/conditional_detr/feature_extraction_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/feature_extraction_conditional_detr.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 """Feature extractor class for Conditional DETR."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_conditional_detr import ConditionalDetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-ConditionalDetrFeatureExtractor = ConditionalDetrImageProcessor
+
+class ConditionalDetrFeatureExtractor(ConditionalDetrImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ConditionalDetrFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
+            " Please use ConditionalDetrImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/convnext/feature_extraction_convnext.py
+++ b/src/transformers/models/convnext/feature_extraction_convnext.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class ConvNextFeatureExtractor(ConvNextImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class ConvNextFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class ConvNextFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use ConvNextImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/convnext/feature_extraction_convnext.py
+++ b/src/transformers/models/convnext/feature_extraction_convnext.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for ConvNeXT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_convnext import ConvNextImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_convnext import ConvNextImageProcessor
 logger = logging.get_logger(__name__)
 
 
-ConvNextFeatureExtractor = ConvNextImageProcessor
+class ConvNextFeatureExtractor(ConvNextImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ConvNextFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use ConvNextImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/deformable_detr/feature_extraction_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/feature_extraction_deformable_detr.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 """Feature extractor class for Deformable DETR."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_deformable_detr import DeformableDetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-DeformableDetrFeatureExtractor = DeformableDetrImageProcessor
+
+class DeformableDetrFeatureExtractor(DeformableDetrImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class DeformableDetrFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
+            " Please use DeformableDetrImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/deit/feature_extraction_deit.py
+++ b/src/transformers/models/deit/feature_extraction_deit.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 """Feature extractor class for DeiT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_deit import DeiTImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-DeiTFeatureExtractor = DeiTImageProcessor
+
+class DeiTFeatureExtractor(DeiTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class DeiTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use DeiTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/deit/feature_extraction_deit.py
+++ b/src/transformers/models/deit/feature_extraction_deit.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class DeiTFeatureExtractor(DeiTImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class DeiTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class DeiTFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use DeiTImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/detr/feature_extraction_detr.py
+++ b/src/transformers/models/detr/feature_extraction_detr.py
@@ -14,9 +14,20 @@
 # limitations under the License.
 """Feature extractor class for DETR."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_detr import DetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
-DetrFeatureExtractor = DetrImageProcessor
+
+
+class DetrFeatureExtractor(DetrImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class DetrFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
+            " Please use DetrImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/donut/feature_extraction_donut.py
+++ b/src/transformers/models/donut/feature_extraction_donut.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for Donut."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_donut import DonutImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_donut import DonutImageProcessor
 logger = logging.get_logger(__name__)
 
 
-DonutFeatureExtractor = DonutImageProcessor
+class DonutFeatureExtractor(DonutImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class DonutFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
+            " use DonutImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/dpt/feature_extraction_dpt.py
+++ b/src/transformers/models/dpt/feature_extraction_dpt.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for DPT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_dpt import DPTImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_dpt import DPTImageProcessor
 logger = logging.get_logger(__name__)
 
 
-DPTFeatureExtractor = DPTImageProcessor
+class DPTFeatureExtractor(DPTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class DPTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use DPTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/dpt/feature_extraction_dpt.py
+++ b/src/transformers/models/dpt/feature_extraction_dpt.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class DPTFeatureExtractor(DPTImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class DPTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class DPTFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use DPTImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/flava/feature_extraction_flava.py
+++ b/src/transformers/models/flava/feature_extraction_flava.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 """Feature extractor class for FLAVA."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_flava import FlavaImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-FlavaFeatureExtractor = FlavaImageProcessor
+
+class FlavaFeatureExtractor(FlavaImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class FlavaFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use FlavaImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/flava/feature_extraction_flava.py
+++ b/src/transformers/models/flava/feature_extraction_flava.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class FlavaFeatureExtractor(FlavaImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class FlavaFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class FlavaFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use FlavaImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/glpn/feature_extraction_glpn.py
+++ b/src/transformers/models/glpn/feature_extraction_glpn.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class GLPNFeatureExtractor(GLPNImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class GLPNFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class GLPNFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use GLPNImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/glpn/feature_extraction_glpn.py
+++ b/src/transformers/models/glpn/feature_extraction_glpn.py
@@ -14,11 +14,20 @@
 # limitations under the License.
 """Feature extractor class for GLPN."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_glpn import GLPNImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-# Feature extractor for GLPN is being replaced by image processor
-GLPNFeatureExtractor = GLPNImageProcessor
+
+class GLPNFeatureExtractor(GLPNImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class GLPNFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use GLPNImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
+++ b/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for ImageGPT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_imagegpt import ImageGPTImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_imagegpt import ImageGPTImageProcessor
 logger = logging.get_logger(__name__)
 
 
-ImageGPTFeatureExtractor = ImageGPTImageProcessor
+class ImageGPTFeatureExtractor(ImageGPTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ImageGPTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use ImageGPTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
+++ b/src/transformers/models/imagegpt/feature_extraction_imagegpt.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class ImageGPTFeatureExtractor(ImageGPTImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class ImageGPTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class ImageGPTFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use ImageGPTImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
@@ -16,10 +16,20 @@
 Feature extractor class for LayoutLMv2.
 """
 
+import warnings
+
 from ...utils import logging
 from .image_processing_layoutlmv2 import LayoutLMv2ImageProcessor
 
 
 logger = logging.get_logger(__name__)
 
-LayoutLMv2FeatureExtractor = LayoutLMv2ImageProcessor
+
+class LayoutLMv2FeatureExtractor(LayoutLMv2ImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class LayoutLMv2FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use LayoutLMv2ImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/feature_extraction_layoutlmv2.py
@@ -28,7 +28,7 @@ logger = logging.get_logger(__name__)
 class LayoutLMv2FeatureExtractor(LayoutLMv2ImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class LayoutLMv2FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class LayoutLMv2FeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use LayoutLMv2ImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
@@ -28,7 +28,7 @@ logger = logging.get_logger(__name__)
 class LayoutLMv3FeatureExtractor(LayoutLMv3ImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class LayoutLMv3FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class LayoutLMv3FeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use LayoutLMv3ImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/feature_extraction_layoutlmv3.py
@@ -16,6 +16,8 @@
 Feature extractor class for LayoutLMv3.
 """
 
+import warnings
+
 from ...utils import logging
 from .image_processing_layoutlmv3 import LayoutLMv3ImageProcessor
 
@@ -23,4 +25,11 @@ from .image_processing_layoutlmv3 import LayoutLMv3ImageProcessor
 logger = logging.get_logger(__name__)
 
 
-LayoutLMv3FeatureExtractor = LayoutLMv3ImageProcessor
+class LayoutLMv3FeatureExtractor(LayoutLMv3ImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class LayoutLMv3FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use LayoutLMv3ImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/levit/feature_extraction_levit.py
+++ b/src/transformers/models/levit/feature_extraction_levit.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for LeViT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_levit import LevitImageProcessor
 
@@ -21,5 +23,11 @@ from .image_processing_levit import LevitImageProcessor
 logger = logging.get_logger(__name__)
 
 
-# Feature extractor for Levit is being replaced by image processor
-LevitFeatureExtractor = LevitImageProcessor
+class LevitFeatureExtractor(LevitImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class LevitFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use LevitImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/levit/feature_extraction_levit.py
+++ b/src/transformers/models/levit/feature_extraction_levit.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class LevitFeatureExtractor(LevitImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class LevitFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class LevitFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use LevitImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/maskformer/feature_extraction_maskformer.py
+++ b/src/transformers/models/maskformer/feature_extraction_maskformer.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for MaskFormer."""
 
+import warnings
+
 from transformers.utils import logging
 
 from .image_processing_maskformer import MaskFormerImageProcessor
@@ -21,4 +23,12 @@ from .image_processing_maskformer import MaskFormerImageProcessor
 
 logger = logging.get_logger(__name__)
 
-MaskFormerFeatureExtractor = MaskFormerImageProcessor
+
+class MaskFormerFeatureExtractor(MaskFormerImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class MaskFormerFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
+            " Please use MaskFormerImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/mobilenet_v1/feature_extraction_mobilenet_v1.py
+++ b/src/transformers/models/mobilenet_v1/feature_extraction_mobilenet_v1.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class MobileNetV1FeatureExtractor(MobileNetV1ImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class MobileNetV1FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class MobileNetV1FeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use MobileNetV1ImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/mobilenet_v1/feature_extraction_mobilenet_v1.py
+++ b/src/transformers/models/mobilenet_v1/feature_extraction_mobilenet_v1.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for MobileNetV1."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_mobilenet_v1 import MobileNetV1ImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_mobilenet_v1 import MobileNetV1ImageProcessor
 logger = logging.get_logger(__name__)
 
 
-MobileNetV1FeatureExtractor = MobileNetV1ImageProcessor
+class MobileNetV1FeatureExtractor(MobileNetV1ImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class MobileNetV1FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use MobileNetV1ImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/mobilenet_v2/feature_extraction_mobilenet_v2.py
+++ b/src/transformers/models/mobilenet_v2/feature_extraction_mobilenet_v2.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class MobileNetV2FeatureExtractor(MobileNetV2ImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class MobileNetV2FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class MobileNetV2FeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use MobileNetV2ImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/mobilenet_v2/feature_extraction_mobilenet_v2.py
+++ b/src/transformers/models/mobilenet_v2/feature_extraction_mobilenet_v2.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for MobileNetV2."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_mobilenet_v2 import MobileNetV2ImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_mobilenet_v2 import MobileNetV2ImageProcessor
 logger = logging.get_logger(__name__)
 
 
-MobileNetV2FeatureExtractor = MobileNetV2ImageProcessor
+class MobileNetV2FeatureExtractor(MobileNetV2ImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class MobileNetV2FeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use MobileNetV2ImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/mobilevit/feature_extraction_mobilevit.py
+++ b/src/transformers/models/mobilevit/feature_extraction_mobilevit.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for MobileViT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_mobilevit import MobileViTImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_mobilevit import MobileViTImageProcessor
 logger = logging.get_logger(__name__)
 
 
-MobileViTFeatureExtractor = MobileViTImageProcessor
+class MobileViTFeatureExtractor(MobileViTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class MobileViTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use MobileViTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/mobilevit/feature_extraction_mobilevit.py
+++ b/src/transformers/models/mobilevit/feature_extraction_mobilevit.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class MobileViTFeatureExtractor(MobileViTImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class MobileViTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class MobileViTFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use MobileViTImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/owlvit/feature_extraction_owlvit.py
+++ b/src/transformers/models/owlvit/feature_extraction_owlvit.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for OwlViT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_owlvit import OwlViTImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_owlvit import OwlViTImageProcessor
 logger = logging.get_logger(__name__)
 
 
-OwlViTFeatureExtractor = OwlViTImageProcessor
+class OwlViTFeatureExtractor(OwlViTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class OwlViTFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
+            " use OwlViTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/perceiver/feature_extraction_perceiver.py
+++ b/src/transformers/models/perceiver/feature_extraction_perceiver.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for Perceiver."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_perceiver import PerceiverImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_perceiver import PerceiverImageProcessor
 logger = logging.get_logger(__name__)
 
 
-PerceiverFeatureExtractor = PerceiverImageProcessor
+class PerceiverFeatureExtractor(PerceiverImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class PerceiverFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use PerceiverImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/perceiver/feature_extraction_perceiver.py
+++ b/src/transformers/models/perceiver/feature_extraction_perceiver.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class PerceiverFeatureExtractor(PerceiverImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class PerceiverFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class PerceiverFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use PerceiverImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/poolformer/feature_extraction_poolformer.py
+++ b/src/transformers/models/poolformer/feature_extraction_poolformer.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class PoolFormerFeatureExtractor(PoolFormerImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class PoolFormerFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class PoolFormerFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use PoolFormerImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/poolformer/feature_extraction_poolformer.py
+++ b/src/transformers/models/poolformer/feature_extraction_poolformer.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for PoolFormer."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_poolformer import PoolFormerImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_poolformer import PoolFormerImageProcessor
 logger = logging.get_logger(__name__)
 
 
-PoolFormerFeatureExtractor = PoolFormerImageProcessor
+class PoolFormerFeatureExtractor(PoolFormerImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class PoolFormerFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use PoolFormerImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/segformer/feature_extraction_segformer.py
+++ b/src/transformers/models/segformer/feature_extraction_segformer.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class SegformerFeatureExtractor(SegformerImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class SegformerFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class SegformerFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use SegformerImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/segformer/feature_extraction_segformer.py
+++ b/src/transformers/models/segformer/feature_extraction_segformer.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for SegFormer."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_segformer import SegformerImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_segformer import SegformerImageProcessor
 logger = logging.get_logger(__name__)
 
 
-SegformerFeatureExtractor = SegformerImageProcessor
+class SegformerFeatureExtractor(SegformerImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class SegformerFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use SegformerImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/videomae/feature_extraction_videomae.py
+++ b/src/transformers/models/videomae/feature_extraction_videomae.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for VideoMAE."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_videomae import VideoMAEImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_videomae import VideoMAEImageProcessor
 logger = logging.get_logger(__name__)
 
 
-VideoMAEFeatureExtractor = VideoMAEImageProcessor
+class VideoMAEFeatureExtractor(VideoMAEImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class VideoMAEFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            " Please use VideoMAEImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/videomae/feature_extraction_videomae.py
+++ b/src/transformers/models/videomae/feature_extraction_videomae.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class VideoMAEFeatureExtractor(VideoMAEImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class VideoMAEFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers."
+            "The class VideoMAEFeatureExtractor is deprecated and will be removed in version 5 of Transformers."
             " Please use VideoMAEImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/vilt/feature_extraction_vilt.py
+++ b/src/transformers/models/vilt/feature_extraction_vilt.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class ViltFeatureExtractor(ViltImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class ViltFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class ViltFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use ViltImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/vilt/feature_extraction_vilt.py
+++ b/src/transformers/models/vilt/feature_extraction_vilt.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for ViLT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_vilt import ViltImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_vilt import ViltImageProcessor
 logger = logging.get_logger(__name__)
 
 
-ViltFeatureExtractor = ViltImageProcessor
+class ViltFeatureExtractor(ViltImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ViltFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use ViltImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/vit/feature_extraction_vit.py
+++ b/src/transformers/models/vit/feature_extraction_vit.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 class ViTFeatureExtractor(ViTImageProcessor):
     def __init__(self, *args, **kwargs) -> None:
         warnings.warn(
-            "The class ViTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            "The class ViTFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
             " use ViTImageProcessor instead.",
             FutureWarning,
         )

--- a/src/transformers/models/vit/feature_extraction_vit.py
+++ b/src/transformers/models/vit/feature_extraction_vit.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for ViT."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_vit import ViTImageProcessor
 
@@ -21,5 +23,11 @@ from .image_processing_vit import ViTImageProcessor
 logger = logging.get_logger(__name__)
 
 
-# Feature extractor for ViT is being replaced by image processor
-ViTFeatureExtractor = ViTImageProcessor
+class ViTFeatureExtractor(ViTImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class ViTFeatureExtractor is deprecated and will be removed in version 4.27 of Transformers. Please"
+            " use ViTImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)

--- a/src/transformers/models/yolos/feature_extraction_yolos.py
+++ b/src/transformers/models/yolos/feature_extraction_yolos.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Feature extractor class for YOLOS."""
 
+import warnings
+
 from ...utils import logging
 from .image_processing_yolos import YolosImageProcessor
 
@@ -21,4 +23,11 @@ from .image_processing_yolos import YolosImageProcessor
 logger = logging.get_logger(__name__)
 
 
-YolosFeatureExtractor = YolosImageProcessor
+class YolosFeatureExtractor(YolosImageProcessor):
+    def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The class YolosFeatureExtractor is deprecated and will be removed in version 5 of Transformers. Please"
+            " use YolosImageProcessor instead.",
+            FutureWarning,
+        )
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
# What does this PR do?

Adds a deprecation warning if someone tries to create a vision feature extractor. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
