### PR TITLE
Change doctests ci launch time

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -6,7 +6,7 @@ on:
       - doctest*
   repository_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 2 * * *"
 
 
 env:


### PR DESCRIPTION
# What does this PR do?

Current doctests CI is launched at 0h (GTM+0), but the docker images are built at  1h (GTM+0), while modeling CI is at  2h (GTM+0).

It happens a few times that we change something in doctest docker image workflow file, expect the failed tests will pass in the next run, and turns out it is not - as the next run is launched 1 hour before the new image is built.

To avoid confusion, this PR **change the doctest launch time to be the same as the modeling CI time - which is after the docker image build CI**.