### PR TITLE
Use `baddbmm` to reduce the number of kernel calls when running T5

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -477,7 +477,7 @@ class T5Attention(nn.Module):
 
         def unshape(states):
             """reshape"""
-            return states.transpose(1, 2).contiguous().view(batch_size, -1, self.inner_dim)
+            return states.transpose(1, 2).reshape(batch_size, -1, self.inner_dim)
 
         def project(hidden_states, proj_layer, key_value_states, past_key_value):
             """projects hidden states correctly to key/query states"""
@@ -517,20 +517,17 @@ class T5Attention(nn.Module):
             hidden_states, self.v, key_value_states, past_key_value[1] if past_key_value is not None else None
         )
 
-        # compute scores
-        scores = torch.matmul(
-            query_states, key_states.transpose(3, 2)
-        )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
-
         if position_bias is None:
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, real_seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, self.n_heads, real_seq_length, key_length),
+                    device=hidden_states.device,
+                    dtype=hidden_states.dtype,
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
             else:
-                position_bias = self.compute_bias(real_seq_length, key_length, device=scores.device)
+                position_bias = self.compute_bias(real_seq_length, key_length, device=hidden_states.device)
 
             # if key and values are already calculated
             # we want only the last query position bias
@@ -547,8 +544,15 @@ class T5Attention(nn.Module):
         else:
             position_bias_masked = position_bias
 
-        scores += position_bias_masked
-        attn_weights = nn.functional.softmax(scores.float(), dim=-1).type_as(
+        # compute scores
+        scores = torch.baddbmm(
+            input=position_bias_masked,
+            batch1=query_states.view(batch_size * self.n_heads, seq_length, self.key_value_proj_dim),
+            key_states=key_states.view(batch_size * self.n_heads, key_length, self.key_value_proj_dim).transpose(1, 2),
+            beta=1,
+            alpha=1,
+        )
+        attn_weights = nn.functional.softmax(scores, dim=-1, dtype=torch.float).type_as(
             scores
         )  # (batch_size, n_heads, seq_length, key_length)
         attn_weights = nn.functional.dropout(


### PR DESCRIPTION
# What does this PR do?

Reduce the number of kernel calls by using `baddbmm` and built-in `F.softmax(..., dtype=torch.float))`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?