### PR TITLE
exclude deleted files in the fixup script

### DIFF
--- a/utils/get_modified_files.py
+++ b/utils/get_modified_files.py
@@ -25,7 +25,9 @@ import sys
 
 
 fork_point_sha = subprocess.check_output("git merge-base main HEAD".split()).decode("utf-8")
-modified_files = subprocess.check_output(f"git diff --name-only {fork_point_sha}".split()).decode("utf-8").split()
+modified_files = (
+    subprocess.check_output(f"git diff --diff-filter=d --name-only {fork_point_sha}".split()).decode("utf-8").split()
+)
 
 joined_dirs = "|".join(sys.argv[1:])
 regex = re.compile(rf"^({joined_dirs}).*?\.py$")


### PR DESCRIPTION
# What does this PR do?

Running `make fixup` after a file is deleted on a branch causes `black` to exit with an error. 

`Error: Invalid value for 'SRC ...': Path /path/to/deleted/file' does not exist.`

This PR resolves the error by setting the `git diff` flag `--diff-filter=d` to exclude deleted files from the list of modified files.