### PR TITLE
to_pil - don't rescale if int and in range 0-255

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -156,12 +156,14 @@ def to_pil_image(
     # If there is a single channel, we squeeze it, as otherwise PIL can't handle it.
     image = np.squeeze(image, axis=-1) if image.shape[-1] == 1 else image
 
-    # PIL.Image can only store uint8 values, so we rescale the image to be between 0 and 255 if needed.
+    # PIL.Image can only store uint8 values so we rescale the image to be between 0 and 255 if needed.
     if do_rescale is None:
-        if np.all(0 <= image) and np.all(image <= 1):
-            do_rescale = True
-        elif np.allclose(image, image.astype(int)):
+        if image.dtype == np.uint8:
             do_rescale = False
+        elif np.allclose(image, image.astype(int)) and np.all(0 <= image) and np.all(image <= 255):
+            do_rescale = False
+        elif np.all(0 <= image) and np.all(image <= 1):
+            do_rescale = True
         else:
             raise ValueError(
                 "The image to be converted to a PIL image contains values outside the range [0, 1], "

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -160,8 +160,14 @@ def to_pil_image(
     if do_rescale is None:
         if image.dtype == np.uint8:
             do_rescale = False
-        elif np.allclose(image, image.astype(int)) and np.all(0 <= image) and np.all(image <= 255):
-            do_rescale = False
+        elif np.allclose(image, image.astype(int)):
+            if np.all(0 <= image) and np.all(image <= 255):
+                do_rescale = False
+            else:
+                raise ValueError(
+                    "The image to be converted to a PIL image contains values outside the range [0, 255], "
+                    f"got [{image.min()}, {image.max()}] which cannot be converted to uint8."
+                )
         elif np.all(0 <= image) and np.all(image <= 1):
             do_rescale = True
         else:

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -101,6 +101,33 @@ class ImageTransformsTester(unittest.TestCase):
         with self.assertRaises(ValueError):
             to_pil_image(image)
 
+        # Make sure binary mask remains a binary mask
+        image = np.random.randint(0, 2, image_shape).astype(np.uint8)
+        pil_image = to_pil_image(image)
+        self.assertIsInstance(pil_image, PIL.Image.Image)
+        self.assertEqual(pil_image.size, (5, 4))
+
+    @require_vision
+    def test_to_pil_image_from_mask(self):
+        # Make sure binary mask remains a binary mask
+        image = np.random.randint(0, 2, (3, 4, 5)).astype(np.uint8)
+        pil_image = to_pil_image(image)
+        self.assertIsInstance(pil_image, PIL.Image.Image)
+        self.assertEqual(pil_image.size, (5, 4))
+
+        np_img = np.asarray(pil_image)
+        self.assertTrue(np_img.min() == 0)
+        self.assertTrue(np_img.max() == 1)
+
+        image = np.random.randint(0, 2, (3, 4, 5)).astype(np.float32)
+        pil_image = to_pil_image(image)
+        self.assertIsInstance(pil_image, PIL.Image.Image)
+        self.assertEqual(pil_image.size, (5, 4))
+
+        np_img = np.asarray(pil_image)
+        self.assertTrue(np_img.min() == 0)
+        self.assertTrue(np_img.max() == 1)
+
     @require_tf
     def test_to_pil_image_from_tensorflow(self):
         # channels_first
@@ -222,7 +249,7 @@ class ImageTransformsTester(unittest.TestCase):
         self.assertIsInstance(resized_image, np.ndarray)
         self.assertEqual(resized_image.shape, (30, 40, 3))
 
-        # Check PIL.Image.Image is return if return_numpy=False
+        # Check PIL.Image.Image is returned if return_numpy=False
         resized_image = resize(image, (30, 40), return_numpy=False)
         self.assertIsInstance(resized_image, PIL.Image.Image)
         # PIL size is in (width, height) order

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -101,11 +101,6 @@ class ImageTransformsTester(unittest.TestCase):
         with self.assertRaises(ValueError):
             to_pil_image(image)
 
-        # Make sure binary mask remains a binary mask
-        image = np.random.randint(0, 2, image_shape).astype(np.uint8)
-        pil_image = to_pil_image(image)
-        self.assertIsInstance(pil_image, PIL.Image.Image)
-        self.assertEqual(pil_image.size, (5, 4))
 
     @require_vision
     def test_to_pil_image_from_mask(self):

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -101,7 +101,6 @@ class ImageTransformsTester(unittest.TestCase):
         with self.assertRaises(ValueError):
             to_pil_image(image)
 
-
     @require_vision
     def test_to_pil_image_from_mask(self):
         # Make sure binary mask remains a binary mask


### PR DESCRIPTION
# What does this PR do?

#21969 Introduced a bug where binary masks would have their values rescaled to between 0-255. 

This was because of [this part](https://github.com/huggingface/transformers/blob/4063fd9cba6b72ebfd5c663a307ab9d5ff1a153d/src/transformers/image_transforms.py#L161) of the logic check. The original assumption was that inputs with their values between 0-1 would be rescaled images with float pixels. However, binary masks aren't and shouldn't be rescaled. 

We now check first if the input is of type uint8. Then check if any precision is lost when converting to int and that the int values are in the valid range 0-255 and finally if float values are between 0-1. 


Fixes #22147


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
