### PR TITLE
Auto api Value Error addition to Troubleshoot

### DIFF
--- a/docs/source/en/troubleshooting.mdx
+++ b/docs/source/en/troubleshooting.mdx
@@ -175,7 +175,7 @@ tensor([[ 0.0082, -0.2307],
 - Some models don't have a padding token.
 - For some use-cases, users want a model to attend to a padding token.
 
-## ValueError: Unrecognized configuration class <XYZ> for this kind of AutoModel
+## ValueError: Unrecognized configuration class XYZ for this kind of AutoModel
 
 Generally, we recommend using the AutoModel class to load pretrained instances of models. This class
 can automatically infer and load the correct architecture from a given checkpoint based on the configuration.

--- a/docs/source/en/troubleshooting.mdx
+++ b/docs/source/en/troubleshooting.mdx
@@ -178,28 +178,21 @@ tensor([[ 0.0082, -0.2307],
 ## ValueError: Unrecognized configuration class <XYZ> for this kind of AutoModel
 
 Generally, we recommend using the AutoModel class to load pretrained instances of models. This class
-can automatically infer and load the correct architecture from a given checkpoint based on the configuration.
-However, there are a few exceptions to this. In rare cases, some models' architectures don't map to any of the
-AutoModelForXXX classes due to the specifics of their API. When trying to load such an exotic model with the AutoModel
-class, you'll get this `ValueError`.
-
-For example:
-
-```py
->>> from transformers import AutoProcessor, AutoModel
-
->>> processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
->>> model = AutoModel.from_pretrained("Salesforce/blip2-opt-2.7b")
-ValueError: Unrecognized configuration class <class 'transformers.models.blip_2.configuration_blip_2.Blip2Config'> for this kind of AutoModel: AutoModel.
-Model type should be one of AlbertConfig, AltCLIPConfig, ASTConfig, BartConfig, BeitConfig, BertConfig, BertGenerationConfig, BigBirdConfig...
-```
-
-In this case, you can use `AutoProcessor` to load BLIP-2's processor, but to load a pretrained BLIP-2 model itself, you have to
-use `Blip2ForConditionalGeneration` explicitly:
+can automatically infer and load the correct architecture from a given checkpoint based on the configuration. If you see
+this `ValueError` when loading a model from a checkpoint, this means that the Auto class couldn't find a mapping from
+the configuration in the given checkpoint to a kind of model you are trying to load. Most commonly this happens when a
+checkpoint doesn't support given task.
+For instance, you'll see this error in the following example because there is no GPT2 for question answering:
 
 ```py
->>> from transformers import AutoProcessor, Blip2ForConditionalGeneration
+>>> from transformers import AutoProcessor, AutoModelForQuestionAnswering
 
->>> processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
->>> model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
+>>> processor = AutoProcessor.from_pretrained("gpt2-medium")
+>>> model = AutoModelForQuestionAnswering.from_pretrained("gpt2-medium")
+ValueError: Unrecognized configuration class <class 'transformers.models.gpt2.configuration_gpt2.GPT2Config'> for this kind of AutoModel: AutoModelForQuestionAnswering.
+Model type should be one of AlbertConfig, BartConfig, BertConfig, BigBirdConfig, BigBirdPegasusConfig, BloomConfig, ...
 ```
+
+In rare cases, this can also happen when using some exotic models with architectures that don't map to any of the
+AutoModelForXXX classes due to the specifics of their API. For example, you can use `AutoProcessor` to load BLIP-2's processor,
+but to load a pretrained BLIP-2 model itself, you have to use `Blip2ForConditionalGeneration` explicitly.

--- a/docs/source/en/troubleshooting.mdx
+++ b/docs/source/en/troubleshooting.mdx
@@ -195,4 +195,4 @@ Model type should be one of AlbertConfig, BartConfig, BertConfig, BigBirdConfig,
 
 In rare cases, this can also happen when using some exotic models with architectures that don't map to any of the
 AutoModelForXXX classes due to the specifics of their API. For example, you can use [`AutoProcessor`] to load BLIP-2's processor,
-but to load a pretrained BLIP-2 model itself, you must explicitly use [`Blip2ForConditionalGeneration`].
+but to load a pretrained BLIP-2 model itself, you must explicitly use [`Blip2ForConditionalGeneration`] as even [`AutoModel`] won't work.

--- a/docs/source/en/troubleshooting.mdx
+++ b/docs/source/en/troubleshooting.mdx
@@ -174,3 +174,32 @@ tensor([[ 0.0082, -0.2307],
 
 - Some models don't have a padding token.
 - For some use-cases, users want a model to attend to a padding token.
+
+## ValueError: Unrecognized configuration class <XYZ> for this kind of AutoModel
+
+Generally, we recommend using the AutoModel class to load pretrained instances of models. This class
+can automatically infer and load the correct architecture from a given checkpoint based on the configuration.
+However, there are a few exceptions to this. In rare cases, some models' architectures don't map to any of the
+AutoModelForXXX classes due to the specifics of their API. When trying to load such an exotic model with the AutoModel
+class, you'll get this `ValueError`.
+
+For example:
+
+```py
+>>> from transformers import AutoProcessor, AutoModel
+
+>>> processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
+>>> model = AutoModel.from_pretrained("Salesforce/blip2-opt-2.7b")
+ValueError: Unrecognized configuration class <class 'transformers.models.blip_2.configuration_blip_2.Blip2Config'> for this kind of AutoModel: AutoModel.
+Model type should be one of AlbertConfig, AltCLIPConfig, ASTConfig, BartConfig, BeitConfig, BertConfig, BertGenerationConfig, BigBirdConfig...
+```
+
+In this case, you can use `AutoProcessor` to load BLIP-2's processor, but to load a pretrained BLIP-2 model itself, you have to
+use `Blip2ForConditionalGeneration` explicitly:
+
+```py
+>>> from transformers import AutoProcessor, Blip2ForConditionalGeneration
+
+>>> processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
+>>> model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b")
+```

--- a/docs/source/en/troubleshooting.mdx
+++ b/docs/source/en/troubleshooting.mdx
@@ -177,11 +177,11 @@ tensor([[ 0.0082, -0.2307],
 
 ## ValueError: Unrecognized configuration class XYZ for this kind of AutoModel
 
-Generally, we recommend using the AutoModel class to load pretrained instances of models. This class
+Generally, we recommend using the [`AutoModel`] class to load pretrained instances of models. This class
 can automatically infer and load the correct architecture from a given checkpoint based on the configuration. If you see
-this `ValueError` when loading a model from a checkpoint, this means that the Auto class couldn't find a mapping from
-the configuration in the given checkpoint to a kind of model you are trying to load. Most commonly this happens when a
-checkpoint doesn't support given task.
+this `ValueError` when loading a model from a checkpoint, this means the Auto class couldn't find a mapping from
+the configuration in the given checkpoint to the kind of model you are trying to load. Most commonly, this happens when a
+checkpoint doesn't support a given task.
 For instance, you'll see this error in the following example because there is no GPT2 for question answering:
 
 ```py
@@ -194,5 +194,5 @@ Model type should be one of AlbertConfig, BartConfig, BertConfig, BigBirdConfig,
 ```
 
 In rare cases, this can also happen when using some exotic models with architectures that don't map to any of the
-AutoModelForXXX classes due to the specifics of their API. For example, you can use `AutoProcessor` to load BLIP-2's processor,
-but to load a pretrained BLIP-2 model itself, you have to use `Blip2ForConditionalGeneration` explicitly.
+AutoModelForXXX classes due to the specifics of their API. For example, you can use [`AutoProcessor`] to load BLIP-2's processor,
+but to load a pretrained BLIP-2 model itself, you must explicitly use [`Blip2ForConditionalGeneration`].


### PR DESCRIPTION
Given the existence of "exotic" models that don't have a mapping to auto classes, this PR adds a small section at the end of the Troubleshooting guide about the error raised when trying to load a model with Auto API when there's no mapping. 