### PR TITLE
[modelcard] Set model name if empty

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -591,7 +591,7 @@ class TrainingSummary:
 
         if model_name is None:
             model_name = Path(trainer.args.output_dir).name
-        if not model_name:
+        if len(model_name) == 0:
             model_name = finetuned_from
 
         # Add `generated_from_trainer` to the tags

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -591,6 +591,8 @@ class TrainingSummary:
 
         if model_name is None:
             model_name = Path(trainer.args.output_dir).name
+        if not model_name:
+            model_name = finetuned_from
 
         # Add `generated_from_trainer` to the tags
         if tags is None:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

When building the model card, if the `model_name` is unspecified we set it to `training_args.output_dir`:
https://github.com/huggingface/transformers/blob/86e435bbb1e54f169351dbb798141afee7fa1b93/src/transformers/modelcard.py#L592-L593

This is typically the case during intermediate push to Hubs during training (when we don't specify any extra push to hub kwargs).

However, if we're fine-tuning from **within** a model repo, we set `--output_dir=./`. This means that `Path(trainer.args.output_dir).name=""`, and so `model_name=""`.

This causes a problem when we try and push the model card to the Hub: a model name of `""` registers as an **empty** model index name, meaning the push is rejected:

```bash
remote: ----------------------------------------------------------        
remote: Sorry, your push was rejected during YAML metadata verification:        
remote: - Error: "model-index[0].name" is not allowed to be empty        
remote: ----------------------------------------------------------        
remote: Please find the documentation at:        
remote: https://huggingface.co/docs/hub/model-cards#model-card-metadata        
remote: ----------------------------------------------------------      
```

This PR sets the `model_name` to `finetuned_from` in the case that it is empty (`""`), meaning that the push to hub is allowed.

Unless there's a neater way of inferring the model repo id, this is probably the best way of preventing rejected push to Hubs?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
