### PR TITLE
Uninstall `torch_tensorrt` in `DeepSpeed` CI image for now

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -22,6 +22,9 @@ RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision torchau
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 
+# The base image ships with `torch_tensorrt` which currently causes the DeepSpeed CI fail from test collection
+RUN python3 -m pip uninstall -y torch_tensorrt
+
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)
 RUN python3 -m pip uninstall -y deepspeed
 # This has to be run (again) inside the GPU VMs running the tests.


### PR DESCRIPTION
# What does this PR do?

Since we update CI to use PyTorch 1.13, it uses a base image `nvcr.io/nvidia/pytorch:22.04-py3` which contains `torch_tensorrt`.
This causes the CI failing from the test collection - i.e. the whole test suite fails from the beginning.

This PR uninstalls `torch_tensorrt` for now (previously, this is not installed for DeepSpeed CI - the stable release version), so at least the CI could run (and to see if any test would fail with PyTorch 1.13).

We will have to work on the `torch_tensorrt` issue though.

#### Current error message

```bash
==================================== ERRORS ====================================
______________ ERROR collecting tests/deepspeed/test_deepspeed.py ______________
ImportError while importing test module '/workspace/transformers/tests/deepspeed/test_deepspeed.py'.
```