### PR TITLE
[GPT2] Propose fix for #21080

### DIFF
--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -559,7 +559,7 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
             if past_length > 0:
-                position_ids = position_ids[:, -1].unsqueeze(-1)
+                position_ids = position_ids[:, past_length : input_shape[-1] + past_length :]
         elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -554,12 +554,11 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
         else:
             past_length = past_key_values[0][0].size(-2)
 
-
-        if attention_mask is not None and len(attention_mask.shape)==2 and position_ids is None:
+        if attention_mask is not None and len(attention_mask.shape) == 2 and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_length>0:
+            if past_length > 0:
                 position_ids = position_ids[:, -1].unsqueeze(-1)
         elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -553,7 +553,13 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-        if position_ids is None:
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if past_key_values:
+                position_ids = position_ids[:, -1].unsqueeze(-1)
+        else:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -553,13 +553,15 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-        if attention_mask is not None and position_ids is None:
+
+
+        if attention_mask is not None and len(attention_mask.shape)==2 and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_key_values:
+            if past_length>0:
                 position_ids = position_ids[:, -1].unsqueeze(-1)
-        else:
+        elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -797,13 +797,15 @@ class GPT2Model(GPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-        if attention_mask is not None and position_ids is None:
+
+
+        if attention_mask is not None and len(attention_mask.shape)==2 and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_key_values:
+            if past_length>0:
                 position_ids = position_ids[:, -1].unsqueeze(-1)
-        else:
+        elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -803,7 +803,7 @@ class GPT2Model(GPT2PreTrainedModel):
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
             if past_length > 0:
-                position_ids = position_ids[:, -1].unsqueeze(-1)
+                position_ids = position_ids[:, past_length : input_shape[-1] + past_length :]
         elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -797,7 +797,13 @@ class GPT2Model(GPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-        if position_ids is None:
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if past_key_values:
+                position_ids = position_ids[:, -1].unsqueeze(-1)
+        else:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -798,12 +798,11 @@ class GPT2Model(GPT2PreTrainedModel):
         else:
             past_length = past_key_values[0][0].size(-2)
 
-
-        if attention_mask is not None and len(attention_mask.shape)==2 and position_ids is None:
+        if attention_mask is not None and len(attention_mask.shape) == 2 and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_length>0:
+            if past_length > 0:
                 position_ids = position_ids[:, -1].unsqueeze(-1)
         elif position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -579,6 +579,27 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
         self.assertListEqual(expected_output_sentence, [non_padded_sentence, padded_sentence])
 
     @slow
+    def test_batch_forward(self):
+        tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+        tokenizer.padding_side = "left"
+
+        # This tokenizer has no pad token, so we have to set it in some way
+        # Define PAD Token = EOS Token = 50256
+        tokenizer.pad_token = tokenizer.eos_token
+
+        model = GPT2LMHeadModel.from_pretrained("gpt2", pad_token_id=tokenizer.eos_token_id)
+        sentences = ["Hello, my dog is a little bit of a mess. I'm not sure if he's"]
+        inputs = tokenizer(sentences, padding=True, return_tensors="pt")
+        logits = model(**inputs).logits[:, -1, :]
+        indexes = torch.argmax(logits).item()
+
+        inputs_padded = tokenizer(sentences, padding="max_length", max_length=30, return_tensors="pt")
+        logits_padded = model(**inputs_padded).logits[:, -1, :]
+        indexes_padded = torch.argmax(logits_padded).item()
+
+        self.assertTrue(indexes == indexes_padded)
+
+    @slow
     def test_batch_generation_2heads(self):
         model = GPT2DoubleHeadsModel.from_pretrained("gpt2")
         model.to(torch_device)


### PR DESCRIPTION
# What does this PR do?
Propose fix for #21080.
Modify the default generation of the positional ids for the `gpt-2` as well as the `decidion_transformer` model. 
In the issue @LysandreJik proposed to update the doc, but when I checked it seemed like this would only affect 2 models, and is backward compatible: 
- potential impact is only for people that where using batched padded input when generating with a single sentence. This means that their output will now be corrected
- default behavior is kept if not attention mask is given. 

If this is not acceptable, I am also glad to add a warning when creating the positional ids.