### PR TITLE
Added mask_time_prob and mask_time_length arguments to wav2vec2 pretraining script

### DIFF
--- a/examples/pytorch/speech-pretraining/README.md
+++ b/examples/pytorch/speech-pretraining/README.md
@@ -79,6 +79,8 @@ accelerate launch run_wav2vec2_pretraining_no_trainer.py \
 	--adam_beta2="0.98" \
 	--adam_epsilon="1e-06" \
 	--gradient_checkpointing \
+	--mask_time_prob="0.65" \
+	--mask_time_length="10"
 ```
 
 The results of this run can be seen [here](https://wandb.ai/patrickvonplaten/wav2vec2-pretrained-demo/reports/Wav2Vec2-PreTraining-Demo-Run--VmlldzoxMDk3MjAw?accessToken=oa05s1y57lizo2ocxy3k01g6db1u4pt8m6ur2n8nl4cb0ug02ms2cw313kb8ruch).
@@ -110,6 +112,8 @@ accelerate launch run_wav2vec2_pretraining_no_trainer.py \
 	--adam_beta2="0.98" \
 	--adam_epsilon="1e-06" \
 	--gradient_checkpointing \
+	--mask_time_prob="0.65" \
+	--mask_time_length="10"
 ```
 
 The experiment was run on 8 GPU V100 (16 GB RAM each) for 4 days. 
@@ -146,6 +150,8 @@ accelerate launch run_wav2vec2_pretraining_no_trainer.py \
 	--adam_beta2=0.98 \
 	--adam_epsilon=1e-06 \
 	--gradient_checkpointing \
+	--mask_time_prob=0.65 \
+	--mask_time_length=10
 ```
 
 The experiment was run on 8 GPU V100 (16 GB RAM each) for 7 days. 


### PR DESCRIPTION
This PR relates to [PR 19997](https://github.com/huggingface/transformers/pull/19997), in which I messed up the PR by forgetting the --force flag when pushing. Hopefully this PR is correctly performed.

@sanchit-gandhi @sgugger @patrickvonplaten 