### PR TITLE
[WhisperModel] fix bug in reshaping labels

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1211,7 +1211,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
+            loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.reshape(-1))
 
         if not return_dict:
             output = (lm_logits,) + outputs[1:]


### PR DESCRIPTION
Currently, in the Whisper model's forward pass, the target `labels` are reshaped using the `view` method before being passed into the loss function:

https://github.com/huggingface/transformers/blob/1567bef3b35c51b7a3cc6b4edf243b208279155d/src/transformers/models/whisper/modeling_whisper.py#L1214

The view method requires the Torch Tensor to be contiguous, and certain operations are commonly performed on the labels that might cause them not to be contiguous.

So using the `view` can cause problems during model training. This issue has already been fixed on another model by the @sanchit-gandhi in a [PR](https://github.com/huggingface/transformers/pull/16748), and I'm just replicating the same solution (using `reshape()` instead of `view()`) here for the Whisper model.
