### PR TITLE
Fix typo in  Align docs 

### DIFF
--- a/docs/source/en/model_doc/align.mdx
+++ b/docs/source/en/model_doc/align.mdx
@@ -59,7 +59,7 @@ The original code is not released, this implementation is based on the Kakao Bra
 
 A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with ALIGN.
 
-- A blog post on [ALIGN and the COYO-700M dataset](https://huggingface.co/blog).
+- A blog post on [ALIGN and the COYO-700M dataset](https://huggingface.co/blog/vit-align).
 - A zero-shot image classification [demo](https://huggingface.co/spaces/adirik/ALIGN-zero-shot-image-classification).
 - [Model card](https://huggingface.co/kakaobrain/align-base) of `kakaobrain/align-base` model.
 


### PR DESCRIPTION
# What does this PR do?
Fixes a broken link to the blog post in the ALIGN docs

## Before submitting
- [ X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
