### PR TITLE
Change a logic in pipeline test regarding TF

### DIFF
--- a/tests/pipelines/test_pipelines_summarization.py
+++ b/tests/pipelines/test_pipelines_summarization.py
@@ -17,8 +17,8 @@ import unittest
 from transformers import (
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
     TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-    TFPreTrainedModel,
     SummarizationPipeline,
+    TFPreTrainedModel,
     pipeline,
 )
 from transformers.testing_utils import get_gpu_count, require_tf, require_torch, slow, torch_device

--- a/tests/pipelines/test_pipelines_summarization.py
+++ b/tests/pipelines/test_pipelines_summarization.py
@@ -17,10 +17,11 @@ import unittest
 from transformers import (
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
     TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+    TFPreTrainedModel,
     SummarizationPipeline,
     pipeline,
 )
-from transformers.testing_utils import require_tf, require_torch, slow, torch_device
+from transformers.testing_utils import get_gpu_count, require_tf, require_torch, slow, torch_device
 from transformers.tokenization_utils import TruncationStrategy
 
 from .test_pipelines_common import ANY, PipelineTestCaseMeta
@@ -64,8 +65,15 @@ class SummarizationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMe
         if model.config.__class__.__name__ not in model_can_handle_longer_seq:
             # Switch Transformers, LED, T5, LongT5 can handle it.
             # Too long.
-            with self.assertRaises(Exception):
-                outputs = summarizer("This " * 1000)
+            # For TF models, if the weights are initialized in GPU context, we won't get expected index error from
+            # the embedding layer.
+            if not (
+                isinstance(model, TFPreTrainedModel)
+                and get_gpu_count() > 0
+                and len(summarizer.model.trainable_weights) > 0
+            ):
+                with self.assertRaises(Exception):
+                    outputs = summarizer("This " * 1000)
         outputs = summarizer("This " * 1000, truncation=TruncationStrategy.ONLY_FIRST)
 
     @require_torch

--- a/tests/pipelines/test_pipelines_summarization.py
+++ b/tests/pipelines/test_pipelines_summarization.py
@@ -52,6 +52,7 @@ class SummarizationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMe
         )
         self.assertEqual(outputs, [{"summary_text": ANY(str)}])
 
+        # Some models (Switch Transformers, LED, T5, LongT5, etc) can handle long sequences.
         model_can_handle_longer_seq = [
             "SwitchTransformersConfig",
             "T5Config",
@@ -63,8 +64,7 @@ class SummarizationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMe
             "ProphetNetConfig",  # positional embeddings up to a fixed maximum size (otherwise clamping the values)
         ]
         if model.config.__class__.__name__ not in model_can_handle_longer_seq:
-            # Switch Transformers, LED, T5, LongT5 can handle it.
-            # Too long.
+            # Too long and exception is expected.
             # For TF models, if the weights are initialized in GPU context, we won't get expected index error from
             # the embedding layer.
             if not (


### PR DESCRIPTION
# What does this PR do?

- **Currently**, the tiny models in pipeline tests are created using `model_class(config)`, and for TF models, the weights are not created at this point. Then we set the device (**which turns to be CPU instead of GPU!**), and the wegiths are created in CPU context --> we get the expected exceptions.
- In the future, we will use the tiny model from Hub repos
- The models are loaded using `from_pretrained`
- If GPU available, those weights are initialized in GPU context automatically for TF models, including embedding layers
- From what @Rocketknight1 says at the end, we won't get the expected exceptions in this situation (TF, layer weights loaded in GPU context)

**In order to use the tiny models from the Hub without any pipeline test failure, we will have to skip this check under the above described situation.**

From @Rocketknight1 
> Embedding layers in Keras have different behaviours on CPU and GPU when you pass invalid indices. On CPU, the layer checks inputs and throws an error if you're out of range, but on GPU you just get a zeros tensor as output with no error