### PR TITLE
Add: doc page for the object detection task

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -73,6 +73,8 @@
       title: Image classification
     - local: tasks/semantic_segmentation
       title: Semantic segmentation
+    - local: tasks/object_detection
+      title: Object detection
     title: Computer Vision
   - sections:
     - local: performance

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -1,0 +1,478 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Object detection
+
+[[open-in-colab]]
+
+Object detection is a computer vision task of detecting instances of semantic objects that belong to a particular
+class (such as humans, buildings, or cars) in parts of an image. Object detection models receive an image as input and output
+coordinates of the bounding boxes and associated labels of the detected objects. An image can contain multiple objects,
+each with its own bounding box and a label. Similarly, several instances of the same class may
+be present in different parts of an image.
+This task is commonly used in autonomous driving for detecting things like pedestrians, road signs, and traffic lights.
+Other applications include counting objects in images, image search, and more.
+
+ <Tip>
+ Check out the [object detection task page](https://huggingface.co/tasks/object-detection) to learn about use cases,
+ models, metrics, and datasets associated with this task.
+ </Tip>
+
+In this guide, you will learn how to:
+
+ 1. Finetune [DETR](https://huggingface.co/docs/transformers/model_doc/detr), a model that combines a convolutional
+ backbone with an encoder-decoder Transformer, on the [CPPE-5](https://huggingface.co/datasets/cppe-5)
+ dataset.
+ 2. Use your finetuned model for inference.
+
+Before you begin, make sure you have all the necessary libraries installed:
+
+```bash
+pip install -q datasets transformers evaluate timm albumentations opencv-python
+```
+
+We encourage you to share your model with the community. Log in to your Hugging Face account to upload it to Hub.
+When prompted, enter your token to log in:
+
+```py
+>>> from huggingface_hub import notebook_login
+
+>>> notebook_login()
+```
+
+## Load the CPPE-5 dataset
+
+In this guide, you'll use the [CPPE-5 dataset](https://huggingface.co/datasets/cppe-5) that contains images with
+annotations identifying medical personal protective equipment (PPE) in the context of the COVID-19 pandemic.
+
+Start by loading the dataset:
+
+```py
+>>> from datasets import load_dataset
+
+>>> cppe5 = load_dataset("cppe-5")
+>>> cppe5
+```
+
+You'll see that this dataset already comes with a training set containing 1000 images and a test set with 29 images.
+
+To get familiar with the data, explore what the examples look like.
+
+```py
+>>> cppe5['train'][0]
+```
+
+The examples in the dataset have the following fields:
+- `image_id`: the example image id
+- `image`: a `PIL.Image.Image` object containing the image
+- `width`: width of the image
+- `height`: height of the image
+- `objects`: A dictionary containing bounding box metadata for the objects in the image:
+  - `id`: The annotation id.
+  - `area`: The area of the bounding box.
+  - `bbox`: The object's bounding box (in the [COCO](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) format).
+  - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
+
+You may notice that the `bbox` field follows the COCO format, which is the format that DETR model expects.
+However, the way grouping of the fields inside `objects` differs from the annotations format DETR requires. You will
+need to apply some preprocessing transformations before using this data for training.
+
+To get an even better understanding of the data, visualize a random example in the dataset.
+
+```py
+>>> import numpy as np
+>>> import os
+>>> from PIL import Image, ImageDraw
+
+>>> # based on https://github.com/woctezuma/finetune-detr/blob/master/finetune_detr.ipynb
+>>> image_ids = cppe5['train']['image_id']
+>>> # let's pick a random image
+>>> image_id = image_ids[np.random.randint(0, len(image_ids))]
+>>> print('Image n°{}'.format(image_id))
+
+>>> image = cppe5['train'][image_id]['image']
+>>> annotations = cppe5['train'][image_id]['objects']
+>>> draw = ImageDraw.Draw(image, "RGBA")
+
+>>> # Retrieve the categories from the dataset's metadata.
+>>> categories = cppe5['train'].features['objects'].feature['category'].names
+
+>>> id2label = {index: x for index, x in enumerate(categories, start=0)}
+>>> label2id = {v: k for k, v in id2label.items()}
+
+>>> for i in range(len(annotations['id'])):
+>>>   box = annotations['bbox'][i-1]
+>>>   class_idx = annotations['category'][i-1]
+>>>   x,y,w,h = tuple(box)
+>>>   draw.rectangle((x,y,x+w,y+h), outline='red', width=1)
+>>>   draw.text((x, y), id2label[class_idx], fill='white')
+
+>>> image
+```
+
+To visualize the bounding boxes with associated labels, you can get the labels from the dataset's metadata, specifically
+the `category` field.
+You'll also want to create dictionaries that map a label id to a label class (`id2label`) and the other way around (`label2id`).
+You'll need them later when setting up your model.
+
+As a final step of getting familiar with the data, explore it for potential issues. One common problem with datasets for
+object detection is bounding boxes that "stretch" beyond the edge of the image. Such "runaway" bounding boxes can raise
+errors during training and should be addressed at this stage. There are a few examples with this issue in this dataset.
+To keep things simple, remove these images from the data.
+
+```py
+>>> remove_idx = [590, 821, 822, 875, 876, 878, 879]
+>>> keep = [i for i in range(len(cppe5["train"])) if i not in remove_idx]
+>>> cppe5["train"] = cppe5["train"].select(keep)
+```
+
+## Preprocess the data
+
+To finetune a model, you must preprocess the data you plan to use to match precisely the approach used for the pre-trained model.
+For DETR models, `DetrImageProcessor` takes care of processing image data to create `pixel_values`, `pixel_mask`, and
+`labels` that a DETR model can train with. The preprocessor has some attributes that you won't have to worry about:
+
+- `image_mean = [0.485, 0.456, 0.406 ]`
+- `image_std = [0.229, 0.224, 0.225]`
+
+These are the mean and standard deviation used to normalize images during the model training. These values are crucial
+to replicate when doing inference or finetuning a pre-trained image model.
+
+Instantiate the `DetrImageProcessor` from the same checkpoint as the model you want to finetune.
+
+```py
+>>> from transformers import DetrImageProcessor
+
+>>> checkpoint = "facebook/detr-resnet-50"
+>>> image_processor = DetrImageProcessor.from_pretrained(checkpoint)
+```
+
+Before passing the images to the `DetrImageProcessor`, apply two preprocessing transformations to the dataset:
+- Augmenting images
+- Re-formatting annotations to meet DETR expectations
+
+First, to make sure the model does not overfit on the training data, you can apply image augmentation with [Albumentations](https://albumentations.ai/docs/).
+This library ensures that transformations affect the image and update the bounding boxes accordingly.
+The 🤗 Datasets library documentation has a detailed [guide on how to augment images for object detection](https://huggingface.co/docs/datasets/object_detection),
+and it uses the exact same dataset as an example. Apply the same approach here, i.e., resize each image to (480, 480),
+flip it horizontally, and brighten it:
+
+```py
+>>> import albumentations as A
+>>> import numpy as np
+>>> import torch
+
+>>> transform = A.Compose([
+>>>     A.Resize(480, 480),
+>>>     A.HorizontalFlip(p=1.0),
+>>>     A.RandomBrightnessContrast(p=1.0),
+>>> ], bbox_params=A.BboxParams(format='coco',  label_fields=['category']))
+```
+
+`DetrImageProcessor` expects the annotations to be in the following format: `{‘image_id’: int, ‘annotations’: List[Dict]}`,
+ where each `Dict` is a COCO object annotation. Building up gradually, add a function to reformat annotations for a single example:
+
+```py
+>>> def formatted_anns(image_id, category, area, bbox):
+
+>>>   annotations = []
+>>>   for i in range(0,len(category)):
+>>>     new_ann = {"image_id": image_id,
+>>>           "category_id": category[i],
+>>>           "isCrowd": 0,
+>>>           "area": area[i],
+>>>           "bbox": list(bbox[i])}
+>>>     annotations.append(new_ann)
+
+>>>   return annotations
+```
+
+Now you can combine the image and annotation transformations to use on a batch of examples:
+
+```py
+>>> # transforming a batch
+>>> def transform_aug_ann(examples):
+>>>   image_ids = examples["image_id"]
+>>>   images, bboxes, area, categories = [], [], [], []
+>>>   for image, objects in zip(examples['image'], examples['objects']):
+>>>     image = np.array(image.convert("RGB"))[:, :, ::-1]
+>>>     out = transform(
+>>>         image=image,
+>>>         bboxes=objects['bbox'],
+>>>         category=objects['category']
+>>>         )
+
+>>>     area.append(objects['area'])
+>>>     images.append(torch.tensor(out['image']).flip(-1).permute(2, 0, 1))
+>>>     bboxes.append(out['bboxes'])
+>>>     categories.append(out['category'])
+
+>>>   targets = [
+>>>       {"image_id": id_, "annotations": formatted_anns(id_, cat_, ar_, box_)} for id_, cat_, ar_, box_  in zip(image_ids, categories, area, bboxes)
+>>>   ]
+
+>>>   return image_processor(images=images, annotations=targets, return_tensors="pt")
+```
+
+Apply this preprocessing function to the entire dataset using 🤗 Datasets `with_transform` method. This method applies
+transformations on the fly when you load an element of the dataset.
+
+At this point, you can check what an example from the dataset looks like after the transformations. You should see a tensor
+with `pixel_values`, a tensor with `pixel_mask`, and `labels`.
+
+```py
+>>> cppe5["train"] = cppe5["train"].with_transform(transform_aug_ann)
+>>> cppe5["train"][15]
+```
+
+You have successfully augmented the individual images and prepared their annotations. However, preprocessing isn't
+complete yet. In the final step, create a custom `collate_fn` to batch images together.
+Pad images (which are now `pixel_values`) to the largest image in a batch, and create a corresponding `pixel_mask`
+to indicate which pixels are real (1) and which are padding (0).
+
+```py
+>>> def collate_fn(batch):
+>>>   pixel_values = [item['pixel_values'] for item in batch]
+>>>   encoding = image_processor.pad_and_create_pixel_mask(pixel_values, return_tensors="pt")
+>>>   labels = [item['labels'] for item in batch]
+>>>   batch = {}
+>>>   batch['pixel_values'] = encoding['pixel_values']
+>>>   batch['pixel_mask'] = encoding['pixel_mask']
+>>>   batch['labels'] = labels
+>>>   return batch
+```
+
+## Training the DERT model
+You have done most of the heavy lifting in the previous sections, so now you are ready to train your model!
+The images in this dataset are still quite large, even after resizing. This means that finetuning this model will
+require at least one GPU.
+
+```py
+>>> import torch
+>>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+```
+
+Training involves the following steps:
+1. Load the model with `DetrForObjectDetection.from_pretrained` using the same checkpoint as in the preprocessing.
+2. Define your training hyperparameters in `TrainingArguments`.
+3. Pass the training arguments to `Trainer` along with the model, dataset, image processor, and data collator.
+4. Call `train()`` to finetune your model.
+
+When loading the model from the same checkpoint that you used for the preprocessing, remember to pass the label to
+id and id to label maps that you created earlier from the dataset's metadata.
+
+```py
+>>> from transformers import DetrForObjectDetection
+
+>>> model = DetrForObjectDetection.from_pretrained(
+>>>     checkpoint,
+>>>     id2label=id2label,
+>>>     label2id=label2id,
+>>>     ignore_mismatched_sizes=True,
+>>> )
+```
+
+In the `TrainingArguments` use `output_dir` to specify where to save your model, then configure hyperparameters as you see fit.
+An important note: do not remove unused columns because this will drop the image column. Without the image column, you
+can't create `pixel_values`. For this reason, set `remove_unused_columns` to `False`.
+If you wish to share your model by pushing to the Hub, set `push_to_hub` to `True` (you must be signed in to Hugging
+Face to upload your model).
+
+```py
+>>> from transformers import TrainingArguments
+
+>>> training_args = TrainingArguments(
+>>>     output_dir="detr-resnet-50_fine_tuned_cppe5",
+>>>     per_device_train_batch_size=8,
+>>>     num_train_epochs=10,
+>>>     fp16=False,
+>>>     save_steps=200,
+>>>     logging_steps=50,
+>>>     learning_rate=1e-5,
+>>>     save_total_limit=2,
+>>>     remove_unused_columns=False,
+>>>     push_to_hub=True,
+>>> )
+```
+
+Finally, bring everything together, and call `train`:
+
+```py
+>>> from transformers import Trainer
+
+>>> trainer = Trainer(
+>>>     model=model,
+>>>     args=training_args,
+>>>     data_collator=collate_fn,
+>>>     train_dataset=cppe5["train"],
+>>>     tokenizer=image_processor,
+>>> )
+
+>>>trainer.train()
+```
+
+## Evaluate
+Object detection models are commonly evaluated with a set of [COCO-style metrics](https://cocodataset.org/#detection-eval).
+You can use one of the existing metrics implementations, here you'll use the one from `torchvision`.
+
+Save your trained model to use for evaluation. Alternatively, you can evaluate the model that you have pushed to the Hub.
+
+```py
+>>> trainer.save_model("./detr-resnet-50_fine_tuned_cppe5")
+```
+
+To use the `torchvision` evaluator, you'll need to prepare a ground truth COCO dataset. The API to build a COCO dataset
+requires the data to be stored in a certain format, so you'll need to save images and annotations to disk first. Just like
+when you prepared your data for training, the annotations from the `cppe5["test"]` need to be formatted. However, images
+should stay as they are.
+
+The following example shows how you can:
+- Create a torchvision CocoDetection dataset
+- Reformat annotations from the `cppe5["test"]`
+- Save images and annotations into files that you can create an instance of CocoDetection dataset from
+- Use `cocoevaluate` metric to compute the [COCO metrics](https://cocodataset.org/#detection-eval).
+
+```py
+import os
+import json
+import evaluate
+import torchvision
+import numpy as np
+from tqdm import tqdm
+
+class CocoDetection(torchvision.datasets.CocoDetection):
+    def __init__(self, img_folder, feature_extractor, ann_file):
+        super(CocoDetection, self).__init__(img_folder, ann_file)
+        self.feature_extractor = feature_extractor
+
+    def __getitem__(self, idx):
+        # read in PIL image and target in COCO format
+        img, target = super(CocoDetection, self).__getitem__(idx)
+
+        # preprocess image and target (converting target to DETR format, resizing + normalization of both image and target)
+        image_id = self.ids[idx]
+        target = {'image_id': image_id, 'annotations': target}
+        encoding = self.feature_extractor(images=img, annotations=target, return_tensors="pt")
+        pixel_values = encoding["pixel_values"].squeeze() # remove batch dimension
+        target = encoding["labels"][0] # remove batch dimension
+
+        return {"pixel_values":pixel_values, "labels":target}
+
+im_processor = DetrImageProcessor.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
+model = DetrForObjectDetection.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
+
+# prepare the test dataset
+def val_formatted_anns(image_id, objects):
+  annotations = []
+  for i in range(0,len(objects["id"])):
+    new_ann = {"id": objects["id"][i],
+          "category_id": objects["category"][i],
+          "iscrowd": 0,
+          "image_id": image_id,
+          "area": objects["area"][i],
+          "bbox": objects["bbox"][i]}
+    annotations.append(new_ann)
+
+  return annotations
+
+# CocoDetection expects to read the data from files in a certain format
+def save_cppe5_annotation_file_images(cppe5):
+  output_json = {}
+  path_output_cppe5 = f"{os.getcwd()}/cppe5/"
+
+  if not os.path.exists(path_output_cppe5):
+    os.makedirs(path_output_cppe5)
+
+  path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
+  categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label ]
+  output_json["images"] = []
+  output_json["annotations"] = []
+  for batch in cppe5:
+      ann = val_formatted_anns(batch["image_id"], batch["objects"])
+      output_json["images"].append(
+        {
+          "id": batch["image_id"],
+          "width": batch["image"].width,
+          "height": batch["image"].height,
+          "file_name": f"{batch['image_id']}.png"
+        }
+      )
+      output_json["annotations"].extend(ann)
+  output_json["categories"] = categories_json
+
+  with open(path_anno, "w") as file:
+      json.dump(output_json, file, ensure_ascii=False, indent=4)
+
+  for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
+      path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
+      im.save(path_img)
+
+  return path_output_cppe5, path_anno
+
+path_output_cppe5, path_anno = save_cppe5_annotation_file_images(cppe5["test"])
+
+dummy = CocoDetection(path_output_cppe5, im_processor, path_anno)
+module = evaluate.load("ybelkada/cocoevaluate", coco=dummy.coco)
+val_dataloader = torch.utils.data.DataLoader(dummy, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn)
+
+with torch.no_grad():
+  for idx, batch in enumerate(tqdm(val_dataloader)):
+      pixel_values = batch["pixel_values"]
+      pixel_mask = batch["pixel_mask"]
+
+      labels = [{k: v for k, v in t.items()} for t in batch["labels"]] # these are in DETR format, resized + normalized
+
+      # forward pass
+      outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
+
+      orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
+      results = im_processor.post_process(outputs, orig_target_sizes) # convert outputs of model to COCO api
+
+      module.add(prediction=results, reference=labels)
+      del batch
+
+results = module.compute()
+print(results)
+```
+
+## Inference
+Now that you have finetuned a DETR model, evaluated it and uploaded it to the 🤗Hub, you can use it for inference.
+
+```py
+>>> import requests
+
+>>> url = "https://chartwell.com/-/media/Images/blog/2020/04/keeping-staff-and-residents-protected.jpeg?mw=1900&hash=B8A76374D6BD24B0DC8A779D0C985027"
+>>> image = Image.open(requests.get(url, stream=True).raw)
+
+>>> image_processor = DetrImageProcessor.from_pretrained("MariaK/detr-resnet-50_fine_tuned_cppe5")
+>>> model = DetrForObjectDetection.from_pretrained("MariaK/detr-resnet-50_fine_tuned_cppe5")
+
+>>> inputs = image_processor(images=image, return_tensors="pt")
+>>> outputs = model(**inputs)
+
+>>> # convert outputs (bounding boxes and class logits) to COCO API
+>>> target_sizes = torch.tensor([image.size[::-1]])
+>>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[
+>>>     0
+>>> ]
+
+>>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
+>>>     box = [round(i, 2) for i in box.tolist()]
+>>>     print(
+>>>         f"Detected {model.config.id2label[label.item()]} with confidence "
+>>>         f"{round(score.item(), 3)} at location {box}"
+>>>     )
+```
+
+
+
+

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -144,7 +144,7 @@ For DETR models, `DetrImageProcessor` takes care of processing image data to cre
 - `image_mean = [0.485, 0.456, 0.406 ]`
 - `image_std = [0.229, 0.224, 0.225]`
 
-These are the mean and standard deviation used to normalize images during the model training. These values are crucial
+These are the mean and standard deviation used to normalize images during the model pre-training. These values are crucial
 to replicate when doing inference or finetuning a pre-trained image model.
 
 Instantiate the `DetrImageProcessor` from the same checkpoint as the model you want to finetune.

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -344,10 +344,11 @@ Face to upload your model).
 ...     output_dir="detr-resnet-50_finetuned_cppe5",
 ...     per_device_train_batch_size=8,
 ...     num_train_epochs=10,
-...     fp16=False,
+...     fp16=True,
 ...     save_steps=200,
 ...     logging_steps=50,
 ...     learning_rate=1e-5,
+...     weight_decay=1e-4,
 ...     save_total_limit=2,
 ...     remove_unused_columns=False,
 ...     push_to_hub=True,
@@ -378,7 +379,7 @@ Hugging Face Hub. Upon training completion, push the final model to the Hub as w
 ```
 
 ## Evaluate
-Object detection models are commonly evaluated with a set of [COCO-style metrics](https://cocodataset.org/#detection-eval).
+Object detection models are commonly evaluated with a set of <a href="https://cocodataset.org/#detection-eval">COCO-style metrics</a>.
 You can use one of the existing metrics implementations, here you'll use the one from `torchvision` to evaluate the final
 model that you pushed to the Hub.
 
@@ -512,19 +513,20 @@ Finally, load the metrics and run the evaluation.
 Accumulating evaluation results...
 DONE (t=0.08s).
 IoU metric: bbox
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.104
- Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.188
- Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.103
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.013
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.027
- Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.105
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.105
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.210
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.248
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.085
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.122
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.261
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.150
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.280
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.130
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.038
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.036
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.182
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.166
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.317
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.335
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.104
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.146
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.382
 ```
+These results can be further improved by adjusting the hyperparameters in the `training_args`. Give it a go!
 
 ## Inference
 Now that you have finetuned a DETR model, evaluated it, and uploaded it to the Hugging Face Hub, you can use it for inference.
@@ -535,7 +537,7 @@ for object detection with your model, and pass an image to it:
 >>> from transformers import pipeline
 >>> import requests
 
->>> url = "https://chartwell.com/-/media/Images/blog/2020/04/keeping-staff-and-residents-protected.jpeg"
+>>> url = "https://i.imgur.com/2lnWoly.jpg"
 >>> image = Image.open(requests.get(url, stream=True).raw)
 
 >>> obj_detector = pipeline("object-detection", model="MariaK/detr-resnet-50_finetuned_cppe5")
@@ -552,7 +554,7 @@ You can also manually replicate the results of the pipeline if you'd like:
 ...     inputs = image_processor(images=image, return_tensors="pt")
 ...     outputs = model(**inputs)
 ...     target_sizes = torch.tensor([image.size[::-1]])
-...     results = image_processor.post_process_object_detection(outputs, threshold=0.4, target_sizes=target_sizes)[0]
+...     results = image_processor.post_process_object_detection(outputs, threshold=0.5, target_sizes=target_sizes)[0]
 
 >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
 ...     box = [round(i, 2) for i in box.tolist()]
@@ -560,5 +562,24 @@ You can also manually replicate the results of the pipeline if you'd like:
 ...         f"Detected {model.config.id2label[label.item()]} with confidence "
 ...         f"{round(score.item(), 3)} at location {box}"
 ...     )
-Detected Coverall with confidence 0.442 at location [1321.16, 172.77, 4381.91, 3197.9]
+Detected Coverall with confidence 0.566 at location [1215.32, 147.38, 4401.81, 3227.08]
+Detected Mask with confidence 0.584 at location [2449.06, 823.19, 3256.43, 1413.9]
 ```
+
+Let's plot the result:
+```py
+>>> draw = ImageDraw.Draw(image)
+
+>>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
+...     box = [round(i, 2) for i in box.tolist()]
+...     x,y,x2,y2 = tuple(box)
+...     draw.rectangle((x,y,x2,y2), outline="red", width=1)
+...     draw.text((x, y), model.config.id2label[label.item()], fill="white")
+
+>>> image
+```
+
+<div class="flex justify-center">
+    <img src="https://i.imgur.com/4QZnf9A.png" alt="Object detection result on a new image"/>
+</div>
+

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -97,7 +97,7 @@ To get an even better understanding of the data, visualize a random example in t
 >>> image_ids = cppe5["train"]["image_id"]
 >>> # let's pick a random image
 >>> image_id = image_ids[np.random.randint(0, len(image_ids))]
->>> print("Image n°{}".format(image_id))
+>>> print(f"Image n°{image_id}")
 
 >>> image = cppe5["train"][image_id]["image"]
 >>> annotations = cppe5["train"][image_id]["objects"]

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -320,7 +320,7 @@ Finally, bring everything together, and call `train`:
 ...     tokenizer=image_processor,
 ... )
 
->>> rainer.train()
+>>> trainer.train()
 ```
 
 ## Evaluate

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -572,8 +572,8 @@ Let's plot the result:
 
 >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
 ...     box = [round(i, 2) for i in box.tolist()]
-...     x,y,x2,y2 = tuple(box)
-...     draw.rectangle((x,y,x2,y2), outline="red", width=1)
+...     x, y, x2, y2 = tuple(box)
+...     draw.rectangle((x, y, x2, y2), outline="red", width=1)
 ...     draw.text((x, y), model.config.id2label[label.item()], fill="white")
 
 >>> image

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -156,7 +156,7 @@ Instantiate the image processor from the same checkpoint as the model you want t
 >>> image_processor = DetrImageProcessor.from_pretrained(checkpoint)
 ```
 
-Before passing the images to the `DetrImageProcessor`, apply two preprocessing transformations to the dataset:
+Before passing the images to the `image_processor`, apply two preprocessing transformations to the dataset:
 - Augmenting images
 - Re-formatting annotations to meet DETR expectations
 

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -99,11 +99,11 @@ The examples in the dataset have the following fields:
 - `image`: a `PIL.Image.Image` object containing the image
 - `width`: width of the image
 - `height`: height of the image
-- `objects`: A dictionary containing bounding box metadata for the objects in the image:
-  - `id`: The annotation id.
-  - `area`: The area of the bounding box.
-  - `bbox`: The object's bounding box (in the [COCO format](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) ).
-  - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
+- `objects`: a dictionary containing bounding box metadata for the objects in the image:
+  - `id`: the annotation id
+  - `area`: the area of the bounding box
+  - `bbox`: the object's bounding box (in the [COCO format](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) )
+  - `category`: the object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`
 
 You may notice that the `bbox` field follows the COCO format, which is the format that the DETR model expects.
 However, the grouping of the fields inside `objects` differs from the annotation format DETR requires. You will

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -225,7 +225,7 @@ Now you can combine the image and annotation transformations to use on a batch o
 ...     return image_processor(images=images, annotations=targets, return_tensors="pt")
 ```
 
-Apply this preprocessing function to the entire dataset using 🤗 Datasets `with_transform` method. This method applies
+Apply this preprocessing function to the entire dataset using 🤗 Datasets `with_transform()` method. This method applies
 transformations on the fly when you load an element of the dataset.
 
 At this point, you can check what an example from the dataset looks like after the transformations. You should see a tensor

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -342,7 +342,7 @@ The following example shows how you can:
 - Create a torchvision CocoDetection dataset
 - Reformat annotations from the `cppe5["test"]`
 - Save images and annotations into files that you can create an instance of CocoDetection dataset from
-- Use `cocoevaluate` metric to compute the [COCO metrics](https://cocodataset.org/#detection-eval).
+- Use the `cocoevaluate` metric to compute the [COCO metrics](https://cocodataset.org/#detection-eval).
 
 ```py
 import os

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -17,7 +17,7 @@ specific language governing permissions and limitations under the License.
 Object detection is a computer vision task of detecting instances of semantic objects that belong to a particular
 class (such as humans, buildings, or cars) in parts of an image. Object detection models receive an image as input and output
 coordinates of the bounding boxes and associated labels of the detected objects. An image can contain multiple objects,
-each with its own bounding box and a label. Similarly, several instances of the same class may
+each with its own bounding box and a label (e.g. it can have a car and a building).
 be present in different parts of an image.
 This task is commonly used in autonomous driving for detecting things like pedestrians, road signs, and traffic lights.
 Other applications include counting objects in images, image search, and more.

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -182,7 +182,7 @@ flip it horizontally, and brighten it:
 ```
 
 The `image_processor` expects the annotations to be in the following format: `{'image_id': int, 'annotations': List[Dict]}`,
- where each `Dict` is a COCO object annotation. Building up gradually, add a function to reformat annotations for a single example:
+ where each dictionary is a COCO object annotation. Building up gradually, let's add a function to reformat annotations for a single example:
 
 ```py
 >>> def formatted_anns(image_id, category, area, bbox):

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -317,7 +317,7 @@ Training involves the following steps:
 4. Call [`~Trainer.train`] to finetune your model.
 
 When loading the model from the same checkpoint that you used for the preprocessing, remember to pass the `label2id`
-and `id2label` maps that you created earlier from the dataset's metadata.
+and `id2label` maps that you created earlier from the dataset's metadata. Additionally, we specify `ignore_mismatched_sizes=True` to replace the existing classification head with a new one.
 
 ```py
 >>> from transformers import AutoModelForObjectDetection

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -16,7 +16,7 @@ specific language governing permissions and limitations under the License.
 
 Object detection is the computer vision task of detecting instances (such as humans, buildings, or cars) in an image. Object detection models receive an image as input and output
 coordinates of the bounding boxes and associated labels of the detected objects. An image can contain multiple objects,
-each with its own bounding box and a label (e.g. it can have a car and a building).
+each with its own bounding box and a label (e.g. it can have a car and a building), and each object can
 be present in different parts of an image (e.g. the image can have several cars).
 This task is commonly used in autonomous driving for detecting things like pedestrians, road signs, and traffic lights.
 Other applications include counting objects in images, image search, and more.
@@ -39,10 +39,10 @@ Before you begin, make sure you have all the necessary libraries installed:
 pip install -q datasets transformers evaluate timm albumentations
 ```
 
-In this guide you'll use `datasets` to load a dataset from the Hugging Face Hub, `transformers` to train your model,
+You'll use 🤗 Datasets to load a dataset from the Hugging Face Hub, 🤗 Transformers to train your model,
 and `albumentations` to augment the data. `timm` is currently required to load a convolutional backbone for the DETR model.
 
-We encourage you to share your model with the community. Log in to your Hugging Face account to upload it to Hub.
+We encourage you to share your model with the community. Log in to your Hugging Face account to upload it to the Hub.
 When prompted, enter your token to log in:
 
 ```py
@@ -53,7 +53,7 @@ When prompted, enter your token to log in:
 
 ## Load the CPPE-5 dataset
 
-In this guide, you'll use the [CPPE-5 dataset](https://huggingface.co/datasets/cppe-5) that contains images with
+The [CPPE-5 dataset](https://huggingface.co/datasets/cppe-5) contains images with
 annotations identifying medical personal protective equipment (PPE) in the context of the COVID-19 pandemic.
 
 Start by loading the dataset:
@@ -105,7 +105,7 @@ The examples in the dataset have the following fields:
   - `bbox`: The object's bounding box (in the [COCO format](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) ).
   - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
 
-You may notice that the `bbox` field follows the COCO format, which is the format that DETR model expects.
+You may notice that the `bbox` field follows the COCO format, which is the format that the DETR model expects.
 However, the grouping of the fields inside `objects` differs from the annotation format DETR requires. You will
 need to apply some preprocessing transformations before using this data for training.
 
@@ -179,12 +179,12 @@ Instantiate the image processor from the same checkpoint as the model you want t
 
 Before passing the images to the `image_processor`, apply two preprocessing transformations to the dataset:
 - Augmenting images
-- Re-formatting annotations to meet DETR expectations
+- Reformatting annotations to meet DETR expectations
 
-First, to make sure the model does not overfit on the training data, you can apply image augmentation with [Albumentations](https://albumentations.ai/docs/).
+First, to make sure the model does not overfit on the training data, you can apply image augmentation with any data augmentation library. Here we use [Albumentations](https://albumentations.ai/docs/) ...
 This library ensures that transformations affect the image and update the bounding boxes accordingly.
 The 🤗 Datasets library documentation has a detailed [guide on how to augment images for object detection](https://huggingface.co/docs/datasets/object_detection),
-and it uses the exact same dataset as an example. Apply the same approach here, i.e., resize each image to (480, 480),
+and it uses the exact same dataset as an example. Apply the same approach here, resize each image to (480, 480),
 flip it horizontally, and brighten it:
 
 ```py
@@ -203,7 +203,7 @@ flip it horizontally, and brighten it:
 ```
 
 The `image_processor` expects the annotations to be in the following format: `{'image_id': int, 'annotations': List[Dict]}`,
- where each dictionary is a COCO object annotation. Building up gradually, let's add a function to reformat annotations for a single example:
+ where each dictionary is a COCO object annotation. Let's add a function to reformat annotations for a single example:
 
 ```py
 >>> def formatted_anns(image_id, category, area, bbox):
@@ -246,7 +246,7 @@ Now you can combine the image and annotation transformations to use on a batch o
 ...     return image_processor(images=images, annotations=targets, return_tensors="pt")
 ```
 
-Apply this preprocessing function to the entire dataset using 🤗 Datasets `with_transform()` method. This method applies
+Apply this preprocessing function to the entire dataset using 🤗 Datasets [`~datasets.Dataset.with_transform`] method. This method applies
 transformations on the fly when you load an element of the dataset.
 
 At this point, you can check what an example from the dataset looks like after the transformations. You should see a tensor
@@ -331,7 +331,7 @@ and `id2label` maps that you created earlier from the dataset's metadata. Additi
 ```
 
 In the [`TrainingArguments`] use `output_dir` to specify where to save your model, then configure hyperparameters as you see fit.
-An important note: do not remove unused columns because this will drop the image column. Without the image column, you
+It is important you do not remove unused columns because this will drop the image column. Without the image column, you
 can't create `pixel_values`. For this reason, set `remove_unused_columns` to `False`.
 If you wish to share your model by pushing to the Hub, set `push_to_hub` to `True` (you must be signed in to Hugging
 Face to upload your model).
@@ -354,7 +354,7 @@ Face to upload your model).
 ... )
 ```
 
-Finally, bring everything together, and call `train`:
+Finally, bring everything together, and call [`~transformers.Trainer.train`]:
 
 ```py
 >>> from transformers import Trainer
@@ -371,7 +371,7 @@ Finally, bring everything together, and call `train`:
 ```
 
 If you have set `push_to_hub` to `True` in the `training_args`, the training checkpoints are pushed to the
-Hugging Face Hub. Upon training completion, push the final model to the Hub as well by calling the `push_to_hub()` method.
+Hugging Face Hub. Upon training completion, push the final model to the Hub as well by calling the [`~transformers.Trainer.push_to_hub`] method.
 
 ```py
 >>> trainer.push_to_hub()
@@ -379,7 +379,7 @@ Hugging Face Hub. Upon training completion, push the final model to the Hub as w
 
 ## Evaluate
 Object detection models are commonly evaluated with a set of <a href="https://cocodataset.org/#detection-eval">COCO-style metrics</a>.
-You can use one of the existing metrics implementations, here you'll use the one from `torchvision` to evaluate the final
+You can use one of the existing metrics implementations, but here you'll use the one from `torchvision` to evaluate the final
 model that you pushed to the Hub.
 
 To use the `torchvision` evaluator, you'll need to prepare a ground truth COCO dataset. The API to build a COCO dataset
@@ -445,7 +445,7 @@ First, prepare the `cppe5["test"]` set: format the annotations and save the data
 ...     return path_output_cppe5, path_anno
 ```
 
-Next, prepare an instance of a CocoDetection class that can be used with `cocoevaluator`.
+Next, prepare an instance of a `CocoDetection` class that can be used with `cocoevaluator`.
 
 ```py
 >>> import torchvision
@@ -525,11 +525,11 @@ IoU metric: bbox
  Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.146
  Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.382
 ```
-These results can be further improved by adjusting the hyperparameters in the `training_args`. Give it a go!
+These results can be further improved by adjusting the hyperparameters in [`~transformers.TrainingArguments`]. Give it a go!
 
 ## Inference
 Now that you have finetuned a DETR model, evaluated it, and uploaded it to the Hugging Face Hub, you can use it for inference.
-The simplest way to try out your finetuned model for inference is to use it in a `pipeline()`. Instantiate a pipeline
+The simplest way to try out your finetuned model for inference is to use it in a [`Pipeline`]. Instantiate a pipeline
 for object detection with your model, and pass an image to it:
 
 ```py

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -456,7 +456,7 @@ print(results)
 ```
 
 ## Inference
-Now that you have finetuned a DETR model, evaluated it and uploaded it to the 🤗Hub, you can use it for inference.
+Now that you have finetuned a DETR model, evaluated it, and uploaded it to the Hugging Face Hub, you can use it for inference.
 
 ```py
 >>> import requests

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -83,7 +83,7 @@ The examples in the dataset have the following fields:
   - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
 
 You may notice that the `bbox` field follows the COCO format, which is the format that DETR model expects.
-However, the way grouping of the fields inside `objects` differs from the annotations format DETR requires. You will
+However, the grouping of the fields inside `objects` differs from the annotation format DETR requires. You will
 need to apply some preprocessing transformations before using this data for training.
 
 To get an even better understanding of the data, visualize a random example in the dataset.

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -117,8 +117,8 @@ To get an even better understanding of the data, visualize an example in the dat
 >>> import os
 >>> from PIL import Image, ImageDraw
 
->>> image = cppe5['train'][0]['image']
->>> annotations = cppe5['train'][0]['objects']
+>>> image = cppe5["train"][0]["image"]
+>>> annotations = cppe5["train"][0]["objects"]
 >>> draw = ImageDraw.Draw(image)
 
 >>> categories = cppe5["train"].features["objects"].feature["category"].names
@@ -193,11 +193,14 @@ flip it horizontally, and brighten it:
 >>> import numpy as np
 >>> import torch
 
->>> transform = albumentations.Compose([
-...     albumentations.Resize(480, 480),
-...     albumentations.HorizontalFlip(p=1.0),
-...     albumentations.RandomBrightnessContrast(p=1.0),
-... ], bbox_params=albumentations.BboxParams(format='coco',  label_fields=['category']))
+>>> transform = albumentations.Compose(
+...     [
+...         albumentations.Resize(480, 480),
+...         albumentations.HorizontalFlip(p=1.0),
+...         albumentations.RandomBrightnessContrast(p=1.0),
+...     ],
+...     bbox_params=albumentations.BboxParams(format="coco", label_fields=["category"]),
+... )
 ```
 
 The `image_processor` expects the annotations to be in the following format: `{'image_id': int, 'annotations': List[Dict]}`,
@@ -232,7 +235,7 @@ Now you can combine the image and annotation transformations to use on a batch o
 ...         out = transform(image=image, bboxes=objects["bbox"], category=objects["category"])
 
 ...         area.append(objects["area"])
-...         images.append(out['image'])
+...         images.append(out["image"])
 ...         bboxes.append(out["bboxes"])
 ...         categories.append(out["category"])
 
@@ -392,57 +395,61 @@ First, prepare the `cppe5["test"]` set: format the annotations and save the data
 
 >>> # format annotations the same as for training, no need for data augmentation
 >>> def val_formatted_anns(image_id, objects):
-...   annotations = []
-...   for i in range(0,len(objects["id"])):
-...     new_ann = {"id": objects["id"][i],
-...           "category_id": objects["category"][i],
-...           "iscrowd": 0,
-...           "image_id": image_id,
-...           "area": objects["area"][i],
-...           "bbox": objects["bbox"][i]}
-...     annotations.append(new_ann)
+...     annotations = []
+...     for i in range(0, len(objects["id"])):
+...         new_ann = {
+...             "id": objects["id"][i],
+...             "category_id": objects["category"][i],
+...             "iscrowd": 0,
+...             "image_id": image_id,
+...             "area": objects["area"][i],
+...             "bbox": objects["bbox"][i],
+...         }
+...         annotations.append(new_ann)
 
-...   return annotations
+...     return annotations
+
 
 >>> # Save images and annotations into the files torchvision.datasets.CocoDetection expects
 >>> def save_cppe5_annotation_file_images(cppe5):
-...   output_json = {}
-...   path_output_cppe5 = f"{os.getcwd()}/cppe5/"
+...     output_json = {}
+...     path_output_cppe5 = f"{os.getcwd()}/cppe5/"
 
-...   if not os.path.exists(path_output_cppe5):
-...     os.makedirs(path_output_cppe5)
+...     if not os.path.exists(path_output_cppe5):
+...         os.makedirs(path_output_cppe5)
 
-...   path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
-...   categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label ]
-...   output_json["images"] = []
-...   output_json["annotations"] = []
-...   for example in cppe5:
-...       ann = val_formatted_anns(example["image_id"], example["objects"])
-...       output_json["images"].append(
-...         {
-...           "id": example["image_id"],
-...           "width": example["image"].width,
-...           "height": example["image"].height,
-...           "file_name": f"{example['image_id']}.png"
-...         }
-...       )
-...       output_json["annotations"].extend(ann)
-...   output_json["categories"] = categories_json
+...     path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
+...     categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label]
+...     output_json["images"] = []
+...     output_json["annotations"] = []
+...     for example in cppe5:
+...         ann = val_formatted_anns(example["image_id"], example["objects"])
+...         output_json["images"].append(
+...             {
+...                 "id": example["image_id"],
+...                 "width": example["image"].width,
+...                 "height": example["image"].height,
+...                 "file_name": f"{example['image_id']}.png",
+...             }
+...         )
+...         output_json["annotations"].extend(ann)
+...     output_json["categories"] = categories_json
 
-...   with open(path_anno, "w") as file:
-...       json.dump(output_json, file, ensure_ascii=False, indent=4)
+...     with open(path_anno, "w") as file:
+...         json.dump(output_json, file, ensure_ascii=False, indent=4)
 
-...   for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
-...       path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
-...       im.save(path_img)
+...     for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
+...         path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
+...         im.save(path_img)
 
-...   return path_output_cppe5, path_anno
+...     return path_output_cppe5, path_anno
 ```
 
 Next, prepare an instance of a CocoDetection class that can be used with `cocoevaluator`.
 
 ```py
 >>> import torchvision
+
 
 >>> class CocoDetection(torchvision.datasets.CocoDetection):
 ...     def __init__(self, img_folder, feature_extractor, ann_file):
@@ -456,12 +463,13 @@ Next, prepare an instance of a CocoDetection class that can be used with `cocoev
 ...         # preprocess image and target: converting target to DETR format,
 ...         # resizing + normalization of both image and target)
 ...         image_id = self.ids[idx]
-...         target = {'image_id': image_id, 'annotations': target}
+...         target = {"image_id": image_id, "annotations": target}
 ...         encoding = self.feature_extractor(images=img, annotations=target, return_tensors="pt")
-...         pixel_values = encoding["pixel_values"].squeeze() # remove batch dimension
-...         target = encoding["labels"][0] # remove batch dimension
+...         pixel_values = encoding["pixel_values"].squeeze()  # remove batch dimension
+...         target = encoding["labels"][0]  # remove batch dimension
 
-...         return {"pixel_values":pixel_values, "labels":target}
+...         return {"pixel_values": pixel_values, "labels": target}
+
 
 >>> im_processor = AutoImageProcessor.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
 
@@ -477,23 +485,27 @@ Finally, load the metrics and run the evaluation.
 
 >>> model = AutoModelForObjectDetection.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
 >>> module = evaluate.load("ybelkada/cocoevaluate", coco=test_ds_coco_format.coco)
->>> val_dataloader = torch.utils.data.DataLoader(test_ds_coco_format, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn)
+>>> val_dataloader = torch.utils.data.DataLoader(
+...     test_ds_coco_format, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn
+... )
 
 >>> with torch.no_grad():
-...   for idx, batch in enumerate(tqdm(val_dataloader)):
-...       pixel_values = batch["pixel_values"]
-...       pixel_mask = batch["pixel_mask"]
+...     for idx, batch in enumerate(tqdm(val_dataloader)):
+...         pixel_values = batch["pixel_values"]
+...         pixel_mask = batch["pixel_mask"]
 
-...       labels = [{k: v for k, v in t.items()} for t in batch["labels"]] # these are in DETR format, resized + normalized
+...         labels = [
+...             {k: v for k, v in t.items()} for t in batch["labels"]
+...         ]  # these are in DETR format, resized + normalized
 
-...       # forward pass
-...       outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
+...         # forward pass
+...         outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
 
-...       orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
-...       results = im_processor.post_process(outputs, orig_target_sizes) # convert outputs of model to COCO api
+...         orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
+...         results = im_processor.post_process(outputs, orig_target_sizes)  # convert outputs of model to COCO api
 
-...       module.add(prediction=results, reference=labels)
-...       del batch
+...         module.add(prediction=results, reference=labels)
+...         del batch
 
 >>> results = module.compute()
 >>> print(results)
@@ -537,10 +549,10 @@ You can also manually replicate the results of the pipeline if you'd like:
 >>> model = AutoModelForObjectDetection.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
 
 >>> with torch.no_grad():
-...   inputs = image_processor(images=image, return_tensors="pt")
-...   outputs = model(**inputs)
-...   target_sizes = torch.tensor([image.size[::-1]])
-...   results = image_processor.post_process_object_detection(outputs, threshold=0.4, target_sizes=target_sizes)[0]
+...     inputs = image_processor(images=image, return_tensors="pt")
+...     outputs = model(**inputs)
+...     target_sizes = torch.tensor([image.size[::-1]])
+...     results = image_processor.post_process_object_detection(outputs, threshold=0.4, target_sizes=target_sizes)[0]
 
 >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
 ...     box = [round(i, 2) for i in box.tolist()]

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -253,7 +253,7 @@ to indicate which pixels are real (1) and which are padding (0).
 ...     return batch
 ```
 
-## Training the DERT model
+## Training the DETR model
 You have done most of the heavy lifting in the previous sections, so now you are ready to train your model!
 The images in this dataset are still quite large, even after resizing. This means that finetuning this model will
 require at least one GPU.

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -68,7 +68,7 @@ You'll see that this dataset already comes with a training set containing 1000 i
 To get familiar with the data, explore what the examples look like.
 
 ```py
->>> cppe5['train'][0]
+>>> cppe5["train"][0]
 ```
 
 The examples in the dataset have the following fields:
@@ -94,27 +94,27 @@ To get an even better understanding of the data, visualize a random example in t
 >>> from PIL import Image, ImageDraw
 
 >>> # based on https://github.com/woctezuma/finetune-detr/blob/master/finetune_detr.ipynb
->>> image_ids = cppe5['train']['image_id']
+>>> image_ids = cppe5["train"]["image_id"]
 >>> # let's pick a random image
 >>> image_id = image_ids[np.random.randint(0, len(image_ids))]
->>> print('Image n°{}'.format(image_id))
+>>> print("Image n°{}".format(image_id))
 
->>> image = cppe5['train'][image_id]['image']
->>> annotations = cppe5['train'][image_id]['objects']
+>>> image = cppe5["train"][image_id]["image"]
+>>> annotations = cppe5["train"][image_id]["objects"]
 >>> draw = ImageDraw.Draw(image, "RGBA")
 
 >>> # Retrieve the categories from the dataset's metadata.
->>> categories = cppe5['train'].features['objects'].feature['category'].names
+>>> categories = cppe5["train"].features["objects"].feature["category"].names
 
 >>> id2label = {index: x for index, x in enumerate(categories, start=0)}
 >>> label2id = {v: k for k, v in id2label.items()}
 
->>> for i in range(len(annotations['id'])):
->>>   box = annotations['bbox'][i-1]
->>>   class_idx = annotations['category'][i-1]
->>>   x,y,w,h = tuple(box)
->>>   draw.rectangle((x,y,x+w,y+h), outline='red', width=1)
->>>   draw.text((x, y), id2label[class_idx], fill='white')
+>>> for i in range(len(annotations["id"])):
+...     box = annotations["bbox"][i - 1]
+...     class_idx = annotations["category"][i - 1]
+...     x, y, w, h = tuple(box)
+...     draw.rectangle((x, y, x + w, y + h), outline="red", width=1)
+...     draw.text((x, y), id2label[class_idx], fill="white")
 
 >>> image
 ```
@@ -171,11 +171,14 @@ flip it horizontally, and brighten it:
 >>> import numpy as np
 >>> import torch
 
->>> transform = A.Compose([
->>>     A.Resize(480, 480),
->>>     A.HorizontalFlip(p=1.0),
->>>     A.RandomBrightnessContrast(p=1.0),
->>> ], bbox_params=A.BboxParams(format='coco',  label_fields=['category']))
+>>> transform = A.Compose(
+...     [
+...         A.Resize(480, 480),
+...         A.HorizontalFlip(p=1.0),
+...         A.RandomBrightnessContrast(p=1.0),
+...     ],
+...     bbox_params=A.BboxParams(format="coco", label_fields=["category"]),
+... )
 ```
 
 `DetrImageProcessor` expects the annotations to be in the following format: `{‘image_id’: int, ‘annotations’: List[Dict]}`,
@@ -184,16 +187,18 @@ flip it horizontally, and brighten it:
 ```py
 >>> def formatted_anns(image_id, category, area, bbox):
 
->>>   annotations = []
->>>   for i in range(0,len(category)):
->>>     new_ann = {"image_id": image_id,
->>>           "category_id": category[i],
->>>           "isCrowd": 0,
->>>           "area": area[i],
->>>           "bbox": list(bbox[i])}
->>>     annotations.append(new_ann)
+...     annotations = []
+...     for i in range(0, len(category)):
+...         new_ann = {
+...             "image_id": image_id,
+...             "category_id": category[i],
+...             "isCrowd": 0,
+...             "area": area[i],
+...             "bbox": list(bbox[i]),
+...         }
+...         annotations.append(new_ann)
 
->>>   return annotations
+...     return annotations
 ```
 
 Now you can combine the image and annotation transformations to use on a batch of examples:
@@ -201,26 +206,23 @@ Now you can combine the image and annotation transformations to use on a batch o
 ```py
 >>> # transforming a batch
 >>> def transform_aug_ann(examples):
->>>   image_ids = examples["image_id"]
->>>   images, bboxes, area, categories = [], [], [], []
->>>   for image, objects in zip(examples['image'], examples['objects']):
->>>     image = np.array(image.convert("RGB"))[:, :, ::-1]
->>>     out = transform(
->>>         image=image,
->>>         bboxes=objects['bbox'],
->>>         category=objects['category']
->>>         )
+...     image_ids = examples["image_id"]
+...     images, bboxes, area, categories = [], [], [], []
+...     for image, objects in zip(examples["image"], examples["objects"]):
+...         image = np.array(image.convert("RGB"))[:, :, ::-1]
+...         out = transform(image=image, bboxes=objects["bbox"], category=objects["category"])
 
->>>     area.append(objects['area'])
->>>     images.append(torch.tensor(out['image']).flip(-1).permute(2, 0, 1))
->>>     bboxes.append(out['bboxes'])
->>>     categories.append(out['category'])
+...         area.append(objects["area"])
+...         images.append(torch.tensor(out["image"]).flip(-1).permute(2, 0, 1))
+...         bboxes.append(out["bboxes"])
+...         categories.append(out["category"])
 
->>>   targets = [
->>>       {"image_id": id_, "annotations": formatted_anns(id_, cat_, ar_, box_)} for id_, cat_, ar_, box_  in zip(image_ids, categories, area, bboxes)
->>>   ]
+...     targets = [
+...         {"image_id": id_, "annotations": formatted_anns(id_, cat_, ar_, box_)}
+...         for id_, cat_, ar_, box_ in zip(image_ids, categories, area, bboxes)
+...     ]
 
->>>   return image_processor(images=images, annotations=targets, return_tensors="pt")
+...     return image_processor(images=images, annotations=targets, return_tensors="pt")
 ```
 
 Apply this preprocessing function to the entire dataset using 🤗 Datasets `with_transform` method. This method applies
@@ -241,14 +243,14 @@ to indicate which pixels are real (1) and which are padding (0).
 
 ```py
 >>> def collate_fn(batch):
->>>   pixel_values = [item['pixel_values'] for item in batch]
->>>   encoding = image_processor.pad_and_create_pixel_mask(pixel_values, return_tensors="pt")
->>>   labels = [item['labels'] for item in batch]
->>>   batch = {}
->>>   batch['pixel_values'] = encoding['pixel_values']
->>>   batch['pixel_mask'] = encoding['pixel_mask']
->>>   batch['labels'] = labels
->>>   return batch
+...     pixel_values = [item["pixel_values"] for item in batch]
+...     encoding = image_processor.pad_and_create_pixel_mask(pixel_values, return_tensors="pt")
+...     labels = [item["labels"] for item in batch]
+...     batch = {}
+...     batch["pixel_values"] = encoding["pixel_values"]
+...     batch["pixel_mask"] = encoding["pixel_mask"]
+...     batch["labels"] = labels
+...     return batch
 ```
 
 ## Training the DERT model
@@ -258,6 +260,7 @@ require at least one GPU.
 
 ```py
 >>> import torch
+
 >>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 ```
 
@@ -274,11 +277,11 @@ id and id to label maps that you created earlier from the dataset's metadata.
 >>> from transformers import DetrForObjectDetection
 
 >>> model = DetrForObjectDetection.from_pretrained(
->>>     checkpoint,
->>>     id2label=id2label,
->>>     label2id=label2id,
->>>     ignore_mismatched_sizes=True,
->>> )
+...     checkpoint,
+...     id2label=id2label,
+...     label2id=label2id,
+...     ignore_mismatched_sizes=True,
+... )
 ```
 
 In the `TrainingArguments` use `output_dir` to specify where to save your model, then configure hyperparameters as you see fit.
@@ -291,17 +294,17 @@ Face to upload your model).
 >>> from transformers import TrainingArguments
 
 >>> training_args = TrainingArguments(
->>>     output_dir="detr-resnet-50_fine_tuned_cppe5",
->>>     per_device_train_batch_size=8,
->>>     num_train_epochs=10,
->>>     fp16=False,
->>>     save_steps=200,
->>>     logging_steps=50,
->>>     learning_rate=1e-5,
->>>     save_total_limit=2,
->>>     remove_unused_columns=False,
->>>     push_to_hub=True,
->>> )
+...     output_dir="detr-resnet-50_fine_tuned_cppe5",
+...     per_device_train_batch_size=8,
+...     num_train_epochs=10,
+...     fp16=False,
+...     save_steps=200,
+...     logging_steps=50,
+...     learning_rate=1e-5,
+...     save_total_limit=2,
+...     remove_unused_columns=False,
+...     push_to_hub=True,
+... )
 ```
 
 Finally, bring everything together, and call `train`:
@@ -310,14 +313,14 @@ Finally, bring everything together, and call `train`:
 >>> from transformers import Trainer
 
 >>> trainer = Trainer(
->>>     model=model,
->>>     args=training_args,
->>>     data_collator=collate_fn,
->>>     train_dataset=cppe5["train"],
->>>     tokenizer=image_processor,
->>> )
+...     model=model,
+...     args=training_args,
+...     data_collator=collate_fn,
+...     train_dataset=cppe5["train"],
+...     tokenizer=image_processor,
+... )
 
->>>trainer.train()
+>>> rainer.train()
 ```
 
 ## Evaluate
@@ -349,6 +352,7 @@ import torchvision
 import numpy as np
 from tqdm import tqdm
 
+
 class CocoDetection(torchvision.datasets.CocoDetection):
     def __init__(self, img_folder, feature_extractor, ann_file):
         super(CocoDetection, self).__init__(img_folder, ann_file)
@@ -360,63 +364,68 @@ class CocoDetection(torchvision.datasets.CocoDetection):
 
         # preprocess image and target (converting target to DETR format, resizing + normalization of both image and target)
         image_id = self.ids[idx]
-        target = {'image_id': image_id, 'annotations': target}
+        target = {"image_id": image_id, "annotations": target}
         encoding = self.feature_extractor(images=img, annotations=target, return_tensors="pt")
-        pixel_values = encoding["pixel_values"].squeeze() # remove batch dimension
-        target = encoding["labels"][0] # remove batch dimension
+        pixel_values = encoding["pixel_values"].squeeze()  # remove batch dimension
+        target = encoding["labels"][0]  # remove batch dimension
 
-        return {"pixel_values":pixel_values, "labels":target}
+        return {"pixel_values": pixel_values, "labels": target}
+
 
 im_processor = DetrImageProcessor.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
 model = DetrForObjectDetection.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
 
 # prepare the test dataset
 def val_formatted_anns(image_id, objects):
-  annotations = []
-  for i in range(0,len(objects["id"])):
-    new_ann = {"id": objects["id"][i],
-          "category_id": objects["category"][i],
-          "iscrowd": 0,
-          "image_id": image_id,
-          "area": objects["area"][i],
-          "bbox": objects["bbox"][i]}
-    annotations.append(new_ann)
+    annotations = []
+    for i in range(0, len(objects["id"])):
+        new_ann = {
+            "id": objects["id"][i],
+            "category_id": objects["category"][i],
+            "iscrowd": 0,
+            "image_id": image_id,
+            "area": objects["area"][i],
+            "bbox": objects["bbox"][i],
+        }
+        annotations.append(new_ann)
 
-  return annotations
+    return annotations
+
 
 # CocoDetection expects to read the data from files in a certain format
 def save_cppe5_annotation_file_images(cppe5):
-  output_json = {}
-  path_output_cppe5 = f"{os.getcwd()}/cppe5/"
+    output_json = {}
+    path_output_cppe5 = f"{os.getcwd()}/cppe5/"
 
-  if not os.path.exists(path_output_cppe5):
-    os.makedirs(path_output_cppe5)
+    if not os.path.exists(path_output_cppe5):
+        os.makedirs(path_output_cppe5)
 
-  path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
-  categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label ]
-  output_json["images"] = []
-  output_json["annotations"] = []
-  for batch in cppe5:
-      ann = val_formatted_anns(batch["image_id"], batch["objects"])
-      output_json["images"].append(
-        {
-          "id": batch["image_id"],
-          "width": batch["image"].width,
-          "height": batch["image"].height,
-          "file_name": f"{batch['image_id']}.png"
-        }
-      )
-      output_json["annotations"].extend(ann)
-  output_json["categories"] = categories_json
+    path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
+    categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label]
+    output_json["images"] = []
+    output_json["annotations"] = []
+    for batch in cppe5:
+        ann = val_formatted_anns(batch["image_id"], batch["objects"])
+        output_json["images"].append(
+            {
+                "id": batch["image_id"],
+                "width": batch["image"].width,
+                "height": batch["image"].height,
+                "file_name": f"{batch['image_id']}.png",
+            }
+        )
+        output_json["annotations"].extend(ann)
+    output_json["categories"] = categories_json
 
-  with open(path_anno, "w") as file:
-      json.dump(output_json, file, ensure_ascii=False, indent=4)
+    with open(path_anno, "w") as file:
+        json.dump(output_json, file, ensure_ascii=False, indent=4)
 
-  for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
-      path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
-      im.save(path_img)
+    for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
+        path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
+        im.save(path_img)
 
-  return path_output_cppe5, path_anno
+    return path_output_cppe5, path_anno
+
 
 path_output_cppe5, path_anno = save_cppe5_annotation_file_images(cppe5["test"])
 
@@ -425,20 +434,22 @@ module = evaluate.load("ybelkada/cocoevaluate", coco=dummy.coco)
 val_dataloader = torch.utils.data.DataLoader(dummy, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn)
 
 with torch.no_grad():
-  for idx, batch in enumerate(tqdm(val_dataloader)):
-      pixel_values = batch["pixel_values"]
-      pixel_mask = batch["pixel_mask"]
+    for idx, batch in enumerate(tqdm(val_dataloader)):
+        pixel_values = batch["pixel_values"]
+        pixel_mask = batch["pixel_mask"]
 
-      labels = [{k: v for k, v in t.items()} for t in batch["labels"]] # these are in DETR format, resized + normalized
+        labels = [
+            {k: v for k, v in t.items()} for t in batch["labels"]
+        ]  # these are in DETR format, resized + normalized
 
-      # forward pass
-      outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
+        # forward pass
+        outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
 
-      orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
-      results = im_processor.post_process(outputs, orig_target_sizes) # convert outputs of model to COCO api
+        orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
+        results = im_processor.post_process(outputs, orig_target_sizes)  # convert outputs of model to COCO api
 
-      module.add(prediction=results, reference=labels)
-      del batch
+        module.add(prediction=results, reference=labels)
+        del batch
 
 results = module.compute()
 print(results)
@@ -461,16 +472,14 @@ Now that you have finetuned a DETR model, evaluated it and uploaded it to the �
 
 >>> # convert outputs (bounding boxes and class logits) to COCO API
 >>> target_sizes = torch.tensor([image.size[::-1]])
->>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[
->>>     0
->>> ]
+>>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[0]
 
 >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
->>>     box = [round(i, 2) for i in box.tolist()]
->>>     print(
->>>         f"Detected {model.config.id2label[label.item()]} with confidence "
->>>         f"{round(score.item(), 3)} at location {box}"
->>>     )
+...     box = [round(i, 2) for i in box.tolist()]
+...     print(
+...         f"Detected {model.config.id2label[label.item()]} with confidence "
+...         f"{round(score.item(), 3)} at location {box}"
+...     )
 ```
 
 

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -181,7 +181,7 @@ flip it horizontally, and brighten it:
 ... )
 ```
 
-`DetrImageProcessor` expects the annotations to be in the following format: `{‘image_id’: int, ‘annotations’: List[Dict]}`,
+The `image_processor` expects the annotations to be in the following format: `{'image_id': int, 'annotations': List[Dict]}`,
  where each `Dict` is a COCO object annotation. Building up gradually, add a function to reformat annotations for a single example:
 
 ```py

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -18,7 +18,7 @@ Object detection is a computer vision task of detecting instances of semantic ob
 class (such as humans, buildings, or cars) in parts of an image. Object detection models receive an image as input and output
 coordinates of the bounding boxes and associated labels of the detected objects. An image can contain multiple objects,
 each with its own bounding box and a label (e.g. it can have a car and a building).
-be present in different parts of an image.
+be present in different parts of an image (e.g. the image can have several cars).
 This task is commonly used in autonomous driving for detecting things like pedestrians, road signs, and traffic lights.
 Other applications include counting objects in images, image search, and more.
 

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -14,8 +14,7 @@ specific language governing permissions and limitations under the License.
 
 [[open-in-colab]]
 
-Object detection is a computer vision task of detecting instances of semantic objects that belong to a particular
-class (such as humans, buildings, or cars) in parts of an image. Object detection models receive an image as input and output
+Object detection is the computer vision task of detecting instances (such as humans, buildings, or cars) in an image. Object detection models receive an image as input and output
 coordinates of the bounding boxes and associated labels of the detected objects. An image can contain multiple objects,
 each with its own bounding box and a label (e.g. it can have a car and a building).
 be present in different parts of an image (e.g. the image can have several cars).

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -268,7 +268,7 @@ Training involves the following steps:
 1. Load the model with `DetrForObjectDetection.from_pretrained` using the same checkpoint as in the preprocessing.
 2. Define your training hyperparameters in `TrainingArguments`.
 3. Pass the training arguments to `Trainer` along with the model, dataset, image processor, and data collator.
-4. Call `train()`` to finetune your model.
+4. Call `train()` to finetune your model.
 
 When loading the model from the same checkpoint that you used for the preprocessing, remember to pass the label to
 id and id to label maps that you created earlier from the dataset's metadata.

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -23,8 +23,8 @@ This task is commonly used in autonomous driving for detecting things like pedes
 Other applications include counting objects in images, image search, and more.
 
  <Tip>
- Check out the [object detection task page](https://huggingface.co/tasks/object-detection) to learn about use cases,
- models, metrics, and datasets associated with this task.
+Check out the <a href="https://huggingface.co/tasks/object-detection">object detection</a> task page to learn about use cases,
+models, metrics, and datasets associated with this task.
  </Tip>
 
 In this guide, you will learn how to:
@@ -37,8 +37,11 @@ In this guide, you will learn how to:
 Before you begin, make sure you have all the necessary libraries installed:
 
 ```bash
-pip install -q datasets transformers evaluate timm albumentations opencv-python
+pip install -q datasets transformers evaluate timm albumentations
 ```
+
+In this guide you'll use `datasets` to load a dataset from the Hugging Face Hub, `transformers` to train your model,
+and `albumentations` to augment the data. `timm` is currently required to load a convolutional backbone for the DETR model.
 
 We encourage you to share your model with the community. Log in to your Hugging Face account to upload it to Hub.
 When prompted, enter your token to log in:
@@ -61,6 +64,16 @@ Start by loading the dataset:
 
 >>> cppe5 = load_dataset("cppe-5")
 >>> cppe5
+DatasetDict({
+    train: Dataset({
+        features: ['image_id', 'image', 'width', 'height', 'objects'],
+        num_rows: 1000
+    })
+    test: Dataset({
+        features: ['image_id', 'image', 'width', 'height', 'objects'],
+        num_rows: 29
+    })
+})
 ```
 
 You'll see that this dataset already comes with a training set containing 1000 images and a test set with 29 images.
@@ -69,6 +82,17 @@ To get familiar with the data, explore what the examples look like.
 
 ```py
 >>> cppe5["train"][0]
+{'image_id': 15,
+ 'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=943x663 at 0x7F9EC9E77C10>,
+ 'width': 943,
+ 'height': 663,
+ 'objects': {'id': [114, 115, 116, 117],
+  'area': [3796, 1596, 152768, 81002],
+  'bbox': [[302.0, 109.0, 73.0, 52.0],
+   [810.0, 100.0, 57.0, 28.0],
+   [160.0, 31.0, 248.0, 616.0],
+   [741.0, 68.0, 202.0, 401.0]],
+  'category': [4, 4, 0, 0]}}
 ```
 
 The examples in the dataset have the following fields:
@@ -79,31 +103,24 @@ The examples in the dataset have the following fields:
 - `objects`: A dictionary containing bounding box metadata for the objects in the image:
   - `id`: The annotation id.
   - `area`: The area of the bounding box.
-  - `bbox`: The object's bounding box (in the [COCO](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) format).
+  - `bbox`: The object's bounding box (in the [COCO format](https://albumentations.ai/docs/getting_started/bounding_boxes_augmentation/#coco) ).
   - `category`: The object's category, with possible values including `Coverall (0)`, `Face_Shield (1)`, `Gloves (2)`, `Goggles (3)` and `Mask (4)`.
 
 You may notice that the `bbox` field follows the COCO format, which is the format that DETR model expects.
 However, the grouping of the fields inside `objects` differs from the annotation format DETR requires. You will
 need to apply some preprocessing transformations before using this data for training.
 
-To get an even better understanding of the data, visualize a random example in the dataset.
+To get an even better understanding of the data, visualize an example in the dataset.
 
 ```py
 >>> import numpy as np
 >>> import os
 >>> from PIL import Image, ImageDraw
 
->>> # based on https://github.com/woctezuma/finetune-detr/blob/master/finetune_detr.ipynb
->>> image_ids = cppe5["train"]["image_id"]
->>> # let's pick a random image
->>> image_id = image_ids[np.random.randint(0, len(image_ids))]
->>> print(f"Image n°{image_id}")
+>>> image = cppe5['train'][0]['image']
+>>> annotations = cppe5['train'][0]['objects']
+>>> draw = ImageDraw.Draw(image)
 
->>> image = cppe5["train"][image_id]["image"]
->>> annotations = cppe5["train"][image_id]["objects"]
->>> draw = ImageDraw.Draw(image, "RGBA")
-
->>> # Retrieve the categories from the dataset's metadata.
 >>> categories = cppe5["train"].features["objects"].feature["category"].names
 
 >>> id2label = {index: x for index, x in enumerate(categories, start=0)}
@@ -119,10 +136,15 @@ To get an even better understanding of the data, visualize a random example in t
 >>> image
 ```
 
+<div class="flex justify-center">
+    <img src="https://i.imgur.com/TdaqPJO.png" alt="CPPE-5 Image Example"/>
+</div>
+
 To visualize the bounding boxes with associated labels, you can get the labels from the dataset's metadata, specifically
 the `category` field.
 You'll also want to create dictionaries that map a label id to a label class (`id2label`) and the other way around (`label2id`).
-You'll need them later when setting up your model.
+You can use them later when setting up the model. Including these maps will make your model reusable by others if you share
+it on the Hugging Face Hub.
 
 As a final step of getting familiar with the data, explore it for potential issues. One common problem with datasets for
 object detection is bounding boxes that "stretch" beyond the edge of the image. Such "runaway" bounding boxes can raise
@@ -138,8 +160,8 @@ To keep things simple in this guide, we remove these images from the data.
 ## Preprocess the data
 
 To finetune a model, you must preprocess the data you plan to use to match precisely the approach used for the pre-trained model.
-For DETR models, `DetrImageProcessor` takes care of processing image data to create `pixel_values`, `pixel_mask`, and
-`labels` that a DETR model can train with. The preprocessor has some attributes that you won't have to worry about:
+[`AutoImageProcessor`] takes care of processing image data to create `pixel_values`, `pixel_mask`, and
+`labels` that a DETR model can train with. The image processor has some attributes that you won't have to worry about:
 
 - `image_mean = [0.485, 0.456, 0.406 ]`
 - `image_std = [0.229, 0.224, 0.225]`
@@ -150,10 +172,10 @@ to replicate when doing inference or finetuning a pre-trained image model.
 Instantiate the image processor from the same checkpoint as the model you want to finetune.
 
 ```py
->>> from transformers import DetrImageProcessor
+>>> from transformers import AutoImageProcessor
 
 >>> checkpoint = "facebook/detr-resnet-50"
->>> image_processor = DetrImageProcessor.from_pretrained(checkpoint)
+>>> image_processor = AutoImageProcessor.from_pretrained(checkpoint)
 ```
 
 Before passing the images to the `image_processor`, apply two preprocessing transformations to the dataset:
@@ -167,18 +189,15 @@ and it uses the exact same dataset as an example. Apply the same approach here, 
 flip it horizontally, and brighten it:
 
 ```py
->>> import albumentations as A
+>>> import albumentations
 >>> import numpy as np
 >>> import torch
 
->>> transform = A.Compose(
-...     [
-...         A.Resize(480, 480),
-...         A.HorizontalFlip(p=1.0),
-...         A.RandomBrightnessContrast(p=1.0),
-...     ],
-...     bbox_params=A.BboxParams(format="coco", label_fields=["category"]),
-... )
+>>> transform = albumentations.Compose([
+...     albumentations.Resize(480, 480),
+...     albumentations.HorizontalFlip(p=1.0),
+...     albumentations.RandomBrightnessContrast(p=1.0),
+... ], bbox_params=albumentations.BboxParams(format='coco',  label_fields=['category']))
 ```
 
 The `image_processor` expects the annotations to be in the following format: `{'image_id': int, 'annotations': List[Dict]}`,
@@ -213,7 +232,7 @@ Now you can combine the image and annotation transformations to use on a batch o
 ...         out = transform(image=image, bboxes=objects["bbox"], category=objects["category"])
 
 ...         area.append(objects["area"])
-...         images.append(torch.tensor(out["image"]).flip(-1).permute(2, 0, 1))
+...         images.append(out['image'])
 ...         bboxes.append(out["bboxes"])
 ...         categories.append(out["category"])
 
@@ -234,6 +253,37 @@ with `pixel_values`, a tensor with `pixel_mask`, and `labels`.
 ```py
 >>> cppe5["train"] = cppe5["train"].with_transform(transform_aug_ann)
 >>> cppe5["train"][15]
+{'pixel_values': tensor([[[ 0.9132,  0.9132,  0.9132,  ..., -1.9809, -1.9809, -1.9809],
+          [ 0.9132,  0.9132,  0.9132,  ..., -1.9809, -1.9809, -1.9809],
+          [ 0.9132,  0.9132,  0.9132,  ..., -1.9638, -1.9638, -1.9638],
+          ...,
+          [-1.5699, -1.5699, -1.5699,  ..., -1.9980, -1.9980, -1.9980],
+          [-1.5528, -1.5528, -1.5528,  ..., -1.9980, -1.9809, -1.9809],
+          [-1.5528, -1.5528, -1.5528,  ..., -1.9980, -1.9809, -1.9809]],
+
+         [[ 1.3081,  1.3081,  1.3081,  ..., -1.8431, -1.8431, -1.8431],
+          [ 1.3081,  1.3081,  1.3081,  ..., -1.8431, -1.8431, -1.8431],
+          [ 1.3081,  1.3081,  1.3081,  ..., -1.8256, -1.8256, -1.8256],
+          ...,
+          [-1.3179, -1.3179, -1.3179,  ..., -1.8606, -1.8606, -1.8606],
+          [-1.3004, -1.3004, -1.3004,  ..., -1.8606, -1.8431, -1.8431],
+          [-1.3004, -1.3004, -1.3004,  ..., -1.8606, -1.8431, -1.8431]],
+
+         [[ 1.4200,  1.4200,  1.4200,  ..., -1.6476, -1.6476, -1.6476],
+          [ 1.4200,  1.4200,  1.4200,  ..., -1.6476, -1.6476, -1.6476],
+          [ 1.4200,  1.4200,  1.4200,  ..., -1.6302, -1.6302, -1.6302],
+          ...,
+          [-1.0201, -1.0201, -1.0201,  ..., -1.5604, -1.5604, -1.5604],
+          [-1.0027, -1.0027, -1.0027,  ..., -1.5604, -1.5430, -1.5430],
+          [-1.0027, -1.0027, -1.0027,  ..., -1.5604, -1.5430, -1.5430]]]),
+ 'pixel_mask': tensor([[1, 1, 1,  ..., 1, 1, 1],
+         [1, 1, 1,  ..., 1, 1, 1],
+         [1, 1, 1,  ..., 1, 1, 1],
+         ...,
+         [1, 1, 1,  ..., 1, 1, 1],
+         [1, 1, 1,  ..., 1, 1, 1],
+         [1, 1, 1,  ..., 1, 1, 1]]),
+ 'labels': {'size': tensor([800, 800]), 'image_id': tensor([756]), 'class_labels': tensor([4]), 'boxes': tensor([[0.7340, 0.6986, 0.3414, 0.5944]]), 'area': tensor([519544.4375]), 'iscrowd': tensor([0]), 'orig_size': tensor([480, 480])}}
 ```
 
 You have successfully augmented the individual images and prepared their annotations. However, preprocessing isn't
@@ -258,25 +308,19 @@ You have done most of the heavy lifting in the previous sections, so now you are
 The images in this dataset are still quite large, even after resizing. This means that finetuning this model will
 require at least one GPU.
 
-```py
->>> import torch
-
->>> device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-```
-
 Training involves the following steps:
-1. Load the model with `DetrForObjectDetection.from_pretrained` using the same checkpoint as in the preprocessing.
-2. Define your training hyperparameters in `TrainingArguments`.
-3. Pass the training arguments to `Trainer` along with the model, dataset, image processor, and data collator.
-4. Call `train()` to finetune your model.
+1. Load the model with [`AutoModelForObjectDetection`] using the same checkpoint as in the preprocessing.
+2. Define your training hyperparameters in [`TrainingArguments`].
+3. Pass the training arguments to [`Trainer`] along with the model, dataset, image processor, and data collator.
+4. Call [`~Trainer.train`] to finetune your model.
 
-When loading the model from the same checkpoint that you used for the preprocessing, remember to pass the label to
-id and id to label maps that you created earlier from the dataset's metadata.
+When loading the model from the same checkpoint that you used for the preprocessing, remember to pass the `label2id`
+and `id2label` maps that you created earlier from the dataset's metadata.
 
 ```py
->>> from transformers import DetrForObjectDetection
+>>> from transformers import AutoModelForObjectDetection
 
->>> model = DetrForObjectDetection.from_pretrained(
+>>> model = AutoModelForObjectDetection.from_pretrained(
 ...     checkpoint,
 ...     id2label=id2label,
 ...     label2id=label2id,
@@ -284,7 +328,7 @@ id and id to label maps that you created earlier from the dataset's metadata.
 ... )
 ```
 
-In the `TrainingArguments` use `output_dir` to specify where to save your model, then configure hyperparameters as you see fit.
+In the [`TrainingArguments`] use `output_dir` to specify where to save your model, then configure hyperparameters as you see fit.
 An important note: do not remove unused columns because this will drop the image column. Without the image column, you
 can't create `pixel_values`. For this reason, set `remove_unused_columns` to `False`.
 If you wish to share your model by pushing to the Hub, set `push_to_hub` to `True` (you must be signed in to Hugging
@@ -294,7 +338,7 @@ Face to upload your model).
 >>> from transformers import TrainingArguments
 
 >>> training_args = TrainingArguments(
-...     output_dir="detr-resnet-50_fine_tuned_cppe5",
+...     output_dir="detr-resnet-50_finetuned_cppe5",
 ...     per_device_train_batch_size=8,
 ...     num_train_epochs=10,
 ...     fp16=False,
@@ -323,156 +367,180 @@ Finally, bring everything together, and call `train`:
 >>> trainer.train()
 ```
 
-## Evaluate
-Object detection models are commonly evaluated with a set of [COCO-style metrics](https://cocodataset.org/#detection-eval).
-You can use one of the existing metrics implementations, here you'll use the one from `torchvision`.
-
-Save your trained model to use for evaluation. Alternatively, you can evaluate the model that you have pushed to the Hub.
+If you have set `push_to_hub` to `True` in the `training_args`, the training checkpoints are pushed to the
+Hugging Face Hub. Upon training completion, push the final model to the Hub as well by calling the `push_to_hub()` method.
 
 ```py
->>> trainer.save_model("./detr-resnet-50_fine_tuned_cppe5")
+>>> trainer.push_to_hub()
 ```
+
+## Evaluate
+Object detection models are commonly evaluated with a set of [COCO-style metrics](https://cocodataset.org/#detection-eval).
+You can use one of the existing metrics implementations, here you'll use the one from `torchvision` to evaluate the final
+model that you pushed to the Hub.
 
 To use the `torchvision` evaluator, you'll need to prepare a ground truth COCO dataset. The API to build a COCO dataset
 requires the data to be stored in a certain format, so you'll need to save images and annotations to disk first. Just like
 when you prepared your data for training, the annotations from the `cppe5["test"]` need to be formatted. However, images
 should stay as they are.
 
-The following example shows how you can:
-- Create a torchvision CocoDetection dataset
-- Reformat annotations from the `cppe5["test"]`
-- Save images and annotations into files that you can create an instance of CocoDetection dataset from
-- Use the `cocoevaluate` metric to compute the [COCO metrics](https://cocodataset.org/#detection-eval).
+The evaluation step requires a bit of work, but it can be split in three major steps.
+First, prepare the `cppe5["test"]` set: format the annotations and save the data to disk.
 
 ```py
-import os
-import json
-import evaluate
-import torchvision
-import numpy as np
-from tqdm import tqdm
+>>> import json
 
+>>> # format annotations the same as for training, no need for data augmentation
+>>> def val_formatted_anns(image_id, objects):
+...   annotations = []
+...   for i in range(0,len(objects["id"])):
+...     new_ann = {"id": objects["id"][i],
+...           "category_id": objects["category"][i],
+...           "iscrowd": 0,
+...           "image_id": image_id,
+...           "area": objects["area"][i],
+...           "bbox": objects["bbox"][i]}
+...     annotations.append(new_ann)
 
-class CocoDetection(torchvision.datasets.CocoDetection):
-    def __init__(self, img_folder, feature_extractor, ann_file):
-        super(CocoDetection, self).__init__(img_folder, ann_file)
-        self.feature_extractor = feature_extractor
+...   return annotations
 
-    def __getitem__(self, idx):
-        # read in PIL image and target in COCO format
-        img, target = super(CocoDetection, self).__getitem__(idx)
+>>> # Save images and annotations into the files torchvision.datasets.CocoDetection expects
+>>> def save_cppe5_annotation_file_images(cppe5):
+...   output_json = {}
+...   path_output_cppe5 = f"{os.getcwd()}/cppe5/"
 
-        # preprocess image and target (converting target to DETR format, resizing + normalization of both image and target)
-        image_id = self.ids[idx]
-        target = {"image_id": image_id, "annotations": target}
-        encoding = self.feature_extractor(images=img, annotations=target, return_tensors="pt")
-        pixel_values = encoding["pixel_values"].squeeze()  # remove batch dimension
-        target = encoding["labels"][0]  # remove batch dimension
+...   if not os.path.exists(path_output_cppe5):
+...     os.makedirs(path_output_cppe5)
 
-        return {"pixel_values": pixel_values, "labels": target}
+...   path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
+...   categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label ]
+...   output_json["images"] = []
+...   output_json["annotations"] = []
+...   for example in cppe5:
+...       ann = val_formatted_anns(example["image_id"], example["objects"])
+...       output_json["images"].append(
+...         {
+...           "id": example["image_id"],
+...           "width": example["image"].width,
+...           "height": example["image"].height,
+...           "file_name": f"{example['image_id']}.png"
+...         }
+...       )
+...       output_json["annotations"].extend(ann)
+...   output_json["categories"] = categories_json
 
+...   with open(path_anno, "w") as file:
+...       json.dump(output_json, file, ensure_ascii=False, indent=4)
 
-im_processor = DetrImageProcessor.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
-model = DetrForObjectDetection.from_pretrained("./detr-resnet-50_fine_tuned_cppe5")
+...   for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
+...       path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
+...       im.save(path_img)
 
-# prepare the test dataset
-def val_formatted_anns(image_id, objects):
-    annotations = []
-    for i in range(0, len(objects["id"])):
-        new_ann = {
-            "id": objects["id"][i],
-            "category_id": objects["category"][i],
-            "iscrowd": 0,
-            "image_id": image_id,
-            "area": objects["area"][i],
-            "bbox": objects["bbox"][i],
-        }
-        annotations.append(new_ann)
+...   return path_output_cppe5, path_anno
+```
 
-    return annotations
+Next, prepare an instance of a CocoDetection class that can be used with `cocoevaluator`.
 
+```py
+>>> import torchvision
 
-# CocoDetection expects to read the data from files in a certain format
-def save_cppe5_annotation_file_images(cppe5):
-    output_json = {}
-    path_output_cppe5 = f"{os.getcwd()}/cppe5/"
+>>> class CocoDetection(torchvision.datasets.CocoDetection):
+...     def __init__(self, img_folder, feature_extractor, ann_file):
+...         super().__init__(img_folder, ann_file)
+...         self.feature_extractor = feature_extractor
 
-    if not os.path.exists(path_output_cppe5):
-        os.makedirs(path_output_cppe5)
+...     def __getitem__(self, idx):
+...         # read in PIL image and target in COCO format
+...         img, target = super(CocoDetection, self).__getitem__(idx)
 
-    path_anno = os.path.join(path_output_cppe5, "cppe5_ann.json")
-    categories_json = [{"supercategory": "none", "id": id, "name": id2label[id]} for id in id2label]
-    output_json["images"] = []
-    output_json["annotations"] = []
-    for batch in cppe5:
-        ann = val_formatted_anns(batch["image_id"], batch["objects"])
-        output_json["images"].append(
-            {
-                "id": batch["image_id"],
-                "width": batch["image"].width,
-                "height": batch["image"].height,
-                "file_name": f"{batch['image_id']}.png",
-            }
-        )
-        output_json["annotations"].extend(ann)
-    output_json["categories"] = categories_json
+...         # preprocess image and target: converting target to DETR format,
+...         # resizing + normalization of both image and target)
+...         image_id = self.ids[idx]
+...         target = {'image_id': image_id, 'annotations': target}
+...         encoding = self.feature_extractor(images=img, annotations=target, return_tensors="pt")
+...         pixel_values = encoding["pixel_values"].squeeze() # remove batch dimension
+...         target = encoding["labels"][0] # remove batch dimension
 
-    with open(path_anno, "w") as file:
-        json.dump(output_json, file, ensure_ascii=False, indent=4)
+...         return {"pixel_values":pixel_values, "labels":target}
 
-    for im, img_id in zip(cppe5["image"], cppe5["image_id"]):
-        path_img = os.path.join(path_output_cppe5, f"{img_id}.png")
-        im.save(path_img)
+>>> im_processor = AutoImageProcessor.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
 
-    return path_output_cppe5, path_anno
+>>> path_output_cppe5, path_anno = save_cppe5_annotation_file_images(cppe5["test"])
+>>> test_ds_coco_format = CocoDetection(path_output_cppe5, im_processor, path_anno)
+```
 
+Finally, load the metrics and run the evaluation.
 
-path_output_cppe5, path_anno = save_cppe5_annotation_file_images(cppe5["test"])
+```py
+>>> import evaluate
+>>> from tqdm import tqdm
 
-dummy = CocoDetection(path_output_cppe5, im_processor, path_anno)
-module = evaluate.load("ybelkada/cocoevaluate", coco=dummy.coco)
-val_dataloader = torch.utils.data.DataLoader(dummy, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn)
+>>> model = AutoModelForObjectDetection.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
+>>> module = evaluate.load("ybelkada/cocoevaluate", coco=test_ds_coco_format.coco)
+>>> val_dataloader = torch.utils.data.DataLoader(test_ds_coco_format, batch_size=8, shuffle=False, num_workers=4, collate_fn=collate_fn)
 
-with torch.no_grad():
-    for idx, batch in enumerate(tqdm(val_dataloader)):
-        pixel_values = batch["pixel_values"]
-        pixel_mask = batch["pixel_mask"]
+>>> with torch.no_grad():
+...   for idx, batch in enumerate(tqdm(val_dataloader)):
+...       pixel_values = batch["pixel_values"]
+...       pixel_mask = batch["pixel_mask"]
 
-        labels = [
-            {k: v for k, v in t.items()} for t in batch["labels"]
-        ]  # these are in DETR format, resized + normalized
+...       labels = [{k: v for k, v in t.items()} for t in batch["labels"]] # these are in DETR format, resized + normalized
 
-        # forward pass
-        outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
+...       # forward pass
+...       outputs = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
 
-        orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
-        results = im_processor.post_process(outputs, orig_target_sizes)  # convert outputs of model to COCO api
+...       orig_target_sizes = torch.stack([target["orig_size"] for target in labels], dim=0)
+...       results = im_processor.post_process(outputs, orig_target_sizes) # convert outputs of model to COCO api
 
-        module.add(prediction=results, reference=labels)
-        del batch
+...       module.add(prediction=results, reference=labels)
+...       del batch
 
-results = module.compute()
-print(results)
+>>> results = module.compute()
+>>> print(results)
+Accumulating evaluation results...
+DONE (t=0.08s).
+IoU metric: bbox
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.104
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.188
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.103
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.013
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.027
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.105
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.105
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.210
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.248
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.085
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.122
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.261
 ```
 
 ## Inference
 Now that you have finetuned a DETR model, evaluated it, and uploaded it to the Hugging Face Hub, you can use it for inference.
+The simplest way to try out your finetuned model for inference is to use it in a `pipeline()`. Instantiate a pipeline
+for object detection with your model, and pass an image to it:
 
 ```py
+>>> from transformers import pipeline
 >>> import requests
 
->>> url = "https://chartwell.com/-/media/Images/blog/2020/04/keeping-staff-and-residents-protected.jpeg?mw=1900&hash=B8A76374D6BD24B0DC8A779D0C985027"
+>>> url = "https://chartwell.com/-/media/Images/blog/2020/04/keeping-staff-and-residents-protected.jpeg"
 >>> image = Image.open(requests.get(url, stream=True).raw)
 
->>> image_processor = DetrImageProcessor.from_pretrained("MariaK/detr-resnet-50_fine_tuned_cppe5")
->>> model = DetrForObjectDetection.from_pretrained("MariaK/detr-resnet-50_fine_tuned_cppe5")
+>>> obj_detector = pipeline("object-detection", model="MariaK/detr-resnet-50_finetuned_cppe5")
+>>> obj_detector(image)
+```
 
->>> inputs = image_processor(images=image, return_tensors="pt")
->>> outputs = model(**inputs)
+You can also manually replicate the results of the pipeline if you'd like:
 
->>> # convert outputs (bounding boxes and class logits) to COCO API
->>> target_sizes = torch.tensor([image.size[::-1]])
->>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[0]
+```py
+>>> image_processor = AutoImageProcessor.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
+>>> model = AutoModelForObjectDetection.from_pretrained("MariaK/detr-resnet-50_finetuned_cppe5")
+
+>>> with torch.no_grad():
+...   inputs = image_processor(images=image, return_tensors="pt")
+...   outputs = model(**inputs)
+...   target_sizes = torch.tensor([image.size[::-1]])
+...   results = image_processor.post_process_object_detection(outputs, threshold=0.4, target_sizes=target_sizes)[0]
 
 >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
 ...     box = [round(i, 2) for i in box.tolist()]
@@ -480,8 +548,5 @@ Now that you have finetuned a DETR model, evaluated it, and uploaded it to the H
 ...         f"Detected {model.config.id2label[label.item()]} with confidence "
 ...         f"{round(score.item(), 3)} at location {box}"
 ...     )
+Detected Coverall with confidence 0.442 at location [1321.16, 172.77, 4381.91, 3197.9]
 ```
-
-
-
-

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -127,7 +127,7 @@ You'll need them later when setting up your model.
 As a final step of getting familiar with the data, explore it for potential issues. One common problem with datasets for
 object detection is bounding boxes that "stretch" beyond the edge of the image. Such "runaway" bounding boxes can raise
 errors during training and should be addressed at this stage. There are a few examples with this issue in this dataset.
-To keep things simple, remove these images from the data.
+To keep things simple in this guide, we remove these images from the data.
 
 ```py
 >>> remove_idx = [590, 821, 822, 875, 876, 878, 879]

--- a/docs/source/en/tasks/object_detection.mdx
+++ b/docs/source/en/tasks/object_detection.mdx
@@ -147,7 +147,7 @@ For DETR models, `DetrImageProcessor` takes care of processing image data to cre
 These are the mean and standard deviation used to normalize images during the model pre-training. These values are crucial
 to replicate when doing inference or finetuning a pre-trained image model.
 
-Instantiate the `DetrImageProcessor` from the same checkpoint as the model you want to finetune.
+Instantiate the image processor from the same checkpoint as the model you want to finetune.
 
 ```py
 >>> from transformers import DetrImageProcessor


### PR DESCRIPTION
This is a PR for the [#20805](https://github.com/huggingface/transformers/issues/20805) issue. The guide has content and working code examples for:
*  Introduction
*  Loading CPPE-5 dataset from Hub
*  Preprocessing both images and annotations. Images are augmented, and annotations are reformatted to be in the format DETR expects
*  Training with Trainer
*  Evaluation
*  Inference