### PR TITLE
Add: task guide for zero shot object detection

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -81,6 +81,8 @@
       title: Video classification
     - local: tasks/object_detection
       title: Object detection
+    - local: tasks/zero_shot_object_detection
+      title: Zero-shot object detection
     title: Computer Vision
   - sections:
     - local: tasks/image_captioning

--- a/docs/source/en/tasks/zero_shot_object_detection.mdx
+++ b/docs/source/en/tasks/zero_shot_object_detection.mdx
@@ -1,0 +1,169 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Zero-shot object detection
+
+[[open-in-colab]]
+
+Traditionally, models used for the [object detection](object_detection) task require labeled image datasets for training,
+and are limited to detecting the set of classes from the training data.
+
+Zero-shot object detection task supported by the [Owl-ViT](./model_doc/owlvit) model uses a different approach. OWL-ViT
+is an open-vocabulary object detector. It means that it can detect objects in images based on free-text queries, without
+the need to fine-tune the model on labeled datasets.
+
+OWL-ViT leverages multi-modal representations to perform open-vocabulary detection. It uses [CLIP](./model_doc/clip) with
+a [ViT](./model_doc/vit)-like Transformer as its backbone to get multi-modal visual and text features. CLIP learns to
+associate images and their corresponding textual descriptions, and ViT can process image patches as inputs. The authors
+of OWL-ViT first trained CLIP from scratch and then fine-tuned it end-to-end on standard object detection datasets using
+a bipartite matching loss.
+
+With this approach, the model can detect objects based on textual descriptions without prior training on labeled datasets.
+
+In this guide, you will learn how to use Owl-ViT:
+- to detect objects based on text prompts
+- for batch object detection
+- for image guided object detection
+
+Before you begin, make sure you have all the necessary libraries installed:
+
+```bash
+pip install -q datasets transformers
+```
+
+## Zero shot object detection pipeline
+
+The simplest way to try out inference with Owl-ViT is to use it in a [`Pipeline`]. Instantiate a pipeline
+for zero shot object detection from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
+
+```python
+>>> from transformers import pipeline
+
+>>> checkpoint = "google/owlvit-base-patch32"
+>>> detector = pipeline(model=checkpoint, task="zero-shot-object-detection")
+```
+
+Next, choose an image you'd like to detect objects in. Here we'll use the image of astronaut Eileen Collins, which is
+part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Great Images dataset.
+
+```py
+>>> import skimage
+>>> import numpy as np
+>>> from PIL import Image
+
+>>> image = skimage.data.astronaut()
+>>> image = Image.fromarray(np.uint8(image)).convert("RGB")
+
+>>> image
+```
+
+<!-- TODO: add the image -->
+
+Pass the image and the candidate object labels to look for to the pipeline.
+Here we pass the image directly but you can also pass a local path to an image or a url.
+
+```py
+>>> predictions = detector(
+...     image,
+...     candidate_labels=["human face", "rocket", "nasa badge", "star-spangled banner"],
+... )
+>>> predictions
+[{'score': 0.3571370542049408,
+  'label': 'human face',
+  'box': {'xmin': 180, 'ymin': 71, 'xmax': 271, 'ymax': 178}},
+ {'score': 0.28099656105041504,
+  'label': 'nasa badge',
+  'box': {'xmin': 129, 'ymin': 348, 'xmax': 206, 'ymax': 427}},
+ {'score': 0.2110239565372467,
+  'label': 'rocket',
+  'box': {'xmin': 350, 'ymin': -1, 'xmax': 468, 'ymax': 288}},
+ {'score': 0.13790413737297058,
+  'label': 'star-spangled banner',
+  'box': {'xmin': 1, 'ymin': 1, 'xmax': 105, 'ymax': 509}},
+ {'score': 0.11950037628412247,
+  'label': 'nasa badge',
+  'box': {'xmin': 277, 'ymin': 338, 'xmax': 327, 'ymax': 380}},
+ {'score': 0.10649408400058746,
+  'label': 'rocket',
+  'box': {'xmin': 358, 'ymin': 64, 'xmax': 424, 'ymax': 280}}]
+```
+
+Let's visualize the predictions:
+
+```py
+>>> from PIL import ImageDraw
+
+>>> draw = ImageDraw.Draw(image)
+
+>>> for prediction in predictions:
+...     box = prediction["box"]
+...     label = prediction["label"]
+...     score = prediction["score"]
+
+...     xmin, ymin, xmax, ymax = box.values()
+...     draw.rectangle((xmin, ymin, xmax, ymax), outline="red", width=1)
+...     draw.text((xmin, ymin), f"{label}: {round(score,2)}", fill="white")
+
+>>> image
+```
+
+<!-- TODO: Insert image-->
+
+## Text-prompted zero shot object detection by hand
+
+Now that you've seen how you can use the zero shot object detection pipeline, let's replicate the same
+result manually.
+
+Start by loading the model and associated processor from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
+
+```py
+>>> from transformers import AutoProcessor, AutoModelForZeroShotObjectDetection
+
+>>> checkpoint = "google/owlvit-base-patch32"
+>>> model = AutoModelForZeroShotObjectDetection.from_pretrained(checkpoint)
+>>> processor = AutoProcessor.from_pretrained(checkpoint)
+```
+
+Here we'll use the same image and text prompts, but you're welcome to switch things up and pick a different example.
+Use the processor to prepare the inputs for the model. The processor combines an image processor that prepares the
+image for the model by resizing and normalizing it, and a [`CLIPTokenizer`] that takes care of the text inputs.
+
+```py
+>>> text_queries = ["human face", "rocket", "nasa badge", "star-spangled banner"]
+>>> inputs = processor(text=text_queries, images=image, return_tensors="pt")
+```
+
+Pass the inputs through the model and visualize the results:
+
+```py
+>>> import torch
+>>> with torch.no_grad():
+...   outputs = model(**inputs)
+...   target_sizes = torch.tensor([image.size[::-1]])
+...   results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)[0]
+
+>>> draw = ImageDraw.Draw(image)
+
+>>> scores = results["scores"].tolist()
+>>> labels = results["labels"].tolist()
+>>> boxes = results["boxes"].tolist()
+
+>>> for box, score, label in zip(boxes, scores, labels):
+...     xmin, ymin, xmax, ymax = box
+...     draw.rectangle((xmin, ymin, xmax, ymax), outline="red", width=1)
+...     draw.text((xmin, ymin), f"{text_queries[label]}: {round(score,2)}", fill="white")
+
+>>> image
+```
+
+## Batch processing
+

