### PR TITLE
Fix state dict loading via symlink on windows

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -397,9 +397,10 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
     """
     Reads a PyTorch checkpoint file, returning properly formatted errors if they arise.
     """
+    checkpoint_file_realpath = os.path.realpath(checkpoint_file)
     if checkpoint_file.endswith(".safetensors") and is_safetensors_available():
         # Check format of the archive
-        with safe_open(checkpoint_file, framework="pt") as f:
+        with safe_open(checkpoint_file_realpath, framework="pt") as f:
             metadata = f.metadata()
         if metadata.get("format") not in ["pt", "tf", "flax"]:
             raise OSError(
@@ -410,12 +411,12 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
             raise NotImplementedError(
                 f"Conversion from a {metadata['format']} safetensors archive to PyTorch is not implemented yet."
             )
-        return safe_load_file(checkpoint_file)
+        return safe_load_file(checkpoint_file_realpath)
     try:
-        return torch.load(checkpoint_file, map_location="cpu")
+        return torch.load(checkpoint_file_realpath, map_location="cpu")
     except Exception as e:
         try:
-            with open(checkpoint_file) as f:
+            with open(checkpoint_file_realpath) as f:
                 if f.read(7) == "version":
                     raise OSError(
                         "You seem to have cloned a repository without having git-lfs installed. Please install "


### PR DESCRIPTION
# What does this PR do?

I ran into an issue trying to run this on Windows 10 (via Git Bash, in a python 3.9.12 Conda environment, deps installed via pip). My requirements.txt included below for completeness.

I tried running an example of SD 2 from the docs

```
from diffusers import DiffusionPipeline, DPMSolverMultistepScheduler
import torch

repo_id = "stabilityai/stable-diffusion-2-base"
pipe = DiffusionPipeline.from_pretrained(repo_id, torch_dtype=torch.float16, revision="fp16")

pipe.scheduler = DPMSolverMultistepScheduler.from_config(pipe.scheduler.config)
pipe = pipe.to("cuda")

prompt = "High quality photo of an astronaut riding a horse in space"
image = pipe(prompt, num_inference_steps=25).images[0]
image.save("astronaut.png")
```

And kept getting output like this:

```
schmavery ~/git/sd-test $ python test.py
A matching Triton is not available, some optimizations will not be enabled.
Error caught was: No module named 'triton'
Downloading pytorch_model.bin: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 681M/681M [00:16<00:00, 41.8MB/s]
Fetching 12 files: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 12/12 [00:16<00:00,  1.38s/it]
Traceback (most recent call last):
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\transformers\modeling_utils.py", line 417, in load_state_dict
    return torch.load(checkpoint_file, map_location="cpu")
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\torch\serialization.py", line 771, in load
    with _open_file_like(f, 'rb') as opened_file:
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\torch\serialization.py", line 270, in _open_file_like
    return _open_file(name_or_buffer, mode)
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\torch\serialization.py", line 251, in __init__
    super(_open_file, self).__init__(open(name, mode))
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\schmavery\\.cache\\huggingface\\hub\\models--stabilityai--stable-diffusion-2-base\\snapshots\\1cb61502fc8b634cdb04e7cd69e06051a728bedf\\text_encoder\\pytorch_model.bin'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\schmavery\git\sd-test\test.py", line 5, in <module>
    pipe = DiffusionPipeline.from_pretrained(repo_id, torch_dtype=torch.float16, revision="fp16")
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\diffusers\pipelines\pipeline_utils.py", line 944, in from_pretrained
    loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\transformers\modeling_utils.py", line 2431, in from_pretrained
    state_dict = load_state_dict(resolved_archive_file)
  File "C:\Users\schmavery\scoop\apps\miniconda3\current\lib\site-packages\transformers\modeling_utils.py", line 420, in load_state_dict
    with open(checkpoint_file) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\schmavery\\.cache\\huggingface\\hub\\models--stabilityai--stable-diffusion-2-base\\snapshots\\1cb61502fc8b634cdb04e7cd69e06051a728bedf\\text_encoder\\pytorch_model.bin'
```

I did some poking around and realized that `C:\Users\schmavery\.cache\huggingface\hub\models--stabilityai--stable-diffusion-2-base\snapshots\1cb61502fc8b634cdb04e7cd69e06051a728bedf\text_encoder\pytorch_model.bin` is a symlink to another file in `C:\Users\schmavery\.cache\huggingface\hub\models--stabilityai--stable-diffusion-2-base\blobs`.

Some searching online revealed some issues with python loading files via symlink in Windows, mostly due to Window's funny handling of symlinks. I tried adding a call to `os.path.realpath` to resolve the path before opening the file, and that solved the problem!

I thought I'd post this here in case it helps anyone.

requirements.txt:
```
accelerate==0.17.1
brotlipy==0.7.0
certifi @ file:///C:/b/abs_85o_6fm0se/croot/certifi_1671487778835/work/certifi
cffi @ file:///C:/b/abs_49n3v2hyhr/croot/cffi_1670423218144/work
charset-normalizer @ file:///tmp/build/80754af9/charset-normalizer_1630003229654/work
colorama @ file:///C:/b/abs_a9ozq0l032/croot/colorama_1672387194846/work
conda==23.1.0
conda-package-handling @ file:///C:/b/abs_fcga8w0uem/croot/conda-package-handling_1672865024290/work
conda_package_streaming @ file:///C:/b/abs_0e5n5hdal3/croot/conda-package-streaming_1670508162902/work
cryptography @ file:///C:/b/abs_8ecplyc3n2/croot/cryptography_1677533105000/work
diffusers==0.14.0
filelock==3.10.0
huggingface-hub==0.13.2
idna @ file:///C:/b/abs_bdhbebrioa/croot/idna_1666125572046/work
importlib-metadata==6.0.0
Jinja2==3.1.2
MarkupSafe==2.1.2
menuinst @ file:///C:/ci/menuinst_1631733438520/work
mpmath==1.3.0
mypy-extensions==1.0.0
networkx==3.0
numpy==1.24.2
packaging==23.0
Pillow==9.4.0
pluggy @ file:///C:/ci/pluggy_1648024580010/work
psutil==5.9.4
pycosat @ file:///C:/b/abs_4b1rrw8pn9/croot/pycosat_1666807711599/work
pycparser @ file:///tmp/build/80754af9/pycparser_1636541352034/work
pyOpenSSL @ file:///C:/b/abs_552w85x1jz/croot/pyopenssl_1677607703691/work
pyre-extensions==0.0.23
PySocks @ file:///C:/ci/pysocks_1605307512533/work
pywin32==305.1
PyYAML==6.0
regex==2022.10.31
requests @ file:///C:/ci/requests_1657735342357/work
ruamel.yaml @ file:///C:/b/abs_30ee5qbthd/croot/ruamel.yaml_1666304562000/work
ruamel.yaml.clib @ file:///C:/b/abs_aarblxbilo/croot/ruamel.yaml.clib_1666302270884/work
sympy==1.11.1
tokenizers==0.13.2
toolz @ file:///C:/b/abs_cfvk6rc40d/croot/toolz_1667464080130/work
torch==1.13.1+cu117
torchaudio==0.13.1+cu117
torchvision==0.14.1+cu117
tqdm @ file:///C:/b/abs_0axbz66qik/croots/recipe/tqdm_1664392691071/work
transformers==4.27.1
typing-inspect==0.8.0
typing_extensions==4.5.0
urllib3 @ file:///C:/b/abs_9bcwxczrvm/croot/urllib3_1673575521331/work
win-inet-pton @ file:///C:/ci/win_inet_pton_1605306162074/work
wincertstore==0.2
xformers==0.0.16
zipp==3.15.0
zstandard==0.19.0
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

^^ This is such a small change that it shouldn't affect any docs/tests I think

## Who can review?

Looks like @sgugger and @stas00 were the last to touch this area in the file, though it wasn't particularly recently. I wonder if some change was made in how the models are cached that could have caused this.. 🤷 

My original local fix just changed the torch load to `torch.load(os.path.realpath(checkpoint_file_realpath), map_location="cpu")`, but this seems like it might catch a couple more cases. I considered just overriding the `checkpoint_file` variable to point to the realpath but I thought that might have made the error messages less clear.