### PR TITLE
Generate: documented function to compute the transition scores

### DIFF
--- a/docs/source/en/main_classes/text_generation.mdx
+++ b/docs/source/en/main_classes/text_generation.mdx
@@ -37,6 +37,7 @@ and how to create and save a customized generation configuration, refer to the
 
 [[autodoc]] generation.GenerationMixin
 	- generate
+	- compute_transition_scores
 	- greedy_search
 	- sample
 	- beam_search

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1002,8 +1002,8 @@ class GenerationMixin:
         >>> print(np.allclose(outputs.sequences_scores, reconstructed_scores))
         True
         ```"""
-        # 1. In abcense of `beam_indices`, we can assume that we come from e.g. greedy search, which is equivalent
-        # to a beam search approach were the first (and only) beam was always selected
+        # 1. In absence of `beam_indices`, we can assume that we come from e.g. greedy search, which is equivalent
+        # to a beam search approach were the first (and only) beam is always selected
         if beam_indices is None:
             beam_indices = torch.arange(scores[0].shape[0]).view(-1, 1).to(sequences.device)
             beam_indices = beam_indices.expand(-1, len(scores))
@@ -1012,7 +1012,7 @@ class GenerationMixin:
         # seq_len - input_length
         scores = torch.stack(scores).reshape(len(scores), -1).transpose(0, 1)
 
-        # 3. Optionally normalize the logits
+        # 3. Optionally normalize the logits (across the vocab dimension)
         if normalize_logits:
             scores = scores.reshape(-1, self.config.vocab_size, scores.shape[-1])
             scores = torch.nn.functional.log_softmax(scores, dim=1)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -929,7 +929,7 @@ class GenerationMixin:
         sequences: torch.Tensor,
         scores: Tuple[torch.Tensor],
         beam_indices: Optional[torch.Tensor] = None,
-        renormalize_logits: bool = True,
+        normalize_logits: bool = True,
     ) -> torch.Tensor:
         """
         Computes the transition scores of sequences given the generation scores (and beam indices, if beam search was
@@ -943,49 +943,100 @@ class GenerationMixin:
                 Beam transition scores for each vocabulary token at each generation step. Beam transition scores
                 consisting of log probabilities of tokens conditioned on log softmax of previously generated tokens in
                 this beam. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for each
-                generated token), with each tensor of shape `(batch_size*num_beams*num_return_sequences,
-                config.vocab_size)`.
+                generated token), with each tensor of shape `(batch_size*num_beams, config.vocab_size)`.
             beam_indices (`tuple(tuple(torch.LongTensor))`, *optional*):
                 Beam indices of generated token id at each generation step. `torch.LongTensor` of shape
                 `(batch_size*num_return_sequences, input_ids.shape[-1])`. Only required if a `num_beams>1` at
                 generate-time.
-            renormalize_logits (`bool`, *optional*, defaults to `True`):
-                Whether to renormalize the logits (which, due to legacy, may be unnormalized).
+            normalize_logits (`bool`, *optional*, defaults to `True`):
+                Whether to normalize the logits (which, due to legacy, may be unnormalized).
 
         Return:
             `torch.Tensor`: A `torch.Tensor` of shape `(batch_size*num_return_sequences, sequence_length)` containing
-                the transition scores
-        """
+                the transition scores (logits)
+
+        Examples:
+
+        ```python
+        >>> from transformers import GPT2Tokenizer, AutoModelForCausalLM
+        >>> import numpy as np
+
+        >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2", padding_side="left")
+        >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
+        >>> tokenizer.pad_token_id = tokenizer.eos_token_id
+        >>> inputs = tokenizer(["Today is"], return_tensors="pt", padding=True)
+
+        >>> # Example 1: Print the scores for each token generated with Greedy Search
+        >>> outputs = model.generate(**inputs, max_new_tokens=5, return_dict_in_generate=True, output_scores=True)
+        >>> transition_scores = model.compute_transition_beam_scores(outputs.sequences, outputs.scores)
+        >>> input_length = inputs.input_ids.shape[1]
+        >>> generated_tokens = outputs.sequences[:, input_length:]
+        >>> for tok, score in zip(generated_tokens[0], transition_scores[0]):
+        ...     # | token | token string | logits | probability
+        ...     print(f"| {tok:5d} | {tokenizer.decode(tok):8s} | {score.numpy():.4f} | {np.exp(score.numpy()):.2%}")
+        |   262 |  the     | -1.4136 | 24.33%
+        |  1110 |  day     | -2.6089 | 7.36%
+        |   618 |  when    | -2.0096 | 13.40%
+        |   356 |  we      | -1.8593 | 15.58%
+        |   460 |  can     | -2.5083 | 8.14%
+
+        >>> # Example 2: Reconstruct the sequence scores from Beam Search
+        >>> outputs = model.generate(
+        ...     **inputs,
+        ...     max_new_tokens=5,
+        ...     num_beams=4,
+        ...     num_return_sequences=4,
+        ...     return_dict_in_generate=True,
+        ...     output_scores=True,
+        ... )
+        >>> transition_scores = model.compute_transition_beam_scores(
+        ...     outputs.sequences, outputs.scores, outputs.beam_indices, normalize_logits=False
+        ... )
+        >>> # If you sum the generated tokens' scores and apply the length penalty, you'll get the sequence scores.
+        >>> # Tip: set `normalize_logits=True` to recompute the scores from the normalized logits.
+        >>> output_length = inputs.input_ids.shape[1] + np.sum(transition_scores.numpy() < 0, axis=1)
+        >>> length_penalty = model.generation_config.length_penalty
+        >>> reconstructed_scores = transition_scores.sum(axis=1) / (output_length**length_penalty)
+        >>> print(np.allclose(outputs.sequences_scores, reconstructed_scores))
+        True
+        ```"""
         # 1. In abcense of `beam_indices`, we can assume that we come from e.g. greedy search, which is equivalent
         # to a beam search approach were the first (and only) beam was always selected
         if beam_indices is None:
             beam_indices = torch.arange(scores[0].shape[0]).view(-1, 1)
             beam_indices = beam_indices.expand(-1, len(scores))
 
-        # 2. reshape scores as [batch_size, vocab_size, # generation steps]
-        # with # generation steps being seq_len - input_length
+        # 2. reshape scores as [batch_size*vocab_size, # generation steps] with # generation steps being
+        # seq_len - input_length
         scores = torch.stack(scores).reshape(len(scores), -1).transpose(0, 1)
-        breakpoint()
-        scores = scores.reshape(sequences.shape[0], self.config.vocab_size, -1)
 
-        # 3. cut beam_indices to longest beam length
+        # 3. Optionally normalize the logits
+        if normalize_logits:
+            scores = scores.reshape(sequences.shape[0], self.config.vocab_size, -1)
+            scores = torch.nn.functional.log_softmax(scores, dim=1)
+            scores = scores.reshape(-1, scores.shape[-1])
+
+        # 4. cut beam_indices to longest beam length
         beam_indices_mask = beam_indices < 0
         max_beam_length = (1 - beam_indices_mask.long()).sum(-1).max()
         beam_indices = beam_indices[:, :max_beam_length]
         beam_indices_mask = beam_indices_mask[:, :max_beam_length]
 
-        # 4. Set indices of beams that finished early to 0
+        # 5. Set indices of beams that finished early to 0
         # such indices will be masked correctly afterwards
         beam_indices[beam_indices_mask] = 0
 
-        # 5. Define which indices contributed to scores
+        # 6. multiply beam_indices with vocab size to gather correctly from scores
+        beam_sequence_indices = beam_indices * self.config.vocab_size
+
+        # 7. Define which indices contributed to scores
         cut_idx = sequences.shape[-1] - max_beam_length
-        indices = sequences[:, cut_idx:]
+        indices = sequences[:, cut_idx:] + beam_sequence_indices
 
-        # 6. Compute scores
-        transition_scores = scores.gather(1, indices[:, None, :])
+        # 8. Compute scores
+        transition_scores = scores.gather(0, indices)
 
-        # 7. Mask out transition_scores of beams that stopped early
+        # 9. Mask out transition_scores of beams that stopped early
         transition_scores[beam_indices_mask] = 0
 
         return transition_scores

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -940,15 +940,15 @@ class GenerationMixin:
                 The generated sequences. The second dimension (sequence_length) is either equal to `max_length` or
                 shorter if all batches finished early due to the `eos_token_id`.
             scores (`tuple(torch.FloatTensor)`):
-                Beam transition scores for each vocabulary token at each generation step. Beam transition scores
-                consisting of log probabilities of tokens conditioned on log softmax of previously generated tokens in
-                this beam. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for each
+                Transition scores for each vocabulary token at each generation step. Beam transition scores
+                consisting of log probabilities of tokens conditioned on log softmax of previously generated tokens
+                Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for each
                 generated token), with each tensor of shape `(batch_size*num_beams, config.vocab_size)`.
             beam_indices (`tuple(tuple(torch.LongTensor))`, *optional*):
                 Beam indices of generated token id at each generation step. `torch.LongTensor` of shape
                 `(batch_size*num_return_sequences, input_ids.shape[-1])`. Only required if a `num_beams>1` at
                 generate-time.
-            normalize_logits (`bool`, *optional*, defaults to `True`):
+            normalize_logits (`bool`, *optional*, defaults to `False`):
                 Whether to normalize the logits (which, for legacy reasons, may be unnormalized).
 
         Return:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -962,10 +962,11 @@ class GenerationMixin:
             beam_indices = torch.arange(scores[0].shape[0]).view(-1, 1)
             beam_indices = beam_indices.expand(-1, len(scores))
 
-        # 2. reshape scores as [vocab_size, batch_size, # generation steps]
+        # 2. reshape scores as [batch_size, vocab_size, # generation steps]
         # with # generation steps being seq_len - input_length
         scores = torch.stack(scores).reshape(len(scores), -1).transpose(0, 1)
-        scores = scores.reshape(sequences.shape[0], self.config.vocab_size, -1).transpose(0, 1)
+        breakpoint()
+        scores = scores.reshape(sequences.shape[0], self.config.vocab_size, -1)
 
         # 3. cut beam_indices to longest beam length
         beam_indices_mask = beam_indices < 0
@@ -982,7 +983,7 @@ class GenerationMixin:
         indices = sequences[:, cut_idx:]
 
         # 6. Compute scores
-        transition_scores = scores.gather(0, indices[None, :, :]).squeeze(0)
+        transition_scores = scores.gather(1, indices[:, None, :])
 
         # 7. Mask out transition_scores of beams that stopped early
         transition_scores[beam_indices_mask] = 0

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -940,10 +940,10 @@ class GenerationMixin:
                 The generated sequences. The second dimension (sequence_length) is either equal to `max_length` or
                 shorter if all batches finished early due to the `eos_token_id`.
             scores (`tuple(torch.FloatTensor)`):
-                Transition scores for each vocabulary token at each generation step. Beam transition scores
-                consisting of log probabilities of tokens conditioned on log softmax of previously generated tokens
-                Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for each
-                generated token), with each tensor of shape `(batch_size*num_beams, config.vocab_size)`.
+                Transition scores for each vocabulary token at each generation step. Beam transition scores consisting
+                of log probabilities of tokens conditioned on log softmax of previously generated tokens Tuple of
+                `torch.FloatTensor` with up to `max_new_tokens` elements (one element for each generated token), with
+                each tensor of shape `(batch_size*num_beams, config.vocab_size)`.
             beam_indices (`tuple(tuple(torch.LongTensor))`, *optional*):
                 Beam indices of generated token id at each generation step. `torch.LongTensor` of shape
                 `(batch_size*num_return_sequences, input_ids.shape[-1])`. Only required if a `num_beams>1` at
@@ -961,10 +961,10 @@ class GenerationMixin:
         >>> from transformers import GPT2Tokenizer, AutoModelForCausalLM
         >>> import numpy as np
 
-        >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2", padding_side="left")
+        >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
         >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
         >>> tokenizer.pad_token_id = tokenizer.eos_token_id
-        >>> inputs = tokenizer(["Today is"], return_tensors="pt", padding=True)
+        >>> inputs = tokenizer(["Today is"], return_tensors="pt")
 
         >>> # Example 1: Print the scores for each token generated with Greedy Search
         >>> outputs = model.generate(**inputs, max_new_tokens=5, return_dict_in_generate=True, output_scores=True)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -924,7 +924,7 @@ class GenerationMixin:
         default_list.extend(custom_list)
         return default_list
 
-    def compute_transition_beam_scores(
+    def compute_transition_scores(
         self,
         sequences: torch.Tensor,
         scores: Tuple[torch.Tensor],
@@ -968,7 +968,7 @@ class GenerationMixin:
 
         >>> # Example 1: Print the scores for each token generated with Greedy Search
         >>> outputs = model.generate(**inputs, max_new_tokens=5, return_dict_in_generate=True, output_scores=True)
-        >>> transition_scores = model.compute_transition_beam_scores(
+        >>> transition_scores = model.compute_transition_scores(
         ...     outputs.sequences, outputs.scores, normalize_logits=True
         ... )
         >>> input_length = inputs.input_ids.shape[1]
@@ -991,7 +991,7 @@ class GenerationMixin:
         ...     return_dict_in_generate=True,
         ...     output_scores=True,
         ... )
-        >>> transition_scores = model.compute_transition_beam_scores(
+        >>> transition_scores = model.compute_transition_scores(
         ...     outputs.sequences, outputs.scores, outputs.beam_indices, normalize_logits=False
         ... )
         >>> # If you sum the generated tokens' scores and apply the length penalty, you'll get the sequence scores.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2485,6 +2485,29 @@ class GenerationIntegrationTests(unittest.TestCase):
 
         self.assertListEqual(output_sequences_no_mask.tolist(), output_sequences_with_mask.tolist())
 
+    def test_transition_scores_greedy_search(self):
+        articles = [
+            "Justin Timberlake",
+            "Michael Phelps",
+        ]
+        tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        tokenizer.pad_token = tokenizer.eos_token
+
+        model = GPT2LMHeadModel.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+
+        input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
+        outputs = model.generate(
+            input_ids=input_ids,
+            max_new_tokens=10,
+            pad_token_id=tokenizer.eos_token_id,
+            eos_token_id=None,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+
+        transition_scores = model.compute_transition_beam_scores(outputs.sequences, outputs.scores)
+        breakpoint()
+
     def test_transition_scores_beam_search_encoder_decoder(self):
         articles = [
             "Justin Timberlake and Jessica Biel, welcome to parenthood.",

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2507,7 +2507,7 @@ class GenerationIntegrationTests(unittest.TestCase):
             output_scores=True,
         )
 
-        transition_scores = model.compute_transition_beam_scores(outputs.sequences, outputs.scores)
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores)
         expected_scores = np.array(
             [
                 [0.3596273, 0.39646253, 0.46157718, 0.4594633, 0.44866616],
@@ -2536,9 +2536,7 @@ class GenerationIntegrationTests(unittest.TestCase):
             output_scores=True,
         )
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, normalize_logits=True
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, normalize_logits=True)
         expected_scores = np.array(
             [
                 [-6.5532393, -6.5158753, -6.451863, -6.4527144, -6.459402],
@@ -2568,9 +2566,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
         outputs = model.generate(input_ids=input_ids)
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, outputs.beam_indices
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, outputs.beam_indices)
         transition_scores_sum = transition_scores.sum(-1)
 
         self.assertTrue(torch.allclose(transition_scores_sum, outputs.sequences_scores, atol=1e-3))
@@ -2595,9 +2591,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
         outputs = model.generate(input_ids=input_ids)
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, outputs.beam_indices
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, outputs.beam_indices)
         transition_scores_sum = transition_scores.sum(-1)
 
         self.assertTrue(torch.allclose(transition_scores_sum, outputs.sequences_scores, atol=1e-3))
@@ -2626,9 +2620,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
         outputs = model.generate(input_ids=input_ids)
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, outputs.beam_indices
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, outputs.beam_indices)
         transition_scores_sum = transition_scores.sum(-1)
 
         self.assertTrue(torch.allclose(transition_scores_sum, outputs.sequences_scores, atol=1e-3))
@@ -2655,9 +2647,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
         outputs = model.generate(input_ids=input_ids)
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, outputs.beam_indices
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, outputs.beam_indices)
         transition_scores_sum = transition_scores.sum(-1)
 
         self.assertTrue(torch.allclose(transition_scores_sum, outputs.sequences_scores, atol=1e-3))
@@ -2684,9 +2674,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         input_ids = tokenizer(articles, return_tensors="pt", padding=True).input_ids.to(torch_device)
         outputs = model.generate(input_ids=input_ids)
 
-        transition_scores = model.compute_transition_beam_scores(
-            outputs.sequences, outputs.scores, outputs.beam_indices
-        )
+        transition_scores = model.compute_transition_scores(outputs.sequences, outputs.scores, outputs.beam_indices)
         transition_scores_sum = transition_scores.sum(-1)
 
         self.assertTrue(torch.allclose(transition_scores_sum, outputs.sequences_scores, atol=1e-3))
@@ -2715,7 +2703,7 @@ class GenerationIntegrationTests(unittest.TestCase):
             length_penalty=0.0,
         )
 
-        transition_scores = model.compute_transition_beam_scores(
+        transition_scores = model.compute_transition_scores(
             sequences=result.sequences, scores=result.scores, beam_indices=result.beam_indices
         )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2488,10 +2488,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertListEqual(output_sequences_no_mask.tolist(), output_sequences_with_mask.tolist())
 
     def test_transition_scores_greedy_search(self):
-        articles = [
-            "Justin Timberlake",
-            "Michael Phelps",
-        ]
+        articles = ["Justin Timberlake", "Michael Phelps"]
         tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         tokenizer.pad_token = tokenizer.eos_token
 
@@ -2517,10 +2514,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertTrue(np.allclose(transition_scores.cpu().numpy(), expected_scores))
 
     def test_transition_scores_greedy_search_normalized(self):
-        articles = [
-            "Justin Timberlake",
-            "Michael Phelps",
-        ]
+        articles = ["Justin Timberlake", "Michael Phelps"]
         tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         tokenizer.pad_token = tokenizer.eos_token
 


### PR DESCRIPTION
# What does this PR do?

Fixes #18616; Addresses comments in #5164, #20008 (and in a few other issues that I've lost track of).

## The issue

A few users would like to have a simple function to obtain the transition scores (i.e. the logits for each selected token at generate time). This is very useful for exploring the generated contents and simplifies the construction of powerful color-coded interfaces (e.g. [this one](https://joel.tools/codegen/)). It is also commonly requested to compare our models against OpenAI's.

We had a function for that in PT, `compute_beam_transition_scores`, but it was unknown to most users. This is because it was limited to Beam-based approaches, was not in our documents, and had no examples.

## The solution

This PR upgrades the function above to a first-class citizen 🥇 :
1. Makes it compatible with all generation strategies (e.g. Sample)
2. Adds a flag to renormalize the logits before fetching the right ones, which is a frequent downstream use
3. Adds it to the documentation
4. Populates the docstring with examples for which I've got questions a few times (how to print the token probabilities and how to recompute the score of the sequences in beam search)

In the process, I've decided to update the name of the function (`compute_beam_transition_scores` -> `compute_transition_scores`), to match better what it does. Although this technically breaks the API, the function was not part of our documented functions and, given the number of related issues, I'd say it was mostly unknown.