--- a/docs/source/en/tasks/zero_shot_object_detection.mdx
+++ b/docs/source/en/tasks/zero_shot_object_detection.mdx
@@ -21,8 +21,8 @@ Zero-shot object detection task supported by the [Owl-ViT](./model_doc/owlvit) m
 is an open-vocabulary object detector. It means that it can detect objects in images based on free-text queries, without
 the need to fine-tune the model on labeled datasets.
 
-OWL-ViT leverages multi-modal representations to perform open-vocabulary detection. It uses [CLIP](./model_doc/clip) with
-a [ViT](./model_doc/vit)-like Transformer as its backbone to get multi-modal visual and text features. CLIP learns to
+OWL-ViT leverages multi-modal representations to perform open-vocabulary detection. It combines [CLIP](./model_doc/clip) with
+a [ViT](./model_doc/vit)-like Transformer to get multi-modal visual and text features. CLIP learns to
 associate images and their corresponding textual descriptions, and ViT can process image patches as inputs. The authors
 of OWL-ViT first trained CLIP from scratch and then fine-tuned it end-to-end on standard object detection datasets using
 a bipartite matching loss.
@@ -32,7 +32,7 @@ With this approach, the model can detect objects based on textual descriptions w
 In this guide, you will learn how to use Owl-ViT:
 - to detect objects based on text prompts
 - for batch object detection
