### PR TITLE
Add `keep_in_fp32_modules` support

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2292,8 +2292,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if not is_accelerate_available() and torch_dtype == torch.float16:
                     use_keep_in_fp32_modules = False
                     logger.warning(
-                        " `_keep_in_fp32_modules` is not set to `None` and you don't have `accelerate` installed"
-                        " it is recommended to have `accelerate` installed in this case `pip install accelerate`.",
+                        " For stability purposes, it is recommended to have accelerate installed when using this model"
+                        " in torch.flaot16, please install it with pip install accelerate.",
                     )
                 else:
                     use_keep_in_fp32_modules = True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2288,8 +2288,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             # Check if `_keep_in_fp32_modules` is not None
             # but not force users to have `accelerate`
-            keep_in_fp32_modules = cls._keep_in_fp32_modules
-            if keep_in_fp32_modules is not None:
+            if cls._keep_in_fp32_modules is not None:
                 if not is_accelerate_available() and torch_dtype == torch.float16:
                     use_keep_in_fp32_modules = False
                     logger.warning(
@@ -2298,7 +2297,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                 else:
                     use_keep_in_fp32_modules = True
-                    low_cpu_mem_usage = True
             else:
                 use_keep_in_fp32_modules = False
 
@@ -2324,6 +2322,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         with ContextManagers(init_contexts):
             model = cls(config, *model_args, **model_kwargs)
+
+        if use_keep_in_fp32_modules:
+            low_cpu_mem_usage = True
+        keep_in_fp32_modules = model._keep_in_fp32_modules
 
         if load_in_8bit:
             from .utils.bitsandbytes import get_keys_to_not_convert, replace_8bit_linear

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2301,7 +2301,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             ):
                 logger.warning(
                     "For stability purposes, it is recommended to have accelerate installed when using this model in"
-                    " torch.flaot16, please install it with `pip install accelerate`"
+                    " torch.float16, please install it with `pip install accelerate`"
                 )
 
             if is_sharded:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -615,7 +615,7 @@ def _load_state_dict_into_meta_model(
             if (
                 keep_in_fp32_modules is not None
                 and any(module_to_keep_in_fp32 in param_name for module_to_keep_in_fp32 in keep_in_fp32_modules)
-                and dtype != torch.bfloat16
+                and dtype == torch.float16
             ):
                 param = param.to(torch.float32)
             else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2289,10 +2289,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # Check if `_keep_in_fp32_modules` is not None
             # but not force users to have `accelerate`
             if cls._keep_in_fp32_modules is not None:
-                if not is_accelerate_available() or torch_dtype == torch.bfloat16:
+                if not is_accelerate_available() and torch_dtype == torch.float16:
                     use_keep_in_fp32_modules = False
                     logger.warning(
-                        " `_keep_in_fp32_modules` is not set to `None` and you don't have `accelerate` installed",
+                        " `_keep_in_fp32_modules` is not set to `None` and you don't have `accelerate` installed"
                         " it is recommended to have `accelerate` installed in this case `pip install accelerate`.",
                     )
                 else:
@@ -2571,8 +2571,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 # upcast in fp32 if any
                 target_dtype = dtype
-                if keep_in_fp32_modules is not None and any(
-                    module_to_keep_in_fp32 in key for module_to_keep_in_fp32 in keep_in_fp32_modules
+                if (
+                    keep_in_fp32_modules is not None
+                    and dtype == torch.float16
+                    and any(module_to_keep_in_fp32 in key for module_to_keep_in_fp32 in keep_in_fp32_modules)
                 ):
                     target_dtype = torch.float32
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2297,6 +2297,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                 else:
                     use_keep_in_fp32_modules = True
+                    low_cpu_mem_usage = True
             else:
                 use_keep_in_fp32_modules = False
 
@@ -2323,9 +2324,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         with ContextManagers(init_contexts):
             model = cls(config, *model_args, **model_kwargs)
 
-        keep_in_fp32_modules = model._keep_in_fp32_modules
-        if keep_in_fp32_modules is not None:
-            low_cpu_mem_usage = True
+        if use_keep_in_fp32_modules:
+            keep_in_fp32_modules = model._keep_in_fp32_modules
 
         if load_in_8bit:
             from .utils.bitsandbytes import get_keys_to_not_convert, replace_8bit_linear

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2345,6 +2345,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 modules_to_not_convert = load_in_8bit_skip_modules
 
+            if not isinstance(modules_to_not_convert, list):
+                modules_to_not_convert = [modules_to_not_convert]
+
             modules_to_not_convert.extend(keep_in_fp32_modules)
 
             model = replace_8bit_linear(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2291,7 +2291,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 dtype_orig = cls._set_default_torch_dtype(torch_dtype)
 
             # Check if `_keep_in_fp32_modules` is not None
-            use_keep_in_fp32_modules = cls._keep_in_fp32_modules is not None and is_accelerate_available()
+            use_keep_in_fp32_modules = (
+                (cls._keep_in_fp32_modules is not None) and is_accelerate_available() and torch_dtype == torch.float16
+            )
+            if (
+                (cls._keep_in_fp32_modules is not None)
+                and not is_accelerate_available()
+                and torch_dtype == torch.float16
+            ):
+                logger.warning(
+                    "For stability purposes, it is recommended to have accelerate installed when using this model in"
+                    " torch.flaot16, please install it with `pip install accelerate`"
+                )
 
             if is_sharded:
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2271,6 +2271,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                 else:
                     use_keep_in_fp32_modules = True
+            else:
+                use_keep_in_fp32_modules = False
 
             # set dtype to instantiate the model under:
             # 1. If torch_dtype is not None, we use that dtype

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1989,13 +1989,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             elif not low_cpu_mem_usage:
                 raise ValueError("Passing along a `device_map` requires `low_cpu_mem_usage=True`")
 
-        # if keep_in_fp32_modules is not None and not low_cpu_mem_usage:
-        #     # Force `low_cpu_mem_usage` to be set to `True` - check the PR:
-        #     logger.warning(
-        #         "The argument `keep_in_fp32_modules` is used, force-enabling `low_cpu_mem_usage` to load the model"
-        #     )
-        #     low_cpu_mem_usage = True
-
         if low_cpu_mem_usage:
             # low_cpu_mem_usage requires PyTorch >= 1.9 to have the meta device.
             require_version_core("torch>=1.9")
@@ -2273,6 +2266,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             #    weights entry that is of a floating type - we assume all floating dtype weights are of the same dtype
             # we also may have config.torch_dtype available, but we won't rely on it till v5
             dtype_orig = None
+
             if torch_dtype is not None:
                 if isinstance(torch_dtype, str):
                     if torch_dtype == "auto":
@@ -2294,7 +2288,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
             else:
                 loaded_state_dict_keys = [k for k in state_dict.keys()]
-            if low_cpu_mem_usage:
+            if low_cpu_mem_usage or cls._keep_in_fp32_modules is not None:
                 state_dict = None
 
         config.name_or_path = pretrained_model_name_or_path

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2288,7 +2288,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             # Check if `_keep_in_fp32_modules` is not None
             # but not force users to have `accelerate`
-            if cls._keep_in_fp32_modules is not None:
+            keep_in_fp32_modules = cls._keep_in_fp32_modules
+            if keep_in_fp32_modules is not None:
                 if not is_accelerate_available() and torch_dtype == torch.float16:
                     use_keep_in_fp32_modules = False
                     logger.warning(
@@ -2323,9 +2324,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         with ContextManagers(init_contexts):
             model = cls(config, *model_args, **model_kwargs)
-
-        if use_keep_in_fp32_modules:
-            keep_in_fp32_modules = model._keep_in_fp32_modules
 
         if load_in_8bit:
             from .utils.bitsandbytes import get_keys_to_not_convert, replace_8bit_linear

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2291,7 +2291,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 dtype_orig = cls._set_default_torch_dtype(torch_dtype)
 
             # Check if `_keep_in_fp32_modules` is not None
-            use_keep_in_fp32_modules = cls._keep_in_fp32_modules is not None
+            use_keep_in_fp32_modules = cls._keep_in_fp32_modules is not None and is_accelerate_available()
 
             if is_sharded:
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2323,9 +2323,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         with ContextManagers(init_contexts):
             model = cls(config, *model_args, **model_kwargs)
 
-        if use_keep_in_fp32_modules:
+        # Check first if we are `from_pt`
+        if from_pt and use_keep_in_fp32_modules:
             low_cpu_mem_usage = True
-        keep_in_fp32_modules = model._keep_in_fp32_modules
+            keep_in_fp32_modules = model._keep_in_fp32_modules if use_keep_in_fp32_modules else []
 
         if load_in_8bit:
             from .utils.bitsandbytes import get_keys_to_not_convert, replace_8bit_linear
@@ -2338,8 +2339,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 modules_to_not_convert = load_in_8bit_skip_modules
 
-            if keep_in_fp32_modules is not None and isinstance(keep_in_fp32_modules, list):
-                modules_to_not_convert.extend(keep_in_fp32_modules)
+            modules_to_not_convert.extend(keep_in_fp32_modules)
 
             model = replace_8bit_linear(
                 model, threshold=load_in_8bit_threshold, modules_to_not_convert=modules_to_not_convert

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -757,6 +757,7 @@ class T5PreTrainedModel(PreTrainedModel):
     is_parallelizable = True
     supports_gradient_checkpointing = True
     _no_split_modules = ["T5Block"]
+    _keep_in_fp32_modules = ["wo"]
 
     @property
     def dummy_inputs(self):

--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -150,7 +150,7 @@ def get_keys_to_not_convert(model):
 
     # Ignore this for base models (BertModel, GPT2Model, etc.)
     if (not has_tied_params) and is_base_model:
-        return ""
+        return []
 
     # otherwise they have an attached head
     list_modules = list(model.named_parameters())

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -155,6 +155,15 @@ class MixedInt8Test(BaseMixedInt8Test):
         # Check this does not throw an error
         _ = self.model_fp16.float()
 
+    def test_fp32_int8_conversion(self):
+        r"""
+        Test whether it is possible to mix both `int8` and `fp32` weights when using `keep_in_fp32_modules` correctly.
+        """
+        model = AutoModelForSeq2SeqLM.from_pretrained(
+            "t5-small", load_in_8bit=True, keep_in_fp32_modules=["wo"], device_map="auto"
+        )
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
+
 
 class MixedInt8ModelClassesTest(BaseMixedInt8Test):
     def setUp(self):

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -159,9 +159,7 @@ class MixedInt8Test(BaseMixedInt8Test):
         r"""
         Test whether it is possible to mix both `int8` and `fp32` weights when using `keep_in_fp32_modules` correctly.
         """
-        model = AutoModelForSeq2SeqLM.from_pretrained(
-            "t5-small", load_in_8bit=True, keep_in_fp32_modules=["wo"], device_map="auto"
-        )
+        model = AutoModelForSeq2SeqLM.from_pretrained("t5-small", load_in_8bit=True, device_map="auto")
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
 
 

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -19,7 +19,14 @@ import tempfile
 import unittest
 
 from transformers import T5Config, is_torch_available
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
+from transformers.testing_utils import (
+    require_accelerate,
+    require_sentencepiece,
+    require_tokenizers,
+    require_torch,
+    slow,
+    torch_device,
+)
 from transformers.utils import cached_property
 
 from ...generation.test_utils import GenerationTesterMixin
@@ -818,6 +825,36 @@ class T5EncoderOnlyModelTest(ModelTesterMixin, unittest.TestCase):
 
 def use_task_specific_params(model, task):
     model.config.update(model.config.task_specific_params[task])
+
+
+@require_torch
+@require_accelerate
+@require_tokenizers
+class T5ModelFp16Tests(unittest.TestCase):
+    def test_fp16_fp32_conversion(self):
+        r"""
+        A test to check whether the argument `keep_in_fp32_modules` correctly does its job
+        """
+        # Load without using `accelerate`
+        model = T5ForConditionalGeneration.from_pretrained(
+            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"]
+        )
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
+
+        # Load without using `accelerate`
+        model = T5ForConditionalGeneration.from_pretrained(
+            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"], low_cpu_mem_usage=True
+        )
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
+
+        # Load using `accelerate`
+        model = T5ForConditionalGeneration.from_pretrained(
+            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"], device_map="auto"
+        )
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
 
 
 @require_torch

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -836,23 +836,19 @@ class T5ModelFp16Tests(unittest.TestCase):
         A test to check whether the argument `keep_in_fp32_modules` correctly does its job
         """
         # Load without using `accelerate`
-        model = T5ForConditionalGeneration.from_pretrained(
-            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"]
-        )
+        model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.float16)
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
 
         # Load without using `accelerate`
         model = T5ForConditionalGeneration.from_pretrained(
-            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"], low_cpu_mem_usage=True
+            "t5-small", torch_dtype=torch.float16, low_cpu_mem_usage=True
         )
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
 
         # Load using `accelerate`
-        model = T5ForConditionalGeneration.from_pretrained(
-            "t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"], device_map="auto"
-        )
+        model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.float16, device_map="auto")
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
 

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -830,6 +830,7 @@ def use_task_specific_params(model, task):
 @require_torch
 @require_accelerate
 @require_tokenizers
+@slow
 class T5ModelFp16Tests(unittest.TestCase):
     def test_fp16_fp32_conversion(self):
         r"""

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -841,6 +841,23 @@ class T5ModelFp16Tests(unittest.TestCase):
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.float16)
 
+        # Load without in bf16
+        model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.bfloat16)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.bfloat16)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.bfloat16)
+
+        # Load using `accelerate` in bf16
+        model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.bfloat16, device_map="auto")
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.bfloat16)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.bfloat16)
+
+        # Load using `accelerate` in bf16
+        model = T5ForConditionalGeneration.from_pretrained(
+            "t5-small", torch_dtype=torch.bfloat16, low_cpu_mem_usage=True
+        )
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.bfloat16)
+        self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wi.weight.dtype == torch.bfloat16)
+
         # Load without using `accelerate`
         model = T5ForConditionalGeneration.from_pretrained(
             "t5-small", torch_dtype=torch.float16, low_cpu_mem_usage=True


### PR DESCRIPTION
# What does this PR do?

This PR partially addresses #20287 - although half-precision and int8 conversion work extremely well for most of the models, for some architectures (e.g. T5) the casting leads in a drastic performance degradation. 

This can be fixed by manually force-casting some modules in `float32`. For FLAN-T5, @larsmennen and @navjotts have found out that keeping only these weights in `fp32` enables to run largest models in fp16 or int8 with no performance degradation.

This PR introduces a new utils in `from_pretrained` method, termed as `keep_in_fp32_modules` that partially addresses this issue.

How this util works? For T5:
```
from transformers import T5ForConditionalGeneration

model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.float16, keep_in_fp32_modules=["wo"])
print(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype)
>>> torch.float32
```

When using `keep_in_fp32_modules` , `low_cpu_mem_usage` needs to be force-set to `True`. This is because if `low_cpu_mem_usage=False`, it is the function from pytorch `_load_from_state_dict` that is called under the hood on each sub-module. This function calls `copy_` from Pytorch which seems to keep the tensor in its native `dtype` regardless the `dtype` of the input module

```
import torch

param = torch.Tensor([0.1, 0.2, 0.3]).to(torch.float16)
to_copy_param = torch.Tensor([0.2, 0.1, 0.3]).to(torch.float32)

param.copy_(to_copy_param)
print(param.dtype)
>>> torch.float16
```

Keeping this as a draft for now as this util needs to be manually patched with fixes such as https://github.com/huggingface/transformers/issues/20287#issuecomment-1342219429 , otherwise users will encounter issues about incompatible `dtype` between input and weights

cc @sgugger 