### PR TITLE
Avoid CI runs under users' own CircleCI personal account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
                 if [ "$CIRCLE_PROJECT_USERNAME" = "huggingface" ]; then
                     exit 0
                 else
-                    echo "The CI is running under the $CIRCLE_PROJECT_USERNAME personal account. Please following https://support.circleci.com/hc/en-us/articles/360008097173-Troubleshooting-why-pull-requests-are-not-triggering-jobs-on-my-organization- to fix it."; exit -1
+                    echo "The CI is running under the $CIRCLE_PROJECT_USERNAME personal account. Please follow https://support.circleci.com/hc/en-us/articles/360008097173-Troubleshooting-why-pull-requests-are-not-triggering-jobs-on-my-organization- to fix it."; exit -1
                 fi
     # Fetch the tests to run
     fetch_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
                 if [ "$CIRCLE_PROJECT_USERNAME" = "huggingface" ]; then
                     exit 0
                 else
-                    exit -1
+                    echo "The CI is running under the $CIRCLE_PROJECT_USERNAME personal account. Please following https://support.circleci.com/hc/en-us/articles/360008097173-Troubleshooting-why-pull-requests-are-not-triggering-jobs-on-my-organization- to fix it."; exit -1
                 fi
     # Fetch the tests to run
     fetch_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
                 if [ "$CIRCLE_PROJECT_USERNAME" = "huggingface" ]; then
                     exit 0
                 else
-                    echo "The CI is running under the $CIRCLE_PROJECT_USERNAME personal account. Please follow https://support.circleci.com/hc/en-us/articles/360008097173-Troubleshooting-why-pull-requests-are-not-triggering-jobs-on-my-organization- to fix it."; exit -1
+                    echo "The CI is running under $CIRCLE_PROJECT_USERNAME personal account. Please follow https://support.circleci.com/hc/en-us/articles/360008097173-Troubleshooting-why-pull-requests-are-not-triggering-jobs-on-my-organization- to fix it."; exit -1
                 fi
     # Fetch the tests to run
     fetch_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,19 @@ parameters:
         default: false
 
 jobs:
+    # Ensure running with CircleCI/huggingface
+    check_circle_user:
+        docker:
+            - image: cimg/python:3.7.12
+        parallelism: 1
+        steps:
+            - run: echo $CIRCLE_PROJECT_USERNAME
+            - run: |
+                if [ "$CIRCLE_PROJECT_USERNAME" = "huggingface" ]; then
+                    exit 0
+                else
+                    exit -1
+                fi
     # Fetch the tests to run
     fetch_tests:
         working_directory: ~/transformers
@@ -171,13 +184,15 @@ workflows:
         when:
             not: <<pipeline.parameters.nightly>>
         jobs:
-            - check_code_quality
-            - check_repository_consistency
-            - fetch_tests
+            - check_circle_user
+#            - check_code_quality
+#            - check_repository_consistency
+#            - fetch_tests
 
     nightly:
         when: <<pipeline.parameters.nightly>>
         jobs:
+            - check_circle_user
             - check_code_quality
             - check_repository_consistency
             - fetch_all_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
 
 jobs:
     # Ensure running with CircleCI/huggingface
-    check_circle_user:
+    check_circleci_user:
         docker:
             - image: cimg/python:3.7.12
         parallelism: 1
@@ -184,7 +184,7 @@ workflows:
         when:
             not: <<pipeline.parameters.nightly>>
         jobs:
-            - check_circle_user
+            - check_circleci_user
             - check_code_quality
             - check_repository_consistency
             - fetch_tests
@@ -192,7 +192,7 @@ workflows:
     nightly:
         when: <<pipeline.parameters.nightly>>
         jobs:
-            - check_circle_user
+            - check_circleci_user
             - check_code_quality
             - check_repository_consistency
             - fetch_all_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,9 @@ workflows:
             not: <<pipeline.parameters.nightly>>
         jobs:
             - check_circle_user
-#            - check_code_quality
-#            - check_repository_consistency
-#            - fetch_tests
+            - check_code_quality
+            - check_repository_consistency
+            - fetch_tests
 
     nightly:
         when: <<pipeline.parameters.nightly>>


### PR DESCRIPTION
# What does this PR do?

Sometimes the tests will run in the CircleCI of the user and not run our tests since they don't have access to our resources. One example is on [this PR](https://github.com/huggingface/transformers/pull/20479#issuecomment-1369690668) where the "real" tests were not run.

**We can make the new job `check_circleci_user` required (too) - once this PR is merged into `main`**