### PR TITLE
Make the attention_head_size in distilbert an object attribute

### DIFF
--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -158,7 +158,9 @@ class MultiHeadSelfAttention(nn.Module):
     def prune_heads(self, heads: List[int]):
         if len(heads) == 0:
             return
-        heads, index = find_pruneable_heads_and_indices(heads, self.n_heads, self.attention_head_size, self.pruned_heads)
+        heads, index = find_pruneable_heads_and_indices(
+            heads, self.n_heads, self.attention_head_size, self.pruned_heads
+        )
         # Prune linear layers
         self.q_lin = prune_linear_layer(self.q_lin, index)
         self.k_lin = prune_linear_layer(self.k_lin, index)

--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -153,12 +153,12 @@ class MultiHeadSelfAttention(nn.Module):
         self.out_lin = nn.Linear(in_features=config.dim, out_features=config.dim)
 
         self.pruned_heads: Set[int] = set()
+        self.attention_head_size = self.dim // self.n_heads
 
     def prune_heads(self, heads: List[int]):
-        attention_head_size = self.dim // self.n_heads
         if len(heads) == 0:
             return
-        heads, index = find_pruneable_heads_and_indices(heads, self.n_heads, attention_head_size, self.pruned_heads)
+        heads, index = find_pruneable_heads_and_indices(heads, self.n_heads, self.attention_head_size, self.pruned_heads)
         # Prune linear layers
         self.q_lin = prune_linear_layer(self.q_lin, index)
         self.k_lin = prune_linear_layer(self.k_lin, index)
@@ -166,7 +166,7 @@ class MultiHeadSelfAttention(nn.Module):
         self.out_lin = prune_linear_layer(self.out_lin, index, dim=1)
         # Update hyper params
         self.n_heads = self.n_heads - len(heads)
-        self.dim = attention_head_size * self.n_heads
+        self.dim = self.attention_head_size * self.n_heads
         self.pruned_heads = self.pruned_heads.union(heads)
 
     def forward(


### PR DESCRIPTION
# What does this PR do?

It simply moves the attention_head_size in the distilbert model to be an object attribute. This is necessary if you want to use the Distilbert model in the nn_pruning library. It will also benefit anyone who ever needs to access the attention_head_size attribute from an instance of a Distilbert model. This change is consistent with other transformer models in this library (see BERT https://github.com/huggingface/transformers/blob/main/src/transformers/models/bert/modeling_bert.py#L253 or BART https://github.com/huggingface/transformers/blob/main/src/transformers/models/bart/modeling_bart.py#L157)