### PR TITLE
Make `test_save_pretrained_signatures` slow test

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -2266,6 +2266,7 @@ class UtilsFunctionsTest(unittest.TestCase):
                 for p1, p2 in zip(model.weights, new_model.weights):
                     self.assertTrue(np.allclose(p1.numpy(), p2.numpy()))
 
+    @slow
     def test_save_pretrained_signatures(self):
         model = TFBertModel.from_pretrained("hf-internal-testing/tiny-random-bert")
 


### PR DESCRIPTION
# What does this PR do?

`UtilsFunctionsTest.test_save_pretrained_signatures` in `tests/test_modeling_tf_common.py` is introduced on Oct. 2022, which runs about ~60 seconds, and failed a lot of times **on Push CI** due to the timeout limit on Push CI job setting (`PYTEST_TIMEOUT`).

Notice that, on CircleCI, we have `PYTEST_TIMEOUT=120` - as we use flag `-n 8` to run tests in parallel. I don't want to set `120` for Push CI at this moment (without running with it first), as it might make the CI slow down (a lot).