### PR TITLE
Convert tokenizer outputs for Keras in doc example

### DIFF
--- a/docs/source/de/training.mdx
+++ b/docs/source/de/training.mdx
@@ -185,6 +185,8 @@ from transformers import AutoTokenizer
 
 tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 tokenized_data = tokenizer(dataset["text"], return_tensors="np", padding=True)
+# Tokenizer returns a BatchEncoding, but we convert that to a dict for Keras
+tokenized_data = dict(tokenized_data)
 
 labels = np.array(dataset["label"])  # Label is already an array of 0 and 1
 ```

--- a/docs/source/en/training.mdx
+++ b/docs/source/en/training.mdx
@@ -185,6 +185,8 @@ from transformers import AutoTokenizer
 
 tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
 tokenized_data = tokenizer(dataset["text"], return_tensors="np", padding=True)
+# Tokenizer returns a BatchEncoding, but we convert that to a dict for Keras
+tokenized_data = dict(tokenized_data)
 
 labels = np.array(dataset["label"])  # Label is already an array of 0 and 1
 ```


### PR DESCRIPTION
The TF examples in `training.mdx` don't turn the tokenizer outputs into a `dict`, so Keras gets confused.

Fixes #20709 