### PR TITLE
Install video dependency for pipeline CI

### DIFF
--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -9,7 +9,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 
 ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
-RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing]
+RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing,video]
 
 # If set to nothing, will install the latest version
 ARG PYTORCH='1.13.0'


### PR DESCRIPTION
# What does this PR do?

PR #20151 added video classification pipeline, which requires video dependency (`decord`). It is not currently installed in the CI image used for Pipeline CI - so we have failure.

This PR adds the dependency (same as in CircleCI).