### PR TITLE
[tests] add missing `report_to none`

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -778,6 +778,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
                 "load_best_model_at_end": True,
                 "max_steps": 1,
                 "deepspeed": ds_config_dict,
+                "report_to": "none",
             }
 
             training_args = TrainingArguments(output_dir, **args_dict)


### PR DESCRIPTION
wandb keeps on breaking, ensuring it doesn't run in deepspeed tests