### PR TITLE
Make beam sample more robust

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2470,8 +2470,11 @@ class GenerationMixin:
                         else (outputs.hidden_states,)
                     )
 
+            broken_batch_indices = torch.where(torch.max(next_token_scores, dim=-1).values == -torch.inf)[0]
+            _next_token_scores = next_token_scores.index_fill(dim=0, index=broken_batch_indices, value=0.0)
+
             # sample
-            probs = nn.functional.softmax(next_token_scores, dim=-1)
+            probs = nn.functional.softmax(_next_token_scores, dim=-1)
             next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
 
             # finished sentences should have their next token be a padding token

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3087,7 +3087,9 @@ class GenerationMixin:
             vocab_size = next_token_scores.shape[-1]
             next_token_scores = next_token_scores.view(batch_size, num_beams * vocab_size)
 
-            probs = nn.functional.softmax(next_token_scores, dim=-1)
+            broken_batch_indices = torch.where(torch.max(next_token_scores, dim=-1).values == -torch.inf)[0]
+            _next_token_scores = next_token_scores.index_fill(dim=0, index=broken_batch_indices, value=0.0)
+            probs = nn.functional.softmax(_next_token_scores, dim=-1)
 
             next_tokens = torch.multinomial(probs, num_samples=2 * num_beams)
             next_token_scores = torch.gather(next_token_scores, -1, next_tokens)


### PR DESCRIPTION
# What does this PR do?

Make beam sample more robust.

The probability (more generally, scores) in `torch.multinomial` could not contain `nan`. However, the computation
```python
probs = nn.functional.softmax(next_token_scores, dim=-1)
```
could have `next_token_scores` being all `-inf` (along some batch dim.) due to the processing in logit warpers and beam scorers, 
 and this leads to `probs`  being all `nan` along that batch dim, and we sometimes get the following error in the sampling-style generation methods
```
RuntimeError: probability tensor contains either inf, nan or element < 0
```

This PR makes sure the probability to `torch.multinomial` is a valid input while not affecting the existing generation process.

Related PRs:

#17972

#18053