### PR TITLE
[`bnb`] fix `bnb` decoders bug

### DIFF
--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -84,7 +84,7 @@ def set_module_8bit_tensor_to_device(module, tensor_name, device, value=None):
             module._parameters[tensor_name] = new_value
 
 
-def replace_8bit_linear(model, threshold=6.0, modules_to_not_convert="lm_head"):
+def replace_8bit_linear(model, threshold=6.0, modules_to_not_convert="lm_head", current_key_name=None):
     """
     A helper function to replace all `torch.nn.Linear` modules by `bnb.nn.Linear8bit` modules from the `bitsandbytes`
     library. This will enable running your models using mixed int8 precision as described by the paper `GPT3.int8():
@@ -108,20 +108,32 @@ def replace_8bit_linear(model, threshold=6.0, modules_to_not_convert="lm_head"):
         modules_to_not_convert (`str`, *optional*, defaults to `lm_head`):
             Name of the module to not convert in `Linear8bitLt`. In practice we keep the `lm_head` in full precision
             for numerical stability reasons.
+        current_key_name (`List[`str`]`, *optional*):
+            An array to track the current key of the recursion. This is used to check whether the current key (part of
+            it) is not in the list of modules to not convert (for instances modules that are offloaded to `cpu` or
+            `disk`).
     """
     for name, module in model.named_children():
+        if current_key_name is None:
+            current_key_name = []
+        current_key_name.append(name)
+
         if len(list(module.children())) > 0:
-            replace_8bit_linear(module, threshold, modules_to_not_convert)
+            replace_8bit_linear(module, threshold, modules_to_not_convert, current_key_name)
 
         if isinstance(module, nn.Linear) and name not in modules_to_not_convert:
-            with init_empty_weights():
-                model._modules[name] = bnb.nn.Linear8bitLt(
-                    module.in_features,
-                    module.out_features,
-                    module.bias is not None,
-                    has_fp16_weights=False,
-                    threshold=threshold,
-                )
+            # Check if the current key is not in the `modules_to_not_convert`
+            if not any(key in ".".join(current_key_name) for key in modules_to_not_convert):
+                with init_empty_weights():
+                    model._modules[name] = bnb.nn.Linear8bitLt(
+                        module.in_features,
+                        module.out_features,
+                        module.bias is not None,
+                        has_fp16_weights=False,
+                        threshold=threshold,
+                    )
+        # Remove the last key for recursion
+        current_key_name.pop(-1)
     return model
 
 
@@ -159,4 +171,13 @@ def get_keys_to_not_convert(model):
     intersection = set(list_last_module) - set(tied_keys)
     list_untouched = tied_keys + list(intersection)
 
-    return [module_name.split(".")[0] for module_name in list_untouched]
+    # remove ".weight" from the keys
+    names_to_remove = [".weight", ".bias"]
+    filtered_module_names = []
+    for name in list_untouched:
+        for name_to_remove in names_to_remove:
+            if name_to_remove in name:
+                name = name.replace(name_to_remove, "")
+        filtered_module_names.append(name)
+
+    return filtered_module_names

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -237,9 +237,14 @@ class MixedInt8T5Test(unittest.TestCase):
         both cases.
         """
         from transformers import T5ForConditionalGeneration
+        import bitsandbytes as bnb
 
         # test with `t5-small`
         model = T5ForConditionalGeneration.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
+
+        # there was a bug with decoders - this test checks that it is fixed
+        self.assertTrue(isinstance(model.decoder.block[0].layer[0].SelfAttention.q, bnb.nn.Linear8bitLt))
+
         encoded_input = self.tokenizer(self.input_text, return_tensors="pt").to(0)
         _ = model.generate(**encoded_input)
 

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -269,8 +269,9 @@ class MixedInt8T5Test(unittest.TestCase):
         `flan-t5-small` uses `T5DenseGatedActDense` whereas `t5-small` uses `T5DenseReluDense`. We need to test
         both cases.
         """
-        from transformers import T5ForConditionalGeneration
         import bitsandbytes as bnb
+
+        from transformers import T5ForConditionalGeneration
 
         # test with `t5-small`
         model = T5ForConditionalGeneration.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")


### PR DESCRIPTION
# What does this PR do?

Currently on the `main` branch, there is a silent bug with `bnb` and encoder-decoder models leading to some modules not being converted in `int8` for these models and hurting users that are using the `main` branch - such as `peft`: https://github.com/huggingface/peft/issues/108 

With https://github.com/huggingface/transformers/pull/21579 being introduced, the check to know if we should keep the module as `nn.Linear` has been slightly changed and [being more robust ](https://github.com/huggingface/transformers/blob/7f1cdf18958efef6339040ba91edb32ae7377720/src/transformers/utils/bitsandbytes.py#L126).

Before #21579 the function `get_keys_to_not_convert` used to return `['decoder', 'lm_head', 'wo']` which is wrong, and leading to all decoder layers being not converted in int8 with the new check as mentioned above.

This PR fixes the bug that was in this function, and adds a new test to make sure this will never happen

Fixes: https://github.com/huggingface/peft/issues/108

cc @sgugger @amyeroberts 