### PR TITLE
[FX tracer] Make `concrete_args` from outside available

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -984,7 +984,13 @@ class HFTracer(Tracer):
                     continue
                 if param.default is inspect.Parameter.empty:
                     raise ValueError(f"You need to specify a default value for the parameter {param.name}.")
-            concrete_args.update({p.name: p.default for p in sig.parameters.values() if p.name not in dummy_inputs})
+            concrete_args.update(
+                {
+                    p.name: p.default
+                    for p in sig.parameters.values()
+                    if (p.name not in dummy_inputs and p.name not in concrete_args)
+                }
+            )
 
         input_names = sig.parameters.keys() - concrete_args.keys()
 


### PR DESCRIPTION
# What does this PR do?

Current `HFTracer` implementation will replace `concrete_args` with their default values from function signature, this behavior is different from the one in the description of flag `complete_concrete_args_with_inputs_not_in_dummy_inputs`:

> If `True`, and `dummy_inputs` is specified, every argument that `root` can take that is not in `dummy_inputs` **AND NOT IN `concrete_args`** will be added to `concrete_args`, otherwise does nothing.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.