-- for image guided object detection
+- for image-guided object detection
 
 Before you begin, make sure you have all the necessary libraries installed:
 
@@ -123,35 +123,47 @@ Let's visualize the predictions:
 Now that you've seen how you can use the zero shot object detection pipeline, let's replicate the same
 result manually.
 
-Start by loading the model and associated processor from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
+Start by loading the model and associated processor from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit).
+Here we'll use the same checkpoint as before:
 
 ```py
 >>> from transformers import AutoProcessor, AutoModelForZeroShotObjectDetection
 
->>> checkpoint = "google/owlvit-base-patch32"
 >>> model = AutoModelForZeroShotObjectDetection.from_pretrained(checkpoint)
 >>> processor = AutoProcessor.from_pretrained(checkpoint)
 ```
 
-Here we'll use the same image and text prompts, but you're welcome to switch things up and pick a different example.
+Let's take a different image to switch things up.
+
+```py
+>>> import requests
+
+>>> url = "https://unsplash.com/photos/oj0zeY2Ltk4/download?ixid=MnwxMjA3fDB8MXxzZWFyY2h8MTR8fHBpY25pY3xlbnwwfHx8fDE2Nzc0OTE1NDk&force=true&w=640"
+>>> im = Image.open(requests.get(url, stream=True).raw)
+im
+```
+<!--  TODO: add the image-->
+
 Use the processor to prepare the inputs for the model. The processor combines an image processor that prepares the
 image for the model by resizing and normalizing it, and a [`CLIPTokenizer`] that takes care of the text inputs.
 
 ```py
->>> text_queries = ["human face", "rocket", "nasa badge", "star-spangled banner"]
->>> inputs = processor(text=text_queries, images=image, return_tensors="pt")
+>>> text_queries = ["hat", "book", "sunglasses"]
+>>> inputs = processor(text=text_queries, images=im, return_tensors="pt")
 ```
 
-Pass the inputs through the model and visualize the results:
+Pass the inputs through the model, post process and visualize the results. As the images are resized by the image processor
+before being fed to the model, you need to use the `post_process_object_detection` method to make sure the predicted bounding
+boxes have the correct coordinates related to the original image:
 
 ```py
 >>> import torch
 >>> with torch.no_grad():
 ...   outputs = model(**inputs)
-...   target_sizes = torch.tensor([image.size[::-1]])
+...   target_sizes = torch.tensor([im.size[::-1]])
 ...   results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)[0]
 
->>> draw = ImageDraw.Draw(image)
+>>> draw = ImageDraw.Draw(im)
 
 >>> scores = results["scores"].tolist()
 >>> labels = results["labels"].tolist()
@@ -162,8 +174,49 @@ Pass the inputs through the model and visualize the results:
 ...     draw.rectangle((xmin, ymin, xmax, ymax), outline="red", width=1)
 ...     draw.text((xmin, ymin), f"{text_queries[label]}: {round(score,2)}", fill="white")
 
->>> image
+>>> im
 ```
 
+<!--  TODO: add the image with labels -->
+
 ## Batch processing
