### PR TITLE
check paths in `utils/documentation_tests.txt`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
             - run: python utils/check_repo.py
             - run: python utils/check_inits.py
             - run: python utils/check_config_docstrings.py
+            - run: python utils/check_doctest_list.py
             - run: make deps_table_check_updated
             - run: python utils/tests_fetcher.py --sanity_check
             - run: python utils/update_metadata.py --check-only

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ repo-consistency:
 	python utils/check_repo.py
 	python utils/check_inits.py
 	python utils/check_config_docstrings.py
+	python utils/check_doctest_list.py
 	python utils/tests_fetcher.py --sanity_check
 	python utils/update_metadata.py --check-only
 

--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+# All paths are set with the intent you should run this script from the root of the repo with the command
+# python utils/check_doctest_list.py
+REPO_PATH = "."
+
+
+if __name__ == "__main__":
+
+    doctest_file_path = os.path.join(REPO_PATH, "utils/documentation_tests.txt")
+    non_existent_paths = []
+    with open(doctest_file_path) as fp:
+        for line in fp:
+            line = line.strip()
+            path = os.path.join(REPO_PATH, line)
+            if not (os.path.isfile(path) or os.path.isdir(path)):
+                non_existent_paths.append(line)
+    if len(non_existent_paths) > 0:
+        non_existent_paths = "\n".join(non_existent_paths)
+        raise ValueError(f"`utils/documentation_tests.txt` contains non-existent paths:\n{non_existent_paths}")


### PR DESCRIPTION
# What does this PR do?

This PR adds a new check to ensure the paths in `utils/documentation_tests.txt` are all valid, so doctest CI won't fail from the beginning.

related PR: #21314 - ~~We need to wait that PR merged before margining this one.~~ It's merged.

The effect of this PR 

<img width="800" alt="Screenshot 2023-01-26 111139" src="https://user-images.githubusercontent.com/2521628/214810581-4367c7d8-94b7-4534-94f6-b51d3582a5cb.png">
