### PR TITLE
[WIP] A potential fix for `AutoConfig` and `AutoModel`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -791,8 +791,8 @@ class PretrainedConfig(PushToHubMixin):
             `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
         """
         output = copy.deepcopy(self.__dict__)
-        if hasattr(self.__class__, "model_type"):
-            output["model_type"] = self.__class__.model_type
+        if hasattr(self, "model_type"):
+            output["model_type"] = self.model_type
         if "_auto_class" in output:
             del output["_auto_class"]
         if "_commit_hash" in output:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -357,7 +357,6 @@ FROM_PRETRAINED_FLAX_DOCSTRING = """
 
 
 def _get_model_class(config, model_mapping):
-
     if config.model_type not in model_mapping._config_mapping:
         if config.model_type in model_mapping._model_mapping:
             model_class_name = model_mapping._model_mapping[config.model_type]

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -357,6 +357,13 @@ FROM_PRETRAINED_FLAX_DOCSTRING = """
 
 
 def _get_model_class(config, model_mapping):
+
+    if config.model_type not in model_mapping._config_mapping:
+        if config.model_type in model_mapping._model_mapping:
+            model_class_name = model_mapping._model_mapping[config.model_type]
+            model_class = model_mapping._load_attr_from_module(config.model_type, model_class_name)
+            return model_class
+
     supported_models = model_mapping[type(config)]
     if not isinstance(supported_models, (list, tuple)):
         return supported_models

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -26,10 +26,7 @@ from ...utils import CONFIG_NAME, logging
 
 logger = logging.get_logger(__name__)
 
-SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES = {
-    "nllb": "m2m_100",
-    "decision_transformer_gpt2": "decision_transformer"
-}
+SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES = {"nllb": "m2m_100", "decision_transformer_gpt2": "decision_transformer"}
 
 CONFIG_MAPPING_NAMES = OrderedDict(
     [
@@ -909,7 +906,7 @@ class AutoConfig:
             model_type = config_dict["model_type"]
             if model_type not in CONFIG_MAPPING:
                 if model_type in SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES:
-                   model_type = SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES[model_type]
+                    model_type = SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES[model_type]
             config_class = CONFIG_MAPPING[model_type]
             return config_class.from_dict(config_dict, **unused_kwargs)
         else:

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -26,6 +26,11 @@ from ...utils import CONFIG_NAME, logging
 
 logger = logging.get_logger(__name__)
 
+SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES = {
+    "nllb": "m2m_100",
+    "decision_transformer_gpt2": "decision_transformer_gpt2"
+}
+
 CONFIG_MAPPING_NAMES = OrderedDict(
     [
         # Add configs here
@@ -901,7 +906,11 @@ class AutoConfig:
             config_class.register_for_auto_class()
             return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
         elif "model_type" in config_dict:
-            config_class = CONFIG_MAPPING[config_dict["model_type"]]
+            model_type = config_dict["model_type"]
+            if model_type not in CONFIG_MAPPING:
+                if model_type in SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES:
+                   model_type = SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES[model_type]
+            config_class = CONFIG_MAPPING[model_type]
             return config_class.from_dict(config_dict, **unused_kwargs)
         else:
             # Fallback: use pattern matching on the string.

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -575,6 +575,7 @@ SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
         ("maskformer-swin", "maskformer"),
         ("xclip", "x_clip"),
         ("decision_transformer_gpt2", "decision_transformer"),
+        # ("nllb", "nllb"),  # Question: I am not sure how to deal with this.
     ]
 )
 

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -28,7 +28,7 @@ logger = logging.get_logger(__name__)
 
 SPECIAL_MODEL_TYPES_TO_CANONICAL_MODEL_TYPES = {
     "nllb": "m2m_100",
-    "decision_transformer_gpt2": "decision_transformer_gpt2"
+    "decision_transformer_gpt2": "decision_transformer"
 }
 
 CONFIG_MAPPING_NAMES = OrderedDict(

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -574,6 +574,7 @@ SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
         ("donut-swin", "donut"),
         ("maskformer-swin", "maskformer"),
         ("xclip", "x_clip"),
+        ("decision_transformer_gpt2", "decision_transformer"),
     ]
 )
 


### PR DESCRIPTION
# What does this PR do?

⚠️ This is just to demonstrate the issue and a (maybe super wrong) way to fix it: 

- Maybe the usage of such models is very low - not worth the time
  - I can't find `DecisionTransformerGPT2Model` on the Hub.
  - `nllb` is not a real issue, as it contains only tokniezer, which `AutoTokenizer` works well. 

- Should we instead creating new configuration classes and associate them to some `model_type` shown below?
  - The current fix is kind hacky, and it also prevents obtaining the complete list in the different `XXX_MODEL_MAPPINGS`. 

## Issue

Some keys in `MODEL_MAPPING_NAMES` are not in `CONFIG_MAPPING_NAMES`. Here are 2 examples

- `decision_transformer_gpt2` (associate to model class `DecisionTransformerGPT2Model`)
- `nllb` (associate to model class `M2M100Model`)

When we have a configuration with these `model_type`:
  - saving the configuration won't save the specified `model_type`
  - so loading will load the  **wrong** (in some sense) `model_type` in the configuration, and therefore using the wrong model class to load the model checkpoint (in some case).

The following code snippet shows the problems

### Code snippet

#### This shows the model type `decision_transformer_gpt2` is not saved
```python
import os
import json
import tempfile
from transformers import DecisionTransformerConfig, AutoConfig

config = DecisionTransformerConfig()
# originally being `decision_transformer`
print(config.model_type)

config.model_type = "decision_transformer_gpt2"
# become `decision_transformer_gpt2`
print(config.model_type)

with tempfile.TemporaryDirectory() as tmpdir:
    config.save_pretrained(tmpdir)
    # check what is saved
    with open(os.path.join(tmpdir, "config.json")) as fp:
        config_dict = json.load(fp)
        # this should be `"decision_transformer_gpt2"`, but we get `decision_transformer`
        print(config_dict["model_type"])
    auto_config = AutoConfig.from_pretrained(tmpdir)
    # this should be `"decision_transformer_gpt2"`, but we get `decision_transformer`
    print(auto_config.model_type)
    assert auto_config.model_type == "decision_transformer_gpt2"
```

#### This shows `AutoModel` loads the model checkpoint with the wrong model class 
```
import tempfile
from transformers import DecisionTransformerConfig, AutoModel, DecisionTransformerGPT2Model

config = DecisionTransformerConfig()
# originally being `decision_transformer`
print(config.model_type)

config.model_type = "decision_transformer_gpt2"
# become `decision_transformer_gpt2`
print(config.model_type)

# create a model with type `DecisionTransformerGPT2Model`
model = DecisionTransformerGPT2Model(config)

with tempfile.TemporaryDirectory() as tmpdir:
    model.save_pretrained(tmpdir)
    auto_model = AutoModel.from_pretrained(tmpdir)
    # this should be `"decision_transformer_gpt2"`, but we get `decision_transformer`
    print(auto_model.config.model_type)
    # this should be `"DecisionTransformerGPT2Model"`, but we get `DecisionTransformerModel`
    print(auto_model.__class__.__name__)
    assert auto_model.__class__.__name__ == "DecisionTransformerGPT2Model"
```

Enhance `AutoConfig`