### PR TITLE
Enable PyTorch/XLA Fully Sharded Data Parallel (FSDP)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1505,6 +1505,7 @@ class Trainer:
                     # Apply gradient checkpointing to auto-wrapped sub-modules if specified
                     def auto_wrapper_callable(m, *args, **kwargs):
                         return FSDP(checkpoint_module(m), *args, **kwargs)
+
                 # Wrap the base model with an outer FSDP wrapper
                 self.model = model = FSDP(
                     model,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -417,7 +417,7 @@ class Trainer:
                 raise ValueError(
                     "Using --fsdp xxx together with --deepspeed is not possible, deactivate one of those flags."
                 )
-            if not is_torch_tpu_available() and args.local_rank == -1:
+            if args.local_rank == -1:
                 raise ValueError("Using fsdp only works in distributed training.")
 
             # dep_version_check("torch>=1.12.0")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -417,7 +417,7 @@ class Trainer:
                 raise ValueError(
                     "Using --fsdp xxx together with --deepspeed is not possible, deactivate one of those flags."
                 )
-            if args.local_rank == -1:
+            if not args.fsdp_config["xla"] and args.local_rank == -1:
                 raise ValueError("Using fsdp only works in distributed training.")
 
             # dep_version_check("torch>=1.12.0")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1423,7 +1423,7 @@ class Trainer:
                 # PyTorch FSDP!
                 from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision
                 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
-                    from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
+                from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 
                 if FSDPOption.OFFLOAD in self.args.fsdp:
                     cpu_offload = CPUOffload(offload_params=True)
@@ -1469,7 +1469,7 @@ class Trainer:
                         device_id=self.args.device,
                         backward_prefetch=self.backward_prefetch,
                         forward_prefetch=self.forword_prefetch,
-                    limit_all_gathers=self.limit_all_gathers,
+                        limit_all_gathers=self.limit_all_gathers,
                     )
             else:
                 try:
@@ -1518,6 +1518,7 @@ class Trainer:
                     if barrier:
                         xm.mark_step()
                     return loss
+
                 xm.optimizer_step = patched_optimizer_step
         elif is_sagemaker_dp_enabled():
             model = nn.parallel.DistributedDataParallel(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1437,9 +1437,9 @@ class Trainer:
                         auto_wrap_policy = functools.partial(
                             size_based_auto_wrap_policy, min_num_params=self.args.fsdp_config["fsdp_min_num_params"]
                         )
-                    elif self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] is not None:
+                    elif self.args.fsdp_config.get("fsdp_transformer_layer_cls_to_wrap", None) is not None:
                         transformer_cls_to_wrap = set()
-                        for layer_class in self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]:
+                        for layer_class in self.args.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]:
                             transformer_cls = get_module_class_from_name(model, layer_class)
                             if transformer_cls is None:
                                 raise Exception("Could not find the transformer layer class to wrap in the model.")
@@ -1484,9 +1484,9 @@ class Trainer:
                     auto_wrap_policy = functools.partial(
                         size_based_auto_wrap_policy, min_num_params=self.args.fsdp_config["fsdp_min_num_params"]
                     )
-                elif self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] is not None:
+                elif self.args.fsdp_config.get("fsdp_transformer_layer_cls_to_wrap", None) is not None:
                     transformer_cls_to_wrap = set()
-                    for layer_class in self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]:
+                    for layer_class in self.args.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]:
                         transformer_cls = get_module_class_from_name(model, layer_class)
                         if transformer_cls is None:
                             raise Exception("Could not find the transformer layer class to wrap in the model.")

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1511,6 +1511,7 @@ class Trainer:
                     auto_wrapper_callable=auto_wrapper_callable,
                     **fsdp_kwargs,
                 )
+
                 # Patch `xm.optimizer_step` should not reduce gradients in this case,
                 # as FSDP does not need gradient reduction over sharded parameters.
                 def patched_optimizer_step(optimizer, barrier=False, optimizer_args={}):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1503,7 +1503,8 @@ class Trainer:
                 fsdp_kwargs = self.args.xla_fsdp_config
                 if self.args.fsdp_config["xla_fsdp_grad_ckpt"]:
                     # Apply gradient checkpointing to auto-wrapped sub-modules if specified
