### PR TITLE
Flax beam search fix

### DIFF
--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -452,6 +452,10 @@ class FlaxGenerationMixin:
                 model_kwargs["attention_mask"] = self._expand_to_num_beams(
                     model_kwargs["attention_mask"], num_beams=generation_config.num_beams
                 )
+            if "decoder_attention_mask" in model_kwargs:
+                model_kwargs["decoder_attention_mask"] = self._expand_to_num_beams(
+                    model_kwargs["decoder_attention_mask"], num_beams=generation_config.num_beams
+                )
 
             return self._beam_search(
                 input_ids,
@@ -823,6 +827,8 @@ class FlaxGenerationMixin:
             )
         if "attention_mask" in model_kwargs:
             model_kwargs["attention_mask"] = flatten_beam_dim(model_kwargs["attention_mask"])
+        if "decoder_attention_mask" in model_kwargs:
+            model_kwargs["decoder_attention_mask"] = flatten_beam_dim(model_kwargs["decoder_attention_mask"])
 
         # initialize model specific kwargs
         model_kwargs = self.prepare_inputs_for_generation(flatten_beam_dim(input_ids), max_length, **model_kwargs)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -448,15 +448,11 @@ class FlaxGenerationMixin:
                     model_kwargs["encoder_outputs"]["last_hidden_state"], num_beams=generation_config.num_beams
                 )
 
-            if "attention_mask" in model_kwargs:
-                model_kwargs["attention_mask"] = self._expand_to_num_beams(
-                    model_kwargs["attention_mask"], num_beams=generation_config.num_beams
-                )
-                
-            if "decoder_attention_mask" in model_kwargs:
-                model_kwargs["decoder_attention_mask"] = self._expand_to_num_beams(
-                    model_kwargs["decoder_attention_mask"], num_beams=generation_config.num_beams
-                )
+            for kwarg in ["attention_mask", "decoder_attention_mask"]:
+                if kwarg in model_kwargs:
+                    model_kwargs[kwarg] = self._expand_to_num_beams(
+                        model_kwargs[kwarg], num_beams=generation_config.num_beams
+                    )
 
             return self._beam_search(
                 input_ids,
@@ -826,10 +822,9 @@ class FlaxGenerationMixin:
             model_kwargs["encoder_outputs"]["last_hidden_state"] = flatten_beam_dim(
                 model_kwargs["encoder_outputs"]["last_hidden_state"]
             )
-        if "attention_mask" in model_kwargs:
-            model_kwargs["attention_mask"] = flatten_beam_dim(model_kwargs["attention_mask"])
-        if "decoder_attention_mask" in model_kwargs:
-            model_kwargs["decoder_attention_mask"] = flatten_beam_dim(model_kwargs["decoder_attention_mask"])
+        for kwarg in ["attention_mask", "decoder_attention_mask"]:
+            if kwarg in model_kwargs:
+                model_kwargs[kwarg] = flatten_beam_dim(model_kwargs[kwarg])
 
         # initialize model specific kwargs
         model_kwargs = self.prepare_inputs_for_generation(flatten_beam_dim(input_ids), max_length, **model_kwargs)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -452,6 +452,7 @@ class FlaxGenerationMixin:
                 model_kwargs["attention_mask"] = self._expand_to_num_beams(
                     model_kwargs["attention_mask"], num_beams=generation_config.num_beams
                 )
+                
             if "decoder_attention_mask" in model_kwargs:
                 model_kwargs["decoder_attention_mask"] = self._expand_to_num_beams(
                     model_kwargs["decoder_attention_mask"], num_beams=generation_config.num_beams


### PR DESCRIPTION
# What does this PR do?

Makes it so you can pass `decoder_attention_mask` into `model.generate` for flax models when doing beam search. This is helpful for models like Whisper where there may be variable length decoder prefixes across a batch, so you'd have to define a `decoder_attention_mask`.

@sanchit-gandhi
@sgugger 
@frmccann97