### PR TITLE
TrOCR comment change

### DIFF
--- a/src/transformers/models/trocr/modeling_trocr.py
+++ b/src/transformers/models/trocr/modeling_trocr.py
@@ -915,7 +915,7 @@ class TrOCRForCausalLM(TrOCRPreTrainedModel):
 
         >>> # TrOCR is a decoder model and should be used within a VisionEncoderDecoderModel
         >>> # init vision2text model with random weights
-        >>> encoder = ViTModel(ViTConfig())
+        >>> encoder = ViTModel(ViTConfig(image_size=384))
         >>> decoder = TrOCRForCausalLM(TrOCRConfig())
         >>> model = VisionEncoderDecoderModel(encoder=encoder, decoder=decoder)
 


### PR DESCRIPTION
Thanks for the TrOCR modules @NielsRogge !

I noticed something very small in one of the comments - if you copy pasted the lines from the comment block, they wouldn't work, because the default image size in `ViTConfig` is 224, while the `processor` is expecting the image to be resized to 384x384. 