### PR TITLE
Make Slack CI reporting stronger

### DIFF
--- a/.github/workflows/check_runner_status.yml
+++ b/.github/workflows/check_runner_status.yml
@@ -57,6 +57,7 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_EVENT: runner status check
           RUNNER_STATUS: ${{ needs.check_runner_status.result }}
           OFFLINE_RUNNERS: ${{ needs.check_runner_status.outputs.offline_runners }}

--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -291,6 +291,7 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID_PAST_FUTURE }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_EVENT: nightly-build
           RUNNER_STATUS: ${{ needs.check_runner_status.result }}
           RUNNER_ENV_STATUS: ${{ needs.check_runners.result }}

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -254,6 +254,7 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID_PAST_FUTURE }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_EVENT: Past CI - ${{ inputs.framework }}-${{ inputs.version }}
           RUNNER_STATUS: ${{ needs.check_runner_status.result }}
           RUNNER_ENV_STATUS: ${{ needs.check_runners.result }}

--- a/.github/workflows/self-push.yml
+++ b/.github/workflows/self-push.yml
@@ -568,6 +568,7 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_EVENT: push
           CI_TITLE_PUSH: ${{ github.event.head_commit.message }}
           CI_TITLE_WORKFLOW_RUN: ${{ github.event.workflow_run.head_commit.message }}

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -482,6 +482,7 @@ jobs:
           CI_SLACK_CHANNEL_ID_DAILY: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY }}
+          ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_EVENT: scheduled
           RUNNER_STATUS: ${{ needs.check_runner_status.result }}
           RUNNER_ENV_STATUS: ${{ needs.check_runners.result }}

--- a/utils/extract_warnings.py
+++ b/utils/extract_warnings.py
@@ -83,19 +83,14 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     # Required parameters
-    parser.add_argument(
-        "--workflow_run_id", default=None, type=str, required=True, help="A GitHub Actions workflow run id."
-    )
+    parser.add_argument("--workflow_run_id", type=str, required=True, help="A GitHub Actions workflow run id.")
     parser.add_argument(
         "--output_dir",
-        default=None,
         type=str,
         required=True,
         help="Where to store the downloaded artifacts and other result files.",
     )
-    parser.add_argument(
-        "--token", default=None, type=str, required=True, help="A token that has actions:read permission."
-    )
+    parser.add_argument("--token", default=None, type=str, help="A token that has actions:read permission.")
     # optional parameters
     parser.add_argument(
         "--targets",
@@ -119,7 +114,7 @@ if __name__ == "__main__":
         os.makedirs(args.output_dir, exist_ok=True)
 
         # get download links
-        artifacts = get_artifacts_links(args.workflow_run_id)
+        artifacts = get_artifacts_links(args.workflow_run_id, token=args.token)
         with open(os.path.join(args.output_dir, "artifacts.json"), "w", encoding="UTF-8") as fp:
             json.dump(artifacts, fp, ensure_ascii=False, indent=4)
 

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -4,6 +4,7 @@ import math
 import os
 import subprocess
 import time
+import traceback
 import zipfile
 from collections import Counter
 
@@ -31,7 +32,7 @@ def get_job_links(workflow_run_id, token=None):
 
         return job_links
     except Exception as e:
-        print("Unknown error, could not fetch links.", e)
+        print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}
 
@@ -57,7 +58,7 @@ def get_artifacts_links(worflow_run_id, token=None):
 
         return artifacts
     except Exception as e:
-        print("Unknown error, could not fetch links.", e)
+        print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}
 

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -31,7 +31,7 @@ def get_job_links(workflow_run_id, token=None):
             job_links.update({job["name"]: job["html_url"] for job in result["jobs"]})
 
         return job_links
-    except Exception as e:
+    except Exception:
         print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}
@@ -57,7 +57,7 @@ def get_artifacts_links(worflow_run_id, token=None):
             artifacts.update({artifact["name"]: artifact["archive_download_url"] for artifact in result["artifacts"]})
 
         return artifacts
