### PR TITLE
Adding `evaluate` to the list of libraries required in generated notebooks

### DIFF
--- a/docs/source/_config.py
+++ b/docs/source/_config.py
@@ -1,7 +1,7 @@
 # docstyle-ignore
 INSTALL_CONTENT = """
 # Transformers installation
-! pip install transformers datasets
+! pip install transformers datasets evaluate
 # To install from source instead of the last release, comment the command above and uncomment the following one.
 # ! pip install git+https://github.com/huggingface/transformers.git
 """


### PR DESCRIPTION
This PR is based on the discussion in [doc-builder/Add custom first cell #50](https://github.com/huggingface/doc-builder/pull/50#issuecomment-1359312952).
It modifies the config file that defines the contents of the first cell for the Colab notebooks generated from the doc pages. This change adds `evaluate` to the list of libraries that are installed in the first cell of every generated notebook. 
Currently, only `transformers` and `dataset` libraries are installed by default. However, many notebooks also require `evaluate`. See examples: 
https://huggingface.co/docs/transformers/tasks/sequence_classification
https://huggingface.co/docs/transformers/tasks/semantic_segmentation