### PR TITLE
[`CLAP`] Fix few broken things

### DIFF
--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -898,8 +898,8 @@ class ClapAudioEncoder(nn.Module):
     def forward(
         self,
         input_features,
-        head_mask: Optional[torch.FloatTensor] = None,
         is_longer: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
         output_attentions: Optional[bool] = False,
         output_hidden_states: Optional[bool] = False,
         output_hidden_states_before_downsampling: Optional[bool] = False,
@@ -2068,8 +2068,8 @@ class ClapModel(ClapPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        is_longer: Optional[torch.BoolTensor] = None,
         input_features: Optional[torch.FloatTensor] = None,
+        is_longer: Optional[torch.BoolTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         return_loss: Optional[bool] = None,

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -2143,7 +2143,7 @@ class ClapModel(ClapPreTrainedModel):
         loss = None
         if return_loss:
             caption_loss = contrastive_loss(logits_per_text)
-            audio_loss = contrastive_loss(logits_per_text.t())
+            audio_loss = contrastive_loss(logits_per_audio.t())
             loss = (caption_loss + audio_loss) / 2.0
 
         if not return_dict:

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -2068,6 +2068,7 @@ class ClapModel(ClapPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
+        is_longer: Optional[torch.BoolTensor] = None,
         input_features: Optional[torch.FloatTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
@@ -2108,6 +2109,7 @@ class ClapModel(ClapPreTrainedModel):
 
         audio_outputs = self.audio_model(
             input_features=input_features,
+            is_longer=is_longer,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -1673,7 +1673,7 @@ class ClapPreTrainedModel(PreTrainedModel):
     models.
     """
 
-    config_class = ClapTextConfig
+    config_class = ClapConfig
     base_model_prefix = "clap"
     supports_gradient_checkpointing = False
     _keys_to_ignore_on_load_missing = [r"position_ids", r"logit_scale_a", r"logit_scale_t"]

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -1746,7 +1746,7 @@ class ClapAudioModel(ClapPreTrainedModel):
         >>> inputs = processor(audios=audio_sample, return_tensors="pt")
 
         >>> outputs = model(**inputs)
-        >>> last_hidden_state = outputs.audio_emmbeds
+        >>> last_hidden_state = outputs.last_hidden_state
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -2205,7 +2205,7 @@ class ClapTextModelWithProjection(ClapPreTrainedModel):
         >>> model = ClapTextModelWithProjection.from_pretrained("laion/clap-htsat-unfused")
         >>> tokenizer = AutoTokenizer.from_pretrained("laion/clap-htsat-unfused")
 
-        >>> inputs = tokenizer(["a photo of a cat", "a photo of a dog"], padding=True, return_tensors="pt")
+        >>> inputs = tokenizer(["a sound of a cat", "a sound of a dog"], padding=True, return_tensors="pt")
 
         >>> outputs = model(**inputs)
         >>> text_embeds = outputs.text_embeds

--- a/tests/models/clap/test_modeling_clap.py
+++ b/tests/models/clap/test_modeling_clap.py
@@ -268,7 +268,7 @@ class ClapAudioModelTest(ModelTesterMixin, unittest.TestCase):
         for model_name in CLAP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
             model = ClapAudioModelWithProjection.from_pretrained(model_name)
             self.assertIsNotNone(model)
-            self.assertTrue(hasattr(model, "visual_projection"))
+            self.assertTrue(hasattr(model, "audio_projection"))
 
 
 class ClapTextModelTester:


### PR DESCRIPTION
# What does this PR do?

This PR fixes the forward pass that was broken in the `main` branch of `transformers` for `ClapModel`. To reproduce:

```python
from datasets import load_dataset
from transformers import ClapModel, ClapProcessor

dataset = load_dataset('ashraq/esc50')
input_text = ["Sound of a dog", "Sound of vaccum cleaner"]
audio_sample = dataset["train"]["audio"][-1]['array']

model_id = "ybelkada/clap-htsat-unfused"

processor = ClapProcessor.from_pretrained(model_id)
model = ClapModel.from_pretrained(model_id)

input_text = processor.tokenizer(input_text, return_tensors="pt", padding=True)
input_sample = processor.feature_extractor(audio_sample, return_tensors="pt")

out = model(input_ids=input_text.input_ids, attention_mask=input_text.attention_mask, input_features=input_sample.input_features, is_longer=input_sample.is_longer)
print(out.logits_per_audio.softmax(dim=-1)[0])
```

This PR fixes also few other nits that were missing during the bad rebase

This PR also fixes the doctest and the failing slow tests

cc @ArthurZucker @sgugger 