### PR TITLE
Fix typo in QA task guide

### DIFF
--- a/docs/source/en/tasks/question_answering.mdx
+++ b/docs/source/en/tasks/question_answering.mdx
@@ -26,8 +26,6 @@ This guide will show you how to:
 1. Finetune [DistilBERT](https://huggingface.co/distilbert-base-uncased) on the [SQuAD](https://huggingface.co/datasets/squad) dataset for extractive question answering.
 2. Use your finetuned model for inference.
 
-[ALBERT](../model_doc/albert)
-
 <Tip>
 The task illustrated in this tutorial is supported by the following model architectures:
 


### PR DESCRIPTION
Removes random link to ALBERT model doc in the question-answering task guide.