### PR TITLE
Revert "Use `dash==2.8.1` for now for daily CI"

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -59,9 +59,6 @@ RUN python3 -m pip install --no-cache-dir decord av==9.2.0
 ## For `dinat` model
 #RUN python3 -m pip install --no-cache-dir natten -f https://shi-labs.com/natten/wheels/$CUDA/
 
-# dash 2.9.0 has some issue.
-RUN python3 -m pip install -U dash==2.8.1
-
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop

--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -40,9 +40,6 @@ RUN python3 -m pip uninstall -y deepspeed
 # TODO: Find out why test fail.
 RUN DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 DS_BUILD_AIO=1 DS_BUILD_UTILS=1 python3 -m pip install deepspeed --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check 2>&1
 
-# dash 2.9.0 has some issue.
-RUN python3 -m pip install -U dash==2.8.1
-
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -29,9 +29,6 @@ RUN python3 -m pip uninstall -y tensorflow flax
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
-# dash 2.9.0 has some issue.
-RUN python3 -m pip install -U dash==2.8.1
-
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop


### PR DESCRIPTION
Reverts huggingface/transformers#22227

New version [dash 2.9.1](https://github.com/plotly/dash/releases/tag/v2.9.1) works with our CI. Tested and it works.
We no longer need the change in #22227
