### PR TITLE
fix past_key_values in GPTNeoXForCausalLM.prepare_inputs_for_generation

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -697,7 +697,11 @@ class GPTNeoXForCausalLM(GPTNeoXPreTrainedModel):
         if past and past[0] is not None:
             input_ids = input_ids[:, -1:]
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past or model_kwargs.get("past_key_values")}
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "past_key_values": past or model_kwargs.get("past_key_values"),
+        }
 
     def _reorder_cache(self, past, beam_idx):
         reordered_past = ()

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -697,7 +697,7 @@ class GPTNeoXForCausalLM(GPTNeoXPreTrainedModel):
         if past and past[0] is not None:
             input_ids = input_ids[:, -1:]
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past}
+        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past or model_kwargs.get("past_key_values")}
 
     def _reorder_cache(self, past, beam_idx):
         reordered_past = ()


### PR DESCRIPTION
# What does this PR do?

@gante @sgugger 

Fixes `past_key_values` in `GPTNeoXForCausalLM.prepare_inputs_for_generation`. Passing `past_key_values` to `model.generate` had no effect whatsoever, since the argument was swallowed. Described in Issue #20347 (note that the validation bug was fixed in PR #20353, but the argument was still not passed along to the forward method)

The attached commit fixes the issue on my end, i.e. I now get different results when passing `past_key_values` to `generate`, as opposed to before.