### PR TITLE
Install torch-tensorrt 1.3.0

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -22,8 +22,7 @@ RUN python3 -m pip install --no-cache-dir -U torch==$PYTORCH torchvision torchau
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 
-# The base image ships with `torch_tensorrt` which currently causes the DeepSpeed CI fail from test collection
-RUN python3 -m pip uninstall -y torch_tensorrt
+RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com/pytorch/TensorRT/releases/expanded_assets/v1.3.0
 
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)
 RUN python3 -m pip uninstall -y deepspeed


### PR DESCRIPTION
# What does this PR do?

It turns out that the issue mentioned in #20758 could be fixed by installing newer version of `torch-tensorrt (1.3.0)` (the pre-installed one in the base image was `1.1.0a0`).

Notice that before our CI using torch 1.13.0, we didn't have `torch-tensorrt` installed in the docker image (for daily CI with stable release of torch/deepspeed). But guess we can have it anyway.