### PR TITLE
Update image processor parameters if creating with kwargs

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -318,6 +318,14 @@ class ImageProcessingMixin(PushToHubMixin):
         """
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
 
+        # The `size` parameter is a dict and was previously an int or tuple in feature extractors.
+        # We set `size` here directly to the `image_processor_dict` so that it is converted to the appropriate
+        # dict within the image processor and isn't overwritten if `size` is passed in as a kwarg.
+        if "size" in kwargs and "size" in image_processor_dict:
+            image_processor_dict["size"] = kwargs.pop("size")
+        if "crop_size" in kwargs and "crop_size" in image_processor_dict:
+            image_processor_dict["crop_size"] = kwargs.pop("crop_size")
+
         image_processor = cls(**image_processor_dict)
 
         # Update image_processor with kwargs if needed

--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -316,6 +316,7 @@ class ImageProcessingMixin(PushToHubMixin):
             [`~image_processing_utils.ImageProcessingMixin`]: The image processor object instantiated from those
             parameters.
         """
+        image_processor_dict = image_processor_dict.copy()
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
 
         # The `size` parameter is a dict and was previously an int or tuple in feature extractors.

--- a/src/transformers/models/beit/image_processing_beit.py
+++ b/src/transformers/models/beit/image_processing_beit.py
@@ -139,13 +139,7 @@ class BeitImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "reduce_labels" in kwargs:
-            warnings.warn(
-                "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_reduce_labels` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
-
+            image_processor_dict["reduce_labels"] = kwargs.pop("reduce_labels")
         return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(

--- a/src/transformers/models/beit/image_processing_beit.py
+++ b/src/transformers/models/beit/image_processing_beit.py
@@ -15,7 +15,7 @@
 """Image processor class for Beit."""
 
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -130,6 +130,21 @@ class BeitImageProcessor(BaseImageProcessor):
         self.image_mean = image_mean if image_mean is not None else IMAGENET_STANDARD_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD
         self.do_reduce_labels = do_reduce_labels
+
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
+        is create using from_dict and kwargs e.g. `BeitImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
+        """
+        if "reduce_labels" in kwargs:
+            warnings.warn(
+                "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_reduce_labels` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
+        return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(
         self,

--- a/src/transformers/models/beit/image_processing_beit.py
+++ b/src/transformers/models/beit/image_processing_beit.py
@@ -137,6 +137,7 @@ class BeitImageProcessor(BaseImageProcessor):
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
         is create using from_dict and kwargs e.g. `BeitImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "reduce_labels" in kwargs:
             warnings.warn(
                 "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
@@ -144,6 +145,7 @@ class BeitImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(

--- a/src/transformers/models/beit/image_processing_beit.py
+++ b/src/transformers/models/beit/image_processing_beit.py
@@ -135,7 +135,7 @@ class BeitImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
-        is create using from_dict and kwargs e.g. `BeitImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
+        is created using from_dict and kwargs e.g. `BeitImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "reduce_labels" in kwargs:

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -815,6 +815,32 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_pad = do_pad
 
+    @classmethod
+    # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.from_dict with Detr->ConditionalDetr
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
+        max_size=800)`
+        """
+        if "max_size" in kwargs:
+            warnings.warn(
+                "The `max_size` parameter is deprecated and will be removed in v4.27. "
+                "Please specify in `size['longest_edge'] instead`.",
+                FutureWarning,
+            )
+            max_size = kwargs.pop("max_size")
+            image_processor_dict["max_size"] = max_size
+
+        if "pad_and_return_pixel_mask" in kwargs:
+            warnings.warn(
+                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_pad` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+        return super().from_dict(image_processor_dict, **kwargs)
+
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->ConditionalDetr
     def prepare_annotation(
         self,

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -825,20 +825,9 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.27. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
             image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
-            warnings.warn(
-                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_pad` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
-
+            image_processor_dict["pad_and_return_pixel_mask"] = kwargs.pop("pad_and_return_pixel_mask")
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->ConditionalDetr

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -823,15 +823,14 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         create using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
             warnings.warn(
                 "The `max_size` parameter is deprecated and will be removed in v4.27. "
                 "Please specify in `size['longest_edge'] instead`.",
                 FutureWarning,
             )
-            max_size = kwargs.pop("max_size")
-            image_processor_dict["max_size"] = max_size
-
+            image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
             warnings.warn(
                 "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
@@ -839,6 +838,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->ConditionalDetr

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -820,7 +820,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
+        created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -823,20 +823,9 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.27. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
             image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
-            warnings.warn(
-                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_pad` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
-
+            image_processor_dict["pad_and_return_pixel_mask"] = kwargs.pop("pad_and_return_pixel_mask")
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->DeformableDetr

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -818,7 +818,7 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `DeformableDetrImageProcessor.from_pretrained(checkpoint, size=600,
+        created using from_dict and kwargs e.g. `DeformableDetrImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -813,6 +813,32 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_pad = do_pad
 
+    @classmethod
+    # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.from_dict with Detr->DeformableDetr
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `DeformableDetrImageProcessor.from_pretrained(checkpoint, size=600,
+        max_size=800)`
+        """
+        if "max_size" in kwargs:
+            warnings.warn(
+                "The `max_size` parameter is deprecated and will be removed in v4.27. "
+                "Please specify in `size['longest_edge'] instead`.",
+                FutureWarning,
+            )
+            max_size = kwargs.pop("max_size")
+            image_processor_dict["max_size"] = max_size
+
+        if "pad_and_return_pixel_mask" in kwargs:
+            warnings.warn(
+                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_pad` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+        return super().from_dict(image_processor_dict, **kwargs)
+
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->DeformableDetr
     def prepare_annotation(
         self,

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -821,15 +821,14 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
         create using from_dict and kwargs e.g. `DeformableDetrImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
             warnings.warn(
                 "The `max_size` parameter is deprecated and will be removed in v4.27. "
                 "Please specify in `size['longest_edge'] instead`.",
                 FutureWarning,
             )
-            max_size = kwargs.pop("max_size")
-            image_processor_dict["max_size"] = max_size
-
+            image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
             warnings.warn(
                 "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
@@ -837,6 +836,7 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation with DETR->DeformableDetr

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -805,20 +805,9 @@ class DetrImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.27. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
             image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
-            warnings.warn(
-                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_pad` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
-
+            image_processor_dict["pad_and_return_pixel_mask"] = kwargs.pop("pad_and_return_pixel_mask")
         return super().from_dict(image_processor_dict, **kwargs)
 
     def prepare_annotation(

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -801,7 +801,8 @@ class DetrImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `DetrImageProcessor.from_pretrained(checkpoint, size=600, max_size=800)`
+        created using from_dict and kwargs e.g. `DetrImageProcessor.from_pretrained(checkpoint, size=600,
+        max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -803,15 +803,14 @@ class DetrImageProcessor(BaseImageProcessor):
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
         create using from_dict and kwargs e.g. `DetrImageProcessor.from_pretrained(checkpoint, size=600, max_size=800)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
             warnings.warn(
                 "The `max_size` parameter is deprecated and will be removed in v4.27. "
                 "Please specify in `size['longest_edge'] instead`.",
                 FutureWarning,
             )
-            max_size = kwargs.pop("max_size")
-            image_processor_dict["max_size"] = max_size
-
+            image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
             warnings.warn(
                 "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
@@ -819,6 +818,7 @@ class DetrImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     def prepare_annotation(

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -797,6 +797,30 @@ class DetrImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_pad = do_pad
 
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `DetrImageProcessor.from_pretrained(checkpoint, size=600, max_size=800)`
+        """
+        if "max_size" in kwargs:
+            warnings.warn(
+                "The `max_size` parameter is deprecated and will be removed in v4.27. "
+                "Please specify in `size['longest_edge'] instead`.",
+                FutureWarning,
+            )
+            max_size = kwargs.pop("max_size")
+            image_processor_dict["max_size"] = max_size
+
+        if "pad_and_return_pixel_mask" in kwargs:
+            warnings.warn(
+                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_pad` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+        return super().from_dict(image_processor_dict, **kwargs)
+
     def prepare_annotation(
         self,
         image: np.ndarray,

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -299,6 +299,7 @@ class FlavaImageProcessor(BaseImageProcessor):
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
         create using from_dict and kwargs e.g. `FlavaImageProcessor.from_pretrained(checkpoint, codebook_size=600)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "codebook_size" in kwargs:
             image_processor_dict["codebook_size"] = kwargs.pop("codebook_size")
         if "codebook_crop_size" in kwargs:

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -297,7 +297,7 @@ class FlavaImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `FlavaImageProcessor.from_pretrained(checkpoint, codebook_size=600)`
+        created using from_dict and kwargs e.g. `FlavaImageProcessor.from_pretrained(checkpoint, codebook_size=600)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "codebook_size" in kwargs:

--- a/src/transformers/models/flava/image_processing_flava.py
+++ b/src/transformers/models/flava/image_processing_flava.py
@@ -17,7 +17,7 @@
 import math
 import random
 from functools import lru_cache
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -292,6 +292,18 @@ class FlavaImageProcessor(BaseImageProcessor):
         self.codebook_image_mean = codebook_image_mean
         self.codebook_image_mean = codebook_image_mean if codebook_image_mean is not None else FLAVA_CODEBOOK_MEAN
         self.codebook_image_std = codebook_image_std if codebook_image_std is not None else FLAVA_CODEBOOK_STD
+
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `FlavaImageProcessor.from_pretrained(checkpoint, codebook_size=600)`
+        """
+        if "codebook_size" in kwargs:
+            image_processor_dict["codebook_size"] = kwargs.pop("codebook_size")
+        if "codebook_crop_size" in kwargs:
+            image_processor_dict["codebook_crop_size"] = kwargs.pop("codebook_crop_size")
+        return super().from_dict(image_processor_dict, **kwargs)
 
     @lru_cache()
     def masking_generator(

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -440,21 +440,9 @@ class MaskFormerImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.27. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
             image_processor_dict["max_size"] = kwargs.pop("max_size")
-
         if "size_divisibility" in kwargs:
-            warnings.warn(
-                "The `size_divisibility` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `size_divisor` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["size_divisor"] = kwargs.pop("size_divisibility")
-
+            image_processor_dict["size_divisibility"] = kwargs.pop("size_divisibility")
         return super().from_dict(image_processor_dict, **kwargs)
 
     @property

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -438,14 +438,14 @@ class MaskFormerImageProcessor(BaseImageProcessor):
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
         create using from_dict and kwargs e.g. `MaskFormerImageProcessor.from_pretrained(checkpoint, max_size=800)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
             warnings.warn(
                 "The `max_size` parameter is deprecated and will be removed in v4.27. "
                 "Please specify in `size['longest_edge'] instead`.",
                 FutureWarning,
             )
-            max_size = kwargs.pop("max_size")
-            image_processor_dict["max_size"] = max_size
+            image_processor_dict["max_size"] = kwargs.pop("max_size")
 
         if "size_divisibility" in kwargs:
             warnings.warn(
@@ -453,8 +453,7 @@ class MaskFormerImageProcessor(BaseImageProcessor):
                 "Please specify `size_divisor` instead`.",
                 FutureWarning,
             )
-            size_divisibility = kwargs.pop("size_divisibility")
-            image_processor_dict["size_divisor"] = size_divisibility
+            image_processor_dict["size_divisor"] = kwargs.pop("size_divisibility")
 
         return super().from_dict(image_processor_dict, **kwargs)
 

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -400,7 +400,7 @@ class MaskFormerImageProcessor(BaseImageProcessor):
         if "size_divisibility" in kwargs:
             warnings.warn(
                 "The `size_divisibility` argument is deprecated and will be removed in v4.27. Please use "
-                "`size_divisibility` instead.",
+                "`size_divisor` instead.",
                 FutureWarning,
             )
             size_divisor = kwargs.pop("size_divisibility")
@@ -431,6 +431,32 @@ class MaskFormerImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.ignore_index = ignore_index
         self.reduce_labels = reduce_labels
+
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `MaskFormerImageProcessor.from_pretrained(checkpoint, max_size=800)`
+        """
+        if "max_size" in kwargs:
+            warnings.warn(
+                "The `max_size` parameter is deprecated and will be removed in v4.27. "
+                "Please specify in `size['longest_edge'] instead`.",
+                FutureWarning,
+            )
+            max_size = kwargs.pop("max_size")
+            image_processor_dict["max_size"] = max_size
+
+        if "size_divisibility" in kwargs:
+            warnings.warn(
+                "The `size_divisibility` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `size_divisor` instead`.",
+                FutureWarning,
+            )
+            size_divisibility = kwargs.pop("size_divisibility")
+            image_processor_dict["size_divisor"] = size_divisibility
+
+        return super().from_dict(image_processor_dict, **kwargs)
 
     @property
     def size_divisibility(self):

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -436,7 +436,7 @@ class MaskFormerImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `MaskFormerImageProcessor.from_pretrained(checkpoint, max_size=800)`
+        created using from_dict and kwargs e.g. `MaskFormerImageProcessor.from_pretrained(checkpoint, max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:

--- a/src/transformers/models/segformer/image_processing_segformer.py
+++ b/src/transformers/models/segformer/image_processing_segformer.py
@@ -15,7 +15,7 @@
 """Image processor class for Segformer."""
 
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -118,6 +118,22 @@ class SegformerImageProcessor(BaseImageProcessor):
         self.image_mean = image_mean if image_mean is not None else IMAGENET_DEFAULT_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_reduce_labels = do_reduce_labels
+
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
+        is create using from_dict and kwargs e.g. `SegformerImageProcessor.from_pretrained(checkpoint,
+        reduce_labels=True)`
+        """
+        if "reduce_labels" in kwargs:
+            warnings.warn(
+                "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_reduce_labels` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
+        return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(
         self,

--- a/src/transformers/models/segformer/image_processing_segformer.py
+++ b/src/transformers/models/segformer/image_processing_segformer.py
@@ -128,13 +128,7 @@ class SegformerImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "reduce_labels" in kwargs:
-            warnings.warn(
-                "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_reduce_labels` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
-
+            image_processor_dict["reduce_labels"] = kwargs.pop("reduce_labels")
         return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(

--- a/src/transformers/models/segformer/image_processing_segformer.py
+++ b/src/transformers/models/segformer/image_processing_segformer.py
@@ -123,7 +123,7 @@ class SegformerImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
-        is create using from_dict and kwargs e.g. `SegformerImageProcessor.from_pretrained(checkpoint,
+        is created using from_dict and kwargs e.g. `SegformerImageProcessor.from_pretrained(checkpoint,
         reduce_labels=True)`
         """
         image_processor_dict = image_processor_dict.copy()

--- a/src/transformers/models/segformer/image_processing_segformer.py
+++ b/src/transformers/models/segformer/image_processing_segformer.py
@@ -126,6 +126,7 @@ class SegformerImageProcessor(BaseImageProcessor):
         is create using from_dict and kwargs e.g. `SegformerImageProcessor.from_pretrained(checkpoint,
         reduce_labels=True)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "reduce_labels" in kwargs:
             warnings.warn(
                 "The `reduce_labels` parameter is deprecated and will be removed in v4.27. "
@@ -133,6 +134,7 @@ class SegformerImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_reduce_labels"] = kwargs.pop("reduce_labels")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -185,6 +185,21 @@ class ViltImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD
         self.do_pad = do_pad
 
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
+        is create using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
+        """
+        if "pad_and_return_pixel_mask" in kwargs:
+            warnings.warn(
+                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_pad` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+        return super().from_dict(image_processor_dict, **kwargs)
+
     def resize(
         self,
         image: np.ndarray,

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -191,6 +191,7 @@ class ViltImageProcessor(BaseImageProcessor):
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
         is create using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "pad_and_return_pixel_mask" in kwargs:
             warnings.warn(
                 "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -189,16 +189,12 @@ class ViltImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
-        is create using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint, reduce_labels=True)`
+        is create using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint,
+        pad_and_return_pixel_mask=False)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "pad_and_return_pixel_mask" in kwargs:
-            warnings.warn(
-                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_pad` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+            image_processor_dict["pad_and_return_pixel_mask"] = kwargs.pop("pad_and_return_pixel_mask")
         return super().from_dict(image_processor_dict, **kwargs)
 
     def resize(

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -189,7 +189,7 @@ class ViltImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure `reduce_labels` is updated if image processor
-        is create using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint,
+        is created using from_dict and kwargs e.g. `ViltImageProcessor.from_pretrained(checkpoint,
         pad_and_return_pixel_mask=False)`
         """
         image_processor_dict = image_processor_dict.copy()

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -733,15 +733,14 @@ class YolosImageProcessor(BaseImageProcessor):
         create using from_dict and kwargs e.g. `YolosImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
+        image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
             warnings.warn(
                 "The `max_size` parameter is deprecated and will be removed in v4.27. "
                 "Please specify in `size['longest_edge'] instead`.",
                 FutureWarning,
             )
-            max_size = kwargs.pop("max_size")
-            image_processor_dict["max_size"] = max_size
-
+            image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
             warnings.warn(
                 "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
@@ -749,6 +748,7 @@ class YolosImageProcessor(BaseImageProcessor):
                 FutureWarning,
             )
             image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -735,20 +735,9 @@ class YolosImageProcessor(BaseImageProcessor):
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.27. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
             image_processor_dict["max_size"] = kwargs.pop("max_size")
         if "pad_and_return_pixel_mask" in kwargs:
-            warnings.warn(
-                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
-                "Please specify `do_pad` instead`.",
-                FutureWarning,
-            )
-            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
-
+            image_processor_dict["pad_and_return_pixel_mask"] = kwargs.pop("pad_and_return_pixel_mask")
         return super().from_dict(image_processor_dict, **kwargs)
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -725,6 +725,32 @@ class YolosImageProcessor(BaseImageProcessor):
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_pad = do_pad
 
+    @classmethod
+    # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.from_dict with Detr->Yolos
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        create using from_dict and kwargs e.g. `YolosImageProcessor.from_pretrained(checkpoint, size=600,
+        max_size=800)`
+        """
+        if "max_size" in kwargs:
+            warnings.warn(
+                "The `max_size` parameter is deprecated and will be removed in v4.27. "
+                "Please specify in `size['longest_edge'] instead`.",
+                FutureWarning,
+            )
+            max_size = kwargs.pop("max_size")
+            image_processor_dict["max_size"] = max_size
+
+        if "pad_and_return_pixel_mask" in kwargs:
+            warnings.warn(
+                "The `pad_and_return_pixel_mask` parameter is deprecated and will be removed in v4.27. "
+                "Please specify `do_pad` instead`.",
+                FutureWarning,
+            )
+            image_processor_dict["do_pad"] = kwargs.pop("pad_and_return_pixel_mask")
+        return super().from_dict(image_processor_dict, **kwargs)
+
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.prepare_annotation
     def prepare_annotation(
         self,

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -730,7 +730,7 @@ class YolosImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        create using from_dict and kwargs e.g. `YolosImageProcessor.from_pretrained(checkpoint, size=600,
+        created using from_dict and kwargs e.g. `YolosImageProcessor.from_pretrained(checkpoint, size=600,
         max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()

--- a/tests/models/beit/test_feature_extraction_beit.py
+++ b/tests/models/beit/test_feature_extraction_beit.py
@@ -125,6 +125,19 @@ class BeitFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         self.assertTrue(hasattr(feature_extractor, "image_mean"))
         self.assertTrue(hasattr(feature_extractor, "image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 20, "width": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+        self.assertEqual(feature_extractor.do_reduce_labels, False)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, crop_size=84, reduce_labels=True
+        )
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+        self.assertEqual(feature_extractor.do_reduce_labels, True)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/chinese_clip/test_feature_extraction_chinese_clip.py
+++ b/tests/models/chinese_clip/test_feature_extraction_chinese_clip.py
@@ -135,6 +135,15 @@ class ChineseCLIPFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittes
         self.assertTrue(hasattr(feature_extractor, "image_std"))
         self.assertTrue(hasattr(feature_extractor, "do_convert_rgb"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 224, "width": 224})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/clip/test_feature_extraction_clip.py
+++ b/tests/models/clip/test_feature_extraction_clip.py
@@ -135,6 +135,15 @@ class CLIPFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         self.assertTrue(hasattr(feature_extractor, "image_std"))
         self.assertTrue(hasattr(feature_extractor, "do_convert_rgb"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/conditional_detr/test_feature_extraction_conditional_detr.py
+++ b/tests/models/conditional_detr/test_feature_extraction_conditional_detr.py
@@ -133,6 +133,17 @@ class ConditionalDetrFeatureExtractionTest(FeatureExtractionSavingTestMixin, uni
         self.assertTrue(hasattr(feature_extractor, "do_resize"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18, "longest_edge": 1333})
+        self.assertEqual(feature_extractor.do_pad, True)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, max_size=84, pad_and_return_pixel_mask=False
+        )
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42, "longest_edge": 84})
+        self.assertEqual(feature_extractor.do_pad, False)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/convnext/test_feature_extraction_convnext.py
+++ b/tests/models/convnext/test_feature_extraction_convnext.py
@@ -96,6 +96,13 @@ class ConvNextFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.T
         self.assertTrue(hasattr(feature_extractor, "image_mean"))
         self.assertTrue(hasattr(feature_extractor, "image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 20})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/deformable_detr/test_feature_extraction_deformable_detr.py
+++ b/tests/models/deformable_detr/test_feature_extraction_deformable_detr.py
@@ -135,6 +135,17 @@ class DeformableDetrFeatureExtractionTest(FeatureExtractionSavingTestMixin, unit
         self.assertTrue(hasattr(feature_extractor, "do_pad"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18, "longest_edge": 1333})
+        self.assertEqual(feature_extractor.do_pad, True)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, max_size=84, pad_and_return_pixel_mask=False
+        )
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42, "longest_edge": 84})
+        self.assertEqual(feature_extractor.do_pad, False)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/deit/test_feature_extraction_deit.py
+++ b/tests/models/deit/test_feature_extraction_deit.py
@@ -103,6 +103,15 @@ class DeiTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         self.assertTrue(hasattr(feature_extractor, "image_mean"))
         self.assertTrue(hasattr(feature_extractor, "image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 20, "width": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/detr/test_feature_extraction_detr.py
+++ b/tests/models/detr/test_feature_extraction_detr.py
@@ -136,6 +136,17 @@ class DetrFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "do_pad"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18, "longest_edge": 1333})
+        self.assertEqual(feature_extractor.do_pad, True)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, max_size=84, pad_and_return_pixel_mask=False
+        )
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42, "longest_edge": 84})
+        self.assertEqual(feature_extractor.do_pad, False)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/donut/test_feature_extraction_donut.py
+++ b/tests/models/donut/test_feature_extraction_donut.py
@@ -103,6 +103,17 @@ class DonutFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
         self.assertTrue(hasattr(feature_extractor, "image_mean"))
         self.assertTrue(hasattr(feature_extractor, "image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 20})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
+        # Previous config had dimensions in (width, height) order
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=(42, 84))
+        self.assertEqual(feature_extractor.size, {"height": 84, "width": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/dpt/test_feature_extraction_dpt.py
+++ b/tests/models/dpt/test_feature_extraction_dpt.py
@@ -92,6 +92,13 @@ class DPTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestCa
         self.assertTrue(hasattr(feature_extractor, "do_resize"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
     def test_call_pil(self):
         # Initialize feature_extractor
         feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)

--- a/tests/models/flava/test_feature_extraction_flava.py
+++ b/tests/models/flava/test_feature_extraction_flava.py
@@ -193,6 +193,21 @@ class FlavaFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
         self.assertTrue(hasattr(feature_extractor, "codebook_image_mean"))
         self.assertTrue(hasattr(feature_extractor, "codebook_image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 224, "width": 224})
+        self.assertEqual(feature_extractor.crop_size, {"height": 224, "width": 224})
+        self.assertEqual(feature_extractor.codebook_size, {"height": 112, "width": 112})
+        self.assertEqual(feature_extractor.codebook_crop_size, {"height": 112, "width": 112})
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, crop_size=84, codebook_size=33, codebook_crop_size=66
+        )
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+        self.assertEqual(feature_extractor.codebook_size, {"height": 33, "width": 33})
+        self.assertEqual(feature_extractor.codebook_crop_size, {"height": 66, "width": 66})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/imagegpt/test_feature_extraction_imagegpt.py
+++ b/tests/models/imagegpt/test_feature_extraction_imagegpt.py
@@ -96,6 +96,13 @@ class ImageGPTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.T
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "do_normalize"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
     def test_feat_extract_to_json_string(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_dict)
         obj = json.loads(feat_extract.to_json_string())

--- a/tests/models/layoutlmv2/test_feature_extraction_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_feature_extraction_layoutlmv2.py
@@ -80,6 +80,13 @@ class LayoutLMv2FeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "apply_ocr"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/layoutlmv3/test_feature_extraction_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_feature_extraction_layoutlmv3.py
@@ -80,6 +80,13 @@ class LayoutLMv3FeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "apply_ocr"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/levit/test_feature_extraction_levit.py
+++ b/tests/models/levit/test_feature_extraction_levit.py
@@ -100,6 +100,15 @@ class LevitFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
         self.assertTrue(hasattr(feature_extractor, "do_center_crop"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/maskformer/test_feature_extraction_maskformer.py
+++ b/tests/models/maskformer/test_feature_extraction_maskformer.py
@@ -152,6 +152,17 @@ class MaskFormerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         self.assertTrue(hasattr(feature_extractor, "ignore_index"))
         self.assertTrue(hasattr(feature_extractor, "num_labels"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 32, "longest_edge": 1333})
+        self.assertEqual(feature_extractor.size_divisor, 0)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, max_size=84, size_divisibility=8
+        )
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42, "longest_edge": 84})
+        self.assertEqual(feature_extractor.size_divisor, 8)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/mobilenet_v1/test_feature_extraction_mobilenet_v1.py
+++ b/tests/models/mobilenet_v1/test_feature_extraction_mobilenet_v1.py
@@ -89,6 +89,15 @@ class MobileNetV1FeatureExtractionTest(FeatureExtractionSavingTestMixin, unittes
         self.assertTrue(hasattr(feature_extractor, "do_center_crop"))
         self.assertTrue(hasattr(feature_extractor, "center_crop"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/mobilenet_v2/test_feature_extraction_mobilenet_v2.py
+++ b/tests/models/mobilenet_v2/test_feature_extraction_mobilenet_v2.py
@@ -87,7 +87,16 @@ class MobileNetV2FeatureExtractionTest(FeatureExtractionSavingTestMixin, unittes
         self.assertTrue(hasattr(feature_extractor, "do_resize"))
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "do_center_crop"))
-        self.assertTrue(hasattr(feature_extractor, "center_crop"))
+        self.assertTrue(hasattr(feature_extractor, "crop_size"))
+
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
 
     def test_batch_feature(self):
         pass

--- a/tests/models/mobilevit/test_feature_extraction_mobilevit.py
+++ b/tests/models/mobilevit/test_feature_extraction_mobilevit.py
@@ -93,6 +93,15 @@ class MobileViTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.
         self.assertTrue(hasattr(feature_extractor, "center_crop"))
         self.assertTrue(hasattr(feature_extractor, "do_flip_channel_order"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 20})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/owlvit/test_feature_extraction_owlvit.py
+++ b/tests/models/owlvit/test_feature_extraction_owlvit.py
@@ -103,6 +103,15 @@ class OwlViTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Tes
         self.assertTrue(hasattr(feature_extractor, "image_std"))
         self.assertTrue(hasattr(feature_extractor, "do_convert_rgb"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_call_pil(self):
         # Initialize feature_extractor
         feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)

--- a/tests/models/poolformer/test_feature_extraction_poolformer.py
+++ b/tests/models/poolformer/test_feature_extraction_poolformer.py
@@ -97,6 +97,15 @@ class PoolFormerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest
         self.assertTrue(hasattr(feature_extractor, "image_mean"))
         self.assertTrue(hasattr(feature_extractor, "image_std"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 30})
+        self.assertEqual(feature_extractor.crop_size, {"height": 30, "width": 30})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/segformer/test_feature_extraction_segformer.py
+++ b/tests/models/segformer/test_feature_extraction_segformer.py
@@ -115,6 +115,17 @@ class SegformerFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.
         self.assertTrue(hasattr(feature_extractor, "image_std"))
         self.assertTrue(hasattr(feature_extractor, "do_reduce_labels"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 30, "width": 30})
+        self.assertEqual(feature_extractor.do_reduce_labels, False)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, reduce_labels=True
+        )
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+        self.assertEqual(feature_extractor.do_reduce_labels, True)
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/videomae/test_feature_extraction_videomae.py
+++ b/tests/models/videomae/test_feature_extraction_videomae.py
@@ -100,6 +100,15 @@ class VideoMAEFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.T
         self.assertTrue(hasattr(feature_extractor, "do_center_crop"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18})
+        self.assertEqual(feature_extractor.crop_size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42, crop_size=84)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+        self.assertEqual(feature_extractor.crop_size, {"height": 84, "width": 84})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/vilt/test_feature_extraction_vilt.py
+++ b/tests/models/vilt/test_feature_extraction_vilt.py
@@ -136,6 +136,13 @@ class ViltFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         self.assertTrue(hasattr(feature_extractor, "size"))
         self.assertTrue(hasattr(feature_extractor, "size_divisor"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 30})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/vit/test_feature_extraction_vit.py
+++ b/tests/models/vit/test_feature_extraction_vit.py
@@ -92,6 +92,13 @@ class ViTFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestCa
         self.assertTrue(hasattr(feature_extractor, "do_resize"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"height": 18, "width": 18})
+
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict, size=42)
+        self.assertEqual(feature_extractor.size, {"height": 42, "width": 42})
+
     def test_batch_feature(self):
         pass
 

--- a/tests/models/yolos/test_feature_extraction_yolos.py
+++ b/tests/models/yolos/test_feature_extraction_yolos.py
@@ -133,6 +133,17 @@ class YolosFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.Test
         self.assertTrue(hasattr(feature_extractor, "do_resize"))
         self.assertTrue(hasattr(feature_extractor, "size"))
 
+    def test_feat_extract_from_dict_with_kwargs(self):
+        feature_extractor = self.feature_extraction_class.from_dict(self.feat_extract_dict)
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 18, "longest_edge": 1333})
+        self.assertEqual(feature_extractor.do_pad, True)
+
+        feature_extractor = self.feature_extraction_class.from_dict(
+            self.feat_extract_dict, size=42, max_size=84, pad_and_return_pixel_mask=False
+        )
+        self.assertEqual(feature_extractor.size, {"shortest_edge": 42, "longest_edge": 84})
+        self.assertEqual(feature_extractor.do_pad, False)
+
     def test_batch_feature(self):
         pass
 


### PR DESCRIPTION
# What does this PR do?

Ensures backwards compatibility with previous feature extractor creation when using `from_pretrained` and `from_dict`.

**Updates attribute before instantiation:** 
Previously, `size` attributes were stored as an int/tuple. This has been updated to a dictionary to reduce ambiguity of whether the int represents the shortest edge, height or width. If the feature extractor / image processor is created with `size` as an int, it is converted to the appropriate dictionary with a `logging.info` message. However, if the image processor is created using `from_pretrained` or `from_dict` with `size` as a kwarg, the class is first instantiated and then the `size` kwarg overwrites the class parameter. In this case, `image_processor.size` is an int, and is not be converted to the correct dictionary format. This PR makes sure the dict creating the instance has the updated value, which is then converted to a dict if necessary. 

**Renames attribute before instantiation**
Some feature extractor instance attributes have been removed when updating to image processors. For example `reduce_labels` became `do_reduce_labels` to ensure naming consistency and `max_size` is now part of the `size` dictionary as `size["longest_edge"]`. In `from_dict`, if the instance doesn't have the attribute, and the attribute is passed in as a kwarg with its old name, the instance won't have it added as an attribute. This PR will update the name of the attribute in `from_dict` to the new name if necessary.

Previously:
```python
>>> image_processor = DetrImageProcessor.from_pretrained("facebook/detr-resnet-50", size=600, max_size=800)
>>> image_processor
DetrImageProcessor {
  "do_normalize": true,
  "do_pad": true,
  "do_rescale": true,
  "do_resize": true,
  "feature_extractor_type": "DetrFeatureExtractor",
  "format": "coco_detection",
  "image_mean": [
    0.485,
    0.456,
    0.406
  ],
  "image_processor_type": "DetrImageProcessor",
  "image_std": [
    0.229,
    0.224,
    0.225
  ],
  "resample": 2,
  "rescale_factor": 0.00392156862745098,
  "size": 600
}
```  

Now:
```python
>>> image_processor = DetrImageProcessor.from_pretrained("facebook/detr-resnet-50", size=600, max_size=800)
>>> image_processor
DetrImageProcessor {
  "do_normalize": true,
  "do_pad": true,
  "do_rescale": true,
  "do_resize": true,
  "feature_extractor_type": "DetrFeatureExtractor",
  "format": "coco_detection",
  "image_mean": [
    0.485,
    0.456,
    0.406
  ],
  "image_processor_type": "DetrImageProcessor",
  "image_std": [
    0.229,
    0.224,
    0.225
  ],
  "resample": 2,
  "rescale_factor": 0.00392156862745098,
  "size": {
    "longest_edge": 800,
    "shortest_edge": 600
  }
}
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
