### PR TITLE
Removed .mdx extension in two links

### DIFF
--- a/docs/source/en/model_doc/dpt.mdx
+++ b/docs/source/en/model_doc/dpt.mdx
@@ -34,7 +34,7 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 
 - Demo notebooks for [`DPTForDepthEstimation`] can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/DPT).
 - [Semantic segmentation task guide](../tasks/semantic_segmentation)
-- [Monocular depth estimation task guide](../tasks/monocular_depth_estimation.mdx)
+- [Monocular depth estimation task guide](../tasks/monocular_depth_estimation)
 
 If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we'll review it! The resource should ideally demonstrate something new instead of duplicating an existing resource.
 

--- a/docs/source/en/model_doc/glpn.mdx
+++ b/docs/source/en/model_doc/glpn.mdx
@@ -45,7 +45,7 @@ This model was contributed by [nielsr](https://huggingface.co/nielsr). The origi
 A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with GLPN.
 
 - Demo notebooks for [`GLPNForDepthEstimation`] can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/GLPN).
-- [Monocular depth estimation task guide](../tasks/monocular_depth_estimation.mdx)
+- [Monocular depth estimation task guide](../tasks/monocular_depth_estimation)
 
 ## GLPNConfig
 


### PR DESCRIPTION
This PR fixes two links that had .mdx in them that shouldn't have been there.