-                    auto_wrapper_callable = lambda m, *args, **kwargs: FSDP(checkpoint_module(m), *args, **kwargs)
+                    def auto_wrapper_callable(m, *args, **kwargs):
+                        return FSDP(checkpoint_module(m), *args, **kwargs)
                 # Wrap the base model with an outer FSDP wrapper
                 self.model = model = FSDP(
                     model,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -463,7 +463,6 @@ class Trainer:
             or ((args.fp16_full_eval or args.bf16_full_eval) and not args.do_train)
             or (self.sharded_ddp in [ShardedDDPOption.ZERO_DP_2, ShardedDDPOption.ZERO_DP_3])
             or (self.fsdp is not None)
-            or (args.xla_fsdp is not None)
         ):
             self.place_model_on_device = False
 
@@ -1420,105 +1419,98 @@ class Trainer:
                 ).to(self.args.device)
         # Distributed training using PyTorch FSDP
         elif self.fsdp is not None:
-            # PyTorch FSDP!
-            from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision
-            from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
-            from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
+            if not self.fsdp_config["xla"]:
+                # PyTorch FSDP!
+                from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision
+                from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+                    from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 
-            if FSDPOption.OFFLOAD in self.args.fsdp:
-                cpu_offload = CPUOffload(offload_params=True)
-            else:
-                cpu_offload = CPUOffload(offload_params=False)
+                if FSDPOption.OFFLOAD in self.args.fsdp:
+                    cpu_offload = CPUOffload(offload_params=True)
+                else:
+                    cpu_offload = CPUOffload(offload_params=False)
 
-            auto_wrap_policy = None
+                auto_wrap_policy = None
 
-            if FSDPOption.AUTO_WRAP in self.args.fsdp:
-                if self.args.fsdp_config["fsdp_min_num_params"] > 0:
+                if FSDPOption.AUTO_WRAP in self.args.fsdp:
+                    if self.args.fsdp_config["fsdp_min_num_params"] > 0:
+                        auto_wrap_policy = functools.partial(
+                            size_based_auto_wrap_policy, min_num_params=self.args.fsdp_config["fsdp_min_num_params"]
+                        )
+                    elif self.args.fsdp_transformer_layer_cls_to_wrap is not None:
+                        transformer_cls_to_wrap = get_module_class_from_name(
+                            model, self.args.fsdp_transformer_layer_cls_to_wrap
+                        )
+                        if transformer_cls_to_wrap is None:
+                            raise Exception("Could not find the transformer layer class to wrap in the model.")
+                        auto_wrap_policy = functools.partial(
+                            transformer_auto_wrap_policy,
+                            # Transformer layer class to wrap
+                            transformer_layer_cls={transformer_cls_to_wrap},
+                        )
+                mixed_precision_policy = None
+                dtype = None
+                if self.args.fp16:
+                    dtype = torch.float16
+                elif self.args.bf16:
+                    dtype = torch.bfloat16
+                if dtype is not None:
+                    mixed_precision_policy = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
+                if type(model) != FSDP:
+                    # XXX: Breaking the self.model convention but I see no way around it for now.
+                    self.model = model = FSDP(
+                        model,
+                        sharding_strategy=self.fsdp,
+                        cpu_offload=cpu_offload,
+                        auto_wrap_policy=auto_wrap_policy,
+                        mixed_precision=mixed_precision_policy,
+                        device_id=self.args.device,
+                        backward_prefetch=self.backward_prefetch,
+                        forward_prefetch=self.forword_prefetch,
+                    limit_all_gathers=self.limit_all_gathers,
+                    )
+            else
+                try:
+                    from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
+                    from torch_xla.distributed.fsdp import checkpoint_module
+                    from torch_xla.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
+                except ImportError:
+                    raise ImportError("Missing XLA FSDP related module; please make sure to use torch-xla >= 2.0.")
+                auto_wrap_policy = None
+                auto_wrapper_callable = None
+                if self.fsdp_config["fsdp_min_num_params"] > 0:
                     auto_wrap_policy = functools.partial(
-                        size_based_auto_wrap_policy, min_num_params=self.args.fsdp_config["fsdp_min_num_params"]
+                        size_based_auto_wrap_policy, min_num_params=self.fsdp_config["fsdp_min_num_params"]
                     )
                 elif self.args.fsdp_transformer_layer_cls_to_wrap is not None:
