### PR TITLE
Fix bug: replace left over FE references

### DIFF
--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -27,13 +27,13 @@ class DonutProcessor(ProcessorMixin):
     Constructs a Donut processor which wraps a Donut image processor and an XLMRoBERTa tokenizer into a single
     processor.
 
-    [`DonutProcessor`] offers all the functionalities of [`DonutFeatureExtractor`] and
+    [`DonutProcessor`] offers all the functionalities of [`DonutImageProcessor`] and
     [`XLMRobertaTokenizer`/`XLMRobertaTokenizerFast`]. See the [`~DonutProcessor.__call__`] and
     [`~DonutProcessor.decode`] for more information.
 
     Args:
-        image_processor ([`DonutFeatureExtractor`]):
-            An instance of [`DonutFeatureExtractor`]. The image processor is a required input.
+        image_processor ([`DonutImageProcessor`]):
+            An instance of [`DonutImageProcessor`]. The image processor is a required input.
         tokenizer ([`XLMRobertaTokenizer`/`XLMRobertaTokenizerFast`]):
             An instance of [`XLMRobertaTokenizer`/`XLMRobertaTokenizerFast`]. The tokenizer is a required input.
     """
@@ -62,8 +62,8 @@ class DonutProcessor(ProcessorMixin):
 
     def __call__(self, *args, **kwargs):
         """
-        When used in normal mode, this method forwards all its arguments to AutoFeatureExtractor's
-        [`~AutoFeatureExtractor.__call__`] and returns its output. If used in the context
+        When used in normal mode, this method forwards all its arguments to AutoImageProcessor's
+        [`~AutoImageProcessor.__call__`] and returns its output. If used in the context
         [`~DonutProcessor.as_target_processor`] this method forwards all its arguments to DonutTokenizer's
         [`~DonutTokenizer.__call__`]. Please refer to the doctsring of the above two methods for more information.
         """

--- a/src/transformers/models/flava/processing_flava.py
+++ b/src/transformers/models/flava/processing_flava.py
@@ -29,15 +29,15 @@ class FlavaProcessor(ProcessorMixin):
     r"""
     Constructs a FLAVA processor which wraps a FLAVA image processor and a FLAVA tokenizer into a single processor.
 
-    [`FlavaProcessor`] offers all the functionalities of [`FlavaFeatureExtractor`] and [`BertTokenizerFast`]. See the
+    [`FlavaProcessor`] offers all the functionalities of [`FlavaImageProcessor`] and [`BertTokenizerFast`]. See the
     [`~FlavaProcessor.__call__`] and [`~FlavaProcessor.decode`] for more information.
 
     Args:
-        image_processor ([`FlavaFeatureExtractor`]): The image processor is a required input.
+        image_processor ([`FlavaImageProcessor`]): The image processor is a required input.
         tokenizer ([`BertTokenizerFast`]): The tokenizer is a required input.
     """
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = "FlavaFeatureExtractor"
+    image_processor_class = "FlavaImageProcessor"
     tokenizer_class = ("BertTokenizer", "BertTokenizerFast")
 
     def __init__(self, image_processor=None, tokenizer=None, **kwargs):
@@ -81,7 +81,7 @@ class FlavaProcessor(ProcessorMixin):
         **kwargs
     ):
         """
-        This method uses [`FLAVAFeatureExtractor.__call__`] method to prepare image(s) for the model, and
+        This method uses [`FlavaImageProcessor.__call__`] method to prepare image(s) for the model, and
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
         Please refer to the docstring of the above two methods for more information.

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -28,17 +28,17 @@ class ViltProcessor(ProcessorMixin):
     r"""
     Constructs a ViLT processor which wraps a BERT tokenizer and ViLT image processor into a single processor.
 
-    [`ViltProcessor`] offers all the functionalities of [`ViltFeatureExtractor`] and [`BertTokenizerFast`]. See the
+    [`ViltProcessor`] offers all the functionalities of [`ViltImageProcessor`] and [`BertTokenizerFast`]. See the
     docstring of [`~ViltProcessor.__call__`] and [`~ViltProcessor.decode`] for more information.
 
     Args:
-        image_processor (`ViltFeatureExtractor`):
-            An instance of [`ViltFeatureExtractor`]. The image processor is a required input.
+        image_processor (`ViltImageProcessor`):
+            An instance of [`ViltImageProcessor`]. The image processor is a required input.
         tokenizer (`BertTokenizerFast`):
             An instance of ['BertTokenizerFast`]. The tokenizer is a required input.
     """
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = "ViltFeatureExtractor"
+    image_processor_class = "ViltImageProcessor"
     tokenizer_class = ("BertTokenizer", "BertTokenizerFast")
 
     def __init__(self, image_processor=None, tokenizer=None, **kwargs):
@@ -80,7 +80,7 @@ class ViltProcessor(ProcessorMixin):
         **kwargs
     ) -> BatchEncoding:
         """
-        This method uses [`ViltFeatureExtractor.__call__`] method to prepare image(s) for the model, and
+        This method uses [`ViltImageProcessor.__call__`] method to prepare image(s) for the model, and
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
         Please refer to the docstring of the above two methods for more information.


### PR DESCRIPTION
# What does this PR do?

Fixes failing Flava processor tests introduced by #20590 - replaces any exisiting feature extractor reference with image processors. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?