### PR TITLE
Proper map location for optimizer load

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2435,9 +2435,10 @@ class Trainer:
                 else:
                     # We use the CPU when training on one GPU to avoid OOM for GPU RAM when training big models.
                     # In distributed training however, we load directly on each GPU and risk the GPU OOM as it's more
-                    # likely to get OOM on CPU (since we load num_gpu times the optimizer state)
+                    # likely to get OOM on CPU (since we load num_gpu times the optimizer state
+                    map_location = self.args.device if self.args.world_size > 1 else "cpu"
                     self.optimizer.load_state_dict(
-                        torch.load(os.path.join(checkpoint, OPTIMIZER_NAME), map_location="cpu")
+                        torch.load(os.path.join(checkpoint, OPTIMIZER_NAME), map_location=map_location)
                     )
                 with warnings.catch_warnings(record=True) as caught_warnings:
                     self.lr_scheduler.load_state_dict(torch.load(os.path.join(checkpoint, SCHEDULER_NAME)))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2433,6 +2433,9 @@ class Trainer:
 
                     self.model_wrapped.register_post_step_hook(opt_load_hook)
                 else:
+                    # We use the CPU when training on one GPU to avoid OOM for GPU RAM when training big models.
+                    # In distributed training however, we load directly on each GPU and risk the GPU OOM as it's more
+                    # likely to get OOM on CPU (since we load num_gpu times the optimizer state)
                     self.optimizer.load_state_dict(
                         torch.load(os.path.join(checkpoint, OPTIMIZER_NAME), map_location="cpu")
                     )


### PR DESCRIPTION
# What does this PR do?

I have been thinking more about #22159 and now remember why it might be better to load the optimizer state on the device directly: in multi-GPU training, the optimizer state is load in each process, so that would load it num_processes times on the CPU and risk a CPU RAM OOM.

Therefore, this adjusts #22159 to load the optimizer state:
- on CPU when there is only one process
- on each device directly when there are multiple.