### PR TITLE
[WIP] [Whisper] Add specaugment

### DIFF
--- a/docs/source/en/model_doc/whisper.mdx
+++ b/docs/source/en/model_doc/whisper.mdx
@@ -49,6 +49,7 @@ The original code can be found [here](https://github.com/openai/whisper).
 
 [[autodoc]] WhisperFeatureExtractor
     - __call__
+    - _mask_input_features
 
 ## WhisperProcessor
 

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -29,7 +29,7 @@ from ...utils import TensorType, logging
 logger = logging.get_logger(__name__)
 
 
-# Copied from transformers.models.wav2vec2.modeling_wav2vec2._compute_mask_indices with attention_mask from torch.LongTensor to np.array
+# Modified from transformers.models.wav2vec2.modeling_wav2vec2._compute_mask_indices with attention_mask from torch.LongTensor to np.array
 def _compute_mask_indices(
     shape: Tuple[int, int],
     mask_prob: float,
@@ -85,9 +85,7 @@ def _compute_mask_indices(
 
     # compute number of masked spans in batch
     input_lengths = (
-        attention_mask.sum(-1).tolist()
-        if attention_mask is not None
-        else [sequence_length for _ in range(batch_size)]
+        attention_mask.sum(-1).tolist() if attention_mask is not None else [sequence_length for _ in range(batch_size)]
     )
 
     # SpecAugment mask to fill
@@ -394,11 +392,11 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
 
         Args:
             input_features (`np.ndarray` of shape `(batch_size, feature_size, sequence_length)`):
-                Float values mel features extracted from the raw speech waveform. Raw speech waveform can be obtained by
-                loading a `.flac` or `.wav` audio file into an array of type `List[float]` or a `numpy.ndarray`, *e.g.* via
-                the soundfile library (`pip install soundfile`). To prepare the array into `input_features`, the
-                [`WhisperFeatureExtractor`] should be used for extracting the mel features, padding and conversion into a
-                tensor of type `torch.FloatTensor`.
+                Float values mel features extracted from the raw speech waveform. Raw speech waveform can be obtained
+                by loading a `.flac` or `.wav` audio file into an array of type `List[float]` or a `numpy.ndarray`,
+                *e.g.* via the soundfile library (`pip install soundfile`). To prepare the array into `input_features`,
+                the [`WhisperFeatureExtractor`] should be used for extracting the mel features, padding and conversion
+                into a tensor of type `torch.FloatTensor`.
             mask_time_indices (`np.ndarray`, *optional*, defaults to None):
                 Indices to mask extracted features along time axis.
             attention_mask (`np.ndarray`, *optional*, defaults to None):
@@ -550,7 +548,7 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
 
             padded_inputs["input_features"] = self._mask_input_features(
                 padded_inputs["input_features"],
-                attention_mask=padded_inputs["attention_mask"][:, ::self.hop_length],
+                attention_mask=padded_inputs["attention_mask"][:, :: self.hop_length],
             )
 
         if return_tensors is not None:

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -413,8 +413,6 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
                 min_masks=self.mask_time_min_masks,
             )
             mask_time_indices = np.broadcast_to(mask_time_indices[:, None], (batch_size, hidden_size, sequence_length))
-            # mask_time_indices = np.tile(mask_time_indices, (1, hidden_size, 1))
-            # mask_time_indices = np.repeat(mask_time_indices[:, None, :], hidden_size, axis=1)
             input_features[mask_time_indices] = 0
 
         if self.mask_feature_prob > 0:

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -491,6 +491,8 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
                 "Failing to do so can result in silent errors that might be hard to debug."
             )
 
+        return_attention_mask = return_attention_mask or self.apply_spec_augment
+
         is_batched = bool(
             isinstance(raw_speech, (list, tuple))
             and (isinstance(raw_speech[0], np.ndarray) or isinstance(raw_speech[0], (tuple, list)))
@@ -511,14 +513,13 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
 
         # convert into correct format for padding
 
-        # todo: auto return_attention_mask
         padded_inputs = self.pad(
             batched_speech,
             padding=padding,
             max_length=max_length if max_length else self.n_samples,
             truncation=truncation,
             pad_to_multiple_of=pad_to_multiple_of,
-            return_attention_mask=True,
+            return_attention_mask=return_attention_mask,
         )
         # make sure list is in array format
         input_features = padded_inputs.get("input_features").transpose(2, 0, 1)

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -502,7 +502,7 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
 
             padded_inputs["input_features"] = self._mask_input_features(
                 padded_inputs["input_features"],
-                attention_mask=padded_inputs.attention_mask[:, ::self.hop_length],
+                attention_mask=padded_inputs["attention_mask"][:, ::self.hop_length],
             )
 
         if return_tensors is not None:

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -173,6 +173,37 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
             Size of the Fourier transform.
         padding_value (`float`, *optional*, defaults to 0.0):
             Padding value used to pad the audio. Should correspond to silences.
+        return_attention_mask (`bool`, *optional*):
+            Whether to return the attention mask.
+        apply_spec_augment (`bool`, *optional*, defaults to `False`):
+            Whether to apply *SpecAugment* data augmentation to the log-Mel spectrogram features. For reference see
+            [SpecAugment: A Simple Data Augmentation Method for Automatic Speech
+            Recognition](https://arxiv.org/abs/1904.08779).
+        mask_time_prob (`float`, *optional*, defaults to 0.0):
+            Percentage (between 0 and 1) of all feature vectors along the time axis which will be masked. The masking
+            procecure generates ''mask_time_prob*len(time_axis)/mask_time_length'' independent masks over the axis. If
+            reasoning from the propability of each feature vector to be chosen as the start of the vector span to be
+            masked, *mask_time_prob* should be `prob_vector_start*mask_time_length`. Note that overlap may decrease the
+            actual percentage of masked vectors. This is only relevant if `apply_spec_augment is True`.
+        mask_time_length (`int`, *optional*, defaults to 10):
+            Length of vector span along the time axis.
+        mask_time_min_masks (`int`, *optional*, defaults to 2),:
+            The minimum number of masks of length `mask_feature_length` generated along the time axis, each time step,
+            irrespectively of `mask_feature_prob`. Only relevant if ''mask_time_prob*len(time_axis)/mask_time_length <
+            mask_time_min_masks''
+        mask_feature_prob (`float`, *optional*, defaults to 0.0):
+            Percentage (between 0 and 1) of all feature vectors along the feature axis which will be masked. The
+            masking procecure generates ''mask_feature_prob*len(feature_axis)/mask_time_length'' independent masks over
+            the axis. If reasoning from the propability of each feature vector to be chosen as the start of the vector
+            span to be masked, *mask_feature_prob* should be `prob_vector_start*mask_feature_length`. Note that overlap
+            may decrease the actual percentage of masked vectors. This is only relevant if `apply_spec_augment is
+            True`.
+        mask_feature_length (`int`, *optional*, defaults to 10):
+            Length of vector span along the feature axis.
+        mask_feature_min_masks (`int`, *optional*, defaults to 0),:
+            The minimum number of masks of length `mask_feature_length` generated along the feature axis, each time
+            step, irrespectively of `mask_feature_prob`. Only relevant if
+            ''mask_feature_prob*len(feature_axis)/mask_feature_length < mask_feature_min_masks''
     """
 
     model_input_names = ["input_features"]

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -240,7 +240,7 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
         self.nb_max_frames = self.n_samples // hop_length
         self.sampling_rate = sampling_rate
         self.mel_filters = self.get_mel_filters(sampling_rate, n_fft, n_mels=feature_size)
-        # specaugment related
+        # SpecAugment related
         self.apply_spec_augment = apply_spec_augment
         self.mask_time_prob = mask_time_prob
         self.mask_time_length = mask_time_length
@@ -384,13 +384,25 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
     # Modified from transformers.models.wav2vec2.modeling_wav2vec2.Wav2Vec2Model._mask_hidden_states
     def _mask_input_features(
         self,
-        input_features: List[np.array],
-        mask_time_indices: Optional[np.array] = None,
-        attention_mask: Optional[np.array] = None,
-    ):
+        input_features: np.ndarray,
+        mask_time_indices: Optional[np.ndarray] = None,
+        attention_mask: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """
         Masks extracted features along time axis and/or along feature axis according to
         [SpecAugment](https://arxiv.org/abs/1904.08779).
+
+        Args:
+            input_features (`np.ndarray` of shape `(batch_size, feature_size, sequence_length)`):
+                Float values mel features extracted from the raw speech waveform. Raw speech waveform can be obtained by
+                loading a `.flac` or `.wav` audio file into an array of type `List[float]` or a `numpy.ndarray`, *e.g.* via
+                the soundfile library (`pip install soundfile`). To prepare the array into `input_features`, the
+                [`WhisperFeatureExtractor`] should be used for extracting the mel features, padding and conversion into a
+                tensor of type `torch.FloatTensor`.
+            mask_time_indices (`np.ndarray`, *optional*, defaults to None):
+                Indices to mask extracted features along time axis.
+            attention_mask (`np.ndarray`, *optional*, defaults to None):
+                A (right-padded) attention mask which independently shortens the feature axis of each batch dimension.
         """
 
         # generate indices & apply SpecAugment along time axis

--- a/tests/models/whisper/test_feature_extraction_whisper.py
+++ b/tests/models/whisper/test_feature_extraction_whisper.py
@@ -223,3 +223,14 @@ class WhisperFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.
         feaure_extractor = WhisperFeatureExtractor()
         input_features = feaure_extractor(input_speech, return_tensors="pt").input_features
         self.assertTrue(torch.allclose(input_features[0, 0, :30], EXPECTED_INPUT_FEATURES, atol=1e-4))
+
+    def test_mask_feat(self):
+        input_speech = self._load_datasamples(1)
+        feaure_extractor = WhisperFeatureExtractor(
+            mask_time_prob=0.1, mask_feature_prob=0.1, mask_time_min_masks=1, mask_feature_min_masks=1
+        )
+        input_features = feaure_extractor(input_speech, sampling_rate=16_000, apply_spec_augment=True).input_features
+        # at least feaure_extractor.mask_time_length samples along time should be masked
+        self.assertTrue((input_features[0, 0] == 0).sum() >= feaure_extractor.mask_time_length)
+        # at least feaure_extractor.mask_feature_length samples along feature should be masked
+        self.assertTrue((input_features[0, :, 0] == 0).sum() >= feaure_extractor.mask_feature_length)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Hi @ArthurZucker 👋,

As discussed in another conversation, in this PR I try to add [SpecAugment](https://arxiv.org/abs/1904.08779) to whisper models. It was used as one of regularization methods to train the `large-v2` model (https://github.com/openai/whisper/discussions/661).

Here the `SpecAugment` is implemented into `WhisperFeatureExtractor` in numpy. It masks the computed fbank features along the time and the feature axis.

Here are the steps in my mind. Please correct me if I miss something.

- [x] Return `attention_mask` by `pad` function to get the actual input lengths in the batch. And rescale it from sample level to feature level (48000 -> 3000)
- [x] Copy `_compute_mask_indices` function of wav2vec2, which will be used to generate masks
- [x] Add `_mask_input_features` function to mask along time or feature axis
- [ ] Add `apply_spec_augment`, `mask_time_prob`, etc to config and `__call__` function

It's still in draft. I will add the parameters to config and fix the test errors later :)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts and @NielsRogge
- speech models: @sanchit-gandhi

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
