### PR TITLE
[LongT5] Remove duplicate encoder_attention_mask default value check

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -1449,11 +1449,6 @@ class LongT5Stack(LongT5PreTrainedModel):
 
         if attention_mask is None:
             attention_mask = torch.ones(batch_size, mask_seq_length, device=inputs_embeds.device)
-        if self.is_decoder and encoder_attention_mask is None and encoder_hidden_states is not None:
-            encoder_seq_length = encoder_hidden_states.shape[1]
-            encoder_attention_mask = torch.ones(
-                batch_size, encoder_seq_length, device=inputs_embeds.device, dtype=torch.long
-            )
 
         # initialize past_key_values with `None` if past does not exist
         if past_key_values is None:


### PR DESCRIPTION
# What does this PR do?

This PR performs a minor code clean-up by removing duplicate code in the LongT5 stack. 
Currently, if the stack is a decoder block with `encoder_hidden_states` provided, the check for the existence of `encoder_attention_mask` is done twice:

1. https://github.com/huggingface/transformers/blob/c8f35a9ce37bd03f37fcf8336172bdcbe7ffc86a/src/transformers/models/longt5/modeling_longt5.py#L1452
2. https://github.com/huggingface/transformers/blob/c8f35a9ce37bd03f37fcf8336172bdcbe7ffc86a/src/transformers/models/longt5/modeling_longt5.py#L1479

Because the conditions on the second check are identical to that of the first check (`self.is_decoder is True`, `encoder_attention_mask is None`, `encoder_hidden_states is not None`), the second check will never be True since  `encoder_hidden_states` was updated during the second check.

This PR proposes removing the first check and only use the second when the extended encoder attention mask is set anyway.

## Who can review?
 @ArthurZucker , @younesbelkada 
