### PR TITLE
Fix type in gpt2 config docstring

### DIFF
--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -65,7 +65,7 @@ class GPT2Config(PretrainedConfig):
             Activation function, to be selected in the list `["relu", "silu", "gelu", "tanh", "gelu_new"]`.
         resid_pdrop (`float`, *optional*, defaults to 0.1):
             The dropout probability for all fully connected layers in the embeddings, encoder, and pooler.
-        embd_pdrop (`int`, *optional*, defaults to 0.1):
+        embd_pdrop (`float`, *optional*, defaults to 0.1):
             The dropout ratio for the embeddings.
         attn_pdrop (`float`, *optional*, defaults to 0.1):
             The dropout ratio for the attention.


### PR DESCRIPTION
This PR corrects the type of the field `embd_pdrop` in the docstring of `configuration_gpt2.py`, the field should be a float not an int, like the default value `0.1` suggests.


## Who can review?
Documentation: @sgugger, @stevhliu and @MKhalusova

