### PR TITLE
Add cPython files in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -424,7 +424,7 @@ setup(
     url="https://github.com/huggingface/transformers",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    package_data={"transformers": ["py.typed", "*.cu", "*.cpp", "*.cuh", "*.h"]},
+    package_data={"transformers": ["py.typed", "*.cu", "*.cpp", "*.cuh", "*.h", "*.pyx"]},
     zip_safe=False,
     extras_require=extras,
     entry_points={"console_scripts": ["transformers-cli=transformers.commands.transformers_cli:main"]},


### PR DESCRIPTION
# What does this PR do?

As reported by @clefourrier the Graphormer model in the last release is not usable as is, as the cpython file containing the code for the collation of samples is not included in the built package. This PR fixes that by including the extensions (similar to what we did for custom CUDA kernels).

This will be included in the next patch release.