### PR TITLE
Don't call deprecated method

### DIFF
--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -430,7 +430,7 @@ class DonutImageProcessor(BaseImageProcessor):
             images = [self.thumbnail(image=image, size=size) for image in images]
 
         if do_pad:
-            images = [self.pad(image=image, size=size, random_padding=random_padding) for image in images]
+            images = [self.pad_image(image=image, size=size, random_padding=random_padding) for image in images]
 
         if do_rescale:
             images = [self.rescale(image=image, scale=rescale_factor) for image in images]


### PR DESCRIPTION
# What does this PR do?

Call `pad_image` instead of `pad` which has been deprecated in order to maintain consistent method naming across image processors. 

There's no difference in logic, as `pad` calls `pad_image`, it just reduces excessive logging raised in [this comment](https://github.com/huggingface/transformers/pull/20425#issuecomment-1364747167).


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?