### PR TITLE
[Doctest] Fix `Blenderbot` doctest

### DIFF
--- a/src/transformers/models/blenderbot/modeling_blenderbot.py
+++ b/src/transformers/models/blenderbot/modeling_blenderbot.py
@@ -544,7 +544,7 @@ BLENDERBOT_GENERATION_EXAMPLE = r"""
     >>> inputs = tokenizer([NEXT_UTTERANCE], return_tensors="pt")
     >>> next_reply_ids = model.generate(**inputs)
     >>> print("Bot: ", tokenizer.batch_decode(next_reply_ids, skip_special_tokens=True)[0])
-    Bot:   That's too bad. Have you tried encouraging them to change their eating habits?
+    Bot:   I see. Well, it's good that they're trying to change their eating habits.
     ```
 """
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the doctest `transformers.models.blenderbot.modeling_blenderbot.BlenderbotForConditionalGeneration.forward` . Link to failing job is here: https://github.com/huggingface/transformers/actions/runs/4002271138/jobs/6869333719 

Updating the prediction with the correct result seems to be the correct fix. I am usure whether this was tested before so I cannot compare for now. 

One thing that I suspect is that we get different results across different PT versions, but not sure

cc @ydshieh 
