### PR TITLE
fix both failing RoCBert tests

### DIFF
--- a/tests/models/roc_bert/test_modeling_roc_bert.py
+++ b/tests/models/roc_bert/test_modeling_roc_bert.py
@@ -710,4 +710,4 @@ class RoCBertModelIntegrationTest(unittest.TestCase):
         # convert to tokens is: ['[CLS]', '巴', '*', '黎', '是', '法', '国', '的', '首', '都', '[SEP]']
         expected_output = torch.tensor([[101, 2349, 115, 7944, 3221, 3791, 1744, 4638, 7674, 6963, 102]])
 
-        self.assertEqual(output_ids, expected_output)
+        assert torch.allclose(output_ids, expected_output)

--- a/tests/models/roc_bert/test_tokenization_roc_bert.py
+++ b/tests/models/roc_bert/test_tokenization_roc_bert.py
@@ -299,8 +299,8 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         encoded_sentence = tokenizer.build_inputs_with_special_tokens(text)
         encoded_pair = tokenizer.build_inputs_with_special_tokens(text, text_2)
 
-        assert encoded_sentence == [101] + text + [102]
-        assert encoded_pair == [101] + text + [102] + text_2 + [102]
+        assert encoded_sentence == [1] + text + [2]
+        assert encoded_pair == [1] + text + [2] + text_2 + [2]
 
     def test_prepare_for_model(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)


### PR DESCRIPTION
# What does this PR do?
Fixes two failing test : 
- tokenization test did not take into account that the dummy tokenizer's `pad_token_id = 2` and `bos_token_id = 1`. The values used were `102, 101`. 
- on of the modeling test used `assertEqual` on tensors and not list, which is ambigus. 
 