### PR TITLE
fix natten installation

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -54,8 +54,6 @@ RUN python3 -m pip install --no-cache-dir bitsandbytes
 RUN python3 -m pip install --no-cache-dir decord
 
 # For `dinat` model
-RUN python3 -m pip install --no-cache-dir natten
-
 RUN python3 -m pip install --no-cache-dir natten -f https://shi-labs.com/natten/wheels/$CUDA/
 
 # When installing in editable mode, `transformers` is not recognized as a package.


### PR DESCRIPTION
# What does this PR do?

I made a mistake in #20546 and it ended up with
```bash
# For `dinat` model
RUN python3 -m pip install --no-cache-dir natten

RUN python3 -m pip install --no-cache-dir natten -f https://shi-labs.com/natten/wheels/$CUDA/
```
so the CUDA version was not installed (due to `Requirement already satisfied`)