### PR TITLE
Add `inputs_embeds` functionality when generating with BioGPT 

### DIFF
--- a/src/transformers/models/biogpt/modeling_biogpt.py
+++ b/src/transformers/models/biogpt/modeling_biogpt.py
@@ -703,7 +703,9 @@ class BioGptForCausalLM(BioGptPreTrainedModel):
             cross_attentions=outputs.cross_attentions,
         )
 
-    def prepare_inputs_for_generation(self, input_ids, attention_mask, inputs_embeds = None, past_key_values=None, **kwargs):
+    def prepare_inputs_for_generation(
+        self, input_ids, attention_mask, inputs_embeds=None, past_key_values=None, **kwargs
+    ):
         # only last token for inputs_ids if past is defined in kwargs
         if past_key_values:
             input_ids = input_ids[:, -1].unsqueeze(-1)
@@ -715,9 +717,9 @@ class BioGptForCausalLM(BioGptPreTrainedModel):
 
         model_inputs.update(
             {
-            "attention_mask": attention_mask,
-            "past_key_values": past_key_values,
-            "use_cache": kwargs.get("use_cache"),
+                "attention_mask": attention_mask,
+                "past_key_values": past_key_values,
+                "use_cache": kwargs.get("use_cache"),
             }
         )
 

--- a/src/transformers/models/biogpt/modeling_biogpt.py
+++ b/src/transformers/models/biogpt/modeling_biogpt.py
@@ -703,17 +703,25 @@ class BioGptForCausalLM(BioGptPreTrainedModel):
             cross_attentions=outputs.cross_attentions,
         )
 
-    def prepare_inputs_for_generation(self, input_ids, attention_mask, past_key_values=None, **kwargs):
+    def prepare_inputs_for_generation(self, input_ids, attention_mask, inputs_embeds = None, past_key_values=None, **kwargs):
         # only last token for inputs_ids if past is defined in kwargs
         if past_key_values:
             input_ids = input_ids[:, -1].unsqueeze(-1)
 
-        return {
-            "input_ids": input_ids,
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs = {"inputs_embeds": inputs_embeds}
+        else:
+            model_inputs = {"input_ids": input_ids}
+
+        model_inputs.update(
+            {
             "attention_mask": attention_mask,
             "past_key_values": past_key_values,
             "use_cache": kwargs.get("use_cache"),
-        }
+            }
+        )
+
+        return model_inputs
 
     @staticmethod
     def _reorder_cache(past_key_values, beam_idx):


### PR DESCRIPTION
# What does this PR do?


This PR extends https://github.com/huggingface/transformers/pull/21405 by @gante to BioGPT, making it accept inputs_embeds when generating.

```
import torch
from transformers import  BioGptTokenizer, BioGptForCausalLM


model = BioGptForCausalLM.from_pretrained("microsoft/biogpt")
tokenizer = BioGptTokenizer.from_pretrained("microsoft/biogpt")

inputs_embeds = torch.rand((1, 1, 1024)) # 1 dummy soft-prompt token embeddings
attention_mask = torch.ones(inputs_embeds.shape[:2], dtype=torch.long)
filler_input_ids = torch.LongTensor([[model.config.bos_token_id]])

model.generate(filler_input_ids,attention_mask = attention_mask, inputs_embeds=inputs_embeds, max_new_tokens=300, num_beams=4)
```
# Who can Review?
@gante 
