### PR TITLE
Fix `AutomaticSpeechRecognitionPipelineTests.run_pipeline_test`

### DIFF
--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -119,9 +119,8 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             )
         else:
             # Non CTC models cannot use return_timestamps
-            with self.assertRaises(ValueError) as v:
+            with self.assertRaisesRegex(ValueError, "^We cannot return_timestamps yet on non-ctc models !$"):
                 outputs = speech_recognizer(audio, return_timestamps="char")
-            self.assertEqual(str(v.exception), "We cannot return_timestamps yet on non-ctc models !")
 
     @require_torch
     @slow
@@ -143,9 +142,8 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
         self.assertEqual(output, {"text": "(Applaudissements)"})
 
         # Non CTC models cannot use return_timestamps
-        with self.assertRaises(ValueError) as v:
+        with self.assertRaisesRegex(ValueError, "^We cannot return_timestamps yet on non-ctc models !$"):
             _ = speech_recognizer(waveform, return_timestamps="char")
-        self.assertEqual(str(v.exception), "We cannot return_timestamps yet on non-ctc models !")
 
     @require_torch
     def test_small_model_pt_seq2seq(self):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -121,7 +121,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError) as v:
                 outputs = speech_recognizer(audio, return_timestamps="char")
-            self.assertEqual(v.exception, "")
+            self.assertEqual(v.exception, "We cannot return_timestamps yet on non-ctc models !")
 
     @require_torch
     @slow

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -118,11 +118,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
                 },
             )
         else:
-            # Non CTC models cannot use chunk_length
-            with self.assertRaises(ValueError) as v:
-                outputs = speech_recognizer(audio, chunk_length_s=10)
-            self.assertEqual(v.exception, "")
-
             # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError) as v:
                 outputs = speech_recognizer(audio, return_timestamps="char")

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -121,7 +121,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase, metaclass=Pipel
             # Non CTC models cannot use return_timestamps
             with self.assertRaises(ValueError) as v:
                 outputs = speech_recognizer(audio, return_timestamps="char")
-            self.assertEqual(v.exception, "We cannot return_timestamps yet on non-ctc models !")
+            self.assertEqual(str(v.exception), "We cannot return_timestamps yet on non-ctc models !")
 
     @require_torch
     @slow


### PR DESCRIPTION
# What does this PR do?

Fix `AutomaticSpeechRecognitionPipelineTests.run_pipeline_test` which was changed in #19570 and #20104.

See the comments in this PR changes.

I detected this when working on improving pipeline tests using tiny models. Previously, `Speech2TextConfig` is not used in ASR pipeline tests, but now it does, and  gives errors without this PR.