### PR TITLE
Fix `PushToHubCallback` import in Share a model docs

### DIFF
--- a/docs/source/de/model_sharing.mdx
+++ b/docs/source/de/model_sharing.mdx
@@ -146,7 +146,7 @@ Geben Sie ein Modell mit [`PushToHubCallback`] an den Hub weiter. In der [`PushT
 - Die `hub_model_id`, die Ihr Hub-Benutzername und Modellname ist.
 
 ```py
->>> from transformers.keras.callbacks import PushToHubCallback
+>>> from transformers import PushToHubCallback
 
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="./your_model_save_path", tokenizer=tokenizer, hub_model_id="your-username/my-awesome-model"

--- a/docs/source/en/model_sharing.mdx
+++ b/docs/source/en/model_sharing.mdx
@@ -146,7 +146,7 @@ Share a model to the Hub with [`PushToHubCallback`]. In the [`PushToHubCallback`
 - The `hub_model_id`, which is your Hub username and model name.
 
 ```py
->>> from transformers.keras.callbacks import PushToHubCallback
+>>> from transformers import PushToHubCallback
 
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="./your_model_save_path", tokenizer=tokenizer, hub_model_id="your-username/my-awesome-model"

--- a/docs/source/es/model_sharing.mdx
+++ b/docs/source/es/model_sharing.mdx
@@ -139,7 +139,7 @@ Los usuarios de TensorFlow pueden activar la misma funcionalidad con [`PushToHub
 - El `hub_model_id`, el cual es tu usuario Hub y el nombre del modelo.
 
 ```py
->>> from transformers.keras.callbacks import PushToHubCallback
+>>> from transformers import PushToHubCallback
 
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="./your_model_save_path", tokenizer=tokenizer, hub_model_id="your-username/my-awesome-model"

--- a/docs/source/it/model_sharing.mdx
+++ b/docs/source/it/model_sharing.mdx
@@ -150,7 +150,7 @@ Condividi un modello nell'Hub con [`PushToHubCallback`]. Nella funzione [`PushTo
 - L'`hub_model_id`, che è il tuo username sull'Hub e il nome del modello.
 
 ```py
->>> from transformers.keras.callbacks import PushToHubCallback
+>>> from transformers import PushToHubCallback
 
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="./il_path_dove_salvare_il_tuo_modello",


### PR DESCRIPTION
# What does this PR do?

Fixes a typo in the Share a model docs section. The example to push a Tensorflow model to the Hub used to call the method`PushToHubCallback` from `transformers.keras.callbacks`, resulting in `ImportError`.

This PR corrects that example in all languages so that `PushToHubCallback` is imported directly from `transformers`.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

# Who can review?
@sgugger, @stevhliu and @MKhalusova
Thank you!