### PR TITLE
🚨🚨 Generate: correct beam search best possible score computation and handling

### DIFF
--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -884,7 +884,7 @@ class BeamHypotheses:
         elif self.early_stopping:
             return True
         else:
-            if self.length_penalty < 0.0:
+            if self.length_penalty > 0.0:
                 cur_score = best_sum_logprobs / self.max_length**self.length_penalty
             else:
                 cur_score = best_sum_logprobs / cur_len**self.length_penalty

--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from abc import ABC, abstractmethod
 from collections import UserDict
 from typing import List, Optional, Tuple
@@ -433,7 +432,7 @@ class ConstrainedBeamSearchScorer(BeamScorer):
         self.device = device
         self.length_penalty = length_penalty
         self.do_early_stopping = do_early_stopping
-        self.max_length = max_length,
+        self.max_length = (max_length,)
         self.num_beam_hyps_to_keep = num_beam_hyps_to_keep
         self.num_beam_groups = num_beam_groups
         self.group_size = self.num_beams // self.num_beam_groups

--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -432,7 +432,7 @@ class ConstrainedBeamSearchScorer(BeamScorer):
         self.device = device
         self.length_penalty = length_penalty
         self.do_early_stopping = do_early_stopping
-        self.max_length = (max_length,)
+        self.max_length = max_length
         self.num_beam_hyps_to_keep = num_beam_hyps_to_keep
         self.num_beam_groups = num_beam_groups
         self.group_size = self.num_beams // self.num_beam_groups

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -804,7 +804,7 @@ class FlaxGenerationMixin:
             worst_finished_score = jnp.where(
                 state.is_sent_finished, jnp.min(state.scores, axis=1, keepdims=True), np.array(-1.0e7)
             )
-            improvement_still_possible = jnp.all(worst_finished_score < best_running_score)
+            improvement_still_possible = jnp.any(best_running_score > worst_finished_score)
 
             # 3. is there still a beam that has not finished?
             still_open_beam = ~(jnp.all(state.is_sent_finished) & early_stopping)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -797,7 +797,10 @@ class FlaxGenerationMixin:
             not_max_length_yet = state.cur_len < max_length
 
             # 2. can the new beams still improve?
-            best_running_score = state.running_scores[:, -1:] / (max_length**length_penalty)
+            if length_penalty < 0.0:
+                best_running_score = state.running_scores[:, -1:] / (max_length**length_penalty)
+            else:
+                best_running_score = state.running_scores[:, -1:] / (state.cur_len**length_penalty)
             worst_finished_score = jnp.where(
                 state.is_sent_finished, jnp.min(state.scores, axis=1, keepdims=True), np.array(-1.0e7)
             )

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -797,7 +797,7 @@ class FlaxGenerationMixin:
             not_max_length_yet = state.cur_len < max_length
 
             # 2. can the new beams still improve?
-            if length_penalty < 0.0:
+            if length_penalty > 0.0:
                 best_running_score = state.running_scores[:, -1:] / (max_length**length_penalty)
             else:
                 best_running_score = state.running_scores[:, -1:] / (state.cur_len**length_penalty)

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -3066,7 +3066,7 @@ class TFGenerationMixin:
             not_max_length_yet = cur_len < max_length
 
             # 2. can the new beams still improve?
-            if length_penalty < 0.0:
+            if length_penalty > 0.0:
                 best_running_score = running_scores[:, :1] / (max_length**length_penalty)
             else:
                 best_running_score = running_scores[:, :1] / (tf.cast(cur_len, dtype=tf.float32) ** length_penalty)

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -3069,11 +3069,11 @@ class TFGenerationMixin:
             if length_penalty < 0.0:
                 best_running_score = running_scores[:, :1] / (max_length**length_penalty)
             else:
-                best_running_score = running_scores[:, :1] / (tf.cast(cur_len, dtype=tf.float32)**length_penalty)
+                best_running_score = running_scores[:, :1] / (tf.cast(cur_len, dtype=tf.float32) ** length_penalty)
             worst_finished_score = tf.where(
                 is_sent_finished, tf.math.reduce_min(scores, axis=1, keepdims=True), -1.0e9
             )
