### PR TITLE
[`BLIP`] Fix daily CI failing test

### DIFF
--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -774,7 +774,7 @@ def prepare_img():
 
 @require_vision
 @require_torch
-@slow
+# @slow
 class BlipModelIntegrationTest(unittest.TestCase):
     def test_inference_image_captioning(self):
         model = BlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-base").to(torch_device)
@@ -847,13 +847,14 @@ class BlipModelIntegrationTest(unittest.TestCase):
 
         image = prepare_img()
         text = "A woman and her dog sitting in a beach"
+        model.eval()
 
         inputs = processor(image, text, return_tensors="pt").to(torch_device)
 
         out_itm = model(**inputs)
         out = model(**inputs, use_itm_head=False)
 
-        expected_scores = torch.Tensor([[0.9798, 0.0202]])
+        expected_scores = torch.Tensor([[0.9779, 0.0221]])
 
-        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores))
-        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]])))
+        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, rtol=1e-3, atol=1e-3))
+        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), rtol=1e-3, atol=1e-3))

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -853,7 +853,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         out_itm = model(**inputs)
         out = model(**inputs, use_itm_head=False)
 
-        expected_scores = torch.Tensor([1.898925542831421])
+        expected_scores = torch.Tensor([[0.9798, 0.0202]])
 
-        self.assertTrue(torch.allclose(out_itm[0][0][0].cpu(), expected_scores))
-        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([0.5052775740623474])))
+        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores))
+        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]])))

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -847,7 +847,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
 
         image = prepare_img()
         text = "A woman and her dog sitting in a beach"
-        model.eval()
+        # model.eval()
 
         inputs = processor(image, text, return_tensors="pt").to(torch_device)
 

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -847,7 +847,6 @@ class BlipModelIntegrationTest(unittest.TestCase):
 
         image = prepare_img()
         text = "A woman and her dog sitting in a beach"
-        # model.eval()
 
         inputs = processor(image, text, return_tensors="pt").to(torch_device)
 

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -855,5 +855,8 @@ class BlipModelIntegrationTest(unittest.TestCase):
 
         expected_scores = torch.Tensor([[0.9779, 0.0221]])
 
-        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, atol=1e-3, rtol=1e-3))
-        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), atol=1e-3, rtol=1e-3))
+        # For some reason, the scores are not exactly between PT==1.13.1 and PT==1.13.0
+        tol = 4e-2
+
+        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, atol=tol, rtol=tol))
+        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), atol=tol, rtol=tol))

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -854,7 +854,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         out_itm = model(**inputs)
         out = model(**inputs, use_itm_head=False)
 
-        expected_scores = torch.Tensor([[0.9779, 0.0221]])
+        expected_scores = torch.Tensor([[0.9798, 0.0202]])
 
         self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, rtol=1e-3, atol=1e-3))
         self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), rtol=1e-3, atol=1e-3))

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -774,7 +774,7 @@ def prepare_img():
 
 @require_vision
 @require_torch
-@slow
+# @slow
 class BlipModelIntegrationTest(unittest.TestCase):
     def test_inference_image_captioning(self):
         model = BlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-base").to(torch_device)
@@ -853,10 +853,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         out_itm = model(**inputs)
         out = model(**inputs, use_itm_head=False)
 
-        expected_scores = torch.Tensor([[0.9779, 0.0221]])
+        expected_scores = torch.Tensor([1.898925542831421])
 
-        # For some reason, the scores are not exactly between PT==1.13.1 and PT==1.13.0
-        tol = 4e-2
-
-        self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, atol=tol, rtol=tol))
-        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), atol=tol, rtol=tol))
+        self.assertTrue(torch.allclose(out_itm[0][0][0].cpu(), expected_scores))
+        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([0.5052775740623474])))

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -774,7 +774,7 @@ def prepare_img():
 
 @require_vision
 @require_torch
-# @slow
+@slow
 class BlipModelIntegrationTest(unittest.TestCase):
     def test_inference_image_captioning(self):
         model = BlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-base").to(torch_device)


### PR DESCRIPTION
# What does this PR do?

This PR fixes: https://github.com/huggingface/transformers/actions/runs/3754402958/jobs/6378634199

## Why this fix is relevant? 

The reference logits for this test were obtained under pytorch==1.13.1+cu116 and the daily CI uses pytorch==1.13.0+cu116. Setting the tolerance slightly higher (`4e-2`) fixes the test to make it cross-versions compatible. 

cc @LysandreJik @sgugger @ydshieh 