### PR TITLE
[`BLIP`] update blip path on slow tests

### DIFF
--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -1081,7 +1081,7 @@ class BlipTextImageModelTest(ModelTesterMixin, unittest.TestCase):
 
 # We will verify our results on an image of cute cats
 def prepare_img():
-    url = "https://storage.googleapis.com/sfr-vision-language-research/BLIP/demo.jpg"
+    url = "https://huggingface.co/ybelkada/blip-test-image/resolve/main/demo.jpg"
     im = Image.open(requests.get(url, stream=True).raw)
     return im
 

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -1081,7 +1081,7 @@ class BlipTextImageModelTest(ModelTesterMixin, unittest.TestCase):
 
 # We will verify our results on an image of cute cats
 def prepare_img():
-    url = "https://huggingface.co/ybelkada/blip-test-image/resolve/main/demo.jpg"
+    url = "https://huggingface.co/hf-internal-testing/blip-test-image/resolve/main/demo.jpg"
     im = Image.open(requests.get(url, stream=True).raw)
     return im
 


### PR DESCRIPTION
# What does this PR do?

This PR updates the path to the image we use for running BLIP slow tests - as pointed out by @NielsRogge better to upload these images on the Hub in case they get removed from the original place
Happy also to move the Hub repo on `hf-internal-testing` but I am not a member of the org

Also the image is quite large, so I prefer to upload it on the Hub rather than pushing it on the repo here

cc @NielsRogge @sgugger 