### PR TITLE
[`MBart`] Fix cross attention mask check

### DIFF
--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -1055,7 +1055,7 @@ class MBartDecoder(MBartPreTrainedModel):
                 if attn_mask.size()[0] != len(self.layers):
                     raise ValueError(
                         f"The `{mask_name}` should be specified for {len(self.layers)} layers, but it is for"
-                        f" {head_mask.size()[0]}."
+                        f" {attn_mask.size()[0]}."
                     )
         for idx, decoder_layer in enumerate(self.layers):
             # add LayerDrop (see https://arxiv.org/abs/1909.11556 for description)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/21728

The current `MBart` code leads to an error that is hard to interpret for users due to a possible typo as pointed out in https://github.com/huggingface/transformers/issues/21728 
To reproduce: 
```python
import torch
from transformers import MBartModel

input_ids = torch.LongTensor([[0, 1, 1, 0]])
model = MBartModel.from_pretrained("facebook/mbart-large-cc25")

head_mask = None

cross_attn_head_mask = torch.ones(1000, 1, 1, 1)
model(input_ids, head_mask=head_mask, cross_attn_head_mask=cross_attn_head_mask)
```

This PR fixes this

cc @sgugger 