### PR TITLE
[ `T5`] fix fp16 loading issue

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -609,7 +609,6 @@ def _load_state_dict_into_meta_model(
             param_name = param_name[len(start_prefix) :]
 
         module_name = param_name
-        force_upcast_dtype = None
         set_module_kwargs = {}
 
         # We convert floating dtypes to the `dtype` passed. We want to keep the buffers/params
@@ -621,11 +620,11 @@ def _load_state_dict_into_meta_model(
                 and dtype == torch.float16
             ):
                 param = param.to(torch.float32)
-                force_upcast_dtype = torch.float32
 
                 # For backward compatibility with older versions of `accelerate`
-                if set_module_tensor_to_device.__code__.co_argcount == 5:
-                    set_module_kwargs["dtype"] = force_upcast_dtype
+                # TODO: @sgugger replace this check with version check at the next `accelerate` release
+                if "dtype" in list(inspect.signature(set_module_tensor_to_device).parameters):
+                    set_module_kwargs["dtype"] = torch.float32
             else:
                 param = param.to(dtype)
 


### PR DESCRIPTION
# What does this PR do?

This PR mainly fixes https://github.com/huggingface/transformers/actions/runs/3754402958/jobs/6378652143 

Since the PR https://github.com/huggingface/accelerate/pull/920 has been merged, the fix proposed in https://github.com/huggingface/transformers/pull/20760 seems to not work anymore using the main branch of `accelerate` for some specific cases. 

To reproduce (use the main branch of `accelerate`): 
```
import torch
from transformers import T5ForConditionalGeneration

model = T5ForConditionalGeneration.from_pretrained("t5-small", torch_dtype=torch.float16)
print(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype)
>>> torch.float16
```

Why?

I believe this is because the aforementioned PR introduced a new argument `dtype` on the function `set_module_tensor_to_device`, if this argument is set to `None` (by default), the target value [is automatically set to the `dtype` of the old tensor](https://github.com/huggingface/accelerate/blob/53b8ed1e8ed5fb8e9d2978744515c31c09e1423e/src/accelerate/utils/modeling.py#L129) - which slightly breaks some assumptions made in https://github.com/huggingface/transformers/pull/20760
I believe upstreaming this change on `modeling_utils` by adding the support of this new argument should be the fix. As some users might not use the latest version of accelerate, I added a small hack to make this change backward compatible, but I am not sure if this is the best solution

Tested this fix on the main branch of `accelerate`,  `accelerate==0.15.0` and all relevant tests pass

cc @sgugger 