+
+You can pass multiple sets of images and text queries to search for different (or same) objects in several images.
+Let's use both an astronaut image, and the beach image together.
+For batch processing, you need to pass text queries as a nested list to the processor and images as lists of PIL images,
+or PyTorch tensors, or NumPy arrays.
+
+```py
+>>> images = [image, im]
+>>> text_queries = [["human face", "rocket", "nasa badge", "star-spangled banner"], ["hat", "book", "sunglasses"]]
+>>> inputs = processor(text=text_queries, images=images, return_tensors="pt")
+```
+
+Previously for post processing you passed the single image's size as a tensor, but you can also pass a tuple, or, in case
+of several images, a list of tuples. Let's create predictions for the two examples, and visualize the second one (`image_idx = 1`).
+
+```py
+>>> with torch.no_grad():
+...   outputs = model(**inputs)
+...   target_sizes = [x.size[::-1] for x in images]
+...   results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)
+
+>>> image_idx = 1
+>>> draw = ImageDraw.Draw(images[image_idx])
+
+>>> scores = results[image_idx]["scores"].tolist()
+>>> labels = results[image_idx]["labels"].tolist()
+>>> boxes = results[image_idx]["boxes"].tolist()
+
+>>> for box, score, label in zip(boxes, scores, labels):
+...     xmin, ymin, xmax, ymax = box
+...     draw.rectangle((xmin, ymin, xmax, ymax), outline="red", width=1)
+...     draw.text((xmin, ymin), f"{text_queries[image_idx][label]}: {round(score,2)}", fill="white")
+
+>>> images[image_idx]
+```
+
+<!--  TODO: add the image with labels -->
+
+## Image-guided object detection
 

--- a/docs/source/en/tasks/zero_shot_object_detection.mdx
+++ b/docs/source/en/tasks/zero_shot_object_detection.mdx
@@ -17,19 +17,19 @@ specific language governing permissions and limitations under the License.
 Traditionally, models used for the [object detection](object_detection) task require labeled image datasets for training,
 and are limited to detecting the set of classes from the training data.
 
-Zero-shot object detection task supported by the [Owl-ViT](./model_doc/owlvit) model uses a different approach. OWL-ViT
+Zero-shot object detection task supported by the [OWL-ViT](./model_doc/owlvit) model uses a different approach. OWL-ViT
 is an open-vocabulary object detector. It means that it can detect objects in images based on free-text queries, without
 the need to fine-tune the model on labeled datasets.
 
 OWL-ViT leverages multi-modal representations to perform open-vocabulary detection. It combines [CLIP](./model_doc/clip) with
 a [ViT](./model_doc/vit)-like Transformer to get multi-modal visual and text features. CLIP learns to
 associate images and their corresponding textual descriptions, and ViT can process image patches as inputs. The authors
-of OWL-ViT first trained CLIP from scratch and then fine-tuned it end-to-end on standard object detection datasets using
+of OWL-ViT first trained CLIP from scratch and then fine-tuned OWL-ViT end to end on standard object detection datasets using
 a bipartite matching loss.
 
 With this approach, the model can detect objects based on textual descriptions without prior training on labeled datasets.
 
-In this guide, you will learn how to use Owl-ViT:
+In this guide, you will learn how to use OWL-ViT:
 - to detect objects based on text prompts
 - for batch object detection
 - for image-guided object detection
@@ -37,12 +37,12 @@ In this guide, you will learn how to use Owl-ViT:
 Before you begin, make sure you have all the necessary libraries installed:
 
 ```bash
-pip install -q datasets transformers
+pip install -q transformers
 ```
 
 ## Zero shot object detection pipeline
 
-The simplest way to try out inference with Owl-ViT is to use it in a [`Pipeline`]. Instantiate a pipeline
+The simplest way to try out inference with OWL-ViT is to use it in a [`Pipeline`]. Instantiate a pipeline
 for zero shot object detection from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
 
 ```python
@@ -53,7 +53,7 @@ for zero shot object detection from a [checkpoint on the Hugging Face Hub](https
 ```
 
 Next, choose an image you'd like to detect objects in. Here we'll use the image of astronaut Eileen Collins, which is
-part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Great Images dataset.
+a part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Great Images dataset.
 
 ```py
 >>> import skimage
@@ -66,7 +66,9 @@ part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Grea
 >>> image
 ```
 
-<!-- TODO: add the image -->
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_1.png" alt="Astronaut Eileen Collins"/>
+</div>
 
 Pass the image and the candidate object labels to look for to the pipeline.
 Here we pass the image directly but you can also pass a local path to an image or a url.
