### PR TITLE
Use larger atol in `torch.allclose` for some tests

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2497,7 +2497,7 @@ class ModelTesterMixin:
                 torch.manual_seed(0)
                 new_output = new_model(**inputs_dict_class)
 
-                self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+                self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
 
     @require_accelerate
     @mark.accelerate_tests
@@ -2533,7 +2533,7 @@ class ModelTesterMixin:
                     torch.manual_seed(0)
                     new_output = new_model(**inputs_dict_class)
 
-                    self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+                    self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
 
     @require_accelerate
     @mark.accelerate_tests
@@ -2569,7 +2569,7 @@ class ModelTesterMixin:
                     torch.manual_seed(0)
                     new_output = new_model(**inputs_dict_class)
 
-                    self.assertTrue(torch.allclose(base_output[0], new_output[0]))
+                    self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
 
     def test_problem_types(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

Running CI against torch 2.0 (and therefore CUDA 11.7), some tests for `BridgeTowerModel` failed:
- test_disk_offload
- test_cpu_offload
- test_model_parallelism

While with torch `1.13.1` (with CUDA 11.6), the difference between `base_output` and `new_output` in these 3 tests are 0.0, we get `1e-7 ~ 3e-6` as difference for torch `2.0`.

**Deep debugging reveals that the first non-zero difference occurs when `nn.MultiheadAttention` is called.**

This PR increase the atol to `1e-5` (the default one is `1e-8`) in `ModelTesterMixin`.

If we don't feel super good with this for all model tests, we can override these 3 tests in `BridgeTowerModelTest`.
(But when more models start using `nn.MultiheadAttention`, it's best to keep this larger value in common testing file)

