### PR TITLE
Show the number of `huggingface_hub` warnings in CI report

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -215,7 +215,7 @@ class Message:
             # Use the actual job link
             job_link = f"{github_actions_job_links['Extract warnings in CI artifacts']}"
 
-        huggingface_hub_warnings = [x for x in self.warnings if "huggingface_hub" in x]
+        huggingface_hub_warnings = [x for x in self.selected_warnings if "huggingface_hub" in x]
         text = f"There are {len(self.selected_warnings)} warnings being selected."
         text += f"\n{len(huggingface_hub_warnings)} of them are from `huggingface_hub`."
 

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -217,7 +217,7 @@ class Message:
 
         huggingface_hub_warnings = [x for x in self.warnings if "huggingface_hub" in x]
         text = f"There are {len(self.selected_warnings)} warnings being selected."
-        text += f"{len(huggingface_hub_warnings)} of them are from `huggingface_hub`."
+        text += f"\n{len(huggingface_hub_warnings)} of them are from `huggingface_hub`."
 
         return {
             "type": "section",

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -215,11 +215,15 @@ class Message:
             # Use the actual job link
             job_link = f"{github_actions_job_links['Extract warnings in CI artifacts']}"
 
+        huggingface_hub_warnings = [x for x in self.warnings if "huggingface_hub" in x]
+        text = f"There are {len(self.selected_warnings)} warnings being selected."
+        text += f"{len(huggingface_hub_warnings)} of them are from `huggingface_hub`."
+
         return {
             "type": "section",
             "text": {
                 "type": "plain_text",
-                "text": f"There were {len(self.selected_warnings)} warnings being selected.",
+                "text": text,
                 "emoji": True,
             },
             "accessory": {


### PR DESCRIPTION
# What does this PR do?

Show the number of `huggingface_hub` warnings in CI report, as discussed in #22051

Will be shown like below

<img width="488" alt="Screenshot 2023-03-09 134910" src="https://user-images.githubusercontent.com/2521628/224050100-90c1477a-c33f-485e-85e1-ec648cbb4f91.png">
