### PR TITLE
CLI: update hub PR URL

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -359,7 +359,7 @@ class PTtoTFCommand(BaseTransformersCLICommand):
             commit_descrition = (
                 "Model converted by the [`transformers`' `pt_to_tf`"
                 " CLI](https://github.com/huggingface/transformers/blob/main/src/transformers/commands/pt_to_tf.py). "
-                "All converted model outputs and hidden layers were validated against its Pytorch counterpart.\n\n"
+                "All converted model outputs and hidden layers were validated against its PyTorch counterpart.\n\n"
                 f"Maximum crossload output difference={max_crossload_output_diff:.3e}; "
                 f"Maximum crossload hidden layer difference={max_crossload_hidden_diff:.3e};\n"
                 f"Maximum conversion output difference={max_conversion_output_diff:.3e}; "
@@ -391,5 +391,5 @@ class PTtoTFCommand(BaseTransformersCLICommand):
                 commit_description=commit_descrition,
                 repo_type="model",
                 create_pr=True,
-            )
+            ).pr_url
             self._logger.warning(f"PR open in {hub_pr_url}")


### PR DESCRIPTION
# What does this PR do?

Keeps up with hub API changes, and updates the instruction to get the PR URL (which was returning an object)