### PR TITLE
[Trainer] add error when passing `8bit`models

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -358,7 +358,7 @@ class Trainer:
             self.is_model_parallel = False
 
         # At this stage the model is already loaded
-        if getattr(self, "is_loaded_in_8bit", False):
+        if getattr(model, "is_loaded_in_8bit", False):
             raise ValueError(
                 "The model you have picked is already loaded in 8-bit precision. "
                 "Training an 8-bit model is not supported yet. "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -360,7 +360,7 @@ class Trainer:
         # At this stage the model is already loaded
         if getattr(model, "is_loaded_in_8bit", False):
             raise ValueError(
-                "The model you have picked is already loaded in 8-bit precision. "
+                "The model you want to train is loaded in 8-bit precision. "
                 "Training an 8-bit model is not supported yet. "
             )
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -357,6 +357,13 @@ class Trainer:
         else:
             self.is_model_parallel = False
 
+        # At this stage the model is already loaded
+        if getattr(self, "is_loaded_in_8bit", False):
+            raise ValueError(
+                "The model you have picked is already loaded in 8-bit precision. "
+                "Training an 8-bit model is not supported yet. "
+            )
+
         # Setup Sharded DDP training
         self.sharded_ddp = None
         if len(args.sharded_ddp) > 0:


### PR DESCRIPTION
# What does this PR do?

Before this PR, any user could load an 8bit model and pass it to a Trainer, which is wrong. In fact, it is not possible to train an 8bit model (yet). Therefore we should raise an error until this will be supported in the future

Related: https://github.com/huggingface/transformers/issues/20348#issuecomment-1335106257

cc @ydshieh @sgugger 

