### PR TITLE
Fix dynamic module import error

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -148,9 +148,11 @@ def get_class_in_module(class_name, module_path):
     # copy to a temporary directory
     shutil.copytree(module_dir, module_dir_backup_temp)
 
-    # remove and recreate an empty directory
-    os.system(f"rm -rf {module_dir}")
-    os.makedirs(module_dir)
+    # remove `configuration.py`: this is necessary when we try to import modeling module, or other tokenizer/processor
+    # modules, while configuration module has been imported previously.
+    # TODO: This is only a simple heuristic. In general, we might need to consider any dynamic module that has been
+    #       imported. However, we don't have this information so far.
+    os.system(f"rm -rf {module_dir}/configuration.py")
 
     # copy back the target module file - and ONLY this single file
     # Without this hack, we may get error: `ModuleNotFoundError: No module named 'transformers_modules.local.modeling'`
@@ -159,26 +161,7 @@ def get_class_in_module(class_name, module_path):
 
     # import the module
     module_path = module_path.replace(os.path.sep, ".")
-
-    # up to the parent of the target module
-    parent_module_path = ".".join(module_path.split(".")[:-1])
-
-    try:
-        module = importlib.import_module(module_path)
-    except ModuleNotFoundError as e:
-        # 'transformers_modules.hf-internal-testing.test_dynamic_model_with_util.b731e5fae6d80a4a775461251c4388886fb7a249.util"
-        missing_module_path = str(e).replace("No module named ", "")[1:-1]
-
-        # anything after the parent of the target module
-        missing_module_path_short = missing_module_path.replace(parent_module_path + ".", "")
-        missing_module_file_path_short = missing_module_path_short.replace(".", os.path.sep)
-
-        # full path to the missing module
-        missing_module_file_path = module_dir / missing_module_file_path_short
-
-        missing_module_file_path_2 = Path(module_dir_backup_temp) / missing_module_file_path_short
-        shutil.copytree(os.path.join(missing_module_file_path_2, missing_module_file_path), module_dir)
-        module = importlib.import_module(module_path)
+    module = importlib.import_module(module_path)
 
     # copy the whole directory back
     os.system(f"rm -rf {module_dir}")

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -237,7 +237,7 @@ def get_cached_module_file(
     # Download and cache module_file from the repo `pretrained_model_name_or_path` of grab it if it's a local file.
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)
     if os.path.isdir(pretrained_model_name_or_path):
-        submodule = "local"
+        submodule = f"local_{pretrained_model_name_or_path}"
     else:
         submodule = pretrained_model_name_or_path.replace("/", os.path.sep)
 
