### PR TITLE
Corrected a spelling mistake in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
 Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+the representative at an online or offline event.
 
 ## Enforcement
 


### PR DESCRIPTION


# What does this PR do?

Corrected an English grammar mistake

The noun phrase representative seems to be missing a determiner before it. Consider adding an article like 'the' or ' a'.