### PR TITLE
Add visualbert in visual question answering model mapping

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -707,10 +707,7 @@ MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 )
 
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
-    [
-        ("vilt", "ViltForQuestionAnswering"),
-        ("visual_bert", "VisualBertForQuestionAnswering")
-    ]
+    [("vilt", "ViltForQuestionAnswering"), ("visual_bert", "VisualBertForQuestionAnswering")]
 )
 
 MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -709,6 +709,7 @@ MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         ("vilt", "ViltForQuestionAnswering"),
+        ("visual_bert", "VisualBertForQuestionAnswering")
     ]
 )
 


### PR DESCRIPTION
Following the doc https://huggingface.co/docs/transformers/v4.25.1/en/model_doc/visual_bert#transformers.VisualBertForQuestionAnswering I reckon this one was missing.

## Who can review?
@ydshieh do I need to write any additional test for this?
