### PR TITLE
[CORE] Use model prefix instead of cls

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2508,7 +2508,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         start_prefix = ""
         model_to_load = model
         if len(cls.base_model_prefix) > 0 and not hasattr(model, cls.base_model_prefix) and has_prefix_module:
-            start_prefix = cls.base_model_prefix + "."
+            start_prefix = model.base_model_prefix + "."
         if len(cls.base_model_prefix) > 0 and hasattr(model, cls.base_model_prefix) and not has_prefix_module:
             model_to_load = getattr(model, cls.base_model_prefix)
             base_model_expected_keys = list(model_to_load.state_dict().keys())


### PR DESCRIPTION
# What does this PR do?
This adresses a very particular bug found when `base_model_prefix` is specific to the instance. 
The `JukeboxPrior` are defined by their level of generation. Thus to each level, the corresponding base model prefix : `priors.0`. 
When load the checkpoints from a pretrained `JukeboxModel`, the `_load_pretrained_model` uses the `cls.base_model_prefix` while the `model.base_model_prefix` is also always available. This means that the weights will [not be properly loaded](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L472), but it will be silent. 
This should adresse any current and futur model loading issues where the `base_model_prefix` is modified per instance. 