-                    transformer_cls_to_wrap = get_module_class_from_name(
-                        model, self.args.fsdp_transformer_layer_cls_to_wrap
-                    )
-                    if transformer_cls_to_wrap is None:
-                        raise Exception("Could not find the transformer layer class to wrap in the model.")
+                    transformer_cls_to_wrap = set()
+                    for layer_class in self.args.xla_fsdp_transformer_layer_cls_to_wrap:
+                        transformer_cls = get_module_class_from_name(model, layer_class)
+                        if transformer_cls is None:
+                            raise Exception("Could not find the transformer layer class to wrap in the model.")
+                        else:
+                            transformer_cls_to_wrap.add(transformer_cls)
                     auto_wrap_policy = functools.partial(
                         transformer_auto_wrap_policy,
                         # Transformer layer class to wrap
-                        transformer_layer_cls={transformer_cls_to_wrap},
+                        transformer_layer_cls=transformer_cls_to_wrap,
                     )
-            mixed_precision_policy = None
-            dtype = None
-            if self.args.fp16:
-                dtype = torch.float16
-            elif self.args.bf16:
-                dtype = torch.bfloat16
-            if dtype is not None:
-                mixed_precision_policy = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
-            if type(model) != FSDP:
-                # XXX: Breaking the self.model convention but I see no way around it for now.
+                fsdp_kwargs = self.args.xla_fsdp_config
+                if self.fsdp_config["xla_fsdp_grad_ckpt"]:
+                    # Apply gradient checkpointing to auto-wrapped sub-modules if specified
+                    auto_wrapper_callable = lambda m, *args, **kwargs: FSDP(checkpoint_module(m), *args, **kwargs)
+                # Wrap the base model with an outer FSDP wrapper
                 self.model = model = FSDP(
-                    model,
-                    sharding_strategy=self.fsdp,
-                    cpu_offload=cpu_offload,
-                    auto_wrap_policy=auto_wrap_policy,
-                    mixed_precision=mixed_precision_policy,
-                    device_id=self.args.device,
-                    backward_prefetch=self.backward_prefetch,
-                    forward_prefetch=self.forword_prefetch,
-                    limit_all_gathers=self.limit_all_gathers,
+                    model, auto_wrap_policy=auto_wrap_policy, auto_wrapper_callable=auto_wrapper_callable, **fsdp_kwargs
                 )
