### PR TITLE
feature: update wandb callback to upload checkpoints

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -664,7 +664,7 @@ class WandbCallback(TrainerCallback):
         Setup the optional Weights & Biases (*wandb*) integration.
 
         One can subclass and override this method to customize the setup if needed. Find more information
-        [here](https://docs.wandb.ai/integrations/huggingface). You can also override the following environment
+        [here](https://docs.wandb.ai/guides/integrations/huggingface). You can also override the following environment
         variables:
 
         Environment:

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -681,11 +681,11 @@ class WandbCallback(TrainerCallback):
             to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the checkpoint
             will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be uploaded. Use along
             with [`~transformers.TrainingArguments.load_best_model_at_end`] to upload best model.
-            
+
             <Deprecated version="5.0">
-            
+
             Setting `WANDB_LOG_MODEL` as `bool` will be deprecated in version 5 of 🤗 Transformers.
-            
+
             </Deprecated>
         - **WANDB_WATCH** (`str`, *optional* defaults to `"false"`):
             Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -677,12 +677,11 @@ class WandbCallback(TrainerCallback):
 
         Environment:
         - **WANDB_LOG_MODEL** (`str`, *optional*, defaults to `"false"`):
-            Whether to log model and checkpoints during training. Can be `"end"`, `"checkpoint"` or `"false"`.
-            If set to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the
-            checkpoint will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be
-            uploaded. Use along with *TrainingArguments.load_best_model_at_end* to upload best model.
-            *Warning*: Setting `WANDB_LOG_MODEL` as `bool` is deprecated and will be removed in future
-            versions.
+            Whether to log model and checkpoints during training. Can be `"end"`, `"checkpoint"` or `"false"`. If set
+            to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the checkpoint
+            will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be uploaded. Use along
+            with *TrainingArguments.load_best_model_at_end* to upload best model. *Warning*: Setting `WANDB_LOG_MODEL`
+            as `bool` is deprecated and will be removed in future versions.
         - **WANDB_WATCH** (`str`, *optional* defaults to `"false"`):
             Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and
             parameters.

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -644,7 +644,7 @@ class TensorBoardCallback(TrainerCallback):
 
 class WandbCallback(TrainerCallback):
     """
-    A [`TrainerCallback`] that sends the logs to [Weight and Biases](https://www.wandb.com/).
+    A [`TrainerCallback`] that logs metrics, media, model checkpoints to [Weight and Biases](https://www.wandb.com/).
     """
 
     def __init__(self):

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -714,10 +714,9 @@ class WandbCallback(TrainerCallback):
                 self._wandb.define_metric("*", step_metric="train/global_step", step_sync=True)
 
             # keep track of model topology and gradients, unsupported on TPU
-            if not is_torch_tpu_available() and os.getenv("WANDB_WATCH") != "false":
-                self._wandb.watch(
-                    model, log=os.getenv("WANDB_WATCH", "gradients"), log_freq=max(100, args.logging_steps)
-                )
+            _watch_model = os.getenv("WANDB_WATCH", "false")
+            if not is_torch_tpu_available() and _watch_model in ("all", "parameters", "gradients"):
+                self._wandb.watch(model, log=_watch_model, log_freq=max(100, args.logging_steps))
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):
         if self._wandb is None:

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -660,7 +660,7 @@ class WandbCallback(TrainerCallback):
         if os.getenv("WANDB_LOG_MODEL", "FALSE").upper() in ENV_VARS_TRUE_VALUES.union({"TRUE"}):
             DeprecationWarning(
                 f"Setting `WANDB_LOG_MODEL` as {os.getenv('WANDB_LOG_MODEL')} is deprecated and will be removed in "
-                "future versions. Use one of `end` or `checkpoint` instead."
+                "version 5 of transformers. Use one of `'end'` or `'checkpoint'` instead."
             )
             logger.info(f"Setting `WANDB_LOG_MODEL` from {os.getenv('WANDB_LOG_MODEL')} to `end` instead")
             self._log_model = "end"

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -693,7 +693,7 @@ class WandbCallback(TrainerCallback):
         - **WANDB_PROJECT** (`str`, *optional*, defaults to `"huggingface"`):
             Set this to a custom string to store results in a different project.
         - **WANDB_DISABLED** (`bool`, *optional*, defaults to `False`):
-            Whether to disable wandb entirely. Set *WANDB_DISABLED=true* to disable.
+            Whether to disable wandb entirely. Set `WANDB_DISABLED=true` to disable.
         """
         if self._wandb is None:
             return

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -680,8 +680,13 @@ class WandbCallback(TrainerCallback):
             Whether to log model and checkpoints during training. Can be `"end"`, `"checkpoint"` or `"false"`. If set
             to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the checkpoint
             will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be uploaded. Use along
-            with *TrainingArguments.load_best_model_at_end* to upload best model. *Warning*: Setting `WANDB_LOG_MODEL`
-            as `bool` is deprecated and will be removed in future versions.
+            with [`~transformers.TrainingArguments.load_best_model_at_end`] to upload best model.
+            
+            <Deprecated version="5.0">
+            
+            Setting `WANDB_LOG_MODEL` as `bool` will be deprecated in version 5 of 🤗 Transformers.
+            
+            </Deprecated>
         - **WANDB_WATCH** (`str`, *optional* defaults to `"false"`):
             Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and
             parameters.

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -677,19 +677,19 @@ class WandbCallback(TrainerCallback):
 
         Environment:
         - **WANDB_LOG_MODEL** (`str`, *optional*, defaults to `"false"`):
-                    Whether to log model and checkpoints during training. Can be `"end"`, `"checkpoint"` or `"false"`.
-                    If set to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the
-                    checkpoint will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be
-                    uploaded. Use along with *TrainingArguments.load_best_model_at_end* to upload best model.
-                    *Warning*: Setting `WANDB_LOG_MODEL` as `bool` is deprecated and will be removed in future
-                    versions.
+            Whether to log model and checkpoints during training. Can be `"end"`, `"checkpoint"` or `"false"`.
+            If set to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the
+            checkpoint will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be
+            uploaded. Use along with *TrainingArguments.load_best_model_at_end* to upload best model.
+            *Warning*: Setting `WANDB_LOG_MODEL` as `bool` is deprecated and will be removed in future
+            versions.
         - **WANDB_WATCH** (`str`, *optional* defaults to `"false"`):
-                    Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and
-                    parameters.
+            Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and
+            parameters.
         - **WANDB_PROJECT** (`str`, *optional*, defaults to `"huggingface"`):
-                    Set this to a custom string to store results in a different project.
+            Set this to a custom string to store results in a different project.
         - **WANDB_DISABLED** (`bool`, *optional*, defaults to `False`):
-                    Whether to disable wandb entirely. Set *WANDB_DISABLED=true* to disable.
+            Whether to disable wandb entirely. Set *WANDB_DISABLED=true* to disable.
         """
         if self._wandb is None:
             return


### PR DESCRIPTION
# What does this PR do?

The PR updates the `WandbCallback` with the following changes:
- Adds `on_save` method to upload model checkpoints as artifacts.
- Changes the default value of environment variable `WANDB_WATCH` from `gradients` to `false`. This enables quicker training when defaults are used. The user can easily change this behavior by setting the env variable.
- Changes the `WANDB_LOG_MODEL` variable from `bool` to `str` allowing for different settings to upload artifacts.
- Modifies the class dostring to reflect the above changes.
- Fixes broken link to wandb documentation
- Changes the wandb `run_name` from `output_dir` to wandb auto generated name. this avoids duplication of run names in wandb workspace

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).


## Who can review?
- trainer: @sgugger
- documentation: @stevhliu


## Examples
- Example [colab](https://colab.research.google.com/drive/17imujjBEL2cQL3odAJEbVvjR6zVsDRuH?usp=sharing) reflecting all the changes to the WandbCallback
- Example Weights & Biases [workspace](https://wandb.ai/parambharat/hf_transformers?workspace=user-parambharat) with runs that show different settings.
- Example Weights & Biases [Artifact](https://wandb.ai/parambharat/hf_transformers/artifacts/checkpoint/checkpoint-ajdcez6k/v4) created for checkpoints