### PR TITLE
Add `inputs_embeds` support when generating with GPT-J

### DIFF
--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -790,13 +790,13 @@ class GPTJForCausalLM(GPTJPreTrainedModel):
                 position_ids = position_ids[:, -1].unsqueeze(-1)
         else:
             position_ids = None
-            
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}
         else:
             model_inputs = {"input_ids": input_ids}
-            
+
         model_inputs.update(
             {
                 "past_key_values": past_key_values,
@@ -806,7 +806,7 @@ class GPTJForCausalLM(GPTJPreTrainedModel):
                 "token_type_ids": token_type_ids,
             }
         )
-            
+
         return model_inputs
 
     @add_start_docstrings_to_model_forward(GPTJ_INPUTS_DOCSTRING.format("batch_size, sequence_length"))

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -771,7 +771,7 @@ class GPTJForCausalLM(GPTJPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.lm_head = new_embeddings
 
-    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, inputs_embeds=None, **kwargs):
         token_type_ids = kwargs.get("token_type_ids", None)
         # only last token for inputs_ids if past is defined in kwargs
         if past_key_values:
@@ -790,14 +790,24 @@ class GPTJForCausalLM(GPTJPreTrainedModel):
                 position_ids = position_ids[:, -1].unsqueeze(-1)
         else:
             position_ids = None
-        return {
-            "input_ids": input_ids,
-            "past_key_values": past_key_values,
-            "use_cache": kwargs.get("use_cache"),
-            "position_ids": position_ids,
-            "attention_mask": attention_mask,
-            "token_type_ids": token_type_ids,
-        }
+            
+        # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs = {"inputs_embeds": inputs_embeds}
+        else:
+            model_inputs = {"input_ids": input_ids}
+            
+        model_inputs.update(
+            {
+                "past_key_values": past_key_values,
+                "use_cache": kwargs.get("use_cache"),
+                "position_ids": position_ids,
+                "attention_mask": attention_mask,
+                "token_type_ids": token_type_ids,
+            }
+        )
+            
+        return model_inputs
 
     @add_start_docstrings_to_model_forward(GPTJ_INPUTS_DOCSTRING.format("batch_size, sequence_length"))
     @add_code_sample_docstrings(


### PR DESCRIPTION
# What does this PR do?


This PR extends https://github.com/huggingface/transformers/pull/21405 by @gante to GPT-J, making it accept `inputs_embeds` when generating.

This is generally useful for soft-prompting but I am specifically using this with https://github.com/jmerullo/limber by @jmerullo

Importantly, I find that dummy `input_ids` are still required. Sample code using this feature with GPT-J:
```
from transformers import GPTJForCausalLM, AutoTokenizer

model_name = "hf-internal-testing/tiny-random-GPTJModel"; revision="main"
model = GPTJForCausalLM.from_pretrained(model_name, revision=revision)
tokenizer = AutoTokenizer.from_pretrained(model_name)

inputs_embeds = torch.rand((1, 144, 32,)) # 144 dummy soft-prompt token embeddings
filler_input_ids = torch.zeros((1, inputs_embeds.shape[1]), dtype=torch.long).to(model.device)
filler_input_ids += model.config.bos_token_id # setting dummy input_ids to bos tokens

model.generate(filler_input_ids, inputs_embeds=inputs_embeds, max_length=300)
```
