### PR TITLE
[trainer: `distributed_concat`] ensure `all_gather`'s inputs are contiguous

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -189,7 +189,7 @@ def distributed_concat(tensor: Any, num_total_examples: Optional[int] = None) ->
     try:
         if isinstance(tensor, (tuple, list)):
             return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
-        tensor = atleast_1d(tensor)
+        tensor = atleast_1d(tensor).contiguous()
         output_tensors = [tensor.clone() for _ in range(dist.get_world_size())]
         dist.all_gather(output_tensors, tensor)
         concat = torch.cat(output_tensors, dim=0)


### PR DESCRIPTION
This PR fixes https://github.com/huggingface/transformers/issues/20942 where a user's code results in a non-contiguous tensor being passed to `all_gather` which fails with:

```
Traceback (most recent call last):
  File "contiguous.py", line 83, in <module>
    preds = torch.tensor(trainer.predict(eval_dataset)[0])
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer.py", line 2894, in predict
    output = eval_loop(
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer.py", line 3024, in evaluation_loop
    logits = self._nested_gather(logits)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer.py", line 3140, in _nested_gather
    tensors = distributed_concat(tensors)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in distributed_concat
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in <genexpr>
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in distributed_concat
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in <genexpr>
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in distributed_concat
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 191, in <genexpr>
    return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
  File "/mnt/nvme0/code/huggingface/transformers-master-2/src/transformers/trainer_pt_utils.py", line 194, in distributed_concat
    dist.all_gather(output_tensors, tensor)
  File "/home/stas/anaconda3/envs/py38-pt113/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 2275, in all_gather
    work = default_pg.allgather([tensor_list], [tensor])
RuntimeError: Tensors must be contiguous
```

the fix adds `.contiguous()` which will do nothing if the tensor is already contiguous and will make it contiguous if it is not.


Fixes: https://github.com/huggingface/transformers/issues/20942