### PR TITLE
Fix Data2VecTextForCasualLM example code documentation

### DIFF
--- a/src/transformers/models/data2vec/modeling_data2vec_text.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_text.py
@@ -958,13 +958,13 @@ class Data2VecTextForCausalLM(Data2VecTextPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import Data2VecTextTokenizer, Data2VecTextForCausalLM, Data2VecTextConfig
+        >>> from transformers import RobertaTokenizer, Data2VecTextForCausalLM, Data2VecTextConfig
         >>> import torch
 
-        >>> tokenizer = Data2VecTextTokenizer.from_pretrained("facebook/data2vec-text-base")
-        >>> config = Data2VecTextConfig.from_pretrained("data2vec-base")
+        >>> tokenizer = RobertaTokenizer.from_pretrained("facebook/data2vec-text-base")
+        >>> config = Data2VecTextConfig.from_pretrained("facebook/data2vec-text-base")
         >>> config.is_decoder = True
-        >>> model = Data2VecTextForCausalLM.from_pretrained("data2vec-base", config=config)
+        >>> model = Data2VecTextForCausalLM.from_pretrained("facebook/data2vec-text-base", config=config)
 
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         >>> outputs = model(**inputs)

--- a/src/transformers/models/data2vec/modeling_data2vec_text.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_text.py
@@ -958,10 +958,10 @@ class Data2VecTextForCausalLM(Data2VecTextPreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import RobertaTokenizer, Data2VecTextForCausalLM, Data2VecTextConfig
+        >>> from transformers import AutoTokenizer, Data2VecTextForCausalLM, Data2VecTextConfig
         >>> import torch
 
-        >>> tokenizer = RobertaTokenizer.from_pretrained("facebook/data2vec-text-base")
+        >>> tokenizer = AutoTokenizer.from_pretrained("facebook/data2vec-text-base")
         >>> config = Data2VecTextConfig.from_pretrained("facebook/data2vec-text-base")
         >>> config.is_decoder = True
         >>> model = Data2VecTextForCausalLM.from_pretrained("facebook/data2vec-text-base", config=config)


### PR DESCRIPTION
# What does this PR do?

Fixes documentation of Data2VecTextForCasualLM example code, as it is currently importing `Data2VecTextTokenizer`, which does not exist, and the tokenizer is actually `RobertaTokenizer`. At the same time, the model name `"data2vec-base"` does not exist, and it doesn't particularly say to create one locally (with the change, it aims to `"facebook/data2vec-text-base"`).