### PR TITLE
Avoid flaky generation sampling tests

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -780,7 +780,7 @@ class GenerationTesterMixin:
                 forced_eos_token_id=model.config.forced_eos_token_id,
                 max_length=max_length,
             )
-            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=1)
+            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=2)
 
             # check `generate()` and `sample()` are equal
             output_sample, output_generate = self._sample_generate(

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -621,7 +621,7 @@ class SwitchTransformersModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
             config.forced_eos_token_id = None
 
             model = model_class.from_pretrained("google/switch-base-8").to(torch_device).eval()
-            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=1)
+            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=2)
 
             num_return_sequences = 2
             if model.config.is_encoder_decoder:
@@ -670,7 +670,7 @@ class SwitchTransformersModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
             config.eos_token_id = None
             config.forced_eos_token_id = None
 
-            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=1)
+            logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=2)
 
             model = model_class.from_pretrained("google/switch-base-8").to(torch_device).eval()
 


### PR DESCRIPTION
# What does this PR do?

Avoid the CI failure
```bash
tests/models/switch_transformers/test_modeling_switch_transformers.py::SwitchTransformersModelTest::test_beam_sample_generate_dict_output
(line 3099)  RuntimeError: probability tensor contains either inf, nan or element < 0
```

For 
```bash
tests/models/marian/test_modeling_marian.py::MarianStandaloneDecoderModelTest::test_sample_generate
(line 2482)  RuntimeError: probability tensor contains either inf, nan or element < 0
```
it's not clear what I can change in https://github.com/huggingface/transformers/blob/6c62cfb2eff095c181481d8ae86c7f836b65d2d7/tests/generation/test_utils.py#L108-L155

I changed to `logits_warper_kwargs, logits_warper = self._get_warper_and_kwargs(num_beams=2)` despite this is not beam sampling test.