### PR TITLE
Fix `torchscript` tests for `AltCLIP`

### DIFF
--- a/tests/models/altclip/test_modeling_altclip.py
+++ b/tests/models/altclip/test_modeling_altclip.py
@@ -490,6 +490,15 @@ class AltCLIPModelTest(ModelTesterMixin, unittest.TestCase):
             model_state_dict = model.state_dict()
             loaded_model_state_dict = loaded_model.state_dict()
 
+            non_persistent_buffers = {}
+            for key in loaded_model_state_dict.keys():
+                if key not in model_state_dict.keys():
+                    non_persistent_buffers[key] = loaded_model_state_dict[key]
+
+            loaded_model_state_dict = {
+                key: value for key, value in loaded_model_state_dict.items() if key not in non_persistent_buffers
+            }
+
             self.assertEqual(set(model_state_dict.keys()), set(loaded_model_state_dict.keys()))
 
             models_equal = True


### PR DESCRIPTION
# What does this PR do?

Fix `torchscript` tests for `AltCLIP`.

This model uses `roberta` as text model, which has 
```python
        self.register_buffer(
            "token_type_ids", torch.zeros(self.position_ids.size(), dtype=torch.long), persistent=False
        )
```
and this requires the change in this PR to pass the test.

See [current failing job run page](https://github.com/huggingface/transformers/actions/runs/3889079663/jobs/6637067165)