### PR TITLE
[Vision] Support different floating precision inputs from the `ImageProcessor`

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -132,8 +132,8 @@ class BatchFeature(UserDict):
             return self
 
         # Convert to TensorType
-        if not isinstance(tensor_type, TensorType):
-            tensor_type = TensorType(tensor_type)
+        # Convert to TensorType
+        tensor_type = TensorType(tensor_type)
 
         # Get a function reference for the correct framework
         if tensor_type == TensorType.TENSORFLOW:
@@ -197,9 +197,8 @@ class BatchFeature(UserDict):
             target_dtype = getattr(target_framework, float_precision)
         else:
             raise ValueError(
-                f"Failed to import the`dtype` {target_dtype} from the framework {target_framework} - please use a"
-                " supported",
-                " `dtype` for your targetted framework.",
+                f"Failed to import the `dtype` {target_dtype} from the framework {target_framework} - please use a"
+                " supported `dtype` for your targeted framework.",
             )
 
         # Do the tensor conversion in batch

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -159,7 +159,7 @@ class BatchFeature(UserDict):
             target_framework = torch
 
             def cast_fun(x, dtype):
-                x.to(dtype=dtype)
+                return x.to(dtype=dtype)
 
             def is_floating(x):
                 return x.dtype in (torch.float16, torch.float32, torch.double, torch.bfloat16)
@@ -175,7 +175,7 @@ class BatchFeature(UserDict):
             target_framework = jnp
 
             def cast_fun(x, dtype):
-                x.astype(dtype=dtype)
+                return x.astype(dtype=dtype)
 
             def is_floating(x):
                 return x.dtype in (jnp.float16, jnp.float32, jnp.double, jnp.bfloat16)

--- a/src/transformers/models/vit/image_processing_vit.py
+++ b/src/transformers/models/vit/image_processing_vit.py
@@ -193,6 +193,7 @@ class ViTImageProcessor(BaseImageProcessor):
         image_std: Optional[Union[float, List[float]]] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         data_format: Union[str, ChannelDimension] = ChannelDimension.FIRST,
+        float_precision: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -231,6 +232,8 @@ class ViTImageProcessor(BaseImageProcessor):
                 - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
                 - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
                 - Unset: Use the channel dimension format of the input image.
+            float_precision (`str`, *optional*):
+                The output floating point precision [float16, float32, double, bfloat16]
         """
         do_resize = do_resize if do_resize is not None else self.do_resize
         do_rescale = do_rescale if do_rescale is not None else self.do_rescale
@@ -273,4 +276,4 @@ class ViTImageProcessor(BaseImageProcessor):
         images = [to_channel_dimension_format(image, data_format) for image in images]
 
         data = {"pixel_values": images}
-        return BatchFeature(data=data, tensor_type=return_tensors)
+        return BatchFeature(data=data, tensor_type=return_tensors, float_precision=float_precision)


### PR DESCRIPTION
# What does this PR do?

This PR introduces the input casting mechanism for image processors. Since the introduction of `accelerate` supported models for Vision, I have been playing around with half-precision models. I found it a bit inintuitive to manually cast the `pixel_values` outside the `ImageProcessor` class. Therefore for some models, [small hacks have been introduced](https://github.com/huggingface/transformers/blob/main/src/transformers/models/vit/modeling_vit.py#L571-L574) to make the casting operation more user-friendly.
With this PR, it will be possible to cast the input tensors to any floating point precision, for any framework, at the`ImageProcessor` level as follows:
```
from transformers import ViTFeatureExtractor
from PIL import Image
import requests

url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
image = Image.open(requests.get(url, stream=True).raw)
feature_extractor = ViTFeatureExtractor.from_pretrained('google/vit-large-patch32-384')
inputs = feature_extractor(images=image, return_tensors="np", float_precision="float16")
print(inputs.pixel_values.dtype)
>>> float16
```
The casting discards non-floating point tensors, therefore these tensors should not be affected by the casting mechanism (thinking for eg for `ViLT` that takes both text + image)

With this PR, the hacks introduced on ViT and OWLViT will be removed!

cc @amyeroberts @ydshieh 