### PR TITLE
Wrap RemBert integration test forward passes with torch.no_grad()

### DIFF
--- a/tests/models/rembert/test_modeling_rembert.py
+++ b/tests/models/rembert/test_modeling_rembert.py
@@ -464,7 +464,8 @@ class RemBertModelIntegrationTest(unittest.TestCase):
         model = RemBertModel.from_pretrained("google/rembert")
         input_ids = torch.tensor([[312, 56498, 313, 2125, 313]])
         segment_ids = torch.tensor([[0, 0, 0, 1, 1]])
-        output = model(input_ids, token_type_ids=segment_ids, output_hidden_states=True)
+        with torch.no_grad():
+            output = model(input_ids, token_type_ids=segment_ids, output_hidden_states=True)
 
         hidden_size = 1152
 


### PR DESCRIPTION
# What does this PR do?

Fixes #14642. Wrapped the forward pass inside RemBert's integration test with `with torch.no_grad()` to ensure no gradients are computed during inference.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@LysandreJik Please let me know if this fix works. Thank you:)