### PR TITLE
Generate: fix TF XLA tests on models with `max_position_embeddings` or `max_target_positions`

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -1865,6 +1865,17 @@ class TFModelTesterMixin:
             config.eos_token_id = None  # Generate until max length
             config.do_sample = False
 
+            # fix config for models with additional sequence-length limiting settings
+            for var_name in ["max_position_embeddings", "max_target_positions"]:
+                attr = getattr(config, var_name, None)
+                if attr is not None and attr < generate_kwargs["max_new_tokens"]:
+                    try:
+                        setattr(config, var_name, generate_kwargs["max_new_tokens"])
+                    except NotImplementedError:
+                        # xlnet will raise an exception when trying to set
+                        # max_position_embeddings.
+                        pass
+
             model = model_class(config)
 
             if model.supports_xla_generation:


### PR DESCRIPTION
# What does this PR do?

Extracted from #20901 -- the lines added in this PR were incorrectly removed [here](https://github.com/huggingface/transformers/commit/0f78529f982eceb79c5855d0466c287ec8a18df1), causing some XLA tests to fail.

These changes fixes 8 slow TF tests on `test_xla_generate_slow`. They were also approved in the PR linked above, which was redone as part of the discussion (and closed).