### PR TITLE
Fix `WhisperModelTest` 

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -996,9 +996,7 @@ class WhisperDecoder(WhisperPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length).to(
-            inputs_embeds.device
-        )
+        positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length)
 
         hidden_states = inputs_embeds + positions
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -996,7 +996,9 @@ class WhisperDecoder(WhisperPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length)
+        positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length).to(
+            inputs_embeds.device
+        )
 
         hidden_states = inputs_embeds + positions
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)


### PR DESCRIPTION
# What does this PR do?


### Fix `test_model_parallelism` for `Whisper`
A merged PR `Add WhisperTokenizerFast` (#21222)  (02/21) started failing `test_model_parallelism` .
That PR didn't change relevant test/modeling file, but just changed the model tester's vocab size from `99` to `200`.

When I traced it, I found at this places inside `WhisperDecoder`
```python
inputs_embeds = self.embed_tokens(input_ids)
positions = self.embed_positions(input_ids, ...)
hidden_states = inputs_embeds + positions
```
- in previous commit,  `embed_tokens` and `embed_positions` weight matrices are on the same GPU `1`.
- After that PR, one is on GPU `0` another being on GPU `1`. 

I fixed the issue by adding

```python
    # Needs higher percentages after model tester's vocab_size is changed to 200 (PR #21222)
    model_split_percents = [0.8, 0.9]
```

### Fix `test_torchscript_*` for `Whisper`

PR #21298 added an optional argument `attention_mask` to `WhisperModel` model classes. `torchscript` tests need a bit change to make it work.