### PR TITLE
Avoid modeling tests run in pipeline CI jobs

### DIFF
--- a/tests/models/bridgetower/test_modeling_bridgetower.py
+++ b/tests/models/bridgetower/test_modeling_bridgetower.py
@@ -215,7 +215,6 @@ class BridgeTowerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    @unittest.skip(reason="skip temporarily to avoid failure on `main`")
     def test_for_image_and_text_retrieval(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_image_and_text_retrieval(*config_and_inputs)
@@ -263,12 +262,7 @@ class BridgeTowerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
                 max_diff = np.amax(np.abs(out_1 - out_2))
                 self.assertLessEqual(max_diff, 1e-5)
 
-    @unittest.skip(reason="skip temporarily to avoid failure on `main`")
-    def test_feed_forward_chunking(self):
-        pass
-
     # Override this as `hidden states output` is different for BridgeTower
-    @unittest.skip(reason="skip temporarily to avoid failure on `main`")
     def test_hidden_states_output(self):
         def check_hidden_states_output(inputs_dict, config, model_class):
             model = model_class(config)

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -105,7 +105,6 @@ PATH_TO_TRANSFORMERS = os.path.join(Path(__file__).parent.parent, "src/transform
 transformers_module = direct_transformers_import(PATH_TO_TRANSFORMERS)
 
 
-@is_pipeline_test
 class PipelineTesterMixin:
     model_tester = None
     pipeline_model_mapping = None
@@ -279,102 +278,127 @@ class PipelineTesterMixin:
 
         run_batch_test(pipeline, examples)
 
+    @is_pipeline_test
     @require_torch
     def test_pipeline_audio_classification(self):
         self.run_task_tests(task="audio-classification")
 
+    @is_pipeline_test
     def test_pipeline_automatic_speech_recognition(self):
         self.run_task_tests(task="automatic-speech-recognition")
 
+    @is_pipeline_test
     def test_pipeline_conversational(self):
         self.run_task_tests(task="conversational")
 
+    @is_pipeline_test
     @require_vision
     @require_timm
     @require_torch
     def test_pipeline_depth_estimation(self):
         self.run_task_tests(task="depth-estimation")
 
+    @is_pipeline_test
     @require_pytesseract
     @require_torch
     @require_vision
     def test_pipeline_document_question_answering(self):
         self.run_task_tests(task="document-question-answering")
 
+    @is_pipeline_test
     def test_pipeline_feature_extraction(self):
         self.run_task_tests(task="feature-extraction")
 
+    @is_pipeline_test
     def test_pipeline_fill_mask(self):
         self.run_task_tests(task="fill-mask")
 
+    @is_pipeline_test
     @require_torch_or_tf
     @require_vision
     def test_pipeline_image_classification(self):
         self.run_task_tests(task="image-classification")
 
+    @is_pipeline_test
     @require_vision
     @require_timm
     @require_torch
     def test_pipeline_image_segmentation(self):
         self.run_task_tests(task="image-segmentation")
 
+    @is_pipeline_test
     @require_vision
     def test_pipeline_image_to_text(self):
         self.run_task_tests(task="image-to-text")
 
+    @is_pipeline_test
     @require_vision
     @require_timm
     @require_torch
     def test_pipeline_object_detection(self):
         self.run_task_tests(task="object-detection")
 
+    @is_pipeline_test
     def test_pipeline_question_answering(self):
         self.run_task_tests(task="question-answering")
 
+    @is_pipeline_test
     def test_pipeline_summarization(self):
         self.run_task_tests(task="summarization")
 
+    @is_pipeline_test
     def test_pipeline_table_question_answering(self):
         self.run_task_tests(task="table-question-answering")
 
+    @is_pipeline_test
     def test_pipeline_text2text_generation(self):
         self.run_task_tests(task="text2text-generation")
 
+    @is_pipeline_test
     def test_pipeline_text_classification(self):
         self.run_task_tests(task="text-classification")
 
+    @is_pipeline_test
     @require_torch_or_tf
     def test_pipeline_text_generation(self):
         self.run_task_tests(task="text-generation")
 
+    @is_pipeline_test
     def test_pipeline_token_classification(self):
         self.run_task_tests(task="token-classification")
 
+    @is_pipeline_test
     def test_pipeline_translation(self):
         self.run_task_tests(task="translation")
 
+    @is_pipeline_test
     @require_torch_or_tf
     @require_vision
     @require_decord
     def test_pipeline_video_classification(self):
         self.run_task_tests(task="video-classification")
 
+    @is_pipeline_test
     @require_torch
     @require_vision
     def test_pipeline_visual_question_answering(self):
         self.run_task_tests(task="visual-question-answering")
 
+    @is_pipeline_test
     def test_pipeline_zero_shot(self):
         self.run_task_tests(task="zero-shot")
 
+    @is_pipeline_test
     @require_torch
     def test_pipeline_zero_shot_audio_classification(self):
         self.run_task_tests(task="zero-shot-audio-classification")
 
+    @is_pipeline_test
     @require_vision
     def test_pipeline_zero_shot_image_classification(self):
         self.run_task_tests(task="zero-shot-image-classification")
 
+    @is_pipeline_test
     @require_vision
     @require_torch
     def test_pipeline_zero_shot_object_detection(self):


### PR DESCRIPTION
# What does this PR do?

Avoid modeling tests run in pipeline CI jobs.


PR #21887 applied
```
@is_pipeline_test
class PipelineTesterMixin:
```
Together the changes in #21516
```
class BertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
```
these 2 make all modeling test methods become pipeline tests, therefore CircleCI pipeline jobs run all pipeline tests + all model tests. This causes OOM as pipeline jobs are run with `-n 8`.

This PR applies `@is_pipeline_test` to each test methods instead of the test class to avoid such issue.


### Effect

Run
```python
python -m pytest -m is_pipeline_test -v tests/models/bridgetower/test_modeling_bridgetower.py::BridgeTowerModelTest::test_model
```

#### On main
test pass

#### on this PR
test deselected