### PR TITLE
Fix `TrainingArguments.label_names` docs to reflect the correct default value behaviour

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -352,7 +352,7 @@ class TrainingArguments:
         label_names (`List[str]`, *optional*):
             The list of keys in your dictionary of inputs that correspond to the labels.
 
-            Will eventually default to the list of arguments names in `model.forward` that contain the word "label",
+            Will eventually default to the list of argument names accepted by the model that contain the word "label",
             except if the model used is one of the `XxxForQuestionAnswering` in which case it will also include the
             `["start_positions", "end_positions"]` keys.
         load_best_model_at_end (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -352,8 +352,8 @@ class TrainingArguments:
         label_names (`List[str]`, *optional*):
             The list of keys in your dictionary of inputs that correspond to the labels.
 
-            Will eventually default to the list of input keys that contain the word "label", except if the model used is
-            one of the `XxxForQuestionAnswering` in which case it will also include the
+            Will eventually default to the list of arguments names in `model.forward` that contain the word "label",
+            except if the model used is one of the `XxxForQuestionAnswering` in which case it will also include the
             `["start_positions", "end_positions"]` keys.
         load_best_model_at_end (`bool`, *optional*, defaults to `False`):
             Whether or not to load the best model found during training at the end of training.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -352,8 +352,9 @@ class TrainingArguments:
         label_names (`List[str]`, *optional*):
             The list of keys in your dictionary of inputs that correspond to the labels.
 
-            Will eventually default to `["labels"]` except if the model used is one of the `XxxForQuestionAnswering` in
-            which case it will default to `["start_positions", "end_positions"]`.
+            Will eventually default to the list of input keys that contain the word "label", except if the model used is
+            one of the `XxxForQuestionAnswering` in which case it will also include the
+            `["start_positions", "end_positions"]` keys.
         load_best_model_at_end (`bool`, *optional*, defaults to `False`):
             Whether or not to load the best model found during training at the end of training.
 


### PR DESCRIPTION
Fixes #21287
@sgugger
