### PR TITLE
Fix `RealmModelIntegrationTest.test_inference_open_qa`

### DIFF
--- a/tests/models/realm/test_modeling_realm.py
+++ b/tests/models/realm/test_modeling_realm.py
@@ -480,15 +480,12 @@ class RealmModelIntegrationTest(unittest.TestCase):
     def test_inference_open_qa(self):
         from transformers.models.realm.retrieval_realm import RealmRetriever
 
-        config = RealmConfig()
-
         tokenizer = RealmTokenizer.from_pretrained("google/realm-orqa-nq-openqa")
         retriever = RealmRetriever.from_pretrained("google/realm-orqa-nq-openqa")
 
         model = RealmForOpenQA.from_pretrained(
             "google/realm-orqa-nq-openqa",
             retriever=retriever,
-            config=config,
         )
 
         question = "Who is the pioneer in modern computer science?"


### PR DESCRIPTION
# What does this PR do?

The test `RealmModelIntegrationTest::test_inference_open_qa` fails since my PR #21000. This integration test creates a config manually by `config = RealmConfig()` and passes it to `from_pretrained`, therefore it doesn't have the attribute `searcher_seq_len` (which is removed in #21000).

Using `from_pretrained` without specifying `config` will load from the Hub checkpoint which has `searcher_seq_len` in the config (loaded via `super().__init__(..., **kwargs)`), and fix the test.