-    except Exception as e:
+    except Exception:
         print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -10,11 +10,15 @@ from collections import Counter
 import requests
 
 
-def get_job_links(workflow_run_id):
+def get_job_links(workflow_run_id, token=None):
     """Extract job names and their job links in a GitHub Actions workflow run"""
 
+    headers = None
+    if token is not None:
+        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
-    result = requests.get(url).json()
+    result = requests.get(url, headers=headers).json()
     job_links = {}
 
     try:
@@ -22,7 +26,7 @@ def get_job_links(workflow_run_id):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = requests.get(url + f"&page={i + 2}").json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_links.update({job["name"]: job["html_url"] for job in result["jobs"]})
 
         return job_links
@@ -32,11 +36,15 @@ def get_job_links(workflow_run_id):
     return {}
 
 
-def get_artifacts_links(worflow_run_id):
+def get_artifacts_links(worflow_run_id, token=None):
     """Get all artifact links from a workflow run"""
 
+    headers = None
+    if token is not None:
+        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{worflow_run_id}/artifacts?per_page=100"
-    result = requests.get(url).json()
+    result = requests.get(url, headers=headers).json()
     artifacts = {}
 
     try:
@@ -44,7 +52,7 @@ def get_artifacts_links(worflow_run_id):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = requests.get(url + f"&page={i + 2}").json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             artifacts.update({artifact["name"]: artifact["archive_download_url"] for artifact in result["artifacts"]})
 
         return artifacts
@@ -211,24 +219,19 @@ def make_github_table_per_model(reduced_by_model):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # Required parameters
-    parser.add_argument(
-        "--workflow_run_id", default=None, type=str, required=True, help="A GitHub Actions workflow run id."
-    )
+    parser.add_argument("--workflow_run_id", type=str, required=True, help="A GitHub Actions workflow run id.")
     parser.add_argument(
         "--output_dir",
-        default=None,
         type=str,
         required=True,
         help="Where to store the downloaded artifacts and other result files.",
     )
-    parser.add_argument(
-        "--token", default=None, type=str, required=True, help="A token that has actions:read permission."
-    )
+    parser.add_argument("--token", default=None, type=str, help="A token that has actions:read permission.")
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    _job_links = get_job_links(args.workflow_run_id)
+    _job_links = get_job_links(args.workflow_run_id, token=args.token)
     job_links = {}
     # To deal with `workflow_call` event, where a job name is the combination of the job names in the caller and callee.
     # For example, `PyTorch 1.11 / Model tests (models/albert, single-gpu)`.
@@ -242,7 +245,7 @@ if __name__ == "__main__":
     with open(os.path.join(args.output_dir, "job_links.json"), "w", encoding="UTF-8") as fp:
         json.dump(job_links, fp, ensure_ascii=False, indent=4)
 
-    artifacts = get_artifacts_links(args.workflow_run_id)
+    artifacts = get_artifacts_links(args.workflow_run_id, token=args.token)
     with open(os.path.join(args.output_dir, "artifacts.json"), "w", encoding="UTF-8") as fp:
         json.dump(artifacts, fp, ensure_ascii=False, indent=4)
 

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -25,11 +25,15 @@ def extract_time_from_single_job(job):
     return job_info
 
 
-def get_job_time(workflow_run_id):
+def get_job_time(workflow_run_id, token=None):
     """Extract time info for all jobs in a GitHub Actions workflow run"""
 
+    headers = None
+    if token is not None:
+        headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
-    result = requests.get(url).json()
+    result = requests.get(url, headers=headers).json()
     job_time = {}
 
     try:
@@ -37,7 +41,7 @@ def get_job_time(workflow_run_id):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = requests.get(url + f"&page={i + 2}").json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
 
         return job_time
@@ -56,9 +60,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     # Required parameters
-    parser.add_argument(
-        "--workflow_run_id", default=None, type=str, required=True, help="A GitHub Actions workflow run id."
-    )
+    parser.add_argument("--workflow_run_id", type=str, required=True, help="A GitHub Actions workflow run id.")
     args = parser.parse_args()
 
     job_time = get_job_time(args.workflow_run_id)

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -3,6 +3,7 @@ import math
 
 import dateutil.parser as date_parser
 import requests
