### PR TITLE
Fix DeepSpeed CI

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -24,8 +24,10 @@ RUN python3 -m pip install --no-cache-dir -U torch torchvision torchaudio --inde
 
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 
-# This will uninstall torch 2.0.0
-# TODO: uncomment the following line once `torch-tensorrt` is ready for `torch 2.0.0`
+# Uninstall `torch-tensorrt` shipped with the base image
+RUN python3 -m pip uninstall -y torch-tensorrt
+# This installation instruction will uninstall torch 2.0.0
+# TODO: uncomment and update the following line once `torch-tensorrt` is ready for `torch 2.0.0`
 # RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com/pytorch/TensorRT/releases/expanded_assets/v1.3.0
 
 # recompile apex

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -26,9 +26,6 @@ RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 
 # Uninstall `torch-tensorrt` shipped with the base image
 RUN python3 -m pip uninstall -y torch-tensorrt
-# This installation instruction will uninstall torch 2.0.0
-# TODO: uncomment and update the following line once `torch-tensorrt` is ready for `torch 2.0.0`
-# RUN python3 -m pip install torch-tensorrt==1.3.0 --find-links https://github.com/pytorch/TensorRT/releases/expanded_assets/v1.3.0
 
 # recompile apex
 RUN python3 -m pip uninstall -y apex


### PR DESCRIPTION
# What does this PR do?

Since 2 days, the daily CI runs with torch 2.0.0. In DeepSpeed CI job, there is an issue regarding `torch-tensorrt` (currently `v1.3.0`).
The installation was already disabled in #22135, but there was a version shipped with the base image, and I forgot to uninstall it in our docker image during building.

Remark: The failure is our `undefined symbo` friend
```python
E   ImportError: /opt/conda/lib/python3.8/site-packages/torch_tensorrt/lib/libtorchtrt.so: undefined symbol: _ZN2at11show_configB5cxx11Ev
```