### PR TITLE
[`Whiper`] add `get_input_embeddings` to `WhisperForAudioClassification`

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -767,6 +767,9 @@ class WhisperEncoder(WhisperPreTrainedModel):
             param.requires_grad = False
         self._requires_grad = False
 
+    def get_input_embeddings(self) -> nn.Module:
+        return self.conv1
+
     def forward(
         self,
         input_features,
@@ -1330,6 +1333,9 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
     def set_output_embeddings(self, new_embeddings):
         self.proj_out = new_embeddings
 
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.get_input_embeddings()
+
     def freeze_encoder(self):
         """
         Calling this function will disable the gradient computation for the Whisper encoder so that its parameters will
@@ -1634,6 +1640,9 @@ class WhisperForAudioClassification(WhisperPreTrainedModel):
         not be updated during training. Only the projection layers and classification head will be updated.
         """
         self.encoder._freeze_parameters()
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.encoder.get_input_embeddings()
 
     @add_start_docstrings_to_model_forward(WHISPER_ENCODER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=SequenceClassifierOutput, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1029,7 +1029,10 @@ class WhisperDecoder(WhisperPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length)
+        if input_ids is not None:
+            positions = self.embed_positions(input_ids, past_key_values_length=past_key_values_length)
+        else:
+            positions = self.embed_positions(inputs_embeds, past_key_values_length=past_key_values_length)
 
         hidden_states = inputs_embeds + positions
         hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -770,6 +770,9 @@ class WhisperEncoder(WhisperPreTrainedModel):
     def get_input_embeddings(self) -> nn.Module:
         return self.conv1
 
+    def set_input_embeddings(self, value: nn.Module):
+        self.conv1 = value
+
     def forward(
         self,
         input_features,
@@ -1643,6 +1646,9 @@ class WhisperForAudioClassification(WhisperPreTrainedModel):
 
     def get_input_embeddings(self) -> nn.Module:
         return self.encoder.get_input_embeddings()
+
+    def set_input_embeddings(self, value: nn.Module):
+        self.encoder.set_input_embeddings(value)
 
     @add_start_docstrings_to_model_forward(WHISPER_ENCODER_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=SequenceClassifierOutput, config_class=_CONFIG_FOR_DOC)

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -357,9 +357,26 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         return config, input_ids, None, max_length
 
-    # not implemented currently
     def test_inputs_embeds(self):
-        pass
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            model.to(torch_device)
+            model.eval()
+
+            inputs = copy.deepcopy(self._prepare_for_class(inputs_dict, model_class))
+
+            encoder_input_ids = inputs["input_features"]
+            decoder_input_ids = inputs.get("decoder_input_ids", encoder_input_ids)
+            inputs.pop("decoder_input_ids", None)
+            inputs.pop("decoder_attention_mask", None)
+
+            wte = model.get_input_embeddings()
+            inputs["decoder_inputs_embeds"] = wte(decoder_input_ids)
+
+            with torch.no_grad():
+                model(**inputs)[0]
 
     # training is not supported yet
     def test_training(self):

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -368,8 +368,7 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
             inputs = copy.deepcopy(self._prepare_for_class(inputs_dict, model_class))
 
             encoder_input_ids = inputs["input_features"]
-            decoder_input_ids = inputs.get("decoder_input_ids", encoder_input_ids)
-            inputs.pop("decoder_input_ids", None)
+            decoder_input_ids = inputs.pop("decoder_input_ids", None)
             inputs.pop("decoder_attention_mask", None)
 
             wte = model.get_input_embeddings()

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1566,9 +1566,16 @@ class WhisperEncoderModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
 
             self.assertTrue((outputs_embeds == outputs).all())
 
-    # WhisperEncoder has no inputs_embeds and thus the `get_input_embeddings` fn is not implemented
+    # Needs to override as the encoder input embedding is a Conv1d
     def test_model_common_attributes(self):
-        pass
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            self.assertIsInstance(model.get_input_embeddings(), (torch.nn.Conv1d))
+            model.set_input_embeddings(torch.nn.Conv1d(10, 10, 3))
+            x = model.get_output_embeddings()
+            self.assertTrue(x is None or isinstance(x, torch.nn.Conv1d))
 
     # WhisperEncoder cannot resize token embeddings since it has no tokens embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -367,7 +367,6 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
             inputs = copy.deepcopy(self._prepare_for_class(inputs_dict, model_class))
 
-            encoder_input_ids = inputs["input_features"]
             decoder_input_ids = inputs.pop("decoder_input_ids", None)
             inputs.pop("decoder_attention_mask", None)
 


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/peft/issues/173

Fixes: https://github.com/huggingface/transformers/issues/22131

This PR adds `get_input_embeddings` method to `WhisperForAudioClassification` and `WhisperForConditionalGeneration` to avoid some issues such as [here](https://github.com/huggingface/peft/issues/173)

In my understanding `get_input_embeddings` method should return the first module that converts the input to the first hidden states and not necessarly an `nn.Embedding` layer

cc @ArthurZucker @sgugger 