### PR TITLE
Fix `EfficientFormer`

### DIFF
--- a/src/transformers/models/efficientformer/modeling_efficientformer.py
+++ b/src/transformers/models/efficientformer/modeling_efficientformer.py
@@ -137,7 +137,9 @@ class EfficientFormerSelfAttention(nn.Module):
         # Let's do it manually here, so users won't have to do this everytime.
         if not self.training:
             self.ab = self.ab.to(self.attention_bias_idxs.device)
-        attention_probs = (torch.matmul(query_layer, key_layer.transpose(-2, -1))) * self.scale + (self.attention_biases[:, self.attention_bias_idxs] if self.training else self.ab)
+        attention_probs = (torch.matmul(query_layer, key_layer.transpose(-2, -1))) * self.scale + (
+            self.attention_biases[:, self.attention_bias_idxs] if self.training else self.ab
+        )
 
         attention_probs = attention_probs.softmax(dim=-1)
 

--- a/src/transformers/models/efficientformer/modeling_efficientformer.py
+++ b/src/transformers/models/efficientformer/modeling_efficientformer.py
@@ -136,7 +136,7 @@ class EfficientFormerSelfAttention(nn.Module):
         # set `model.to(torch_device)` won't change `self.ab.device`, if there is no follow-up `train` or `eval` call.
         # Let's do it manually here, so users won't have to do this everytime.
         if not self.training:
-            self.ab = self.ab.to(self.attention_bias_idxs.device)
+            self.ab = self.ab.to(self.attention_biases.device)
         attention_probs = (torch.matmul(query_layer, key_layer.transpose(-2, -1))) * self.scale + (
             self.attention_biases[:, self.attention_bias_idxs] if self.training else self.ab
         )

--- a/src/transformers/models/efficientformer/modeling_efficientformer.py
+++ b/src/transformers/models/efficientformer/modeling_efficientformer.py
@@ -42,7 +42,7 @@ logger = logging.get_logger(__name__)
 _CONFIG_FOR_DOC = "EfficientFormerConfig"
 
 # Base docstring
-_CHECKPOINT_FOR_DOC = "efficientformer-l1-300"
+_CHECKPOINT_FOR_DOC = "snap-research/efficientformer-l1-300"
 _EXPECTED_OUTPUT_SHAPE = [1, 197, 768]
 
 # Image classification docstring
@@ -51,7 +51,7 @@ _IMAGE_CLASS_EXPECTED_OUTPUT = "Egyptian cat"
 
 
 EFFICIENTFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "huggingface/efficientformer-l1-300",
+    "snap-research/efficientformer-l1-300",
     # See all EfficientFormer models at https://huggingface.co/models?filter=efficientformer
 ]
 


### PR DESCRIPTION
# What does this PR do?

Fix `EfficientFormer`:

  - correct checkpoints
  - fix an device issue regarding `EfficientFormerSelfAttention.ab`, see [failed job run page](https://github.com/huggingface/transformers/actions/runs/3992425421/jobs/6848316487)

    The error:
    ```bash
    (line 136)  RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
    ```