### PR TITLE
Add TFVisionTextDualEncoder

### DIFF
--- a/docs/source/en/index.mdx
+++ b/docs/source/en/index.mdx
@@ -397,7 +397,7 @@ Flax), PyTorch, and/or TensorFlow.
 |           VideoMAE            |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |
 |             ViLT              |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |
 |    Vision Encoder decoder     |       ❌       |       ❌       |       ✅        |         ✅         |      ✅      |
-|     VisionTextDualEncoder     |       ❌       |       ❌       |       ✅        |         ❌         |      ✅      |
+|     VisionTextDualEncoder     |       ❌       |       ❌       |       ✅        |         ✅         |      ✅      |
 |          VisualBERT           |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |
 |              ViT              |       ❌       |       ❌       |       ✅        |         ✅         |      ✅      |
 |          ViT Hybrid           |       ❌       |       ❌       |       ✅        |         ❌         |      ❌      |

--- a/docs/source/en/model_doc/vision-text-dual-encoder.mdx
+++ b/docs/source/en/model_doc/vision-text-dual-encoder.mdx
@@ -41,3 +41,8 @@ new zero-shot vision tasks such as image classification or retrieval.
 
 [[autodoc]] FlaxVisionTextDualEncoderModel
     - __call__
+
+## TFVisionTextDualEncoderModel
+
+[[autodoc]] TFVisionTextDualEncoderModel
+    - call

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -3275,6 +3275,7 @@ else:
         ]
     )
     _import_structure["models.vision_encoder_decoder"].extend(["TFVisionEncoderDecoderModel"])