-        elif self.args.xla_fsdp is not None:
-            try:
-                from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
-                from torch_xla.distributed.fsdp import checkpoint_module
-                from torch_xla.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
-            except ImportError:
-                raise ImportError("Missing XLA FSDP related module; please make sure to use torch-xla >= 2.0.")
-            auto_wrap_policy = None
-            auto_wrapper_callable = None
-            if self.args.xla_fsdp_min_num_params > 0:
-                auto_wrap_policy = functools.partial(
-                    size_based_auto_wrap_policy, min_num_params=self.args.xla_fsdp_min_num_params
-                )
-            elif self.args.xla_fsdp_transformer_layer_cls_to_wrap is not None:
-                transformer_cls_to_wrap = set()
-                for layer_class in self.args.xla_fsdp_transformer_layer_cls_to_wrap:
-                    transformer_cls = get_module_class_from_name(model, layer_class)
-                    if transformer_cls is None:
-                        raise Exception("Could not find the transformer layer class to wrap in the model.")
-                    else:
-                        transformer_cls_to_wrap.add(transformer_cls)
-                auto_wrap_policy = functools.partial(
-                    transformer_auto_wrap_policy,
-                    # Transformer layer class to wrap
-                    transformer_layer_cls=transformer_cls_to_wrap,
-                )
-            fsdp_kwargs = self.args.xla_fsdp_config
-            if self.args.xla_fsdp_grad_ckpt:
-                # Apply gradient checkpointing to auto-wrapped sub-modules if specified
-                auto_wrapper_callable = lambda m, *args, **kwargs: FSDP(checkpoint_module(m), *args, **kwargs)
-            # Wrap the base model with an outer FSDP wrapper
-            # Also, copy the signature of the original model's forward method -- otherwise
-            # columns not appearing in the forward method's argument will be dropped by
-            # the `_remove_unused_columns` method
-            forward_signature = inspect.signature(model.forward.__func__)
-            model = FSDP(
-                model, auto_wrap_policy=auto_wrap_policy, auto_wrapper_callable=auto_wrapper_callable, **fsdp_kwargs
-            )
-            model.forward.__func__.__signature__ = forward_signature
-            self.model = model
-
-            # Patch `xm.optimizer_step` should not reduce gradients in this case,
-            # as FSDP does not need gradient reduction over sharded parameters.
-            def patched_optimizer_step(optimizer, barrier=False, optimizer_args={}):
-                loss = optimizer.step(**optimizer_args)
-                if barrier:
-                    xm.mark_step()
-                return loss
-
-            xm.optimizer_step = patched_optimizer_step
+                # Patch `xm.optimizer_step` should not reduce gradients in this case,
+                # as FSDP does not need gradient reduction over sharded parameters.
+                def patched_optimizer_step(optimizer, barrier=False, optimizer_args={}):
+                    loss = optimizer.step(**optimizer_args)
+                    if barrier:
+                        xm.mark_step()
+                    return loss
+                xm.optimizer_step = patched_optimizer_step
         elif is_sagemaker_dp_enabled():
             model = nn.parallel.DistributedDataParallel(
                 model, device_ids=[int(os.getenv("SMDATAPARALLEL_LOCAL_RANK"))]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1475,7 +1475,10 @@ class Trainer:
                 try:
                     from torch_xla.distributed.fsdp import XlaFullyShardedDataParallel as FSDP
                     from torch_xla.distributed.fsdp import checkpoint_module
-                    from torch_xla.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
+                    from torch_xla.distributed.fsdp.wrap import (
+                        size_based_auto_wrap_policy,
+                        transformer_auto_wrap_policy,
+                    )
                 except ImportError:
                     raise ImportError("Missing XLA FSDP related module; please make sure to use torch-xla >= 2.0.")
                 auto_wrap_policy = None
@@ -1503,7 +1506,10 @@ class Trainer:
                     auto_wrapper_callable = lambda m, *args, **kwargs: FSDP(checkpoint_module(m), *args, **kwargs)
                 # Wrap the base model with an outer FSDP wrapper
                 self.model = model = FSDP(
-                    model, auto_wrap_policy=auto_wrap_policy, auto_wrapper_callable=auto_wrapper_callable, **fsdp_kwargs
+                    model,
+                    auto_wrap_policy=auto_wrap_policy,
+                    auto_wrapper_callable=auto_wrapper_callable,
+                    **fsdp_kwargs,
                 )
                 # Patch `xm.optimizer_step` should not reduce gradients in this case,
                 # as FSDP does not need gradient reduction over sharded parameters.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -584,9 +584,6 @@ class TrainingArguments:
             The mode to use in `torch.compile`. If set to any value, `torch_compile` will be set to `True`.
 
             Possible choices are `"default"`, `"reduce-overhead"` and `"max-autotune"`.
-
-
-
     """
 
     framework = "pt"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -417,7 +417,7 @@ class TrainingArguments:
                     FSDP's minimum number of parameters for Default Auto Wrapping. (useful only when `fsdp` field is
                     passed).
                 - fsdp_transformer_layer_cls_to_wrap (`List[str]`, *optional*):
-                    List of transformer layer class names (case-sensitive) to wrap, e.g, 
+                    List of transformer layer class names (case-sensitive) to wrap, e.g,
                     `BertLayer`, `GPTJBlock`, `T5Block` .... (useful only when `fsdp` flag is passed).
                 - fsdp_backward_prefetch (`str`, *optional*)
                     FSDP's backward prefetch mode. Controls when to prefetch next set of parameters (useful only when
@@ -449,9 +449,9 @@ class TrainingArguments:
                     https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py).
                 - xla_fsdp_grad_ckpt (`bool`, *optional*, defaults to `False`):
                     Will use gradient checkpointing over each nested XLA FSDP wrapped layer. This setting can only be
-                    used when the xla flag is set to true, and an auto wrapping policy is specified through 
+                    used when the xla flag is set to true, and an auto wrapping policy is specified through
                     fsdp_min_num_params or fsdp_transformer_layer_cls_to_wrap.
-                    
+
         deepspeed (`str` or `dict`, *optional*):
             Use [Deepspeed](https://github.com/microsoft/deepspeed). This is an experimental feature and its API may
             evolve in the future. The value is either the location of DeepSpeed json config file (e.g.,
@@ -584,8 +584,8 @@ class TrainingArguments:
             The mode to use in `torch.compile`. If set to any value, `torch_compile` will be set to `True`.
 
             Possible choices are `"default"`, `"reduce-overhead"` and `"max-autotune"`.
-        
-    
+
+
 
     """
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -569,7 +569,7 @@ class TrainingArguments:
             The mode to use in `torch.compile`. If set to any value, `torch_compile` will be set to `True`.
 
             Possible choices are `"default"`, `"reduce-overhead"` and `"max-autotune"`.
-        
+            
         xla_fsdp (`str`, `dict`, *optional*):
             Use PyTorch/XLA Fully Sharded Data Parallel Training
 
@@ -1039,7 +1039,7 @@ class TrainingArguments:
         metadata={
             "help": (
                 "Automatically recursively wrap layers with XLA FSDP if they have at least the specified number of parameters." 
-                " This setting may only be used with xla_fsdp."
+                " This setting is only useful when used with xla_fsdp."
             ),
         },
     )
