### PR TITLE
[docs] improve issue template for i18n

### DIFF
--- a/.github/ISSUE_TEMPLATE/i18n.md
+++ b/.github/ISSUE_TEMPLATE/i18n.md
@@ -1,36 +1,41 @@
 ---
 name: 🌐 Translating a new language?
 about: Start a new translation effort in your language
-title: '[i18n-<languageCode>] Translating docs to <languageName>'
+title: '🌐 [i18n-LANGCODE] Translating docs to LANGUAGE'
 labels: WIP
 assignees: ''
 
 ---
 
 <!--
-Note: Please search to see if an issue already exists for the language you are trying to translate.
+*IMPORTANT*
+Please search to see if an issue already exists for the language you are trying to translate.
+Once you are clear, please replace all LANGUAGE (-> plain English) and LANGCODE (-> 2 letter acronym) placeholders including this issue's title.
+The corresponding LANGCODE (ISO 639-1) for your language can be found here: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+For example- for Korean- LANGUAGE would be 'Korean' and LANGCODE would be 'KO'.
 -->
 
 Hi!
 
-Let's bring the documentation to all the <languageName>-speaking community 🌐 (currently 0 out of 267 complete)
+Let's bring the documentation to all of the LANGUAGE-speaking community 🌐 (currently 0 out of 267 complete)
 
-Who would want to translate? Please follow the 🤗 [TRANSLATING guide](https://github.com/huggingface/transformers/blob/main/docs/TRANSLATING.md). Here is a list of the files ready for translation. Let us know in this issue if you'd like to translate any, and we'll add your name to the list.
+Would you like to translate? Please follow the 🤗 [TRANSLATING guide](https://github.com/huggingface/transformers/blob/main/docs/TRANSLATING.md). Here is a list of the files ready for translation. Let us know in this issue if you'd like to translate any, and we'll add your name to the list.
 
 Some notes:
 
 * Please translate using an informal tone (imagine you are talking with a friend about transformers 🤗).
 * Please translate in a gender-neutral way.
-* Add your translations to the folder called `<languageCode>` inside the [source folder](https://github.com/huggingface/transformers/tree/main/docs/source).
-* Register your translation in `<languageCode>/_toctree.yml`; please follow the order of the [English version](https://github.com/huggingface/transformers/blob/main/docs/source/en/_toctree.yml).
+* Add your translations to the folder called `LANGCODE` inside the [source folder](https://github.com/huggingface/transformers/tree/main/docs/source).
+* Register your translation in `LANGCODE/_toctree.yml`; please follow the order of the [English version](https://github.com/huggingface/transformers/blob/main/docs/source/en/_toctree.yml).
 * Once you're finished, open a pull request and tag this issue by including #issue-number in the description, where issue-number is the number of this issue. Please ping @ArthurZucker, @sgugger for review.
 * 🙋 If you'd like others to help you with the translation, you can also post in the 🤗 [forums](https://discuss.huggingface.co/).
 
-## Get Started section
+<!-- Bonus points if you could translate the above to fit your language. -->
 
-- [ ] [index.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/index.mdx) https://github.com/huggingface/transformers/pull/20180
-- [ ] [quicktour.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/quicktour.mdx) (waiting for initial PR to go through)
-- [ ] [installation.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/installation.mdx).
+## Get Started section
+- [ ] [index.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/index.mdx)
+- [ ] [quicktour.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/quicktour.mdx)
+- [ ] [installation.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/installation.mdx)
 
 ## Tutorial section
 - [ ] [pipeline_tutorial.mdx](https://github.com/huggingface/transformers/blob/main/docs/source/en/pipeline_tutorial.mdx)


### PR DESCRIPTION
# What does this PR do?

The initial issue template (https://github.com/huggingface/transformers/pull/20199) includes minor typos and a closed PR link.
It makes it seem that the index page of a new language is already translated when it isn't.
Also some comment regarding what `langCode` or `langName` is would be helpful.

[x] Fixed typos.
[x] Removed irrelevant PR link.
[x] Explained what `langCode` or `langName` is more easily. (Replaced it rather)

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/20955


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
May you please review this PR, @sgugger?