### PR TITLE
[deepspeed tests] fix issues introduced by #21700

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -52,9 +52,9 @@ if is_torch_available():
         RegressionModelConfig,
         RegressionPreTrainedModel,
     )
+    # hack to restore original logging level pre #21700
+    get_regression_trainer = partial(tests.trainer.test_trainer.get_regression_trainer, log_level="info")
 
-# hack to restore original logging level pre #21700
-get_regression_trainer = partial(tests.trainer.test_trainer.get_regression_trainer, log_level="info")
 
 set_seed(42)
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -19,10 +19,12 @@ import json
 import os
 import unittest
 from copy import deepcopy
+from functools import partial
 
 import datasets
 from parameterized import parameterized
 
+import tests.trainer.test_trainer
 from tests.trainer.test_trainer import TrainerIntegrationCommon  # noqa
 from transformers import AutoModel, TrainingArguments, is_torch_available, logging
 from transformers.deepspeed import HfDeepSpeedConfig, is_deepspeed_available, unset_hf_deepspeed_config
@@ -49,9 +51,10 @@ if is_torch_available():
     from tests.trainer.test_trainer import (  # noqa
         RegressionModelConfig,
         RegressionPreTrainedModel,
-        get_regression_trainer,
     )
 
+# hack to restore original logging level pre #21700
+get_regression_trainer = partial(tests.trainer.test_trainer.get_regression_trainer, log_level="info")
 
 set_seed(42)
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -52,6 +52,7 @@ if is_torch_available():
         RegressionModelConfig,
         RegressionPreTrainedModel,
     )
+
     # hack to restore original logging level pre #21700
     get_regression_trainer = partial(tests.trainer.test_trainer.get_regression_trainer, log_level="info")
 


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/21700 changed the default logging level - which broke multiple deepspeed tests.

Applying a hack to restore the log-level to how it was before.
