### PR TITLE
[`ViTHybrid`] + [`BiT`] cleaner `__init__`

### DIFF
--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -671,15 +671,6 @@ class BitPreTrainedModel(PreTrainedModel):
         if isinstance(module, BitModel):
             module.gradient_checkpointing = value
 
-    @torch.no_grad()
-    def _get_feature_map(self, dummy_image):
-        training = self.training
-        if training:
-            self.eval()
-        feature_map = self(dummy_image).feature_maps[-1]
-        self.train(training)
-        return feature_map
-
 
 BIT_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it

--- a/src/transformers/models/vit_hybrid/configuration_vit_hybrid.py
+++ b/src/transformers/models/vit_hybrid/configuration_vit_hybrid.py
@@ -69,6 +69,8 @@ class ViTHybridConfig(PretrainedConfig):
             The number of input channels.
         qkv_bias (`bool`, *optional*, defaults to `True`):
             Whether to add a bias to the queries, keys and values.
+        backbone_config (`Union[Dict[str, Any], PretrainedConfig]`, *optional*, defaults to `None`):
+            The configuration of the backbone in a dictionary or the config object of the backbone.
 
     Example:
 

--- a/src/transformers/models/vit_hybrid/modeling_vit_hybrid.py
+++ b/src/transformers/models/vit_hybrid/modeling_vit_hybrid.py
@@ -167,7 +167,8 @@ class ViTHybridPatchEmbeddings(nn.Module):
 
         if feature_size is None:
             dummy_image = torch.zeros(1, num_channels, image_size[0], image_size[1])
-            feature_map = self.backbone._get_feature_map(dummy_image)
+            with torch.no_grad():
+                feature_map = self.backbone(dummy_image).feature_maps[-1]
             feature_size = feature_map.shape[-2:]
             feature_dim = feature_map.shape[1]
         else:


### PR DESCRIPTION
# What does this PR do?

a function in `BiT` is not needed, thus this PR makes the codebase less error-prone.
Before that, to get the feature maps size from the backbone model, `ViTHybrid` assumed that the backbone has the method `_get_feature_map` which is not the case for all backbones.

Related #20645