### PR TITLE
Update `notification_service.py`

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -820,7 +820,7 @@ if __name__ == "__main__":
 
                 for line in artifact["summary_short"].split("\n"):
                     if line.startswith("FAILED "):
-                        line = line[len("FAILED "):]
+                        line = line[len("FAILED ") :]
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in model_results[model]["failures"]:
@@ -911,7 +911,7 @@ if __name__ == "__main__":
             if failed:
                 for line in artifact["summary_short"].split("\n"):
                     if line.startswith("FAILED "):
-                        line = line[len("FAILED "):]
+                        line = line[len("FAILED ") :]
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in additional_results[key]["failures"]:

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -819,8 +819,8 @@ if __name__ == "__main__":
                 stacktraces = handle_stacktraces(artifact["failures_line"])
 
                 for line in artifact["summary_short"].split("\n"):
-                    if re.search("FAILED", line):
-                        line = line.replace("FAILED ", "")
+                    if line.startswith("FAILED "):
+                        line = line[len("FAILED "):]
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in model_results[model]["failures"]:
@@ -910,8 +910,8 @@ if __name__ == "__main__":
 
             if failed:
                 for line in artifact["summary_short"].split("\n"):
-                    if re.search("FAILED", line):
-                        line = line.replace("FAILED ", "")
+                    if line.startswith("FAILED "):
+                        line = line[len("FAILED "):]
                         line = line.split()[0].replace("\n", "")
 
                         if artifact_path["gpu"] not in additional_results[key]["failures"]:


### PR DESCRIPTION
# What does this PR do?

While working on CI report with PyTorch `2.0.0`, the first run failed to send the report due to the following problem:

- The original code checked each line in `summary_short.txt` by `if re.search("FAILED", line):`
- We expect such occurrences have 1-1 correspondence in the file `failures_line.txt`
- However, some lines in `summary_short.txt` might have ` FAILED` but not really what we are looking for. For example, some tests in `tests/extended/test_trainer_ext.py` using `execute_subprocess_async` and we get some lines like
  ```
  /transformers/examples/pytorch/translation/run_translation.py FAILED
  ```
- In such cases, we get error `stacktraces.pop(0)` at some point, as there is no more element to pop (`stacktraces`, obtained from `failures_line.txt`)
- **This PR avoids this situation by checking with `if line.startswith("FAILED "):` which should give the desired 1-1 correspondence.**
