### PR TITLE
Replace the frequent permutation generations with a pre-allocated permutation table  

### DIFF
--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -641,7 +641,7 @@ class BigBirdBlockSparseAttention(nn.Module):
         np.random.seed(seed)
         if from_seq_len in [1024, 3072, 4096]:  # old plans used in paper
             rand_attn = self._bigbird_block_rand_mask_fast(
-                from_seq_len, self.max_seqlen, from_block_size, to_block_size, n_rand_blocks, 1024, n_heads
+                from_seq_len, from_block_size, n_rand_blocks, n_heads
             )
         else:
             if plan_from_length is None:

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -25,6 +25,7 @@ import torch
 import torch.utils.checkpoint
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
+from itertools import permutations
 
 from ...activations import ACT2FN
 from ...modeling_outputs import (
@@ -436,6 +437,45 @@ class BigBirdBlockSparseAttention(nn.Module):
         self.key = nn.Linear(config.hidden_size, self.all_head_size, bias=config.use_bias)
         self.value = nn.Linear(config.hidden_size, self.all_head_size, bias=config.use_bias)
 
+
+        self.rand_attn_tables = [ [] for _ in range( config.max_position_embeddings // config.block_size - 1 ) ]
+        self.generate_rand_attn_tables(self.max_seqlen, self.max_seqlen, self.block_size, self.block_size, self.num_random_blocks, 1024)
+        self.rand_attn_tables_prepared_arg = [self.max_seqlen, self.max_seqlen, self.block_size, self.block_size, self.num_random_blocks, 1024]
+
+    def generate_one_table(self, o_table, start_i, end_i, num_rand_blocks):
+        return list(permutations(o_table[start_i:end_i], num_rand_blocks))
+
+    """
+    This function is used to generate the permutations table. The difference between it and _bigbird_block_rand_mask
+    is that it will generate all possible permutations rather than choosing one for each iteration.
+    """
+    def generate_rand_attn_tables(self, from_seq_length, to_seq_length, from_block_size, to_block_size, num_rand_blocks, last_idx):
+        all_tables = self.rand_attn_tables
+        middle_seq = np.arange(1, to_seq_length // to_block_size - 1, dtype=np.int32)
+        last = to_seq_length // to_block_size - 1
+        if last_idx > (2 * to_block_size):
+            last = (last_idx // to_block_size) - 1
+        for i in range(1, from_seq_length // from_block_size - 1):
+            start = i - 2
+            end = i
+            if i == 1:
+                all_tables[i-1] = self.generate_one_table(middle_seq, 2, last, num_rand_blocks)
+            elif i == 2:
+                all_tables[i-1] = self.generate_one_table(middle_seq, 3, last, num_rand_blocks)
+            elif i == from_seq_length // from_block_size - 3:
+                all_tables[i-1] = self.generate_one_table(middle_seq, 0, last, num_rand_blocks)
+            elif i == from_seq_length // from_block_size - 2:
+                all_tables[i-1] = self.generate_one_table(middle_seq, 0, last, num_rand_blocks)
+            else:
+                if start > last:
+                    start = last
+                    all_tables[i-1] = self.generate_one_table(middle_seq, 0, start, num_rand_blocks)
+                elif (end + 1) == last:
+                    all_tables[i-1] = self.generate_one_table(middle_seq, 0, start, num_rand_blocks)
+                else:
+                    new_middle_seq = np.concatenate((middle_seq[:start], middle_seq[end + 1 : last]))
+                    all_tables[i-1] = self.generate_one_table(new_middle_seq, 0, len(new_middle_seq), num_rand_blocks)
+
     def transpose_for_scores(self, x):
         new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
         x = x.view(*new_x_shape)
@@ -566,12 +606,7 @@ class BigBirdBlockSparseAttention(nn.Module):
         # generate random attention and corresponding masks
         np.random.seed(seed)
         if from_seq_len in [1024, 3072, 4096]:  # old plans used in paper
-            rand_attn = [
-                self._bigbird_block_rand_mask(
-                    self.max_seqlen, self.max_seqlen, from_block_size, to_block_size, n_rand_blocks, last_idx=1024
-                )[: (from_seq_len // from_block_size - 2)]
-                for _ in range(n_heads)
-            ]
+            rand_attn = self._bigbird_block_rand_mask_fast(from_seq_len, self.max_seqlen, from_block_size, to_block_size, n_rand_blocks, 1024, n_heads)
         else:
             if plan_from_length is None:
                 plan_from_length, plan_num_rand_blocks = self._get_rand_attn_plan(
@@ -1051,6 +1086,16 @@ class BigBirdBlockSparseAttention(nn.Module):
             plan_num_rand_blocks.append(num_rand_blocks)
 
         return plan_from_length, plan_num_rand_blocks
+
+    def _bigbird_block_rand_mask_fast(self, 
+            from_seq_length, to_seq_length, from_block_size, to_block_size, num_rand_blocks, last_idx, n_heads
+        ): 
+        rand_attn = [ np.zeros((from_seq_length // from_block_size - 2, num_rand_blocks), dtype=np.int32) for _ in range(n_heads)]
+        for i in range(1, from_seq_length // from_block_size - 1):
+            rand_i = np.random.randint(len(self.rand_attn_tables[i-1]), size=n_heads)
+            for j, rand_index in enumerate(rand_i):
+                rand_attn[j][i-1] = self.rand_attn_tables[i-1][rand_index]
+        return rand_attn
 
     @staticmethod
     def _bigbird_block_rand_mask(

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -453,10 +453,11 @@ class BigBirdBlockSparseAttention(nn.Module):
     def generate_one_table(self, o_table, start_i, end_i, num_rand_blocks):
         """
         Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of
-o_table[start_i:end_i].
+        o_table[start_i:end_i].
+
         Args:
             start_i(`int`): The start index of the original table.
-            end_i(`int`):  The end index of the original table. 
+            end_i(`int`):  The end index of the original table.
             o_table(`list`): The original table.
             num_rand_blocks(`int`): The number of elements in each permutation.
         """
@@ -1128,7 +1129,8 @@ o_table[start_i:end_i].
         self.generate_rand_attn_tables and stored in self.rand_attn_tables. This function choose one of the adjacency
         list from the pre-computed list.
 
-        For the implementation tricks, please refer to the discussion in https://github.com/huggingface/transformers/pull/21499#discussion_r1154818120
+        For the implementation tricks, please refer to the discussion in
+        https://github.com/huggingface/transformers/pull/21499#discussion_r1154818120
 
         Args:
             from_seq_length(`int`): The length of from sequence.

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -451,8 +451,15 @@ class BigBirdBlockSparseAttention(nn.Module):
         ]
 
     def generate_one_table(self, o_table, start_i, end_i, num_rand_blocks):
-        """Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of
-o_table[start_i:end_i]."""
+        """
+        Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of
+o_table[start_i:end_i].
+        Args:
+            start_i(`int`): The start index of the original table.
+            end_i(`int`):  The end index of the original table. 
+            o_table(`list`): The original table.
+            num_rand_blocks(`int`): The number of elements in each permutation.
+        """
         return list(permutations(o_table[start_i:end_i], num_rand_blocks))
 
     def generate_rand_attn_tables(
@@ -1121,10 +1128,13 @@ o_table[start_i:end_i]."""
         self.generate_rand_attn_tables and stored in self.rand_attn_tables. This function choose one of the adjacency
         list from the pre-computed list.
 
+        For the implementation tricks, please refer to the discussion in https://github.com/huggingface/transformers/pull/21499#discussion_r1154818120
+
         Args:
-            from_seq_length: int. length of from sequence.
-            from_block_size: int. size of block in from sequence.
-            num_rand_blocks: int. Number of random chunks per row.
+            from_seq_length(`int`): The length of from sequence.
+            from_block_size(`int`): The size of block in from sequence.
+            num_rand_blocks(`int`): The number of random chunks per row.
+            n_heads(`int`): The number of attention heads.
 
         Returns:
             adjacency list of size from_seq_length//from_block_size-2 by num_rand_blocks

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -451,7 +451,8 @@ class BigBirdBlockSparseAttention(nn.Module):
         ]
 
     def generate_one_table(self, o_table, start_i, end_i, num_rand_blocks):
-        """Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of o_table[start_i:end_i]."""
+        """Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of
+o_table[start_i:end_i]."""
         return list(permutations(o_table[start_i:end_i], num_rand_blocks))
 
     def generate_rand_attn_tables(

--- a/src/transformers/models/big_bird/modeling_big_bird.py
+++ b/src/transformers/models/big_bird/modeling_big_bird.py
@@ -451,6 +451,7 @@ class BigBirdBlockSparseAttention(nn.Module):
         ]
 
     def generate_one_table(self, o_table, start_i, end_i, num_rand_blocks):
+        """Generate a list of permutations. Each element in this list is a num_rand_blocks length permutation of o_table[start_i:end_i]."""
         return list(permutations(o_table[start_i:end_i], num_rand_blocks))
 
     def generate_rand_attn_tables(

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -18,6 +18,7 @@
 import copy
 import math
 import random
+from itertools import permutations
 from typing import List, Optional, Tuple, Union
 
 import numpy as np


### PR DESCRIPTION
# What does this PR do?

This PR fixes the performance issue in model big_bird. In model bigbird, the random masks are generated each time, and it calls a huge number of `np.random.permutation` which has big overheads. 
 the function `bigbird_block_rand_mask` is only executed when the values of `from_seq_length` and `to_seq_length` are less than [4096](https://github.com/huggingface/transformers/blob/main/src/transformers/models/big_bird/modeling_big_bird.py#L56) and the values of `from_block_size` and `to_seq_length` are 64. With all the above limitations, the number of all possible permutations is less than 249,984. Since all variables mentioned above are configured only once at the initialization stage, we generate all possible permutations at this stage and only randomly generate the indexes by using `numpy.random.randint` when we need permutations.
This optimization significantly reduces the computation on the CPU, and its speedup for the whole model is about 1.12X in TorchBench.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker and @younesbelkada 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.



Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts and @NielsRogge
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
