### PR TITLE
Enable PyTorch/XLA Fully Sharded Data Parallel (FSDP) for a Specific Class of Transformer Models

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -535,15 +535,15 @@ class TrainingArguments:
             For a complete list of options, please see [here](
             https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py).
 
-            This is an experimental feature and its API may evolve in the future. The value is the location of config file 
-            (e.g., `fsdp_config.json`). 
+            This is an experimental feature and its API may evolve in the future. The value is the location of config
+            file (e.g., `fsdp_config.json`).
         xla_fsdp_nested (`bool`, *optional*, defaults to `False`):
-            Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with xla_fsdp.
-            Currently, only models which expose their their transformers block through the class attribute `transformer.h`
-            may use this feature. 
+            Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with
+            xla_fsdp. Currently, only models which expose their their transformers block through the class attribute
+            `transformer.h` may use this feature.
         xla_fsdp_grad_ckpt (`bool`, *optional*, defaults to `False`):
-            Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp
-            and xla_fsdp_nested.
+            Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with
+            xla_fsdp and xla_fsdp_nested.
 
     
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -533,12 +533,15 @@ class TrainingArguments:
             Use PyTorch/XLA Fully Sharded Data Parallel Training
 
             For a complete list of options, please see [here](
-            https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py#L120-L196).
+            https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py).
 
-            The value is the location of config file (e.g., `fsdp_config.json`).
-        xla_fsdp_nested (`bool`, *optional*):
-            Will use nested XLA FSDP to shard each model child layer. This setting can only be used with xla_fsdp.
-        xla_fsdp_grad_ckpt (`bool`, *optional*):
+            This is an experimental feature and its API may evolve in the future. The value is the location of config file 
+            (e.g., `fsdp_config.json`). 
+        xla_fsdp_nested (`bool`, *optional*, defaults to `False`):
+            Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with xla_fsdp.
+            Currently, only models which expose their their transformers block through the class attribute `transformer.h`
+            may use this feature. 
+        xla_fsdp_grad_ckpt (`bool`, *optional*, defaults to `False`):
             Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp
             and xla_fsdp_nested.
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1351,10 +1351,14 @@ class TrainingArguments:
                 "torch.float16" : torch.float16,
                 "torch.bfloat16" : torch.bfloat16,
                 }
-            if "compute_dtype" in self.xla_fsdp:
-                self.xla_fsdp["compute_dtype"] = dtype_dict[self.xla_fsdp["compute_dtype"]]
-            if "buffer_dtype" in self.xla_fsdp:
-                self.xla_fsdp["buffer_dtype"] = dtype_dict[self.xla_fsdp["buffer_dtype"]]
+            if "compute_dtype" in self.xla_fsdp_config:
+                self.xla_fsdp_config["compute_dtype"] = dtype_dict[self.xla_fsdp_config["compute_dtype"]]
+            if "buffer_dtype" in self.xla_fsdp_config:
+                self.xla_fsdp_config["buffer_dtype"] = dtype_dict[self.xla_fsdp_config["buffer_dtype"]]
+            if self.xla_fsdp_grad_ckpt and not self.xla_fsdp_nested:
+                raise ValueError(
+                "`--xla_fsdp_grad_ckpt` may only be used when --xla_fsdp_nested is enabled."
+            )
         else:
             if self.xla_fsdp_nested:
                 raise ValueError(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -985,7 +985,9 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use nested XLA FSDP to shard each model child layer. This setting can only be used with xla_fsdp."               
+                "Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with xla_fsdp."
+                " Currently, only models which expose their their transformers block through the class attribute `transformer.h`"
+                " may use this feature."               
             ),
         },
     )
@@ -993,7 +995,8 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp."
+                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp"
+                " and xla_fsdp_nested."
             
             ),
         },

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -17,6 +17,7 @@ import json
 import math
 import os
 import warnings
+import io
 from dataclasses import asdict, dataclass, field, fields
 from datetime import timedelta
 from enum import Enum
@@ -529,16 +530,18 @@ class TrainingArguments:
 
             Possible choices are `"default"`, `"reduce-overhead"` and `"max-autotune"`.
         
