### PR TITLE
Fix GPTJ doctest

### DIFF
--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -904,7 +904,7 @@ class GPTJForSequenceClassification(GPTJPreTrainedModel):
 
     @add_start_docstrings_to_model_forward(GPTJ_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(
-        checkpoint=_CHECKPOINT_FOR_DOC,
+        checkpoint="ydshieh/tiny-random-gptj-for-sequence-classification",
         output_type=SequenceClassifierOutputWithPast,
         config_class=_CONFIG_FOR_DOC,
         real_checkpoint=_REAL_CHECKPOINT_FOR_DOC,


### PR DESCRIPTION
# What does this PR do?

In #21178, the checkpoint used for `GPTJForSequenceClassification` is changed back to `_CHECKPOINT_FOR_DOC`, which is `hf-internal-testing/tiny-random-gptj`. That checkpoint has `self.score` with shape `[2, 512]`, but the model has `self.score` with shape `[2, 32]` as `config.n_embd=32`. The checkpoint has `512` which came from a mistake of using `n_ctx` previously, and that error is fixed in #14190, see [here](https://github.com/huggingface/transformers/commit/ce91bf9a3431b4d260005de84c0b0fa394409a3c#diff-61155574bf9c9669ccdfdf7dd508a5979b4e4915cc95f7ff4a63fee05a0e2715).

The PR uses another tiny checkpoint to pass the test.

