### PR TITLE
[`Blip`] Fix blip doctest

### DIFF
--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -985,8 +985,9 @@ class BlipForConditionalGeneration(BlipPreTrainedModel):
 
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
+        >>> text = "A picture of"
 
-        >>> inputs = processor(images=image, return_tensors="pt")
+        >>> inputs = processor(images=image, text=text, return_tensors="pt")
 
         >>> outputs = model(**inputs)
         ```"""


### PR DESCRIPTION
# What does this PR do?

This PR fixes the Blip doctest that was failing with the changes proposed in https://github.com/huggingface/transformers/pull/21811 

Link to failing job: https://github.com/huggingface/transformers/actions/runs/4299412591/jobs/7494589393

## Why this fix is relevant? 

In #21811 the logic of `BlipForConditionalGeneration` forward pass has changed. If a user wants to use this as a standalone class and call `forward`, the text input must be fed to the model to the text decoder to mimic the implementations of encoder-decoder architectures in `transformers`, check for instance what is done to properly call `forward` on `T5`: https://github.com/huggingface/transformers/blob/b29e2dcaff114762e65eaea739ba1076fc5d1c84/src/transformers/models/t5/modeling_t5.py#L1641 

Hence, the fix of the doctest should be to feed a text input to the decoder by adding a text argument to the processor.

cc @ydshieh @sgugger 💯 