### PR TITLE
[`BLIP`] fix doctest

### DIFF
--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -1176,17 +1176,28 @@ class BlipForQuestionAnswering(BlipPreTrainedModel):
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
+
+        >>> # training
         >>> text = "How many cats are in the picture?"
-
+        >>> label = "2"
         >>> inputs = processor(images=image, text=text, return_tensors="pt")
+        >>> labels = processor(text=label, return_tensors="pt").input_ids
 
+        >>> inputs["labels"] = labels
         >>> outputs = model(**inputs)
+
+        >>> # inference
+        >>> text = "How many cats are in the picture?"
+        >>> inputs = processor(images=image, text=text, return_tensors="pt")
+        >>> outputs = model.generate(**inputs)
+        >>> print(processor.decode(outputs[0], skip_special_tokens=True))
+        2
         ```"""
         if labels is None and decoder_input_ids is None:
             raise ValueError(
                 "Either `decoder_input_ids` or `labels` should be passed when calling `forward` with"
                 " `BlipForQuestionAnswering`. if you are training the model make sure that `labels` is passed, if you"
-                " are using the model for inference make sure that `decoder_input_ids` is passed."
+                " are using the model for inference make sure that `decoder_input_ids` is passed or call `generate`"
             )
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -1392,8 +1403,8 @@ class BlipForImageTextRetrieval(BlipPreTrainedModel):
         >>> import requests
         >>> from transformers import BlipProcessor, BlipForImageTextRetrieval
 
-        >>> model = BlipForImageTextRetrieval.from_pretrained("Salesforce/blip-itm-base")
-        >>> processor = BlipProcessor.from_pretrained("Salesforce/blip-itm-base")
+        >>> model = BlipForImageTextRetrieval.from_pretrained("Salesforce/blip-itm-base-coco")
+        >>> processor = BlipProcessor.from_pretrained("Salesforce/blip-itm-base-coco")
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -1185,6 +1185,8 @@ class BlipForQuestionAnswering(BlipPreTrainedModel):
 
         >>> inputs["labels"] = labels
         >>> outputs = model(**inputs)
+        >>> loss = outputs.loss
+        >>> loss.backward()
 
         >>> # inference
         >>> text = "How many cats are in the picture?"


### PR DESCRIPTION
# What does this PR do?

This PR fixes `BLIP` doctest. 

Link to failing job: https://github.com/huggingface/transformers/actions/runs/3964164193 

The docstring of the `forward` method of `BlipForQuestionAnswering` has been corrected to educate users on how to correctly use this module after https://github.com/huggingface/transformers/pull/21021 being merged. 
The logic now of the `forward` method is pretty much similar to [`T5`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L1592-L1610).  

cc @ydshieh 💯 