### PR TITLE
do not scale gradient in bf16 mode

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -670,7 +670,7 @@ class Trainer:
 
         # torch.compile
         if args.torch_compile and not is_torch_compile_available():
-            raise RuntimeError("Using torch.compile requires a nighly install of PyTorch.")
+            raise RuntimeError("Using torch.compile requires a nighty install of PyTorch.")
 
     def add_callback(self, callback):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -601,16 +601,11 @@ class Trainer:
                     if self.sharded_ddp is not None:
                         self.scaler = ShardedGradScaler()
                     elif self.fsdp is not None:
-                        if self.amp_dtype == torch.float16:
-                            from torch.distributed.fsdp.sharded_grad_scaler import (
-                                ShardedGradScaler as FSDPShardedGradScaler,
-                            )
+                        from torch.distributed.fsdp.sharded_grad_scaler import (
+                            ShardedGradScaler as FSDPShardedGradScaler,
+                        )
 
-                            self.scaler = FSDPShardedGradScaler()
-                        else:
-                            self.do_grad_scaling = False
-                            self.use_cuda_amp = False
-                            self.amp_dtype = None
+                        self.scaler = FSDPShardedGradScaler()
 
                     elif is_torch_tpu_available():
                         from torch_xla.amp import GradScaler

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -597,26 +597,27 @@ class Trainer:
                 self.amp_dtype = torch.float16 if args.fp16 else torch.bfloat16
                 #  bf16 does not need grad scaling
                 self.do_grad_scaling = self.amp_dtype == torch.float16
-                if self.sharded_ddp is not None:
-                    self.scaler = ShardedGradScaler()
-                elif self.fsdp is not None:
-                    if self.amp_dtype == torch.float16:
-                        from torch.distributed.fsdp.sharded_grad_scaler import (
-                            ShardedGradScaler as FSDPShardedGradScaler,
-                        )
+                if self.do_grad_scaling:
+                    if self.sharded_ddp is not None:
+                        self.scaler = ShardedGradScaler()
+                    elif self.fsdp is not None:
+                        if self.amp_dtype == torch.float16:
+                            from torch.distributed.fsdp.sharded_grad_scaler import (
+                                ShardedGradScaler as FSDPShardedGradScaler,
+                            )
 
-                        self.scaler = FSDPShardedGradScaler()
+                            self.scaler = FSDPShardedGradScaler()
+                        else:
+                            self.do_grad_scaling = False
+                            self.use_cuda_amp = False
+                            self.amp_dtype = None
+
+                    elif is_torch_tpu_available():
+                        from torch_xla.amp import GradScaler
+
+                        self.scaler = GradScaler()
                     else:
-                        self.do_grad_scaling = False
-                        self.use_cuda_amp = False
-                        self.amp_dtype = None
-
-                elif is_torch_tpu_available():
-                    from torch_xla.amp import GradScaler
-
-                    self.scaler = GradScaler()
-                else:
-                    self.scaler = torch.cuda.amp.GradScaler()
+                        self.scaler = torch.cuda.amp.GradScaler()
             elif args.half_precision_backend == "cpu_amp":
                 self.use_cpu_amp = True
                 self.amp_dtype = torch.bfloat16

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -606,13 +606,15 @@ class Trainer:
                         )
 
                         self.scaler = FSDPShardedGradScaler()
-
                     elif is_torch_tpu_available():
                         from torch_xla.amp import GradScaler
 
                         self.scaler = GradScaler()
                     else:
                         self.scaler = torch.cuda.amp.GradScaler()
+                elif self.fsdp is not None:
+                    self.use_cuda_amp = False
+                    self.amp_dtype = None
             elif args.half_precision_backend == "cpu_amp":
                 self.use_cpu_amp = True
                 self.amp_dtype = torch.bfloat16

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -670,7 +670,7 @@ class Trainer:
 
         # torch.compile
         if args.torch_compile and not is_torch_compile_available():
-            raise RuntimeError("Using torch.compile requires a nighty install of PyTorch.")
+            raise RuntimeError("Using torch.compile requires a nightly install of PyTorch.")
 
     def add_callback(self, callback):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -596,7 +596,7 @@ class Trainer:
                 self.use_cuda_amp = True
                 self.amp_dtype = torch.float16 if args.fp16 else torch.bfloat16
                 #  bf16 does not need grad scaling
-                self.do_grad_scaling = args.fp16
+                self.do_grad_scaling = self.amp_dtype == torch.float16
                 if self.sharded_ddp is not None:
                     self.scaler = ShardedGradScaler()
                 elif self.fsdp is not None:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -595,7 +595,8 @@ class Trainer:
             if args.half_precision_backend == "cuda_amp":
                 self.use_cuda_amp = True
                 self.amp_dtype = torch.float16 if args.fp16 else torch.bfloat16
-                self.do_grad_scaling = True
+                #  bf16 does not need grad scaling
+                self.do_grad_scaling = args.fp16
                 if self.sharded_ddp is not None:
                     self.scaler = ShardedGradScaler()
                 elif self.fsdp is not None:


### PR DESCRIPTION
# What does this PR do?

Turn off gradient scaling in the trainer when bf16 mode is selected. Only use gradient scaling in float16 mode.

## Who can review?

 @sgugger and @stas00 