### PR TITLE
SageMaker Sharded Data Parallel Support for Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1066,6 +1066,12 @@ class Trainer:
                     "weight_decay": 0.0,
                 },
             ]
+            if is_sagemaker_mp_enabled():
+                opt_grouped_params = []
+                for params in optimizer_grouped_parameters:
+                    if len(params['params']) > 0:
+                        opt_grouped_params.append(params)
+                optimizer_grouped_parameters = opt_grouped_params
             optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
 
             if self.sharded_ddp == ShardedDDPOption.SIMPLE:
@@ -1092,6 +1098,7 @@ class Trainer:
 
         if is_sagemaker_mp_enabled():
             self.optimizer = smp.DistributedOptimizer(self.optimizer)
+            
 
         return self.optimizer
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1069,7 +1069,7 @@ class Trainer:
             if is_sagemaker_mp_enabled():
                 opt_grouped_params = []
                 for params in optimizer_grouped_parameters:
-                    if len(params['params']) > 0:
+                    if len(params["params"]) > 0:
                         opt_grouped_params.append(params)
                 optimizer_grouped_parameters = opt_grouped_params
             optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
@@ -1098,7 +1098,6 @@ class Trainer:
 
         if is_sagemaker_mp_enabled():
             self.optimizer = smp.DistributedOptimizer(self.optimizer)
-            
 
         return self.optimizer
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2745,7 +2745,7 @@ class Trainer:
             if self.args.should_save:
                 self._save(output_dir, state_dict=state_dict)
             if IS_SAGEMAKER_MP_POST_1_10:
-                if smp.state.cfg.sharded_data_parallel_degree > 1:
+                if IS_SAGEMAKER_MP_POST_1_15 and smp.state.cfg.sharded_data_parallel_degree > 1:
                     # delete bogus weights dump
                     if self.args.should_save:
                         file = os.path.join(output_dir, WEIGHTS_NAME)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1779,7 +1779,6 @@ class TrainingArguments:
                 a work description to be used in debug logs
 
         """
-        print(f"[viczhu] main_process_first | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
         if is_torch_available() and self.world_size > 1:
             main_process_desc = "main process"
             if local:
@@ -1795,13 +1794,10 @@ class TrainingArguments:
                     # tell all replicas to wait
                     logger.debug(f"{self.process_index}: waiting for the {main_process_desc} to perform {desc}")
                     if is_torch_tpu_available():
-                        print(f"[viczhu] NOT IS_MAIN_PROCESS ERR??? TORCH_TPU | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         xm.rendezvous(desc)
                     elif is_sagemaker_dp_enabled():
-                        print(f"[viczhu] main_process_first NOT IS_MAIN_PROCESS is_sagemaker_dp_enabled() | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         dist.barrier()
                     else:
-                        print(f"[viczhu] main_process_first NOT_MAIN_BARRIER | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         torch.distributed.barrier()
                 yield
             finally:
@@ -1809,13 +1805,10 @@ class TrainingArguments:
                     # the wait is over
                     logger.debug(f"{self.process_index}: {main_process_desc} completed {desc}, releasing all replicas")
                     if is_torch_tpu_available():
-                        print(f"[viczhu] IS_MAIN_PROCESS ERR??? TORCH_TPU | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         xm.rendezvous(desc)
                     elif is_sagemaker_dp_enabled():
-                        print(f"[viczhu] main_process_first IS_MAIN_PROCESS is_sagemaker_dp_enabled() | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         dist.barrier()
                     else:
-                        print(f"[viczhu] main_process_first IS_MAIN_BARRIER | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         torch.distributed.barrier()
         else:
             yield

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1779,6 +1779,7 @@ class TrainingArguments:
                 a work description to be used in debug logs
 
         """
+        print(f"[viczhu] main_process_first | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
         if is_torch_available() and self.world_size > 1:
             main_process_desc = "main process"
             if local:
@@ -1794,10 +1795,13 @@ class TrainingArguments:
                     # tell all replicas to wait
                     logger.debug(f"{self.process_index}: waiting for the {main_process_desc} to perform {desc}")
                     if is_torch_tpu_available():
+                        print(f"[viczhu] NOT IS_MAIN_PROCESS ERR??? TORCH_TPU | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         xm.rendezvous(desc)
                     elif is_sagemaker_dp_enabled():
+                        print(f"[viczhu] main_process_first NOT IS_MAIN_PROCESS is_sagemaker_dp_enabled() | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         dist.barrier()
                     else:
+                        print(f"[viczhu] main_process_first NOT_MAIN_BARRIER | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         torch.distributed.barrier()
                 yield
             finally:
@@ -1805,10 +1809,13 @@ class TrainingArguments:
                     # the wait is over
                     logger.debug(f"{self.process_index}: {main_process_desc} completed {desc}, releasing all replicas")
                     if is_torch_tpu_available():
+                        print(f"[viczhu] IS_MAIN_PROCESS ERR??? TORCH_TPU | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         xm.rendezvous(desc)
                     elif is_sagemaker_dp_enabled():
+                        print(f"[viczhu] main_process_first IS_MAIN_PROCESS is_sagemaker_dp_enabled() | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         dist.barrier()
                     else:
+                        print(f"[viczhu] main_process_first IS_MAIN_BARRIER | local_process_index: {self.local_process_index} | rank: {smp.rank()} | world_size: {self.world_size}")
                         torch.distributed.barrier()
         else:
             yield


### PR DESCRIPTION
# What does this PR do?

This PR adds support for SageMaker Sharded Data Parallel with SMP version >= 1.15.

We mainly follow Deepspeed's checkpointing logic in our integration.
When sharded data parallel is enabled, we have special checkpointing logic. 
We do not save the full model by default (with `save_model`) as it is an expensive synchronization action like Deepspeed. Instead, the user can enable full model saving by adding an environment variable called `HF_TRAINER_SMP_SDP_SAVE_FULL_MODEL` in their user script. 

SageMaker Model Parallel saves these SDP partial checkpoints in a folder with a "_partial" appended to the input tag.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts and @NielsRogge
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
