### PR TITLE
Bug fix: token classification pipeline while passing offset_mapping

### DIFF
--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -304,7 +304,9 @@ class TokenClassificationPipeline(Pipeline):
                         start_ind = start_ind.item()
                         end_ind = end_ind.item()
                 word_ref = sentence[start_ind:end_ind]
-                if getattr(self.tokenizer._tokenizer.model, "continuing_subword_prefix", None):
+                if getattr(self.tokenizer, "_tokenizer", None) and getattr(
+                    self.tokenizer._tokenizer.model, "continuing_subword_prefix", None
+                ):
                     # This is a BPE, word aware tokenizer, there is a correct way
                     # to fuse tokens
                     is_subword = len(word) != len(word_ref)


### PR DESCRIPTION
# What does this PR do?
Bug fix: add check so `AttributeError` isn't preventing using slow tokenizers with `offset_mapping`

On token-classification pipelines it threw an error (AttributeError None) if using a slow tokenizer & passing `offset_mapping`.

It is intended to work so (if you want) you can calculate offsets yourself while using a slow(or custom) tokenizer. otherwise "start"&"end" values returned from the pipeline are `None`

For example 'google/canine-c' (pretend it is finetuned)

```python
from transformers import pipeline

token_classifier = pipeline(
        "token-classification", model='google/canine-c',
        aggregation_strategy="simple", ignore_labels=[],
    )
offset_mapping=[(0,0)]+[(i,i+1) for i,t in enumerate(text)]+[(0,0)] # canine is an easy enough tokenizer to calculate offsets ourselves accounting for [cls],[sep].
ents=token_classifier(text)
print(ents) # without offset_mapping "start"&"end" is None
ents=token_classifier(text, offset_mapping=offset_mapping)
print(ents) # should return entities with "start"&"end" index values. 
```


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 

- pipelines: @Narsil