@@ -116,7 +118,9 @@ Let's visualize the predictions:
 >>> image
 ```
 
-<!-- TODO: Insert image-->
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_2.png" alt="Visualized predictions on NASA image"/>
+</div>
 
 ## Text-prompted zero shot object detection by hand
 
@@ -140,9 +144,12 @@ Let's take a different image to switch things up.
 
 >>> url = "https://unsplash.com/photos/oj0zeY2Ltk4/download?ixid=MnwxMjA3fDB8MXxzZWFyY2h8MTR8fHBpY25pY3xlbnwwfHx8fDE2Nzc0OTE1NDk&force=true&w=640"
 >>> im = Image.open(requests.get(url, stream=True).raw)
-im
+>>> im
 ```
-<!--  TODO: add the image-->
+
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_3.png" alt="Beach photo"/>
+</div>
 
 Use the processor to prepare the inputs for the model. The processor combines an image processor that prepares the
 image for the model by resizing and normalizing it, and a [`CLIPTokenizer`] that takes care of the text inputs.
@@ -177,7 +184,9 @@ boxes have the correct coordinates related to the original image:
 >>> im
 ```
 
-<!--  TODO: add the image with labels -->
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_4.png" alt="Beach photo with detected objects"/>
+</div>
 
 ## Batch processing
 
@@ -216,7 +225,72 @@ of several images, a list of tuples. Let's create predictions for the two exampl
 >>> images[image_idx]
 ```
 
-<!--  TODO: add the image with labels -->
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_4.png" alt="Beach photo with detected objects"/>
+</div>
 
 ## Image-guided object detection
 
+In addition to zero-shot object detection with text queries, OwlViT offers image guided object detection. In this case
+you can use an image query to find similar objects in the target image.
+Unlike, text queries, only single example image is allowed.
+
+Let's take an image with two cats on a couch as a target image, and an image of a single cat
+as a query:
+
+```py
+>>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+>>> image_target = Image.open(requests.get(url, stream=True).raw)
+
+>>> query_url = "http://images.cocodataset.org/val2017/000000524280.jpg"
+>>> query_image = Image.open(requests.get(query_url, stream=True).raw)
+```
+
+Let's take a quick look at the images:
+
+```py
+>>> import matplotlib.pyplot as plt
+>>> from matplotlib import rcParams
+
+>>> %matplotlib inline
+>>> rcParams['figure.figsize'] = 11 ,8
+
+>>> fig, ax = plt.subplots(1,2)
+>>> ax[0].imshow(image_target)
+>>> ax[1].imshow(query_image)
+```
+
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_5.png" alt="Cats"/>
+</div>
+
+In the preprocessing step, instead of text queries, you now need to use `query_images`:
+
+```py
+>>> inputs = processor(images=image_target, query_images=query_image, return_tensors="pt")
+```
+
+For predictions, instead of passing the inputs to model, pass them to `model.image_guided_detection()`. Draw the predictions
+as before except now there are no labels.
+
+```py
+>>> with torch.no_grad():
+...   outputs = model.image_guided_detection(**inputs)
+...   target_sizes = torch.tensor([image_target.size[::-1]])
+...   results = processor.post_process_image_guided_detection(outputs=outputs, target_sizes=target_sizes)[0]
+
+>>> draw = ImageDraw.Draw(image_target)
+
+>>> scores = results["scores"].tolist()
+>>> boxes = results["boxes"].tolist()
+
+>>> for box, score, label in zip(boxes, scores, labels):
+...     xmin, ymin, xmax, ymax = box
+...     draw.rectangle((xmin, ymin, xmax, ymax), outline="white", width=4)
+
+>>> image_target
+```
+
+<div class="flex justify-center">
+     <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_6.png" alt="Cats with bounding boxes"/>
+</div>

