### PR TITLE
[Whisper] fix all issues with unk token

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -479,8 +479,11 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return self.encoder.get(token, self.encoder.get(self.unk_token))
 
     def _convert_id_to_token(self, index):
-        """Converts an index (integer) in a token (str) using the vocab."""
-        return self.decoder.get(index, self.decoder.get(self.unk_token_id))
+        """
+        Converts an index (integer) in a token (str) using the vocab.
+        Whisper's base tokenizer always decodes OOV tokens as "", thus we do not use the `unk_token` here.
+        """
+        return self.decoder.get(index, "")
 
     def _normalize(self, text):
         """

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -480,8 +480,8 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
     def _convert_id_to_token(self, index):
         """
-        Converts an index (integer) in a token (str) using the vocab.
-        Whisper's base tokenizer always decodes OOV tokens as "", thus we do not use the `unk_token` here.
+        Converts an index (integer) in a token (str) using the vocab. Whisper's base tokenizer always decodes OOV
+        tokens as "", thus we do not use the `unk_token` here.
         """
         return self.decoder.get(index, "")
 


### PR DESCRIPTION
# What does this PR do?
Previously, all OOV ( and thus timestamp tokens) outputed by the model are decoded to `<|endoftext|>` by the `xxx.en` whisper models. This does not happen with the multilingual model only because I added `""` to the vocabulary, and the `unk_token_id` is the same `""`. But this does not really make sense. 
As the default behavior for Whisper is just to outptu `""` for any OOV, now the `_convert_id_to_token` function does not use a `unk_token`. 

This will fix the inconsistency, and will help for the whisper refactoring. 
