### PR TITLE
[trainer] fix bug in grad accum with multiple epochs

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1888,7 +1888,7 @@ class Trainer:
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                print(f"total_steps={total_steps}")
+                #print(f"total_steps={total_steps}")
                 if (
                     ((total_steps + 1) % args.gradient_accumulation_steps != 0)
                     and args.local_rank != -1
@@ -1916,13 +1916,13 @@ class Trainer:
                 if self.deepspeed:
                     self.deepspeed.step()
 
-                print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
+                #print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
                 if (total_steps + 1) % args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps
                     steps_in_epoch <= args.gradient_accumulation_steps
                     and (step + 1) == steps_in_epoch
                 ):
-                    print("boundary")
+                    #print("boundary")
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1888,9 +1888,9 @@ class Trainer:
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                #print(f"total_steps={total_steps}")
+                # print(f"total_steps={total_steps}")
                 if (
-                    ((total_steps + 1) % args.gradient_accumulation_steps != 0)
+                    (total_steps % args.gradient_accumulation_steps != 0)
                     and args.local_rank != -1
                     and args._no_sync_in_gradient_accumulation
                 ):
@@ -1916,13 +1916,13 @@ class Trainer:
                 if self.deepspeed:
                     self.deepspeed.step()
 
-                #print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
-                if (total_steps + 1) % args.gradient_accumulation_steps == 0 or (
+                # print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
+                if total_steps % args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps
                     steps_in_epoch <= args.gradient_accumulation_steps
                     and (step + 1) == steps_in_epoch
                 ):
-                    #print("boundary")
+                    # print("boundary")
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1831,7 +1831,7 @@ class Trainer:
                     # AT THE VERY END!
                     _ = list(train_dataloader.sampler)
 
-        total_steps = 0
+        total_batched_samples = 0
         for epoch in range(epochs_trained, num_train_epochs):
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):
                 train_dataloader.sampler.set_epoch(epoch)
@@ -1868,7 +1868,7 @@ class Trainer:
 
             step = -1
             for step, inputs in enumerate(epoch_iterator):
-                total_steps += 1
+                total_batched_samples += 1
                 if rng_to_sync:
                     self._load_rng_state(resume_from_checkpoint)
                     rng_to_sync = False
@@ -1888,9 +1888,8 @@ class Trainer:
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
-                # print(f"total_steps={total_steps}")
                 if (
-                    (total_steps % args.gradient_accumulation_steps != 0)
+                    (total_batched_samples % args.gradient_accumulation_steps != 0)
                     and args.local_rank != -1
                     and args._no_sync_in_gradient_accumulation
                 ):
@@ -1916,13 +1915,11 @@ class Trainer:
                 if self.deepspeed:
                     self.deepspeed.step()
 
-                # print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
-                if total_steps % args.gradient_accumulation_steps == 0 or (
+                if total_batched_samples % args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps
                     steps_in_epoch <= args.gradient_accumulation_steps
                     and (step + 1) == steps_in_epoch
                 ):
-                    # print("boundary")
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1831,6 +1831,7 @@ class Trainer:
                     # AT THE VERY END!
                     _ = list(train_dataloader.sampler)
 
+        total_steps = 0
         for epoch in range(epochs_trained, num_train_epochs):
             if isinstance(train_dataloader, DataLoader) and isinstance(train_dataloader.sampler, DistributedSampler):
                 train_dataloader.sampler.set_epoch(epoch)
@@ -1867,6 +1868,7 @@ class Trainer:
 
             step = -1
             for step, inputs in enumerate(epoch_iterator):
+                total_steps += 1
                 if rng_to_sync:
                     self._load_rng_state(resume_from_checkpoint)
                     rng_to_sync = False
@@ -1886,8 +1888,9 @@ class Trainer:
                 if step % args.gradient_accumulation_steps == 0:
                     self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
+                print(f"total_steps={total_steps}")
                 if (
-                    ((step + 1) % args.gradient_accumulation_steps != 0)
+                    ((total_steps + 1) % args.gradient_accumulation_steps != 0)
                     and args.local_rank != -1
                     and args._no_sync_in_gradient_accumulation
                 ):
@@ -1913,11 +1916,13 @@ class Trainer:
                 if self.deepspeed:
                     self.deepspeed.step()
 
-                if (step + 1) % args.gradient_accumulation_steps == 0 or (
+                print(f"{step+1} { (step + 1) % args.gradient_accumulation_steps }")
+                if (total_steps + 1) % args.gradient_accumulation_steps == 0 or (
                     # last step in epoch but step is always smaller than gradient_accumulation_steps
                     steps_in_epoch <= args.gradient_accumulation_steps
                     and (step + 1) == steps_in_epoch
                 ):
+                    print("boundary")
                     # Gradient clipping
                     if args.max_grad_norm is not None and args.max_grad_norm > 0 and not self.deepspeed:
                         # deepspeed does its own clipping


### PR DESCRIPTION
Please see https://github.com/huggingface/transformers/issues/22082 for the analysis printout of the problem.

But basically we have a bug in grad accum machinery when `steps_in_epoch % gradient_accumulation_steps != 0`

we always check for `step+1 % gradient_accumulation_steps != 0` and when we hit the epoch boundary we end up running more than `gradient_accumulation_steps` in that iteration.

I proposed a fix using a total step counter - please feel free to suggest a different fix.

I left the debug prints if you'd like to validate the situation yourself. will remove when happy.

Fixes: https://github.com/huggingface/transformers/issues/22082
