### PR TITLE
Make loading of pretrained gpt2 faster by avoiding initialization of Conv1D's weights

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -105,10 +105,9 @@ class Conv1D(nn.Module):
     def __init__(self, nf, nx):
         super().__init__()
         self.nf = nf
-        w = torch.empty(nx, nf)
-        nn.init.normal_(w, std=0.02)
-        self.weight = nn.Parameter(w)
+        self.weight = nn.Parameter(torch.empty(nx, nf))
         self.bias = nn.Parameter(torch.zeros(nf))
+        nn.init.normal_(self.weight, std=0.02)
 
     def forward(self, x):
         size_out = x.size()[:-1] + (self.nf,)


### PR DESCRIPTION
# What does this PR do?
Currently, pytorch_util's Conv1D always computes `normal_` to initialize weights regardless of `init_empty_weights`.
It makes model loading time of gpt2 longer.
This PR fixes this by reordering the initialization of Conv1D to apply `normal_` after assigning weight as `nn.Parameter` to avoid unnecessary initialization computation.

gpt2-xl.py
```py
from transformers import AutoModelForCausalLM
import torch

model = AutoModelForCausalLM.from_pretrained(
        "gpt2-xl",
        torch_dtype=torch.half,
        low_cpu_mem_usage=True)
```

before
```
$ python -m cProfile -s tottime gpt2-xl.py | head
         1815860 function calls (1739023 primitive calls) in 25.421 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      243   19.131    0.079   19.131    0.079 {method 'normal_' of 'torch._C._TensorBase' objects}
     1256    1.820    0.001    1.820    0.001 {method '_set_from_file' of 'torch._C.StorageBase' objects}
     3045    1.427    0.000    1.427    0.000 {method 'to' of 'torch._C._TensorBase' objects}
        2    0.677    0.339    0.677    0.339 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        2    0.380    0.190    0.380    0.190 {method 'read' of '_ssl._SSLSocket' objects}
```

after
```
$ python -m cProfile -s tottime gpt2-xl.py | head
         1816052 function calls (1739215 primitive calls) in 5.691 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1256    1.791    0.001    1.791    0.001 {method '_set_from_file' of 'torch._C.StorageBase' objects}
     3045    0.892    0.000    0.892    0.000 {method 'to' of 'torch._C._TensorBase' objects}
        2    0.676    0.338    0.676    0.338 {method 'do_handshake' of '_ssl._SSLSocket' objects}
        2    0.402    0.201    0.402    0.201 {method 'connect' of '_socket.socket' objects}
        2    0.373    0.186    0.373    0.186 {method 'read' of '_ssl._SSLSocket' objects}
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #21863

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
