### PR TITLE
make states contiguous for past_key_values

### DIFF
--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -223,8 +223,8 @@ class BartAttention(nn.Module):
 
         proj_shape = (bsz * self.num_heads, -1, self.head_dim)
         query_states = self._shape(query_states, tgt_len, bsz).view(*proj_shape)
-        key_states = key_states.view(*proj_shape)
-        value_states = value_states.view(*proj_shape)
+        key_states = key_states.contiguous().view(*proj_shape)
+        value_states = value_states.contiguous().view(*proj_shape)
 
         src_len = key_states.size(1)
         attn_weights = torch.bmm(query_states, key_states.transpose(1, 2))


### PR DESCRIPTION
Add contiguous for key and value states.

If someone uses past_key_values, it seems to raise the following exception:

`
RuntimeError: view size is not compatible with input tensor‘s size and stride ...
`
since bart executes torch.cat in BartAttention class:

`
key_states = torch.cat([past_key_value[0], key_states], dim=2)
`
`
value_states = torch.cat([past_key_value[1], value_states], dim=2)
`
Thus, we should make key_states and value_states contiguous.


@patrickvonplaten

---
More, bart cannot correctly process the length of attention_mask when the item of past_key_values is added.

