### PR TITLE
Update `HubertModelIntegrationTest.test_inference_keyword_spotting`

### DIFF
--- a/tests/models/hubert/test_modeling_hubert.py
+++ b/tests/models/hubert/test_modeling_hubert.py
@@ -802,7 +802,7 @@ class HubertModelIntegrationTest(unittest.TestCase):
         expected_logits = torch.tensor([7.6692, 17.7795, 11.1562, 11.8232], dtype=torch.float16, device=torch_device)
 
         self.assertListEqual(predicted_ids.tolist(), expected_labels)
-        self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=2e-2))
+        self.assertTrue(torch.allclose(predicted_logits, expected_logits, atol=3e-2))
 
     def test_inference_intent_classification(self):
         model = HubertForSequenceClassification.from_pretrained(


### PR DESCRIPTION
# What does this PR do?

Our CI is updated to use torch 1.13 (which also use cuda 11.6) instead of torch 1.12 (cuda 11.3), this test fails. The tolerance `2e-2` is not enough anymore, but it passes with `3e-2`.