--- a/docs/source/en/tasks/zero_shot_object_detection.mdx
+++ b/docs/source/en/tasks/zero_shot_object_detection.mdx
@@ -18,7 +18,7 @@ Traditionally, models used for the [object detection](object_detection) task req
 and are limited to detecting the set of classes from the training data.
 
 Zero-shot object detection task supported by the [OWL-ViT](./model_doc/owlvit) model uses a different approach. OWL-ViT
-is an open-vocabulary object detector. It means that it can detect objects in images based on free-text queries, without
+is an open-vocabulary object detector. It means that it can detect objects in images based on free-text queries without
 the need to fine-tune the model on labeled datasets.
 
 OWL-ViT leverages multi-modal representations to perform open-vocabulary detection. It combines [CLIP](./model_doc/clip) with
@@ -40,10 +40,10 @@ Before you begin, make sure you have all the necessary libraries installed:
 pip install -q transformers
 ```
 
-## Zero shot object detection pipeline
+## Zero-shot object detection pipeline
 
 The simplest way to try out inference with OWL-ViT is to use it in a [`Pipeline`]. Instantiate a pipeline
-for zero shot object detection from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
+for zero-shot object detection from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit):
 
 ```python
 >>> from transformers import pipeline
@@ -52,7 +52,7 @@ for zero shot object detection from a [checkpoint on the Hugging Face Hub](https
 >>> detector = pipeline(model=checkpoint, task="zero-shot-object-detection")
 ```
 
-Next, choose an image you'd like to detect objects in. Here we'll use the image of astronaut Eileen Collins, which is
+Next, choose an image you'd like to detect objects in. Here we'll use the image of astronaut Eileen Collins that is
 a part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Great Images dataset.
 
 ```py
@@ -71,7 +71,7 @@ a part of the [NASA](https://www.nasa.gov/multimedia/imagegallery/index.html) Gr
 </div>
 
 Pass the image and the candidate object labels to look for to the pipeline.
-Here we pass the image directly but you can also pass a local path to an image or a url.
+Here we pass the image directly; other suitable options include a local path to an image or an image url.
 
 ```py
 >>> predictions = detector(
@@ -122,9 +122,9 @@ Let's visualize the predictions:
      <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/zero-sh-obj-detection_2.png" alt="Visualized predictions on NASA image"/>
 </div>
 
-## Text-prompted zero shot object detection by hand
+## Text-prompted zero-shot object detection by hand
 
-Now that you've seen how you can use the zero shot object detection pipeline, let's replicate the same
+Now that you've seen how to use the zero-shot object detection pipeline, let's replicate the same
 result manually.
 
 Start by loading the model and associated processor from a [checkpoint on the Hugging Face Hub](https://huggingface.co/models?other=owlvit).
@@ -159,8 +159,8 @@ image for the model by resizing and normalizing it, and a [`CLIPTokenizer`] that
 >>> inputs = processor(text=text_queries, images=im, return_tensors="pt")
 ```
 
-Pass the inputs through the model, post process and visualize the results. As the images are resized by the image processor
-before being fed to the model, you need to use the `post_process_object_detection` method to make sure the predicted bounding
+Pass the inputs through the model, post-process, and visualize the results. As the image processor resized images before
+feeding them to the model, you need to use the `post_process_object_detection` method to make sure the predicted bounding
 boxes have the correct coordinates related to the original image:
 
 ```py
@@ -192,8 +192,8 @@ boxes have the correct coordinates related to the original image:
 ## Batch processing
 
 You can pass multiple sets of images and text queries to search for different (or same) objects in several images.
-Let's use both an astronaut image, and the beach image together.
-For batch processing, you need to pass text queries as a nested list to the processor and images as lists of PIL images,
+Let's use both an astronaut image and the beach image together.
+For batch processing, you should pass text queries as a nested list to the processor and images as lists of PIL images,
 or PyTorch tensors, or NumPy arrays.
 
 ```py
@@ -202,7 +202,7 @@ or PyTorch tensors, or NumPy arrays.
 >>> inputs = processor(text=text_queries, images=images, return_tensors="pt")
 ```
 
-Previously for post processing you passed the single image's size as a tensor, but you can also pass a tuple, or, in case
+Previously for post-processing you passed the single image's size as a tensor, but you can also pass a tuple, or, in case
 of several images, a list of tuples. Let's create predictions for the two examples, and visualize the second one (`image_idx = 1`).
 
 ```py
@@ -232,9 +232,9 @@ of several images, a list of tuples. Let's create predictions for the two exampl
 
 ## Image-guided object detection
 
-In addition to zero-shot object detection with text queries, OwlViT offers image guided object detection. In this case
+In addition to zero-shot object detection with text queries, OWL-ViT offers image-guided object detection. This means
 you can use an image query to find similar objects in the target image.
-Unlike, text queries, only single example image is allowed.
+Unlike text queries, only a single example image is allowed.
 
 Let's take an image with two cats on a couch as a target image, and an image of a single cat
 as a query:

--- a/docs/source/en/tasks/zero_shot_object_detection.mdx
+++ b/docs/source/en/tasks/zero_shot_object_detection.mdx
@@ -165,10 +165,11 @@ boxes have the correct coordinates related to the original image:
 
 ```py
 >>> import torch
+
 >>> with torch.no_grad():
-...   outputs = model(**inputs)
-...   target_sizes = torch.tensor([im.size[::-1]])
-...   results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)[0]
+...     outputs = model(**inputs)
+...     target_sizes = torch.tensor([im.size[::-1]])
+...     results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)[0]
 
 >>> draw = ImageDraw.Draw(im)
 
@@ -206,9 +207,9 @@ of several images, a list of tuples. Let's create predictions for the two exampl
 
 ```py
 >>> with torch.no_grad():
-...   outputs = model(**inputs)
-...   target_sizes = [x.size[::-1] for x in images]
-...   results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)
+...     outputs = model(**inputs)
+...     target_sizes = [x.size[::-1] for x in images]
+...     results = processor.post_process_object_detection(outputs, threshold=0.1, target_sizes=target_sizes)
 
 >>> image_idx = 1
 >>> draw = ImageDraw.Draw(images[image_idx])
@@ -250,12 +251,8 @@ Let's take a quick look at the images:
 
 ```py
 >>> import matplotlib.pyplot as plt
->>> from matplotlib import rcParams
 
->>> %matplotlib inline
->>> rcParams['figure.figsize'] = 11 ,8
-
->>> fig, ax = plt.subplots(1,2)
+>>> fig, ax = plt.subplots(1, 2)
 >>> ax[0].imshow(image_target)
 >>> ax[1].imshow(query_image)
 ```
@@ -275,9 +272,9 @@ as before except now there are no labels.
 
 ```py
 >>> with torch.no_grad():
-...   outputs = model.image_guided_detection(**inputs)
-...   target_sizes = torch.tensor([image_target.size[::-1]])
-...   results = processor.post_process_image_guided_detection(outputs=outputs, target_sizes=target_sizes)[0]
+...     outputs = model.image_guided_detection(**inputs)
+...     target_sizes = torch.tensor([image_target.size[::-1]])
+...     results = processor.post_process_image_guided_detection(outputs=outputs, target_sizes=target_sizes)[0]
 
 >>> draw = ImageDraw.Draw(image_target)
 


### PR DESCRIPTION
This PR adds a task guide for zero-shot object detection. Unlike other task guides, there is no fine-tuning and complex preprocessing of custom data. However, the task illustrates different ways of inferencing with OWL-ViT, such as using the pipeline, manual inference with text queries, manual inference for a batch of examples, and image-guided object detection. 
The task guide is based on [this notebook](https://github.com/huggingface/notebooks/blob/main/examples/zeroshot_object_detection_with_owlvit.ipynb) with some additions (e.g. pipeline example) and some modifications. 