### PR TITLE
Template for framework-agnostic tests

### DIFF
--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -1,0 +1,40 @@
+"""
+Framework agnostic tests for the generate()-related methods.
+"""
+
+from transformers import AutoTokenizer
+import numpy as np
+
+
+class GenerationIntegrationTestsMixin:
+
+    # To be populated by the child classes
+    framework_dependent_parameters = {
+        "AutoModelForSeq2SeqLM": None,
+        "create_tensor": None,
+        "return_tensors": None,
+    }
+
+    def test_validate_generation_inputs(self):
+        model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
+        return_tensors = self.framework_dependent_parameters["return_tensors"]
+        create_tensor = self.framework_dependent_parameters["create_tensor"]
+
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-t5")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-t5")
+
+        encoder_input_str = "Hello world"
+        input_ids = tokenizer(encoder_input_str, return_tensors=return_tensors).input_ids
+
+        # typos are quickly detected (the correct argument is `do_sample`)
+        with self.assertRaisesRegex(ValueError, "do_samples"):
+            model.generate(input_ids, do_samples=True)
+
+        # arbitrary arguments that will not be used anywhere are also not accepted
+        with self.assertRaisesRegex(ValueError, "foo"):
+            fake_model_kwargs = {"foo": "bar"}
+            model.generate(input_ids, **fake_model_kwargs)
+
+        # however, valid model_kwargs are accepted
+        valid_model_kwargs = {"attention_mask": create_tensor(np.zeros_like(input_ids))}
+        model.generate(input_ids, **valid_model_kwargs)

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -2,8 +2,9 @@
 Framework agnostic tests for generate()-related methods.
 """
 
-from transformers import AutoTokenizer
 import numpy as np
+
+from transformers import AutoTokenizer
 
 
 class GenerationIntegrationTestsMixin:

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -12,14 +12,14 @@ class GenerationIntegrationTestsMixin:
     # To be populated by the child classes
     framework_dependent_parameters = {
         "AutoModelForSeq2SeqLM": None,
-        "create_tensor": None,
+        "create_tensor_fn": None,
         "return_tensors": None,
     }
 
     def test_validate_generation_inputs(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
         return_tensors = self.framework_dependent_parameters["return_tensors"]
-        create_tensor = self.framework_dependent_parameters["create_tensor"]
+        create_tensor_fn = self.framework_dependent_parameters["create_tensor_fn"]
 
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-t5")
         model = model_cls.from_pretrained("hf-internal-testing/tiny-random-t5")
@@ -37,5 +37,5 @@ class GenerationIntegrationTestsMixin:
             model.generate(input_ids, **fake_model_kwargs)
 
         # however, valid model_kwargs are accepted
-        valid_model_kwargs = {"attention_mask": create_tensor(np.zeros_like(input_ids))}
+        valid_model_kwargs = {"attention_mask": create_tensor_fn(np.zeros_like(input_ids))}
         model.generate(input_ids, **valid_model_kwargs)

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -1,5 +1,5 @@
 """
-Framework agnostic tests for the generate()-related methods.
+Framework agnostic tests for generate()-related methods.
 """
 
 from transformers import AutoTokenizer

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -132,7 +132,7 @@ class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTests
     if is_tf_available():
         framework_dependent_parameters = {
             "AutoModelForSeq2SeqLM": TFAutoModelForSeq2SeqLM,
-            "create_tensor": tf.convert_to_tensor,
+            "create_tensor_fn": tf.convert_to_tensor,
             "return_tensors": "tf",
         }
 

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -19,11 +19,13 @@ import unittest
 from transformers import is_tf_available
 from transformers.testing_utils import require_tf, slow
 
+from .test_framework_agnostic import GenerationIntegrationTestsMixin
+
 
 if is_tf_available():
     import tensorflow as tf
 
-    from transformers import AutoTokenizer, TFAutoModelForCausalLM, TFAutoModelForSeq2SeqLM, tf_top_k_top_p_filtering
+    from transformers import TFAutoModelForCausalLM, TFAutoModelForSeq2SeqLM, tf_top_k_top_p_filtering
 
 
 @require_tf
@@ -124,7 +126,14 @@ class UtilsFunctionsTest(unittest.TestCase):
 
 
 @require_tf
-class TFGenerationIntegrationTests(unittest.TestCase):
+class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMixin):
+
+    framework_dependent_parameters = {
+        "AutoModelForSeq2SeqLM": TFAutoModelForSeq2SeqLM,
+        "create_tensor": tf.convert_to_tensor,
+        "return_tensors": "tf",
+    }
+
     @slow
     def test_generate_tf_function_export(self):
         test_model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
@@ -165,19 +174,3 @@ class TFGenerationIntegrationTests(unittest.TestCase):
                 tf_func_outputs = serving_func(**inputs)["sequences"]
                 tf_model_outputs = test_model.generate(**inputs, max_new_tokens=max_length)
                 tf.debugging.assert_equal(tf_func_outputs, tf_model_outputs)
-
-    def test_validate_generation_inputs(self):
-        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-t5")
-        model = TFAutoModelForSeq2SeqLM.from_pretrained("hf-internal-testing/tiny-random-t5")
-
-        encoder_input_str = "Hello world"
-        input_ids = tokenizer(encoder_input_str, return_tensors="tf").input_ids
-
-        # typos are quickly detected (the correct argument is `do_sample`)
-        with self.assertRaisesRegex(ValueError, "do_samples"):
-            model.generate(input_ids, do_samples=True)
-
-        # arbitrary arguments that will not be used anywhere are also not accepted
-        with self.assertRaisesRegex(ValueError, "foo"):
-            fake_model_kwargs = {"foo": "bar"}
-            model.generate(input_ids, **fake_model_kwargs)

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -128,11 +128,13 @@ class UtilsFunctionsTest(unittest.TestCase):
 @require_tf
 class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMixin):
 
-    framework_dependent_parameters = {
-        "AutoModelForSeq2SeqLM": TFAutoModelForSeq2SeqLM,
-        "create_tensor": tf.convert_to_tensor,
-        "return_tensors": "tf",
-    }
+    # setting framework_dependent_parameters needs to be gated, just like its contents' imports
+    if is_tf_available():
+        framework_dependent_parameters = {
+            "AutoModelForSeq2SeqLM": TFAutoModelForSeq2SeqLM,
+            "create_tensor": tf.convert_to_tensor,
+            "return_tensors": "tf",
+        }
 
     @slow
     def test_generate_tf_function_export(self):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1793,11 +1793,13 @@ class UtilsFunctionsTest(unittest.TestCase):
 @require_torch
 class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMixin):
 
-    framework_dependent_parameters = {
-        "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
-        "create_tensor": torch.tensor,
-        "return_tensors": "pt",
-    }
+    # setting framework_dependent_parameters needs to be gated, just like its contents' imports
+    if is_torch_available():
+        framework_dependent_parameters = {
+            "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
+            "create_tensor": torch.tensor,
+            "return_tensors": "pt",
+        }
 
     @slow
     def test_diverse_beam_search(self):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1797,7 +1797,7 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
     if is_torch_available():
         framework_dependent_parameters = {
             "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
-            "create_tensor": torch.tensor,
+            "create_tensor_fn": torch.tensor,
             "return_tensors": "pt",
         }
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -23,6 +23,7 @@ from transformers import is_torch_available, pipeline
 from transformers.testing_utils import require_torch, slow, torch_device
 
 from ..test_modeling_common import floats_tensor, ids_tensor
+from .test_framework_agnostic import GenerationIntegrationTestsMixin
 
 
 if is_torch_available():
@@ -1790,7 +1791,14 @@ class UtilsFunctionsTest(unittest.TestCase):
 
 
 @require_torch
-class GenerationIntegrationTests(unittest.TestCase):
+class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMixin):
+
+    framework_dependent_parameters = {
+        "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
+        "create_tensor": torch.tensor,
+        "return_tensors": "pt",
+    }
+
     @slow
     def test_diverse_beam_search(self):
         article = """Justin Timberlake and Jessica Biel, welcome to parenthood.
