### PR TITLE
Add missing optional argument summary_proj_to_labels to XLNetConfig

### DIFF
--- a/src/transformers/models/xlnet/configuration_xlnet.py
+++ b/src/transformers/models/xlnet/configuration_xlnet.py
@@ -95,7 +95,7 @@ class XLNetConfig(PretrainedConfig):
             Argument used when doing sequence summary. Used in the sequence classification and multiple choice models.
 
             Pass `"tanh"` for a tanh activation to the output, any other value will result in no activation.
-        summary_proj_to_labels (`boo`, *optional*, defaults to `True`):
+        summary_proj_to_labels (`bool`, *optional*, defaults to `True`):
             Used in the sequence classification and multiple choice models.
 
             Whether the projection outputs should have `config.num_labels` or `config.hidden_size` classes.
@@ -170,6 +170,7 @@ class XLNetConfig(PretrainedConfig):
         summary_type="last",
         summary_use_proj=True,
         summary_activation="tanh",
+        summary_proj_to_labels=True,
         summary_last_dropout=0.1,
         start_n_top=5,
         end_n_top=5,
@@ -209,6 +210,7 @@ class XLNetConfig(PretrainedConfig):
         self.summary_type = summary_type
         self.summary_use_proj = summary_use_proj
         self.summary_activation = summary_activation
+        self.summary_proj_to_labels = summary_proj_to_labels
         self.summary_last_dropout = summary_last_dropout
         self.start_n_top = start_n_top
         self.end_n_top = end_n_top


### PR DESCRIPTION
# What does this PR do?

`XLNetConfig` (`src\transformers\models\xlnet\configuration_xlnet.py`) lists an argument `summary_proj_to_labels` as optional and with a default value of `True`. However, this is not actually included in the arguments and is not set anywhere. Initializing an XLNet model thus results in no such parameter existing. Also fixes a very minor typo (`boo` -> `bool`).

For reference: the same argument also is utilized in `XLMConfig` (`src\transformers\models\xlm\configuration_xlm.py`) but is actually utilized there.

From personal experience, this argument is used in `SequenceSummary` (`src\transformers\modeling_utils.py`). When using default arguments, there is an inconsistency between the models where one would have `hidden_size` -> `hidden_size` layers while the other would have `hidden_size` -> `num_labels` layers. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc: @sgugger 

Still a draft right now. Need to make changes to the tests to adapt to this. Please let me know if this is intended functionality though.