### PR TITLE
Update summarization `run_pipeline_test`

### DIFF
--- a/tests/pipelines/test_pipelines_summarization.py
+++ b/tests/pipelines/test_pipelines_summarization.py
@@ -56,11 +56,10 @@ class SummarizationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMe
             "T5Config",
             "LongT5Config",
             "LEDConfig",
-            # tokenizers that get small `model_max_length`
-            "PegasusXConfig",  # `PegasusXModelTester` sets `max_position_embeddings=30`
-            "FSMTConfig",  # `FSMTModelTester` sets `max_position_embeddings=20`
-            "M2M100Config",  # `M2M100ModelTester` sets `max_position_embeddings=20`
-            "ProphetNetConfig",  # `ProphetNetModelTester` sets `max_position_embeddings=30`
+            "PegasusXConfig",
+            "FSMTConfig",
+            "M2M100Config",
+            "ProphetNetConfig",  # positional embeddings up to a fixed maximum size (otherwise clamping the values)
         ]
         if model.config.__class__.__name__ not in model_can_handle_longer_seq:
             # Switch Transformers, LED, T5, LongT5 can handle it.

--- a/tests/pipelines/test_pipelines_summarization.py
+++ b/tests/pipelines/test_pipelines_summarization.py
@@ -17,11 +17,7 @@ import unittest
 from transformers import (
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
     TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-    LEDConfig,
-    LongT5Config,
     SummarizationPipeline,
-    SwitchTransformersConfig,
-    T5Config,
     pipeline,
 )
 from transformers.testing_utils import require_tf, require_torch, slow, torch_device
@@ -55,7 +51,18 @@ class SummarizationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMe
         )
         self.assertEqual(outputs, [{"summary_text": ANY(str)}])
 
-        if not isinstance(model.config, (SwitchTransformersConfig, T5Config, LongT5Config, LEDConfig)):
+        model_can_handle_longer_seq = [
+            "SwitchTransformersConfig",
+            "T5Config",
+            "LongT5Config",
+            "LEDConfig",
+            # tokenizers that get small `model_max_length`
+            "PegasusXConfig",  # `PegasusXModelTester` sets `max_position_embeddings=30`
+            "FSMTConfig",  # `FSMTModelTester` sets `max_position_embeddings=20`
+            "M2M100Config",  # `M2M100ModelTester` sets `max_position_embeddings=20`
+            "ProphetNetConfig",  # `ProphetNetModelTester` sets `max_position_embeddings=30`
+        ]
+        if model.config.__class__.__name__ not in model_can_handle_longer_seq:
             # Switch Transformers, LED, T5, LongT5 can handle it.
             # Too long.
             with self.assertRaises(Exception):


### PR DESCRIPTION
# What does this PR do?

Update summarization `run_pipeline_test`.

A few more models can handle longer sequences, and won't give expected exception at this place
```python
            with self.assertRaises(Exception):
                outputs = summarizer("This " * 1000)
```
So we need to ignore those model config classes.