### PR TITLE
[`CVT`] Fix module initialization issue

### DIFF
--- a/src/transformers/models/cvt/modeling_cvt.py
+++ b/src/transformers/models/cvt/modeling_cvt.py
@@ -451,11 +451,7 @@ class CvtStage(nn.Module):
         self.config = config
         self.stage = stage
         if self.config.cls_token[self.stage]:
-            self.cls_token = nn.Parameter(
-                nn.init.trunc_normal_(
-                    torch.zeros(1, 1, self.config.embed_dim[-1]), mean=0.0, std=config.initializer_range
-                )
-            )
+            self.cls_token = nn.Parameter(torch.randn(1, 1, self.config.embed_dim[-1]))
 
         self.embedding = CvtEmbeddings(
             patch_size=config.patch_sizes[self.stage],
@@ -557,6 +553,11 @@ class CvtPreTrainedModel(PreTrainedModel):
         elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
+        elif isinstance(module, CvtStage):
+            if self.config.cls_token[module.stage]:
+                module.cls_token.data = nn.init.trunc_normal_(
+                    torch.zeros(1, 1, self.config.embed_dim[-1]), mean=0.0, std=self.config.initializer_range
+                )
 
 
 CVT_START_DOCSTRING = r"""


### PR DESCRIPTION
# What does this PR do?

This PR fixes the issue described in the PR https://github.com/huggingface/transformers/pull/20803 and this comment: https://github.com/huggingface/transformers/pull/20803#discussion_r1059138540 for `CVT`

Before this PR if a user wants to initialize CVT model in half precision with the example script below they will encounter an issue that is hard to interpret: 
```
from transformers import AutoFeatureExtractor, CvtForImageClassification
from PIL import Image
import requests
import torch

url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
image = Image.open(requests.get(url, stream=True).raw)

feature_extractor = AutoFeatureExtractor.from_pretrained('microsoft/cvt-13')
model = CvtForImageClassification.from_pretrained('microsoft/cvt-13', torch_dtype=torch.float16).to(0)

inputs = feature_extractor(images=image, return_tensors="pt").to(0, torch.float16)
outputs = model(**inputs)
logits = outputs.logits
# model predicts one of the 1000 ImageNet classes
predicted_class_idx = logits.argmax(-1).item()
print("Predicted class:", model.config.id2label[predicted_class_idx])
```
Error message:
```
RuntimeError: "erfinv_vml_cpu" not implemented for 'Half'
```
The reason of the error is described in https://github.com/huggingface/transformers/pull/20803#discussion_r1059138540 
Therefore this PR circumvent this issue by forcing the `cls_token` module to be initialized on the correct place. 
All slow tests pass

cc @sgugger @ydshieh  

If this PR gets merged, there should be no more modules in `transformers` that will be initialized with `trunc_normal_` outside `init_weights` method