### PR TITLE
Can't install tf2 on M1 Chip by default

### DIFF
--- a/docs/source/en/installation.mdx
+++ b/docs/source/en/installation.mdx
@@ -63,6 +63,18 @@ pip install transformers[torch]
 pip install transformers[tf-cpu]
 ```
 
+<Tip warning={true}>
+
+M1 / ARM Users
+    
+You will need to install the following before installing TensorFLow 2.0
+```
+brew install cmake
+brew install pkg-config
+```
+
+</Tip>
+
 🤗 Transformers and Flax:
 
 ```bash


### PR DESCRIPTION
# What does this PR do?

Trying to 
```
pip install 'transformers[tf-cpu]'
```

will give you a confusing error like below
```
Collecting sentencepiece==0.1.91
  Using cached sentencepiece-0.1.91.tar.gz (500 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [5 lines of output]
      Package sentencepiece was not found in the pkg-config search path.
      Perhaps you should add the directory containing `sentencepiece.pc'
      to the PKG_CONFIG_PATH environment variable
      No package 'sentencepiece' found
      Failed to find sentencepiece pkgconfig
      [end of output]

```

The answer is to install `cmake` and `pkg-config` based on the reply here: 
https://github.com/google/sentencepiece/issues/378#issuecomment-969896519

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger, @stevhliu and @MKhalusova