### PR TITLE
Whilelist Transformers private method in DummyObject

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1004,7 +1004,7 @@ class DummyObject(type):
     """
 
     def __getattribute__(cls, key):
-        if key.startswith("_"):
+        if key.startswith("_") and key != "_from_config":
             return super().__getattribute__(key)
         requires_backends(cls, cls._backends)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #20671

As reported in #20671, calling `AutoModel.from_config` on a model with a missing specific soft dependency does not raise the appropriate error. This is because this method ends up calling `ModelClass._from_config` and the `DummyObject` class does not raise the error on all private attributes (basically because we need the `__xxx__` attribute to stay the same). This PR whitelists `_from_config` to fix the issue.