### PR TITLE
Deprecate `clean_up_tokenization_spaces` for BLOOM

### DIFF
--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -16,7 +16,7 @@
 
 
 import json
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from tokenizers import pre_tokenizers
 
@@ -154,6 +154,25 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             )
 
         return super()._encode_plus(*args, **kwargs)
+
+    def _decode(
+        self,
+        token_ids: Union[int, List[int]],
+        skip_special_tokens: bool = False,
+        clean_up_tokenization_spaces: bool = True,
+        **kwargs
+    ) -> str:
+        if clean_up_tokenization_spaces:
+            logger.warning(
+                "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
+                " `clean_up_tokenization_spaces=False`."
+            )
+        return super()._decode(
+            token_ids=token_ids,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
 
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         files = self._tokenizer.model.save(save_directory, name=filename_prefix)

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -165,21 +165,6 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
 
         return super()._encode_plus(*args, **kwargs)
 
-    def _decode(
-        self,
-        token_ids: Union[int, List[int]],
-        skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: bool = True,
-        **kwargs
-    ) -> str:
-
-        return super()._decode(
-            token_ids=token_ids,
-            skip_special_tokens=skip_special_tokens,
-            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
-            **kwargs,
-        )
-
     def batch_decode(
         self,
         sequences: Union[List[int], List[List[int]], "np.ndarray", "torch.Tensor", "tf.Tensor"],
@@ -195,7 +180,7 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             skip_special_tokens (`bool`, *optional*, defaults to `False`):
                 Whether or not to remove special tokens in the decoding.
-            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `False`):
+            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `True`):
                 Whether or not to clean up the tokenization spaces.
             kwargs (additional keyword arguments, *optional*):
                 Will be passed to the underlying model specific decode method.
@@ -220,7 +205,7 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
         self,
         token_ids: Union[int, List[int], "np.ndarray", "torch.Tensor", "tf.Tensor"],
         skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: bool = False,
+        clean_up_tokenization_spaces: bool = True,
         **kwargs
     ) -> str:
         """
@@ -234,7 +219,7 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             skip_special_tokens (`bool`, *optional*, defaults to `False`):
                 Whether or not to remove special tokens in the decoding.
-            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `False`):
+            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `True`):
                 Whether or not to clean up the tokenization spaces.
             kwargs (additional keyword arguments, *optional*):
                 Will be passed to the underlying model specific decode method.

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -16,6 +16,7 @@
 
 
 import json
+import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
@@ -192,7 +193,7 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             warnings.warn(
                 "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
                 " `clean_up_tokenization_spaces=False`. This flag is deprecated and will be remove in v5. The"
-                " behaviour will correspond to `clean_up_tokenization_spaces=False`"
+                " behaviour will correspond to `clean_up_tokenization_spaces=False`",
                 FutureWarning,
             )
         return super().batch_decode(
@@ -229,10 +230,11 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             `str`: The decoded sentence.
         """
         if clean_up_tokenization_spaces:
