### PR TITLE
[Examples] Generalise run audio classification for log-mel models

### DIFF
--- a/examples/pytorch/audio-classification/run_audio_classification.py
+++ b/examples/pytorch/audio-classification/run_audio_classification.py
@@ -168,9 +168,6 @@ class ModelArguments:
         default=False,
         metadata={"help": "Will enable to load a pretrained model whose head dimensions are different."},
     )
-    dropout: Optional[float] = field(
-        default=0., metadata={"help": "Encoder dropout to apply."}
-    )
 
     def __post_init__(self):
         if not self.freeze_feature_extractor and self.freeze_feature_encoder:
@@ -345,7 +342,6 @@ def main():
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
-    config.activation_dropout = config.attention_dropout = config.dropout = model_args.dropout
     model = AutoModelForAudioClassification.from_pretrained(
         model_args.model_name_or_path,
         from_tf=bool(".ckpt" in model_args.model_name_or_path),

--- a/examples/pytorch/audio-classification/run_audio_classification.py
+++ b/examples/pytorch/audio-classification/run_audio_classification.py
@@ -289,24 +289,27 @@ def main():
         data_args.audio_column_name, datasets.features.Audio(sampling_rate=feature_extractor.sampling_rate)
     )
 
+    model_input_name = feature_extractor.model_input_names[0]
+
     def train_transforms(batch):
         """Apply train_transforms across a batch."""
-        output_batch = {"input_values": []}
+        output_batch = {model_input_name: []}
         for audio in batch[data_args.audio_column_name]:
             wav = random_subsample(
-                audio["array"], max_length=data_args.max_length_seconds, sample_rate=feature_extractor.sampling_rate
+                audio["array"], max_length=data_args.max_length_seconds, sample_rate=audio["sampling_rate"]
             )
-            output_batch["input_values"].append(wav)
+            inputs = feature_extractor(wav, sampling_rate=audio["sampling_rate"])
+            output_batch[model_input_name].append(inputs.get(model_input_name)[0])
         output_batch["labels"] = list(batch[data_args.label_column_name])
 
         return output_batch
 
     def val_transforms(batch):
         """Apply val_transforms across a batch."""
-        output_batch = {"input_values": []}
+        output_batch = {model_input_name: []}
         for audio in batch[data_args.audio_column_name]:
-            wav = audio["array"]
-            output_batch["input_values"].append(wav)
+            inputs = feature_extractor(audio["array"], sampling_rate=audio["sampling_rate"])
+            output_batch[model_input_name].append(inputs.get(model_input_name)[0])
         output_batch["labels"] = list(batch[data_args.label_column_name])
 
         return output_batch


### PR DESCRIPTION
# What does this PR do?

Currently, `run_audio_classification.py` hard-codes the model input name to `input_values` in the pre-processing function. This makes it compatible with Wav2Vec2-style CTC models, but not other speech models that use log-mel `input_features` (e.g. Whisper or AST).

We adopt the same strategy that we use in `run_speech_recognition_seq2seq.py` and set this to the correct model input name (based on the feature extractor's attribute `.model_input_names`):
https://github.com/huggingface/transformers/blob/1d4b79785263077f9f09ddde5a75ae4f116e85d7/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py#L419