### PR TITLE
Fix whisper export

### DIFF
--- a/src/transformers/models/whisper/configuration_whisper.py
+++ b/src/transformers/models/whisper/configuration_whisper.py
@@ -264,8 +264,8 @@ class WhisperOnnxConfig(OnnxSeq2SeqConfigWithPast):
             time_duration=time_duration,
             frequency=frequency,
         )
-        input_feature_size = encoder_inputs["input_features"].shape[2]
-        seq_length = input_feature_size // 2 if self.use_past else seq_length
+        encoder_sequence_length = encoder_inputs["input_features"].shape[2]
+        seq_length = encoder_sequence_length // 2 if self.use_past else seq_length
 
         decoder_inputs = super().generate_dummy_inputs(
             preprocessor.tokenizer, batch_size, seq_length, is_pair, framework

--- a/src/transformers/models/whisper/configuration_whisper.py
+++ b/src/transformers/models/whisper/configuration_whisper.py
@@ -264,8 +264,10 @@ class WhisperOnnxConfig(OnnxSeq2SeqConfigWithPast):
             time_duration=time_duration,
             frequency=frequency,
         )
+        input_feature_size = encoder_inputs["input_features"].shape[2]
+
         decoder_inputs = super().generate_dummy_inputs(
-            preprocessor.tokenizer, batch_size, seq_length, is_pair, framework
+            preprocessor.tokenizer, batch_size, input_feature_size // 2, is_pair, framework
         )
 
         dummy_inputs["input_features"] = encoder_inputs.pop("input_features")

--- a/src/transformers/models/whisper/configuration_whisper.py
+++ b/src/transformers/models/whisper/configuration_whisper.py
@@ -265,9 +265,10 @@ class WhisperOnnxConfig(OnnxSeq2SeqConfigWithPast):
             frequency=frequency,
         )
         input_feature_size = encoder_inputs["input_features"].shape[2]
+        seq_length = input_feature_size // 2 if self.use_past else seq_length
 
         decoder_inputs = super().generate_dummy_inputs(
-            preprocessor.tokenizer, batch_size, input_feature_size // 2, is_pair, framework
+            preprocessor.tokenizer, batch_size, seq_length, is_pair, framework
         )
 
         dummy_inputs["input_features"] = encoder_inputs.pop("input_features")


### PR DESCRIPTION
# What does this PR do?

Fix the export for the whisper model

The current export for whisper fails with error `Invalid Feed Input Name:past_key_values.3.encoder.value`, because the cross attention key values are not exported as input in the ONNX model after the new condition introduced in the [transformers@97a51](https://github.com/huggingface/transformers/commit/97a51b0c7d483cdf13ea878a987f9aa1c9eecc91).

The error occurs due to incorrect dummy input generation for cross attention key values for export. The PR fixes the same.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@lewtun 