### PR TITLE
[`pipeline`] A simple fix for half-precision & 8bit models 

### DIFF
--- a/docs/source/en/pipeline_tutorial.mdx
+++ b/docs/source/en/pipeline_tutorial.mdx
@@ -271,12 +271,9 @@ using `device_map="auto"`
 ```py
 # pip install accelerate
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+from transformers import pipeline
 
-model = AutoModelForCausalLM.from_pretrained("bigscience/bloom", torch_dtype=torch.bfloat16, device_map="auto")
-tokenizer = AutoTokenizer.from_pretrained("bigscience/bloom")
-
-pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+pipe = pipeline(model="bigscience/bloom", torch_dtype=torch.bfloat16, device_map="auto")
 output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
 ```
 
@@ -285,11 +282,8 @@ You can also pass 8-bit loaded models if you install `bitsandbytes` and add the 
 ```py
 # pip install accelerate bitsandbytes
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+from transformers import pipeline
 
-model = AutoModelForCausalLM.from_pretrained("bigscience/bloom", device_map="auto", load_in_8bit=True)
-tokenizer = AutoTokenizer.from_pretrained("bigscience/bloom")
-
-pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+pipe = pipeline(model="bigscience/bloom", device_map="auto", model_kwargs={"load_in_8bit":True})
 output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
 ```

--- a/docs/source/en/pipeline_tutorial.mdx
+++ b/docs/source/en/pipeline_tutorial.mdx
@@ -105,6 +105,8 @@ If the model is too large for a single GPU, you can set `device_map="auto"` to a
 generator(model="openai/whisper-large", device_map="auto")
 ```
 
+Note that if  `device_map="auto"` is passed, there is no need to add the argument `device=device` when instantiating your `pipeline` as you may encounter some unexpected behavior!
+
 ### Batch size
 
 By default, pipelines will not batch inference for reasons explained in detail [here](https://huggingface.co/docs/transformers/main_classes/pipelines#pipeline-batching). The reason is that batching is not necessarily faster, and can actually be quite slower in some cases.
@@ -258,3 +260,36 @@ pip install pytesseract
 ```
 
 </Tip>
+
+## Using `pipeline` on large models with 🤗 `accelerate`:
+
+You can easily run `pipeline` on large models using 🤗 `accelerate`! First make sure you have installed `accelerate` with `pip install accelerate`. 
+
+Let's assume you fullfill the hardware requirements to run a large model such as `bloom` (which has 176B parameters, so ~350GB in `bfloat16`). First load your model
+using `device_map="auto"`
+
+```py
+# pip install accelerate
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+model = AutoModelForCausalLM.from_pretrained("bigscience/bloom", torch_dtype=torch.bfloat16, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("bigscience/bloom")
+
+pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
+```
+
+You can also pass 8-bit loaded models if you install `bitsandbytes` and add the argument `load_in_8bit=True`
+
+```py
+# pip install accelerate bitsandbytes
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+model = AutoModelForCausalLM.from_pretrained("bigscience/bloom", device_map="auto", load_in_8bit=True)
+tokenizer = AutoTokenizer.from_pretrained("bigscience/bloom")
+
+pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
+```

--- a/docs/source/en/pipeline_tutorial.mdx
+++ b/docs/source/en/pipeline_tutorial.mdx
@@ -265,15 +265,14 @@ pip install pytesseract
 
 You can easily run `pipeline` on large models using 🤗 `accelerate`! First make sure you have installed `accelerate` with `pip install accelerate`. 
 
-Let's assume you fullfill the hardware requirements to run a large model such as `bloom` (which has 176B parameters, so ~350GB in `bfloat16`). First load your model
-using `device_map="auto"`
+First load your model using `device_map="auto"`! We will use `facebook/opt-1.3b` for our example.
 
 ```py
 # pip install accelerate
 import torch
 from transformers import pipeline
 
-pipe = pipeline(model="bigscience/bloom", torch_dtype=torch.bfloat16, device_map="auto")
+pipe = pipeline(model="facebook/opt-1.3b", torch_dtype=torch.bfloat16, device_map="auto")
 output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
 ```
 
@@ -284,6 +283,8 @@ You can also pass 8-bit loaded models if you install `bitsandbytes` and add the 
 import torch
 from transformers import pipeline
 
