### PR TITLE
Fix `AlignModelTest` tests

### DIFF
--- a/tests/models/align/test_modeling_align.py
+++ b/tests/models/align/test_modeling_align.py
@@ -521,6 +521,15 @@ class AlignModelTest(ModelTesterMixin, unittest.TestCase):
             model_state_dict = model.state_dict()
             loaded_model_state_dict = loaded_model.state_dict()
 
+            non_persistent_buffers = {}
+            for key in loaded_model_state_dict.keys():
+                if key not in model_state_dict.keys():
+                    non_persistent_buffers[key] = loaded_model_state_dict[key]
+
+            loaded_model_state_dict = {
+                key: value for key, value in loaded_model_state_dict.items() if key not in non_persistent_buffers
+            }
+
             self.assertEqual(set(model_state_dict.keys()), set(loaded_model_state_dict.keys()))
 
             models_equal = True

--- a/tests/models/align/test_modeling_align.py
+++ b/tests/models/align/test_modeling_align.py
@@ -65,7 +65,7 @@ class AlignVisionModelTester:
     def __init__(
         self,
         parent,
-        batch_size=13,
+        batch_size=12,
         image_size=32,
         num_channels=3,
         kernel_sizes=[3, 3, 5],
@@ -234,7 +234,7 @@ class AlignTextModelTester:
     def __init__(
         self,
         parent,
-        batch_size=13,
+        batch_size=12,
         seq_length=7,
         is_training=True,
         use_input_mask=True,


### PR DESCRIPTION
# What does this PR do?

- Fix `AlignModelTest` torchscript tests.  This model has non-persistent buffer, and need a bit more care (same as in common test)
```python
        self.register_buffer(
            "token_type_ids", torch.zeros(self.position_ids.size(), dtype=torch.long), persistent=False
        )
```

- Fix `AlignModelTest.test_multi_gpu_data_parallel_forward`: same as CLIP, we need a even number for `batch_size`, as this model have `logits_per_image` and `logits_per_text` which is of shape `(batch_size, batch_size)`, and in order to gather across devices, we need the second dim being the same. 