### PR TITLE
Exclude the madeup words from M2M100Tokenizer.vocab_size

### DIFF
--- a/src/transformers/models/m2m_100/tokenization_m2m_100.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100.py
@@ -193,7 +193,7 @@ class M2M100Tokenizer(PreTrainedTokenizer):
 
     @property
     def vocab_size(self) -> int:
-        return len(self.encoder) + len(self.lang_token_to_id) + self.num_madeup_words
+        return len(self.encoder) + len(self.lang_token_to_id)
 
     @property
     def src_lang(self) -> str:

--- a/tests/models/m2m_100/test_tokenization_m2m_100.py
+++ b/tests/models/m2m_100/test_tokenization_m2m_100.py
@@ -84,15 +84,13 @@ class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(self.get_tokenizer()._convert_id_to_token(token_id), token)
 
     def test_get_vocab(self):
-        vocab_keys = list(self.get_tokenizer().get_vocab().keys())
+        tokenizer = self.get_tokenizer()
+        vocab_keys = list(tokenizer.get_vocab().keys())
 
         self.assertEqual(vocab_keys[0], "</s>")
         self.assertEqual(vocab_keys[1], "<unk>")
         self.assertEqual(vocab_keys[-1], "<s>")
-        self.assertEqual(len(vocab_keys), 110)
-
-    def test_vocab_size(self):
-        self.assertEqual(self.get_tokenizer().vocab_size, 117)
+        self.assertEqual(len(vocab_keys), tokenizer.vocab_size + len(tokenizer.get_added_vocab()))
 
     @unittest.skip("Skip this test while all models are still to be uploaded.")
     def test_pretrained_model_lists(self):
@@ -161,7 +159,10 @@ class M2M100TokenizerIntegrationTest(unittest.TestCase):
         self.assertEqual(self.tokenizer.get_lang_id("mr"), 128063)
 
     def test_get_vocab(self):
-        self.assertIn(self.tokenizer.get_lang_token("en"), self.tokenizer.get_vocab())
+        vocab = self.tokenizer.get_vocab()
+        self.assertEqual(len(vocab), self.tokenizer.vocab_size)
+        self.assertEqual(vocab["<unk>"], 3)
+        self.assertIn(self.tokenizer.get_lang_token("en"), vocab)
 
     def test_tokenizer_batch_encode_plus(self):
         self.tokenizer.src_lang = "en"


### PR DESCRIPTION
# What does this PR do?

The `<unk>` token has an incorrect ID in `M2M100Tokenizer.get_vocab`:

```python
>>> tokenizer = transformers.M2M100Tokenizer.from_pretrained("facebook/m2m100_418M")
>>> tokenizer.convert_tokens_to_ids("<unk>")
3
>>> tokenizer.get_vocab()["<unk>"]
128111
```

The reason is the vocabulary is defined like this:

```
vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
```

but `_convert_id_to_token` converts the "madeup words" to `<unk>`.

We can fix this issue by excluding the "madeup words" from the vocabulary size, which is consistent with how other tokenizers work such as `NllbTokenizer`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker