### PR TITLE
Update the list of contributors to reflect current organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,58 +17,53 @@ body:
       description: |
         Your issue will be replied to more quickly if you can figure out the right person to tag with @
         If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
+        
+        All issues are read by one of the core maintainers, so if you don't know who to tag, just leave this blank and
+        a core maintainer will ping the right person.
+        
         Please tag fewer than 3 people.
         
         Models:
 
-          - ALBERT, BERT, XLM, DeBERTa, DeBERTa-v2, ELECTRA, MobileBert, SqueezeBert: `@LysandreJik`
-          - T5, Pegasus, EncoderDecoder: `@patrickvonplaten`
-          - Blenderbot, MBART, BART, Marian, Pegasus: `@patil-suraj`
-          - Reformer, TransfoXL, XLNet, FNet: `@patrickvonplaten`
-          - Longformer, BigBird: `@ydshieh`
-          - FSMT: `@stas00`
-          - Funnel: `@sgugger`
-          - GPT-2, GPT: `@patil-suraj`, `@patrickvonplaten`, `@LysandreJik`
-          - RAG, DPR: `@patrickvonplaten`, `@lhoestq`
-          - TensorFlow: `@Rocketknight1`
-          - JAX/Flax: `@patil-suraj`
-          - TAPAS, LayoutLM, LayoutLMv2, LUKE, ViT, BEiT, DEiT, DETR, CANINE: `@NielsRogge`
-          - GPT-Neo, GPT-J, CLIP: `@patil-suraj`
-          - Wav2Vec2, HuBERT, UniSpeech, UniSpeechSAT, SEW, SEW-D: `@patrickvonplaten`, `@anton-l`
-          - SpeechEncoderDecoder, Speech2Text, Speech2Text2: `@sanchit-gandhi`, `@patrickvonplaten`, `@anton-l`
-          
-          If the model isn't in the list, ping `@LysandreJik` who will redirect you to the correct contributor.
-
+        - text models: @ArthurZucker and @younesbelkada
+        - vision models: @amyeroberts and @NielsRogge
+        - speech models: @sanchit-gandhi
+        
         Library:
-          - Benchmarks: `@patrickvonplaten`
-          - Deepspeed: `@stas00`
-          - Ray/raytune: `@richardliaw`, `@amogkam`
-          - Text generation: `@patrickvonplaten`, `@Narsil`, `@gante`
-          - Tokenizers: `@SaulLu`
-          - Trainer: `@sgugger`
-          - Pipelines: `@Narsil`
-          - Speech: `@patrickvonplaten`, `@anton-l`, `@sanchit-gandhi`
-          - Vision: `@NielsRogge`, `@sgugger`
-
-        Documentation: `@sgugger`, `@stevhliu`
-
+        
+        - flax: @sanchit-gandhi
+        - generate: @gante
+        - pipelines: @Narsil
+        - tensorflow: @gante and @Rocketknight1
+        - tokenizers: @ArthurZucker
+        - trainer: @sgugger
+        
+        Integrations:
+        
+        - deepspeed: @stas00
+        - ray/raytune: @richardliaw, @amogkam
+        
+        Documentation: @sgugger and @stevhliu
+        
         Model hub:
 
           - for issues with a model, report at https://discuss.huggingface.co/ and tag the model's creator.
-
+        
         HF projects:
