### PR TITLE
[bnb optim] fixing test

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1044,10 +1044,14 @@ class Trainer:
 
                     manager = bitsandbytes.optim.GlobalOptimManager.get_instance()
 
+                    skipped = 0
                     for module in opt_model.modules():
                         if isinstance(module, nn.Embedding):
+                            skipped += sum(dict((p.data_ptr(), p.numel()) for p in module.parameters()).values())
+                            print(f"skipped {module}: {skipped/2**20}M params")
                             manager.register_module_override(module, "weight", {"optim_bits": 32})
                             logger.debug(f"bitsandbytes: will optimize {module} in fp32")
+                    print(f"skipped: {skipped/2**20}M params")
 
         if is_sagemaker_mp_enabled():
             self.optimizer = smp.DistributedOptimizer(self.optimizer)

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -234,7 +234,6 @@ class TestTrainerExt(TestCasePlus):
         gpu_peak_mem_bnb, gpu_alloc_mem_bnb, loss_bnb = train_and_return_metrics(OptimizerNames.ADAMW_BNB.value)
 
         gpu_alloc_mem_diff = gpu_alloc_mem_orig - gpu_alloc_mem_bnb
-        # gpu_peak_mem_diff = gpu_peak_mem_orig - gpu_peak_mem_bnb
 
         gpu_total_mem_orig = gpu_peak_mem_orig + gpu_alloc_mem_orig
         gpu_total_mem_bnb = gpu_peak_mem_bnb + gpu_alloc_mem_bnb
@@ -255,7 +254,8 @@ class TestTrainerExt(TestCasePlus):
         # that we have at least 120MB in savings
         expected_savings = 120
 
