### PR TITLE
Fix page counting in Slack CI report script.

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -585,10 +585,10 @@ def get_job_links():
 
     try:
         jobs.update({job["name"]: job["html_url"] for job in result["jobs"]})
-        pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
+        pages_to_iterate_over = math.ceil((result["total_count"]) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = requests.get(url + f"&page={i + 2}").json()
+            result = requests.get(url + f"&page={i + 1}").json()
             jobs.update({job["name"]: job["html_url"] for job in result["jobs"]})
 
         return jobs


### PR DESCRIPTION
# What does this PR do?

We started having an issue getting slack report for our CI. The error shown at the end indicates there is an issue to get all the job links for a workflow run. I take a look and find a change is necessary.

I am not sure why it was that way, especially for `i+2` part. But I remembered it has to be that to avoid duplicated pages. Maybe GitHub Actions change their API now and causes the issue.


```bash
    "url": f"{github_actions_job_links['Extract warnings in CI artifacts']}",
KeyError: 'Extract warnings in CI artifacts'
```