### PR TITLE
[`GPTNeo`] Fix gradient checkpointing bug

### DIFF
--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -587,7 +587,7 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
 
         output_shape = input_shape + (hidden_states.size(-1),)
 
-        presents = () if use_cache else None
+        presents = () if use_cache and not self.gradient_checkpointing else None
         all_self_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -587,7 +587,14 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
 
         output_shape = input_shape + (hidden_states.size(-1),)
 
-        presents = () if use_cache and not self.gradient_checkpointing else None
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        presents = () if use_cache else None
         all_self_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
@@ -595,11 +602,6 @@ class GPTNeoModel(GPTNeoPreTrainedModel):
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
             if self.gradient_checkpointing and self.training:
-                if use_cache:
-                    logger.warning(
-                        "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                    )
-                    use_cache = False
 
                 def create_custom_forward(module):
                     def custom_forward(*inputs):


### PR DESCRIPTION
# What does this PR do?
 
This PR fixes a small bug that a user can encounter while using `generate` and models that use `gradient_checkpointing` . In the context of `trl` we call `generate` on the active model that uses `gradient_checkpointing` to save memory. 

Currently this snippet fails on `main`: 

```python
import torch

from transformers import AutoModelForCausalLM

# Now let's build the model, the reference model, and the tokenizer.
model = AutoModelForCausalLM.from_pretrained("edbeeching/gpt-neo-125M-imdb", device_map="auto")
model.train()
model.gradient_checkpointing_enable()
gen = model.generate(input_ids=torch.LongTensor([0,1,2,3]).unsqueeze(0)) 
```

This is because `gradient_checkpointing_enable` and `use_cache` are not compatible, and calling `generate` uses `use_cache` by default. Though there is a check to force `use_cache` to be set to `False`, this check is not enough since the `present` tuple will be still tried to be populated but remains empty since it will be intialized with an empty tuple, Hence leading to a confusing error.
IMO the fix should be to force-set `presents` tuple to `None` if the model is using `gradient_checkpointing`

cc @sgugger @amyeroberts 