### PR TITLE
Generate: PT Dynamo without graph breaks in the main greedy/sample loop

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -298,6 +298,9 @@ class GenerationConfig(PushToHubMixin):
         self.validate()
 
     def __eq__(self, other):
+        if not isinstance(other, GenerationConfig):
+            return False
+
         self_dict = self.__dict__.copy()
         other_dict = other.__dict__.copy()
         # ignore metadata


### PR DESCRIPTION
# What does this PR do?

This PR is part of our PT Dynamo + `.generate()` readiness.

Let's start with the basics: 
1 - Calling generate after `torch.compile()` doesn't explode -- this PR fixes the error seen in https://github.com/pytorch/pytorch/issues/93042
2 - There are no graph breaks in the main generation loop, for greedy search and sample. [Graph breaks are a major source of slowdowns](https://pytorch.org/docs/master/dynamo/faq.html#why-am-i-not-seeing-speedups).

A quick run on GPT2 shows that we gain a ~1.5x speed with `torch.compile()` on `.generate()`, after these changes (~4 mins of compilation time). Please note that this is a quick check, and not a proper benchmark ;)