### PR TITLE
Enable `requires_grad` on input embedding to train on top of frozen layers

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1148,6 +1148,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return False
         return True
 
+    def enable_input_require_grads(self):
+        """
+        Enables the gradients for the input embeddings. This is useful for
+        fine-tuning adapter weights while keeping the model weights fixed.
+        """
+
+        def make_inputs_require_grads(module, input, output):
+            output.requires_grad_(True)
+
+        self.get_input_embeddings().register_forward_hook(make_inputs_require_grads)
+
     def get_input_embeddings(self) -> nn.Module:
         """
         Returns the model's input embeddings.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1150,8 +1150,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
     def enable_input_require_grads(self):
         """
-        Enables the gradients for the input embeddings. This is useful for
-        fine-tuning adapter weights while keeping the model weights fixed.
+        Enables the gradients for the input embeddings. This is useful for fine-tuning adapter weights while keeping
+        the model weights fixed.
         """
 
         def make_inputs_require_grads(module, input, output):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1157,7 +1157,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         def make_inputs_require_grads(module, input, output):
             output.requires_grad_(True)
 
-        self.get_input_embeddings().register_forward_hook(make_inputs_require_grads)
+        self._require_grads_hook = self.get_input_embeddings().register_forward_hook(make_inputs_require_grads)
+
+    def disable_input_require_grads(self):
+        """
+        Removes the `_require_grads_hook`.
+        """
+        self._require_grads_hook.remove()
 
     def get_input_embeddings(self) -> nn.Module:
         """


### PR DESCRIPTION
# What does this PR do?

## Motivation

In the context of `peft`, users currently needs to manually add a forward hook that enables gradient computation to the input after computing the embedding, for e.g. for `t5` one needs to call:
```python
def make_inputs_require_grad(module, input, output):
    output.requires_grad_(True)

model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
```


This PR makes the life easy for the users by wrapping this protocol in a single method `enable_input_require_grads` | Related: https://github.com/huggingface/peft/issues/80

cc @pacman100 

Wdyt @sgugger ? Maybe there is a better solution but not sure here, would love some guidance!