### PR TITLE
Goodbye to Blip-2 doctests

### DIFF
--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -35,7 +35,6 @@ src/transformers/models/blenderbot/configuration_blenderbot.py
 src/transformers/models/blenderbot/modeling_blenderbot.py
 src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
 src/transformers/models/blenderbot_small/modeling_blenderbot_small.py
-src/transformers/models/blip_2/modeling_blip_2.py
 src/transformers/models/blip/modeling_blip.py
 src/transformers/models/bloom/configuration_bloom.py
 src/transformers/models/camembert/configuration_camembert.py


### PR DESCRIPTION
# What does this PR do?

Blip-2 causes GPU OOM on doctest, and potentially causes some subsequential tests failing (as the GPU is not in good state, but I didn't verify thoroughly).

This PR tries to avoid this situation, despite the added lines is not really meant to be in a doc for users.