### PR TITLE
Remove trailing 'extractive' word from en documentation

### DIFF
--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -217,7 +217,7 @@ Question answering is another token-level task that returns an answer to a quest
 
 There are two common types of question answering:
 
-* extractive: extractive: given a question and some context, the answer is a span of text from the context the model must extract
+* extractive: given a question and some context, the answer is a span of text from the context the model must extract
 * abstractive: given a question and some context, the answer is generated from the context; this approach is handled by the [`Text2TextGenerationPipeline`] instead of the [`QuestionAnsweringPipeline`] shown below
 
 


### PR DESCRIPTION
# What does this PR do?

Removes an extra word from the documentation.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Documentation: @sgugger, @stevhliu and @MKhalusova