-pipe = pipeline(model="bigscience/bloom", device_map="auto", model_kwargs={"load_in_8bit":True})
+pipe = pipeline(model="facebook/opt-1.3b", device_map="auto", model_kwargs={"load_in_8bit": True})
 output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
 ```
+
+Note that you can replace the checkpoint with any of the Hugging Face model that supports large model loading such as BLOOM!

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -741,6 +741,11 @@ def pipeline(
                 'You cannot use both `pipeline(... device_map=..., model_kwargs={"device_map":...})` as those'
                 " arguments might conflict, use only one.)"
             )
+        if device is not None:
+            logger.warning(
+                "Both `device` and `device_map` are specified. `device` will override `device_map`. You"
+                " will most likely encounter unexpected behavior. Please remove `device` and keep `device_map`."
+            )
         model_kwargs["device_map"] = device_map
     if torch_dtype is not None:
         if "torch_dtype" in model_kwargs:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -287,9 +287,9 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             installed. If no framework is specified, will default to the one currently installed. If no framework is
             specified and both frameworks are installed, will default to the framework of the `model`, or to PyTorch if
             no model is provided.
-        device (`int`, *optional*, defaults to -1):
-            Device ordinal for CPU/GPU supports. Setting this to -1 will leverage CPU, a positive will run the model on
-            the associated CUDA device id.
+        device (Union[`int`, `torch.device`], *optional*, defaults to `None`):
+            Device ordinal for CPU/GPU supports. Setting this to `None` will leverage CPU, a positive will run the
+            model on the associated CUDA device id.
         decoder (`pyctcdecode.BeamSearchDecoderCTC`, *optional*):
             [PyCTCDecode's
             BeamSearchDecoderCTC](https://github.com/kensho-technologies/pyctcdecode/blob/2fd33dc37c4111417e08d89ccd23d28e9b308d19/pyctcdecode/decoder.py#L180)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -287,7 +287,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             installed. If no framework is specified, will default to the one currently installed. If no framework is
             specified and both frameworks are installed, will default to the framework of the `model`, or to PyTorch if
             no model is provided.
-        device (Union[`int`, `torch.device`], *optional*, defaults to `None`):
+        device (Union[`int`, `torch.device`], *optional*):
             Device ordinal for CPU/GPU supports. Setting this to `None` will leverage CPU, a positive will run the
             model on the associated CUDA device id.
         decoder (`pyctcdecode.BeamSearchDecoderCTC`, *optional*):

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -766,8 +766,6 @@ class Pipeline(_ScikitCompat):
         self.framework = framework
 
         if self.framework == "pt" and device is not None:
-            if isinstance(device, int) and device == -1:
-                device = "cpu"
             self.model = self.model.to(device=device)
 
         if device is None:

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -780,7 +780,9 @@ class Pipeline(_ScikitCompat):
 
         # Special handling
         if self.framework == "pt" and self.device.type != "cpu":
-            self.model = self.model.to(self.device)
+            # there is no need to call `.to` on a model that has been loaded with  `accelerate`
+            if not hasattr(self.model, "hf_device_map"):
+                self.model = self.model.to(self.device)
 
         # Update config with task specific parameters
         task_specific_params = self.model.config.task_specific_params

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1057,10 +1057,8 @@ class Pipeline(_ScikitCompat):
         self.call_count += 1
         if self.call_count > 10 and self.framework == "pt" and self.device.type == "cuda":
             warnings.warn(
-                (
-                    "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
-                    " use a dataset"
-                ),
+                "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
+                " use a dataset",
                 UserWarning,
             )
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -800,7 +800,7 @@ class Pipeline(_ScikitCompat):
                 else:
                     main_device = [d for d in hf_device_map.values() if d not in ["cpu", "disk"]][0]
                     accelerate_device = torch.device(f"cuda:{main_device}")
-                
+
                 self.device = accelerate_device
             else:
                 self.device = torch.device("cpu")
@@ -1071,8 +1071,10 @@ class Pipeline(_ScikitCompat):
         self.call_count += 1
         if self.call_count > 10 and self.framework == "pt" and self.device.type == "cuda":
             warnings.warn(
-                "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a"
-                " dataset",
+                (
+                    "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
+                    " use a dataset"
+                ),
                 UserWarning,
             )
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -780,7 +780,7 @@ class Pipeline(_ScikitCompat):
 
         # Special handling
         if self.framework == "pt" and device is not None:
-            self.model = self.model.to(device=device)
+            self.model = self.model.to(device=self.device)
 
             hf_device_map = getattr(self.model, "hf_device_map", None)
             if hf_device_map is not None:
@@ -1071,10 +1071,8 @@ class Pipeline(_ScikitCompat):
         self.call_count += 1
         if self.call_count > 10 and self.framework == "pt" and self.device.type == "cuda":
             warnings.warn(
-                (
-                    "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
-                    " use a dataset"
-                ),
+                "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
+                " use a dataset",
                 UserWarning,
             )
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1057,8 +1057,8 @@ class Pipeline(_ScikitCompat):
         self.call_count += 1
         if self.call_count > 10 and self.framework == "pt" and self.device.type == "cuda":
             warnings.warn(
-                "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please"
-                " use a dataset",
+                "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a"
+                " dataset",
                 UserWarning,
             )
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -766,6 +766,8 @@ class Pipeline(_ScikitCompat):
         self.framework = framework
 
         if self.framework == "pt" and device is not None:
+            if isinstance(device, int) and device == -1:
+                device = "cpu"
             self.model = self.model.to(device=device)
 
         if device is None:

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -774,7 +774,7 @@ class Pipeline(_ScikitCompat):
             else:
                 self.device = torch.device(f"cuda:{device}")
         else:
-            self.device = device
+            self.device = device if device is not None else -1
         self.torch_dtype = torch_dtype
         self.binary_output = binary_output
 

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -255,7 +255,6 @@ class QuestionAnsweringPipeline(ChunkPipeline):
         tokenizer: PreTrainedTokenizer,
         modelcard: Optional[ModelCard] = None,
         framework: Optional[str] = None,
-        device: int = -1,
         task: str = "",
         **kwargs,
     ):
@@ -264,7 +263,6 @@ class QuestionAnsweringPipeline(ChunkPipeline):
             tokenizer=tokenizer,
             modelcard=modelcard,
             framework=framework,
-            device=device,
             task=task,
             **kwargs,
         )

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -326,10 +326,5 @@ class TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseM
     def test_pipeline_accelerate_top_p(self):
         import torch
 
-        model_id = "hf-internal-testing/tiny-random-bloom"
-
-        model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", torch_dtype=torch.float16)
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-
-        pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device_map="auto", torch_dtype=torch.float16)
         pipe("This is a test", do_sample=True, top_p=0.5)

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -14,14 +14,7 @@
 
 import unittest
 
-from transformers import (
-    MODEL_FOR_CAUSAL_LM_MAPPING,
-    TF_MODEL_FOR_CAUSAL_LM_MAPPING,
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    TextGenerationPipeline,
-    pipeline,
-)
+from transformers import MODEL_FOR_CAUSAL_LM_MAPPING, TF_MODEL_FOR_CAUSAL_LM_MAPPING, TextGenerationPipeline, pipeline
 from transformers.testing_utils import (
     require_accelerate,
     require_tf,

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -14,7 +14,14 @@
 
 import unittest
 
-from transformers import MODEL_FOR_CAUSAL_LM_MAPPING, TF_MODEL_FOR_CAUSAL_LM_MAPPING, TextGenerationPipeline, pipeline
+from transformers import (
+    MODEL_FOR_CAUSAL_LM_MAPPING,
+    TF_MODEL_FOR_CAUSAL_LM_MAPPING,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TextGenerationPipeline,
+    pipeline,
+)
 from transformers.testing_utils import (
     require_accelerate,
     require_tf,
@@ -312,3 +319,17 @@ class TextGenerationPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseM
 
         pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device=0, torch_dtype=torch.float16)
         pipe("This is a test")
+
+    @require_torch
+    @require_accelerate
+    @require_torch_gpu
+    def test_pipeline_accelerate_top_p(self):
+        import torch
+
+        model_id = "hf-internal-testing/tiny-random-bloom"
+
+        model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", torch_dtype=torch.float16)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+        pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
+        pipe("This is a test", do_sample=True, top_p=0.5)


### PR DESCRIPTION
# What does this PR do?

Currently on the `main` branch of `transformers` if a user wants to run a `pipeline` using large models (thus, ideally loaded with `device_map=...`) and in half precision (or in int8), they may encounter some issues when calling `pipeline` with `top_p` & `top_k` sampling:
```bash
RuntimeError: "topk_cpu" not implemented for 'Half'
```

## Snippet to reproduce & explanations:

```python
import torch
from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM

