### PR TITLE
[ConvBert] Fix #21523

### DIFF
--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -316,7 +316,7 @@ class ConvBertSelfAttention(nn.Module):
         if config.hidden_size % self.num_attention_heads != 0:
             raise ValueError("hidden_size should be divisible by num_attention_heads")
 
-        self.attention_head_size = config.hidden_size // config.num_attention_heads
+        self.attention_head_size = (config.hidden_size // self.num_attention_heads) // 2
         self.all_head_size = self.num_attention_heads * self.attention_head_size
 
         self.query = nn.Linear(config.hidden_size, self.all_head_size)

--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -414,7 +414,9 @@ class ConvBertSelfAttention(nn.Module):
         context_layer = torch.cat([context_layer, conv_out], 2)
 
         # conv and context
-        new_context_layer_shape = context_layer.size()[:-2] + (self.num_attention_heads * self.attention_head_size * 2,)
+        new_context_layer_shape = context_layer.size()[:-2] + (
+            self.num_attention_heads * self.attention_head_size * 2,
+        )
         context_layer = context_layer.view(*new_context_layer_shape)
 
         outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)

--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -413,7 +413,7 @@ class ConvBertSelfAttention(nn.Module):
         conv_out = torch.reshape(conv_out_layer, [batch_size, -1, self.num_attention_heads, self.attention_head_size])
         context_layer = torch.cat([context_layer, conv_out], 2)
 
-        new_context_layer_shape = context_layer.size()[:-2] + (self.head_ratio * self.all_head_size,)
+        new_context_layer_shape = context_layer.size()[:-2] + (self.num_attention_heads * self.attention_head_size * 2,)  # conv and context
         context_layer = context_layer.view(*new_context_layer_shape)
 
         outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)

--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -413,9 +413,8 @@ class ConvBertSelfAttention(nn.Module):
         conv_out = torch.reshape(conv_out_layer, [batch_size, -1, self.num_attention_heads, self.attention_head_size])
         context_layer = torch.cat([context_layer, conv_out], 2)
 
-        new_context_layer_shape = context_layer.size()[:-2] + (
-            self.num_attention_heads * self.attention_head_size * 2,
-        )  # conv and context
+        # conv and context
+        new_context_layer_shape = context_layer.size()[:-2] + (self.num_attention_heads * self.attention_head_size * 2,)
         context_layer = context_layer.view(*new_context_layer_shape)
 
         outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)

--- a/src/transformers/models/convbert/modeling_convbert.py
+++ b/src/transformers/models/convbert/modeling_convbert.py
@@ -413,7 +413,9 @@ class ConvBertSelfAttention(nn.Module):
         conv_out = torch.reshape(conv_out_layer, [batch_size, -1, self.num_attention_heads, self.attention_head_size])
         context_layer = torch.cat([context_layer, conv_out], 2)
 
-        new_context_layer_shape = context_layer.size()[:-2] + (self.num_attention_heads * self.attention_head_size * 2,)  # conv and context
+        new_context_layer_shape = context_layer.size()[:-2] + (
+            self.num_attention_heads * self.attention_head_size * 2,
+        )  # conv and context
         context_layer = context_layer.view(*new_context_layer_shape)
 
         outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)

--- a/tests/models/convbert/test_modeling_convbert.py
+++ b/tests/models/convbert/test_modeling_convbert.py
@@ -447,9 +447,9 @@ class ConvBertModelTest(ModelTesterMixin, unittest.TestCase):
         self.assertEqual(result.last_hidden_state.shape, (batch_size, seq_length, config.hidden_size))
 
     def test_reducing_attention_heads(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config, *inputs_dict = self.model_tester.prepare_config_and_inputs()
         config.head_ratio = 4
-        self.model_tester.create_and_check_for_masked_lm(config, inputs_dict)
+        self.model_tester.create_and_check_for_masked_lm(config, *inputs_dict)
 
 
 @require_torch

--- a/tests/models/convbert/test_modeling_convbert.py
+++ b/tests/models/convbert/test_modeling_convbert.py
@@ -446,6 +446,11 @@ class ConvBertModelTest(ModelTesterMixin, unittest.TestCase):
         result = model(inputs_embeds=inputs_embeds)
         self.assertEqual(result.last_hidden_state.shape, (batch_size, seq_length, config.hidden_size))
 
+    def test_reducing_attention_heads(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.head_ratio = 4
+        self.model_tester.create_and_check_for_masked_lm(config, inputs_dict)
+
 
 @require_torch
 class ConvBertModelIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?
Fixes #21523, the invalid reshaping of the context layer and adds a test to make sure we support different head ratios.
Made sur that the slow test all pass. 
