### PR TITLE
Allow to add more information in `is_flaky`

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1690,7 +1690,7 @@ class RequestCounter:
         return self.old_request(method=method, **kwargs)
 
 
-def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None):
+def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None, description: Optional[str] = None):
     """
     To decorate flaky tests. They will be retried on failures.
 
@@ -1699,6 +1699,8 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None):
             The maximum number of attempts to retry the flaky test.
         wait_before_retry (`float`, *optional*):
             If provided, will wait that number of seconds before retrying the test.
+        description (`str`, *optional*):
+            A string to describe the situation (what / where / why is flaky, link to GH issue/PR comments, errors, etc.)
     """
 
     def decorator(test_func_ref):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1700,7 +1700,8 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None, d
         wait_before_retry (`float`, *optional*):
             If provided, will wait that number of seconds before retrying the test.
         description (`str`, *optional*):
-            A string to describe the situation (what / where / why is flaky, link to GH issue/PR comments, errors, etc.)
+            A string to describe the situation (what / where / why is flaky, link to GH issue/PR comments, errors,
+            etc.)
     """
 
     def decorator(test_func_ref):


### PR DESCRIPTION
# What does this PR do?

As mentioned once offline, I think it's better for us to make a bit more effort to describe the situation for tests decorated by `is_flaky`. We don't always know the exact reasons (and for known cases, we don't always have good way to fix - at least not in a few months sometimes). A `description` is always good IMO.

For future PRs, if new tests being decorated with `is_flaky`, let's keep 👀 on if `description` is provided - despite it's an optional parameter 🙏 .