### PR TITLE
Fix past CI by Skipping `LevitModelTest.test_problem_types`

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -28,6 +28,7 @@ logger = logging.get_logger(__name__)
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
 is_torch_less_than_1_8 = parsed_torch_version_base < version.parse("1.8.0")
+is_torch_less_than_1_9 = parsed_torch_version_base < version.parse("1.9.0")
 is_torch_greater_or_equal_than_1_10 = parsed_torch_version_base >= version.parse("1.10")
 is_torch_less_than_1_11 = parsed_torch_version_base < version.parse("1.11")
 

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -28,7 +28,6 @@ logger = logging.get_logger(__name__)
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
 is_torch_less_than_1_8 = parsed_torch_version_base < version.parse("1.8.0")
-is_torch_less_than_1_9 = parsed_torch_version_base < version.parse("1.9.0")
 is_torch_greater_or_equal_than_1_10 = parsed_torch_version_base >= version.parse("1.10")
 is_torch_less_than_1_11 = parsed_torch_version_base < version.parse("1.11")
 

--- a/tests/models/levit/test_modeling_levit.py
+++ b/tests/models/levit/test_modeling_levit.py
@@ -20,6 +20,8 @@ import unittest
 import warnings
 from math import ceil, floor
 
+from packaging import version
+
 from transformers import LevitConfig
 from transformers.file_utils import cached_property, is_torch_available, is_vision_available
 from transformers.models.auto import get_values
@@ -40,7 +42,7 @@ if is_torch_available():
         LevitModel,
     )
     from transformers.models.levit.modeling_levit import LEVIT_PRETRAINED_MODEL_ARCHIVE_LIST
-    from transformers.pytorch_utils import is_torch_greater_or_equal_than_1_10, is_torch_less_than_1_9
+
 
 if is_vision_available():
     from PIL import Image
@@ -336,8 +338,9 @@ class LevitModelTest(ModelTesterMixin, unittest.TestCase):
 
     def test_problem_types(self):
 
-        if not (is_torch_less_than_1_9 or is_torch_greater_or_equal_than_1_10):
-            self.skipTest(reason="This test fails with PyTorch 1.9: some CUDA issue")
+        parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
+        if parsed_torch_version_base.base_version.startswith("1.9"):
+            self.skipTest(reason="This test fails with PyTorch 1.9.x: some CUDA issue")
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/models/levit/test_modeling_levit.py
+++ b/tests/models/levit/test_modeling_levit.py
@@ -40,7 +40,7 @@ if is_torch_available():
         LevitModel,
     )
     from transformers.models.levit.modeling_levit import LEVIT_PRETRAINED_MODEL_ARCHIVE_LIST
-
+    from transformers.pytorch_utils import is_torch_greater_or_equal_than_1_10, is_torch_less_than_1_9
 
 if is_vision_available():
     from PIL import Image
@@ -335,6 +335,10 @@ class LevitModelTest(ModelTesterMixin, unittest.TestCase):
             loss.backward()
 
     def test_problem_types(self):
+
+        if not (is_torch_less_than_1_9 or is_torch_greater_or_equal_than_1_10):
+            self.skipTest(reason="This test fails with PyTorch 1.9: some CUDA issue")
+
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         problem_types = [


### PR DESCRIPTION
# What does this PR do?

Fix past CI by Skipping `LevitModelTest.test_problem_types` for `PyTorch 1.9`.

This test failed with torch 1.9 with some CUDA error, but it passes with `torch 1.8` and `torch >= 1.10`.

The error is
```bash
input = <[RuntimeError('CUDA error: an illegal memory access was encountered\nCUDA kernel errors might be asynchronously repor...incorrect.\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1.') raised in repr()] Tensor object at 0x7fcb37dbd900>
weight = <[RuntimeError('CUDA error: an illegal memory access was encountered\nCUDA kernel errors might be asynchronously repor...orrect.\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1.') raised in repr()] Parameter object at 0x7fcb36c935c0>, bias = None

FAILED tests/models/levit/test_modeling_levit.py::LevitModelTest::test_problem_types - RuntimeError: CUDA error: CUBLAS_STATUS_EXECUTION_FAILED when calling `cublasSgemm( handle, opa, opb, m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc)`
```