### PR TITLE
[`MobileNet-v2`] Fix ONNX typo 

### DIFF
--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -408,12 +408,12 @@ class FeaturesManager:
             "question-answering",
             onnx_config_cls="models.mobilebert.MobileBertOnnxConfig",
         ),
-        "mobilenet_v1": supported_features_mapping(
+        "mobilenet-v1": supported_features_mapping(
             "default",
             "image-classification",
             onnx_config_cls="models.mobilenet_v1.MobileNetV1OnnxConfig",
         ),
-        "mobilenet_v2": supported_features_mapping(
+        "mobilenet-v2": supported_features_mapping(
             "default",
             "image-classification",
             onnx_config_cls="models.mobilenet_v2.MobileNetV2OnnxConfig",

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -272,7 +272,12 @@ def _get_models_to_test(export_models_list):
                     feature: FeaturesManager.get_config(name, feature) for _ in features for feature in _
                 }
             else:
-                feature_config_mapping = FeaturesManager.get_supported_features_for_model_type(name)
+                # pre-process the model names
+                model_type = name.replace("_", "-")
+                model_name = getattr(model, "name", "")
+                feature_config_mapping = FeaturesManager.get_supported_features_for_model_type(
+                    model_type, model_name=model_name
+                )
 
             for feature, onnx_config_class_constructor in feature_config_mapping.items():
                 models_to_test.append((f"{name}_{feature}", name, model, feature, onnx_config_class_constructor))


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/20856

In order to get which model is exportable with ONNX, we need first to pre-process the model type before checking with `FeaturesManager` by replacing the `_` with `-`. 

This has been forgotten for `mobilenet` family models which leads to errors such as the one described in #20856 

It seems that the proper way to call the method `get_supported_features_for_model_type`, is to first apply some pre-preprocessing as it is done [here](https://github.com/huggingface/transformers/blob/d87e381f9303c7d6a8aa7333dc09ed767de7395f/src/transformers/onnx/features.py#L723). This patch has been added to `tests/onnx/test_onnx_v2.py` too

This PR fixes these issues.

Also I would like to hear from @lewtun as it's my first ONNX-related PR.

cc @sgugger @ArthurZucker 
