### PR TITLE
Fix OneFormer Docstrings

### DIFF
--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -3112,8 +3112,8 @@ class OneFormerForUniversalSegmentation(OneFormerPreTrainedModel):
         >>> class_queries_logits = outputs.class_queries_logits
         >>> masks_queries_logits = outputs.masks_queries_logits
 
-        >>> # you can pass them to feature_extractor for semantic postprocessing
-        >>> predicted_semantic_map = feature_extractor.post_process_semantic_segmentation(
+        >>> # you can pass them to processor for semantic postprocessing
+        >>> predicted_semantic_map = processor.post_process_semantic_segmentation(
         ...     outputs, target_sizes=[image.size[::-1]]
         ... )[0]
         >>> f"👉 Semantic Predictions Shape: {list(predicted_semantic_map.shape)}"
@@ -3129,8 +3129,8 @@ class OneFormerForUniversalSegmentation(OneFormerPreTrainedModel):
         >>> class_queries_logits = outputs.class_queries_logits
         >>> masks_queries_logits = outputs.masks_queries_logits
 
-        >>> # you can pass them to feature_extractor for instance postprocessing
-        >>> predicted_instance_map = feature_extractor.post_process_instance_segmentation(
+        >>> # you can pass them to processor for instance postprocessing
+        >>> predicted_instance_map = processor.post_process_instance_segmentation(
         ...     outputs, target_sizes=[image.size[::-1]]
         ... )[0]["segmentation"]
         >>> f"👉 Instance Predictions Shape: {list(predicted_instance_map.shape)}"
@@ -3146,8 +3146,8 @@ class OneFormerForUniversalSegmentation(OneFormerPreTrainedModel):
         >>> class_queries_logits = outputs.class_queries_logits
         >>> masks_queries_logits = outputs.masks_queries_logits
 
-        >>> # you can pass them to feature_extractor for panoptic postprocessing
-        >>> predicted_panoptic_map = feature_extractor.post_process_panoptic_segmentation(
+        >>> # you can pass them to processor for panoptic postprocessing
+        >>> predicted_panoptic_map = processor.post_process_panoptic_segmentation(
         ...     outputs, target_sizes=[image.size[::-1]]
         ... )[0]["segmentation"]
         >>> f"👉 Panoptic Predictions Shape: {list(predicted_panoptic_map.shape)}"

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -2917,7 +2917,7 @@ class OneFormerModel(OneFormerPreTrainedModel):
         >>> class_predictions = outputs.transformer_decoder_class_predictions
 
         >>> f"👉 Mask Predictions Shape: {list(mask_predictions.shape)}, Class Predictions Shape: {list(class_predictions.shape)}"
-        '👉 Mask Predictions Shape: [1, 150, 128, 176], Class Predictions Shape: [1, 150, 151]'
+        '👉 Mask Predictions Shape: [1, 150, 128, 171], Class Predictions Shape: [1, 150, 151]'
         ```"""
 
         if pixel_values is None:


### PR DESCRIPTION
# What does this PR do?

Fixes docstrings for OneFormer.

- [x] Checked that all the doctests passed for the following command:

```bash
python3 -m pytest -v --make-reports doc_tests_gpu --doctest-modules src/transformers/models/oneformer/ -sv --doctest-continue-on-failure --doctest-glob="*.mdx"
```
## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ydshieh 