### PR TITLE
Remove Niels from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,7 +26,7 @@ body:
         Models:
 
           - text models: @ArthurZucker and @younesbelkada
-          - vision models: @amyeroberts and @NielsRogge
+          - vision models: @amyeroberts
           - speech models: @sanchit-gandhi
           - graph models: @clefourrier
         

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ members/contributors who may be interested in your PR.
 Models:
 
 - text models: @ArthurZucker and @younesbelkada
-- vision models: @amyeroberts and @NielsRogge
+- vision models: @amyeroberts
 - speech models: @sanchit-gandhi
 - graph models: @clefourrier
 


### PR DESCRIPTION
# What does this PR do?

As @NielsRogge will be leaving the opensource team on Monday, this PR updates the templates to remove him from the persons to tag. Thanks all your help @NielsRogge !