-        # leave this for now if CI gets very different results - requires py38 for a new print feature
+        # uncomment the following if this test starts failing - requires py38 for a new print feature
+        # gpu_peak_mem_diff = gpu_peak_mem_orig - gpu_peak_mem_bnb
         # print(f"{gpu_alloc_mem_orig=}MB {gpu_peak_mem_orig=}MB {gpu_alloc_mem_orig+gpu_peak_mem_orig=}MB")
         # print(f" {gpu_alloc_mem_bnb=}MB  {gpu_peak_mem_bnb=}MB  {gpu_alloc_mem_bnb+gpu_peak_mem_bnb=}MB")
         # print(f"{gpu_alloc_mem_diff=}MB")

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -274,9 +274,9 @@ class TestTrainerExt(TestCasePlus):
         self.assertGreater(
             gpu_total_mem_diff,
             expected_savings,
-            "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
-            f" a difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"
-            f" gpu_alloc_mem_bnb={gpu_total_mem_bnb}MB",
+            "should use ~150MB less total gpu memory with BNB, compared to without it for this model but got"
+            f" a difference of {gpu_total_mem_diff}MB, with gpu_total_mem_orig={gpu_total_mem_orig}MB and"
+            f" gpu_total_mem_bnb={gpu_total_mem_bnb}MB",
         )
 
         self.assertEqual(

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -220,7 +220,7 @@ class TestTrainerExt(TestCasePlus):
                 extra_args_str=extra_args,
                 do_eval=False,
                 do_predict=False,
-                n_gpus_to_use=1, # to allow deterministic fixed memory usage
+                n_gpus_to_use=1,  # to allow deterministic fixed memory usage
             )
 
             # Check metrics

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -272,7 +272,7 @@ class TestTrainerExt(TestCasePlus):
         )
 
         self.assertGreater(
-            gpu_alloc_mem_diff,
+            gpu_total_mem_diff,
             expected_savings,
             "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
             f" a difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -22,7 +22,6 @@ from typing import Tuple
 from unittest.mock import patch
 
 from parameterized import parameterized
-from transformers import AutoModel
 from transformers.testing_utils import (
     CaptureStderr,
     ExtendSysPath,
@@ -208,7 +207,7 @@ class TestTrainerExt(TestCasePlus):
         from transformers.training_args import OptimizerNames
 
         def train_and_return_metrics(optim: str) -> Tuple[int, float]:
-            extra_args = f"--skip_memory_metrics 0"
+            extra_args = "--skip_memory_metrics 0"
 
             output_dir = self.run_trainer(
                 max_len=128,
@@ -235,7 +234,7 @@ class TestTrainerExt(TestCasePlus):
         gpu_peak_mem_bnb, gpu_alloc_mem_bnb, loss_bnb = train_and_return_metrics(OptimizerNames.ADAMW_BNB.value)
 
         gpu_alloc_mem_diff = gpu_alloc_mem_orig - gpu_alloc_mem_bnb
-        gpu_peak_mem_diff = gpu_peak_mem_orig - gpu_peak_mem_bnb
+        # gpu_peak_mem_diff = gpu_peak_mem_orig - gpu_peak_mem_bnb
 
         gpu_total_mem_orig = gpu_peak_mem_orig + gpu_alloc_mem_orig
         gpu_total_mem_bnb = gpu_peak_mem_bnb + gpu_alloc_mem_bnb
@@ -249,7 +248,7 @@ class TestTrainerExt(TestCasePlus):
 
         # leave this for now if CI gets very different results - requires py38 for a new print feature
         # print(f"{gpu_alloc_mem_orig=}MB {gpu_peak_mem_orig=}MB {gpu_alloc_mem_orig+gpu_peak_mem_orig=}MB")
-        # print(f" {gpu_alloc_mem_bnb=}MB  {gpu_peak_mem_bnb=} MB  {gpu_alloc_mem_bnb+gpu_peak_mem_bnb=}MB")
+        # print(f" {gpu_alloc_mem_bnb=}MB  {gpu_peak_mem_bnb=}MB  {gpu_alloc_mem_bnb+gpu_peak_mem_bnb=}MB")
         # print(f"{gpu_alloc_mem_diff=}MB")
         # print(f"{gpu_peak_mem_diff=}MB")
         # print(f"{gpu_total_mem_orig=}MB, {gpu_total_mem_bnb=}MB")
@@ -355,7 +354,7 @@ class TestTrainerExt(TestCasePlus):
         if distributed:
 
             if n_gpus_to_use is None:
-                n_gpu_to_use = get_gpu_count()
+                n_gpus_to_use = get_gpu_count()
             master_port = get_torch_dist_unique_port()
             distributed_args = f"""
                 -m torch.distributed.launch

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -247,13 +247,13 @@ class TestTrainerExt(TestCasePlus):
         # thus we should expect ~300MB total memory saved.
         # peak memory can be the same - but the total should be different by about that margin
 
-        # leave this for now if CI gets very different results
-        print(f"{gpu_alloc_mem_orig=}MB {gpu_peak_mem_orig=}MB {gpu_alloc_mem_orig+gpu_peak_mem_orig=}MB")
-        print(f" {gpu_alloc_mem_bnb=}MB  {gpu_peak_mem_bnb=} MB  {gpu_alloc_mem_bnb+gpu_peak_mem_bnb=}MB")
-        print(f"{gpu_alloc_mem_diff=}MB")
-        print(f"{gpu_peak_mem_diff=}MB")
-        print(f"{gpu_total_mem_orig=}MB, {gpu_total_mem_bnb=}MB")
-        print(f"{gpu_total_mem_diff=}MB, {gpu_total_mem_diff=}MB")
+        # leave this for now if CI gets very different results - requires py38 for a new print feature
+        # print(f"{gpu_alloc_mem_orig=}MB {gpu_peak_mem_orig=}MB {gpu_alloc_mem_orig+gpu_peak_mem_orig=}MB")
+        # print(f" {gpu_alloc_mem_bnb=}MB  {gpu_peak_mem_bnb=} MB  {gpu_alloc_mem_bnb+gpu_peak_mem_bnb=}MB")
+        # print(f"{gpu_alloc_mem_diff=}MB")
+        # print(f"{gpu_peak_mem_diff=}MB")
+        # print(f"{gpu_total_mem_orig=}MB, {gpu_total_mem_bnb=}MB")
+        # print(f"{gpu_total_mem_diff=}MB, {gpu_total_mem_diff=}MB")
 
         self.assertGreater(
             gpu_alloc_mem_diff,

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -240,15 +240,18 @@ class TestTrainerExt(TestCasePlus):
         gpu_total_mem_bnb = gpu_peak_mem_bnb + gpu_alloc_mem_bnb
         gpu_total_mem_diff = gpu_total_mem_orig - gpu_total_mem_bnb
 
-        # sshleifer/student_marian_en_ro_6_1 is 54M params, 29M of which is nn.Embedding which
-        # doesn't get quantized and remains in fp32. Therefore we only have 25M params quantized in 2 bytes
-        # therefore the diff in optim memory usage:
-        # - normal 25*8=~200MB (8 bytes per param)
-        # - bnb    25*2=~50MB (2 bytes per param)
-        # thus we should expect ~150MB total memory saved.
-        # peak memory should be the same - the total should be different by about that same margin
+        # sshleifer/student_marian_en_ro_6_1 has 54M parameter, 29M of which is `nn.Embedding` which
+        # doesn't get quantized and remains in fp32. Therefore we only have 25M parameters quantized
+        # in 2 bytes and the diff in optim memory usage is derived as so:
         #
-        # thus after leaving a small margin to accommodate for differences between gpus let's check
+        # - normal 25*8=~200MB (8 bytes per param)
+        # - bnb    25*2= ~50MB (2 bytes per param)
+        #
+        # Thus we should expect ~150MB total memory saved.
+        #
+        # Peak memory should be the same - the total should be different by about that same margin
+        #
+        # After leaving a small margin to accommodate for differences between gpus let's check
         # that we have at least 120MB in savings
         expected_savings = 120
 
@@ -264,7 +267,7 @@ class TestTrainerExt(TestCasePlus):
             gpu_alloc_mem_diff,
             expected_savings,
             "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
-            f"a difference of {gpu_alloc_mem_diff}MB, with gpu_alloc_mem_orig={gpu_alloc_mem_orig}MB and"
+            f" a difference of {gpu_alloc_mem_diff}MB, with gpu_alloc_mem_orig={gpu_alloc_mem_orig}MB and"
             f" gpu_alloc_mem_bnb={gpu_alloc_mem_bnb}MB",
         )
 
@@ -272,7 +275,7 @@ class TestTrainerExt(TestCasePlus):
             gpu_alloc_mem_diff,
             expected_savings,
             "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
-            f"a difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"
+            f" a difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"
             f" gpu_alloc_mem_bnb={gpu_total_mem_bnb}MB",
         )
 

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -240,11 +240,17 @@ class TestTrainerExt(TestCasePlus):
         gpu_total_mem_bnb = gpu_peak_mem_bnb + gpu_alloc_mem_bnb
         gpu_total_mem_diff = gpu_total_mem_orig - gpu_total_mem_bnb
 
-        # sshleifer/student_marian_en_ro_6_1 is 54M params, so optim memory usage:
-        # - normal 54*8=~400MB (8 bytes per param)
-        # - bnb    54*2=~100MB (2 bytes per param)
-        # thus we should expect ~300MB total memory saved.
-        # peak memory can be the same - but the total should be different by about that margin
+        # sshleifer/student_marian_en_ro_6_1 is 54M params, 29M of which is nn.Embedding which
+        # doesn't get quantized and remains in fp32. Therefore we only have 25M params quantized in 2 bytes
+        # therefore the diff in optim memory usage:
+        # - normal 25*8=~200MB (8 bytes per param)
+        # - bnb    25*2=~50MB (2 bytes per param)
+        # thus we should expect ~150MB total memory saved.
+        # peak memory should be the same - the total should be different by about that same margin
+        #
+        # thus after leaving a small margin to accommodate for differences between gpus let's check
+        # that we have at least 120MB in savings
+        expected_savings = 120
 
         # leave this for now if CI gets very different results - requires py38 for a new print feature
         # print(f"{gpu_alloc_mem_orig=}MB {gpu_peak_mem_orig=}MB {gpu_alloc_mem_orig+gpu_peak_mem_orig=}MB")
@@ -256,17 +262,17 @@ class TestTrainerExt(TestCasePlus):
 
         self.assertGreater(
             gpu_alloc_mem_diff,
-            100,
-            "should use <200MB less alloc gpu memory with BNB, compared to without it for this modelbut got"
-            f" difference of {gpu_alloc_mem_diff}MB, with gpu_alloc_mem_orig={gpu_alloc_mem_orig}MB and"
+            expected_savings,
+            "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
+            f"a difference of {gpu_alloc_mem_diff}MB, with gpu_alloc_mem_orig={gpu_alloc_mem_orig}MB and"
             f" gpu_alloc_mem_bnb={gpu_alloc_mem_bnb}MB",
         )
 
         self.assertGreater(
-            gpu_total_mem_diff,
-            100,
-            "should use <200MB less alloc gpu memory with BNB, compared to without it for this modelbut got"
-            f" difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"
+            gpu_alloc_mem_diff,
+            expected_savings,
+            "should use ~150MB less alloc gpu memory with BNB, compared to without it for this model but got"
+            f"a difference of {gpu_total_mem_diff}MB, with gpu_alloc_mem_orig={gpu_total_mem_orig}MB and"
             f" gpu_alloc_mem_bnb={gpu_total_mem_bnb}MB",
         )
 

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -220,6 +220,7 @@ class TestTrainerExt(TestCasePlus):
                 extra_args_str=extra_args,
                 do_eval=False,
                 do_predict=False,
+                n_gpus_to_use=1, # to allow deterministic fixed memory usage
             )
 
             # Check metrics
@@ -288,6 +289,7 @@ class TestTrainerExt(TestCasePlus):
         do_train: bool = True,
         do_eval: bool = True,
         do_predict: bool = True,
+        n_gpus_to_use: int = None,
     ):
         data_dir = self.test_file_dir / "../fixtures/tests_samples/wmt_en_ro"
         output_dir = self.get_auto_remove_tmp_dir()
@@ -351,11 +353,13 @@ class TestTrainerExt(TestCasePlus):
             args += extra_args_str.split()
 
         if distributed:
-            n_gpu = get_gpu_count()
+
+            if n_gpus_to_use is None:
+                n_gpu_to_use = get_gpu_count()
             master_port = get_torch_dist_unique_port()
             distributed_args = f"""
                 -m torch.distributed.launch
-                --nproc_per_node={n_gpu}
+                --nproc_per_node={n_gpus_to_use}
                 --master_port={master_port}
                 {self.examples_dir_str}/pytorch/translation/run_translation.py
             """.split()


### PR DESCRIPTION
**Note to reviewers: we are dealing with a slow test, so a green CI doesn't tell anything.**

This work is a continuation of https://github.com/huggingface/transformers/pull/21019 where this test failure was first reported by @ydshieh 

This PR:

- extends/improves the `run_trainer` wrapper which simplifies the bnb test
- drops the percentage-based asserts as those are quite meaningless - since they don't measure the memory used by the optimizer but the whole memory - it replaces them with the actual calculated saved memory expectation since we know exactly what the saved memory should be for a particular model. it's `6*params` bytes but not for `nn.Embedding` which gets fp32 - so let's measure that carefully. 

https://github.com/huggingface/transformers/blob/35a7052b61579cfe8df1a059d4cd3359310ec2d1/src/transformers/trainer.py#L1042-L1050

- drops the peak gpu memory comparison since on its own it's totally meaningless, in my testing I get both optims produce the same peak memory - what we care about is the total gpu memory.
- forces 1 gpu - so that the gpu memory usage is the same in all environments, to support 2+ gpus we need to have a different threshold for each - except this is totally unncessary
- switches to MBs everywhere, so it's much easier to debug 

Now, the test should be very deterministic on any gpu/platform. I still gave a small margin for differences.

You can read my notes in the test for the exact math.

@ydshieh. please verify it works on the CI and we will then merge it. Thank you!