### PR TITLE
[`Vision-Encoder- Decoder`] Add `vision-encoder-decoder` on `AutoProcessor`

### DIFF
--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -63,6 +63,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("unispeech", "Wav2Vec2Processor"),
         ("unispeech-sat", "Wav2Vec2Processor"),
         ("vilt", "ViltProcessor"),
+        ("vision-encoder-decoder", "TrOCRProcessor"),
         ("vision-text-dual-encoder", "VisionTextDualEncoderProcessor"),
         ("wav2vec2", "Wav2Vec2Processor"),
         ("wav2vec2-conformer", "Wav2Vec2Processor"),


### PR DESCRIPTION
# What does this PR do?

Similarly as https://github.com/huggingface/transformers/pull/21319 & #21299 a doctest was failing because the correct processor was not mapped in the `AutoProcessor` mapping for `vision-encoder-decoder`

This fixes also a doctest that was failing, link to failing job: https://github.com/huggingface/transformers/actions/runs/4002271138/jobs/6869333719 

cc @ydshieh @sgugger 