### PR TITLE
Revert "[GPT2] Propose fix for #21080"

### DIFF
--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -553,14 +553,7 @@ class DecisionTransformerGPT2Model(DecisionTransformerGPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-
-        if attention_mask is not None and len(attention_mask.shape) == 2 and position_ids is None:
-            # create position_ids on the fly for batch generation
-            position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_length > 0:
-                position_ids = position_ids[:, past_length : input_shape[-1] + past_length :]
-        elif position_ids is None:
+        if position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -797,14 +797,7 @@ class GPT2Model(GPT2PreTrainedModel):
             past_key_values = tuple([None] * len(self.h))
         else:
             past_length = past_key_values[0][0].size(-2)
-
-        if attention_mask is not None and len(attention_mask.shape) == 2 and position_ids is None:
-            # create position_ids on the fly for batch generation
-            position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 1)
-            if past_length > 0:
-                position_ids = position_ids[:, past_length : input_shape[-1] + past_length :]
-        elif position_ids is None:
+        if position_ids is None:
             position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
             position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
 

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -591,27 +591,6 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         self.assertListEqual(expected_output_sentence, [non_padded_sentence, padded_sentence])
 
     @slow
-    def test_batch_forward(self):
-        tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
-        tokenizer.padding_side = "left"
-
-        # This tokenizer has no pad token, so we have to set it in some way
-        # Define PAD Token = EOS Token = 50256
-        tokenizer.pad_token = tokenizer.eos_token
-
-        model = GPT2LMHeadModel.from_pretrained("gpt2", pad_token_id=tokenizer.eos_token_id)
-        sentences = ["Hello, my dog is a little bit of a mess. I'm not sure if he's"]
-        inputs = tokenizer(sentences, padding=True, return_tensors="pt")
-        logits = model(**inputs).logits[:, -1, :]
-        indexes = torch.argmax(logits).item()
-
-        inputs_padded = tokenizer(sentences, padding="max_length", max_length=30, return_tensors="pt")
-        logits_padded = model(**inputs_padded).logits[:, -1, :]
-        indexes_padded = torch.argmax(logits_padded).item()
-
-        self.assertTrue(indexes == indexes_padded)
-
-    @slow
     def test_batch_generation_2heads(self):
         model = GPT2DoubleHeadsModel.from_pretrained("gpt2")
         model.to(torch_device)


### PR DESCRIPTION
Reverts huggingface/transformers#21853

A few PT/TF and PT/Flax cross tests started to fail after #21853. Revert that PR for now. We need to look what went wrong (and why it is not reported in the PR CI)

```
FAILED tests/models/gpt2/test_modeling_tf_gpt2.py::TFGPT2ModelTest::test_pt_tf_model_equivalence - AssertionError: 3.225274 not less than or equal to 1e-05 : outputs.last_hidden_state: Difference between torch and tf is 3.225274085998535 (>= 1e-05).
FAILED tests/models/encoder_decoder/test_modeling_tf_encoder_decoder.py::TFGPT2EncoderDecoderModelTest::test_pt_tf_model_equivalence - AssertionError: 0.3753911 not less than or equal to 1e-05 : outputs.logits: Difference between torch and tf is 0.3753910958766937 (>= 1e-05).
FAILED tests/models/vision_encoder_decoder/test_modeling_tf_vision_encoder_decoder.py::TFViT2GPT2EncoderDecoderModelTest::test_pt_tf_model_equivalence - AssertionError: 0.42845678 not less than or equal to 1e-05 : outputs.logits: Difference between torch and tf is 0.42845678329467773 (>= 1e-05).
```

A job run with failed tests is [here](https://app.circleci.com/pipelines/github/huggingface/transformers/59606/workflows/fd5cb028-f3df-4ac6-83ae-b0cc68396af8/jobs/728991)

