### PR TITLE
[Tests] Improve test_attention_outputs

### DIFF
--- a/tests/models/convnext/test_modeling_convnext.py
+++ b/tests/models/convnext/test_modeling_convnext.py
@@ -159,10 +159,6 @@ class ConvNextModelTest(ModelTesterMixin, unittest.TestCase):
     def create_and_test_config_common_properties(self):
         return
 
-    @unittest.skip(reason="ConvNext does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip(reason="ConvNext does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/convnext/test_modeling_tf_convnext.py
+++ b/tests/models/convnext/test_modeling_tf_convnext.py
@@ -129,6 +129,7 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
     test_onnx = False
     test_resize_embeddings = False
     test_head_masking = False
+    has_attentions = False
 
     def setUp(self):
         self.model_tester = TFConvNextModelTester(self)

--- a/tests/models/convnext/test_modeling_tf_convnext.py
+++ b/tests/models/convnext/test_modeling_tf_convnext.py
@@ -170,10 +170,6 @@ class TFConvNextModelTest(TFModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    @unittest.skip(reason="Model doesn't have attention layers")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skipIf(
         not is_tf_available() or len(tf.config.list_physical_devices("GPU")) == 0,
         reason="TF does not support backprop for grouped convolutions on CPU.",

--- a/tests/models/poolformer/test_modeling_poolformer.py
+++ b/tests/models/poolformer/test_modeling_poolformer.py
@@ -142,10 +142,6 @@ class PoolFormerModelTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    @unittest.skip(reason="PoolFormer does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip("PoolFormer does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/regnet/test_modeling_regnet.py
+++ b/tests/models/regnet/test_modeling_regnet.py
@@ -147,10 +147,6 @@ class RegNetModelTest(ModelTesterMixin, unittest.TestCase):
     def create_and_test_config_common_properties(self):
         return
 
-    @unittest.skip(reason="RegNet does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip(reason="RegNet does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/regnet/test_modeling_tf_regnet.py
+++ b/tests/models/regnet/test_modeling_tf_regnet.py
@@ -147,10 +147,6 @@ class TFRegNetModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_model_common_attributes(self):
         pass
 
-    @unittest.skip(reason="Model doesn't have attention layers")
-    def test_attention_outputs(self):
-        pass
-
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/resnet/test_modeling_resnet.py
+++ b/tests/models/resnet/test_modeling_resnet.py
@@ -188,10 +188,6 @@ class ResNetModelTest(ModelTesterMixin, unittest.TestCase):
     def create_and_test_config_common_properties(self):
         return
 
-    @unittest.skip(reason="ResNet does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip(reason="ResNet does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/models/resnet/test_modeling_tf_resnet.py
+++ b/tests/models/resnet/test_modeling_tf_resnet.py
@@ -150,10 +150,6 @@ class TFResNetModelTest(TFModelTesterMixin, unittest.TestCase):
     def test_inputs_embeds(self):
         pass
 
-    @unittest.skip(reason="ResNet does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip(reason="ResNet does not support input and output embeddings")
     def test_model_common_attributes(self):
         pass

--- a/tests/models/van/test_modeling_van.py
+++ b/tests/models/van/test_modeling_van.py
@@ -144,10 +144,6 @@ class VanModelTest(ModelTesterMixin, unittest.TestCase):
     def create_and_test_config_common_properties(self):
         return
 
-    @unittest.skip(reason="Van does not output attentions")
-    def test_attention_outputs(self):
-        pass
-
     @unittest.skip(reason="Van does not use inputs_embeds")
     def test_inputs_embeds(self):
         pass

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -554,6 +554,9 @@ class ModelTesterMixin:
             loss.backward()
 
     def test_attention_outputs(self):
+        if not self.has_attentions:
+            return
+
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -555,7 +555,7 @@ class ModelTesterMixin:
 
     def test_attention_outputs(self):
         if not self.has_attentions:
-            return
+            self.skipTest(reason="Model does not output attentions")
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -831,7 +831,7 @@ class TFModelTesterMixin:
 
     def test_attention_outputs(self):
         if not self.has_attentions:
-            return
+            self.skipTest(reason="Model does not output attentions")
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -830,6 +830,9 @@ class TFModelTesterMixin:
             self.assertLess(np.sum(np.abs(output_dict - output_keywords)), 1e-6)
 
     def test_attention_outputs(self):
+        if not self.has_attentions:
+            return
+
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True
         decoder_seq_length = getattr(self.model_tester, "decoder_seq_length", self.model_tester.seq_length)


### PR DESCRIPTION
# What does this PR do?

I noticed several vision models overwrite `test_attention_outputs`, but we have a `has_attentions` flag exactly for this purpose.

Hence, I've adapted the test in `test_modeling_common.py` and `test_modeling_tf_common.p`y to improve this.