### PR TITLE
[Flax] Fix erroneous kwargs being passed to generate config

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -653,7 +653,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                 **kwargs,
             )
         else:
-            model_kwargs = kwargs
+            model_kwargs = kwargs.copy()
 
         if commit_hash is None:
             commit_hash = getattr(config, "_commit_hash", None)


### PR DESCRIPTION
# What does this PR do?

Setting the `dtype` with Flax `.from_pretrained` is throwing a `TypeError`:

```python
from transformers import FlaxAutoModelForSpeechSeq2Seq
import jax.numpy as jnp

model = FlaxAutoModelForSpeechSeq2Seq.from_pretrained("openai/whisper-tiny.en", dtype=getattr(jnp, "float32"))
```

<details>
<summary> Traceback </summary>

```python
  File "<string>", line 1, in <module>
  File "/Users/sanchitgandhi/transformers/src/transformers/models/auto/auto_factory.py", line 471, in from_pretrained
    return model_class.from_pretrained(
  File "/Users/sanchitgandhi/transformers/src/transformers/modeling_flax_utils.py", line 955, in from_pretrained
    model.generation_config = GenerationConfig.from_pretrained(
  File "/Users/sanchitgandhi/transformers/src/transformers/generation/configuration_utils.py", line 539, in from_pretrained
    return cls.from_dict(config_dict, **kwargs)
  File "/Users/sanchitgandhi/transformers/src/transformers/generation/configuration_utils.py", line 575, in from_dict
    logger.info(f"Generate config {config}")
  File "/Users/sanchitgandhi/transformers/src/transformers/generation/configuration_utils.py", line 313, in __repr__
    return f"{self.__class__.__name__} {self.to_json_string()}"
  File "/Users/sanchitgandhi/transformers/src/transformers/generation/configuration_utils.py", line 649, in to_json_string
    return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/opt/homebrew/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type _ScalarMeta is not JSON serializable
```
</details>

It looks like the dtype arg is erroneously being forwarded to the generation config via `**kwargs`. This line appears to be the culprit, where we point `kwargs` to `model_kwargs`:
https://github.com/huggingface/transformers/blob/0ffa22f9f6662ec9a0b6b6225bf152d32ab3e151/src/transformers/modeling_flax_utils.py#L656
And then append `dtype` to `model_kwargs`:
https://github.com/huggingface/transformers/blob/0ffa22f9f6662ec9a0b6b6225bf152d32ab3e151/src/transformers/modeling_flax_utils.py#L661-L662
The `dtype` then gets silently forwarded to generate config via `**kwargs`:
https://github.com/huggingface/transformers/blob/0ffa22f9f6662ec9a0b6b6225bf152d32ab3e151/src/transformers/modeling_flax_utils.py#L967

This PR simply sets `model_kwargs` as a copy of `kwargs` to avoid this.