### PR TITLE
Make `_LazyAutoMapping` a bit less lazy 😪 🔥 

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -582,6 +582,10 @@ class _LazyAutoMapping(OrderedDict):
         self._extra_content = {}
         self._modules = {}
 
+    def __len__(self):
+        common_keys = set(self._config_mapping.keys()).intersection(self._model_mapping.keys())
+        return len(common_keys) + len(self._extra_content)
+
     def __getitem__(self, key):
         if key in self._extra_content:
             return self._extra_content[key]


### PR DESCRIPTION
# What does this PR do?

Current `_LazyAutoMapping` is a bit too lazy, and potentially to give silent failure/error. For example, tests being skipped by mistake. One explicit example is
https://github.com/huggingface/transformers/blob/c26b1503f22feb20d37588d4243bd444d297bc13/tests/test_pipeline_common.py#L86
(so far in a not-yet merged PR), which was previously
```python
if model_mapping is None or len(model_mapping) == 0: 
```
and the tests were all skipped, and I am like 😕 .

As a former mathematician, it's hard for me to accept length being 0 in this case 🔢 . I decide to make it less lazy!

## Results

### Before this PR
```python
from transformers import TF_MODEL_MAPPING

print(len(TF_MODEL_MAPPING)) # 0
```

### After this PR
```after
from transformers import TF_MODEL_MAPPING

print(len(TF_MODEL_MAPPING))  # 60
```