### PR TITLE
Add a progress bar for the total download of shards

### DIFF
--- a/src/transformers/models/detr/configuration_detr.py
+++ b/src/transformers/models/detr/configuration_detr.py
@@ -239,6 +239,7 @@ class DetrConfig(PretrainedConfig):
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`DetrConfig`] (or a derived class) from a pre-trained backbone model configuration.
+
         Args:
             backbone_config ([`PretrainedConfig`]):
                 The backbone configuration.

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -918,7 +918,7 @@ def get_checkpoint_shard_files(
     last_shard = try_to_load_from_cache(
         pretrained_model_name_or_path, shard_filenames[-1], cache_dir=cache_dir, revision=_commit_hash
     )
-    show_progress_bar = last_shard is _CACHED_NO_EXIST or force_download
+    show_progress_bar = last_shard is None or last_shard is _CACHED_NO_EXIST or force_download
     for shard_filename in tqdm(shard_filenames, desc="Downloading shards", disable=not show_progress_bar):
         try:
             # Load from URL

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -918,7 +918,7 @@ def get_checkpoint_shard_files(
     last_shard = try_to_load_from_cache(
         pretrained_model_name_or_path, shard_filenames[-1], cache_dir=cache_dir, revision=_commit_hash
     )
-    show_progress_bar = last_shard is None or last_shard is _CACHED_NO_EXIST or force_download
+    show_progress_bar = last_shard is None or force_download
     for shard_filename in tqdm(shard_filenames, desc="Downloading shards", disable=not show_progress_bar):
         try:
             # Load from URL

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -390,7 +390,7 @@ def cached_file(
     if isinstance(cache_dir, Path):
         cache_dir = str(cache_dir)
 
-    if _commit_hash is not None:
+    if _commit_hash is not None and not force_download:
         # If the file is cached under that commit hash, we return it directly.
         resolved_file = try_to_load_from_cache(
             path_or_repo_id, full_filename, cache_dir=cache_dir, revision=_commit_hash
@@ -913,7 +913,13 @@ def get_checkpoint_shard_files(
 
     # At this stage pretrained_model_name_or_path is a model identifier on the Hub
     cached_filenames = []
-    for shard_filename in shard_filenames:
+    # Check if the model is already cached or not. We only try the last checkpoint, this should cover most cases of
+    # downloaded (if interrupted).
+    last_shard = try_to_load_from_cache(
+        pretrained_model_name_or_path, shard_filenames[-1], cache_dir=cache_dir, revision=_commit_hash
+    )
+    show_progress_bar = last_shard is _CACHED_NO_EXIST or force_download
+    for shard_filename in tqdm(shard_filenames, desc="Downloading shards", disable=not show_progress_bar):
         try:
             # Load from URL
             cached_filename = cached_file(


### PR DESCRIPTION
# What does this PR do?

This PR adds a feature requested in #22047 and fixes a small bug I encountered while testing it.

**The feature**: a new progress bar is added when loading a sharded checkpoint that gives the overall progress.

**The bug**: when passing along `force_download=True`, the files were not downloaded if cached, because an early return in `cached_file` returned the cached file.

Fixes #22047 