### PR TITLE
Fix Hubert models in TFHubertModel and TFHubertForCTC documentation code

### DIFF
--- a/src/transformers/models/hubert/modeling_tf_hubert.py
+++ b/src/transformers/models/hubert/modeling_tf_hubert.py
@@ -1457,8 +1457,8 @@ class TFHubertModel(TFHubertPreTrainedModel):
         >>> from datasets import load_dataset
         >>> import soundfile as sf
 
-        >>> processor = Wav2Vec2Processor.from_pretrained("facebook/hubert-base-960h")
-        >>> model = TFHubertModel.from_pretrained("facebook/hubert-base-960h")
+        >>> processor = Wav2Vec2Processor.from_pretrained("facebook/hubert-large-ls960-ft")
+        >>> model = TFHubertModel.from_pretrained("facebook/hubert-large-ls960-ft")
 
 
         >>> def map_to_array(batch):
@@ -1583,8 +1583,8 @@ class TFHubertForCTC(TFHubertPreTrainedModel):
         >>> from datasets import load_dataset
         >>> import soundfile as sf
 
-        >>> processor = Wav2Vec2Processor.from_pretrained("facebook/hubert-base-960h")
-        >>> model = TFHubertForCTC.from_pretrained("facebook/hubert-base-960h")
+        >>> processor = Wav2Vec2Processor.from_pretrained("facebook/hubert-large-ls960-ft")
+        >>> model = TFHubertForCTC.from_pretrained("facebook/hubert-large-ls960-ft")
 
 
         >>> def map_to_array(batch):


### PR DESCRIPTION
# What does this PR do?

This PR updates the used models in the `TFHubertModel` and `TFHubertModelForCTC` example codes to the same model used in `HubertModel` and `HubertModelForCTC` other examples in the same documentation as `"facebook/hubert-base-960h"` does not exist and the actual code doesn't run.