### PR TITLE
[`BiT`] Small patch fix

### DIFF
--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -18,6 +18,7 @@ import collections
 import math
 from typing import Optional, Tuple
 
+import numpy as np
 import torch
 import torch.utils.checkpoint
 from torch import Tensor, nn
@@ -593,9 +594,7 @@ class BitEncoder(nn.Module):
 
         layer_dropouts = [
             x.tolist()
-            for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), dtype=torch.float32).split(
-                config.depths
-            )
+            for x in torch.Tensor(np.linspace(0, config.drop_path_rate, sum(config.depths))).split(config.depths)
         ]
 
         for stage_idx, (current_depth, current_hidden_size, layer_dropout) in enumerate(

--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -592,7 +592,10 @@ class BitEncoder(nn.Module):
         dilation = 1
 
         layer_dropouts = [
-            x.tolist() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths)).split(config.depths)
+            x.tolist()
+            for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), dtype=torch.float32).split(
+                config.depths
+            )
         ]
 
         for stage_idx, (current_depth, current_hidden_size, layer_dropout) in enumerate(


### PR DESCRIPTION
# What does this PR do?

This PR fixes a tiny issue that you can encounter if you load `BiT` in fp16.
`diffusers` uses this model under the hood for Depth Estimation inpainting and users get this error:
```
    593 
    594         layer_dropouts = [
--> 595             x.tolist() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), dtype=torch.float32).split(config.depths)
    596         ]
    597 

RuntimeError: "linspace_cpu" not implemented for 'Half'

```
However on `diffusers` side this can be fixed by installing `accelerate` and load the pipeline with `low_cpu_mem_usage=True`. But better to fix it to avoid any misleading issue


cc @sgugger @patil-suraj 

Otherwise to reproduce:
```
import torch
from transformers import BitModel

model = BitModel.from_pretrained("google/bit-50", torch_dtype=torch.float16)
```