### PR TITLE
Add `require_torch` to 2 pipeline tests

### DIFF
--- a/tests/pipelines/test_pipelines_table_question_answering.py
+++ b/tests/pipelines/test_pipelines_table_question_answering.py
@@ -481,6 +481,7 @@ class TQAPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
             )
 
     @slow
+    @require_torch
     def test_integration_wtq_pt(self):
         table_querier = pipeline("table-question-answering")
 
@@ -574,6 +575,7 @@ class TQAPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         self.assertListEqual(results, expected_results)
 
     @slow
+    @require_torch
     def test_integration_sqa_pt(self):
         table_querier = pipeline(
             "table-question-answering",


### PR DESCRIPTION
# What does this PR do?

The 2 tests are for `pytorch`, but in TF pipeline test CI job (where `torch` is not available), it runs with TF models.
This is not expected.

Before #20149, these 2 tests are decorated with `require_torch_scatter`. After that PR, the tests try to run with TF, but failed with `TFTapasMainLayer requires the tensorflow_probability library but it was not found in your environment.`
(this is another thing to fix in docker file)