@@ -1048,7 +1048,7 @@ class TrainingArguments:
         metadata={
             "help": (
                 "Automatically recursively wrap layers with XLA FSDP if their transformer layer class name matches one in the"
-                " specified list (case-sensitive). This setting may only be used with xla_fsdp."
+                " specified list (case-sensitive). This setting is only useful when used with xla_fsdp."
             ),
         },
     )
@@ -1056,9 +1056,7 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting can only be used with xla_fsdp"
-                " and xla_fsdp_nested."
-            
+                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting is only useful when used with xla_fsdp."
             ),
         },
     )
@@ -1428,26 +1426,24 @@ class TrainingArguments:
         if self.xla_fsdp:
             # gather fsdp configuration parameters into a dictionary from specified json file
             with io.open(self.xla_fsdp, "r", encoding="utf-8") as f:
-                self.xla_fsdp = json.load(f)
+                self.xla_fsdp_config = json.load(f)
             # apply appropriate string to torch.dtype conversions for parameters
             if "compute_dtype" in self.xla_fsdp_config:
                 self.xla_fsdp_config["compute_dtype"] = getattr(torch, self.xla_fsdp_config["compute_dtype"])
             if "buffer_dtype" in self.xla_fsdp_config:
                 self.xla_fsdp_config["buffer_dtype"] = getattr(torch, self.xla_fsdp_config["buffer_dtype"])
             
-            if self.fsdp_min_num_params > 0 and self.fsdp_transformer_layer_cls_to_wrap is not None:
+            if self.xla_fsdp_min_num_params > 0 and self.xla_fsdp_transformer_layer_cls_to_wrap is not None:
                 raise ValueError(
                     "`--xla_fsdp_min_num_params` and `--xla_fsdp_transformer_layer_cls_to_wrap` are mutually exclusive."
                 )
         else:
-             if self.fsdp_min_num_params > 0:
+            if self.xla_fsdp_min_num_params > 0:
                 warnings.warn("`--xla_fsdp_min_num_params` is useful only when `--xla_fsdp` is specified.")
-            if self.fsdp_transformer_layer_cls_to_wrap is not None:
+            if self.xla_fsdp_transformer_layer_cls_to_wrap is not None:
                 warnings.warn("`--xla_fsdp_transformer_layer_cls_to_wrap` is useful only when `--xla_fsdp` is specified.")
-            elif self.xla_fsdp_grad_ckpt:
-                raise ValueError(
-                "`--xla_fsdp_grad_ckpt` may only be used when --xla_fsdp is enabled."
-            )
+            if self.xla_fsdp_grad_ckpt:
+                warnings.warn("`--xla_fsdp_grad_ckpt` is useful only when `--xla_fsdp` is specified.")
 
 
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -17,6 +17,7 @@ import io
 import json
 import math
 import os
+import io
 import warnings
 from dataclasses import asdict, dataclass, field, fields
 from datetime import timedelta

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1445,6 +1445,8 @@ class TrainingArguments:
                 warnings.warn(
                     "`--xla_fsdp_transformer_layer_cls_to_wrap` is useful only when `--xla_fsdp` is specified."
                 )
+            if self.xla_fsdp_grad_ckpt:
+                warnings.warn("`--xla_fsdp_grad_ckpt` is useful only when `--xla_fsdp` is specified.")
 
 
         if self.push_to_hub_token is not None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -417,8 +417,8 @@ class TrainingArguments:
                     FSDP's minimum number of parameters for Default Auto Wrapping. (useful only when `fsdp` field is
                     passed).
                 - fsdp_transformer_layer_cls_to_wrap (`List[str]`, *optional*):