model_id = "EleutherAI/gpt-neo-125M"

tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", torch_dtype=torch.float16)

pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, max_length=20, temperature=1, do_sample=True, top_p=0.95, top_k=60, num_return_sequences=3)
text = "What can you tell me about the LHC?"
response = pipe(text)
print(response[0]["generated_text"])
```

This is because the `input_ids` are automatically set on `cpu` since the argument `device` is not passed when initializing the `pipeline`. A model that is loaded with `device_map=...` (i.e. with `accelerate`) always sets the output tensor of the model to the `device` of the input tensor thanks to the forward hooks. Therefore when calling the top_k method, the output tensor is in fp16 (because the model has been loaded in fp16) & on `cpu` hence the torch error above.

Currently a hack to fix this is to add `device=0` when initializing the `pipeline` but this leads to inconsistent and undesirable behaviours for some cases, for example when loading large models in several GPUs, since the call `model.to(self.device)` will break some internals (the hooks will be still there but the weights will be set on the wrong devices). A snippet to reproduce below:

```python
import torch
from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM

model_id = "EleutherAI/gpt-neo-125M"

tokenizer = AutoTokenizer.from_pretrained(model_id)
model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced", torch_dtype=torch.float16)

pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, max_length=20, temperature=1, do_sample=True, top_p=0.95, top_k=60, num_return_sequences=3, device=0)
text = "What can you tell me about the LHC?"
response = pipe(text)
print(response[0]["generated_text"])
```

adding this hack also breaks the usage of `pipeline` with int8 models, since the `to` method is blocked for these models:

```bash
ValueError: `.to` is not supported for `8-bit` models. Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.
```

Thus, I propose to fix this by simply checking whether a model has been loaded with `accelerate` by looking at the attribute `hf_device_map` , and set the model on the correct device only if it has not been loaded with accelerate as backend. This fixes 3 bugs: using `pipeline` with a fp16 model that has been loaded with `accelerate` without having any error in case of multi-gpu usage, using `pipeline` with a fp16 model w `accelerate` & sampling strategies, and using `pipeline` with int8 models & sampling strategies.

cc @sgugger @Narsil