### PR TITLE
[trainer] add `--optim adamw_torch_fused` for pt-2.0+

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1122,11 +1122,13 @@ class Trainer:
 
             optimizer_cls = AdamW
             optimizer_kwargs.update(adam_kwargs)
-        elif args.optim == OptimizerNames.ADAMW_TORCH:
+        elif args.optim in [OptimizerNames.ADAMW_TORCH, OptimizerNames.ADAMW_TORCH_FUSED]:
             from torch.optim import AdamW
 
             optimizer_cls = AdamW
             optimizer_kwargs.update(adam_kwargs)
+            if args.optim == OptimizerNames.ADAMW_TORCH_FUSED:
+                optimizer_kwargs.update({"fused": True})
         elif args.optim == OptimizerNames.ADAMW_TORCH_XLA:
             try:
                 from torch_xla.amp.syncfree import AdamW

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2300,7 +2300,7 @@ class TrainingArguments:
 
         Args:
             name (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`):
-                The optimizer to use: `"adamw_hf"`, `"adamw_torch"`, `"adamw_torch_fused"`,`"adamw_apex_fused"`,
+                The optimizer to use: `"adamw_hf"`, `"adamw_torch"`, `"adamw_torch_fused"`, `"adamw_apex_fused"`,
                 `"adamw_anyprecision"` or `"adafactor"`.
             learning_rate (`float`, *optional*, defaults to 5e-5):
                 The initial learning rate.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -471,7 +471,7 @@ class TrainingArguments:
             - `"tpu_metrics_debug"`: print debug metrics on TPU
 
             The options should be separated by whitespaces.
-        optim (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`:
+        optim (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`):
             The optimizer to use: adamw_hf, adamw_torch, adamw_torch_fused, adamw_apex_fused, adamw_anyprecision or
             adafactor.
         optim_args (`str`, *optional*):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -950,11 +950,9 @@ class TrainingArguments:
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}
     )
 
-    default_optim = (
-        "adamw_torch_fused"
-        if version.parse(version.parse(torch.__version__).base_version) >= version.parse("2.0.0")
-        else "adamw_hf"
-    )
+    default_optim = "adamw_hf"
+    if is_torch_available() and version.parse(version.parse(torch.__version__).base_version) >= version.parse("2.0.0"):
+        default_optim = "adamw_torch_fused"
     optim: Union[OptimizerNames, str] = field(
         default=default_optim,
         metadata={"help": "The optimizer to use."},
@@ -1223,9 +1221,11 @@ class TrainingArguments:
                 FutureWarning,
             )
             self.optim = OptimizerNames.ADAFACTOR
-        if self.optim == OptimizerNames.ADAMW_TORCH_FUSED and version.parse(
-            version.parse(torch.__version__).base_version
-        ) < version.parse("2.0.0"):
+        if (
+            self.optim == OptimizerNames.ADAMW_TORCH_FUSED
+            and is_torch_available()
+            and version.parse(version.parse(torch.__version__).base_version) < version.parse("2.0.0")
+        ):
             raise ValueError("--optim adamw_torch_fused requires PyTorch 2.0 or higher")
 
         if (

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -471,7 +471,7 @@ class TrainingArguments:
             - `"tpu_metrics_debug"`: print debug metrics on TPU
 
             The options should be separated by whitespaces.
-        optim (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`):
+        optim (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_torch_fused"` (for torch<2.0 `"adamw_hf"`):
             The optimizer to use: adamw_hf, adamw_torch, adamw_torch_fused, adamw_apex_fused, adamw_anyprecision or
             adafactor.
         optim_args (`str`, *optional*):
@@ -949,8 +949,14 @@ class TrainingArguments:
     label_smoothing_factor: float = field(
         default=0.0, metadata={"help": "The label smoothing epsilon to apply (zero means no label smoothing)."}
     )
+
+    default_optim = (
+        "adamw_torch_fused"
+        if version.parse(version.parse(torch.__version__).base_version) >= version.parse("2.0.0")
+        else "adamw_hf"
+    )
     optim: Union[OptimizerNames, str] = field(
-        default="adamw_hf",
+        default=default_optim,
         metadata={"help": "The optimizer to use."},
     )
     optim_args: Optional[str] = field(default=None, metadata={"help": "Optional arguments to supply to optimizer."})

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -135,6 +135,7 @@ class OptimizerNames(ExplicitEnum):
 
     ADAMW_HF = "adamw_hf"
     ADAMW_TORCH = "adamw_torch"
+    ADAMW_TORCH_FUSED = "adamw_torch_fused"
     ADAMW_TORCH_XLA = "adamw_torch_xla"
     ADAMW_APEX_FUSED = "adamw_apex_fused"
     ADAFACTOR = "adafactor"
@@ -471,7 +472,8 @@ class TrainingArguments:
 
             The options should be separated by whitespaces.
         optim (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`):
-            The optimizer to use: adamw_hf, adamw_torch, adamw_apex_fused, adamw_anyprecision or adafactor.
+            The optimizer to use: adamw_hf, adamw_torch, adamw_torch_fused, adamw_apex_fused, adamw_anyprecision or
+            adafactor.
         optim_args (`str`, *optional*):
             Optional arguments that are supplied to AnyPrecisionAdamW.
         group_by_length (`bool`, *optional*, defaults to `False`):
@@ -1215,6 +1217,10 @@ class TrainingArguments:
                 FutureWarning,
             )
             self.optim = OptimizerNames.ADAFACTOR
+        if self.optim == OptimizerNames.ADAMW_TORCH_FUSED and version.parse(
+            version.parse(torch.__version__).base_version
+        ) < version.parse("2.0.0"):
+            raise ValueError("--optim adamw_torch_fused requires PyTorch 2.0 or higher")
 
         if (
             self.framework == "pt"
@@ -2285,8 +2291,8 @@ class TrainingArguments:
 
         Args:
             name (`str` or [`training_args.OptimizerNames`], *optional*, defaults to `"adamw_hf"`):
-                The optimizer to use: `"adamw_hf"`, `"adamw_torch"`, `"adamw_apex_fused"`, `"adamw_anyprecision"` or
-                `"adafactor"`.
+                The optimizer to use: `"adamw_hf"`, `"adamw_torch"`, `"adamw_torch_fused"`,`"adamw_apex_fused"`,
+                `"adamw_anyprecision"` or `"adafactor"`.
             learning_rate (`float`, *optional*, defaults to 5e-5):
                 The initial learning rate.
             weight_decay (`float`, *optional*, defaults to 0):


### PR DESCRIPTION
This PR implement the discussion of https://github.com/huggingface/transformers/issues/22141 to 
1. add support for the fused version of torch's AdamW. via `--optim adamw_torch_fused`
2. due it being too new, untested and a known bug the fix of which didn't make it into pt-2.0.0 - I did not make `--optim adamw_torch_fused` the default for pt>=2.0 - but prepared a place holder to do that for pt-2.1 instead.
3. added an assert for `--fp16` as apparently it's buggy with fp16/AMP https://github.com/huggingface/transformers/issues/22141#issuecomment-1467013132 fixed in https://github.com/pytorch/pytorch/issues/95781 but didn't make it into pt-2.0 cut off - this should be fixed in pt-2.0.1. But should already work with pt-2.1.0 nightly - except I think it's broken still (reported on pytroch slack).

**Bottom line: for pt-2.0 `--optim adamw_torch_fused` will become available for any use except `--fp16` which will automatically be re-enabled upon pt-2.0.1 release, which probably will happen a month later. And we want to give `--optim adamw_torch_fused` time before making it a default.**

## Quality and Speed Comparison Benchmarks:

```
PYTHONPATH=src CUDA_VISIBLE_DEVICES=0 python scripts/benchmark/trainer-benchmark.py --base-cmd ' \
examples/pytorch/translation/run_translation.py --model_name_or_path t5-base --output_dir output_dir \
--do_train --label_smoothing 0.1 --logging_strategy no --save_strategy no --per_device_train_batch_size 32 \
--max_source_length 512 --max_target_length 512 --num_train_epochs 1 --overwrite_output_dir \
--source_lang en --target_lang ro --dataset_name wmt16 --dataset_config "ro-en" \
--source_prefix "translate English to Romanian: "  --warmup_steps 50 \
--max_train_samples 20000 --dataloader_num_workers 2 --fp16 \
' --target-metric-key train_samples_per_second --repeat-times 1 --variations '--optim adamw_torch_fused|--optim adamw_torch|--optim adamw_apex_fused' --report-metric-keys train_loss --base-variation '--optim adamw_torch'
```

and then adding `--bf16` and `--fp16` for the non-fp32 benchmarks.

### bf16 

| Variation                 |   Train<br>samples<br>per<br>second |   Diff<br>% |   Train<br>loss |
|:--------------------------|------------------------------------:|------------:|----------------:|
| --optim adamw_torch_fused |                              382.06 |           9 |            2.22 |
| --optim adamw_torch       |                              350.22 |           0 |            2.22 |
| --optim adamw_apex_fused  |                              386.81 |          10 |            2.22 |

### fp16

| Variation                 |   Train<br>samples<br>per<br>second |   Diff<br>% |   Train<br>loss |
|:--------------------------|------------------------------------:|------------:|----------------:|
| --optim adamw_torch_fused |                              389.41 |           0 |            2.66 |
| --optim adamw_torch       |                              389.37 |           0 |            2.55 |
| --optim adamw_apex_fused  |                              399.27 |           3 |            2.53 |

it's easy to see fp16 is broken - bad loss

### fp32

| Variation                 |   Train<br>samples<br>per<br>second |   Diff<br>% |   Train<br>loss |
|:--------------------------|------------------------------------:|------------:|----------------:|
| --optim adamw_torch_fused |                              107.98 |           3 |            2.21 |
| --optim adamw_torch       |                              105.14 |           0 |            2.21 |
| --optim adamw_apex_fused  |                              108.20 |           3 |            2.21 |


*** Setup:

```
Datetime    : 2023-03-13 15:17:47

Software:
transformers: 4.27.0.dev0
torch       : 2.1.0.dev20230312+cu117
cuda        : 11.7
python      : 3.8.16

Hardware:
1 GPUs      : NVIDIA A100 80GB PCIe, 79.21GB
```

Fixes: https://github.com/huggingface/transformers/issues/22141