### PR TITLE
Fixes to TF collators

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -159,7 +159,7 @@ def tf_default_data_collator(features: List[InputDataClass]) -> Dict[str, Any]:
         label_col_name = None
     if label_col_name is not None:
         if isinstance(first[label_col_name], tf.Tensor):
-            dtype = tf.int64 if first[label_col_name].dtype.is_integer() else tf.float32
+            dtype = tf.int64 if first[label_col_name].dtype.is_integer else tf.float32
         elif isinstance(first[label_col_name], np.ndarray) or isinstance(first[label_col_name], np.generic):
             dtype = tf.int64 if np.issubdtype(first[label_col_name].dtype, np.integer) else tf.float32
         elif isinstance(first[label_col_name], (tuple, list)):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1304,7 +1304,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         collate_fn_args: Optional[Dict[str, Any]] = None,
         drop_remainder: Optional[bool] = None,
         prefetch: bool = True,
-        num_workers: int = 0,
     ):
         """
         Wraps a HuggingFace [`~datasets.Dataset`] as a `tf.data.Dataset` with collation and batching. This method is
@@ -1391,7 +1390,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             collate_fn=collate_fn,
             collate_fn_args=collate_fn_args,
             prefetch=prefetch,
-            num_workers=num_workers,
         )
         return tf_dataset
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1304,6 +1304,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         collate_fn_args: Optional[Dict[str, Any]] = None,
         drop_remainder: Optional[bool] = None,
         prefetch: bool = True,
+        num_workers: int = 0,
     ):
         """
         Wraps a HuggingFace [`~datasets.Dataset`] as a `tf.data.Dataset` with collation and batching. This method is
@@ -1390,6 +1391,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             collate_fn=collate_fn,
             collate_fn_args=collate_fn_args,
             prefetch=prefetch,
+            num_workers=num_workers,
         )
         return tf_dataset
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1346,9 +1346,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
         if collate_fn is None:
             if tokenizer is None:
-                collate_fn = DefaultDataCollator(return_tensors="tf")
+                collate_fn = DefaultDataCollator(return_tensors="np")
             else:
-                collate_fn = DataCollatorWithPadding(tokenizer=tokenizer, return_tensors="tf")
+                collate_fn = DataCollatorWithPadding(tokenizer=tokenizer, return_tensors="np")
         if collate_fn_args is None:
             collate_fn_args = dict()
 


### PR DESCRIPTION
This PR makes a couple of fixes to TF data collators:

1) Fixes an incorrect call to `is_integer` when the default data collator receives `tf.Tensor` input and is outputting `tf.Tensor` as well
2) Prefer "np" tensors rather than "tf" tensors when calling our collators via `to_tf_dataset`. This is because data preprocessing is generally done with `np.ndarray` rather than `tf.Tensor` anyway, and Keras/`tf.data` can do the final conversion to `tf.Tensor` for us.