+    _import_structure["models.vision_text_dual_encoder"].extend(["TFVisionTextDualEncoderModel"])
     _import_structure["models.vit"].extend(
         [
             "TFViTForImageClassification",
@@ -6335,6 +6336,7 @@ if TYPE_CHECKING:
             TFTransfoXLPreTrainedModel,
         )
         from .models.vision_encoder_decoder import TFVisionEncoderDecoderModel
+        from .models.vision_text_dual_encoder import TFVisionTextDualEncoderModel
         from .models.vit import TFViTForImageClassification, TFViTModel, TFViTPreTrainedModel
         from .models.vit_mae import TFViTMAEForPreTraining, TFViTMAEModel, TFViTMAEPreTrainedModel
         from .models.wav2vec2 import (

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -892,8 +892,6 @@ def load_tf_weights(model, resolved_archive_file, ignore_mismatched_sizes=False,
 
 
 def load_tf_weights_from_h5(model, resolved_archive_file, ignore_mismatched_sizes=False, _prefix=None):
-    missing_layers = []
-    unexpected_layers = []
     mismatched_layers = []
 
     # Read the H5 file

--- a/src/transformers/models/auto/modeling_tf_auto.py
+++ b/src/transformers/models/auto/modeling_tf_auto.py
@@ -81,6 +81,7 @@ TF_MODEL_MAPPING_NAMES = OrderedDict(
         ("t5", "TFT5Model"),
         ("tapas", "TFTapasModel"),
         ("transfo-xl", "TFTransfoXLModel"),
+        ("vision-text-dual-encoder", "TFVisionTextDualEncoderModel"),
         ("vit", "TFViTModel"),
         ("vit_mae", "TFViTMAEModel"),
         ("wav2vec2", "TFWav2Vec2Model"),

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -900,6 +900,8 @@ class TFCLIPPreTrainedModel(TFPreTrainedModel):
 
     config_class = CLIPConfig
     base_model_prefix = "clip"
+    _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_unexpected = [r"position_ids"]
 
 
 CLIP_START_DOCSTRING = r"""

--- a/src/transformers/models/vision_text_dual_encoder/__init__.py
+++ b/src/transformers/models/vision_text_dual_encoder/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_available, is_torch_available
+from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_available, is_torch_available, is_tf_available
 
 
 _import_structure = {
@@ -39,10 +39,18 @@ except OptionalDependencyNotAvailable:
 else:
     _import_structure["modeling_flax_vision_text_dual_encoder"] = ["FlaxVisionTextDualEncoderModel"]
 
+try:
+    if not is_tf_available():
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    pass
+else:
+    _import_structure["modeling_tf_vision_text_dual_encoder"] = ["TFVisionTextDualEncoderModel"]
+
 
 if TYPE_CHECKING:
     from .configuration_vision_text_dual_encoder import VisionTextDualEncoderConfig
-    from .processing_visiotn_text_dual_encoder import VisionTextDualEncoderProcessor
+    from .processing_vision_text_dual_encoder import VisionTextDualEncoderProcessor
 
     try:
         if not is_torch_available():
@@ -58,7 +66,15 @@ if TYPE_CHECKING:
     except OptionalDependencyNotAvailable:
         pass
     else:
-        from .modeling_vision_text_dual_encoder import FlaxVisionTextDualEncoderModel
+        from .modeling_flax_vision_text_dual_encoder import FlaxVisionTextDualEncoderModel
+
+    try:
+        if not is_tf_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        pass
+    else:
+        from .modeling_tf_vision_text_dual_encoder import TFVisionTextDualEncoderModel
 
 
 else:

--- a/src/transformers/models/vision_text_dual_encoder/__init__.py
+++ b/src/transformers/models/vision_text_dual_encoder/__init__.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_available, is_torch_available, is_tf_available
+from ...utils import (
+    OptionalDependencyNotAvailable,
+    _LazyModule,
+    is_flax_available,
+    is_tf_available,
+    is_torch_available,
+)
 
 
 _import_structure = {

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" PyTorch VisionTextDualEncoder model."""
+"""TensorFlow VisionTextDualEncoder model."""
 
 
 from typing import Optional, Tuple, Union
 
-import torch
-from torch import nn
+import tensorflow as tf
 
-from ...modeling_utils import PreTrainedModel
-from ...utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
+from ...modeling_tf_utils import TFPreTrainedModel, unpack_inputs
+from ...utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging, replace_return_docstrings, DUMMY_INPUTS
+from ...tf_utils import shape_list
 from ..auto.configuration_auto import AutoConfig
-from ..auto.modeling_auto import AutoModel
-from ..clip.modeling_clip import CLIPOutput, CLIPVisionConfig, CLIPVisionModel
+from ..auto.modeling_tf_auto import TFAutoModel
+from ..clip.modeling_tf_clip import TFCLIPOutput, CLIPVisionConfig, TFCLIPVisionModel
 from .configuration_vision_text_dual_encoder import VisionTextDualEncoderConfig
+from ...configuration_utils import PretrainedConfig
+
+import tempfile
+import os
+import gc
+
+from tensorflow.keras.layers import Dense
+
 
 
 logger = logging.get_logger(__name__)
@@ -35,7 +43,7 @@ _CONFIG_FOR_DOC = "VisionTextDualEncoderConfig"
 VISION_TEXT_DUAL_ENCODER_START_DOCSTRING = r"""
     This class can be used to initialize a vision-text dual encoder model with any pretrained vision autoencoding model
     as the vision encoder and any pretrained text model as the text encoder. The vision and text encoders are loaded
-    via the [`~AutoModel.from_pretrained`] method. The projection layers are automatically added to the model and
+    via the [`~TFAutoModel.from_pretrained`] method. The projection layers are automatically added to the model and
     should be fine-tuned on a downstream task, like contrastive image-text modeling.
 
     In [LiT: Zero-Shot Transfer with Locked-image Text Tuning](https://arxiv.org/abs/2111.07991) it is shown how
@@ -45,24 +53,24 @@ VISION_TEXT_DUAL_ENCODER_START_DOCSTRING = r"""
     After such a Vision-Text-Dual-Encoder model has been trained/fine-tuned, it can be saved/loaded just like any other
     models (see the examples for more information).
 
-    This model inherits from [`PreTrainedModel`]. Check the superclass documentation for the generic methods the
+    This model inherits from [`TFPreTrainedModel`]. Check the superclass documentation for the generic methods the
     library implements for all its model (such as downloading or saving, resizing the input embeddings, pruning heads
     etc.)
 
-    This model is also a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass.
-    Use it as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage
+    This model is also a Keras [Model](https://www.tensorflow.org/api_docs/python/tf/keras/Model) subclass.
+    Use it as a regular Keras Model and refer to the TF documentation for all matter related to general usage
     and behavior.
 
     Parameters:
         config ([`VisionEncoderDecoderConfig`]): Model configuration class with all the parameters of the model.
             Initializing with a config file does not load the weights associated with the model, only the
-            configuration. Check out the [`~PreTrainedModel.from_pretrained`] method to load the model weights.
+            configuration. Check out the [`~TFPreTrainedModel.from_pretrained`] method to load the model weights.
 """
 
 
 VISION_TEXT_DUAL_ENCODER_TEXT_INPUTS_DOCSTRING = r"""
     Args:
-        input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+        input_ids (`tf.Tensor` of shape `(batch_size, sequence_length)`):
             Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you provide
             it.
 
@@ -70,14 +78,14 @@ VISION_TEXT_DUAL_ENCODER_TEXT_INPUTS_DOCSTRING = r"""
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
-        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+        attention_mask (`tf.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
 
             - 1 for tokens that are **not masked**,
             - 0 for tokens that are **masked**.
 
             [What are attention masks?](../glossary#attention-mask)
-        position_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+        position_ids (`tf.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
             config.max_position_embeddings - 1]`.
 
@@ -94,7 +102,7 @@ VISION_TEXT_DUAL_ENCODER_TEXT_INPUTS_DOCSTRING = r"""
 
 VISION_TEXT_DUAL_ENCODER_VISION_INPUTS_DOCSTRING = r"""
     Args:
-        pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, height, width)`):
+        pixel_values (`tf.Tensor` of shape `(batch_size, num_channels, height, width)`):
             Pixel values. Padding will be ignored by default should you provide it. Pixel values can be obtained using
             [`AutoImageProcessor`]. See [`CLIPImageProcessor.__call__`] for details.
         output_attentions (`bool`, *optional*):
@@ -109,7 +117,7 @@ VISION_TEXT_DUAL_ENCODER_VISION_INPUTS_DOCSTRING = r"""
 
 VISION_TEXT_DUAL_ENCODER_INPUTS_DOCSTRING = r"""
     Args:
-        input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+        input_ids (`tf.Tensor` of shape `(batch_size, sequence_length)`):
             Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you provide
             it.
 
@@ -117,19 +125,19 @@ VISION_TEXT_DUAL_ENCODER_INPUTS_DOCSTRING = r"""
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
-        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+        attention_mask (`tf.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
 
             - 1 for tokens that are **not masked**,
             - 0 for tokens that are **masked**.
 
             [What are attention masks?](../glossary#attention-mask)
-        position_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+        position_ids (`tf.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
             Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
             config.max_position_embeddings - 1]`.
 
             [What are position IDs?](../glossary#position-ids)
-        pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, height, width)`):
+        pixel_values (`tf.Tensor` of shape `(batch_size, num_channels, height, width)`):
             Pixel values. Padding will be ignored by default should you provide it. Pixel values can be obtained using
             an image processor (e.g. if you use ViT as the encoder, you should use [`AutoImageProcessor`]). See
             [`ViTImageProcessor.__call__`] for details.
@@ -146,28 +154,33 @@ VISION_TEXT_DUAL_ENCODER_INPUTS_DOCSTRING = r"""
 """
 
 
-# Copied from transformers.models.clip.modeling_clip.contrastive_loss
-def contrastive_loss(logits: torch.Tensor) -> torch.Tensor:
-    return nn.functional.cross_entropy(logits, torch.arange(len(logits), device=logits.device))
+# Copied from transformers.models.clip.modeling_tf_clip.contrastive_loss
+def contrastive_loss(logits: tf.Tensor) -> tf.Tensor:
+    return tf.math.reduce_mean(
+        tf.keras.metrics.sparse_categorical_crossentropy(
+            y_true=tf.range(shape_list(logits)[0]), y_pred=logits, from_logits=True
+        )
+    )
 
 
-# Copied from transformers.models.clip.modeling_clip.clip_loss
-def clip_loss(similarity: torch.Tensor) -> torch.Tensor:
+# Copied from transformers.models.clip.modeling_tf_clip.clip_loss
+def clip_loss(similarity: tf.Tensor) -> tf.Tensor:
     caption_loss = contrastive_loss(similarity)
-    image_loss = contrastive_loss(similarity.t())
+    image_loss = contrastive_loss(tf.transpose(similarity))
     return (caption_loss + image_loss) / 2.0
 
 
 @add_start_docstrings(VISION_TEXT_DUAL_ENCODER_START_DOCSTRING)
-class VisionTextDualEncoderModel(PreTrainedModel):
+class TFVisionTextDualEncoderModel(TFPreTrainedModel):
     config_class = VisionTextDualEncoderConfig
     base_model_prefix = "vision_text_dual_encoder"
+    load_weight_prefix = "tf_vision_text_dual_encoder_model"
 
     def __init__(
         self,
         config: Optional[VisionTextDualEncoderConfig] = None,
-        vision_model: Optional[PreTrainedModel] = None,
-        text_model: Optional[PreTrainedModel] = None,
+        vision_model: Optional[TFPreTrainedModel] = None,
+        text_model: Optional[TFPreTrainedModel] = None,
     ):
         if config is None and (vision_model is None or text_model is None):
             raise ValueError("Either a configuration or an vision and a text model has to be provided")
@@ -183,12 +196,12 @@ class VisionTextDualEncoderModel(PreTrainedModel):
 
         if vision_model is None:
             if isinstance(config.vision_config, CLIPVisionConfig):
-                vision_model = CLIPVisionModel(config.vision_config)
+                vision_model = TFCLIPVisionModel.from_config(config.vision_config, name="vision_model")
             else:
-                vision_model = AutoModel.from_config(config.vision_config)
+                vision_model = TFAutoModel.from_config(config.vision_config, name="vision_model")
 
         if text_model is None:
-            text_model = AutoModel.from_config(config.text_config)
+            text_model = TFAutoModel.from_config(config.text_config, name="text_model")
 
         self.vision_model = vision_model
         self.text_model = text_model
@@ -202,9 +215,71 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         self.text_embed_dim = config.text_config.hidden_size
         self.projection_dim = config.projection_dim
 
-        self.visual_projection = nn.Linear(self.vision_embed_dim, self.projection_dim, bias=False)
-        self.text_projection = nn.Linear(self.text_embed_dim, self.projection_dim, bias=False)
-        self.logit_scale = nn.Parameter(torch.ones([]) * self.config.logit_scale_init_value)
+        self.visual_projection = Dense(self.projection_dim, use_bias=False, name="visual_projection")
+        self.text_projection = Dense(self.projection_dim, use_bias=False, name="text_projection")
+        self.logit_scale = None
+
+    def build(self, input_shape=None):
+        # Build in the build() method to make sure the names are right
+        initializer = tf.keras.initializers.Constant(self.config.logit_scale_init_value)
+        self.logit_scale = self.add_weight(shape=(1,), initializer=initializer, name="logit_scale")
+
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        from_pt = kwargs.pop("from_pt", False)
+        if from_pt:
+            import torch
+
+            from transformers import VisionTextDualEncoderModel
+
+            # a workaround to load from pytorch checkpoint, adapted from TFVisionEncoderDecoderModel
+            _model = VisionTextDualEncoderModel.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
+            config = _model.config
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                vision_model_dir = os.path.join(tmpdirname, "vision_model")
+                text_model_dir = os.path.join(tmpdirname, "text_model")
+                _model.vision_model.save_pretrained(vision_model_dir)
+                _model.text_model.save_pretrained(text_model_dir)
+
+                extra_weights = False
+                if hasattr(_model, "visual_projection"):
+                    visual_projection_kernel = tf.transpose(
+                        tf.constant(_model.visual_projection.weight.detach().to("cpu").numpy()), perm=(1, 0)
+                    )
+                    extra_weights = True
+                if hasattr(_model, "text_projection"):
+                    text_projection_kernel = tf.transpose(
+                        tf.constant(_model.text_projection.weight.detach().to("cpu").numpy()), perm=(1, 0)
+                    )
+                    extra_weights = True
+                if hasattr(_model, "logit_scale"):
+                    logit_scale = tf.constant(_model.logit_scale.detach().to("cpu").numpy())
+                    extra_weights = True
+
+                del _model
+                gc.collect()
+                torch.cuda.empty_cache()
+
+                model = cls.from_vision_text_pretrained(
+                    vision_model_dir, text_model_dir, vision_from_pt=True, text_from_pt=True
+                )
+                # This is only for copying some specific attributes of this particular model.
+                model.config = config
+
+                if extra_weights:
+                    model(model.dummy_inputs)  # Make sure it's built
+                    if hasattr(model, "visual_projection"):
+                        model.visual_projection.kernel = visual_projection_kernel
+                    if hasattr(model, "text_projection"):
+                        model.text_projection.kernel = text_projection_kernel
+                    if hasattr(model, "logit_scale"):
+                        model.logit_scale = logit_scale
+
+                return model
+
+        return super().from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 
     @add_start_docstrings_to_model_forward(VISION_TEXT_DUAL_ENCODER_TEXT_INPUTS_DOCSTRING)
     def get_text_features(
@@ -225,9 +300,9 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         Examples:
 
         ```python
-        >>> from transformers import VisionTextDualEncoderModel, AutoTokenizer
+        >>> from transformers import TFVisionTextDualEncoderModel, AutoTokenizer
 
-        >>> model = VisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian")
+        >>> model = TFVisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian")
         >>> tokenizer = AutoTokenizer.from_pretrained("clip-italian/clip-italian")
 
         >>> inputs = tokenizer(["una foto di un gatto", "una foto di un cane"], padding=True, return_tensors="pt")
@@ -266,7 +341,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         ```python
         >>> from PIL import Image
         >>> import requests
-        >>> from transformers import VisionTextDualEncoderModel, AutoImageProcessor
+        >>> from transformers import TFVisionTextDualEncoderModel, AutoImageProcessor
 
         >>> model = VisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian")
         >>> image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
@@ -274,7 +349,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
-        >>> inputs = image_processor(images=image, return_tensors="pt")
+        >>> inputs = image_processor(images=image, return_tensors="np")
 
         >>> image_features = model.get_image_features(**inputs)
         ```"""
@@ -290,20 +365,22 @@ class VisionTextDualEncoderModel(PreTrainedModel):
 
         return image_features
 
+    @unpack_inputs
     @add_start_docstrings_to_model_forward(VISION_TEXT_DUAL_ENCODER_INPUTS_DOCSTRING)
-    @replace_return_docstrings(output_type=CLIPOutput, config_class=_CONFIG_FOR_DOC)
-    def forward(
+    @replace_return_docstrings(output_type=TFCLIPOutput, config_class=_CONFIG_FOR_DOC)
+    def call(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
+        input_ids: Optional[tf.Tensor] = None,
+        pixel_values: Optional[tf.Tensor] = None,
+        attention_mask: Optional[tf.Tensor] = None,
+        position_ids: Optional[tf.Tensor] = None,
         return_loss: Optional[bool] = None,
-        token_type_ids: Optional[torch.LongTensor] = None,
+        token_type_ids: Optional[tf.Tensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple[torch.Tensor], CLIPOutput]:
+        training: bool = False,
+    ) -> Union[Tuple[tf.Tensor], TFCLIPOutput]:
         r"""
         Returns:
 
@@ -313,7 +390,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         >>> from PIL import Image
         >>> import requests
         >>> from transformers import (
-        ...     VisionTextDualEncoderModel,
+        ...     TFVisionTextDualEncoderModel,
         ...     VisionTextDualEncoderProcessor,
         ...     AutoImageProcessor,
         ...     AutoTokenizer,
@@ -322,7 +399,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         >>> image_processor = AutoImageProcessor.from_pretrained("google/vit-base-patch16-224")
         >>> processor = VisionTextDualEncoderProcessor(image_processor, tokenizer)
-        >>> model = VisionTextDualEncoderModel.from_vision_text_pretrained(
+        >>> model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(
         ...     "google/vit-base-patch16-224", "bert-base-uncased"
         ... )
 
@@ -345,12 +422,12 @@ class VisionTextDualEncoderModel(PreTrainedModel):
 
         >>> # save and load from pretrained
         >>> model.save_pretrained("vit-bert")
-        >>> model = VisionTextDualEncoderModel.from_pretrained("vit-bert")
+        >>> model = TFVisionTextDualEncoderModel.from_pretrained("vit-bert")
 
         >>> # inference
         >>> outputs = model(**inputs)
         >>> logits_per_image = outputs.logits_per_image  # this is the image-text similarity score
-        >>> probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities
+        >>> probs = tf.nn.softmax(logits_per_image, axis=1)  # we can take the softmax to get the label probabilities
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
@@ -359,6 +436,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            training=training,
         )
 
         text_outputs = self.text_model(
@@ -369,6 +447,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            training=training,
         )
 
         image_embeds = vision_outputs[1]  # pooler_output
@@ -378,13 +457,13 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         text_embeds = self.text_projection(text_embeds)
 
         # normalized features
-        image_embeds = image_embeds / image_embeds.norm(dim=-1, keepdim=True)
-        text_embeds = text_embeds / text_embeds.norm(dim=-1, keepdim=True)
+        image_embeds = image_embeds / tf.norm(image_embeds, axis=-1, keepdims=True)
+        text_embeds = text_embeds / tf.norm(text_embeds, axis=-1, keepdims=True)
 
         # cosine similarity as logits
-        logit_scale = self.logit_scale.exp()
-        logits_per_text = torch.matmul(text_embeds, image_embeds.t()) * logit_scale
-        logits_per_image = logits_per_text.T
+        logit_scale = tf.math.exp(self.logit_scale)
+        logits_per_text = tf.matmul(text_embeds, image_embeds, transpose_b=True) * logit_scale
+        logits_per_image = tf.transpose(logits_per_text)
 
         loss = None
         if return_loss:
@@ -394,7 +473,7 @@ class VisionTextDualEncoderModel(PreTrainedModel):
             output = (logits_per_image, logits_per_text, text_embeds, image_embeds, text_outputs, vision_outputs)
             return ((loss,) + output) if loss is not None else output
 
-        return CLIPOutput(
+        return TFCLIPOutput(
             loss=loss,
             logits_per_image=logits_per_image,
             logits_per_text=logits_per_text,
@@ -405,20 +484,13 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         )
 
     @classmethod
-    def from_pretrained(cls, *args, **kwargs):
-        # At the moment fast initialization is not supported
-        # for composite models
-        kwargs["_fast_init"] = False
-        return super().from_pretrained(*args, **kwargs)
-
-    @classmethod
     def from_vision_text_pretrained(
         cls,
         vision_model_name_or_path: str = None,
         text_model_name_or_path: str = None,
         *model_args,
         **kwargs,
-    ) -> PreTrainedModel:
+    ) -> TFPreTrainedModel:
         """
         Params:
             vision_model_name_or_path (`str`, *optional*, defaults to `None`):
@@ -428,11 +500,9 @@ class VisionTextDualEncoderModel(PreTrainedModel):
                       Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
                       user or organization name, like `dbmdz/bert-base-german-cased`.
                     - A path to a *directory* containing model weights saved using
-                      [`~PreTrainedModel.save_pretrained`], e.g., `./my_model_directory/`.
+                      [`~TFPreTrainedModel.save_pretrained`], e.g., `./my_model_directory/`.
                     - A path or url to a *PyTorch checkpoint folder* (e.g, `./pt_model`). In this case, `from_pt`
-                      should be set to `True` and a configuration object should be provided as `config` argument. This
-                      loading path is slower than converting the PyTorch checkpoint in a Flax model using the provided
-                      conversion scripts and loading the Flax model afterwards.
+                      should be set to `True` and a configuration object should be provided as `config` argument.
 
             text_model_name_or_path (`str`, *optional*):
                 Information necessary to initiate the text model. Can be either:
@@ -441,11 +511,9 @@ class VisionTextDualEncoderModel(PreTrainedModel):
                       Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced under a
                       user or organization name, like `dbmdz/bert-base-german-cased`.
                     - A path to a *directory* containing model weights saved using
-                      [`~PreTrainedModel.save_pretrained`], e.g., `./my_model_directory/`.
+                      [`~TFPreTrainedModel.save_pretrained`], e.g., `./my_model_directory/`.
                     - A path or url to a *PyTorch checkpoint folder* (e.g, `./pt_model`). In this case, `from_pt`
-                      should be set to `True` and a configuration object should be provided as `config` argument. This
-                      loading path is slower than converting the PyTorch checkpoint in a Flax model using the provided
-                      conversion scripts and loading the Flax model afterwards.
+                      should be set to `True` and a configuration object should be provided as `config` argument.
 
             model_args (remaining positional arguments, *optional*):
                 All remaning positional arguments will be passed to the underlying model's `__init__` method.
@@ -463,16 +531,16 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         Example:
 
         ```python
-        >>> from transformers import VisionTextDualEncoderModel
+        >>> from transformers import TFVisionTextDualEncoderModel
 
         >>> # initialize a model from pretrained ViT and BERT models. Note that the projection layers will be randomly initialized.
-        >>> model = VisionTextDualEncoderModel.from_vision_text_pretrained(
+        >>> model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(
         ...     "google/vit-base-patch16-224", "bert-base-uncased"
         ... )
         >>> # saving model after fine-tuning
         >>> model.save_pretrained("./vit-bert")
         >>> # load fine-tuned model
-        >>> model = VisionTextDualEncoderModel.from_pretrained("./vit-bert")
+        >>> model = TFVisionTextDualEncoderModel.from_pretrained("./vit-bert")
         ```"""
         kwargs_vision = {
             argument[len("vision_") :]: value for argument, value in kwargs.items() if argument.startswith("vision_")
@@ -495,17 +563,24 @@ class VisionTextDualEncoderModel(PreTrainedModel):
                 raise ValueError(
                     "If `vision_model` is not defined as an argument, a `vision_model_name_or_path` has to be defined"
                 )
+            kwargs_vision["name"] = "vision_model"
+            kwargs_vision["load_weight_prefix"] = cls.load_weight_prefix
 
-            if "config" not in kwargs_vision:
+            vision_config_dict, unused_args = PretrainedConfig.get_config_dict(vision_model_name_or_path, **kwargs)
+            if vision_config_dict.get("model_type", None) == "clip_vision_model":
+                vision_config = CLIPVisionConfig.from_dict(vision_config_dict)
+            else:
                 vision_config = AutoConfig.from_pretrained(vision_model_name_or_path)
 
-            if vision_config.model_type == "clip":
+            if vision_config.model_type == "clip_vision_model":
+                kwargs_vision["config"] = vision_config
+                vision_model = TFCLIPVisionModel.from_pretrained(vision_model_name_or_path, *model_args, **kwargs_vision)
+            elif vision_config.model_type == "clip":
                 kwargs_vision["config"] = vision_config.vision_config
-                vision_model = CLIPVisionModel.from_pretrained(vision_model_name_or_path, *model_args, **kwargs_vision)
-                # TODO: Should we use the pre-trained projection as well ?
+                vision_model = TFCLIPVisionModel.from_pretrained(vision_model_name_or_path, *model_args, **kwargs_vision)
             else:
                 kwargs_vision["config"] = vision_config
-                vision_model = AutoModel.from_pretrained(vision_model_name_or_path, *model_args, **kwargs_vision)
+                vision_model = TFAutoModel.from_pretrained(vision_model_name_or_path, *model_args, **kwargs_vision)
 
         text_model = kwargs_text.pop("model", None)
         if text_model is None:
@@ -513,12 +588,14 @@ class VisionTextDualEncoderModel(PreTrainedModel):
                 raise ValueError(
                     "If `text_model` is not defined as an argument, a `text_model_name_or_path` has to be defined"
                 )
+            kwargs_text["name"] = "text_model"
+            kwargs_text["load_weight_prefix"] = cls.load_weight_prefix
 
             if "config" not in kwargs_text:
                 text_config = AutoConfig.from_pretrained(text_model_name_or_path)
                 kwargs_text["config"] = text_config
 
-            text_model = AutoModel.from_pretrained(text_model_name_or_path, *model_args, **kwargs_text)
+            text_model = TFAutoModel.from_pretrained(text_model_name_or_path, *model_args, **kwargs_text)
 
         # instantiate config with corresponding kwargs
         config = VisionTextDualEncoderConfig.from_vision_text_configs(vision_model.config, text_model.config, **kwargs)
@@ -535,3 +612,27 @@ class VisionTextDualEncoderModel(PreTrainedModel):
         )
 
         return model
+
+    @property
+    def dummy_inputs(self):
+        """
+        Dummy inputs to build the network.
+
+        Returns:
+            `Dict[str, tf.Tensor]`: The dummy inputs.
+        """
+        input_ids = tf.constant(DUMMY_INPUTS, dtype=tf.int32)
+        batch_size, seq_len = input_ids.shape
+
+        VISION_DUMMY_INPUTS = tf.random.uniform(
+            shape=(
+                batch_size,
+                self.config.vision_config.num_channels,
+                self.config.vision_config.image_size,
+                self.config.vision_config.image_size,
+            ),
+            dtype=tf.float32,
+        )
+        pixel_values = tf.constant(VISION_DUMMY_INPUTS)
+        dummy = {"pixel_values": pixel_values, "input_ids": input_ids}
+        return dummy

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -304,7 +304,7 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
         r"""
         Returns:
             image_features (`tf.Tensor` of shape `(batch_size, output_dim`): The image embeddings obtained by
-            applying the projection layer to the pooled output of [`CLIPVisionModel`].
+            applying the projection layer to the pooled output of [`TFCLIPVisionModel`].
 
         Examples:
 

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -264,8 +264,8 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
     ):
         r"""
         Returns:
-            text_features (`tf.Tensor` of shape `(batch_size, output_dim`): The text embeddings obtained by
-            applying the projection layer to the pooled output of [`TFCLIPTextModel`].
+            text_features (`tf.Tensor` of shape `(batch_size, output_dim`): The text embeddings obtained by applying
+            the projection layer to the pooled output of [`TFCLIPTextModel`].
 
         Examples:
 
@@ -303,8 +303,8 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
     ):
         r"""
         Returns:
-            image_features (`tf.Tensor` of shape `(batch_size, output_dim`): The image embeddings obtained by
-            applying the projection layer to the pooled output of [`TFCLIPVisionModel`].
+            image_features (`tf.Tensor` of shape `(batch_size, output_dim`): The image embeddings obtained by applying
+            the projection layer to the pooled output of [`TFCLIPVisionModel`].
 
         Examples:
 

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -303,7 +303,7 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
     ):
         r"""
         Returns:
-            image_features (`torch.FloatTensor` of shape `(batch_size, output_dim`): The image embeddings obtained by
+            image_features (`tf.Tensor` of shape `(batch_size, output_dim`): The image embeddings obtained by
             applying the projection layer to the pooled output of [`CLIPVisionModel`].
 
         Examples:

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -264,7 +264,7 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
     ):
         r"""
         Returns:
-            text_features (`torch.FloatTensor` of shape `(batch_size, output_dim`): The text embeddings obtained by
+            text_features (`tf.Tensor` of shape `(batch_size, output_dim`): The text embeddings obtained by
             applying the projection layer to the pooled output of [`CLIPTextModel`].
 
         Examples:

--- a/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
+++ b/src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
@@ -265,7 +265,7 @@ class TFVisionTextDualEncoderModel(TFPreTrainedModel):
         r"""
         Returns:
             text_features (`tf.Tensor` of shape `(batch_size, output_dim`): The text embeddings obtained by
-            applying the projection layer to the pooled output of [`CLIPTextModel`].
+            applying the projection layer to the pooled output of [`TFCLIPTextModel`].
 
         Examples:
 

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -2469,6 +2469,13 @@ class TFVisionEncoderDecoderModel(metaclass=DummyObject):
         requires_backends(self, ["tf"])
 
 
+class TFVisionTextDualEncoderModel(metaclass=DummyObject):
+    _backends = ["tf"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tf"])
+
+
 class TFViTForImageClassification(metaclass=DummyObject):
     _backends = ["tf"]
 

--- a/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
@@ -1,0 +1,416 @@
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Testing suite for the PyTorch VisionTextDualEncoder model. """
+
+
+import collections
+import tempfile
+import unittest
+
+import numpy as np
+
+from transformers.testing_utils import require_tf, require_vision, slow
+from transformers.utils import is_vision_available, is_tf_available
+
+from ...test_modeling_tf_common import floats_tensor, ids_tensor, random_attention_mask
+from ..bert.test_modeling_tf_bert import TFBertModelTester
+from ..clip.test_modeling_tf_clip import TFCLIPVisionModelTester
+from ..deit.test_modeling_tf_deit import TFDeiTModelTester
+from ..roberta.test_modeling_tf_roberta import TFRobertaModelTester
+from ..vit.test_modeling_tf_vit import TFViTModelTester
+
+
+if is_tf_available():
+    from transformers import (
+        TFBertModel,
+        TFCLIPVisionModel,
+        TFDeiTModel,
+        TFRobertaModel,
+        VisionTextDualEncoderConfig,
+        TFVisionTextDualEncoderModel,
+        TFViTModel,
+    )
+
+if is_vision_available():
+    from PIL import Image
+    from transformers import VisionTextDualEncoderProcessor
+
+
+# Inspired by
+# https://github.com/rwightman/pytorch-image-models/blob/b9bd960a032c75ca6b808ddeed76bee5f3ed4972/timm/models/layers/helpers.py
+# From PyTorch internals
+def to_2tuple(x):
+    if isinstance(x, collections.abc.Iterable):
+        return x
+    return (x, x)
+
+
+@require_tf
+class TFVisionTextDualEncoderMixin:
+    def get_vision_text_model(self, config, text_config):
+        pass
+
+    def prepare_config_and_inputs(self):
+        pass
+
+    def get_pretrained_model_and_inputs(self):
+        pass
+
+    def check_model_from_pretrained_configs(
+        self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs
+    ):
+        config = VisionTextDualEncoderConfig.from_vision_text_configs(vision_config, text_config)
+
+        model = TFVisionTextDualEncoderModel(config)
+
+        output = model(input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask)
+
+        self.assertEqual(output["text_embeds"].shape, (input_ids.shape[0], config.projection_dim))
+        self.assertEqual(output["image_embeds"].shape, (pixel_values.shape[0], config.projection_dim))
+
+    def check_vision_text_dual_encoder_model(
+        self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs
+    ):
+        vision_model, text_model = self.get_vision_text_model(vision_config, text_config)
+        model = TFVisionTextDualEncoderModel(vision_model=vision_model, text_model=text_model)
+
+        output = model(input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask)
+
+        self.assertEqual(output["text_embeds"].shape, (input_ids.shape[0], model.config.projection_dim))
+        self.assertEqual(output["image_embeds"].shape, (pixel_values.shape[0], model.config.projection_dim))
+
+    def check_vision_text_dual_encoder_from_pretrained(
+        self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs
+    ):
+        vision_model, text_model = self.get_vision_text_model(vision_config, text_config)
+        kwargs = {"vision_model": vision_model, "text_model": text_model}
+        model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(**kwargs)
+
+        output = model(input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask)
+
+        self.assertEqual(output["text_embeds"].shape, (input_ids.shape[0], model.config.projection_dim))
+        self.assertEqual(output["image_embeds"].shape, (pixel_values.shape[0], model.config.projection_dim))
+
+    def check_save_load(self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs):
+        vision_model, text_model = self.get_vision_text_model(vision_config, text_config)
+        model = TFVisionTextDualEncoderModel(vision_model=vision_model, text_model=text_model)
+
+        output = model(input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask)
+        out_1 = output[0].numpy()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.save_pretrained(tmpdirname)
+            model = TFVisionTextDualEncoderModel.from_pretrained(tmpdirname)
+
+            after_output = model(input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask)
+            out_2 = after_output[0].numpy()
+            max_diff = np.amax(np.abs(out_2 - out_1))
+            self.assertLessEqual(max_diff, 1e-5)
+
+    def check_vision_text_output_attention(
+        self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs
+    ):
+        vision_model, text_model = self.get_vision_text_model(vision_config, text_config)
+        model = TFVisionTextDualEncoderModel(vision_model=vision_model, text_model=text_model)
+
+        output = model(
+            input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask, output_attentions=True
+        )
+
+        vision_attentions = output.vision_model_output.attentions
+        self.assertEqual(len(vision_attentions), vision_config.num_hidden_layers)
+
+        # in ViT, the seq_len equals the number of patches + 1 (we add 1 for the [CLS] token)
+        image_size = to_2tuple(vision_model.config.image_size)
+        patch_size = to_2tuple(vision_model.config.patch_size)
+        num_patches = (image_size[1] // patch_size[1]) * (image_size[0] // patch_size[0])
+        seq_len = num_patches + 1
+        self.assertEqual(vision_attentions[0].shape[-3:], (vision_config.num_attention_heads, seq_len, seq_len))
+
+        text_attentions = output.text_model_output.attentions
+        self.assertEqual(len(text_attentions), text_config.num_hidden_layers)
+
+        self.assertEqual(
+            text_attentions[0].shape[-3:],
+            (text_config.num_attention_heads, input_ids.shape[-1], input_ids.shape[-1]),
+        )
+
+    def assert_almost_equals(self, a: np.ndarray, b: np.ndarray, tol: float):
+        diff = np.abs((a - b)).max()
+        self.assertLessEqual(diff, tol, f"Difference between torch and flax is {diff} (>= {tol}).")
+
+    def test_vision_text_dual_encoder_model(self):
+        inputs_dict = self.prepare_config_and_inputs()
+        self.check_vision_text_dual_encoder_model(**inputs_dict)
+
+    def test_model_from_pretrained_configs(self):
+        inputs_dict = self.prepare_config_and_inputs()
+        self.check_model_from_pretrained_configs(**inputs_dict)
+
+    def test_vision_text_dual_encoder_from_pretrained(self):
+        inputs_dict = self.prepare_config_and_inputs()
+        self.check_vision_text_dual_encoder_from_pretrained(**inputs_dict)
+
+    def test_save_load(self):
+        inputs_dict = self.prepare_config_and_inputs()
+        self.check_save_load(**inputs_dict)
+
+    def test_vision_text_output_attention(self):
+        inputs_dict = self.prepare_config_and_inputs()
+        self.check_vision_text_output_attention(**inputs_dict)
+
+    @slow
+    def test_real_model_save_load_from_pretrained(self):
+        model_2, inputs = self.get_pretrained_model_and_inputs()
+
+        outputs = model_2(**inputs)
+        out_2 = outputs[0].numpy()
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model_2.save_pretrained(tmp_dirname)
+            model_1 = TFVisionTextDualEncoderModel.from_pretrained(tmp_dirname)
+
+            after_outputs = model_1(**inputs)
+            out_1 = after_outputs[0].numpy()
+            max_diff = np.amax(np.abs(out_1 - out_2))
+            self.assertLessEqual(max_diff, 1e-5)
+
+
+@require_tf
+class TFViTBertModelTest(TFVisionTextDualEncoderMixin, unittest.TestCase):
+    def get_pretrained_model_and_inputs(self):
+        model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(
+            "hf-internal-testing/tiny-random-vit", "hf-internal-testing/tiny-random-bert"
+        )
+        batch_size = 13
+        pixel_values = floats_tensor(
+            [
+                batch_size,
+                model.vision_model.config.num_channels,
+                model.vision_model.config.image_size,
+                model.vision_model.config.image_size,
+            ]
+        )
+        input_ids = ids_tensor([batch_size, 4], model.text_model.config.vocab_size)
+        attention_mask = random_attention_mask([batch_size, 4])
+        inputs = {"pixel_values": pixel_values, "input_ids": input_ids, "attention_mask": attention_mask}
+
+        return model, inputs
+
+    def get_vision_text_model(self, vision_config, text_config):
+        vision_model = TFViTModel(vision_config, name="vision_model")
+        text_model = TFBertModel(text_config, name="text_model")
+        return vision_model, text_model
+
+    def prepare_config_and_inputs(self):
+        vit_model_tester = TFViTModelTester(self)
+        bert_model_tester = TFBertModelTester(self)
+        vision_config_and_inputs = vit_model_tester.prepare_config_and_inputs()
+        text_config_and_inputs = bert_model_tester.prepare_config_and_inputs()
+
+        vision_config, pixel_values, _ = vision_config_and_inputs
+
+        (
+            text_config,
+            input_ids,
+            token_type_ids,
+            input_mask,
+            sequence_labels,
+            token_labels,
+            choice_labels,
+        ) = text_config_and_inputs
+
+        return {
+            "text_config": text_config,
+            "vision_config": vision_config,
+            "pixel_values": pixel_values,
+            "attention_mask": input_mask,
+            "input_ids": input_ids,
+            "text_token_type_ids": token_type_ids,
+            "text_sequence_labels": sequence_labels,
+            "text_token_labels": token_labels,
+            "text_choice_labels": choice_labels,
+        }
+
+
+@require_tf
+class TFDeiTRobertaModelTest(TFVisionTextDualEncoderMixin, unittest.TestCase):
+    def get_pretrained_model_and_inputs(self):
+        # DeiT repo doesn't have TF weights, but we don't actually use the weights at all so let's
+        # just reinitialize it.
+        model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(
+            "Rocketknight1/tiny-random-deit-tf", "hf-internal-testing/tiny-random-roberta"
+        )
+        batch_size = 13
+        pixel_values = floats_tensor(
+            [
+                batch_size,
+                model.vision_model.config.num_channels,
+                model.vision_model.config.image_size,
+                model.vision_model.config.image_size,
+            ]
+        )
+        input_ids = ids_tensor([batch_size, 4], model.text_model.config.vocab_size)
+        attention_mask = random_attention_mask([batch_size, 4])
+        inputs = {"pixel_values": pixel_values, "input_ids": input_ids, "attention_mask": attention_mask}
+
+        return model, inputs
+
+    def check_vision_text_output_attention(
+        self, text_config, input_ids, attention_mask, vision_config, pixel_values=None, **kwargs
+    ):
+        vision_model, text_model = self.get_vision_text_model(vision_config, text_config)
+        model = TFVisionTextDualEncoderModel(vision_model=vision_model, text_model=text_model)
+
+        output = model(
+            input_ids=input_ids, pixel_values=pixel_values, attention_mask=attention_mask, output_attentions=True
+        )
+
+        vision_attentions = output.vision_model_output.attentions
+        self.assertEqual(len(vision_attentions), vision_config.num_hidden_layers)
+
+        # in DEiT, the seq_len equals the number of patches + 2 (we add 2 for the [CLS] and distillation tokens)
+        image_size = to_2tuple(vision_model.config.image_size)
+        patch_size = to_2tuple(vision_model.config.patch_size)
+        num_patches = (image_size[1] // patch_size[1]) * (image_size[0] // patch_size[0])
+        seq_len = num_patches + 2
+        self.assertEqual(vision_attentions[0].shape[-3:], (vision_config.num_attention_heads, seq_len, seq_len))
+
+        text_attentions = output.text_model_output.attentions
+        self.assertEqual(len(text_attentions), text_config.num_hidden_layers)
+
+        self.assertEqual(
+            text_attentions[0].shape[-3:],
+            (text_config.num_attention_heads, input_ids.shape[-1], input_ids.shape[-1]),
+        )
+
+    def get_vision_text_model(self, vision_config, text_config):
+        vision_model = TFDeiTModel(vision_config, name="vision_model")
+        text_model = TFRobertaModel(text_config, name="text_model")
+        return vision_model, text_model
+
+    def prepare_config_and_inputs(self):
+        vit_model_tester = TFDeiTModelTester(self)
+        bert_model_tester = TFRobertaModelTester(self)
+        vision_config_and_inputs = vit_model_tester.prepare_config_and_inputs()
+        text_config_and_inputs = bert_model_tester.prepare_config_and_inputs()
+
+        vision_config, pixel_values, _ = vision_config_and_inputs
+
+        (
+            text_config,
+            input_ids,
+            token_type_ids,
+            input_mask,
+            sequence_labels,
+            token_labels,
+            choice_labels,
+        ) = text_config_and_inputs
+
+        return {
+            "text_config": text_config,
+            "vision_config": vision_config,
+            "pixel_values": pixel_values,
+            "attention_mask": input_mask,
+            "input_ids": input_ids,
+            "text_token_type_ids": token_type_ids,
+            "text_sequence_labels": sequence_labels,
+            "text_token_labels": token_labels,
+            "text_choice_labels": choice_labels,
+        }
+
+
+@require_tf
+class TFCLIPVisionBertModelTest(TFVisionTextDualEncoderMixin, unittest.TestCase):
+    def get_pretrained_model_and_inputs(self):
+        model = TFVisionTextDualEncoderModel.from_vision_text_pretrained(
+            "Rocketknight1/tiny-random-clip-tf", "hf-internal-testing/tiny-random-bert"
+        )
+        batch_size = 13
+        pixel_values = floats_tensor(
+            [
+                batch_size,
+                model.vision_model.config.num_channels,
+                model.vision_model.config.image_size,
+                model.vision_model.config.image_size,
+            ]
+        )
+        input_ids = ids_tensor([batch_size, 4], model.text_model.config.vocab_size)
+        attention_mask = random_attention_mask([batch_size, 4])
+        inputs = {"pixel_values": pixel_values, "input_ids": input_ids, "attention_mask": attention_mask}
+
+        return model, inputs
+
+    def get_vision_text_model(self, vision_config, text_config):
+        vision_model = TFCLIPVisionModel(vision_config, name="vision_model")
+        text_model = TFBertModel(text_config, name="text_model")
+        return vision_model, text_model
+
+    def prepare_config_and_inputs(self):
+        clip_model_tester = TFCLIPVisionModelTester(self)
+        bert_model_tester = TFBertModelTester(self)
+        vision_config_and_inputs = clip_model_tester.prepare_config_and_inputs()
+        text_config_and_inputs = bert_model_tester.prepare_config_and_inputs()
+
+        vision_config, pixel_values = vision_config_and_inputs
+
+        (
+            text_config,
+            input_ids,
+            token_type_ids,
+            input_mask,
+            sequence_labels,
+            token_labels,
+            choice_labels,
+        ) = text_config_and_inputs
+
+        return {
+            "text_config": text_config,
+            "vision_config": vision_config,
+            "pixel_values": pixel_values,
+            "attention_mask": input_mask,
+            "input_ids": input_ids,
+            "text_token_type_ids": token_type_ids,
+            "text_sequence_labels": sequence_labels,
+            "text_token_labels": token_labels,
+            "text_choice_labels": choice_labels,
+        }
+
+
+@require_vision
+@require_tf
+class TFVisionTextDualEncoderIntegrationTest(unittest.TestCase):
+    @slow
+    def test_inference(self):
+        model = TFVisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1, from_pt=True)
+        processor = VisionTextDualEncoderProcessor.from_pretrained("clip-italian/clip-italian")
+
+        image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
+        inputs = processor(
+            text=["una foto di un gatto", "una foto di un cane"], images=image, padding=True, return_tensors="np"
+        )
+
+        outputs = model(**inputs)
+
+        # verify the logits
+        self.assertEqual(outputs.logits_per_image.shape, (inputs.pixel_values.shape[0], inputs.input_ids.shape[0]))
+        self.assertEqual(
+            outputs.logits_per_text.shape,
+            (inputs.input_ids.shape[0], inputs.pixel_values.shape[0]),
+        )
+
+        expected_logits = np.array([[1.2284727, 0.3104122]])
+
+        self.assertTrue(np.allclose(outputs.logits_per_image.numpy(), expected_logits, atol=1e-3))

--- a/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
@@ -22,7 +22,7 @@ import unittest
 import numpy as np
 
 from transformers.testing_utils import require_tf, require_vision, slow
-from transformers.utils import is_vision_available, is_tf_available
+from transformers.utils import is_tf_available, is_vision_available
 
 from ...test_modeling_tf_common import floats_tensor, ids_tensor, random_attention_mask
 from ..bert.test_modeling_tf_bert import TFBertModelTester
@@ -38,13 +38,14 @@ if is_tf_available():
         TFCLIPVisionModel,
         TFDeiTModel,
         TFRobertaModel,
-        VisionTextDualEncoderConfig,
         TFVisionTextDualEncoderModel,
         TFViTModel,
+        VisionTextDualEncoderConfig,
     )
 
 if is_vision_available():
     from PIL import Image
+
     from transformers import VisionTextDualEncoderProcessor
 
 
@@ -394,7 +395,9 @@ class TFCLIPVisionBertModelTest(TFVisionTextDualEncoderMixin, unittest.TestCase)
 class TFVisionTextDualEncoderIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
-        model = TFVisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1, from_pt=True)
+        model = TFVisionTextDualEncoderModel.from_pretrained(
+            "clip-italian/clip-italian", logit_scale_init_value=1, from_pt=True
+        )
         processor = VisionTextDualEncoderProcessor.from_pretrained("clip-italian/clip-italian")
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -173,6 +173,7 @@ TEST_FILES_WITH_NO_COMMON_TESTS = [
     "models/xlm_prophetnet/test_modeling_xlm_prophetnet.py",
     "models/xlm_roberta/test_modeling_xlm_roberta.py",
     "models/vision_text_dual_encoder/test_modeling_vision_text_dual_encoder.py",
+    "models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py",
     "models/vision_text_dual_encoder/test_modeling_flax_vision_text_dual_encoder.py",
     "models/decision_transformer/test_modeling_decision_transformer.py",
 ]

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -198,6 +198,7 @@ src/transformers/models/vilt/modeling_vilt.py
 src/transformers/models/vision_encoder_decoder/configuration_vision_encoder_decoder.py
 src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
 src/transformers/models/vision_text_dual_encoder/configuration_vision_text_dual_encoder.py
+src/transformers/models/vision_text_dual_encoder/modeling_tf_vision_text_dual_encoder.py
 src/transformers/models/vit/configuration_vit.py
 src/transformers/models/vit/modeling_vit.py
 src/transformers/models/vit/modeling_tf_vit.py


### PR DESCRIPTION
This PR uses the new weight crossloading functions to add the missing `TFVisionTextDualEncoder` class.