@@ -3049,26 +3057,6 @@ class GenerationIntegrationTests(unittest.TestCase):
         # output_sequences_batched.scores[0][1] -> 1st set of logits, 2nd sequence
         max_score_diff = (output_sequences_batched.scores[0][1] - output_sequences.scores[0][0]).abs().max()
         self.assertTrue(max_score_diff < 1e-5)
-
-    def test_validate_generation_inputs(self):
-        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-roberta")
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-roberta")
-
-        encoder_input_str = "Hello world"
-        input_ids = tokenizer(encoder_input_str, return_tensors="pt").input_ids
-
-        # typos are quickly detected (the correct argument is `do_sample`)
-        with self.assertRaisesRegex(ValueError, "do_samples"):
-            model.generate(input_ids, do_samples=True)
-
-        # arbitrary arguments that will not be used anywhere are also not accepted
-        with self.assertRaisesRegex(ValueError, "foo"):
-            fake_model_kwargs = {"foo": "bar"}
-            model.generate(input_ids, **fake_model_kwargs)
-
-        # However, valid model_kwargs are accepted
-        valid_model_kwargs = {"attention_mask": torch.zeros_like(input_ids)}
-        model.generate(input_ids, **valid_model_kwargs)
 
     def test_eos_token_id_int_and_list_greedy_search(self):
         generation_kwargs = {

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -466,12 +466,13 @@ def module_to_test_file(module_fname):
 # This list contains the list of test files we expect never to be launched from a change in a module/util. Those are
 # launched separately.
 EXPECTED_TEST_FILES_NEVER_TOUCHED = [
-    "tests/utils/test_doc_samples.py",  # Doc tests
+    "tests/generation/test_framework_agnostic.py",  # Mixins inherited by actual test classes
+    "tests/mixed_int8/test_mixed_int8.py",  # Mixed-int8 bitsandbytes test
     "tests/pipelines/test_pipelines_common.py",  # Actually checked by the pipeline based file
     "tests/sagemaker/test_single_node_gpu.py",  # SageMaker test
     "tests/sagemaker/test_multi_node_model_parallel.py",  # SageMaker test
     "tests/sagemaker/test_multi_node_data_parallel.py",  # SageMaker test
-    "tests/mixed_int8/test_mixed_int8.py",  # Mixed-int8 bitsandbytes test
+    "tests/utils/test_doc_samples.py",  # Doc tests
 ]
 
 


### PR DESCRIPTION
# What does this PR do?

There are a few cross-framework pain points I often encounter: 
1. Ensuring the interface of `.generate()` or models stay consistent across frameworks;
2. Ensuring that TF doesn't get neglected and satisfies 1., when contributors add features/fixes on the PT side;
3. Blocking cases where the interface is the same, but there are numerical differences.

After a brief chat with @sgugger, I thought inheritable framework-agnostic tests could be nice to help with these problems. This week I'll have to write a few TF `.generate()` tests that already exist on the PT side, so this could be a great chance to kill 2 birds with one stone. 

However, I'd like to get the pattern right, hence this small PR -- replaces a pair of framework-specific tests with a framework-agnostic test. `Flax` is intentionally left out, as it is missing many testable features and is not being maintained, but it can easily be added in the future.

Let me know what you think of it!