### PR TITLE
Fix big model inference for T5 models in float16

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2564,25 +2564,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             elif len(special_dtypes) > 0:
                 logger.warn(
                     "This model has some weights that should be kept in higher precision, you need to upgrade "
-                    "`accelerate` to properly deal with them (`pip install accelerate`)."
+                    "`accelerate` to properly deal with them (`pip install --upgrade accelerate`)."
                 )
             if device_map != "sequential" and get_balanced_memory is not None:
                 max_memory = get_balanced_memory(
                     model,
-                    max_memory=max_memory,
-                    no_split_module_classes=no_split_modules,
                     dtype=torch_dtype,
-                    special_dtypes=special_dtypes,
                     low_zero=(device_map == "balanced_low_0"),
+                    **kwargs,
                 )
             # Make sure tied weights are tied before creating the device map.
             model.tie_weights()
             device_map = infer_auto_device_map(
                 model,
-                no_split_module_classes=no_split_modules,
                 dtype=torch_dtype if not load_in_8bit else torch.int8,
-                max_memory=max_memory,
-                special_dtypes=special_dtypes,
+                **kwargs
             )
 
             if load_in_8bit:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2542,6 +2542,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             ) >= version.parse("0.37.0")
 
         if isinstance(device_map, str):
+            special_dtypes = {
+                name: torch.float32
+                for name, _ in model.named_parameters()
+                if any(m in name for m in keep_in_fp32_modules)
+            }
             if model._no_split_modules is None:
                 raise ValueError(f"{model.__class__.__name__} does not support `device_map='{device_map}'` yet.")
             no_split_modules = model._no_split_modules
@@ -2552,12 +2557,22 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
             elif device_map in ["balanced", "balanced_low_0"] and get_balanced_memory is None:
                 raise ValueError(f"`device_map={device_map}` requires a source install of Accelerate.")
+
+            kwargs = {"no_split_module_classes": no_split_modules, "max_memory": max_memory}
+            if "special_dtypes" in inspect.signature(infer_auto_device_map).parameters:
+                kwargs["special_dtypes"] = special_dtypes
+            elif len(special_dtypes) > 0:
+                logger.warn(
+                    "This model has some weights that should be kept in higher precision, you need to upgrade "
+                    "`accelerate` to properly deal with them (`pip install accelerate`)."
+                )
             if device_map != "sequential" and get_balanced_memory is not None:
                 max_memory = get_balanced_memory(
                     model,
                     max_memory=max_memory,
                     no_split_module_classes=no_split_modules,
                     dtype=torch_dtype,
+                    special_dtypes=special_dtypes,
                     low_zero=(device_map == "balanced_low_0"),
                 )
             # Make sure tied weights are tied before creating the device map.
@@ -2567,6 +2582,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 no_split_module_classes=no_split_modules,
                 dtype=torch_dtype if not load_in_8bit else torch.int8,
                 max_memory=max_memory,
+                special_dtypes=special_dtypes,
             )
 
             if load_in_8bit:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2575,11 +2575,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
             # Make sure tied weights are tied before creating the device map.
             model.tie_weights()
-            device_map = infer_auto_device_map(
-                model,
-                dtype=torch_dtype if not load_in_8bit else torch.int8,
-                **kwargs
-            )
+            device_map = infer_auto_device_map(model, dtype=torch_dtype if not load_in_8bit else torch.int8, **kwargs)
 
             if load_in_8bit:
                 # The LM head / tied weights or any last module can stay on disk / CPU


### PR DESCRIPTION
# What does this PR do?

This PR fixes big model inference for large T5 models. The problem is that T5 models have some weights kept in float32, which interferes with the computation of `infer_auto_device_map`. Accelerate adds the functionality to deal with this in [this PR](https://github.com/huggingface/accelerate/pull/1179), and a patch release will be out soon with the fix in a release.

When this is done, this PR can be merged so the fix can be used. With this I can do
```py
from transformers import T5ForConditionalGeneration, AutoTokenizer
import torch
tokenizer = AutoTokenizer.from_pretrained('google/flan-ul2')
model = T5ForConditionalGeneration.from_pretrained('google/flan-ul2', device_map = 'auto', torch_dtype=torch.float16)
input_string = 'Answer the following question by reasoning step by step. I start with 10 bananas. A monkey eats three of them, and then gives me an avocado. How many bananas do I have left?'
inputs = tokenizer(input_string, return_tensors = 'pt').to('cuda:0')
outputs = model.generate(inputs['input_ids'], max_length = 200)
print(tokenizer.decode(outputs[0]))
```
whereas before this went OOM.