### PR TITLE
[`Blip2`] Add int8 support for `blip2-flan-t5-xxl` 

### DIFF
--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -285,6 +285,7 @@ class Blip2PreTrainedModel(PreTrainedModel):
         r"language_model.decoder.embed_tokens.weight",
     ]
     _no_split_modules = ["Blip2Attention", "T5Block", "OPTDecoderLayer"]
+    _keep_in_fp32_modules = ["wo"]
 
     def _init_weights(self, module):
         """Initialize the weights"""


### PR DESCRIPTION
# What does this PR do?

Similarly as https://github.com/huggingface/transformers/pull/20683 - currently the largest blip2 + flan-t5-xxl fails to run in int8 since we forgot to add the patch presented in the aforementioned PR

This PR adds the `_keep_in_fp32_modules` support for `Blip2` so that users can run this model in fp16 and int8 with no performance degradation as the original model trained in bf16

cc @sgugger @NielsRogge 
