### PR TITLE
Add a progress bar for large model loading

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2659,6 +2659,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 disk_only_shard_files = []
 
+            if len(resolved_archive_file) > 1:
+                resolved_archive_file = logging.tqdm(resolved_archive_file, desc="Loading checkpoint shards")
             for shard_file in resolved_archive_file:
                 # Skip the load for shards that only contain disk-offloaded weights when using safetensors for the offload.
                 if shard_file in disk_only_shard_files:


### PR DESCRIPTION
# What does this PR do?

As requested in #20669, this PR adds a progress bar when loading large models. The progress bar can be removed with `transformers.utils.disable_progress_bar()`.

Fixes #20669