-                    List of transformer layer class names (case-sensitive) to wrap, e.g,
-                    `BertLayer`, `GPTJBlock`, `T5Block` .... (useful only when `fsdp` flag is passed).
+                    List of transformer layer class names (case-sensitive) to wrap, e.g, `BertLayer`, `GPTJBlock`,
+                    `T5Block` .... (useful only when `fsdp` flag is passed).
                 - fsdp_backward_prefetch (`str`, *optional*)
                     FSDP's backward prefetch mode. Controls when to prefetch next set of parameters (useful only when
                     `fsdp` field is passed).

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -582,13 +582,12 @@ class TrainingArguments:
             Automatically recursively wrap layers with XLA FSDP if they have at least the specified number of parameters. This setting may only be used with xla_fsdp. It is
             one of two (mutually exclusive) training arguments that determines an auto wrap policy for XLA FSDP; the other is xla_fsdp_transformer_layer_cls_to_wrap.
         xla_fsdp_transformer_layer_cls_to_wrap (`List[str]`, *optional*):
-            Automatically recursively wrap layers with XLA FSDP if their transformer layer class name matches one in the specified list (case-sensitive). This setting 
-            may only be used with xla_fsdp. It is one of two (mutually exclusive) training arguments that determines an auto wrap policy for XLA FSDP; the other is 
+            Automatically recursively wrap layers with XLA FSDP if their transformer layer class name matches one in the specified list (case-sensitive). This setting
+            may only be used with xla_fsdp. It is one of two (mutually exclusive) training arguments that determines an auto wrap policy for XLA FSDP; the other is
             xla_fsdp_min_num_params.
         xla_fsdp_grad_ckpt (`bool`, *optional*, defaults to `False`):
             Will use gradient checkpointing over each nested XLA FSDP wrapped layer. This setting can only be used with
             xla_fsdp when an auto wrapping policy is specified through xla_fsdp_min_num_params or xla_fsdp_transformer_layer_cls_to_wrap.
