### PR TITLE
Fix pipe comm test

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -302,7 +302,6 @@ SUPPORTED_TASKS = {
     },
     "zero-shot-audio-classification": {
         "impl": ZeroShotAudioClassificationPipeline,
-        "tf": (TFAutoModel,) if is_tf_available() else (),
         "pt": (AutoModel,) if is_torch_available() else (),
         "default": {
             "model": {

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -302,6 +302,7 @@ SUPPORTED_TASKS = {
     },
     "zero-shot-audio-classification": {
         "impl": ZeroShotAudioClassificationPipeline,
+        "tf": (),
         "pt": (AutoModel,) if is_torch_available() else (),
         "default": {
             "model": {


### PR DESCRIPTION
# What does this PR do?

PR #21600 added task `zero-shot-audio-classification`:
```python
    "zero-shot-audio-classification": {
        "impl": ZeroShotAudioClassificationPipeline,
        "tf": (TFAutoModel,) if is_tf_available() else (),
        "pt": (AutoModel,) if is_torch_available() else (),
        "default": {
            "model": {
                "pt": ("laion/clap-htsat-fused", "f39917b"),
            }
        },
        "type": "multimodal",
    },
```

But this fails the test `tests/pipelines/test_pipelines_common.py::PipelineUtilsTest::test_load_default_pipelines_tf` as there is `tf` key under the `task`, but not under `task/default`. There is a check in that test method:
```python
        if len(relevant_auto_classes) == 0:
            # task has no default
            logger.debug(f"{task} in {framework} has no default")
            return
```
So I decide to set `"tf": (),` for now. 

(We have no `TFClap` yet)