### PR TITLE
fix missing () in is_flaky

### DIFF
--- a/tests/models/donut/test_feature_extraction_donut.py
+++ b/tests/models/donut/test_feature_extraction_donut.py
@@ -106,7 +106,7 @@ class DonutFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
     def test_batch_feature(self):
         pass
 
-    @is_flaky
+    @is_flaky()
     def test_call_pil(self):
         # Initialize feature_extractor
         feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)
@@ -139,7 +139,7 @@ class DonutFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
             ),
         )
 
-    @is_flaky
+    @is_flaky()
     def test_call_numpy(self):
         # Initialize feature_extractor
         feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)
@@ -172,7 +172,7 @@ class DonutFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
             ),
         )
 
-    @is_flaky
+    @is_flaky()
     def test_call_pytorch(self):
         # Initialize feature_extractor
         feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)


### PR DESCRIPTION
# What does this PR do?

#20739 uses `is_flaky` without `()` at the end. This will make the actual test (that being decorated) not running at all.
This PR adds `()`.
