### PR TITLE
Install natten with CUDA version

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -56,6 +56,8 @@ RUN python3 -m pip install --no-cache-dir decord
 # For `dinat` model
 RUN python3 -m pip install --no-cache-dir natten
 
+RUN python3 -m pip install --no-cache-dir natten -f https://shi-labs.com/natten/wheels/$CUDA/
+
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop


### PR DESCRIPTION
# What does this PR do?

The PR #20511 install `natten`, but on GPU machines, we need install it with CUDA supported versions.