### PR TITLE
Fix 2 paths in the doctest list

### DIFF
--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -108,8 +108,8 @@ src/transformers/models/longformer/modeling_tf_longformer.py
 src/transformers/models/longt5/modeling_longt5.py
 src/transformers/models/marian/modeling_marian.py
 src/transformers/models/markuplm/modeling_markuplm.py
-src/transformers/models/maskformer/configuration_mask2former.py
-src/transformers/models/maskformer/modeling_mask2former.py
+src/transformers/models/mask2former/configuration_mask2former.py
+src/transformers/models/mask2former/modeling_mask2former.py
 src/transformers/models/maskformer/configuration_maskformer.py
 src/transformers/models/maskformer/modeling_maskformer.py
 src/transformers/models/mbart/configuration_mbart.py


### PR DESCRIPTION
# What does this PR do?

doctest has 0 failures 
```
🌞 There were no failures: all 0 tests passed. The suite ran in 0h0m0s.
```
which is caused by 
```
ERROR: file or directory not found: src/transformers/models/maskformer/configuration_mask2former.py
collecting ... collected 0 items
```
😭😭😭
This PR makes the failures (if any) visible again.