### PR TITLE
Fix test for file not found

### DIFF
--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -281,7 +281,7 @@ class TFAutoModelTest(unittest.TestCase):
     def test_model_file_not_found(self):
         with self.assertRaisesRegex(
             EnvironmentError,
-            "hf-internal-testing/config-no-model does not appear to have a file named tf_model.h5",
+            "hf-internal-testing/config-no-model does not appear to have a file named pytorch_model.bin",
         ):
             _ = TFAutoModel.from_pretrained("hf-internal-testing/config-no-model")
 


### PR DESCRIPTION
# What does this PR do?

The test for file not found in the TensorFlow auto model tests is failing on main as the message does not match exactly (see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/53015/workflows/6ea05b10-a541-46db-bcce-b93dc654610e/jobs/636205)). This PR fixes that.