### PR TITLE
Declare __len__ method in PreTrainedTokenizerBase

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1578,6 +1578,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             f" special_tokens={self.special_tokens_map_extended})"
         )
 
+    def __len__(self) -> int:
+        raise NotImplementedError()
+
     def get_vocab(self) -> Dict[str, int]:
         """
         Returns the vocabulary as a dictionary of token to index.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1578,6 +1578,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             f" special_tokens={self.special_tokens_map_extended})"
         )
 
+    def __len__(self) -> int:
+        return len(self.get_vocab())
+
     def get_vocab(self) -> Dict[str, int]:
         """
         Returns the vocabulary as a dictionary of token to index.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1578,9 +1578,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             f" special_tokens={self.special_tokens_map_extended})"
         )
 
-    def __len__(self) -> int:
-        return len(self.get_vocab())
-
     def get_vocab(self) -> Dict[str, int]:
         """
         Returns the vocabulary as a dictionary of token to index.

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -165,12 +165,6 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         added_vocab = dict((tok, index) for tok, index in full_vocab.items() if tok not in base_vocab)
         return added_vocab
 
-    def __len__(self) -> int:
-        """
-        Size of the full vocabulary with the added tokens.
-        """
-        return self._tokenizer.get_vocab_size(with_added_tokens=True)
-
     @property
     def backend_tokenizer(self) -> TokenizerFast:
         """

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -165,6 +165,12 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         added_vocab = dict((tok, index) for tok, index in full_vocab.items() if tok not in base_vocab)
         return added_vocab
 
+    def __len__(self) -> int:
+        """
+        Size of the full vocabulary with the added tokens.
+        """
+        return self._tokenizer.get_vocab_size(with_added_tokens=True)
+
     @property
     def backend_tokenizer(self) -> TokenizerFast:
         """


### PR DESCRIPTION
# What does this PR do?

When type hinting a tokenizer with `PreTrainedTokenizerBase`, it doesn't know supprt `len(tokenizer)`, but both slow and fast version implement `__len__` so we declare it at least to make the type hints happy, we could make this an `abstract_method` as well if needed