@@ -265,7 +265,7 @@ def get_cached_module_file(
     full_submodule = TRANSFORMERS_DYNAMIC_MODULE_NAME + os.path.sep + submodule
     create_dynamic_module(full_submodule)
     submodule_path = Path(HF_MODULES_CACHE) / full_submodule
-    if submodule == "local":
+    if submodule == f"local_{pretrained_model_name_or_path}":
         # We always copy local files (we could hash the file to see if there was a change, and give them the name of
         # that hash, to only copy when there is a modification but it seems overkill for now).
         # The only reason we do the copy is to avoid putting too many folders in sys.path.

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -158,7 +158,7 @@ def get_class_in_module(class_name, module_path):
     if os.path.isfile(f"{module_dir}/configuration.py"):
         os.remove(f"{module_dir}/configuration.py")
     # This has to be deleted too!
-    if os.path.isfile(f"{module_dir}/__pycache__"):
+    if os.path.isdir(f"{module_dir}/__pycache__"):
         os.remove(f"{module_dir}/__pycache__")
 
     # copy back the target module file - and ONLY this single file

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -145,6 +145,9 @@ def get_class_in_module(class_name, module_path):
     """
     module_dir = Path(HF_MODULES_CACHE) / os.path.dirname(module_path)
     module_dir_backup_temp = str(module_dir) + "_backup_temp"
+    # make sure it doesn't exist yet
+    if os.path.isdir(module_dir_backup_temp):
+        shutil.rmtree(module_dir_backup_temp)
     # copy to a temporary directory
     shutil.copytree(module_dir, module_dir_backup_temp)
 
@@ -152,7 +155,8 @@ def get_class_in_module(class_name, module_path):
     # modules, while configuration module has been imported previously.
     # TODO: This is only a simple heuristic. In general, we might need to consider any dynamic module that has been
     #       imported. However, we don't have this information so far.
-    os.system(f"rm -rf {module_dir}/configuration.py")
+    if os.path.isfile(f"{module_dir}/configuration.py"):
+        os.remove(f"{module_dir}/configuration.py")
 
     # copy back the target module file - and ONLY this single file
     # Without this hack, we may get error: `ModuleNotFoundError: No module named 'transformers_modules.local.modeling'`
@@ -163,12 +167,12 @@ def get_class_in_module(class_name, module_path):
     module_path = module_path.replace(os.path.sep, ".")
     module = importlib.import_module(module_path)
 
-    # copy the whole directory back
-    os.system(f"rm -rf {module_dir}")
+    # copy the whole directory backg
+    shutil.rmtree(f"{module_dir}")
     shutil.copytree(module_dir_backup_temp, module_dir)
 
     # remove the backup directory
-    os.system(f"rm -rf {module_dir_backup_temp}")
+    shutil.rmtree(module_dir_backup_temp)
 
     return getattr(module, class_name)
 

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -157,7 +157,10 @@ def get_class_in_module(class_name, module_path):
     #       imported. However, we don't have this information so far.
     if os.path.isfile(f"{module_dir}/configuration.py"):
         os.remove(f"{module_dir}/configuration.py")
-    # This has to be deleted too!
+    # `__init__.py` has to be deleted too!
+    if os.path.isfile(f"{module_dir}/__init__.py"):
+        os.remove(f"{module_dir}/__init__.py")
+    # `__pycache__` directory has to be deleted too!
     if os.path.isdir(f"{module_dir}/__pycache__"):
         shutil.rmtree(f"{module_dir}/__pycache__")
 

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -159,7 +159,7 @@ def get_class_in_module(class_name, module_path):
         os.remove(f"{module_dir}/configuration.py")
     # This has to be deleted too!
     if os.path.isdir(f"{module_dir}/__pycache__"):
-        os.remove(f"{module_dir}/__pycache__")
+        shutil.rmtree(f"{module_dir}/__pycache__")
 
     # copy back the target module file - and ONLY this single file
     # Without this hack, we may get error: `ModuleNotFoundError: No module named 'transformers_modules.local.modeling'`

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -148,19 +148,12 @@ def get_class_in_module(class_name, module_path):
     
         module_dir = Path(HF_MODULES_CACHE) / os.path.dirname(module_path)
         module_file_name = module_path.split(os.path.sep)[-1] + ".py"
-        other_module_files = ["__init__.py", "__pycache__"]
-        if module_file_name != "configuration.py":
-            other_module_files += ["configuration.py"]
-    
+
         # copy to a temporary directory
-        for fn in [module_file_name] + other_module_files:
-            if os.path.isfile(f"{module_dir}/{fn}"):
-                shutil.copy(f"{module_dir}/{fn}", tmp_dir)
-                cmd = f'import os; os.remove("{module_dir}/{fn}")'
-                os.system(f"python3 -c '{cmd}'")
-                # os.remove(f"{module_dir}/{fn}")
-            elif os.path.isdir(f"{module_dir}/{fn}"):
-                shutil.rmtree(f"{module_dir}/{fn}")
+        shutil.copy(f"{module_dir}/{module_file_name}", tmp_dir)
+        cmd = f'import os; os.remove("{module_dir}/{module_file_name}")'
+        os.system(f"python3 -c '{cmd}'")
+        # os.remove(f"{module_dir}/{module_file_name}")
 
         # copy back the file that we want to import
         shutil.copyfile(f"{tmp_dir}/{module_file_name}", f"{module_dir}/{module_file_name}")
@@ -169,10 +162,6 @@ def get_class_in_module(class_name, module_path):
         module_path = module_path.replace(os.path.sep, ".")
         module = importlib.import_module(module_path)
 
-        # copy back the config file
-        if os.path.isfile(f"{tmp_dir}/configuration.py"):
-            shutil.copyfile(f"{tmp_dir}/configuration.py", f"{module_dir}/configuration.py")
-    
         return getattr(module, class_name)
 
 

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -19,8 +19,8 @@ import os
 import re
 import shutil
 import sys
-from pathlib import Path
 import tempfile
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 from huggingface_hub import model_info
@@ -145,7 +145,6 @@ def get_class_in_module(class_name, module_path):
     Import a module on the cache directory for modules and extract a class from it.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
-    
         module_dir = Path(HF_MODULES_CACHE) / os.path.dirname(module_path)
         module_file_name = module_path.split(os.path.sep)[-1] + ".py"
 
@@ -157,7 +156,7 @@ def get_class_in_module(class_name, module_path):
 
         # copy back the file that we want to import
         shutil.copyfile(f"{tmp_dir}/{module_file_name}", f"{module_dir}/{module_file_name}")
-    
+
         # import the module
         module_path = module_path.replace(os.path.sep, ".")
         module = importlib.import_module(module_path)

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -258,7 +258,7 @@ def get_cached_module_file(
     full_submodule = TRANSFORMERS_DYNAMIC_MODULE_NAME + os.path.sep + submodule
     create_dynamic_module(full_submodule)
     submodule_path = Path(HF_MODULES_CACHE) / full_submodule
-    if submodule == f"local_{pretrained_model_name_or_path.replace(os.path.sep, '_')}":
+    if submodule == pretrained_model_name_or_path.split(os.path.sep)[-1]:
         # We always copy local files (we could hash the file to see if there was a change, and give them the name of
         # that hash, to only copy when there is a modification but it seems overkill for now).
         # The only reason we do the copy is to avoid putting too many folders in sys.path.


### PR DESCRIPTION
# What does this PR do?

### Issue

We have failing test 
```bash
FAILED tests/models/auto/test_modeling_auto.py::AutoModelTest::test_from_pretrained_dynamic_model_distant

ModuleNotFoundError: No module named 'transformers_modules.local.modeling'
```
The full trace is given at the end.

After a long debug process, it turns out that, when reloading from the saved model
```python
model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model", trust_remote_code=True)
with tempfile.TemporaryDirectory() as tmp_dir:
    model.save_pretrained(tmp_dir)
    reloaded_model = AutoModel.from_pretrained(tmp_dir, trust_remote_code=True)
```
if `configuration.py` appears in the dynamic module directory (here `transformers_modules/local`), sometimes it interferes the import of `transformers_modules.local.modeling`. I have no clear reason for this situation however.

### What this PR fixes

This PR therefore tries to avoid the appearance of other module files while the code imports a specific module file, around this line
```
def get_class_in_module():
    ...
    module = importlib.import_module(module_path)
    ...
```

### Result

Running the reproduce code snippet (provided in the comment below) in a loop of 300 times:

 - with this PR: this issue doesn't appear, [job run](https://app.circleci.com/pipelines/github/huggingface/transformers/57824/workflows/fb3b74ed-9231-41f8-80c9-7d43fb871a35/jobs/702257/steps)
 
 - without the fix: this issue appears with 50% probability [job run](https://app.circleci.com/pipelines/github/huggingface/transformers/57826/workflows/1dee1636-9aa3-433c-a044-0c4c4c9dcbff/jobs/702277/steps)

#### Full traceback
```bash
Traceback (most recent call last):
    ...
    reloaded_model = AutoModel.from_pretrained(tmp_dir, trust_remote_code=True)
  File "/home/circleci/.pyenv/versions/3.7.12/lib/python3.7/site-packages/transformers/models/auto/auto_factory.py", line 463, in from_pretrained
    pretrained_model_name_or_path, module_file + ".py", class_name, **hub_kwargs, **kwargs
  File "/home/circleci/.pyenv/versions/3.7.12/lib/python3.7/site-packages/transformers/dynamic_module_utils.py", line 367, in get_class_from_dynamic_module
    return get_class_in_module(class_name, final_module.replace(".py", ""))
  File "/home/circleci/.pyenv/versions/3.7.12/lib/python3.7/site-packages/transformers/dynamic_module_utils.py", line 147, in get_class_in_module
    module = importlib.import_module(module_path)
  File "/home/circleci/.pyenv/versions/3.7.12/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'transformers_modules.local.modeling'
```