### PR TITLE
Docs Improvement - In ZSH, not using ' ' around pip install fails, fix it

### DIFF
--- a/docs/source/en/installation.mdx
+++ b/docs/source/en/installation.mdx
@@ -54,19 +54,19 @@ pip install transformers
 For CPU-support only, you can conveniently install 🤗 Transformers and a deep learning library in one line. For example, install 🤗 Transformers and PyTorch with:
 
 ```bash
-pip install transformers[torch]
+pip install 'transformers[torch]'
 ```
 
 🤗 Transformers and TensorFlow 2.0:
 
 ```bash
-pip install transformers[tf-cpu]
+pip install 'transformers[tf-cpu]'
 ```
 
 🤗 Transformers and Flax:
 
 ```bash
-pip install transformers[flax]
+pip install 'transformers[flax]'
 ```
 
 Finally, check if 🤗 Transformers has been properly installed by running the following command. It will download a pretrained model:


### PR DESCRIPTION
# What does this PR do?

Running 
```
pip install transformers[torch]
```
in the default ZSH terminal will fail with the error `zsh: no matches found: transformers[torch]`

The solution is to wrap the installation path in ' ' like 
```
pip install 'transformers[torch]'
```

Relevant StackOverflow: https://stackoverflow.com/questions/30539798/zsh-no-matches-found-requestssecurity

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger, @stevhliu and @MKhalusova