### PR TITLE
Fix (DeepSpeed) docker image build issue

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -115,8 +115,6 @@ jobs:
   # Can't build 2 images in a single job `latest-torch-deepspeed-docker` (for `nvcr.io/nvidia`)
   latest-torch-deepspeed-docker-for-push-ci-daily-build:
     name: "Latest PyTorch + DeepSpeed (Push CI - Daily Build)"
-    # Can't run in parallel, otherwise get an error:
-    #   `Error response from daemon: Get "https://registry-1.docker.io/v2/": received unexpected HTTP status: 503 Service Unavailable`
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -117,7 +117,6 @@ jobs:
     name: "Latest PyTorch + DeepSpeed (Push CI - Daily Build)"
     # Can't run in parallel, otherwise get an error:
     #   `Error response from daemon: Get "https://registry-1.docker.io/v2/": received unexpected HTTP status: 503 Service Unavailable`
-    needs: latest-torch-deepspeed-docker
     runs-on: ubuntu-latest
     steps:
       -

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -27,6 +27,7 @@ RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com
 # recompile apex
 RUN python3 -m pip uninstall -y apex
 RUN git clone https://github.com/NVIDIA/apex
+# Use `MAX_JOBS=1` to avoid memory issue when building image on GitHub Action (standard) runners
 RUN cd apex && MAX_JOBS=1 python3 -m pip install --global-option="--cpp_ext" --global-option="--cuda_ext" --no-cache -v --disable-pip-version-check .
 
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -27,7 +27,7 @@ RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com
 # recompile apex
 RUN python3 -m pip uninstall -y apex
 RUN git clone https://github.com/NVIDIA/apex
-# Use `MAX_JOBS=1` to avoid memory issue when building image on GitHub Action (standard) runners
+#  `MAX_JOBS=1` disables parallel building to avoid cpu memory OOM when building image on GitHub Action (standard) runners
 RUN cd apex && MAX_JOBS=1 python3 -m pip install --global-option="--cpp_ext" --global-option="--cuda_ext" --no-cache -v --disable-pip-version-check .
 
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -27,7 +27,7 @@ RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com
 # recompile apex
 RUN python3 -m pip uninstall -y apex
 RUN git clone https://github.com/NVIDIA/apex
-RUN cd apex && python3 -m pip install --global-option="--cpp_ext" --global-option="--cuda_ext" --no-cache -v --disable-pip-version-check .
+RUN cd apex && MAX_JOBS=1 python3 -m pip install --global-option="--cpp_ext" --global-option="--cuda_ext" --no-cache -v --disable-pip-version-check .
 
 # Pre-build **latest** DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)
 RUN python3 -m pip uninstall -y deepspeed


### PR DESCRIPTION
# What does this PR do?

Currently, the docker image build job [Latest PyTorch + DeepSpeed](https://github.com/huggingface/transformers/actions/runs/3834393836/jobs/6526754769) from time to time. The issue occurs after #20788 where `apex` is recompiled during the build. It seems a resource issue (most likely the memory issue) due to the parallel build (multiple worker). So set `MAX_JOB=1` to avoid the failure.

This will increase the build time to `1h30m`, but we have to build 2 same image (for daily CI and push CI), therefore 3h, and this is way too long. Previously those 2 images are built sequentially due to some issue, but now it seems the issue is gone and we can build them in parallel.