### PR TITLE
Use large VM for `repo_utils_job`

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -387,7 +387,7 @@ repo_utils_job = CircleCIJob(
     ],
     parallelism=None,
     pytest_num_workers=1,
-    resource_class=None,
+    resource_class="large",
     tests_to_run="tests/repo_utils",
 )
 


### PR DESCRIPTION
# What does this PR do?

Use `large` VM for `repo_utils_job`, as #21856 add `torch` for that job which requires more memory.