### PR TITLE
fix: Race Condition when using Sagemaker Checkpointing and Model Repository

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3727,10 +3727,7 @@ class Trainer:
         if not self.is_world_process_zero():
             return
 
-        patterns = [
-            "*.sagemaker-uploading",
-            "*.sagemaker-uploaded"
-        ]
+        patterns = ["*.sagemaker-uploading", "*.sagemaker-uploaded"]
 
         # Get current .gitignore content
         if os.path.exists(os.path.join(self.repo.local_dir, ".gitignore")):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3721,17 +3721,17 @@ class Trainer:
 
         return nested_numpify(tensors)
 
-    def _add_sm_patterns_to_gitignore(
-        self, patterns: List[str] = [
+    def _add_sm_patterns_to_gitignore(self) -> None:
+        """Add SageMaker Checkpointing patterns to .gitignore file."""
+        # Make sure we only do this on the main process
+        if not self.is_world_process_zero():
+            return
+
+        patterns = [
             "*.sagemaker-uploading",
             "*.sagemaker-uploaded"
-        ]) -> None:
-        """Add SageMaker Checkpointing patterns to .gitignore file.
+        ]
 
-        Args:
-            patterns (List[str], optional): List of patterns to add to .gitignore. Defaults to
-                [".sagemaker-uploading", ".sagemaker-uploaded"].
-        """
         # Get current .gitignore content
         if os.path.exists(os.path.join(self.repo.local_dir, ".gitignore")):
             with open(os.path.join(self.repo.local_dir, ".gitignore"), "r") as f:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3395,6 +3395,10 @@ class Trainer:
             with open(os.path.join(self.args.output_dir, ".gitignore"), "w", encoding="utf-8") as writer:
                 writer.writelines(["checkpoint-*/"])
 
+        # Add "*.sagemaker" to .gitignore if using SageMaker
+        if os.environ.get("SM_TRAINING_ENV"):
+            self._add_sm_patterns_to_gitignore()
+
         self.push_in_progress = None
 
     def create_model_card(
@@ -3716,3 +3720,45 @@ class Trainer:
             tensors = distributed_concat(tensors)
 
         return nested_numpify(tensors)
+
+    def _add_sm_patterns_to_gitignore(
+        self, patterns: List[str] = [
+            "*.sagemaker-uploading",
+            "*.sagemaker-uploaded"
+        ]) -> None:
+        """Add SageMaker Checkpointing patterns to .gitignore file.
+
+        Args:
+            patterns (List[str], optional): List of patterns to add to .gitignore. Defaults to
+                [".sagemaker-uploading", ".sagemaker-uploaded"].
+        """
+        # Get current .gitignore content
+        if os.path.exists(os.path.join(self.repo.local_dir, ".gitignore")):
+            with open(os.path.join(self.repo.local_dir, ".gitignore"), "r") as f:
+                current_content = f.read()
+        else:
+            current_content = ""
+
+        # Add the patterns to .gitignore
+        content = current_content
+        for pattern in patterns:
+            if pattern not in content:
+                if content.endswith("\n"):
+                    content += pattern
+                else:
+                    content += f"\n{pattern}"
+
+        # Write the .gitignore file if it has changed
+        if content != current_content:
+            with open(os.path.join(self.repo.local_dir, ".gitignore"), "w") as f:
+                logger.debug(f"Writing .gitignore file. Content: {content}")
+                f.write(content)
+
+        self.repo.git_add(".gitignore")
+
+        # avoid race condition with git status
+        time.sleep(1)
+
+        if not self.repo.is_repo_clean():
+            self.repo.git_commit("Add *.sagemaker patterns to .gitignore.")
+            self.repo.git_push()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3757,7 +3757,7 @@ class Trainer:
         self.repo.git_add(".gitignore")
 
         # avoid race condition with git status
-        time.sleep(1)
+        time.sleep(0.5)
 
         if not self.repo.is_repo_clean():
             self.repo.git_commit("Add *.sagemaker patterns to .gitignore.")


### PR DESCRIPTION
# What does this PR do?

Fixes #21586

With the following changes:

- Added `_add_sm_patterns_to_gitignore()` as a helper method in the Trainer class that will add the patterns used by the SageMaker Checkpointing feature in the .gitignore file when initializing the Model Repository.
- A condition in the `init_git_repo()` to check if we have an important SageMaker environment variable 

It also includes a fix in the huggingface_hub library in order to consider excluding patterns when defining large files: https://github.com/huggingface/huggingface_hub/pull/1339

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@sgugger as we discussed this issue in the https://github.com/huggingface/transformers/issues/21586