### PR TITLE
Generate: correctly detect default max length

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1215,7 +1215,7 @@ class GenerationMixin:
 
         # 6. Prepare `max_length` depending on other stopping criteria.
         input_ids_seq_length = input_ids.shape[-1]
-        has_default_max_length = kwargs.get("max_length") is None and generation_config.max_length == 20
+        has_default_max_length = kwargs.get("max_length") is None and generation_config.max_length is not None
         if has_default_max_length and generation_config.max_new_tokens is None:
             warnings.warn(
                 "Neither `max_length` nor `max_new_tokens` has been set, `max_length` will default to"


### PR DESCRIPTION
# What does this PR do?

Fixes #20894.

Now that we are using the generation config, we can detect the use of a default `max_length` and a potential clash with `max_new_tokens` with values other than `max_length=20` :)

After this change, the example in the issue linked above works correctly.