### PR TITLE
[`t5`] Fix T5 inference in `float16` + `bnb` error

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -277,6 +277,8 @@ class LongT5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
+            hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
         return hidden_states
 

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -147,6 +147,8 @@ class MT5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
+            hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
         return hidden_states
 
@@ -169,7 +171,8 @@ class MT5DenseGatedActDense(nn.Module):
 
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
-        if hidden_states.dtype != self.wo.weight.dtype:
+        # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -274,6 +274,8 @@ class SwitchTransformersDenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
+            hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
         return hidden_states
 

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -290,6 +290,8 @@ class T5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
+            hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
         return hidden_states
 
@@ -311,7 +313,8 @@ class T5DenseGatedActDense(nn.Module):
 
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
-        if hidden_states.dtype != self.wo.weight.dtype:
+        # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        if hidden_states.dtype != self.wo.weight.dtype and self.wo.weight.dtype != torch.int8:
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -163,6 +163,65 @@ class MixedInt8Test(BaseMixedInt8Test):
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
 
 
+class MixedInt8T5Test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model_name = "t5-small"
+        cls.dense_act_model_name = "google/flan-t5-small"  # flan-t5 uses dense-act instead of dense-relu-dense
+        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
+        cls.input_text = "Translate in German: Hello, my dog is cute"
+
+    def tearDown(self):
+        r"""
+        TearDown function needs to be called at the end of each test to free the GPU memory and cache, also to
+        avoid unexpected behaviors. Please see: https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-cache/14530/27
+        """
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_inference_without_keep_in_fp32(self):
+        r"""
+        Test whether it is possible to mix both `int8` and `fp32` weights when using `keep_in_fp32_modules` correctly.
+        `flan-t5-small` uses `T5DenseGatedActDense` whereas `t5-small` uses `T5DenseReluDense`. We need to test
+        both cases.
+        """
+        from transformers import T5ForConditionalGeneration
+
+        T5ForConditionalGeneration._keep_in_fp32_modules = None
+
+        # test with `t5-small`
+        model = T5ForConditionalGeneration.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt").to(0)
+        _ = model.generate(**encoded_input)
+
+        # test with `flan-t5-small`
+        model = T5ForConditionalGeneration.from_pretrained(
+            self.dense_act_model_name, load_in_8bit=True, device_map="auto"
+        )
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt").to(0)
+        _ = model.generate(**encoded_input)
+
+    def test_inference_with_keep_in_fp32(self):
+        r"""
+        Test whether it is possible to mix both `int8` and `fp32` weights when using `keep_in_fp32_modules` correctly.
+        `flan-t5-small` uses `T5DenseGatedActDense` whereas `t5-small` uses `T5DenseReluDense`. We need to test
+        both cases.
+        """
+        from transformers import T5ForConditionalGeneration
+
+        # test with `t5-small`
+        model = T5ForConditionalGeneration.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt").to(0)
+        _ = model.generate(**encoded_input)
+
+        # test with `flan-t5-small`
+        model = T5ForConditionalGeneration.from_pretrained(
+            self.dense_act_model_name, load_in_8bit=True, device_map="auto"
+        )
+        encoded_input = self.tokenizer(self.input_text, return_tensors="pt").to(0)
+        _ = model.generate(**encoded_input)
+
+
 class MixedInt8ModelClassesTest(BaseMixedInt8Test):
     def setUp(self):
         super().setUp()

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -163,6 +163,11 @@ class MixedInt8Test(BaseMixedInt8Test):
         self.assertTrue(model.decoder.block[0].layer[2].DenseReluDense.wo.weight.dtype == torch.float32)
 
 
+@require_bitsandbytes
+@require_accelerate
+@require_torch
+@require_torch_gpu
+@slow
 class MixedInt8T5Test(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
# What does this PR do?

Currently on the `main` branch, the inference of `t5` is broken in half-precision. 
With the introduction of `_keep_in_fp32_modules` attributes in https://github.com/huggingface/transformers/pull/20683 , `wo` layers needs to be upcasted in `float32` for more accurate inference. 
It appears that in the aforementioned PR, we forgot to apply the same fix in `T5DenseActDense` layers, leading into a broken inference API when running inference in fp16 for models that uses `T5DenseActDense` layers instead of  `T5DenseGatedActDense` layers. This can be reproduced for example with `t5-small`:
```
from transformers import T5ForConditionalGeneration, T5Tokenizer
import torch

model_id = "t5-small"

model = T5ForConditionalGeneration.from_pretrained(model_id, device_map="auto", torch_dtype=torch.float16)

tokenizer = T5Tokenizer.from_pretrained(model_id)
input_tokens = tokenizer.encode("Translate the following in German: My name is Younes.", return_tensors="pt").to("cuda")

output = model.generate(input_tokens, max_length=32, num_beams=4, early_stopping=True)
print(tokenizer.decode(output[0], skip_special_tokens=True))
```
This is not the case for `flan` family since `flan-t5` uses `T5DenseGatedActDense` that has been correctly fixed in https://github.com/huggingface/transformers/pull/20760

This PR adds also a fix for 8-bit models. If a user wants to run inference in 8-bit without `_keep_in_fp32_modules` for backward compatibility reasons:
```
from transformers import T5ForConditionalGeneration, T5Tokenizer
import torch

T5ForConditionalGeneration._keep_in_fp32_modules = None
model_id = "google/flan-t5-small"

model = T5ForConditionalGeneration.from_pretrained(model_id, device_map="auto", torch_dtype=torch.float16)

tokenizer = T5Tokenizer.from_pretrained(model_id)
input_tokens = tokenizer.encode("Translate the following in German: My name is Younes.", return_tensors="pt").to("cuda")

output = model.generate(input_tokens, max_length=32, num_beams=4, early_stopping=True)
print(tokenizer.decode(output[0], skip_special_tokens=True))
```
They face an issue that is hard to interpret:
```
"addmm_cuda" not implemented for 'Char'
```
See for example: https://github.com/TimDettmers/bitsandbytes/issues/111#issuecomment-1368952450 

This is because the `hidden_states` are converted in `int8` [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L313-L314), leading to entering a linear layer with an 8bit input, which leads to the error. Therefore one should cast to `self.wo.weight.dtype` only if `dtype != torch.int8`. (pointed out also [here](https://github.com/TimDettmers/bitsandbytes/issues/111#issuecomment-1402113167) )

This PR applies also `make fix-copies` introducing the fix to other architectures too - happy to revert that since this issue is only relevant for `T5` (LongT5 etc does not have `_keep_in_fp32_modules`)

This PR also tests everything, making sure this will never happen again!

cc @sgugger 