### PR TITLE
Add-warning-tokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -575,7 +575,11 @@ class AutoTokenizer:
 
             if use_fast and tokenizer_fast_class_name is not None:
                 tokenizer_class = tokenizer_class_from_name(tokenizer_fast_class_name)
-
+            else:
+                logger.warning(
+                        "`use_fast` is set to `True` but the tokenizer class does not have a fast version. "
+                        " Falling back to the slow version."
+                )
             if tokenizer_class is None:
                 tokenizer_class = tokenizer_class_from_name(tokenizer_class_name)
 

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -573,13 +573,14 @@ class AutoTokenizer:
 
             tokenizer_class_name, tokenizer_fast_class_name = tokenizer_class_tuple
 
-            if use_fast and tokenizer_fast_class_name is not None:
-                tokenizer_class = tokenizer_class_from_name(tokenizer_fast_class_name)
-            else:
-                logger.warning(
+            if use_fast:
+                if tokenizer_fast_class_name is not None:
+                    tokenizer_class = tokenizer_class_from_name(tokenizer_fast_class_name)
+                else:
+                    logger.warning(
                         "`use_fast` is set to `True` but the tokenizer class does not have a fast version. "
                         " Falling back to the slow version."
-                )
+                    )
             if tokenizer_class is None:
                 tokenizer_class = tokenizer_class_from_name(tokenizer_class_name)
 


### PR DESCRIPTION
# What does this PR do?
Adds a warning when the user wants to use a fast tokenizer but it doesn't exist. Should help with #20817