### PR TITLE
Clarify and add missing typical_p argument docstring.

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -144,6 +144,10 @@ class PretrainedConfig(PushToHubMixin):
         top_p (`float`, *optional*, defaults to 1):
             Value that will be used by default in the `generate` method of the model for `top_p`. If set to float < 1,
             only the most probable tokens with probabilities that add up to `top_p` or higher are kept for generation.
+        typical_p (`float`, *optional*, defaults to 1):
+            Locally typical sampling orders tokens according to how similar the negative log probability of predicting a
+            specific token is to the expected conditional entropy of a random next token. The smallest set of most
+            similar tokens with probability masses that add up to `typical_p` or higher are kept for generation.
         repetition_penalty (`float`, *optional*, defaults to 1):
             Parameter for repetition penalty that will be used by default in the `generate` method of the model. 1.0
             means no penalty.

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -145,9 +145,11 @@ class PretrainedConfig(PushToHubMixin):
             Value that will be used by default in the `generate` method of the model for `top_p`. If set to float < 1,
             only the most probable tokens with probabilities that add up to `top_p` or higher are kept for generation.
         typical_p (`float`, *optional*, defaults to 1):
-            Locally typical sampling orders tokens according to how similar the negative log probability of predicting a
-            specific token is to the expected conditional entropy of a random next token. If set to float < 1, the smallest set of most
-            similar tokens with probability masses that add up to `typical_p` or higher are kept for generation.
+            Local typicality measures how similar the conditional probability of predicting a target token next is to
+            the expected conditional probability of predicting a random token next, given the partial text already
+            generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that
+            add up to `typical_p` or higher are kept for generation.
+            See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         repetition_penalty (`float`, *optional*, defaults to 1):
             Parameter for repetition penalty that will be used by default in the `generate` method of the model. 1.0
             means no penalty.

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -148,8 +148,8 @@ class PretrainedConfig(PushToHubMixin):
             Local typicality measures how similar the conditional probability of predicting a target token next is to
             the expected conditional probability of predicting a random token next, given the partial text already
             generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that
-            add up to `typical_p` or higher are kept for generation.
-            See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+            add up to `typical_p` or higher are kept for generation. See [this
+            paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         repetition_penalty (`float`, *optional*, defaults to 1):
             Parameter for repetition penalty that will be used by default in the `generate` method of the model. 1.0
             means no penalty.

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -146,7 +146,7 @@ class PretrainedConfig(PushToHubMixin):
             only the most probable tokens with probabilities that add up to `top_p` or higher are kept for generation.
         typical_p (`float`, *optional*, defaults to 1):
             Locally typical sampling orders tokens according to how similar the negative log probability of predicting a
-            specific token is to the expected conditional entropy of a random next token. The smallest set of most
+            specific token is to the expected conditional entropy of a random next token. If set to float < 1, the smallest set of most
             similar tokens with probability masses that add up to `typical_p` or higher are kept for generation.
         repetition_penalty (`float`, *optional*, defaults to 1):
             Parameter for repetition penalty that will be used by default in the `generate` method of the model. 1.0

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -107,8 +107,9 @@ class GenerationConfig(PushToHubMixin):
             If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
             `top_p` or higher are kept for generation.
         typical_p (`float`, *optional*, defaults to 1.0):
-            The amount of probability mass from the original distribution to be considered in typical decoding. If set
-            to 1.0 it takes no effect. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+            If set to float < 1, the smallest set of tokens whose probabilities differ the least from the expected
+            next token probability with probabilities that add up to `typical_p` or higher are kept for generation.
+            See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         diversity_penalty (`float`, *optional*, defaults to 0.0):
             This value is subtracted from a beam's score if it generates a token same as any beam from other group at a
             particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -107,8 +107,10 @@ class GenerationConfig(PushToHubMixin):
             If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to
             `top_p` or higher are kept for generation.
         typical_p (`float`, *optional*, defaults to 1.0):
-            If set to float < 1, the smallest set of tokens whose probabilities differ the least from the expected
-            next token probability with probabilities that add up to `typical_p` or higher are kept for generation.
+            Local typicality measures how similar the conditional probability of predicting a target token next is to
+            the expected conditional probability of predicting a random token next, given the partial text already
+            generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that
+            add up to `typical_p` or higher are kept for generation.
             See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         diversity_penalty (`float`, *optional*, defaults to 0.0):
             This value is subtracted from a beam's score if it generates a token same as any beam from other group at a

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -110,8 +110,8 @@ class GenerationConfig(PushToHubMixin):
             Local typicality measures how similar the conditional probability of predicting a target token next is to
             the expected conditional probability of predicting a random token next, given the partial text already
             generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that
-            add up to `typical_p` or higher are kept for generation.
-            See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+            add up to `typical_p` or higher are kept for generation. See [this
+            paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
         diversity_penalty (`float`, *optional*, defaults to 0.0):
             This value is subtracted from a beam's score if it generates a token same as any beam from other group at a
             particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This adds an argument docstring of locally typical sampling (implemented in #15504) that was missing in `src/transformers/configuration_utils.py` and clarifies the existing docstring in `src/transformers/generation/configuration_utils.py`.


## Who can review?
@stevhliu @patrickvonplaten 