### PR TITLE
[`Speech-Encoder-Decoder`] Add `speech-encoder-decoder` to `AutoProcessor`

### DIFF
--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -57,6 +57,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("owlvit", "OwlViTProcessor"),
         ("sew", "Wav2Vec2Processor"),
         ("sew-d", "Wav2Vec2Processor"),
+        ("speech-encoder-decoder", "Wav2Vec2Processor"),
         ("speech_to_text", "Speech2TextProcessor"),
         ("speech_to_text_2", "Speech2Text2Processor"),
         ("trocr", "TrOCRProcessor"),


### PR DESCRIPTION
# What does this PR do?

Currently loading the correct processor for `speech-encoder-decoder` using `AutoProcessor` is broken on `main`. 
The issue and the fix is very identical as https://github.com/huggingface/transformers/pull/21299 , as a doctest was also failing. Link to failing job: https://github.com/huggingface/transformers/actions/runs/4002271138/jobs/6869333719 

cc @ydshieh @sgugger 
