### PR TITLE
Update deprecated load_module

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -18,6 +18,7 @@
 
 import importlib.util
 import os
+import sys
 from pathlib import Path
 
 from .dynamic_module_utils import custom_object_save
@@ -31,7 +32,9 @@ logger = logging.get_logger(__name__)
 spec = importlib.util.spec_from_file_location(
     "transformers", Path(__file__).parent / "__init__.py", submodule_search_locations=[Path(__file__).parent]
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 
 AUTO_TO_BASE_CLASS_MAPPING = {

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -74,7 +74,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"),
     submodule_search_locations=[PATH_TO_TRANSFORMERS],
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 
 class ANY:

--- a/utils/check_config_attributes.py
+++ b/utils/check_config_attributes.py
@@ -17,6 +17,7 @@ import importlib
 import inspect
 import os
 import re
+import sys
 
 
 # All paths are set with the intent you should run this script from the root of the repo with the command
@@ -30,7 +31,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"),
     submodule_search_locations=[PATH_TO_TRANSFORMERS],
 )
-transformers = spec.loader.load_module()
+transformers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers)
+transformers = sys.modules["transformers"]
 
 CONFIG_MAPPING = transformers.models.auto.configuration_auto.CONFIG_MAPPING
 

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -17,6 +17,7 @@ import importlib
 import inspect
 import os
 import re
+import sys
 
 
 # All paths are set with the intent you should run this script from the root of the repo with the command
@@ -30,7 +31,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"),
     submodule_search_locations=[PATH_TO_TRANSFORMERS],
 )
-transformers = spec.loader.load_module()
+transformers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers)
+transformers = sys.modules["transformers"]
 
 CONFIG_MAPPING = transformers.models.auto.configuration_auto.CONFIG_MAPPING
 

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -18,6 +18,7 @@ import glob
 import importlib.util
 import os
 import re
+import sys
 
 import black
 from doc_builder.style_doc import style_docstrings_in_code
@@ -103,7 +104,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(TRANSFORMERS_PATH, "__init__.py"),
     submodule_search_locations=[TRANSFORMERS_PATH],
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 
 def _should_continue(line, indent):

--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -17,6 +17,7 @@ import collections
 import importlib.util
 import os
 import re
+import sys
 from pathlib import Path
 
 
@@ -279,7 +280,9 @@ def check_submodules():
         os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"),
         submodule_search_locations=[PATH_TO_TRANSFORMERS],
     )
-    transformers = spec.loader.load_module()
+    transformers = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(transformers)
+    transformers = sys.modules["transformers"]
 
     module_not_registered = [
         module

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -17,6 +17,7 @@ import importlib
 import inspect
 import os
 import re
+import sys
 import warnings
 from collections import OrderedDict
 from difflib import get_close_matches
@@ -310,7 +311,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(PATH_TO_TRANSFORMERS, "__init__.py"),
     submodule_search_locations=[PATH_TO_TRANSFORMERS],
 )
-transformers = spec.loader.load_module()
+transformers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers)
+transformers = sys.modules["transformers"]
 
 
 def check_model_list():

--- a/utils/check_table.py
+++ b/utils/check_table.py
@@ -18,6 +18,7 @@ import collections
 import importlib.util
 import os
 import re
+import sys
 
 
 # All paths are set with the intent you should run this script from the root of the repo with the command
@@ -68,7 +69,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(TRANSFORMERS_PATH, "__init__.py"),
     submodule_search_locations=[TRANSFORMERS_PATH],
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 
 # Thanks to https://stackoverflow.com/questions/29916065/how-to-do-camelcase-split-in-python

--- a/utils/check_task_guides.py
+++ b/utils/check_task_guides.py
@@ -16,6 +16,7 @@
 import argparse
 import importlib.util
 import os
+import sys
 
 
 # All paths are set with the intent you should run this script from the root of the repo with the command
@@ -56,7 +57,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(TRANSFORMERS_PATH, "__init__.py"),
     submodule_search_locations=[TRANSFORMERS_PATH],
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 TASK_GUIDE_TO_MODELS = {
     "asr.mdx": transformers_module.models.auto.modeling_auto.MODEL_FOR_CTC_MAPPING_NAMES,

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -18,6 +18,7 @@ import collections
 import importlib.util
 import os
 import re
+import sys
 import tempfile
 
 import pandas as pd
@@ -36,7 +37,9 @@ spec = importlib.util.spec_from_file_location(
     os.path.join(TRANSFORMERS_PATH, "__init__.py"),
     submodule_search_locations=[TRANSFORMERS_PATH],
 )
-transformers_module = spec.loader.load_module()
+transformers_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transformers_module)
+transformers_module = sys.modules["transformers"]
 
 
 # Regexes that match TF/Flax/PT model names.


### PR DESCRIPTION
# What does this PR do?

This PR updates the uses of `load_module` (which is going to be dropped in Python 3.12) to a non-deprecated API (this should work starting Python 3.5, so all good for Transformers).

Fixes #21645 