### PR TITLE
Update expected values for `test_xglm_sample`

### DIFF
--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -428,8 +428,14 @@ class XGLMModelLanguageGenerationTest(unittest.TestCase):
         output_ids = model.generate(input_ids, do_sample=True, num_beams=1)
         output_str = tokenizer.decode(output_ids[0], skip_special_tokens=True)
 
-        EXPECTED_OUTPUT_STR = "Today is a nice day and the sun is shining. A nice day with warm rainy"
-        self.assertEqual(output_str, EXPECTED_OUTPUT_STR)
+        EXPECTED_OUTPUT_STRS = [
+            # TODO: remove this once we move to torch 2.0
+            # torch 1.13.1 + cu116
+            "Today is a nice day and the sun is shining. A nice day with warm rainy",
+            # torch 2.0 + cu117
+            "Today is a nice day and the water is still cold. We just stopped off for some fresh",
+        ]
+        self.assertIn(output_str, EXPECTED_OUTPUT_STRS)
 
     @slow
     def test_xglm_sample_max_time(self):


### PR DESCRIPTION
# What does this PR do?

Despite the `probs` value has only a difference of  `7.59e-07`, the `torch.multinomial(probs, num_samples=1)` still gives different `next_tokens`:

  - 3967 (`sun`) in `torch 1.13.1`
  - 4565 (`water`) in `torch 2.0`

Currently I keep both values, but we can remove the one for `torch 1.13` soon.