+import traceback
 
 
 def extract_time_from_single_job(job):
@@ -46,7 +47,7 @@ def get_job_time(workflow_run_id, token=None):
 
         return job_time
     except Exception as e:
-        print("Unknown error, could not fetch links.", e)
+        print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}
 

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -1,9 +1,9 @@
 import argparse
 import math
+import traceback
 
 import dateutil.parser as date_parser
 import requests
-import traceback
 
 
 def extract_time_from_single_job(job):
@@ -46,7 +46,7 @@ def get_job_time(workflow_run_id, token=None):
             job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
 
         return job_time
-    except Exception as e:
+    except Exception:
         print(f"Unknown error, could not fetch links:\n{traceback.format_exc()}")
 
     return {}

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -207,8 +207,12 @@ class Message:
     @property
     def warnings(self) -> Dict:
         # If something goes wrong, let's avoid the CI report failing to be sent.
-        job_link = "job link not found due to some error"
-        if 'Extract warnings in CI artifacts' in github_actions_job_links:
+        button_text = "Check warnings (Link not found)"
+        # Use the workflow run link
+        job_link = f"https://github.com/huggingface/transformers/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+        if "Extract warnings in CI artifacts" in github_actions_job_links:
+            button_text = "Check warnings"
+            # Use the actual job link
             job_link = f"{github_actions_job_links['Extract warnings in CI artifacts']}"
 
         return {
@@ -220,7 +224,7 @@ class Message:
             },
             "accessory": {
                 "type": "button",
-                "text": {"type": "plain_text", "text": "Check warnings", "emoji": True},
+                "text": {"type": "plain_text", "text": button_text, "emoji": True},
                 "url": job_link,
             },
         }

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -206,6 +206,11 @@ class Message:
 
     @property
     def warnings(self) -> Dict:
+        # If something goes wrong, let's avoid the CI report failing to be sent.
+        job_link = "job link not found due to some error"
+        if 'Extract warnings in CI artifacts' in github_actions_job_links:
+            job_link = f"{github_actions_job_links['Extract warnings in CI artifacts']}"
+
         return {
             "type": "section",
             "text": {
@@ -216,7 +221,7 @@ class Message:
             "accessory": {
                 "type": "button",
                 "text": {"type": "plain_text", "text": "Check warnings", "emoji": True},
-                "url": f"{github_actions_job_links['Extract warnings in CI artifacts']}",
+                "url": job_link,
             },
         }
 

--- a/utils/past_ci_versions.py
+++ b/utils/past_ci_versions.py
@@ -136,8 +136,10 @@ past_versions_testing = {
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Choose the framework and version to install")
-    parser.add_argument("--framework", help="The framework to install. Should be `torch` or `tensorflow`", type=str)
-    parser.add_argument("--version", help="The version of the framework to install.", type=str)
+    parser.add_argument(
+        "--framework", help="The framework to install. Should be `torch` or `tensorflow`", type=str, required=True
+    )
+    parser.add_argument("--version", help="The version of the framework to install.", type=str, required=True)
     args = parser.parse_args()
 
     info = past_versions_testing[args.framework][args.version]


### PR DESCRIPTION
# What does this PR do?

Make Slack CI reporting stronger.

The most important change in this PR is to **use a token when we need to grab some GitHub workflow/jobs information** using api call, like
```python
https://api.github.com/repos/huggingface/transformers/actions/runs
```
to get all job links.

**This could avoid reaching the rate limit in CI runs and keep the CI reporting working.**

Such error occurred once on  2023/02/24, see [this run](https://github.com/huggingface/transformers/actions/runs/4258755021/jobs/7424107028). The log shows `Unknown error, could not fetch links. 'jobs'`, but the underlying reason (I strongly believe) is the rate limit is reached, and the api call returns 2 keys `message` and `documentation` without the key `jobs`.

The other changes are just to make things better too.
