### PR TITLE
[`bnb`] Let's make the daily CI green 🍏 

### DIFF
--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -92,7 +92,9 @@ class MixedInt8Test(BaseMixedInt8Test):
         super().setUp()
 
         # Models and tokenizer
-        self.model_fp16 = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype=torch.float16, device_map="auto")
+        self.model_fp16 = AutoModelForCausalLM.from_pretrained(
+            self.model_name, torch_dtype=torch.float16, device_map="auto"
+        )
         self.model_8bit = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
 
     def tearDown(self):

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -92,7 +92,7 @@ class MixedInt8Test(BaseMixedInt8Test):
         super().setUp()
 
         # Models and tokenizer
-        self.model_fp16 = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", device_map="auto")
+        self.model_fp16 = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype=torch.float16, device_map="auto")
         self.model_8bit = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
 
     def tearDown(self):


### PR DESCRIPTION
# What does this PR do?

This PR fixes a test that is currently failing on the `main` branch.

Link to failing test: https://github.com/huggingface/transformers/actions/runs/4154270129/jobs/7186572507

Since the introduction of https://github.com/huggingface/transformers/pull/21524 - when loading `bigscience/bloom-1b7` it  detects `fp32` weights when using `torch_dtype="auto"`. Therefore the expected relative difference of the memory footprint is different than the expected one. 

This PR fixes the test by forcing `torch_dtype=torch.float16` when loading the fp16 model

cc @ydshieh @sgugger 