### PR TITLE
Fix `GPTSanJapaneseModel`

### DIFF
--- a/src/transformers/models/gptsan_japanese/modeling_gptsan_japanese.py
+++ b/src/transformers/models/gptsan_japanese/modeling_gptsan_japanese.py
@@ -924,7 +924,7 @@ class GPTSanJapaneseModel(GPTSanJapanesePreTrainedModel):
             `MoEModelOutputWithPastAndCrossAttentions` or `tuple` if `return_dict` returns
             MoEModelOutputWithPastAndCrossAttentions insted of tuple
         """
-        return_dict = return_dict if return_dict is not None else self.config.return_dict
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         device = self.position_embeddings.weight.device
         if input_ids is None:
             input_ids = torch.zeros([1, 1]).int().to(device)  # dummy for input_ids was None

--- a/tests/models/gptsan_japanese/test_modeling_gptsan_japanese.py
+++ b/tests/models/gptsan_japanese/test_modeling_gptsan_japanese.py
@@ -151,6 +151,12 @@ class GPTSanJapaneseTest(ModelTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    @unittest.skip(
+        reason="skip for now as the computed `max_memory` by `model_split_percents` in the test method will be changed inside `from_pretrained`"
+    )
+    def test_model_parallelism(self):
+        super().test_model_parallelism()
+
 
 @require_torch
 class GPTSanJapaneseForConditionalGenerationTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):

--- a/tests/models/gptsan_japanese/test_modeling_gptsan_japanese.py
+++ b/tests/models/gptsan_japanese/test_modeling_gptsan_japanese.py
@@ -181,6 +181,12 @@ class GPTSanJapaneseForConditionalGenerationTest(ModelTesterMixin, GenerationTes
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    @unittest.skip(
+        reason="skip for now as the computed `max_memory` by `model_split_percents` in the test method will be changed inside `from_pretrained`"
+    )
+    def test_model_parallelism(self):
+        super().test_model_parallelism()
+
     @slow
     def test_logits(self):
         model = GPTSanJapaneseForConditionalGeneration.from_pretrained("Tanrei/GPTSAN-japanese")


### PR DESCRIPTION
# What does this PR do?

```
return_dict = return_dict if return_dict is not None else self.config.return_dict
```
should be
```
return_dict = return_dict if return_dict is not None else self.config.use_return_dict
```
as in many other places.

Otherwise torchscript tests will fail.