### PR TITLE
[Pipeline] skip feature extraction test if in `IMAGE_PROCESSOR_MAPPING`

### DIFF
--- a/tests/pipelines/test_pipelines_feature_extraction.py
+++ b/tests/pipelines/test_pipelines_feature_extraction.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from transformers import (
     FEATURE_EXTRACTOR_MAPPING,
+    IMAGE_PROCESSOR_MAPPING,
     MODEL_MAPPING,
     TF_MODEL_MAPPING,
     FeatureExtractionPipeline,
@@ -178,7 +179,11 @@ class FeatureExtractionPipelineTests(unittest.TestCase, metaclass=PipelineTestCa
         if tokenizer is None:
             self.skipTest("No tokenizer")
             return
-        elif type(model.config) in FEATURE_EXTRACTOR_MAPPING or isinstance(model.config, LxmertConfig):
+        elif (
+            type(model.config) in FEATURE_EXTRACTOR_MAPPING
+            or isinstance(model.config, LxmertConfig)
+            or type(model.config) in IMAGE_PROCESSOR_MAPPING
+        ):
             self.skipTest("This is a bimodal model, we need to find a more consistent way to switch on those models.")
             return
         elif model.config.is_encoder_decoder:


### PR DESCRIPTION
# What does this PR do?

Fixes the [following failing test](https://app.circleci.com/pipelines/github/huggingface/transformers/53884/workflows/8df76bfb-b6d2-493e-afdf-257b59672b02/jobs/648580)

## Context:

Currently `FeatureExtractionPipelineTests` are skipped for multi-modal models by checking if the model config is in `FEATURE_EXTRACTOR_MAPPING`. The check is done [on this line](https://github.com/huggingface/transformers/blob/1543cee7c8c95ef47f832b1f37625ba2923c4994/tests/pipelines/test_pipelines_feature_extraction.py#L181) 
Recent vision and multimodal models will deprecate the usage of `xxxFeatureExtractor` in favor of `xxxImageProcessors`. For [Blip](https://github.com/huggingface/transformers/pull/20716), the test fails because `BlipFeatureExtractor` is not implemented at all in favor of `BlipImageProcessor`.

## Why this fix is relevant?

Blip seems to be the first multimodal model that relies on `xxxImageProcessor` only. 

cc @Narsil @amyeroberts @NielsRogge 