### PR TITLE
VideoMAE doctest - use valid dummy pixel values

### DIFF
--- a/src/transformers/models/videomae/modeling_videomae.py
+++ b/src/transformers/models/videomae/modeling_videomae.py
@@ -790,7 +790,7 @@ class VideoMAEForPreTraining(VideoMAEPreTrainedModel):
         >>> import torch
 
         >>> num_frames = 16
-        >>> video = list(np.random.randn(16, 3, 224, 224))
+        >>> video = list(np.random.randint(0, 256, (num_frames, 3, 224, 224)))
 
         >>> image_processor = AutoImageProcessor.from_pretrained("MCG-NJU/videomae-base")
         >>> model = VideoMAEForPreTraining.from_pretrained("MCG-NJU/videomae-base")


### PR DESCRIPTION
# What does this PR do?

This PR updates the raw input video frames to the expected data type. 

The pixel values passed into the image processor in the tests took values sampled from a standard normal distribution. For an image (or frame) this represents pixels which have been rescaled between [0 - 1] and normalized i.e. one which has already been passed to the image processor. 

After merging #21969, resizing the image throws an error as this image cannot be converted to a PIL.Image.Image without possibly unexpected behaviour from numpy and overflow issues. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?