### PR TITLE
[GenerationConfig] add additional kwargs handling

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -548,6 +548,15 @@ class GenerationConfig(PushToHubMixin):
         config = cls(**config_dict)
         unused_kwargs = config.update(**kwargs)
 
+        to_remove = []
+        for key, value in kwargs.items():
+            if hasattr(config, key):
+                setattr(config, key, value)
+                if key != "torch_dtype":
+                    to_remove.append(key)
+        for key in to_remove:
+            kwargs.pop(key, None)
+
         logger.info(f"Generate config {config}")
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -284,6 +284,7 @@ class GenerationConfig(PushToHubMixin):
 
         # Additional attributes without default values
         if not self._from_model_config:
+            # we don't want to copy values from the model config if we're initializing a `GenerationConfig` from a model's default configuration file
             for key, value in kwargs.items():
                 try:
                     setattr(self, key, value)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -546,7 +546,6 @@ class GenerationConfig(PushToHubMixin):
             kwargs["_commit_hash"] = config_dict["_commit_hash"]
 
         config = cls(**config_dict)
-        unused_kwargs = config.update(**kwargs)
 
         to_remove = []
         for key, value in kwargs.items():
@@ -557,6 +556,7 @@ class GenerationConfig(PushToHubMixin):
         for key in to_remove:
             kwargs.pop(key, None)
 
+        unused_kwargs = config.update(**kwargs)
         logger.info(f"Generate config {config}")
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -282,6 +282,14 @@ class GenerationConfig(PushToHubMixin):
         self._commit_hash = kwargs.pop("_commit_hash", None)
         self.transformers_version = kwargs.pop("transformers_version", __version__)
 
+        # Additional attributes without default values
+        for key, value in kwargs.items():
+            try:
+                setattr(self, key, value)
+            except AttributeError as err:
+                logger.error(f"Can't set {key} with value {value} for {self}")
+                raise err
+
     def __eq__(self, other):
         self_dict = self.__dict__.copy()
         other_dict = other.__dict__.copy()

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -656,6 +656,7 @@ class GenerationConfig(PushToHubMixin):
             [`GenerationConfig`]: The configuration object instantiated from those parameters.
         """
         config_dict = model_config.to_dict()
+        config_dict.pop("_from_model_config")
         config = cls.from_dict(config_dict, return_unused_kwargs=False, _from_model_config=True)
 
         # Special case: some models have generation attributes set in the decoder. Use them if still unset in the

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -656,7 +656,7 @@ class GenerationConfig(PushToHubMixin):
             [`GenerationConfig`]: The configuration object instantiated from those parameters.
         """
         config_dict = model_config.to_dict()
-        config_dict.pop("_from_model_config")
+        config_dict.pop("_from_model_config", None)
         config = cls.from_dict(config_dict, return_unused_kwargs=False, _from_model_config=True)
 
         # Special case: some models have generation attributes set in the decoder. Use them if still unset in the

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -78,6 +78,20 @@ class GenerationConfigTest(unittest.TestCase):
         # `.update()` returns a dictionary of unused kwargs
         self.assertEqual(unused_kwargs, {"foo": "bar"})
 
+    def test_initialize_new_kwargs(self):
+        generation_config = GenerationConfig()
+        generation_config.foo = "bar"
+
+        with tempfile.TemporaryDirectory("test-generation-config") as tmp_dir:
+            generation_config.save_pretrained(tmp_dir)
+
+            new_config = GenerationConfig.from_pretrained(tmp_dir)
+        # update_kwargs was used to update the config on valid attributes
+        self.assertEqual(new_config.foo, "bar")
+
+        generation_config = GenerationConfig.from_model_config(new_config)
+        assert not hasattr(generation_config, "foo")  # no new kwargs should be initialized if from config
+
 
 @is_staging_test
 class ConfigPushToHubTester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?
This add the same support that we have in the `PretrainedConfig`, where additional kwargs are automaticallu updated. 
This will allow users to re-use the `GenerationConfig` class for most of the use_cases, whithout having to add a model specific class. I was trying to load [the following `generation_config` ](https://huggingface.co/openai/whisper-small/discussions/10/files)and got half of my additional arguments deleted 😉  