### PR TITLE
Fix documentation code to import facebook/detr-resnet-50 model

### DIFF
--- a/docs/source/en/model_doc/detr.mdx
+++ b/docs/source/en/model_doc/detr.mdx
@@ -119,7 +119,7 @@ Option 1: Instantiate DETR with pre-trained weights for entire model
 ```py
 >>> from transformers import DetrForObjectDetection
 
->>> model = DetrForObjectDetection.from_pretrained("facebook/resnet-50")
+>>> model = DetrForObjectDetection.from_pretrained("facebook/detr-resnet-50")
 ```
 
 Option 2: Instantiate DETR with randomly initialized weights for Transformer, but pre-trained weights for backbone


### PR DESCRIPTION
# What does this PR do?

Changes example import line 

`>>> model = DetrForObjectDetection.from_pretrained("facebook/resnet-50")` 

to 

`>>> model = DetrForObjectDetection.from_pretrained("facebook/detr-resnet-50")` 

As trying to import `"facebook/resnet-50"` raises:

```
OSError: facebook/resnet-50 is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
If this is a private repository, make sure to pass a token having permission to this repo with `use_auth_token` or log in with `huggingface-cli login` and pass `use_auth_token=True`.
```
