### PR TITLE
Fixed RAG script which was failing on dummy example

### DIFF
--- a/examples/research_projects/rag-end2end-retriever/finetune_rag.py
+++ b/examples/research_projects/rag-end2end-retriever/finetune_rag.py
@@ -408,11 +408,11 @@ class GenerativeQAModule(BaseTransformer):
         self.save_metrics(metrics, prefix)  # writes to self.metrics_save_path
 
         log_dict = {
-            "val_avg_em": metrics["val_avg_em"],
+            f"{prefix}_avg_em": metrics[f"{prefix}_avg_em"],
             "step_count": metrics["step_count"],
-            "val_avg_loss": metrics["val_avg_loss"],
-            "val_loss": loss,
-            "val_em": metrics_tensor,
+            f"{prefix}_avg_loss": metrics[f"{prefix}_avg_loss"],
+            f"{prefix}_loss": loss,
+            f"{prefix}_em": metrics_tensor,
         }
         self.log_dict(log_dict)
 

--- a/examples/research_projects/rag-end2end-retriever/test_run/dummy-train-data/test.source
+++ b/examples/research_projects/rag-end2end-retriever/test_run/dummy-train-data/test.source
@@ -1,0 +1,8 @@
+What does Moses' rod turn into ?
+Who is Aron?
+Where did Moses grow up ?
+What happens at the command of the Moses ?
+Who manages the Pokémon ?
+Who owned the Pokémon trademark ?
+What else include in Pokémon franchise ?
+How many seasons in Pokémon animme series ?

--- a/examples/research_projects/rag-end2end-retriever/test_run/dummy-train-data/test.target
+++ b/examples/research_projects/rag-end2end-retriever/test_run/dummy-train-data/test.target
@@ -1,0 +1,8 @@
+to a snake
+Moses' assistant
+Egyptian royal court
+let his rod turn in to a snake
+The Pokémon Company
+Nintendo
+world's top-selling toy brand, the top-selling trading card game
+over 20 seasons


### PR DESCRIPTION
# What does this PR do?
Fixed RAG script which was failing on test_epoch_end in dummy example
The dummy example fails when test_epoch_end is called. The prefix="test" should be dynamic in the log metrics too.
Also, test_finetune.sh was failing when test file was not present.

@shamanez would be ideal to review.

Let me know if more information is needed.