### PR TITLE
fix typo output not ouput in bitsandbytes trainer test

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2332,7 +2332,7 @@ if is_torch_available():
 
         optim_test_params.append(
             (
-                TrainingArguments(optim=OptimizerNames.ADAMW_BNB, ouput_dir="None"),
+                TrainingArguments(optim=OptimizerNames.ADAMW_BNB, output_dir="None"),
                 bnb.optim.Adam8bit,
                 default_adam_kwargs,
             )


### PR DESCRIPTION

# What does this PR do?
fixes a typo in the trainer test for bitsandbytes that was causing an error on pytest collection



## Before submitting
- [ yes] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).