### PR TITLE
TF AdamWeightDecay fix for 2.11

### DIFF
--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -22,9 +22,9 @@ import tensorflow as tf
 
 
 try:
-    from tf.keras.optimizers.legacy import Adam
+    from tensorflow.keras.optimizers.legacy import Adam
 except ImportError:
-    from tf.keras.optimizers import Adam
+    from tensorflow.keras.optimizers import Adam
 
 
 class WarmUp(tf.keras.optimizers.schedules.LearningRateSchedule):

--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -21,10 +21,10 @@ from typing import Callable, List, Optional, Union
 import tensorflow as tf
 
 
-if hasattr(tf.keras, "optimizer") and hasattr(tf.keras.optimizer, "legacy"):
-    Adam = tf.keras.optimizer.legacy.Adam
-else:
-    Adam = tf.keras.optimizers.Adam
+try:
+    from tf.keras.optimizers.legacy import Adam
+except ImportError:
+    from tf.keras.optimizers import Adam
 
 
 class WarmUp(tf.keras.optimizers.schedules.LearningRateSchedule):


### PR DESCRIPTION
The TF changelog said that the optimizer had been moved to `tf.keras.optimizer.legacy`, but the true path is `tf.keras.optimizers.legacy`. Because of the conditional in the PR, we didn't notice the error, but it's resolved now!

Fixes #20847 