### PR TITLE
Fix-rag-finetune-project-requirement

### DIFF
--- a/examples/research_projects/rag/requirements.txt
+++ b/examples/research_projects/rag/requirements.txt
@@ -3,6 +3,6 @@ datasets >= 1.0.1
 psutil >= 5.7.0
 torch >= 1.4.0
 ray >= 1.10.0
-pytorch-lightning >= 1.5.10
+pytorch-lightning >= 1.5.10, <=1.6.0
 transformers
 GitPython


### PR DESCRIPTION
# What does this PR do?
Should fix #21692, the requirements for pytorch lightnings need to be pinned to `<=1.60`