### PR TITLE
Support extraction of both train and eval XLA graphs

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3180,7 +3180,9 @@ class Trainer:
         sizes = self._nested_gather(size).cpu()
 
         max_size = max(s[1] for s in sizes)
-        if tensor.shape[1] == max_size:
+        # When extracting XLA graphs for compilation, max_size is 0,
+        # so use inequality to avoid errors.
+        if tensor.shape[1] >= max_size:
             return tensor
 
         # Then pad to the maximum size


### PR DESCRIPTION
Neuron supports extraction of XLA graphs for compilation. However, when both do_train and do_eval options are enabled, sizes returned by tensor operator can be 0. To avoid INVALID_ARGUMENT error, we use inequality in the check whether a tensor needs padding or not.

# What does this PR do?

This PR reduces compilation time of Hugging Face training/evaluation on Trainium using Neuron SDK.

Neuron SDK enables Hugging Face training on Trainium. To reduce compilation time, we have an optional [parallel compilation step](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/frameworks/torch/torch-neuronx/api-reference-guide/training/pytorch-neuron-parallel-compile.html) which 1) extracts XLA HLO graphs by trial execution of the training script with stub graphs that output zeros only, 2) perform parallel compilations of the graphs, and 3) place compiled graphs into Neuron cache. Currently, this flow only works for do_train step in the [HF trainer API tutorial](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/frameworks/torch/torch-neuronx/tutorials/training/finetune_hftrainer.html#) by itself but encounters INVALID_ARGUMENT error when do_eval is included together with do_train. 

The error during parallel compilation is due to code at https://github.com/huggingface/transformers/blob/61a51f5f23d7ce6b8acf61b5aa170e01d7658d74/src/transformers/trainer.py#L3147 that creates new tensor based on the shape of another tensor. The tensor is created but it values are zero (as opposed to the shape) during parallel compilation (trial execution of stub graphs that output zeros only).

This PR introduces an inequality in the check for whether a tensor needs padding or not. During normal execution on all platforms, the max_size is greater than or equal to the tensor size so in no cases should max_size be smaller than tensor size, except in our case where we do trial execution of stub graphs that output zeros only.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger
