### PR TITLE
[Pipeline] fix failing bloom `pipeline` test

### DIFF
--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -284,10 +284,10 @@ class TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseM
             ],
         )
 
-        # torch_dtype not necessary
+        # torch_dtype will be automatically set to float32 if not provided - check: https://github.com/huggingface/transformers/pull/20602
         pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device_map="auto")
         self.assertEqual(pipe.model.device, torch.device(0))
-        self.assertEqual(pipe.model.lm_head.weight.dtype, torch.bfloat16)
+        self.assertEqual(pipe.model.lm_head.weight.dtype, torch.float32)
         out = pipe("This is a test")
         self.assertEqual(
             out,


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `pipeline` test: `tests/pipelines/test_pipelines_text_generation.py::TextGenerationPipelineTests::test_small_model_pt_bloom_accelerate`

- Link to failing job: https://github.com/huggingface/transformers/actions/runs/3691174891/jobs/6248989365 
- Why this fix is relevant? Before https://github.com/huggingface/transformers/pull/20602 there was an inconsistency between models loaded with `accelerate` with no `device_map` set and with `device_map` set (i.e. without `accelerate`). Before the the aforementioned PR, if you load a model as follows:
```
from transformers import AutoModelForCausalLM

model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-bloom", device_map="auto")
print(model.lm_head.weight.dtype)

model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-bloom")
print(model.lm_head.weight.dtype)
```
You get:
```
torch.bfloat16
torch.float32
```
Which is inconsistent. Since that, to load a model with its native dtype, you need to provide `torch_dtype="auto"`.
This PR fixes the failing test by setting `torch.float32` for the expected `dtype`.

cc @ydshieh @sgugger 