+        
+        - accelerate: [different repo](https://github.com/huggingface/accelerate)
+        - datasets: [different repo](https://github.com/huggingface/datasets)
+        - diffusers: [different repo](https://github.com/huggingface/diffusers)
+        - rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
+        
+        Maintained examples (not research project or legacy):
+        
+        - Flax: @sanchit-gandhi
+        - PyTorch: @sgugger
+        - TensorFlow: @Rocketknight1
 
-          - datasets: [different repo](https://github.com/huggingface/datasets)
-          - rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
+        Research projects are not maintained and should be taken as is.
 
-        Examples:
-
-          - maintained examples (not research project or legacy): `@sgugger`, `@patil-suraj`
-
-        For research projetcs, please ping the contributor directly. For example, on the following projects:
-
-          - research_projects/bert-loses-patience: `@JetRunner`
-          - research_projects/distillation: `@VictorSanh`
       placeholder: "@Username ..."
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -25,23 +25,23 @@ body:
         
         Models:
 
-        - text models: @ArthurZucker and @younesbelkada
-        - vision models: @amyeroberts and @NielsRogge
-        - speech models: @sanchit-gandhi
+          - text models: @ArthurZucker and @younesbelkada
+          - vision models: @amyeroberts and @NielsRogge
+          - speech models: @sanchit-gandhi
         
         Library:
         
-        - flax: @sanchit-gandhi
-        - generate: @gante
-        - pipelines: @Narsil
-        - tensorflow: @gante and @Rocketknight1
-        - tokenizers: @ArthurZucker
-        - trainer: @sgugger
+          - flax: @sanchit-gandhi
+          - generate: @gante
+          - pipelines: @Narsil
+          - tensorflow: @gante and @Rocketknight1
+          - tokenizers: @ArthurZucker
+          - trainer: @sgugger
         
         Integrations:
         
-        - deepspeed: @stas00
-        - ray/raytune: @richardliaw, @amogkam
+          - deepspeed: @stas00
+          - ray/raytune: @richardliaw, @amogkam
         
         Documentation: @sgugger and @stevhliu
         
@@ -51,16 +51,16 @@ body:
         
         HF projects:
         
-        - accelerate: [different repo](https://github.com/huggingface/accelerate)
-        - datasets: [different repo](https://github.com/huggingface/datasets)
-        - diffusers: [different repo](https://github.com/huggingface/diffusers)
-        - rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
+          - accelerate: [different repo](https://github.com/huggingface/accelerate)
+          - datasets: [different repo](https://github.com/huggingface/datasets)
+          - diffusers: [different repo](https://github.com/huggingface/diffusers)
+          - rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
         
         Maintained examples (not research project or legacy):
         
-        - Flax: @sanchit-gandhi
-        - PyTorch: @sgugger
-        - TensorFlow: @Rocketknight1
+          - Flax: @sanchit-gandhi
+          - PyTorch: @sgugger
+          - TensorFlow: @Rocketknight1
 
         Research projects are not maintained and should be taken as is.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,36 +39,37 @@ members/contributors who may be interested in your PR.
 
 Models:
 
-- albert, bert, xlm: @LysandreJik
-- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
-- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
-- fsmt: @stas00
-- funnel: @sgugger
-- gpt2: @patrickvonplaten, @LysandreJik
-- rag: @patrickvonplaten, @lhoestq
-- tensorflow: @LysandreJik
+- text models: @ArthurZucker and @younesbelkada
+- vision models: @amyeroberts and @NielsRogge
+- speech models: @sanchit-gandhi
 
 Library:
 
-- benchmarks: @patrickvonplaten
+- flax: @sanchit-gandhi
+- generate: @gante
+- pipelines: @Narsil
+- tensorflow: @gante and @Rocketknight1
+- tokenizers: @ArthurZucker
+- trainer: @sgugger
+
+Integrations:
+
 - deepspeed: @stas00
 - ray/raytune: @richardliaw, @amogkam
-- text generation: @patrickvonplaten
-- tokenizers: @n1t0, @LysandreJik
-- trainer: @sgugger
-- pipelines: @LysandreJik
 
-Documentation: @sgugger
+Documentation: @sgugger and @stevhliu
 
 HF projects:
 
+- accelerate: [different repo](https://github.com/huggingface/accelerate)
 - datasets: [different repo](https://github.com/huggingface/datasets)
+- diffusers: [different repo](https://github.com/huggingface/diffusers)
 - rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)
 
-Examples:
+Maintained examples (not research project or legacy):
 
-- maintained examples (not research project or legacy): @sgugger, @patil-suraj
-- research_projects/bert-loses-patience: @JetRunner
-- research_projects/distillation: @VictorSanh
+- Flax: @sanchit-gandhi
+- PyTorch: @sgugger
+- TensorFlow: @Rocketknight1
 
  -->


### PR DESCRIPTION
# What does this PR do?

This PR updates the list of who to tag on PRs/Issues. With the growing number of models, I chose to split them through modality.