### PR TITLE
Fix link to table transformer detection microsoft model

### DIFF
--- a/src/transformers/models/table_transformer/configuration_table_transformer.py
+++ b/src/transformers/models/table_transformer/configuration_table_transformer.py
@@ -27,8 +27,8 @@ from ...utils import logging
 logger = logging.get_logger(__name__)
 
 TABLE_TRANSFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
-    "microsoft/table-transformer-table-detection": (
-        "https://huggingface.co/microsoft/table-transformer-table-detection/resolve/main/config.json"
+    "microsoft/table-transformer-detection": (
+        "https://huggingface.co/microsoft/table-transformer-detection/resolve/main/config.json"
     ),
 }
 
@@ -38,7 +38,7 @@ class TableTransformerConfig(PretrainedConfig):
     This is the configuration class to store the configuration of a [`TableTransformerModel`]. It is used to
     instantiate a Table Transformer model according to the specified arguments, defining the model architecture.
     Instantiating a configuration with the defaults will yield a similar configuration to that of the Table Transformer
-    [microsoft/table-transformer-table-detection](https://huggingface.co/microsoft/table-transformer-table-detection)
+    [microsoft/table-transformer-detection](https://huggingface.co/microsoft/table-transformer-detection)
     architecture.
 
     Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
@@ -117,10 +117,10 @@ class TableTransformerConfig(PretrainedConfig):
     ```python
     >>> from transformers import TableTransformerModel, TableTransformerConfig
 
-    >>> # Initializing a Table Transformer microsoft/table-transformer-table-detection style configuration
+    >>> # Initializing a Table Transformer microsoft/table-transformer-detection style configuration
     >>> configuration = TableTransformerConfig()
 
-    >>> # Initializing a model from the microsoft/table-transformer-table-detection style configuration
+    >>> # Initializing a model from the microsoft/table-transformer-detection style configuration
     >>> model = TableTransformerModel(configuration)
 
     >>> # Accessing the model configuration

--- a/src/transformers/models/table_transformer/configuration_table_transformer.py
+++ b/src/transformers/models/table_transformer/configuration_table_transformer.py
@@ -38,8 +38,7 @@ class TableTransformerConfig(PretrainedConfig):
     This is the configuration class to store the configuration of a [`TableTransformerModel`]. It is used to
     instantiate a Table Transformer model according to the specified arguments, defining the model architecture.
     Instantiating a configuration with the defaults will yield a similar configuration to that of the Table Transformer
-    [microsoft/table-transformer-detection](https://huggingface.co/microsoft/table-transformer-detection)
-    architecture.
+    [microsoft/table-transformer-detection](https://huggingface.co/microsoft/table-transformer-detection) architecture.
 
     Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.


### PR DESCRIPTION
# What does this PR do?

Similar to #20558 the linking to the `microsoft/table-transformer-detection` model seems to be outdated or it has a typo and redirects to a 404.