### PR TITLE
Hotfix for natten on CircleCI

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -374,7 +374,8 @@ exotic_models_job = CircleCIJob(
         "pip install 'git+https://github.com/facebookresearch/detectron2.git'",
         "sudo apt install tesseract-ocr",
         "pip install pytesseract",
-        "pip install natten",
+        # wait until natten is ready for torch 2.0.0
+        # "pip install natten",
     ],
     tests_to_run=[
         "tests/models/*layoutlmv*",


### PR DESCRIPTION
# What does this PR do?

Hotfix for natten on CircleCI.

The PR CI in #22204 run with `natten` with the version `0.14.4` which run successfully. However, when I merged that PR  into `main`, natten 0.14.5 is released and cause some issues.