### PR TITLE
Pass along revision in dynamic code fetch

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -245,6 +245,7 @@ def get_cached_module_file(
             resume_download=resume_download,
             local_files_only=local_files_only,
             use_auth_token=use_auth_token,
+            revision=revision,
         )
 
     except EnvironmentError:


### PR DESCRIPTION
# What does this PR do?

The `revision` argument wasn't passed along to `cached_file` when fetching a dynamic config/modeling file, this PR fixes that.
Partially fixes #21662