### PR TITLE
Fix `test_run_seq2seq_bnb` CI

### DIFF
--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -202,6 +202,7 @@ class TestTrainerExt(TestCasePlus):
         assert "predict_results.json" in contents
 
     @slow
+    @require_torch_multi_gpu
     @require_bitsandbytes
     def test_run_seq2seq_bnb(self):
         from transformers.training_args import OptimizerNames


### PR DESCRIPTION
# What does this PR do?

Fix `test_run_seq2seq_bnb` CI. See [failed job run](https://github.com/huggingface/transformers/actions/runs/3834635537/jobs/6527258225)

It seems the expected reduced GPU memory usage only happens when running the test on multi GPU env.
I simply add `require_torch_multi_gpu` without trying to understand why it fails with single GPU env.

I can try to figure it out, but the probability that @stas00 knows the reason > 1.0, so I would like to see if he has any comment first.

Error
```
tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_bnb
(line 256)  AssertionError: -0.0023021928988980356 not greater than 10 : should use very little peak gpu memory with BNB, compared to without itbut got gpu_peak_mem_orig=509447168 and gpu_peak_mem_bnb=510622720
```