### PR TITLE
Simplify column_names in run_clm/mlm

### DIFF
--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -419,9 +419,9 @@ def main():
     # Preprocessing the datasets.
     # First we tokenize all the texts.
     if training_args.do_train:
-        column_names = raw_datasets["train"].features.keys()
+        column_names = list(raw_datasets["train"].features)
     else:
-        column_names = raw_datasets["validation"].features.keys()
+        column_names = list(raw_datasets["validation"].features)
     text_column_name = "text" if "text" in column_names else column_names[0]
 
     # since this will be pickled to avoid _LazyModule error in Hasher force logger loading before tokenize_function

--- a/examples/pytorch/language-modeling/run_clm.py
+++ b/examples/pytorch/language-modeling/run_clm.py
@@ -419,15 +419,9 @@ def main():
     # Preprocessing the datasets.
     # First we tokenize all the texts.
     if training_args.do_train:
-        if data_args.streaming:
-            column_names = raw_datasets["train"].features.keys()
-        else:
-            column_names = raw_datasets["train"].column_names
+        column_names = raw_datasets["train"].features.keys()
     else:
-        if data_args.streaming:
-            column_names = raw_datasets["validation"].features.keys()
-        else:
-            column_names = raw_datasets["validation"].column_names
+        column_names = raw_datasets["validation"].features.keys()
     text_column_name = "text" if "text" in column_names else column_names[0]
 
     # since this will be pickled to avoid _LazyModule error in Hasher force logger loading before tokenize_function

--- a/examples/pytorch/language-modeling/run_mlm.py
+++ b/examples/pytorch/language-modeling/run_mlm.py
@@ -405,15 +405,9 @@ def main():
     # Preprocessing the datasets.
     # First we tokenize all the texts.
     if training_args.do_train:
-        if data_args.streaming:
-            column_names = raw_datasets["train"].features.keys()
-        else:
-            column_names = raw_datasets["train"].column_names
+        column_names = list(raw_datasets["train"].features)
     else:
-        if data_args.streaming:
-            column_names = raw_datasets["validation"].features.keys()
-        else:
-            column_names = raw_datasets["validation"].column_names
+        column_names = list(raw_datasets["validation"].features)
     text_column_name = "text" if "text" in column_names else column_names[0]
 
     if data_args.max_seq_length is None:


### PR DESCRIPTION
Following https://github.com/huggingface/transformers/pull/21343

Just a minor change to simplify the code, and fix a small bug (`column_names` needs to be a list to be able to call `column_names[0]`)

cc @stas00 