### PR TITLE
Update expected values in `MgpstrModelIntegrationTest`

### DIFF
--- a/tests/models/mgp_str/test_modeling_mgp_str.py
+++ b/tests/models/mgp_str/test_modeling_mgp_str.py
@@ -262,7 +262,7 @@ class MgpstrModelIntegrationTest(unittest.TestCase):
         self.assertEqual(out_strs["generated_text"][0], expected_text)
 
         expected_slice = torch.tensor(
-            [[[-39.7358, -44.8562, -36.6253], [-62.3605, -64.5908, -59.0069], [-74.6127, -68.9724, -71.7150]]],
+            [[[-39.5397, -44.4024, -36.1844], [-61.4709, -63.8639, -58.3454], [-74.0225, -68.5494, -71.2164]]],
             device=torch_device,
         )
 


### PR DESCRIPTION
# What does this PR do?

[CI](https://github.com/huggingface/transformers/actions/runs/4422120632/jobs/7753698495) failed: the expected values provided by the contributor didn't match the one given in CI runner, and we just need to update it.