### PR TITLE
Fix doctests for audio models

### DIFF
--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1087,7 +1087,7 @@ def add_code_sample_docstrings(
             expected_loss=expected_loss,
         )
 
-        if ["SequenceClassification" in model_class or "AudioClassification" in model_class] and modality == "audio":
+        if ("SequenceClassification" in model_class or "AudioClassification" in model_class) and modality == "audio":
             code_sample = sample_docstrings["AudioClassification"]
         elif "SequenceClassification" in model_class:
             code_sample = sample_docstrings["SequenceClassification"]


### PR DESCRIPTION
# What does this PR do?

The condition was wrong (`[]` should be `()`) and failed some doctests as they get wrong classes

```python
if ["SequenceClassification" in model_class or "AudioClassification" in model_class]
```
should be
```python
if ("SequenceClassification" in model_class or "AudioClassification" in model_class)
```