### PR TITLE
Add: An introductory guide for text generation

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -44,6 +44,8 @@
       title: Use tokenizers from 🤗 Tokenizers
     - local: multilingual
       title: Inference for multilingual models
+    - local: generation_strategies
+      title: Text Generation Strategies
     - sections:
       - local: tasks/sequence_classification
         title: Text classification

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -45,7 +45,7 @@
     - local: multilingual
       title: Inference for multilingual models
     - local: generation_strategies
-      title: Text Generation Strategies
+      title: Text generation strategies
     - sections:
       - local: tasks/sequence_classification
         title: Text classification

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -23,8 +23,9 @@ text outputs for different tasks:
 * [Image captioning](./model_doc/git#transformers.GitForCausalLM.forward.example)
 * [Audio transcription](./model_doc/whisper#transformers.WhisperForConditionalGeneration.forward.example)
 
-Note that the inputs to the generate method depend on the model's modality. They can be `input_ids` for text, `input_values`
-or `input_features` for speech and `pixel_values` for computer vision. When in doubt, refer to the model's documentation.
+Note that the inputs to the generate method depend on the model's modality. They are returned by the model's preprocessor
+class, such as AutoTokenizer or AutoProcessor. If a model's preprocessor creates more than one kind of input, pass all
+the inputs to generate(). You can learn more about the individual model's preprocessor in the corresponding model's documentation.
 
 The process of selecting output tokens to generate text is known as decoding, and you can customize the decoding strategy
 that the `generate()` method will use. Modifying a decoding strategy does not change the values of any trainable parameters.
@@ -74,6 +75,7 @@ You can override any `generation_config` by passing the parameters and their val
 ```python
 >>> my_model.generate(**inputs, num_beams=4, do_sample=True)
 ```
+
 Even if the default decoding strategy mostly works for your task, you can still tweak a few things. Some of the
 commonly adjusted parameters include:
 
@@ -89,6 +91,53 @@ distribution over the entire vocabulary with various strategy-specific adjustmen
 - `num_return_sequences`: the number of sequence candidates to return for each input. This options is only available for
 the decoding strategies that support multiple sequence candidates, e.g. variations of beam search and sampling. Decoding
 strategies like greedy search and contrastive search return a single output sequence.
+
+## Save a custom decoding strategy with your model
+
+If you would like to share your fine-tuned model with a specific generation configuration, you can:
+* Create a [`GenerationConfig`] class instance
+* Specify the decoding strategy parameters
+* Save your generation configuration with [`GenerationConfig.save_pretrained`], making sure to leave its `config_file_name` argument empty
+* Set `push_to_hub` to `True` to upload your config to the model's repo
+
+```python
+>>> from transformers import AutoModelForCausalLM, GenerationConfig
+
+>>> model = AutoModelForCausalLM.from_pretrained("my_account/my_model")
+>>> generation_config = GenerationConfig(
+...     max_new_tokens=50, do_sample=True, top_k=50, eos_token_id=model.config.eos_token_id
+... )
+>>> generation_config.save_pretrained("my_account/my_model", push_to_hub=True)
+```
+
+You can also store several generation configurations in a single directory, making use of the `config_file_name`
+argument in [`GenerationConfig.save_pretrained`]. You can later instantiate them with [`GenerationConfig.from_pretrained`]. This is useful if you want to
+store several generation configurations for a single model (e.g. one for creative text generation with sampling, and
+one for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
+
+```python
+>>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig
+
+>>> tokenizer = AutoTokenizer.from_pretrained("t5-small")
+>>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-small")
+
+>>> translation_generation_config = GenerationConfig(
+...     num_beams=4,
+...     early_stopping=True,
+...     decoder_start_token_id=0,
+...     eos_token_id=model.config.eos_token_id,
+...     pad_token=model.config.pad_token_id,
+... )
+
+>>> translation_generation_config.save_pretrained("t5-small", "translation_generation_config.json", push_to_hub=True)
+
+>>> # You could then use the named generation config file to parameterize generation
+>>> generation_config = GenerationConfig.from_pretrained("t5-small", "translation_generation_config.json")
+>>> inputs = tokenizer("translate English to French: Configuration files are easy to use!", return_tensors="pt")
+>>> outputs = model.generate(**inputs, generation_config=generation_config)
+>>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
+['Les fichiers de configuration sont faciles à utiliser !']
+```
 
 ## Decoding strategies
 
@@ -255,50 +304,3 @@ The groups are selected to ensure they are distinct enough compared to the other
 This guide illustrates the main parameters that enable various decoding strategies. More advanced parameters exist for the
 [`generate`] method, which gives you even further control over the [`generate`] method's behavior.
 For the complete list of the available parameters, refer to the [API documentation](./main_classes/text_generation.mdx).
-
-## Save a custom decoding strategy with your model
-
-If you would like to share your fine-tuned model with a specific generation configuration, you can:
-* Create a [`GenerationConfig`] class instance
-* Specify the decoding strategy parameters
-* Save your generation configuration with [`GenerationConfig.save_pretrained`], making sure to leave its `config_file_name` argument empty
-* Set `push_to_hub` to `True` to upload your config to the model's repo
-
-```python
->>> from transformers import AutoModelForCausalLM, GenerationConfig
-
->>> model = AutoModelForCausalLM.from_pretrained("my_account/my_model")
->>> generation_config = GenerationConfig(
-...     max_new_tokens=50, do_sample=True, top_k=50, eos_token_id=model.config.eos_token_id
-... )
->>> generation_config.save_pretrained("my_account/my_model", push_to_hub=True)
-```
-
-You can also store several generation configurations in a single directory, making use of the `config_file_name`
-argument in [`GenerationConfig.save_pretrained`]. You can later instantiate them with [`GenerationConfig.from_pretrained`]. This is useful if you want to
-store several generation configurations for a single model (e.g. one for creative text generation with sampling, and
-one for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
-
-```python
->>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig
-
->>> tokenizer = AutoTokenizer.from_pretrained("t5-small")
->>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-small")
-
->>> translation_generation_config = GenerationConfig(
-...     num_beams=4,
-...     early_stopping=True,
-...     decoder_start_token_id=0,
-...     eos_token_id=model.config.eos_token_id,
-...     pad_token=model.config.pad_token_id,
-... )
-
->>> translation_generation_config.save_pretrained("t5-small", "translation_generation_config.json", push_to_hub=True)
-
->>> # You could then use the named generation config file to parameterize generation
->>> generation_config = GenerationConfig.from_pretrained("t5-small", "translation_generation_config.json")
->>> inputs = tokenizer("translate English to French: Configuration files are easy to use!", return_tensors="pt")
->>> outputs = model.generate(**inputs, generation_config=generation_config)
->>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
-['Les fichiers de configuration sont faciles à utiliser !']
-```

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -44,10 +44,10 @@ When you load a model explicitly, you can inspect the generation configuration t
 >>> model = AutoModelForCausalLM.from_pretrained("distilgpt2")
 >>> model.generation_config
 GenerationConfig {
-  "_from_model_config": true,
-  "bos_token_id": 50256,
-  "eos_token_id": 50256,
-  "transformers_version": "4.26.0.dev0"
+    "_from_model_config": true,
+    "bos_token_id": 50256,
+    "eos_token_id": 50256,
+    "transformers_version": "4.26.0.dev0"
 }
 ```
 
@@ -109,7 +109,7 @@ Greedy search is the default decoding strategy. For generate() method to use it,
 ### Contrastive Search
 The Contrastive search decoding strategy was proposed in the 2022 paper [A Contrastive Framework for Neural Text Generation](https://arxiv.org/abs/2202.06417).
 It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
-works, check out <a href="https://huggingface.co/blog/introducing-csearch">this blog post</a>.
+works, check out [this blog post](https://huggingface.co/blog/introducing-csearch).
 The two main parameters that enable and control the behavior of the contrastive search are `penalty_alpha` and `top_k`:
 
 ```python
@@ -203,7 +203,7 @@ the `num_beams` that is greater than 1, and set `do_sample=True` to use this dec
 
 ### Diverse beam search decoding
 The Diverse beam search decoding strategy is an extension of the beam search strategy that allows to generate a more diverse
-set of beam sequences to choose from. To learn how it works, refer to <a href="https://arxiv.org/pdf/1610.02424.pdf">Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models</a>.
+set of beam sequences to choose from. To learn how it works, refer to [Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models](https://arxiv.org/pdf/1610.02424.pdf).
 The Diverse Beam Search approach has two main parameters: `num_beams` and `num_beam_groups`.
 The groups are selected to ensure they are distinct enough compared to the others, and regular beam search is used within each group.
 

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -1,0 +1,285 @@
+<!--Copyright 2020 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+# Text Generation Strategies
+
+Text generation is essential to many NLP tasks, such as open-ended text generation, summarization,
+translation, and more. It also plays a role in a variety of mixed-modality applications that have text as an output, e.g.
+speech-to-text, vision-to-text, etc. Some of the models that can generate text in an auto-regressive manner include
+GPT2, XLNet, OpenAi-GPT, CTRL, TransformXL, XLM, Bart, and T5. You can find examples of using the `generate()` method to produce
+text outputs for various tasks in corresponding task guides under the Inference section,
+e.g. [summarization inference with generate()](./tasks/summarization#inference).
+
+The process of selecting output tokens to generate text is known as decoding, and you can customize the decoding strategy
+that the `generate()` method will use. Modifying a decoding strategy does not change the values of any trainable parameters.
+However, it can have a noticeable impact on the quality of the generated output. It can help reduce repetition in the text
+and make it more coherent.
+
+This guide describes:
+- default generation configuration
+- common decoding strategies and their main parameters
+- saving and sharing custom generation configurations with your fine-tuned model on 🤗 Hub
+
+## Default text generation configuration
+
+A decoding strategy for a model is defined in its generation configuration. When using pre-trained models for inference
+within a `pipeline()`, the models call the `PreTrainedModel.generate()` method that applies a default generation
+configuration under the hood. The default configuration is also used when no custom configuration has been saved with
+the model.
+
+When you load a model explicitly, you can inspect the generation configuration that comes with it through
+ `model.generation_config`:
+
+```python
+>>> from transformers import AutoModelForCausalLM
+
+>>> model = AutoModelForCausalLM.from_pretrained("distilgpt2")
+>>> model.generation_config
+GenerationConfig {
+  "_from_model_config": true,
+  "bos_token_id": 50256,
+  "eos_token_id": 50256,
+  "transformers_version": "4.26.0.dev0"
+}
+```
+
+If a model has any modified values in the generation configuration, you can review them at this point. Note, however,
+that the default values are not displayed.
+
+The default generation configuration limits the size of the output combined with the input prompt to a maximum of 20
+tokens to avoid running into resource limitations. And the default decoding strategy is greedy search.
+This is the simplest decoding strategy that picks a token with the highest probability as the next token. For many tasks
+and small output sizes this works well. However, when used to generate longer outputs, greedy search can start
+producing highly repetitive results.
+
+## Customize text generation
+
+You can override any `generation_config` by passing the parameters and their values directly to the generate() method,
+e.g. `my_model.generate(inputs, num_beams=4, do_sample=True)`.
+
+Even if the default decoding strategy mostly works for your task, you can still tweak a few things. Some of the
+commonly adjusted parameters include:
+
+- `max_new_tokens`: the maximum number of tokens to generate. In other words, the size of the output sequence, not
+including the tokens in the prompt.
+- `max_length`: similar to `max_new_tokens`, this parameter limits the size of the generated output, however, it takes
+into account the input's size.
+- `num_beams`: by specifying a number of beams higher than 1, you are effectively switching from greedy search to
+beam search. This strategy evaluates several hypotheses at each time step and eventually chooses the hypothesis that
+has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
+sequences that start with a lower probability initial tokens and would've been ignored by the greedy search.
+- `do_sample`: If set to `True`, this parameter enables such decoding strategies as multinomial sampling, beam-search
+multinomial sampling, Top-K sampling and Top-p sampling. All these strategies select the next token from the probability
+distribution over the entire vocabulary with various strategy-specific adjustments.
+
+## Decoding strategies
+
+Certain combinations of the `generate()` parameters, and ultimately `generation_config`, can be used to enable specific
+decoding strategies. If you are new to this concept, we recommend reading [this blog post that illustrates how common decoding strategies work](https://huggingface.co/blog/how-to-generate).
+
+Here, we'll show what parameters control some of the strategies, and illustrate how you can use them.
+
+### Greedy Search
+Greedy search is the default decoding strategy. For generate() method to use it, `num_beams` has to be set to 1, and
+`do_sample=False`. Because it is a default strategy, you do not have to pass any parameters to `generate()` method to enable it.
+
+```python
+>>> from transformers import AutoModelForCausalLM, AutoTokenizer
+
+>>> prompt = "I look forward to"
+>>> checkpoint = "distilgpt2"
+
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+>>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
+>>> outputs = model.generate(input_ids)
+>>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+['I look forward to seeing you all again!\n\n\n\n\n\n\n\n\n\n\n']
+```
+
+### Contrastive Search
+The Contrastive search decoding strategy was proposed in the 2022 paper ["A Contrastive Framework for Neural Text Generation"](https://arxiv.org/abs/2202.06417).
+It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
+works, check out [this blog post](https://huggingface.co/blog/introducing-csearch).
+The two main parameters that enable and control the behavior of the contrastive search are `penalty_alpha` and `top_k`:
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> checkpoint = 'gpt2-large'
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
+
+>>> prompt = "Hugging Face Company is"
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+>>> outputs = model.generate(input_ids, penalty_alpha=0.6, top_k=4, max_new_tokens=100)
+>>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+['Hugging Face Company is a family owned and operated business. \
+We pride ourselves on being the best in the business and our customer service is second to none.\
+\n\nIf you have any questions about our products or services, feel free to contact us at any time.\
+ We look forward to hearing from you!']
+```
+
+### Multinomial sampling
+As opposed to greedy search that always chooses a token with the highest probability as the
+next token, multinomial sampling randomly selects the next token based on the probability distribution over the entire
+vocabulary given by the model. Every token with a non-zero probability has a chance of being selected, thus reducing the
+risk of repetition.
+
+To enable multinomial sampling set `do_sample=True`.
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForCausalLM
+
+>>> checkpoint = 'gpt2-large'
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
+
+>>> prompt = "Today was an amazing day because"
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+>>> outputs = model.generate(input_ids, do_sample=True, max_new_tokens=100)
+>>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+['Today was an amazing day because we are now in the final stages of our trip to New York City which was very tough. \
+It is a difficult schedule and a challenging part of the year but still worth it. I have been taking things easier and \
+I feel stronger and more motivated to be out there on their tour. Hopefully, that experience is going to help them with \
+their upcoming events which are currently scheduled in Australia.\n\nWe love that they are here. They want to make a \
+name for themselves and become famous for what they']
+```
+
+### Beam-search decoding
+As opposed to the greedy search, beam search decoding keeps several hypotheses at each time step and eventually chooses
+the hypothesis that has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
+sequences that start with a lower probability initial tokens and would've been ignored by the greedy search.
+
+To enable this decoding strategy, specify the `num_beams` that is greater than 1.
+
+```python
+>>> from transformers import AutoModelForCausalLM, AutoTokenizer
+
+>>> prompt = "It is astonishing how one can"
+>>> checkpoint = "gpt2-medium"
+
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+>>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
+
+>>> outputs = model.generate(input_ids, num_beams=5, max_new_tokens=50)
+>>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+['It is astonishing how one can have such a profound impact on the lives of so many people in such a short period of \
+time."\n\nHe added: "I am very proud of the work I have been able to do in the last few years.\n\n"I have']
+```
+
+### Beam-search multinomial sampling
+As the name implies, this decoding strategy combines beam search with multinomial sampling. You need to specify
+the `num_beams` that is greater than 1, and set `do_sample=True` to use this decoding strategy.
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+>>> prompt = "translate English to German: The house is wonderful."
+>>> checkpoint = "t5-small"
+
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+>>> model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint)
+
+>>> outputs = model.generate(input_ids, num_beams=5, do_sample=True)
+>>> tokenizer.decode(outputs[0], skip_special_tokens=True)
+'Das Haus ist wunderbar.'
+```
+
+### Diverse beam search decoding
+The Diverse beam search decoding strategy is an extension of the beam search strategy that allows to generate a more diverse
+set of beam sequences to choose from. To learn how it works, refer to [Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models](https://arxiv.org/pdf/1610.02424.pdf).
+The Diverse Beam Search approach has two main parameters: `num_beams` and `num_beam_groups`.
+The groups are selected to ensure they are distinct enough compared to the others, and regular beam search is used within each group.
+
+```python
+>>> from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+>>> checkpoint = "google/pegasus-xsum"
+>>> prompt = "The Permaculture Design Principles are a set of universal design principles \
+... that can be applied to any location, climate and culture, and they allow us to design \
+... the most efficient and sustainable human habitation and food production systems. \
+... Permaculture is a design system that encompasses a wide variety of disciplines, such \
+... as ecology, landscape design, environmental science and energy conservation, and the \
+... Permaculture design principles are drawn from these various disciplines. Each individual \
+... design principle itself embodies a complete conceptual framework based on sound \
+... scientific principles. When we bring all these separate  principles together, we can \
+... create a design system that both looks at whole systems, the parts that these systems \
+... consist of, and how those parts interact with each other to create a complex, dynamic, \
+... living system. Each design principle serves as a tool that allows us to integrate all \
+... the separate parts of a design, referred to as elements, into a functional, synergistic, \
+... whole system, where the elements harmoniously interact and work together in the most \
+... efficient way possible."
+
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> input_ids = tokenizer(prompt, return_tensors='pt').input_ids
+
+>>> model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint)
+
+>>> outputs = model.generate(input_ids, num_beams=5, num_beam_groups=5, max_new_tokens=30)
+>>> tokenizer.decode(outputs[0], skip_special_tokens=True)
+'The Design Principles are a set of universal design principles that can be applied to any location, climate and culture, and they allow us to design the most efficient and sustainable human habitation and food production systems.'
+```
+
+This guide illustrates the main parameters that enable various decoding strategies. More advanced parameters exist for the
+generate() method, which give you even further control over the generate() method's behavior.
+For the complete list of the available parameters, refer to the [API documentation](./main_classes/text_generation.mdx).
+
+## Save a custom decoding strategy with your model
+If you would like to share your fine-tuned model with a specific generation configuration, you can do so:
+- Create a `GenerationConfig` class instance
+- Specify the decoding strategy parameters
+- Save your generation configuration with `save_pretrained`, making sure to leave its `config_file_name` argument empty
+- Set `push_to_hub` to `True` to upload your config to the model's repo
+
+```python
+>>> from transformers import AutoModelForCausalLM, GenerationConfig
+
+>>> model = AutoModelForCausalLM.from_pretrained("my_account/my_model")
+>>> generation_config = GenerationConfig(max_new_tokens=50, do_sample=True, top_k=50, eos_token_id=model.config.eos_token_id)
+>>> generation_config.save_pretrained("my_account/my_model", push_to_hub=True)
+```
+
+You can also store several generation parametrizations in a single directory, making use of the `config_file_name`
+argument in `save_pretrained`. You can later instantiate them with `from_pretrained`. This is useful if you want to
+store several generation configurations for a single model (e.g. one for creative text generation with sampling, and
+other for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
+
+```python
+>>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig
+
+>>> tokenizer = AutoTokenizer.from_pretrained("t5-small")
+>>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-small")
+
+>>> translation_generation_config = GenerationConfig(
+...     num_beams=4,
+...     early_stopping=True,
+...     decoder_start_token_id=0,
+...     eos_token_id=model.config.eos_token_id,
+...     pad_token=model.config.pad_token_id,
+... )
+
+>>> translation_generation_config.save_pretrained("t5-small", "translation_generation_config.json", push_to_hub=True)
+
+>>> # You could then use the named generation config file to parameterize generation
+>>> generation_config = GenerationConfig.from_pretrained("t5-small", "translation_generation_config.json")
+>>> inputs = tokenizer("translate English to French: Configuration files are easy to use!", return_tensors="pt")
+>>> outputs = model.generate(**inputs, generation_config=generation_config)
+>>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
+['Les fichiers de configuration sont faciles à utiliser !']
+```

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -24,9 +24,9 @@ However, it can have a noticeable impact on the quality of the generated output.
 and make it more coherent.
 
 This guide describes:
-- default generation configuration
-- common decoding strategies and their main parameters
-- saving and sharing custom generation configurations with your fine-tuned model on 🤗 Hub
+* default generation configuration
+* common decoding strategies and their main parameters
+* saving and sharing custom generation configurations with your fine-tuned model on 🤗 Hub
 
 ## Default text generation configuration
 
@@ -107,9 +107,9 @@ Greedy search is the default decoding strategy. For generate() method to use it,
 ```
 
 ### Contrastive Search
-The Contrastive search decoding strategy was proposed in the 2022 paper ["A Contrastive Framework for Neural Text Generation"](https://arxiv.org/abs/2202.06417).
+The Contrastive search decoding strategy was proposed in the 2022 paper <a href="https://arxiv.org/abs/2202.06417">"A Contrastive Framework for Neural Text Generation"</a>.
 It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
-works, check out [this blog post](https://huggingface.co/blog/introducing-csearch).
+works, check out <a href="https://huggingface.co/blog/introducing-csearch">this blog post</a>.
 The two main parameters that enable and control the behavior of the contrastive search are `penalty_alpha` and `top_k`:
 
 ```python
@@ -203,7 +203,7 @@ the `num_beams` that is greater than 1, and set `do_sample=True` to use this dec
 
 ### Diverse beam search decoding
 The Diverse beam search decoding strategy is an extension of the beam search strategy that allows to generate a more diverse
-set of beam sequences to choose from. To learn how it works, refer to [Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models](https://arxiv.org/pdf/1610.02424.pdf).
+set of beam sequences to choose from. To learn how it works, refer to <a href="https://arxiv.org/pdf/1610.02424.pdf">Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models</a>.
 The Diverse Beam Search approach has two main parameters: `num_beams` and `num_beam_groups`.
 The groups are selected to ensure they are distinct enough compared to the others, and regular beam search is used within each group.
 
@@ -242,10 +242,10 @@ For the complete list of the available parameters, refer to the [API documentati
 
 ## Save a custom decoding strategy with your model
 If you would like to share your fine-tuned model with a specific generation configuration, you can do so:
-- Create a `GenerationConfig` class instance
-- Specify the decoding strategy parameters
-- Save your generation configuration with `save_pretrained`, making sure to leave its `config_file_name` argument empty
-- Set `push_to_hub` to `True` to upload your config to the model's repo
+* Create a `GenerationConfig` class instance
+* Specify the decoding strategy parameters
+* Save your generation configuration with `save_pretrained`, making sure to leave its `config_file_name` argument empty
+* Set `push_to_hub` to `True` to upload your config to the model's repo
 
 ```python
 >>> from transformers import AutoModelForCausalLM, GenerationConfig

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -12,11 +12,21 @@ specific language governing permissions and limitations under the License.
 
 # Text generation strategies
 
-Text generation is essential to many NLP tasks, such as open-ended text generation, summarization,
-translation, and more. It also plays a role in a variety of mixed-modality applications that have text as an output like speech-to-text and vision-to-text. Some of the models that can generate text in an auto-regressive manner include
-GPT2, XLNet, OpenAI GPT, CTRL, TransformerXL, XLM, Bart, and T5. You can find examples of using the [`~transformers.generation_utils.GenerationMixin.generate`] method to produce
-text outputs for various tasks in corresponding task guides under the Inference section,
-e.g. [summarization inference with generate()](./tasks/summarization#inference).
+Text generation is essential to many NLP tasks, such as open-ended text generation, summarization, translation, and
+more. It also plays a role in a variety of mixed-modality applications that have text as an output like speech-to-text
+and vision-to-text. Some of the models that can generate text include
+GPT2, XLNet, OpenAI GPT, CTRL, TransformerXL, XLM, Bart, T5, GIT, Whisper.
+
+Check out a few examples that use [`~transformers.generation_utils.GenerationMixin.generate`] method to produce
+text outputs for different tasks:
+* [Text summarization](./tasks/summarization#inference)
+* [Image captioning](./model_doc/git#transformers.GitForCausalLM.forward.example)
+* [Audio transcription](./model_doc/whisper#transformers.WhisperForConditionalGeneration.forward.example)
+
+Note that the inputs to the generate method depend on the model's modality:
+* `input_ids` for the decoder-only models
+* `input_ids`, `input_values`, `input_features`, or `pixel_values` for the encoder-decoder models
+In some cases, such as visual question answering, the inputs should have both `pixel_values` and `input_ids`.
 
 The process of selecting output tokens to generate text is known as decoding, and you can customize the decoding strategy
 that the `generate()` method will use. Modifying a decoding strategy does not change the values of any trainable parameters.
@@ -51,8 +61,8 @@ GenerationConfig {
 }
 ```
 
-If a model has any modified values in the generation configuration, you can review them at this point. Note, however,
-that the default values are not displayed.
+Printing out the `model.generation_config` reveals only the values that are different from the default generation
+configuration, and does not list any of the default values.
 
 The default generation configuration limits the size of the output combined with the input prompt to a maximum of 20
 tokens to avoid running into resource limitations. The default decoding strategy is greedy search, which is the simplest decoding strategy that picks a token with the highest probability as the next token. For many tasks
@@ -61,16 +71,16 @@ producing highly repetitive results.
 
 ## Customize text generation
 
-You can override any `generation_config` by passing the parameters and their values directly to the generate() method,
-e.g. `my_model.generate(inputs, num_beams=4, do_sample=True)`.
+You can override any `generation_config` by passing the parameters and their values directly to the [`generate`] method:
 
+```python
+>>> my_model.generate(inputs, num_beams=4, do_sample=True)
+```
 Even if the default decoding strategy mostly works for your task, you can still tweak a few things. Some of the
 commonly adjusted parameters include:
 
 - `max_new_tokens`: the maximum number of tokens to generate. In other words, the size of the output sequence, not
 including the tokens in the prompt.
-- `max_length`: similar to `max_new_tokens`, this parameter limits the size of the generated output, however, it takes
-into account the input's size.
 - `num_beams`: by specifying a number of beams higher than 1, you are effectively switching from greedy search to
 beam search. This strategy evaluates several hypotheses at each time step and eventually chooses the hypothesis that
 has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
@@ -78,6 +88,9 @@ sequences that start with a lower probability initial tokens and would've been i
 - `do_sample`: if set to `True`, this parameter enables decoding strategies such as multinomial sampling, beam-search
 multinomial sampling, Top-K sampling and Top-p sampling. All these strategies select the next token from the probability
 distribution over the entire vocabulary with various strategy-specific adjustments.
+- `num_return_sequences`: the number of sequence candidates to return for each input. This options is only available for
+the decoding strategies that support multiple sequence candidates, e.g. variations of beam search and sampling. Decoding
+strategies like greedy search and contrastive search return a single output sequence.
 
 ## Decoding strategies
 
@@ -165,7 +178,7 @@ Unlike greedy search, beam-search decoding keeps several hypotheses at each time
 the hypothesis that has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
 sequences that start with lower probability initial tokens and would've been ignored by the greedy search.
 
-To enable this decoding strategy, specify the `num_beams` that is greater than 1.
+To enable this decoding strategy, specify the `num_beams` (aka number of hypotheses to keep track of) that is greater than 1.
 
 ```python
 >>> from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -263,10 +276,10 @@ If you would like to share your fine-tuned model with a specific generation conf
 >>> generation_config.save_pretrained("my_account/my_model", push_to_hub=True)
 ```
 
-You can also store several generation parametrizations in a single directory, making use of the `config_file_name`
+You can also store several generation configurations in a single directory, making use of the `config_file_name`
 argument in [`GenerationConfig.save_pretrained`]. You can later instantiate them with [`GenerationConfig.from_pretrained`]. This is useful if you want to
 store several generation configurations for a single model (e.g. one for creative text generation with sampling, and
-other for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
+one for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
 
 ```python
 >>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -1,4 +1,4 @@
-<!--Copyright 2020 The HuggingFace Team. All rights reserved.
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at
@@ -72,7 +72,7 @@ producing highly repetitive results.
 You can override any `generation_config` by passing the parameters and their values directly to the [`generate`] method:
 
 ```python
->>> my_model.generate(inputs, num_beams=4, do_sample=True)
+>>> my_model.generate(**inputs, num_beams=4, do_sample=True)
 ```
 Even if the default decoding strategy mostly works for your task, you can still tweak a few things. Some of the
 commonly adjusted parameters include:
@@ -109,10 +109,10 @@ Here, we'll show some of the parameters that control the decoding strategies and
 >>> checkpoint = "distilgpt2"
 
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
->>> outputs = model.generate(input_ids)
+>>> outputs = model.generate(**inputs)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['I look forward to seeing you all again!\n\n\n\n\n\n\n\n\n\n\n']
 ```
@@ -132,9 +132,9 @@ The two main parameters that enable and control the behavior of contrastive sear
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 
 >>> prompt = "Hugging Face Company is"
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
->>> outputs = model.generate(input_ids, penalty_alpha=0.6, top_k=4, max_new_tokens=100)
+>>> outputs = model.generate(**inputs, penalty_alpha=0.6, top_k=4, max_new_tokens=100)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['Hugging Face Company is a family owned and operated business. \
 We pride ourselves on being the best in the business and our customer service is second to none.\
@@ -159,9 +159,9 @@ To enable multinomial sampling set `do_sample=True`.
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 
 >>> prompt = "Today was an amazing day because"
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
->>> outputs = model.generate(input_ids, do_sample=True, max_new_tokens=100)
+>>> outputs = model.generate(**inputs, do_sample=True, max_new_tokens=100)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['Today was an amazing day because we are now in the final stages of our trip to New York City which was very tough. \
 It is a difficult schedule and a challenging part of the year but still worth it. I have been taking things easier and \
@@ -185,11 +185,11 @@ To enable this decoding strategy, specify the `num_beams` (aka number of hypothe
 >>> checkpoint = "gpt2-medium"
 
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 
->>> outputs = model.generate(input_ids, num_beams=5, max_new_tokens=50)
+>>> outputs = model.generate(**inputs, num_beams=5, max_new_tokens=50)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['It is astonishing how one can have such a profound impact on the lives of so many people in such a short period of \
 time."\n\nHe added: "I am very proud of the work I have been able to do in the last few years.\n\n"I have']
@@ -207,11 +207,11 @@ the `num_beams` greater than 1, and set `do_sample=True` to use this decoding st
 >>> checkpoint = "t5-small"
 
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
 >>> model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint)
 
->>> outputs = model.generate(input_ids, num_beams=5, do_sample=True)
+>>> outputs = model.generate(**inputs, num_beams=5, do_sample=True)
 >>> tokenizer.decode(outputs[0], skip_special_tokens=True)
 'Das Haus ist wunderbar.'
 ```
@@ -243,11 +243,11 @@ The groups are selected to ensure they are distinct enough compared to the other
 >>> efficient way possible."
 
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
->>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+>>> inputs = tokenizer(prompt, return_tensors="pt")
 
 >>> model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint)
 
->>> outputs = model.generate(input_ids, num_beams=5, num_beam_groups=5, max_new_tokens=30)
+>>> outputs = model.generate(**inputs, num_beams=5, num_beam_groups=5, max_new_tokens=30)
 >>> tokenizer.decode(outputs[0], skip_special_tokens=True)
 'The Design Principles are a set of universal design principles that can be applied to any location, climate and culture, and they allow us to design the most efficient and sustainable human habitation and food production systems.'
 ```

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 Text generation is essential to many NLP tasks, such as open-ended text generation, summarization,
 translation, and more. It also plays a role in a variety of mixed-modality applications that have text as an output, e.g.
 speech-to-text, vision-to-text, etc. Some of the models that can generate text in an auto-regressive manner include
-GPT2, XLNet, OpenAi-GPT, CTRL, TransformXL, XLM, Bart, and T5. You can find examples of using the `generate()` method to produce
+GPT2, XLNet, OpenAi-GPT, CTRL, TransformerXL, XLM, Bart, and T5. You can find examples of using the `generate()` method to produce
 text outputs for various tasks in corresponding task guides under the Inference section,
 e.g. [summarization inference with generate()](./tasks/summarization#inference).
 
@@ -107,7 +107,7 @@ Greedy search is the default decoding strategy. For generate() method to use it,
 ```
 
 ### Contrastive Search
-The Contrastive search decoding strategy was proposed in the 2022 paper <a href="https://arxiv.org/abs/2202.06417">"A Contrastive Framework for Neural Text Generation"</a>.
+The Contrastive search decoding strategy was proposed in the 2022 paper [A Contrastive Framework for Neural Text Generation](https://arxiv.org/abs/2202.06417).
 It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
 works, check out <a href="https://huggingface.co/blog/introducing-csearch">this blog post</a>.
 The two main parameters that enable and control the behavior of the contrastive search are `penalty_alpha` and `top_k`:

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -9,6 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
+
 # Text generation strategies
 
 Text generation is essential to many NLP tasks, such as open-ended text generation, summarization,
@@ -86,6 +87,7 @@ decoding strategies. If you are new to this concept, we recommend reading [this 
 Here, we'll show some of the parameters that control the decoding strategies and illustrate how you can use them.
 
 ### Greedy Search
+
 [`generate`] uses greedy search decoding by default so you don't have to pass any parameters to enable it. This means the parameters `num_beams` is set to 1 and `do_sample=False`.
 `do_sample=False`. Because it is a default strategy, you do not have to pass any parameters to `generate()` method to enable it.
 
@@ -105,6 +107,7 @@ Here, we'll show some of the parameters that control the decoding strategies and
 ```
 
 ### Contrastive search
+
 The contrastive search decoding strategy was proposed in the 2022 paper [A Contrastive Framework for Neural Text Generation](https://arxiv.org/abs/2202.06417).
 It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
 works, check out [this blog post](https://huggingface.co/blog/introducing-csearch).
@@ -129,6 +132,7 @@ We pride ourselves on being the best in the business and our customer service is
 ```
 
 ### Multinomial sampling
+
 As opposed to greedy search that always chooses a token with the highest probability as the
 next token, multinomial sampling randomly selects the next token based on the probability distribution over the entire
 vocabulary given by the model. Every token with a non-zero probability has a chance of being selected, thus reducing the
@@ -156,6 +160,7 @@ name for themselves and become famous for what they']
 ```
 
 ### Beam-search decoding
+
 Unlike greedy search, beam-search decoding keeps several hypotheses at each time step and eventually chooses
 the hypothesis that has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
 sequences that start with lower probability initial tokens and would've been ignored by the greedy search.
@@ -180,6 +185,7 @@ time."\n\nHe added: "I am very proud of the work I have been able to do in the l
 ```
 
 ### Beam-search multinomial sampling
+
 As the name implies, this decoding strategy combines beam search with multinomial sampling. You need to specify
 the `num_beams` greater than 1, and set `do_sample=True` to use this decoding strategy.
 
@@ -200,6 +206,7 @@ the `num_beams` greater than 1, and set `do_sample=True` to use this decoding st
 ```
 
 ### Diverse beam search decoding
+
 The diverse beam search decoding strategy is an extension of the beam search strategy that allows for generating a more diverse
 set of beam sequences to choose from. To learn how it works, refer to [Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models](https://arxiv.org/pdf/1610.02424.pdf).
 This approach has two main parameters: `num_beams` and `num_beam_groups`.
@@ -239,6 +246,7 @@ This guide illustrates the main parameters that enable various decoding strategi
 For the complete list of the available parameters, refer to the [API documentation](./main_classes/text_generation.mdx).
 
 ## Save a custom decoding strategy with your model
+
 If you would like to share your fine-tuned model with a specific generation configuration, you can:
 * Create a [`GenerationConfig`] class instance
 * Specify the decoding strategy parameters

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -23,10 +23,8 @@ text outputs for different tasks:
 * [Image captioning](./model_doc/git#transformers.GitForCausalLM.forward.example)
 * [Audio transcription](./model_doc/whisper#transformers.WhisperForConditionalGeneration.forward.example)
 
-Note that the inputs to the generate method depend on the model's modality:
-* `input_ids` for the decoder-only models
-* `input_ids`, `input_values`, `input_features`, or `pixel_values` for the encoder-decoder models
-In some cases, such as visual question answering, the inputs should have both `pixel_values` and `input_ids`.
+Note that the inputs to the generate method depend on the model's modality. They can be `input_ids` for text, `input_values`
+or `input_features` for speech and `pixel_values` for computer vision. When in doubt, refer to the model's documentation.
 
 The process of selecting output tokens to generate text is known as decoding, and you can customize the decoding strategy
 that the `generate()` method will use. Modifying a decoding strategy does not change the values of any trainable parameters.

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -9,12 +9,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
-# Text Generation Strategies
+# Text generation strategies
 
 Text generation is essential to many NLP tasks, such as open-ended text generation, summarization,
-translation, and more. It also plays a role in a variety of mixed-modality applications that have text as an output, e.g.
-speech-to-text, vision-to-text, etc. Some of the models that can generate text in an auto-regressive manner include
-GPT2, XLNet, OpenAi-GPT, CTRL, TransformerXL, XLM, Bart, and T5. You can find examples of using the `generate()` method to produce
+translation, and more. It also plays a role in a variety of mixed-modality applications that have text as an output like speech-to-text and vision-to-text. Some of the models that can generate text in an auto-regressive manner include
+GPT2, XLNet, OpenAI GPT, CTRL, TransformerXL, XLM, Bart, and T5. You can find examples of using the [`~transformers.generation_utils.GenerationMixin.generate`] method to produce
 text outputs for various tasks in corresponding task guides under the Inference section,
 e.g. [summarization inference with generate()](./tasks/summarization#inference).
 
@@ -31,7 +30,7 @@ This guide describes:
 ## Default text generation configuration
 
 A decoding strategy for a model is defined in its generation configuration. When using pre-trained models for inference
-within a `pipeline()`, the models call the `PreTrainedModel.generate()` method that applies a default generation
+within a [`pipeline`], the models call the `PreTrainedModel.generate()` method that applies a default generation
 configuration under the hood. The default configuration is also used when no custom configuration has been saved with
 the model.
 
@@ -55,8 +54,7 @@ If a model has any modified values in the generation configuration, you can revi
 that the default values are not displayed.
 
 The default generation configuration limits the size of the output combined with the input prompt to a maximum of 20
-tokens to avoid running into resource limitations. And the default decoding strategy is greedy search.
-This is the simplest decoding strategy that picks a token with the highest probability as the next token. For many tasks
+tokens to avoid running into resource limitations. The default decoding strategy is greedy search, which is the simplest decoding strategy that picks a token with the highest probability as the next token. For many tasks
 and small output sizes this works well. However, when used to generate longer outputs, greedy search can start
 producing highly repetitive results.
 
@@ -76,7 +74,7 @@ into account the input's size.
 beam search. This strategy evaluates several hypotheses at each time step and eventually chooses the hypothesis that
 has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
 sequences that start with a lower probability initial tokens and would've been ignored by the greedy search.
-- `do_sample`: If set to `True`, this parameter enables such decoding strategies as multinomial sampling, beam-search
+- `do_sample`: if set to `True`, this parameter enables decoding strategies such as multinomial sampling, beam-search
 multinomial sampling, Top-K sampling and Top-p sampling. All these strategies select the next token from the probability
 distribution over the entire vocabulary with various strategy-specific adjustments.
 
@@ -85,10 +83,10 @@ distribution over the entire vocabulary with various strategy-specific adjustmen
 Certain combinations of the `generate()` parameters, and ultimately `generation_config`, can be used to enable specific
 decoding strategies. If you are new to this concept, we recommend reading [this blog post that illustrates how common decoding strategies work](https://huggingface.co/blog/how-to-generate).
 
-Here, we'll show what parameters control some of the strategies, and illustrate how you can use them.
+Here, we'll show some of the parameters that control the decoding strategies and illustrate how you can use them.
 
 ### Greedy Search
-Greedy search is the default decoding strategy. For generate() method to use it, `num_beams` has to be set to 1, and
+[`generate`] uses greedy search decoding by default so you don't have to pass any parameters to enable it. This means the parameters `num_beams` is set to 1 and `do_sample=False`.
 `do_sample=False`. Because it is a default strategy, you do not have to pass any parameters to `generate()` method to enable it.
 
 ```python
@@ -106,11 +104,11 @@ Greedy search is the default decoding strategy. For generate() method to use it,
 ['I look forward to seeing you all again!\n\n\n\n\n\n\n\n\n\n\n']
 ```
 
-### Contrastive Search
-The Contrastive search decoding strategy was proposed in the 2022 paper [A Contrastive Framework for Neural Text Generation](https://arxiv.org/abs/2202.06417).
+### Contrastive search
+The contrastive search decoding strategy was proposed in the 2022 paper [A Contrastive Framework for Neural Text Generation](https://arxiv.org/abs/2202.06417).
 It demonstrates superior results for generating non-repetitive yet coherent long outputs. To learn how contrastive search
 works, check out [this blog post](https://huggingface.co/blog/introducing-csearch).
-The two main parameters that enable and control the behavior of the contrastive search are `penalty_alpha` and `top_k`:
+The two main parameters that enable and control the behavior of contrastive search are `penalty_alpha` and `top_k`:
 
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForCausalLM
@@ -158,9 +156,9 @@ name for themselves and become famous for what they']
 ```
 
 ### Beam-search decoding
-As opposed to the greedy search, beam search decoding keeps several hypotheses at each time step and eventually chooses
+Unlike greedy search, beam-search decoding keeps several hypotheses at each time step and eventually chooses
 the hypothesis that has the overall highest probability for the entire sequence. This has the advantage of identifying high-probability
-sequences that start with a lower probability initial tokens and would've been ignored by the greedy search.
+sequences that start with lower probability initial tokens and would've been ignored by the greedy search.
 
 To enable this decoding strategy, specify the `num_beams` that is greater than 1.
 
@@ -183,7 +181,7 @@ time."\n\nHe added: "I am very proud of the work I have been able to do in the l
 
 ### Beam-search multinomial sampling
 As the name implies, this decoding strategy combines beam search with multinomial sampling. You need to specify
-the `num_beams` that is greater than 1, and set `do_sample=True` to use this decoding strategy.
+the `num_beams` greater than 1, and set `do_sample=True` to use this decoding strategy.
 
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
@@ -202,9 +200,9 @@ the `num_beams` that is greater than 1, and set `do_sample=True` to use this dec
 ```
 
 ### Diverse beam search decoding
-The Diverse beam search decoding strategy is an extension of the beam search strategy that allows to generate a more diverse
+The diverse beam search decoding strategy is an extension of the beam search strategy that allows for generating a more diverse
 set of beam sequences to choose from. To learn how it works, refer to [Diverse Beam Search: Decoding Diverse Solutions from Neural Sequence Models](https://arxiv.org/pdf/1610.02424.pdf).
-The Diverse Beam Search approach has two main parameters: `num_beams` and `num_beam_groups`.
+This approach has two main parameters: `num_beams` and `num_beam_groups`.
 The groups are selected to ensure they are distinct enough compared to the others, and regular beam search is used within each group.
 
 ```python
@@ -237,14 +235,14 @@ The groups are selected to ensure they are distinct enough compared to the other
 ```
 
 This guide illustrates the main parameters that enable various decoding strategies. More advanced parameters exist for the
-generate() method, which give you even further control over the generate() method's behavior.
+[`generate`] method, which gives you even further control over the [`generate`] method's behavior.
 For the complete list of the available parameters, refer to the [API documentation](./main_classes/text_generation.mdx).
 
 ## Save a custom decoding strategy with your model
-If you would like to share your fine-tuned model with a specific generation configuration, you can do so:
-* Create a `GenerationConfig` class instance
+If you would like to share your fine-tuned model with a specific generation configuration, you can:
+* Create a [`GenerationConfig`] class instance
 * Specify the decoding strategy parameters
-* Save your generation configuration with `save_pretrained`, making sure to leave its `config_file_name` argument empty
+* Save your generation configuration with [`GenerationConfig.save_pretrained`], making sure to leave its `config_file_name` argument empty
 * Set `push_to_hub` to `True` to upload your config to the model's repo
 
 ```python
@@ -258,7 +256,7 @@ If you would like to share your fine-tuned model with a specific generation conf
 ```
 
 You can also store several generation parametrizations in a single directory, making use of the `config_file_name`
-argument in `save_pretrained`. You can later instantiate them with `from_pretrained`. This is useful if you want to
+argument in [`GenerationConfig.save_pretrained`]. You can later instantiate them with [`GenerationConfig.from_pretrained`]. This is useful if you want to
 store several generation configurations for a single model (e.g. one for creative text generation with sampling, and
 other for summarization with beam search). You must have the right Hub permissions to add configuration files to a model.
 

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -115,7 +115,7 @@ The two main parameters that enable and control the behavior of the contrastive 
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForCausalLM
 
->>> checkpoint = 'gpt2-large'
+>>> checkpoint = "gpt2-large"
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 
@@ -141,7 +141,7 @@ To enable multinomial sampling set `do_sample=True`.
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForCausalLM
 
->>> checkpoint = 'gpt2-large'
+>>> checkpoint = "gpt2-large"
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 
@@ -212,22 +212,22 @@ The groups are selected to ensure they are distinct enough compared to the other
 
 >>> checkpoint = "google/pegasus-xsum"
 >>> prompt = "The Permaculture Design Principles are a set of universal design principles \
-... that can be applied to any location, climate and culture, and they allow us to design \
-... the most efficient and sustainable human habitation and food production systems. \
-... Permaculture is a design system that encompasses a wide variety of disciplines, such \
-... as ecology, landscape design, environmental science and energy conservation, and the \
-... Permaculture design principles are drawn from these various disciplines. Each individual \
-... design principle itself embodies a complete conceptual framework based on sound \
-... scientific principles. When we bring all these separate  principles together, we can \
-... create a design system that both looks at whole systems, the parts that these systems \
-... consist of, and how those parts interact with each other to create a complex, dynamic, \
-... living system. Each design principle serves as a tool that allows us to integrate all \
-... the separate parts of a design, referred to as elements, into a functional, synergistic, \
-... whole system, where the elements harmoniously interact and work together in the most \
-... efficient way possible."
+>>> that can be applied to any location, climate and culture, and they allow us to design \
+>>> the most efficient and sustainable human habitation and food production systems. \
+>>> Permaculture is a design system that encompasses a wide variety of disciplines, such \
+>>> as ecology, landscape design, environmental science and energy conservation, and the \
+>>> Permaculture design principles are drawn from these various disciplines. Each individual \
+>>> design principle itself embodies a complete conceptual framework based on sound \
+>>> scientific principles. When we bring all these separate  principles together, we can \
+>>> create a design system that both looks at whole systems, the parts that these systems \
+>>> consist of, and how those parts interact with each other to create a complex, dynamic, \
+>>> living system. Each design principle serves as a tool that allows us to integrate all \
+>>> the separate parts of a design, referred to as elements, into a functional, synergistic, \
+>>> whole system, where the elements harmoniously interact and work together in the most \
+>>> efficient way possible."
 
 >>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
->>> input_ids = tokenizer(prompt, return_tensors='pt').input_ids
+>>> input_ids = tokenizer(prompt, return_tensors="pt").input_ids
 
 >>> model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint)
 
@@ -251,7 +251,9 @@ If you would like to share your fine-tuned model with a specific generation conf
 >>> from transformers import AutoModelForCausalLM, GenerationConfig
 
 >>> model = AutoModelForCausalLM.from_pretrained("my_account/my_model")
->>> generation_config = GenerationConfig(max_new_tokens=50, do_sample=True, top_k=50, eos_token_id=model.config.eos_token_id)
+>>> generation_config = GenerationConfig(
+...     max_new_tokens=50, do_sample=True, top_k=50, eos_token_id=model.config.eos_token_id
+... )
 >>> generation_config.save_pretrained("my_account/my_model", push_to_hub=True)
 ```
 


### PR DESCRIPTION
Context: current [text generation doc](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation) is large, difficult to navigate, and may be overwhelming to users who are new to text generation.  

I suggest splitting the document into two parts: 
1. an introductory guide that explains the basics and provides some examples
2. trimmed down API reference to be used for looking up specific parameter descriptions (https://github.com/huggingface/transformers/pull/21112)
 
This PR is the first part. It adds a guide that introduces readers to the text generation strategies, explains the generation configuration defaults, and provides some examples. The second part will follow in a separate PR.


 
