### PR TITLE
Stop requiring Torch for our TF examples!

### DIFF
--- a/examples/tensorflow/contrastive-image-text/run_clip.py
+++ b/examples/tensorflow/contrastive-image-text/run_clip.py
@@ -273,9 +273,8 @@ def main():
         handlers=[logging.StreamHandler(sys.stdout)],
     )
 
-    if training_args.should_log:
-        # The default of training_args.log_level is passive, so we set log level at info here to have that default.
-        transformers.utils.logging.set_verbosity_info()
+    # The default of training_args.log_level is passive, so we set log level at info here to have that default.
+    transformers.utils.logging.set_verbosity_info()
 
     log_level = training_args.get_process_log_level()
     logger.setLevel(log_level)

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -250,6 +250,13 @@ class TFTrainingArguments(TrainingArguments):
         return self._setup_strategy.num_replicas_in_sync
 
     @property
+    def should_log(self):
+        """
+        Whether or not the current process should produce log.
+        """
+        return False  # TF Logging is handled by Keras not the Trainer
+
+    @property
     def train_batch_size(self) -> int:
         """
         The actual batch size for training (may differ from `per_gpu_train_batch_size` in distributed training).


### PR DESCRIPTION
This PR overrides a property in `TFTrainingArguments` to ensure that our TF examples don't accidentally depend on `torch`