-            logger.warning(
+            warnings.warn(
                 "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
                 " `clean_up_tokenization_spaces=False`. This flag is deprecated and will be remove in v5. The"
-                " behaviour will correspond to `clean_up_tokenization_spaces=False`"
+                " behaviour will correspond to `clean_up_tokenization_spaces=False`",
+                FutureWarning,
             )
         return super().decode(
             token_ids=token_ids,

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -189,10 +189,11 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             `List[str]`: The list of decoded sentences.
         """
         if clean_up_tokenization_spaces:
-            logger.warning(
+            warnings.warn(
                 "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
                 " `clean_up_tokenization_spaces=False`. This flag is deprecated and will be remove in v5. The"
                 " behaviour will correspond to `clean_up_tokenization_spaces=False`"
+                FutureWarning,
             )
         return super().batch_decode(
             sequences=sequences,

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -18,8 +18,11 @@
 import json
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+import numpy as np
+
 from tokenizers import pre_tokenizers
 
+from ... import is_flax_available, is_tf_available, is_torch_available
 from ...tokenization_utils_base import BatchEncoding
 from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import logging
@@ -27,6 +30,13 @@ from ...utils import logging
 
 if TYPE_CHECKING:
     from transformers.pipelines.conversational import Conversation
+
+    if is_torch_available():
+        import torch
+    if is_tf_available():
+        import tensorflow as tf
+    if is_flax_available():
+        import jax.numpy as jnp  # noqa: F401
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -162,12 +162,83 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
         clean_up_tokenization_spaces: bool = True,
         **kwargs
     ) -> str:
+
+        return super()._decode(
+            token_ids=token_ids,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+    def batch_decode(
+        self,
+        sequences: Union[List[int], List[List[int]], "np.ndarray", "torch.Tensor", "tf.Tensor"],
+        skip_special_tokens: bool = False,
+        clean_up_tokenization_spaces: bool = True,
+        **kwargs
+    ) -> List[str]:
+        """
+        Convert a list of lists of token ids into a list of strings by calling decode.
+
+        Args:
+            sequences (`Union[List[int], List[List[int]], np.ndarray, torch.Tensor, tf.Tensor]`):
+                List of tokenized input ids. Can be obtained using the `__call__` method.
+            skip_special_tokens (`bool`, *optional*, defaults to `False`):
+                Whether or not to remove special tokens in the decoding.
+            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `False`):
+                Whether or not to clean up the tokenization spaces.
+            kwargs (additional keyword arguments, *optional*):
+                Will be passed to the underlying model specific decode method.
+
+        Returns:
+            `List[str]`: The list of decoded sentences.
+        """
         if clean_up_tokenization_spaces:
             logger.warning(
                 "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
-                " `clean_up_tokenization_spaces=False`."
+                " `clean_up_tokenization_spaces=False`. This flag is deprecated and will be remove in v5. The"
+                " behaviour will correspond to `clean_up_tokenization_spaces=False`"
             )
-        return super()._decode(
+        return super().batch_decode(
+            sequences=sequences,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+    def decode(
+        self,
+        token_ids: Union[int, List[int], "np.ndarray", "torch.Tensor", "tf.Tensor"],
+        skip_special_tokens: bool = False,
+        clean_up_tokenization_spaces: bool = False,
+        **kwargs
+    ) -> str:
+        """
+        Converts a sequence of ids in a string, using the tokenizer and vocabulary with options to remove special
+        tokens and clean up tokenization spaces.
+
+        Similar to doing `self.convert_tokens_to_string(self.convert_ids_to_tokens(token_ids))`.
+
+        Args:
+            token_ids (`Union[int, List[int], np.ndarray, torch.Tensor, tf.Tensor]`):
+                List of tokenized input ids. Can be obtained using the `__call__` method.
+            skip_special_tokens (`bool`, *optional*, defaults to `False`):
+                Whether or not to remove special tokens in the decoding.
+            clean_up_tokenization_spaces (`bool`, *optional*, defaults to `False`):
+                Whether or not to clean up the tokenization spaces.
+            kwargs (additional keyword arguments, *optional*):
+                Will be passed to the underlying model specific decode method.
+
+        Returns:
+            `str`: The decoded sentence.
+        """
+        if clean_up_tokenization_spaces:
+            logger.warning(
+                "Bloom tokenizer was built in order to have lossless encoding. Most likely, you should use"
+                " `clean_up_tokenization_spaces=False`. This flag is deprecated and will be remove in v5. The"
+                " behaviour will correspond to `clean_up_tokenization_spaces=False`"
+            )
+        return super().decode(
             token_ids=token_ids,
             skip_special_tokens=skip_special_tokens,
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,


### PR DESCRIPTION
# What does this PR do?

Currently in `transformers`:
```python
>>> tok.decode(tok.encode("Hello , there"))
'Hello, there' # notice the missing space between "Hello" and ","
>>> tok.decode(tok.encode("Hello , there"), clean_up_tokenization_spaces=False)
'Hello , there'
```

In order too prevent issues such as this: https://huggingface.co/bigscience/bloom/discussions/153#6397907b71eb2455d898e0a4 we suggest to add a warning, suggesting to users to use `clean_up_tokenization_spaces=False` instead.

As BLOOM tokenizer was developped in order to be lossless encoding mechanism, it should make sense to always remove that option IMO, therefore I'm suggesting to deprecate that option from BLOOM tokenizer. Other option would be to change the default to `True`.
