### PR TITLE
Load optimizer state on CPU to avoid CUDA OOM

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2414,7 +2414,6 @@ class Trainer:
                 self.optimizer.load_state_dict(optimizer_state)
                 self.lr_scheduler.load_state_dict(lr_scheduler_state)
             else:
-                map_location = "cpu" if is_sagemaker_mp_enabled() else self.args.device
                 if is_sagemaker_mp_enabled():
                     if os.path.isfile(os.path.join(checkpoint, "user_content.pt")):
                         # Optimizer checkpoint was saved with smp >= 1.10
@@ -2434,7 +2433,7 @@ class Trainer:
                     self.model_wrapped.register_post_step_hook(opt_load_hook)
                 else:
                     self.optimizer.load_state_dict(
-                        torch.load(os.path.join(checkpoint, OPTIMIZER_NAME), map_location=map_location)
+                        torch.load(os.path.join(checkpoint, OPTIMIZER_NAME), map_location="cpu")
                     )
                 with warnings.catch_warnings(record=True) as caught_warnings:
                     self.lr_scheduler.load_state_dict(torch.load(os.path.join(checkpoint, SCHEDULER_NAME)))


### PR DESCRIPTION
# What does this PR do?

As reported in #22123 resuming from a checkpoint can get a user out of memory if the optimizer state is loaded directly on GPU. This PR loads it on CPU by default and it will be copied over to the proper device by PyTorch in `load_state_dict`. This might be a bit slower at the checkpoint loading time (so just once) but will benefit users training large models.

Fixes #22123 