### PR TITLE
Clarify `use_fast` parameter in docstring

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -525,8 +525,8 @@ class AutoTokenizer:
                 facebook/rag-token-base), specify it here.
             use_fast (`bool`, *optional*, defaults to `True`):
                 Use a [fast Rust-based tokenizer](https://huggingface.co/docs/tokenizers/index) if it is supported for
-                a given model (check the [supported frameworks](./index#supported-frameworks) for the full list). If a
-                fast tokenizer is not available for a given model, a normal Python-based tokenizer is used instead.
+                a given model. If a fast tokenizer is not available for a given model, a normal Python-based tokenizer
+                is returned instead.
             tokenizer_type (`str`, *optional*):
                 Tokenizer type to be loaded.
             trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -524,7 +524,7 @@ class AutoTokenizer:
                 In case the relevant files are located inside a subfolder of the model repo on huggingface.co (e.g. for
                 facebook/rag-token-base), specify it here.
             use_fast (`bool`, *optional*, defaults to `True`):
-                Whether or not to try to load the fast version of the tokenizer.
+                Use a [fast Rust-based tokenizer](https://huggingface.co/docs/tokenizers/index) if it is supported for a given model (check the [supported frameworks](./index#supported-frameworks) for the full list). If a fast tokenizer is not available for a given model, a normal Python-based tokenizer is used instead.
             tokenizer_type (`str`, *optional*):
                 Tokenizer type to be loaded.
             trust_remote_code (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -524,7 +524,9 @@ class AutoTokenizer:
                 In case the relevant files are located inside a subfolder of the model repo on huggingface.co (e.g. for
                 facebook/rag-token-base), specify it here.
             use_fast (`bool`, *optional*, defaults to `True`):
-                Use a [fast Rust-based tokenizer](https://huggingface.co/docs/tokenizers/index) if it is supported for a given model (check the [supported frameworks](./index#supported-frameworks) for the full list). If a fast tokenizer is not available for a given model, a normal Python-based tokenizer is used instead.
+                Use a [fast Rust-based tokenizer](https://huggingface.co/docs/tokenizers/index) if it is supported for
+                a given model (check the [supported frameworks](./index#supported-frameworks) for the full list). If a
+                fast tokenizer is not available for a given model, a normal Python-based tokenizer is used instead.
             tokenizer_type (`str`, *optional*):
                 Tokenizer type to be loaded.
             trust_remote_code (`bool`, *optional*, defaults to `False`):


### PR DESCRIPTION
This PR addresses the ambiguity of the `use_fast` parameter raised in #20817.