### PR TITLE
Fix arguments passed to predict function in QA Seq2seq training script

### DIFF
--- a/examples/pytorch/question-answering/trainer_seq2seq_qa.py
+++ b/examples/pytorch/question-answering/trainer_seq2seq_qa.py
@@ -151,7 +151,7 @@ class QuestionAnsweringSeq2SeqTrainer(Seq2SeqTrainer):
         if self.post_process_function is None or self.compute_metrics is None:
             return output
 
-        predictions = self.post_process_function(predict_examples, predict_dataset, output.predictions, "predict")
+        predictions = self.post_process_function(predict_examples, predict_dataset, output, "predict")
         metrics = self.compute_metrics(predictions)
 
         # Prefix all keys with metric_key_prefix + '_'


### PR DESCRIPTION
# What does this PR do?

I used the script for training Seq2seq QA and realized that `--do_predict` contains a bug - kwarg `outputs` should be an instance of class `EvalLoopOutput`, but NumPy array is passed instead. Together with extracting predictions in the body of the method `post_processing_function`  (line 610 in run_seq2seq_qa.py) this results in an error every time you try to run tests with this script.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@karthikrangasai @sgugger

