### PR TITLE
remove flax from `documentation_tests.txt`

### DIFF
--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -13,7 +13,6 @@ docs/source/en/model_doc/tapex.mdx
 docs/source/en/model_doc/donut.mdx
 docs/source/en/model_doc/encoder-decoder.mdx
 src/transformers/generation/configuration_utils.py
-src/transformers/generation/flax_utils.py
 src/transformers/generation/tf_utils.py
 src/transformers/generation/utils.py
 src/transformers/models/albert/configuration_albert.py


### PR DESCRIPTION
# What does this PR do?

#21009 added `src/transformers/generation/flax_utils.py` to `documentation_tests.txt`, but CI image doesn't have `jax/flax` installed. The whole doctest suite failed, and reported 0 failure.

This PR removes this file from `documentation_tests.txt`. The CI image used is the same as the scheduled CI, and it's intended not to have `jax/flax` in this image.

We can decide if to use a separate image though.