### PR TITLE
Trainer: let generate pick its inputs

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -182,21 +182,8 @@ class Seq2SeqTrainer(Trainer):
             gen_kwargs["synced_gpus"] if gen_kwargs.get("synced_gpus") is not None else default_synced_gpus
         )
 
-        if "attention_mask" in inputs:
-            gen_kwargs["attention_mask"] = inputs.get("attention_mask", None)
-        if "global_attention_mask" in inputs:
-            gen_kwargs["global_attention_mask"] = inputs.get("global_attention_mask", None)
-
-        # prepare generation inputs
-        # some encoder-decoder models can have varying encoder's and thus
-        # varying model input names
-        if hasattr(self.model, "encoder") and self.model.encoder.main_input_name != self.model.main_input_name:
-            generation_inputs = inputs[self.model.encoder.main_input_name]
-        else:
-            generation_inputs = inputs[self.model.main_input_name]
-
         generated_tokens = self.model.generate(
-            generation_inputs,
+            **inputs,
             **gen_kwargs,
         )
         # Temporary hack to ensure the generation config is not initialized for each iteration of the evaluation loop

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -182,10 +182,11 @@ class Seq2SeqTrainer(Trainer):
             gen_kwargs["synced_gpus"] if gen_kwargs.get("synced_gpus") is not None else default_synced_gpus
         )
 
-        generated_tokens = self.model.generate(
-            **inputs,
-            **gen_kwargs,
-        )
+        # TODO (Joao): the following line is needed to keep a consistent result on SQUAD. Ideally, we should not block
+        # users from preparing a dataset with `decoder_input_ids`.
+        inputs = {k: v for k, v in inputs.items() if k != "decoder_input_ids"}
+        generated_tokens = self.model.generate(**inputs, **gen_kwargs)
+
         # Temporary hack to ensure the generation config is not initialized for each iteration of the evaluation loop
         # TODO: remove this hack when the legacy code that initializes generation_config from a model config is
         # removed in https://github.com/huggingface/transformers/blob/98d88b23f54e5a23e741833f1e973fdf600cc2c5/src/transformers/generation/utils.py#L1183


### PR DESCRIPTION
# What does this PR do?

Trainer's `predict_with_generate` seems to have been designed for an older version of `.generate()`, where manual selection of the inputs was needed. The current version of `.generate()` can do it on its own. This is particularly relevant for multimodal models, which can take more than one modality as input. As such, this PR removes the `.generate()` input selection logic from Trainer.

This PR is a requirement for Amazon's [MM-CoT](https://github.com/amazon-science/mm-cot).