### PR TITLE
update model_split_percents

### DIFF
--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -285,7 +285,8 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     test_pruning = False
     test_missing_keys = False
     # Needs higher percentages after model tester's vocab_size is changed to 200 (PR #21222)
-    model_split_percents = [0.8, 0.9]
+    # `0.5` is for `test_disk_offload` (which also works for `test_model_parallelism`)
+    model_split_percents = [0.5, 0.8, 0.9]
 
     input_name = "input_features"
 


### PR DESCRIPTION
# What does this PR do?

#21883 changed `WhisperModelTest`'s `model_split_percents ` from `[0.5, 0.7, 0.9]` to `= [0.8, 0.9]` to make `test_model_parallelism` work. But it fails `test_disk_offload` which uses `self.model_split_percents[0]`.

This PR adds back `0.5`. With `model_split_percents = [0.5, 0.8, 0.9]`, the relevant Whisper tests using `model_split_percents` all pass.

