### PR TITLE
[trainer] apex test fix

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2332,7 +2332,7 @@ if is_torch_available():
 
         optim_test_params.append(
             (
-                TrainingArguments(OptimizerNames.ADAMW_APEX_FUSED, output_dir="None"),
+                TrainingArguments(optim=OptimizerNames.ADAMW_APEX_FUSED, output_dir="None"),
                 apex.optimizers.FusedAdam,
                 default_adam_kwargs,
             )


### PR DESCRIPTION
there was a small mistake in a test of https://github.com/huggingface/transformers/pull/18961, this PR fixes it.

the main CI doesn't have apex installed that's why it missed it.

Thank you, @ydshieh for the heads up about the breakage
