### PR TITLE
[bloom] gradient_checkpointing fix

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -774,6 +774,7 @@ class BloomModel(BloomPreTrainedModel):
                     hidden_states,
                     alibi,
                     causal_mask,
+                    layer_past,
                     head_mask[i],
                 )
             else:


### PR DESCRIPTION
The  `BloomBlock.forward`'s args signature is:

https://github.com/huggingface/transformers/blob/9d1116e9951686f937d17697820117636bfc05a5/src/transformers/models/bloom/modeling_bloom.py#L417-L425

but when it's called in `gradient_checkpointing` code this is used:

https://github.com/huggingface/transformers/blob/9d1116e9951686f937d17697820117636bfc05a5/src/transformers/models/bloom/modeling_bloom.py#L772-L778

so unless I'm mistaken `head_mask` is passed as `layer_past`.

This PR re-injects the missing `layer_past` arg.

I see that there are tests that test the overall feature, but I haven't looked closely at what they test. Perhaps it happens that `head_mask` isn't being used, so it happens to work w/ it.

@younesbelkada, could you please check if this is an omission or it wasn't passed for a specific reason? 