### PR TITLE
[tokenizer] sanitize saved config

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2154,6 +2154,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         if self._auto_class is not None:
             custom_object_save(self, save_directory, config=tokenizer_config)
 
+        # remove private information
+        if "name_or_path" in tokenizer_config:
+            tokenizer_config.pop("name_or_path")
+
         with open(tokenizer_config_file, "w", encoding="utf-8") as f:
             out_str = json.dumps(tokenizer_config, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
             f.write(out_str)

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -230,8 +230,6 @@ class AutoTokenizerTest(unittest.TestCase):
 
         # Check the class of the tokenizer was properly saved (note that it always saves the slow class).
         self.assertEqual(config["tokenizer_class"], "BertTokenizer")
-        # Check other keys just to make sure the config was properly saved /reloaded.
-        self.assertEqual(config["name_or_path"], SMALL_MODEL_IDENTIFIER)
 
     def test_new_tokenizer_registration(self):
         try:


### PR DESCRIPTION
this PR fixes tokenizer's `save_pretrained` to remove the `name_or_path` entry from `tokenizer_config.json` because:
1. it usually contains the local path that was used to save the model, which is not only invalid once published on the hub, it could potentially reveal some personal information.
2. it is not used anywhere, since one needs to know `name_or_path` before they can load this file.

it also adjusts one tokenizer test not to test for the `name_or_path` entry 