### PR TITLE
[NumPy] Remove references to deprecated NumPy type aliases

### DIFF
--- a/examples/legacy/seq2seq/utils.py
+++ b/examples/legacy/seq2seq/utils.py
@@ -371,7 +371,7 @@ def sortish_sampler_indices(data: List, bs: int, shuffle=True) -> np.array:
     ck_idx = [sort_idx[i : i + sz] for i in range(0, len(sort_idx), sz)]
     max_ck = np.argmax([key_fn(ck[0]) for ck in ck_idx])  # find the chunk with the largest key,
     ck_idx[0], ck_idx[max_ck] = ck_idx[max_ck], ck_idx[0]  # then make sure it goes first.
-    sort_idx = np.concatenate(np.random.permutation(ck_idx[1:])) if len(ck_idx) > 1 else np.array([], dtype=np.int)
+    sort_idx = np.concatenate(np.random.permutation(ck_idx[1:])) if len(ck_idx) > 1 else np.array([], dtype=int)
     sort_idx = np.concatenate((ck_idx[0], sort_idx))
     return sort_idx
 

--- a/examples/pytorch/benchmarking/plot_csv_file.py
+++ b/examples/pytorch/benchmarking/plot_csv_file.py
@@ -132,7 +132,7 @@ class Plot:
                 if self.args.plot_along_batch:
                     y_axis_array = np.asarray(
                         [results[(x, inner_loop_value)] for x in x_axis_array if (x, inner_loop_value) in results],
-                        dtype=np.int,
+                        dtype=int,
                     )
                 else:
                     y_axis_array = np.asarray(
@@ -144,7 +144,7 @@ class Plot:
                     ("batch_size", "len") if self.args.plot_along_batch else ("in #tokens", "bsz")
                 )
 
-                x_axis_array = np.asarray(x_axis_array, np.int)[: len(y_axis_array)]
+                x_axis_array = np.asarray(x_axis_array, int)[: len(y_axis_array)]
                 plt.scatter(
                     x_axis_array, y_axis_array, label=f"{label_model_name} - {inner_loop_label}: {inner_loop_value}"
                 )

--- a/examples/research_projects/seq2seq-distillation/utils.py
+++ b/examples/research_projects/seq2seq-distillation/utils.py
@@ -353,7 +353,7 @@ def sortish_sampler_indices(data: List, bs: int, shuffle=True) -> np.array:
     ck_idx = [sort_idx[i : i + sz] for i in range(0, len(sort_idx), sz)]
     max_ck = np.argmax([key_fn(ck[0]) for ck in ck_idx])  # find the chunk with the largest key,
     ck_idx[0], ck_idx[max_ck] = ck_idx[max_ck], ck_idx[0]  # then make sure it goes first.
-    sort_idx = np.concatenate(np.random.permutation(ck_idx[1:])) if len(ck_idx) > 1 else np.array([], dtype=np.int)
+    sort_idx = np.concatenate(np.random.permutation(ck_idx[1:])) if len(ck_idx) > 1 else np.array([], dtype=int)
     sort_idx = np.concatenate((ck_idx[0], sort_idx))
     return sort_idx
 

--- a/examples/tensorflow/benchmarking/plot_csv_file.py
+++ b/examples/tensorflow/benchmarking/plot_csv_file.py
@@ -132,7 +132,7 @@ class Plot:
                 if self.args.plot_along_batch:
                     y_axis_array = np.asarray(
                         [results[(x, inner_loop_value)] for x in x_axis_array if (x, inner_loop_value) in results],
-                        dtype=np.int,
+                        dtype=int,
                     )
                 else:
                     y_axis_array = np.asarray(
@@ -144,7 +144,7 @@ class Plot:
                     ("batch_size", "len") if self.args.plot_along_batch else ("in #tokens", "bsz")
                 )
 
-                x_axis_array = np.asarray(x_axis_array, np.int)[: len(y_axis_array)]
+                x_axis_array = np.asarray(x_axis_array, int)[: len(y_axis_array)]
                 plt.scatter(
                     x_axis_array, y_axis_array, label=f"{label_model_name} - {inner_loop_label}: {inner_loop_value}"
                 )


### PR DESCRIPTION
This change replaces references to a number of deprecated NumPy type aliases (np.bool, np.int, np.float, np.complex, np.object, np.str) with their recommended replacement (bool, int, float, complex, object, str).

NumPy 1.24 drops the deprecated aliases, so we must remove uses before updating NumPy.

See huggingface/diffusers#1810 for a similar issue in diffusers.

Co-authored-by: Peter Hawkins <phawkins@google.com>