### PR TITLE
Fix to KerasMetricCallback when the model returns unstructured output

### DIFF
--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -231,10 +231,10 @@ class KerasMetricCallback(Callback):
                     # This converts any dict-subclass to a regular dict
                     # Keras REALLY doesn't like it when we pass around a BatchEncoding or other derived class
                     predictions = dict(predictions)
-                if self.output_cols is not None:
-                    predictions = {key: predictions[key] for key in self.output_cols}
-                else:
-                    predictions = {key: val for key, val in predictions.items() if key not in ignore_keys + ["loss"]}
+                    if self.output_cols is not None:
+                        predictions = {key: predictions[key] for key in self.output_cols}
+                    else:
+                        predictions = {key: val for key, val in predictions.items() if key not in ignore_keys + ["loss"]}
             prediction_list.append(predictions)
             if not self.use_keras_label:
                 labels = {key: batch[key].numpy() for key in self.label_cols}

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -234,7 +234,9 @@ class KerasMetricCallback(Callback):
                     if self.output_cols is not None:
                         predictions = {key: predictions[key] for key in self.output_cols}
                     else:
-                        predictions = {key: val for key, val in predictions.items() if key not in ignore_keys + ["loss"]}
+                        predictions = {
+                            key: val for key, val in predictions.items() if key not in ignore_keys + ["loss"]
+                        }
             prediction_list.append(predictions)
             if not self.use_keras_label:
                 labels = {key: batch[key].numpy() for key in self.label_cols}

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -260,6 +260,7 @@ class KerasMetricCallback(Callback):
         # in the logs argument. Ordinarily, this is so the callback can read them, but in this case we write a bunch of
         # new keys in there, which will then get read by the History callback and treated like any other metric value.
         # I promise that I have it in writing from Chollet that this is okay.
+        print("DEBUG LINE: Here are the logs I'm seeing: ", logs)
         logs.update(metric_output)
 
 

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -260,7 +260,8 @@ class KerasMetricCallback(Callback):
         # in the logs argument. Ordinarily, this is so the callback can read them, but in this case we write a bunch of
         # new keys in there, which will then get read by the History callback and treated like any other metric value.
         # I promise that I have it in writing from Chollet that this is okay.
-        print("DEBUG LINE: Here are the logs I'm seeing: ", logs)
+        print("\nDEBUG LINE: Here are the logs I'm seeing: ", logs)
+        print("Here is what I'm adding:", metric_output)
         logs.update(metric_output)
 
 

--- a/src/transformers/keras_callbacks.py
+++ b/src/transformers/keras_callbacks.py
@@ -260,8 +260,6 @@ class KerasMetricCallback(Callback):
         # in the logs argument. Ordinarily, this is so the callback can read them, but in this case we write a bunch of
         # new keys in there, which will then get read by the History callback and treated like any other metric value.
         # I promise that I have it in writing from Chollet that this is okay.
-        print("\nDEBUG LINE: Here are the logs I'm seeing: ", logs)
-        print("Here is what I'm adding:", metric_output)
         logs.update(metric_output)
 
 


### PR DESCRIPTION
The `KerasMetricCallback` was only tested on `transformers` models, which usually return dict-like `ModelOutput`. As a result, I missed a bug when the model is a more classical Keras model that just returns a naked array. Thanks to @leadbetterben for pointing out the issue.

Fixes #21674 .