### PR TITLE
Fix `get_class_in_module`

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -154,7 +154,17 @@ def get_class_in_module(class_name, module_path):
         shutil.copy(f"{module_dir}/{module_file_name}", tmp_dir)
         # On Windows, we need this character `r` before the path argument of `os.remove`
         cmd = f'import os; os.remove(r"{module_dir}{os.path.sep}{module_file_name}")'
-        subprocess.run(["python", "-c", cmd])
+        # We don't know which python binary file exists in an environment. For example, if `python3` exists but not
+        # `python`, the call `subprocess.run(["python", ...])` gives `FileNotFoundError` (about python binary). Notice
+        # that, if the file to be removed is not found, we also have `FileNotFoundError`, but it is not raised to the
+        # caller's process.
+        try:
+            subprocess.run(["python", "-c", cmd])
+        except FileNotFoundError:
+            try:
+                subprocess.run(["python3", "-c", cmd])
+            except FileNotFoundError:
+                pass
 
         # copy back the file that we want to import
         shutil.copyfile(f"{tmp_dir}/{module_file_name}", f"{module_dir}/{module_file_name}")


### PR DESCRIPTION
# What does this PR do?

The PR #21646 added a line `subprocess.run(["python", "-c", cmd])`. But in our daily CI (docker env.), `python` binary doesn't exist, only `python3` binary exists, and this causes `FileNotFoundError: [Errno 2] No such file or directory: 'python'`.

This PRs adds `try ... except...` to avoid this failure, but it's really ugly. See my comment in this PR changes.