### PR TITLE
Fix donut image processor

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -202,9 +202,6 @@ def get_resize_output_image_size(
     short, long = (width, height) if width <= height else (height, width)
     requested_new_short = size
 
-    if short == requested_new_short:
-        return (height, width)
-
     new_short, new_long = requested_new_short, int(requested_new_short * long / short)
 
     if max_size is not None:

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -279,7 +279,6 @@ def resize(
         resized_image = to_channel_dimension_format(
             resized_image, data_format, input_channel_dim=ChannelDimension.LAST
         )
-        # resized_image = to_channel_dimension_format(resized_image, data_format)
     return resized_image
 
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -152,6 +152,7 @@ def to_pil_image(
     return PIL.Image.fromarray(image)
 
 
+# Logic adapted from torchvision resizing logic: https://github.com/pytorch/vision/blob/511924c1ced4ce0461197e5caa64ce5b9e558aab/torchvision/transforms/functional.py#L366
 def get_resize_output_image_size(
     input_image: np.ndarray,
     size: Union[int, Tuple[int, int], List[int], Tuple[int]],

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -48,7 +48,11 @@ if is_flax_available():
     import jax.numpy as jnp
 
 
-def to_channel_dimension_format(image: np.ndarray, channel_dim: Union[ChannelDimension, str]) -> np.ndarray:
+def to_channel_dimension_format(
+    image: np.ndarray,
+    channel_dim: Union[ChannelDimension, str],
+    input_channel_dim: Optional[Union[ChannelDimension, str]] = None,
+) -> np.ndarray:
     """
     Converts `image` to the channel dimension format specified by `channel_dim`.
 
@@ -64,9 +68,11 @@ def to_channel_dimension_format(image: np.ndarray, channel_dim: Union[ChannelDim
     if not isinstance(image, np.ndarray):
         raise ValueError(f"Input image must be of type np.ndarray, got {type(image)}")
 
-    current_channel_dim = infer_channel_dimension_format(image)
+    if input_channel_dim is None:
+        input_channel_dim = infer_channel_dimension_format(image)
+
     target_channel_dim = ChannelDimension(channel_dim)
-    if current_channel_dim == target_channel_dim:
+    if input_channel_dim == target_channel_dim:
         return image
 
     if target_channel_dim == ChannelDimension.FIRST:
@@ -269,7 +275,11 @@ def resize(
         # If the input image channel dimension was of size 1, then it is dropped when converting to a PIL image
         # so we need to add it back if necessary.
         resized_image = np.expand_dims(resized_image, axis=-1) if resized_image.ndim == 2 else resized_image
-        resized_image = to_channel_dimension_format(resized_image, data_format)
+        # The image is always in channels last format after converting from a PIL image
+        resized_image = to_channel_dimension_format(
+            resized_image, data_format, input_channel_dim=ChannelDimension.LAST
+        )
+        # resized_image = to_channel_dimension_format(resized_image, data_format)
     return resized_image
 
 

--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -222,7 +222,9 @@ class DonutImageProcessor(BaseImageProcessor):
             data_format (`Optional[Union[str, ChannelDimension]]`, *optional*):
                 The data format of the output image. If unset, the same format as the input image is used.
         """
-        output_size = (size["height"], size["width"])
+        min_size = min(size["height"], size["width"])
+        max_size = max(size["height"], size["width"])
+        output_size = get_resize_output_image_size(image, min_size, default_to_square=False, max_size=max_size)
         return resize(image, size=output_size, resample=resample, reducing_gap=2.0, data_format=data_format, **kwargs)
 
     def resize(

--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -420,7 +420,7 @@ class DonutImageProcessor(BaseImageProcessor):
         images = [to_numpy_array(image) for image in images]
 
         if do_align_long_axis:
-            images = [self.align_long_axis(image) for image in images]
+            images = [self.align_long_axis(image, size=size) for image in images]
 
         if do_resize:
             images = [self.resize(image=image, size=size, resample=resample) for image in images]

--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -235,7 +235,7 @@ class DonutImageProcessor(BaseImageProcessor):
 
         if input_height > input_width:
             width = int(input_width * height / input_height)
-        else:
+        elif input_width > input_height:
             height = int(input_height * width / input_width)
 
         return resize(
@@ -267,7 +267,8 @@ class DonutImageProcessor(BaseImageProcessor):
         size = get_size_dict(size)
         shortest_edge = min(size["height"], size["width"])
         output_size = get_resize_output_image_size(image, size=shortest_edge, default_to_square=False)
-        return resize(image, size=output_size, resample=resample, data_format=data_format, **kwargs)
+        resized_image = resize(image, size=output_size, resample=resample, data_format=data_format, **kwargs)
+        return resized_image
 
     def rescale(
         self,

--- a/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
@@ -836,7 +836,7 @@ class DonutModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size([1, 1, 57532])
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([24.2731, -6.4522, 32.4130]).to(torch_device)
+        expected_slice = torch.tensor([24.3873, -6.4491, 32.5394]).to(torch_device)
         self.assertTrue(torch.allclose(logits[0, 0, :3], expected_slice, atol=1e-4))
 
         # step 2: generation
@@ -872,7 +872,7 @@ class DonutModelIntegrationTest(unittest.TestCase):
         self.assertEqual(len(outputs.scores), 11)
         self.assertTrue(
             torch.allclose(
-                outputs.scores[0][0, :3], torch.tensor([5.3153, -3.5276, 13.4781], device=torch_device), atol=1e-4
+                outputs.scores[0][0, :3], torch.tensor([5.6019, -3.5070, 13.7123], device=torch_device), atol=1e-4
             )
         )
 

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -184,6 +184,25 @@ class ImageTransformsTester(unittest.TestCase):
         image = np.random.randint(0, 256, (3, 50, 40))
         self.assertEqual(get_resize_output_image_size(image, 20, default_to_square=False, max_size=22), (22, 17))
 
+        # Test correct channel dimension is returned if output size if height == 3
+        # Defaults to input format - channels first
+        image = np.random.randint(0, 256, (3, 18, 97))
+        resized_image = resize(image, (3, 20))
+        self.assertEqual(resized_image.shape, (3, 3, 20))
+
+        # Defaults to input format - channels last
+        image = np.random.randint(0, 256, (18, 97, 3))
+        resized_image = resize(image, (3, 20))
+        self.assertEqual(resized_image.shape, (3, 20, 3))
+
+        image = np.random.randint(0, 256, (3, 18, 97))
+        resized_image = resize(image, (3, 20), data_format="channels_last")
+        self.assertEqual(resized_image.shape, (3, 20, 3))
+
+        image = np.random.randint(0, 256, (18, 97, 3))
+        resized_image = resize(image, (3, 20), data_format="channels_first")
+        self.assertEqual(resized_image.shape, (3, 3, 20))
+
     def test_resize(self):
         image = np.random.randint(0, 256, (3, 224, 224))
 


### PR DESCRIPTION
# What does this PR do?

This PR addresses failing integration tests for the Donut image processor which involves four main changes: 

* Resolve bug where `size` wasn't passed to `do_align_axis`
* Remove a bug in the `get_resize_output_image_size` function which wouldn't take account of `max_size` ([inherited from previous resize without fixing](https://github.com/huggingface/transformers/blob/7586a1a367f5974e099e1be2fa8a751aa766179f/src/transformers/image_utils.py#L451))
* Update logic for getting output size in `thumbnail` method - ensuring the image dimensions are never increased. 
* Update test values to reflect changes in resizing logic for thumbnail creation - see notes below. 

### Changing resizing logic for `thumbnail` method

The DonutFeatueExtractor used the [Pillow thumbnail functionality](https://github.com/huggingface/transformers/blob/6cc06d17394f5715cdf2d13a1ef7680bedaee9e2/src/transformers/models/donut/feature_extraction_donut.py#LL109C18-L109C18) to resize images which was [replaced with reusing `resize`](https://github.com/huggingface/transformers/blob/bf9a5882a7125a6050aaad0f52257f07df062d6a/src/transformers/models/donut/image_processing_donut.py#L226) in the image_transforms library. This was done primarily as `image.thumbnail` modifies in place and uses [Pillow's resize](https://github.com/python-pillow/Pillow/blob/1e28c8cffd8492af6bf5df2045e7ffe08b124033/src/PIL/Image.py#LL2538C13-L2538C13) with some additional logic for calculating the output size. Unlike `resize` which will resize an image to the requested `(height, width)`, `thumbnail` will produce an image which is no larger than the original image or requested size i.e. it will scale down an image preserving the aspect ratio c.f. [Pillow docs](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.thumbnail). 

This is a similar behaviour to torchvision when resizing:
* the shortest image edge is resized to `size` (int for torchvision, `min(requested_heigh, requsted_width)` for Pillow)
* the other edge is resized to preserve the aspect ratio
* if the longest edge > `max_size`, the longest edge is resized to `max_size` and the shortest edge resized to preserve the aspect ratio. 

The calculation of the other dimension to preserve the aspect ratio is slightly different between the libraries. In pytorch the length of the edge is found [using `int` to round](https://github.com/pytorch/vision/blob/511924c1ced4ce0461197e5caa64ce5b9e558aab/torchvision/transforms/functional.py#L383), whereas Pillow [rounds to the value which produces an aspect ratio closest to the original image](https://github.com/python-pillow/Pillow/blob/1e28c8cffd8492af6bf5df2045e7ffe08b124033/src/PIL/Image.py#L2505). The torchvision resizing logic is replicated in our image transforms library [here](https://github.com/huggingface/transformers/blob/ae1cffaf3cd42d0ab1d7529e3b3118725bca0bcf/src/transformers/image_transforms.py#L155). 

In the test [`tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py::DonutModelIntegrationTest::test_inference_docvqa`](https://github.com/huggingface/transformers/blob/6cc06d17394f5715cdf2d13a1ef7680bedaee9e2/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py#L816), the input image to the `thumbnail` method has dimension `(3713, 1920)`. The requested size is `(2560, 1920)`. `image.thumbnail` will resize to `(2560, 1373)` and our resizing logic (matching torchvision) will resize to `(2560, 1374)`.

As using torchvision resizing logic is more consistent with the rest of the library; Donut is the only model in the library that used the Pillow thumbnail functionality, and is more experimental than other models; I considered this to be an acceptable change. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?