-        xla_fsdp (`str`, `dict`, *optional*):
+        xla_fsdp (`str`, *optional*):
             Use PyTorch/XLA Fully Sharded Data Parallel Training
 
             For a complete list of options, please see [here](
             https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py#L120-L196).
 
-            The value is the location of config file (e.g., `fsdp_config.json`).
+            This is an experimental feature and its API may evolve in the future. The value is the location of config file 
+            (e.g., `fsdp_config.json`). 
         xla_fsdp_nested (`bool`, *optional*):
-            Will use nested XLA FSDP to shard each model child layer. This setting can only be used with xla_fsdp.
-
+            Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with xla_fsdp.
+            Currently, only models which expose their their transformers block through the class attribute `transformer.h`
+            may use this feature. 
         xla_fsdp_grad_ckpt (`bool`, *optional*):
             Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp.
     """
@@ -979,7 +982,9 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use nested XLA FSDP to shard each model child layer. This setting can only be used with xla_fsdp."               
+                "Will use nested XLA FSDP to shard each transformer block layer. This setting can only be used with xla_fsdp."
+                " Currently, only models which expose their their transformers block through the class attribute `transformer.h`"
+                " may use this feature."               
             ),
         },
     )
@@ -987,7 +992,8 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp."
+                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp"
+                " and xla_fsdp_nested."
             
             ),
         },
@@ -1341,17 +1347,21 @@ class TrainingArguments:
         if self.xla_fsdp:
             # gather fsdp configuration parameters into a dictionary from specified json file
             with io.open(self.xla_fsdp, "r", encoding="utf-8") as f:
-                self.xla_fsdp = json.load(f)
+                self.xla_fsdp_config = json.load(f)
             # apply appropriate string to torch.dtype conversions for parameters
             dtype_dict = {
                 "torch.float32": torch.float32,
                 "torch.float16" : torch.float16,
                 "torch.bfloat16" : torch.bfloat16,
                 }
-            if "compute_dtype" in self.xla_fsdp:
-                self.xla_fsdp["compute_dtype"] = dtype_dict[self.xla_fsdp["compute_dtype"]]
+            if "compute_dtype" in self.xla_fsdp_config:
+                self.xla_fsdp_config["compute_dtype"] = dtype_dict[self.xla_fsdp_config["compute_dtype"]]
             if "buffer_dtype" in self.xla_fsdp:
-                self.xla_fsdp["buffer_dtype"] = dtype_dict[self.xla_fsdp["buffer_dtype"]]
+                self.xla_fsdp_config["buffer_dtype"] = dtype_dict[self.xla_fsdp_config["buffer_dtype"]]
+            if self.xla_fsdp_grad_ckpt and not self.xla_fsdp_nested:
+                raise ValueError(
+                "`--xla_fsdp_grad_ckpt` may only be used when --xla_fsdp_nested is enabled."
+            )
         else:
             if self.xla_fsdp_nested:
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

This PR enables the user to make use of the [PyTorch/XLA implementation of FSDP](https://github.com/pytorch/xla/tree/master/torch_xla/distributed/fsdp). Three arguments have been added to `training_args.py` to facilitate this functionality:

- `xla_fsdp`: this flag is a string containing the location of a `.json` file which specifies the FSDP arguments the user wants to use when wrapping their model.
- `xla_fsdp_nested`: this flag is a bool which determines whether each transformer block is also FSDP wrapped. Only models which expose their transformer blocks through the class attribute `transformer.h` can use this feature.
- `xla_fsdp_grad_ckpt`: this flag is a bool which determines whether gradient checkpointing is enabled for nested FSDP wrapped layers.

# Design notes and future work

1) For very large model sizes (greater than, say, 128B parameters), users may see host-side OOMs on TPUs during initialization. This can be mitigated by initializing layer weights immediately after construction, wrapping with FSDP, and moving onto the XLA device, as can be seen in [this branch](https://github.com/AlexWertheim/transformers/blob/einsum/src/transformers/models/gpt2/modeling_gpt2.py#L690-L723). We opted to enable FSDP wrapping at the trainer level, since it does not necessitate model-specific changes and does not disrupt the existing architecture for model construction and initialization. 
2) Checkpointing support for XLA FSDP is not included as part of this PR. We hope to add it soon via another PR. 
3) As indicated above, nested FSDP is only supported for models which expose their transformer blocks in a specific way. This is because naively wrapping every child layer introduces errors. There is [a PR](https://github.com/pytorch/xla/pull/4318) which will introduce auto-wrapping functionality into FSDP, and we expect that this feature will offer a much better way for all model classes to leverage nested wrapping. We also expect that auto-wrapping will enable users to perform nested wrapping multiple layers deep, which has been seen to introduce performance gains. This auto-wrap functionality needs more testing, but we hope to add this feature in a future PR.
4) We have not included testing for XLA FSDP as part of this PR. We would like to add this in a future PR. 

Thanks to @ronghanghu for his assistance in the preparation of this PR. Among other contributions, the observations that one must copy the model's forward method and replace the optimizer step are his.  


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? -->


## Who can review?

@sgugger @JackCaoG

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts and @NielsRogge
- speech models: @sanchit-gandhi

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger and @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
