### PR TITLE
Fix `Mask2FormerForUniversalSegmentation` and failed tests

### DIFF
--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -2468,7 +2468,7 @@ class Mask2FormerForUniversalSegmentation(Mask2FormerPreTrainedModel):
             transformer_decoder_hidden_states = outputs.transformer_decoder_hidden_states
 
         output_auxiliary_logits = (
-            self.config.use_auxiliary_loss if output_auxiliary_logits is None else output_auxiliary_logits
+            self.config.output_auxiliary_logits if output_auxiliary_logits is None else output_auxiliary_logits
         )
         if not output_auxiliary_logits:
             auxiliary_logits = None


### PR DESCRIPTION
# What does this PR do?

For `Mask2FormerForUniversalSegmentation` , the tests `test_torchscript_xxx` fails due to `auxiliary_logits` in `Mask2FormerForUniversalSegmentationOutput`. This is a `list of dict of tensors`, which is not supported by torchscript tracing.

The related tests will pass if we don't output this value.  Currently, we have

```python
        output_auxiliary_logits = (
            self.config.use_auxiliary_loss if output_auxiliary_logits is None else output_auxiliary_logits
        )
```
where `use_auxiliary_loss` is `True`. However,  this seems strange to me, and I believe it should be `self.config.output_auxiliary_logits` instead. So I change it.

And this also fixes the related tests too, as `output_auxiliary_logits` is `None` (during the tests)
