### PR TITLE
[Doctest] Fix `Perceiver` doctest

### DIFF
--- a/src/transformers/models/perceiver/modeling_perceiver.py
+++ b/src/transformers/models/perceiver/modeling_perceiver.py
@@ -767,7 +767,7 @@ class PerceiverModel(PerceiverPreTrainedModel):
         Examples:
 
         ```python
-        >>> from transformers import PerceiverConfig, AutoTokenizer, PerceiverImageProcessor, PerceiverModel
+        >>> from transformers import PerceiverConfig, PerceiverTokenizer, PerceiverImageProcessor, PerceiverModel
         >>> from transformers.models.perceiver.modeling_perceiver import (
         ...     PerceiverTextPreprocessor,
         ...     PerceiverImagePreprocessor,
@@ -793,7 +793,7 @@ class PerceiverModel(PerceiverPreTrainedModel):
         >>> model = PerceiverModel(config, input_preprocessor=preprocessor, decoder=decoder)
 
         >>> # you can then do a forward pass as follows:
-        >>> tokenizer = AutoTokenizer()
+        >>> tokenizer = PerceiverTokenizer()
         >>> text = "hello world"
         >>> inputs = tokenizer(text, return_tensors="pt").input_ids
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a failing doctest for `PerceiverModel`. Link to failing job: https://github.com/huggingface/transformers/actions/runs/4002271138/jobs/6869333719

With #21225 being merged, the snippet [here](https://github.com/huggingface/transformers/blob/31336dcf3f93dee19cd13c981f16982d612040d2/src/transformers/models/perceiver/modeling_perceiver.py#L796):
```python
...
model = PerceiverModel(config, input_preprocessor=preprocessor, decoder=decoder)
# you can then do a forward pass as follows:
tokenizer = PerceiverTokenizer()
```
has been modified by:
```python
...
model = PerceiverModel(config, input_preprocessor=preprocessor, decoder=decoder)
# you can then do a forward pass as follows:
tokenizer = AutoTokenizer()
```
As there is no canonical way to automatically load a tokenizer from something which is different than a path, or model id, one should load any default tokenizer by instantiating it using the child class and not using `AutoTokenizer`.

This PR reverts this change and fixes the doctest

cc @ydshieh 💯 