-            improvement_still_possible = tf.math.reduce_all(worst_finished_score < best_running_score)
+            improvement_still_possible = tf.math.reduce_any(best_running_score > worst_finished_score)
 
             # 3. is there still a beam that has not finished?
             still_open_beam = ~(tf.math.reduce_all(is_sent_finished) & early_stopping)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3551,7 +3551,7 @@ class GenerationMixin:
         ...     num_beams=num_beams,
         ...     max_length=model.config.max_length,
         ...     device=model.device,
-        ...     constraints=constraints
+        ...     constraints=constraints,
         ... )
 
         >>> # instantiate logits processors

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1406,6 +1406,7 @@ class GenerationMixin:
             beam_scorer = BeamSearchScorer(
                 batch_size=batch_size,
                 num_beams=generation_config.num_beams,
+                max_length=stopping_criteria.max_length,
                 device=inputs_tensor.device,
                 length_penalty=generation_config.length_penalty,
                 do_early_stopping=generation_config.early_stopping,
@@ -1442,6 +1443,7 @@ class GenerationMixin:
             beam_scorer = BeamSearchScorer(
                 batch_size=batch_size * generation_config.num_return_sequences,
                 num_beams=generation_config.num_beams,
+                max_length=stopping_criteria.max_length,
                 device=inputs_tensor.device,
                 length_penalty=generation_config.length_penalty,
                 do_early_stopping=generation_config.early_stopping,
@@ -1577,6 +1579,7 @@ class GenerationMixin:
                 constraints=final_constraints,
                 batch_size=batch_size,
                 num_beams=generation_config.num_beams,
+                max_length=stopping_criteria.max_length,
                 device=inputs_tensor.device,
                 length_penalty=generation_config.length_penalty,
                 do_early_stopping=generation_config.early_stopping,
@@ -2534,6 +2537,7 @@ class GenerationMixin:
         >>> # instantiate beam scorer
         >>> beam_scorer = BeamSearchScorer(
         ...     batch_size=1,
+        ...     max_length=model.config.max_length,
         ...     num_beams=num_beams,
         ...     device=model.device,
         ... )
@@ -3543,7 +3547,11 @@ class GenerationMixin:
 
         >>> # instantiate beam scorer
         >>> beam_scorer = ConstrainedBeamSearchScorer(
-        ...     batch_size=1, num_beams=num_beams, device=model.device, constraints=constraints
+        ...     batch_size=1,
+        ...     num_beams=num_beams,
+        ...     max_length=model.config.max_length,
+        ...     device=model.device,
+        ...     constraints=constraints
         ... )
 
         >>> # instantiate logits processors

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1562,6 +1562,7 @@ class RagTokenForGeneration(RagPreTrainedModel):
             beam_scorer = BeamSearchScorer(
                 batch_size=batch_size,
                 num_beams=generation_config.num_beams,
+                max_length=generation_config.max_length,
                 device=self.device,
                 length_penalty=generation_config.length_penalty,
                 do_early_stopping=generation_config.early_stopping,

--- a/tests/generation/test_beam_search.py
+++ b/tests/generation/test_beam_search.py
@@ -82,7 +82,7 @@ class BeamSearchTester:
 
     def check_beam_hypotheses(self, input_ids, *args):
         # check that correct number of beam hypotheses is set in beam scorer
-        beam_scorer = self.prepare_beam_scorer(do_early_stopping=True)
+        beam_scorer = self.prepare_beam_scorer(do_early_stopping=True, max_length=input_ids.shape[-1])
         beam_hyp = beam_scorer._beam_hyps[0]
 
         self.parent.assertEqual(len(beam_scorer._beam_hyps), self.batch_size)
@@ -101,7 +101,7 @@ class BeamSearchTester:
         self.parent.assertTrue(beam_hyp.is_done(-10.0, 5))
 
         # re-init
-        beam_scorer = self.prepare_beam_scorer(do_early_stopping=False)
+        beam_scorer = self.prepare_beam_scorer(do_early_stopping=False, max_length=input_ids.shape[-1])
         beam_hyp = beam_scorer._beam_hyps[0]
 
         # add `num_beams + 1` beams to change `worst_score`
@@ -311,7 +311,9 @@ class ConstrainedBeamSearchTester:
 
     def check_beam_hypotheses(self, input_ids, *args):
         # check that correct number of beam hypotheses is set in beam scorer
-        constrained_beam_scorer = self.prepare_constrained_beam_scorer(do_early_stopping=True)
+        constrained_beam_scorer = self.prepare_constrained_beam_scorer(
+            do_early_stopping=True, max_length=input_ids.shape[-1]
+        )
         beam_hyp = constrained_beam_scorer._beam_hyps[0]
 
         self.parent.assertEqual(len(constrained_beam_scorer._beam_hyps), self.batch_size)
@@ -330,7 +332,9 @@ class ConstrainedBeamSearchTester:
         self.parent.assertTrue(beam_hyp.is_done(-10.0, 5))
 
         # re-init
-        constrained_beam_scorer = self.prepare_constrained_beam_scorer(do_early_stopping=False)
+        constrained_beam_scorer = self.prepare_constrained_beam_scorer(
+            do_early_stopping=False, max_length=input_ids.shape[-1]
+        )
         beam_hyp = constrained_beam_scorer._beam_hyps[0]
 
         # add `num_beams + 1` beams to change `worst_score`

--- a/tests/generation/test_beam_search.py
+++ b/tests/generation/test_beam_search.py
@@ -66,6 +66,7 @@ class BeamSearchTester:
         return BeamSearchScorer(
             batch_size=kwargs.get("batch_size", self.batch_size),
             num_beams=kwargs.get("num_beams", self.num_beams),
+            max_length=kwargs.get("max_length", self.max_length),
             device=torch_device,
             length_penalty=kwargs.get("length_penalty", self.length_penalty),
             do_early_stopping=kwargs.get("do_early_stopping", self.do_early_stopping),
@@ -291,6 +292,7 @@ class ConstrainedBeamSearchTester:
             constraints=kwargs.get("constraints", self.constraints),
             batch_size=kwargs.get("batch_size", self.batch_size),
             num_beams=kwargs.get("num_beams", self.num_beams),
+            max_length=kwargs.get("max_length", self.max_length),
             device=torch_device,
             length_penalty=kwargs.get("length_penalty", self.length_penalty),
             do_early_stopping=kwargs.get("do_early_stopping", self.do_early_stopping),

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -174,6 +174,7 @@ class GenerationTesterMixin:
         beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=beam_kwargs["num_beams"],
+            max_length=max_length,
             device=torch_device,
             length_penalty=beam_kwargs["length_penalty"],
             do_early_stopping=beam_kwargs["early_stopping"],
@@ -194,6 +195,7 @@ class GenerationTesterMixin:
         beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=beam_kwargs["num_beams"],
+            max_length=max_length,
             device=torch_device,
             length_penalty=beam_kwargs["length_penalty"],
             do_early_stopping=beam_kwargs["early_stopping"],
@@ -214,6 +216,7 @@ class GenerationTesterMixin:
             batch_size=batch_size,
             constraints=constraints,
             num_beams=beam_kwargs["num_beams"],
+            max_length=max_length,
             device=torch_device,
             length_penalty=beam_kwargs["length_penalty"],
             do_early_stopping=beam_kwargs["early_stopping"],
@@ -1898,6 +1901,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=num_beams,
+            max_length=max_length,
             device=torch_device,
         )
         with self.assertWarns(UserWarning):
@@ -1930,6 +1934,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         diverse_beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=num_beams,
+            max_length=max_length,
             device=torch_device,
             num_beam_hyps_to_keep=num_return_sequences,
             num_beam_groups=num_beam_groups,
@@ -2008,6 +2013,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         diverse_beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=num_beams,
+            max_length=max_length,
             device=torch_device,
             num_beam_hyps_to_keep=num_return_sequences,
             num_beam_groups=num_beam_groups,
@@ -2021,59 +2027,6 @@ class GenerationIntegrationTests(unittest.TestCase):
                 max_length=max_length,
                 **model_kwargs,
             )
-
-    def test_beam_search_warning_if_max_length_is_passed(self):
-        article = """Justin Timberlake and Jessica Biel, welcome to parenthood."""
-        bart_tokenizer = BartTokenizer.from_pretrained("hf-internal-testing/tiny-random-bart")
-        bart_model = BartForConditionalGeneration.from_pretrained("hf-internal-testing/tiny-random-bart").to(
-            torch_device
-        )
-
-        batch_size = 1
-        num_beams = 3
-
-        input_ids = bart_tokenizer(article, return_tensors="pt").input_ids.to(torch_device)
-        input_ids = input_ids.expand(num_beams, -1)
-        model_kwargs = bart_model._prepare_encoder_decoder_kwargs_for_generation(input_ids, {})
-
-        # pretend decoder_input_ids correspond to first encoder input id
-        decoder_input_ids = input_ids[:, :1]
-
-        stopping_criteria_max_length = 18
-        stopping_criteria = StoppingCriteriaList([MaxLengthCriteria(max_length=stopping_criteria_max_length)])
-
-        with self.assertWarns(UserWarning):
-            beam_scorer = BeamSearchScorer(
-                batch_size=batch_size,
-                num_beams=num_beams,
-                device=torch_device,
-                max_length=10,
-            )
-
-        generated_ids = bart_model.beam_search(
-            decoder_input_ids,
-            num_beams=num_beams,
-            stopping_criteria=stopping_criteria,
-            beam_scorer=beam_scorer,
-            **model_kwargs,
-        )
-
-        beam_scorer_no_max_len = BeamSearchScorer(
-            batch_size=batch_size,
-            num_beams=num_beams,
-            device=torch_device,
-        )
-
-        generated_ids_no_max_len = bart_model.beam_search(
-            decoder_input_ids,
-            num_beams=num_beams,
-            stopping_criteria=stopping_criteria,
-            beam_scorer=beam_scorer_no_max_len,
-            **model_kwargs,
-        )
-
-        # BeamSearchScorer max_length should not influence "real" max_length
-        self.assertEqual(generated_ids.tolist(), generated_ids_no_max_len.tolist())
 
     def test_custom_stopping_criteria_overload_error(self):
         article = """Justin Timberlake and Jessica Biel, welcome to parenthood."""
@@ -2744,6 +2697,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         beam_scorer = BeamSearchScorer(
             batch_size=1,
             num_beams=num_beams,
+            max_length=model.config.max_length,
             device=model.device,
         )
 
@@ -2924,7 +2878,11 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         # instantiate beam scorer
         beam_scorer = ConstrainedBeamSearchScorer(
-            batch_size=1, num_beams=num_beams, device=model.device, constraints=constraints
+            batch_size=1,
+            num_beams=num_beams,
+            max_length=model.config.max_length,
+            device=model.device,
+            constraints=constraints
         )
 
         # instantiate logits processors

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1996,6 +1996,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         beam_scorer = BeamSearchScorer(
             batch_size=batch_size,
             num_beams=num_beams,
+            max_length=max_length,
             device=torch_device,
         )
         with self.assertWarns(UserWarning):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2882,7 +2882,7 @@ class GenerationIntegrationTests(unittest.TestCase):
             num_beams=num_beams,
             max_length=model.config.max_length,
             device=model.device,
-            constraints=constraints
+            constraints=constraints,
         )
 
         # instantiate logits processors

--- a/tests/models/bart/test_modeling_tf_bart.py
+++ b/tests/models/bart/test_modeling_tf_bart.py
@@ -670,12 +670,10 @@ class TFBartModelIntegrationTest(unittest.TestCase):
         hypotheses_batch = hf.generate(
             input_ids=dct["input_ids"],
             attention_mask=dct["attention_mask"],
-            num_beams=2,
         )
 
         assert hypotheses_batch[:, 1].numpy().tolist() == [0, 0, 0, 0]  # test force_bos_token_to_be_generated
         decoded = tok.batch_decode(hypotheses_batch, skip_special_tokens=True, clean_up_tokenization_spaces=False)
-        breakpoint()
         expected_batch = [
             EXPECTED_SUMMARY_FRANCE,
             EXPECTED_SUMMARY_SHORTER,

--- a/tests/models/bart/test_modeling_tf_bart.py
+++ b/tests/models/bart/test_modeling_tf_bart.py
@@ -670,10 +670,12 @@ class TFBartModelIntegrationTest(unittest.TestCase):
         hypotheses_batch = hf.generate(
             input_ids=dct["input_ids"],
             attention_mask=dct["attention_mask"],
+            num_beams=2,
         )
 
         assert hypotheses_batch[:, 1].numpy().tolist() == [0, 0, 0, 0]  # test force_bos_token_to_be_generated
         decoded = tok.batch_decode(hypotheses_batch, skip_special_tokens=True, clean_up_tokenization_spaces=False)
+        breakpoint()
         expected_batch = [
             EXPECTED_SUMMARY_FRANCE,
             EXPECTED_SUMMARY_SHORTER,

--- a/tests/models/t5/test_modeling_flax_t5.py
+++ b/tests/models/t5/test_modeling_flax_t5.py
@@ -1076,7 +1076,7 @@ class FlaxT5ModelIntegrationTests(unittest.TestCase):
         expected_summaries = [
             'prosecutor: "so far no videos were used in the crash investigation" two magazines claim to have found a'
             " cell phone video of the final seconds . \"one can hear cries of 'My God' in several languages,\" one"
-            " magazine says . all 150 on board were killed when germanwings flight 9525 crashed .",
+            " magazine says . all 150 on board were killed in the crash .",
             "the formal accession was marked by a ceremony at The Hague, in the Netherlands . the ICC opened a"
             " preliminary examination into the situation in the occupied Palestinian territory . as members of the"
             " court, Palestinians may be subject to counter-charges as well .",

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1853,7 +1853,8 @@ class TFModelTesterMixin:
 
             # fix config for models with additional sequence-length limiting settings
             for var_name in ["max_position_embeddings", "max_target_positions"]:
-                if hasattr(config, var_name):
+                attr = getattr(config, var_name, None)
+                if attr is not None and attr < generate_kwargs["max_new_tokens"]:
                     try:
                         setattr(config, var_name, generate_kwargs["max_new_tokens"])
                     except NotImplementedError:

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1851,6 +1851,16 @@ class TFModelTesterMixin:
             config.eos_token_id = None  # Generate until max length
             config.do_sample = False
 
+            # fix config for models with additional sequence-length limiting settings
+            for var_name in ["max_position_embeddings", "max_target_positions"]:
+                if hasattr(config, var_name):
+                    try:
+                        setattr(config, var_name, generate_kwargs["max_new_tokens"])
+                    except NotImplementedError:
+                        # xlnet will raise an exception when trying to set
+                        # max_position_embeddings.
+                        pass
+
             model = model_class(config)
 
             if model.supports_xla_generation:


### PR DESCRIPTION
# What does this PR do?

As initially uncovered by @ydshieh in #20853, there is a gross TF/PT mismatch on the number of steps beam search takes under some circumstances. In practice, all three frameworks had a different and incomplete implementation (see below why), and this PR fixes it.

Added "🚨🚨" to the title, as this PR may change the output of beam search.

### Rationale:

We know that logprobs is a negative value, and we want to maximize it in beam search (i.e. make it as close to 0 as possible). Since logprobs is always negative, and the final score is the sum of the logprobs, we can anticipate the best possible score a running sequence can ever achieve, and use it to terminate beam search early with no drawback (without this shortcut, beam search will always run `max_length` steps unless `early_stopping=True`). Well, it turns out that the method to compute the best possible score depends on the signal of `length_penalty`, and we are not accounting for that!

- Scenario 1, `length_penalty > 0.0`: In this case, as the sentence grows, the denominator grows as well. This means the score can get closer to 0 (i.e. higher) as the sentence grows, and longer sentences are promoted. In this case, the best possible score can be determined from the maximum sequence length (original TF/FLAX implementation).
- Scenario 2, `length_penalty < 0.0`: In this case, as the sentence grows, the denominator gets smaller. This means the score will get farther away to 0 (i.e. lower) as the sentence grows, and shorter sentences are promoted. In this case, the best possible score can be determined from the current sequence length (original PT implementation).

On top of this, FLAX and TF were incorrectly terminating early when `batch_size > 1`: we were saying that a score improvement was no longer possible as soon as one of the batch members could no longer improve (as opposed to all batch members can no longer improve).

Finally, there was an issue with TF where early stopping was not correctly triggered (my bad).

In summary, for different reasons, all frameworks were stopping beam search incorrectly under certain circumstances:
1. PT: when `length_penalty > 0.0` (which is the default case!)
2. Flax: with `batch_size > 1` || `length_penalty < 0.0`
3. TF: with `batch_size > 1` || `length_penalty < 0.0` || incorrect (missing) early stopping trigger. 