### PR TITLE
Fix resume_from_checkpoint for deepspeed

### DIFF
--- a/src/transformers/deepspeed.py
+++ b/src/transformers/deepspeed.py
@@ -395,6 +395,6 @@ def deepspeed_init(trainer, num_training_steps, resume_from_checkpoint=None, inf
             if load_path is None:
                 raise ValueError(f"[deepspeed] failed to resume from checkpoint {resume_from_checkpoint}")
         else:
-            logger.info(f"{resume_from_checkpoint} doesn't have deepspeed checkpoints, doing nothing")
+            raise ValueError(f"Can't find a valid checkpoint at {resume_from_checkpoint}")
 
     return deepspeed_engine, optimizer, lr_scheduler

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1616,7 +1616,7 @@ class Trainer:
             if resume_from_checkpoint is None:
                 raise ValueError(f"No valid checkpoint found in output directory ({args.output_dir})")
 
-        if resume_from_checkpoint is not None and not is_sagemaker_mp_enabled():
+        if resume_from_checkpoint is not None and not is_sagemaker_mp_enabled() and args.deepspeed is None:
             self._load_from_checkpoint(resume_from_checkpoint)
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2087,10 +2087,7 @@ class Trainer:
                     "yield to errors or unwanted behaviors."
                 )
 
-        if self.args.deepspeed:
-            # will be resumed in deepspeed_init
-            pass
-        elif os.path.isfile(os.path.join(resume_from_checkpoint, WEIGHTS_NAME)):
+        if os.path.isfile(os.path.join(resume_from_checkpoint, WEIGHTS_NAME)):
             # If the model is on the GPU, it still works!
             if is_sagemaker_mp_enabled():
                 if os.path.isfile(os.path.join(resume_from_checkpoint, "user_content.pt")):


### PR DESCRIPTION
something is borked with CircleCI when a contributor has a CircleCI account that isn't set up to some requirements - we don't know what - so I re-created the PR from the original https://github.com/huggingface/transformers/pull/21735

------------------

This PR overcomes a possible issue with the using deepspeed resume when a non-deepspeed checkpoint file structure isn't there.

The original code comes from @mosheber and I had to apply a few more adjustments for tests to work after this change. The tests had to be run manually since they require gpus.

Credits to contributor's work have been correctly imported into this new PR.