### PR TITLE
[`Blip2`] skip accelerate test

### DIFF
--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -710,6 +710,10 @@ class Blip2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     def test_save_load_fast_init_to_base(self):
         pass
 
+    @unittest.skip(reason="Does not work on the tiny model as we keep hitting edge cases.")
+    def test_cpu_offload(self):
+        pass
+
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 


### PR DESCRIPTION
# What does this PR do?

This PR skips a test that is currently failing: https://github.com/huggingface/transformers/actions/runs/4395315343/jobs/7697061404

The tiny BLIP2 models uses T5 as a text decoder, that is itself having a parameter named `shared` that is tied with 3 other parameters of the model: `encoder.embed_tokens`, `decoder.embed_tokens`, `lm_head`.

In some very specific usecases (small model, + small `max_memory`), the test hits some corner cases as `accelerate` does not support handling multiple tied weights yet: https://github.com/huggingface/accelerate/blob/37831808444e089a182f66713935d27c39a0cf2c/src/accelerate/utils/modeling.py#L232 & https://github.com/huggingface/accelerate/blob/37831808444e089a182f66713935d27c39a0cf2c/src/accelerate/utils/modeling.py#L566

Not that a similar test is also currently being skipped for T5: https://github.com/huggingface/transformers/blob/102b5ff4a813eea848bb82ff2f451e0f6b17b30c/tests/models/t5/test_modeling_t5.py#L689

As this usecase is very corner case and less likely to happen (most of BLIP2 models are large) and fixing this would require a lot of work on `accelerate`, let's skip this test as we did it for T5

cc @sgugger @ydshieh