### PR TITLE
Speed up git-lfs detection on error

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -415,7 +415,7 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
     except Exception as e:
         try:
             with open(checkpoint_file) as f:
-                if f.read().startswith("version"):
+                if f.read(7) == "version":
                     raise OSError(
                         "You seem to have cloned a repository without having git-lfs installed. Please install "
                         "git-lfs and run `git lfs install` followed by `git lfs pull` in the folder "


### PR DESCRIPTION
Prevent read and discard of entire checkpoint file.

# What does this PR do?

Mutates an error handler that checks only 7 bytes, to only read those 7 bytes rather than an entire checkpoint file.

Fixes # (issue)

Issue not opened. I encountered a memory allocation crash here when exploring disk offloading.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger