### PR TITLE
Add missing image transforms to init

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -744,7 +744,7 @@ except OptionalDependencyNotAvailable:
     ]
 else:
     _import_structure["image_processing_utils"] = ["ImageProcessingMixin"]
-    _import_structure["image_transforms"] = ["rescale", "resize", "to_pil_image"]
+    _import_structure["image_transforms"] = ["center_crop", "normalize", "pad", "rescale", "resize", "to_pil_image"]
     _import_structure["image_utils"] = ["ImageFeatureExtractionMixin"]
     _import_structure["models.beit"].extend(["BeitFeatureExtractor", "BeitImageProcessor"])
     _import_structure["models.bit"].extend(["BitImageProcessor"])
@@ -3938,7 +3938,7 @@ if TYPE_CHECKING:
         from .utils.dummy_vision_objects import *
     else:
         from .image_processing_utils import ImageProcessingMixin
-        from .image_transforms import rescale, resize, to_pil_image
+        from .image_transforms import center_crop, normalize, pad, rescale, resize, to_pil_image
         from .image_utils import ImageFeatureExtractionMixin
         from .models.beit import BeitFeatureExtractor, BeitImageProcessor
         from .models.bit import BitImageProcessor

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -744,7 +744,18 @@ except OptionalDependencyNotAvailable:
     ]
 else:
     _import_structure["image_processing_utils"] = ["ImageProcessingMixin"]
-    _import_structure["image_transforms"] = ["center_crop", "normalize", "pad", "rescale", "resize", "to_pil_image"]
+    _import_structure["image_transforms"] = [
+        "center_crop",
+        "center_to_corners_format",
+        "corners_to_center_format",
+        "id_to_rgb",
+        "normalize",
+        "pad",
+        "rescale",
+        "resize",
+        "rgb_to_id",
+        "to_pil_image",
+    ]
     _import_structure["image_utils"] = ["ImageFeatureExtractionMixin"]
     _import_structure["models.beit"].extend(["BeitFeatureExtractor", "BeitImageProcessor"])
     _import_structure["models.bit"].extend(["BitImageProcessor"])
@@ -3938,7 +3949,18 @@ if TYPE_CHECKING:
         from .utils.dummy_vision_objects import *
     else:
         from .image_processing_utils import ImageProcessingMixin
-        from .image_transforms import center_crop, normalize, pad, rescale, resize, to_pil_image
+        from .image_transforms import (
+            center_crop,
+            center_to_corners_format,
+            corners_to_center_format,
+            id_to_rgb,
+            normalize,
+            pad,
+            rescale,
+            resize,
+            rgb_to_id,
+            to_pil_image,
+        )
         from .image_utils import ImageFeatureExtractionMixin
         from .models.beit import BeitFeatureExtractor, BeitImageProcessor
         from .models.bit import BitImageProcessor

--- a/src/transformers/utils/dummy_vision_objects.py
+++ b/src/transformers/utils/dummy_vision_objects.py
@@ -14,6 +14,18 @@ def center_crop(*args, **kwargs):
     requires_backends(center_crop, ["vision"])
 
 
+def center_to_corners_format(*args, **kwargs):
+    requires_backends(center_to_corners_format, ["vision"])
+
+
+def corners_to_center_format(*args, **kwargs):
+    requires_backends(corners_to_center_format, ["vision"])
+
+
+def id_to_rgb(*args, **kwargs):
+    requires_backends(id_to_rgb, ["vision"])
+
+
 def normalize(*args, **kwargs):
     requires_backends(normalize, ["vision"])
 
@@ -28,6 +40,10 @@ def rescale(*args, **kwargs):
 
 def resize(*args, **kwargs):
     requires_backends(resize, ["vision"])
+
+
+def rgb_to_id(*args, **kwargs):
+    requires_backends(rgb_to_id, ["vision"])
 
 
 def to_pil_image(*args, **kwargs):

--- a/src/transformers/utils/dummy_vision_objects.py
+++ b/src/transformers/utils/dummy_vision_objects.py
@@ -10,6 +10,18 @@ class ImageProcessingMixin(metaclass=DummyObject):
         requires_backends(self, ["vision"])
 
 
+def center_crop(*args, **kwargs):
+    requires_backends(center_crop, ["vision"])
+
+
+def normalize(*args, **kwargs):
+    requires_backends(normalize, ["vision"])
+
+
+def pad(*args, **kwargs):
+    requires_backends(pad, ["vision"])
+
+
 def rescale(*args, **kwargs):
     requires_backends(rescale, ["vision"])
 


### PR DESCRIPTION
# What does this PR do?

Adds functionality in the image transforms library to the init to allow direct imports e.g.:
`from transformers import center_crop`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?