### PR TITLE
Fix minimum version for device_map

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1959,8 +1959,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # low_cpu_mem_usage requires PyTorch >= 1.9 to have the meta device.
             require_version_core("torch>=1.9")
             if device_map is not None:
-                # The max memory utils require PyTorch >= 1.11 to have torch.cuda.mem_get_info.
-                require_version_core("torch>=1.11")
+                # The max memory utils require PyTorch >= 1.10 to have torch.cuda.mem_get_info.
+                require_version_core("torch>=1.10")
 
             if is_deepspeed_zero3_enabled():
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Turns out it all works fine with PyTorch 1.10 which contains `torch.cuda.mem_get_info` used by Accelerate (but this isn't in the documentation of PyTorch 1.10).