### PR TITLE
For IterableDataset, return DataLoader using self._train_batch_size. …

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -868,7 +868,7 @@ class Trainer:
 
             return DataLoader(
                 train_dataset,
-                batch_size=self.args.per_device_train_batch_size,
+                batch_size=self._train_batch_size,
                 collate_fn=data_collator,
                 num_workers=self.args.dataloader_num_workers,
                 pin_memory=self.args.dataloader_pin_memory,


### PR DESCRIPTION
…This is consistent with how we generate a regular DataLoader, and leads to the correct args.per_device_train_batch_size eventually ending up on each GPU.

Fixes # 21444#issuecomment-1416252207

@sgugger 