-
     
 
     """
@@ -1038,8 +1037,8 @@ class TrainingArguments:
         default=0,
         metadata={
             "help": (
-                "Automatically recursively wrap layers with XLA FSDP if they have at least the specified number of parameters." 
-                " This setting is only useful when used with xla_fsdp."
+                "Automatically recursively wrap layers with XLA FSDP if they have at least the specified number of"
+                " parameters. This setting is only useful when used with xla_fsdp."
             ),
         },
     )
@@ -1047,8 +1046,8 @@ class TrainingArguments:
         default=None,
         metadata={
             "help": (
-                "Automatically recursively wrap layers with XLA FSDP if their transformer layer class name matches one in the"
-                " specified list (case-sensitive). This setting is only useful when used with xla_fsdp."
+                "Automatically recursively wrap layers with XLA FSDP if their transformer layer class name matches one"
+                " in the specified list (case-sensitive). This setting is only useful when used with xla_fsdp."
             ),
         },
     )
@@ -1056,7 +1055,8 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": (
-                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting is only useful when used with xla_fsdp."
+                "Will use gradient checkpointing over each XLA FSDP wrapped layer. This setting is only useful when"
+                " used with xla_fsdp."
             ),
         },
     )
@@ -1432,19 +1432,19 @@ class TrainingArguments:
                 self.xla_fsdp_config["compute_dtype"] = getattr(torch, self.xla_fsdp_config["compute_dtype"])
             if "buffer_dtype" in self.xla_fsdp_config:
                 self.xla_fsdp_config["buffer_dtype"] = getattr(torch, self.xla_fsdp_config["buffer_dtype"])
-            
+
             if self.xla_fsdp_min_num_params > 0 and self.xla_fsdp_transformer_layer_cls_to_wrap is not None:
                 raise ValueError(
-                    "`--xla_fsdp_min_num_params` and `--xla_fsdp_transformer_layer_cls_to_wrap` are mutually exclusive."
+                    "`--xla_fsdp_min_num_params` and `--xla_fsdp_transformer_layer_cls_to_wrap` are mutually"
+                    " exclusive."
                 )
         else:
             if self.xla_fsdp_min_num_params > 0:
                 warnings.warn("`--xla_fsdp_min_num_params` is useful only when `--xla_fsdp` is specified.")
             if self.xla_fsdp_transformer_layer_cls_to_wrap is not None:
-                warnings.warn("`--xla_fsdp_transformer_layer_cls_to_wrap` is useful only when `--xla_fsdp` is specified.")
-            if self.xla_fsdp_grad_ckpt:
-                warnings.warn("`--xla_fsdp_grad_ckpt` is useful only when `--xla_fsdp` is specified.")
-
+                warnings.warn(
+                    "`--xla_fsdp_transformer_layer_cls_to_wrap` is useful only when `--xla_fsdp` is specified."
+                )
 
 
         if self.push_to_hub_token is not None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -417,8 +417,8 @@ class TrainingArguments:
                     FSDP's minimum number of parameters for Default Auto Wrapping. (useful only when `fsdp` field is
                     passed).
                 - fsdp_transformer_layer_cls_to_wrap (`List[str]`, *optional*):
-                    List of transformer layer class names (case-sensitive) to wrap, e.g, `BertLayer`, `GPTJBlock`, `T5Block` ....
-                    (useful only when `fsdp` flag is passed).
+                    List of transformer layer class names (case-sensitive) to wrap, e.g, 
+                    `BertLayer`, `GPTJBlock`, `T5Block` .... (useful only when `fsdp` flag is passed).
                 - fsdp_backward_prefetch (`str`, *optional*)
                     FSDP's backward prefetch mode. Controls when to prefetch next set of parameters (useful only when
                     `fsdp` field is passed).
@@ -440,16 +440,18 @@ class TrainingArguments:
                      If `"True"`, FSDP explicitly synchronizes the CPU thread to prevent too many in-flight
                      all-gathers.
                 - xla (`bool`, *optional*, defaults to `False`):
-                    Whether to use PyTorch/XLA Fully Sharded Data Parallel Training. This is an experimental feature and its API may evolve in the future.
-                - xla_fsdp_settings (`str`, *optional*)
-                    The value is the location of a config file (e.g., `fsdp_config.json`) which stores the XLA FSDP wrapping parameters.
+                    Whether to use PyTorch/XLA Fully Sharded Data Parallel Training. This is an experimental feature
+                    and its API may evolve in the future.
+                - xla_fsdp_settings (`dict`, *optional*)
+                    The value is a dictionary which stores the XLA FSDP wrapping parameters.
 
                     For a complete list of options, please see [here](
                     https://github.com/pytorch/xla/blob/master/torch_xla/distributed/fsdp/xla_fully_sharded_data_parallel.py).
                 - xla_fsdp_grad_ckpt (`bool`, *optional*, defaults to `False`):
-                    Will use gradient checkpointing over each nested XLA FSDP wrapped layer. This setting can only be used when the xla flag is set to true,
-                    and an auto wrapping policy is specified through fsdp_min_num_params or fsdp_transformer_layer_cls_to_wrap.
-                
+                    Will use gradient checkpointing over each nested XLA FSDP wrapped layer. This setting can only be
+                    used when the xla flag is set to true, and an auto wrapping policy is specified through 
+                    fsdp_min_num_params or fsdp_transformer_layer_cls_to_wrap.
+                    
         deepspeed (`str` or `dict`, *optional*):
             Use [Deepspeed](https://github.com/microsoft/deepspeed). This is an experimental feature and its API may
             evolve in the future. The value is either the location of DeepSpeed json config file (e.g.,
@@ -933,8 +935,8 @@ class TrainingArguments:
         default=None,
         metadata={
             "help": (
-                "This parameter is deprecated. Transformer layer class name (case-sensitive) to wrap ,e.g, `BertLayer`, `GPTJBlock`, `T5Block` .... "
-                "(useful only when `fsdp` flag is passed)."
+                "This parameter is deprecated. Transformer layer class name (case-sensitive) to wrap, e.g,"
+                " `BertLayer`, `GPTJBlock`, `T5Block` .... (useful only when `fsdp` flag is passed)."
             )
         },
     )
@@ -1346,11 +1348,17 @@ class TrainingArguments:
 
         # if fsdp_config["fsdp_transformer_layer_cls_to_wrap"] is specified as a string, convert it to a list with a single object
         if isinstance(self.fsdp_config.get("fsdp_transformer_layer_cls_to_wrap", None), str):
-            self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = [self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]]
+            self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = [
+                self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"]
+            ]
 
         if self.fsdp_transformer_layer_cls_to_wrap is not None:
-            warnings.warn("using `--fsdp_transformer_layer_cls_to_wrap` is deprecated. Use fsdp_config instead ", FutureWarning)
-            self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = self.fsdp_config.get("fsdp_transformer_layer_cls_to_wrap", [])+[self.fsdp_transformer_layer_cls_to_wrap]
+            warnings.warn(
+                "using `--fsdp_transformer_layer_cls_to_wrap` is deprecated. Use fsdp_config instead ", FutureWarning
+            )
+            self.fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = self.fsdp_config.get(
+                "fsdp_transformer_layer_cls_to_wrap", []
+            ) + [self.fsdp_transformer_layer_cls_to_wrap]
 
         if len(self.fsdp) == 0 and self.fsdp_config["fsdp_min_num_params"] > 0:
             warnings.warn("`--fsdp_min_num_params` is useful only when `--fsdp` is specified.")
@@ -1370,9 +1378,8 @@ class TrainingArguments:
         self.fsdp_config["xla_fsdp_grad_ckpt"] = self.fsdp_config.get("xla_fsdp_grad_ckpt", False)
         if self.fsdp_config["xla"]:
             if len(self.fsdp) > 0:
-                # gather fsdp configuration parameters into a dictionary from specified json file
-                with io.open(self.fsdp_config["xla_fsdp_settings"], "r", encoding="utf-8") as f:
-                    self.xla_fsdp_config = json.load(f)
+                # store XLA fsdp configuration parameters into a dictionary
+                self.xla_fsdp_config = self.fsdp_config.get("xla_fsdp_settings", {})
                 # apply appropriate string to torch.dtype conversions for parameters
                 if "compute_dtype" in self.xla_fsdp_config:
                     self.xla_fsdp_config["compute_dtype"] = getattr(torch, self.xla_fsdp_config["compute_dtype"])


### PR DESCRIPTION
# What does this PR do?

This PR enables the user to make use of the [PyTorch/XLA implementation of FSDP](https://github.com/pytorch/xla/tree/master/torch_xla/distributed/fsdp), including the newly added [auto-wrap feature](https://github.com/pytorch/xla/pull/4318). Four arguments have been added to `training_args.py` to facilitate this functionality:

- `xla_fsdp`: this flag is a string containing the location of a `.json` file which specifies the FSDP arguments the user wants to use when wrapping their model.
- `xla_fsdp_min_num_params`: this flag is an int which will set a size-based automatic wrapping policy which automatically FSDP wraps any module with at least `xla_fsdp_min_num_params` many parameters.
- `xla_fsdp_transformer_layer_cls_to_wrap`: this flag is a list of (case-sensitive) strings which will set a layer-class-based automatic wrapping policy which automatically FSDP wraps any module whose name matches one of the listed strings.
- `xla_fsdp_grad_ckpt`: this flag is a bool which determines whether gradient checkpointing is enabled for the automatically wrapped layers.

# Design notes and future work

1) This PR is an updated version of [this closed PR](https://github.com/huggingface/transformers/pull/20774), which enabled FSDP for a more restricted class of models. This PR now enables nested FSDP wrapping via two auto-wrap policies, avoiding the restrictions of the previous PR.
2) For very large model sizes (greater than, say, 128B parameters), users may see host-side OOMs on TPUs during initialization. This can be mitigated by initializing layer weights immediately after construction, wrapping with FSDP, and moving onto the XLA device, as can be seen in [this branch](https://github.com/AlexWertheim/transformers/blob/einsum/src/transformers/models/gpt2/modeling_gpt2.py#L690-L723). We opted to enable FSDP wrapping at the trainer level, since it does not necessitate model-specific changes and does not disrupt the existing architecture for model construction and initialization. 
3) Checkpointing support for XLA FSDP is not included as part of this PR. We hope to add it soon via another PR. 
4) We have not included testing for XLA FSDP as part of this PR. We would like to add this in a future PR. 

Thanks to @ronghanghu for his assistance in the preparation of this PR. Among many other contributions, the observations that one must copy the model's forward method and replace the optimizer step are his.


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? -->


## Who can review?

@sgugger @JackCaoG

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts and @NielsRogge
- speech models: @sanchit-gandhi

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger and @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
