### PR TITLE
[SpeechT5HifiGan] Handle batched inputs

### DIFF
--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -3030,19 +3030,18 @@ class SpeechT5HifiGan(PreTrainedModel):
 
     def forward(self, spectrogram):
         r"""
-        Converts a log-mel spectrogram into a speech waveform. Passing a batch of log-mel spectrograms
-        returns a batch of speech waveforms. Passing a single, un-batched log-mel spectrogram returns a
-        single, un-batched speech waveform.
+        Converts a log-mel spectrogram into a speech waveform. Passing a batch of log-mel spectrograms returns a batch
+        of speech waveforms. Passing a single, un-batched log-mel spectrogram returns a single, un-batched speech
+        waveform.
 
         Args:
             spectrogram (`torch.FloatTensor`):
-                Tensor containing the log-mel spectrograms. Can be batched and of shape
-                `(batch_size, sequence_length, config.model_in_dim)`, or un-batched
-                and of shape `(sequence_length, config.model_in_dim)`.
+                Tensor containing the log-mel spectrograms. Can be batched and of shape `(batch_size, sequence_length,
+                config.model_in_dim)`, or un-batched and of shape `(sequence_length, config.model_in_dim)`.
 
         Returns:
-            `torch.FloatTensor`: Tensor containing the speech waveform. If the input spectrogram is batched,
-            will be of shape `(batch_size, num_frames,)`. If un-batched, will be of shape `(num_frames,)`.
+            `torch.FloatTensor`: Tensor containing the speech waveform. If the input spectrogram is batched, will be of
+            shape `(batch_size, num_frames,)`. If un-batched, will be of shape `(num_frames,)`.
         """
         if self.config.normalize_before:
             spectrogram = (spectrogram - self.mean) / self.scale

--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -3030,19 +3030,28 @@ class SpeechT5HifiGan(PreTrainedModel):
 
     def forward(self, spectrogram):
         r"""
-        Converts a single log-mel spectogram into a speech waveform.
+        Converts a log-mel spectrogram into a speech waveform. Passing a batch of log-mel spectrograms
+        returns a batch of speech waveforms. Passing a single, un-batched log-mel spectrogram returns a
+        single, un-batched speech waveform.
 
         Args:
-            spectrogram (`torch.FloatTensor` of shape `(sequence_length, config.model_in_dim)`):
-                Tensor containing the log-mel spectrogram.
+            spectrogram (`torch.FloatTensor`):
+                Tensor containing the log-mel spectrograms. Can be batched (of shape
+                `(batch_size, sequence_length, config.model_in_dim)`) or un-batched
+                (of shape `(sequence_length, config.model_in_dim)`).
 
         Returns:
-            `torch.FloatTensor`: Tensor of shape `(num_frames,)` containing the speech waveform.
+            `torch.FloatTensor`: Tensor containing the speech waveform. If the input spectorgram is batched,
+            will be of shape `(batch_size, num_frames,)`. If un-batched, will be of shape `(num_frames,)`.
         """
         if self.config.normalize_before:
             spectrogram = (spectrogram - self.mean) / self.scale
 
-        hidden_states = spectrogram.transpose(1, 0).unsqueeze(0)
+        is_batched = spectrogram.dim() == 3
+        if not is_batched:
+            spectrogram = spectrogram.unsqueeze(0)
+
+        hidden_states = spectrogram.transpose(2, 1)
 
         hidden_states = self.conv_pre(hidden_states)
         for i in range(self.num_upsamples):
@@ -3058,5 +3067,11 @@ class SpeechT5HifiGan(PreTrainedModel):
         hidden_states = self.conv_post(hidden_states)
         hidden_states = torch.tanh(hidden_states)
 
-        waveform = hidden_states.squeeze(0).transpose(1, 0).view(-1)
+        if not is_batched:
+            # remove batch dim and collapse tensor to 1-d audio waveform
+            waveform = hidden_states.squeeze(0).transpose(1, 0).view(-1)
+        else:
+            # remove seq-len dim since this collapses to 1
+            waveform = hidden_states.squeeze(1)
+
         return waveform

--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -3036,12 +3036,12 @@ class SpeechT5HifiGan(PreTrainedModel):
 
         Args:
             spectrogram (`torch.FloatTensor`):
-                Tensor containing the log-mel spectrograms. Can be batched (of shape
-                `(batch_size, sequence_length, config.model_in_dim)`) or un-batched
-                (of shape `(sequence_length, config.model_in_dim)`).
+                Tensor containing the log-mel spectrograms. Can be batched and of shape
+                `(batch_size, sequence_length, config.model_in_dim)`, or un-batched
+                and of shape `(sequence_length, config.model_in_dim)`.
 
         Returns:
-            `torch.FloatTensor`: Tensor containing the speech waveform. If the input spectorgram is batched,
+            `torch.FloatTensor`: Tensor containing the speech waveform. If the input spectrogram is batched,
             will be of shape `(batch_size, num_frames,)`. If un-batched, will be of shape `(num_frames,)`.
         """
         if self.config.normalize_before:

--- a/tests/models/speecht5/test_modeling_speecht5.py
+++ b/tests/models/speecht5/test_modeling_speecht5.py
@@ -1545,3 +1545,21 @@ class SpeechT5HifiGanTest(ModelTesterMixin, unittest.TestCase):
     # skip because it fails on automapping of SpeechT5HifiGanConfig
     def test_save_load_fast_init_to_base(self):
         pass
+
+    def test_batched_inputs_outputs(self):
+        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            batched_inputs = inputs["spectrogram"].unsqueeze(0).repeat(2, 1, 1)
+
+            batched_outputs = model(batched_inputs)
+            self.assertEqual(batched_inputs.shape[0], batched_outputs.shape[0], msg="Got different batch dims for input and output")
+
+    def test_unbatched_inputs_outputs(self):
+        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            outputs = model(inputs["spectrogram"])
+            self.assertTrue(outputs.dim() == 1, msg="Got un-batched inputs but batched output")

--- a/tests/models/speecht5/test_modeling_speecht5.py
+++ b/tests/models/speecht5/test_modeling_speecht5.py
@@ -1554,7 +1554,9 @@ class SpeechT5HifiGanTest(ModelTesterMixin, unittest.TestCase):
             batched_inputs = inputs["spectrogram"].unsqueeze(0).repeat(2, 1, 1)
 
             batched_outputs = model(batched_inputs)
-            self.assertEqual(batched_inputs.shape[0], batched_outputs.shape[0], msg="Got different batch dims for input and output")
+            self.assertEqual(
+                batched_inputs.shape[0], batched_outputs.shape[0], msg="Got different batch dims for input and output"
+            )
 
     def test_unbatched_inputs_outputs(self):
         config, inputs = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

Modifies the SpeechT5 HiFiGAN model to accept batched inputs. This PR is **not** a breaking change:
* If the spectrogram inputs are un-batched, the waveform outputs are un-batched (as before)
* If the spectrogram inputs are batched, the waveform outputs are batched (new)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
