### PR TITLE
fix docs typos in "add_new_model"

### DIFF
--- a/docs/source/en/add_new_model.mdx
+++ b/docs/source/en/add_new_model.mdx
@@ -268,7 +268,7 @@ In general, there are two possible debugging environments for running the origin
 Jupyter notebooks have the advantage that they allow for cell-by-cell execution which can be helpful to better split
 logical components from one another and to have faster debugging cycles as intermediate results can be stored. Also,
 notebooks are often easier to share with other contributors, which might be very helpful if you want to ask the Hugging
-Face team for help. If you are familiar with Jupiter notebooks, we strongly recommend you to work with them.
+Face team for help. If you are familiar with Jupyter notebooks, we strongly recommend you to work with them.
 
 The obvious disadvantage of Jupyter notebooks is that if you are not used to working with them you will have to spend
 some time adjusting to the new programming environment and that you might not be able to use your known debugging tools

--- a/templates/adding_a_new_model/ADD_NEW_MODEL_PROPOSAL_TEMPLATE.md
+++ b/templates/adding_a_new_model/ADD_NEW_MODEL_PROPOSAL_TEMPLATE.md
@@ -387,10 +387,10 @@ execution which can be helpful to better split logical components from
 one another and to have faster debugging cycles as intermediate results
 can be stored. Also, notebooks are often easier to share with other
 contributors, which might be very helpful if you want to ask the Hugging
-Face team for help. If you are familiar with Jupiter notebooks, we
+Face team for help. If you are familiar with Jupyter notebooks, we
 strongly recommend you to work with them.
 
-The obvious disadvantage of Jupyther notebooks is that if you are not
+The obvious disadvantage of Jupyter notebooks is that if you are not
 used to working with them you will have to spend some time adjusting to
 the new programming environment and that you might not be able to use
 your known debugging tools anymore, like `ipdb`.

--- a/templates/adding_a_new_model/open_model_proposals/ADD_BIG_BIRD.md
+++ b/templates/adding_a_new_model/open_model_proposals/ADD_BIG_BIRD.md
@@ -372,10 +372,10 @@ execution which can be helpful to better split logical components from
 one another and to have faster debugging cycles as intermediate results
 can be stored. Also, notebooks are often easier to share with other
 contributors, which might be very helpful if you want to ask the Hugging
-Face team for help. If you are familiar with Jupiter notebooks, we
+Face team for help. If you are familiar with Jupyter notebooks, we
 strongly recommend you to work with them.
 
-The obvious disadvantage of Jupyther notebooks is that if you are not
+The obvious disadvantage of Jupyter notebooks is that if you are not
 used to working with them you will have to spend some time adjusting to
 the new programming environment and that you might not be able to use
 your known debugging tools anymore, like `ipdb`.


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo or improves the docs:

 I changed typos in the "add_new_model" docs, from "Jupiter" to "Jupyter"
