### PR TITLE
Fix Unnecessary move of tensors from CPU to GPU in LlamaRotaryEmbedding

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -99,8 +99,8 @@ class LlamaRotaryEmbedding(torch.nn.Module):
         freqs = torch.einsum("i,j->ij", t, self.inv_freq)
         # Different from paper, but it uses a different permutation in order to obtain the same calculation
         emb = torch.cat((freqs, freqs), dim=-1)
-        self.cos_cached = emb.cos()[None, None, :, :]
-        self.sin_cached = emb.sin()[None, None, :, :]
+        self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
+        self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
 
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
@@ -111,11 +111,11 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             freqs = torch.einsum("i,j->ij", t, self.inv_freq)
             # Different from paper, but it uses a different permutation in order to obtain the same calculation
             emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
-            self.cos_cached = emb.cos()[None, None, :, :].to(dtype=x.dtype)
-            self.sin_cached = emb.sin()[None, None, :, :].to(dtype=x.dtype)
+            self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
+            self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
         return (
-            self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype, device=x.device),
-            self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype, device=x.device),
+            self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+            self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
         )
 
 


### PR DESCRIPTION
# What does this PR do?
The original implementation of LlamaRotaryEmbedding does not use `cos_cached` & `sin_cached` tensors as the PyTorch Parameter or Buffer, thus these tensors do not move to GPU when we use `model.to(gpu_id)` or `model.cuda()`. They will keep in the device CPU.

This PR adjusts the `cos_cached` & `sin_cached` tensors to the Buffer with persistent=False. This keeps these tensors moving from CPU to GPU together with the model, while keeping them out of the model's state_dict as original.

# Fixes:
Fix unnecessary moves of tensors from CPU to GPU in LlamaRotaryEmbedding, for saving a large amount of CPU usage especially when we do inference.

Code for Reproducing the issue:
```python
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "0"    # Single card Generation

from tqdm import tqdm

import torch
from transformers.models.llama.modeling_llama import LlamaForCausalLM
from transformers.models.llama.tokenization_llama import LlamaTokenizer

tokenizer = LlamaTokenizer.from_pretrained("decapoda-research/llama-7b-hf")
model = LlamaForCausalLM.from_pretrained("decapoda-research/llama-7b-hf", torch_dtype=torch.float16)
model = model.cuda()
model.eval()

# Batch generation
inputs = [
    "LLaMa is a large language model developed by Meta AI, for",
] * 32

batch = tokenizer(inputs, return_tensors="pt", add_special_tokens=False)
batch = batch.to(model.device)

# Here we do some high computational batched generation
for i in tqdm(range(5000)): 
    generated = model.generate(batch["input_ids"],
                                temperature=0.7, top_p=0.9, do_sample=True,
                                num_beams=1, max_new_tokens=600,)

```
Use `top` command in bash to watch the CPU usage.

Here are the comparison before applying this PR and after this PR:

Before:
| Fix    | USER | PR | NI | VIRT   | RES  | SHR    | S | %CPU | %MEM | TIME+   | COMMAND  |
|--------|------|----|----|--------|------|--------|---|------|------|---------|----------|
| Before | root | 20 | 0  | 108.6g | 1.9g | 411620 | R | 6263 | 0.2  | 40:28.1 | python   |

After:
| Fix   | USER | PR | NI | VIRT   | RES  | SHR    | S | %CPU | %MEM | TIME+   | COMMAND  |
|-------|------|----|----|--------|------|--------|---|------|------|---------|----------|
| After | root | 20 | 0  | 108.6g | 1.8g | 414360 | R | 98.3 | 0.2  | 03:21.6 | python   |

Here the CPU usage drops to a normal level because the `cos_cached` & `sin_cached` tensors can move to GPU correctly with the model. This helps avoid unnecessary moves of tensors from CPU to GPU in LlamaRotaryEmbedding.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

 @ArthurZucker and @younesbelkada
