### PR TITLE
fix: Text splitting in the BasicTokenizer

### DIFF
--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -427,6 +427,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -398,7 +398,7 @@ class BasicTokenizer(object):
         never_split=None,
         tokenize_chinese_chars=True,
         strip_accents=None,
-        do_split_on_punc=False,
+        do_split_on_punc=True,
         remove_control_chars=True,
     ):
         if never_split is None:

--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -388,8 +388,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -399,7 +397,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -408,7 +405,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -431,9 +427,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -523,7 +517,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -430,7 +430,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
+++ b/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
@@ -790,6 +790,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
+++ b/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
@@ -751,8 +751,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -762,7 +760,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -771,7 +768,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -794,9 +790,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -886,7 +880,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
+++ b/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
@@ -748,20 +748,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -780,7 +794,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -808,7 +824,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -870,7 +886,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
+++ b/src/transformers/models/bert_japanese/tokenization_bert_japanese.py
@@ -793,7 +793,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -168,6 +168,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -196,7 +196,8 @@ class BasicTokenizer(object):
             char = chars[i]
             if _is_punctuation(char):
                 output.append([char])
-                start_new_word = True
+                if char != "'":
+                    start_new_word = True
             else:
                 if start_new_word:
                     output.append([])

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -126,10 +126,21 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
-        self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None, pattern=None
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=False,
+        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -137,12 +148,12 @@ class BasicTokenizer(object):
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
-        self.pattern = pattern
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -161,7 +172,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -171,9 +184,8 @@ class BasicTokenizer(object):
                         token = self._run_strip_accents(token)
                 elif self.strip_accents:
                     token = self._run_strip_accents(token)
-            split_tokens.extend(self._split_on_punc_or_pattern(token, never_split))
+            split_tokens.extend(self._run_split_on_punc(token, never_split))
 
-        print("split_tokens", split_tokens)
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
         return output_tokens
 
@@ -188,13 +200,10 @@ class BasicTokenizer(object):
             output.append(char)
         return "".join(output)
 
-    def _split_on_punc_or_pattern(self, text, never_split=None):
-        """Splits a piece of text by self.pattern or punctuation."""
-        if never_split is not None and text in never_split:
+    def _run_split_on_punc(self, text, never_split=None):
+        """Splits punctuation on a piece of text."""
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
-        if self.pattern:
-            return re.findall(self.pattern, text, flags=re.UNICODE)
-
         chars = list(text)
         i = 0
         start_new_word = True
@@ -255,7 +264,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")
@@ -327,7 +336,7 @@ class CLIPTokenizer(PreTrainedTokenizer):
             self.fix_text = ftfy.fix_text
         except ImportError:
             logger.info("ftfy or spacy is not installed using custom BasicTokenizer instead of ftfy.")
-            self.nlp = BasicTokenizer(do_lower_case=True, pattern=self.pat.pattern)
+            self.nlp = BasicTokenizer(strip_accents=False, do_split_on_punc=False, remove_control_chars=False)
             self.fix_text = None
 
         with open(vocab_file, encoding="utf-8") as vocab_handle:
@@ -474,14 +483,19 @@ class CLIPTokenizer(PreTrainedTokenizer):
         bpe_tokens = []
         if self.fix_text is None:
             text = " ".join(self.nlp.tokenize(text))
+
         else:
             text = whitespace_clean(self.fix_text(text)).lower()
 
         for token in re.findall(self.pat, text):
+            # final = [('text', text)]
+            # final.append(('token', token))
             token = "".join(
                 self.byte_encoder[b] for b in token.encode("utf-8")
             )  # Maps all our bytes to unicode strings, avoiding control tokens of the BPE (spaces in our case)
             bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(" "))
+            # final.append(('bpe_tokens', *[bpe_token for bpe_token in self.bpe(token).split(" ")]))
+            # print('FINAL ', final)
         return bpe_tokens
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 
 import regex as re
 
-from ...tokenization_utils import AddedToken, PreTrainedTokenizer, _is_control, _is_punctuation, _is_whitespace
+from ...tokenization_utils import AddedToken, PreTrainedTokenizer, _is_control, _is_whitespace
 from ...utils import logging
 
 
@@ -449,14 +449,11 @@ class CLIPTokenizer(PreTrainedTokenizer):
         else:
             text = whitespace_clean(self.fix_text(text)).lower()
 
-        test = []
         for token in re.findall(self.pat, text):
             token = "".join(
                 self.byte_encoder[b] for b in token.encode("utf-8")
             )  # Maps all our bytes to unicode strings, avoiding control tokens of the BPE (spaces in our case)
             bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(" "))
-            test.append(token)
-        print('test', test)
         return bpe_tokens
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -129,8 +129,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -140,7 +138,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -149,7 +146,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -172,9 +168,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -264,7 +258,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")
@@ -332,7 +326,7 @@ class CLIPTokenizer(PreTrainedTokenizer):
             self.fix_text = ftfy.fix_text
         except ImportError:
             logger.info("ftfy or spacy is not installed using custom BasicTokenizer instead of ftfy.")
-            self.nlp = BasicTokenizer(strip_accents=False, do_split_on_punc=False, remove_control_chars=False)
+            self.nlp = BasicTokenizer(strip_accents=False, do_split_on_punc=False)
             self.fix_text = None
 
         with open(vocab_file, encoding="utf-8") as vocab_handle:

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -326,10 +326,6 @@ class CLIPTokenizer(PreTrainedTokenizer):
             **kwargs,
         )
 
-        self.pat = re.compile(
-            r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""",
-            re.IGNORECASE,
-        )
         try:
             import ftfy
 
@@ -350,6 +346,11 @@ class CLIPTokenizer(PreTrainedTokenizer):
         bpe_merges = [tuple(merge.split()) for merge in bpe_merges]
         self.bpe_ranks = dict(zip(bpe_merges, range(len(bpe_merges))))
         self.cache = {"<|startoftext|>": "<|startoftext|>", "<|endoftext|>": "<|endoftext|>"}
+
+        self.pat = re.compile(
+            r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""",
+            re.IGNORECASE,
+        )
 
     @property
     def vocab_size(self):
@@ -483,19 +484,14 @@ class CLIPTokenizer(PreTrainedTokenizer):
         bpe_tokens = []
         if self.fix_text is None:
             text = " ".join(self.nlp.tokenize(text))
-
         else:
             text = whitespace_clean(self.fix_text(text)).lower()
 
         for token in re.findall(self.pat, text):
-            # final = [('text', text)]
-            # final.append(('token', token))
             token = "".join(
                 self.byte_encoder[b] for b in token.encode("utf-8")
             )  # Maps all our bytes to unicode strings, avoiding control tokens of the BPE (spaces in our case)
             bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(" "))
-            # final.append(('bpe_tokens', *[bpe_token for bpe_token in self.bpe(token).split(" ")]))
-            # print('FINAL ', final)
         return bpe_tokens
 
     def _convert_token_to_id(self, token):

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -171,7 +171,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -173,7 +173,7 @@ class BasicTokenizer(object):
                     token = self._run_strip_accents(token)
             split_tokens.extend(self._split_on_punc_or_pattern(token, never_split))
 
-        print('split_tokens', split_tokens)
+        print("split_tokens", split_tokens)
         output_tokens = whitespace_tokenize(" ".join(split_tokens))
         return output_tokens
 
@@ -317,18 +317,18 @@ class CLIPTokenizer(PreTrainedTokenizer):
             **kwargs,
         )
 
-        # try:
-        #     import ftfy
-
-        #     self.fix_text = ftfy.fix_text
-        # except ImportError:
-        logger.info("ftfy or spacy is not installed using custom BasicTokenizer instead of ftfy.")
         self.pat = re.compile(
             r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""",
             re.IGNORECASE,
         )
-        self.nlp = BasicTokenizer(do_lower_case=True, pattern=self.pat.pattern)
-        self.fix_text = None
+        try:
+            import ftfy
+
+            self.fix_text = ftfy.fix_text
+        except ImportError:
+            logger.info("ftfy or spacy is not installed using custom BasicTokenizer instead of ftfy.")
+            self.nlp = BasicTokenizer(do_lower_case=True, pattern=self.pat.pattern)
+            self.fix_text = None
 
         with open(vocab_file, encoding="utf-8") as vocab_handle:
             self.encoder = json.load(vocab_handle)

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -139,7 +139,7 @@ class BasicTokenizer(object):
         never_split=None,
         tokenize_chinese_chars=True,
         strip_accents=None,
-        do_split_on_punc=False,
+        do_split_on_punc=True,
         remove_control_chars=True,
     ):
         if never_split is None:

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -196,8 +196,7 @@ class BasicTokenizer(object):
             char = chars[i]
             if _is_punctuation(char):
                 output.append([char])
-                if char != "'":
-                    start_new_word = True
+                start_new_word = True if char != "'" else False
             else:
                 if start_new_word:
                     output.append([])

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -367,6 +367,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -325,20 +325,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -357,7 +371,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -385,7 +401,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -447,7 +463,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -370,7 +370,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -328,8 +328,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -339,7 +337,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -348,7 +345,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -371,9 +367,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -463,7 +457,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/distilbert/tokenization_distilbert.py
+++ b/src/transformers/models/distilbert/tokenization_distilbert.py
@@ -353,8 +353,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -364,7 +362,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -373,7 +370,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -396,9 +392,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -488,7 +482,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/distilbert/tokenization_distilbert.py
+++ b/src/transformers/models/distilbert/tokenization_distilbert.py
@@ -395,7 +395,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/distilbert/tokenization_distilbert.py
+++ b/src/transformers/models/distilbert/tokenization_distilbert.py
@@ -392,6 +392,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/distilbert/tokenization_distilbert.py
+++ b/src/transformers/models/distilbert/tokenization_distilbert.py
@@ -350,20 +350,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -382,7 +396,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -410,7 +426,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -472,7 +488,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/electra/tokenization_electra.py
+++ b/src/transformers/models/electra/tokenization_electra.py
@@ -345,8 +345,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -356,7 +354,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -365,7 +362,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -388,9 +384,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -480,7 +474,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/electra/tokenization_electra.py
+++ b/src/transformers/models/electra/tokenization_electra.py
@@ -384,6 +384,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/electra/tokenization_electra.py
+++ b/src/transformers/models/electra/tokenization_electra.py
@@ -387,7 +387,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/electra/tokenization_electra.py
+++ b/src/transformers/models/electra/tokenization_electra.py
@@ -342,20 +342,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -374,7 +388,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -402,7 +418,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -464,7 +480,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/funnel/tokenization_funnel.py
+++ b/src/transformers/models/funnel/tokenization_funnel.py
@@ -404,7 +404,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/funnel/tokenization_funnel.py
+++ b/src/transformers/models/funnel/tokenization_funnel.py
@@ -359,20 +359,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -391,7 +405,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -419,7 +435,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -481,7 +497,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/funnel/tokenization_funnel.py
+++ b/src/transformers/models/funnel/tokenization_funnel.py
@@ -362,8 +362,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -373,7 +371,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -382,7 +379,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -405,9 +401,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -497,7 +491,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/funnel/tokenization_funnel.py
+++ b/src/transformers/models/funnel/tokenization_funnel.py
@@ -401,6 +401,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -143,20 +143,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -175,7 +189,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -203,7 +219,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -265,7 +281,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -146,8 +146,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -157,7 +155,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -166,7 +163,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -189,9 +185,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -281,7 +275,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -188,7 +188,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -185,6 +185,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/layoutlm/tokenization_layoutlm.py
+++ b/src/transformers/models/layoutlm/tokenization_layoutlm.py
@@ -324,20 +324,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -356,7 +370,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -384,7 +400,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -446,7 +462,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/layoutlm/tokenization_layoutlm.py
+++ b/src/transformers/models/layoutlm/tokenization_layoutlm.py
@@ -369,7 +369,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/layoutlm/tokenization_layoutlm.py
+++ b/src/transformers/models/layoutlm/tokenization_layoutlm.py
@@ -366,6 +366,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/layoutlm/tokenization_layoutlm.py
+++ b/src/transformers/models/layoutlm/tokenization_layoutlm.py
@@ -327,8 +327,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -338,7 +336,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -347,7 +344,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -370,9 +366,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -462,7 +456,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
@@ -1404,6 +1404,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
@@ -1362,20 +1362,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -1394,7 +1408,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -1422,7 +1438,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -1484,7 +1500,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
@@ -1407,7 +1407,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
@@ -1365,8 +1365,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -1376,7 +1374,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -1385,7 +1382,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -1408,9 +1404,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -1500,7 +1494,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/lxmert/tokenization_lxmert.py
+++ b/src/transformers/models/lxmert/tokenization_lxmert.py
@@ -316,20 +316,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -348,7 +362,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -376,7 +392,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -438,7 +454,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/lxmert/tokenization_lxmert.py
+++ b/src/transformers/models/lxmert/tokenization_lxmert.py
@@ -319,8 +319,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -330,7 +328,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -339,7 +336,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -362,9 +358,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -454,7 +448,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/lxmert/tokenization_lxmert.py
+++ b/src/transformers/models/lxmert/tokenization_lxmert.py
@@ -361,7 +361,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/lxmert/tokenization_lxmert.py
+++ b/src/transformers/models/lxmert/tokenization_lxmert.py
@@ -358,6 +358,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/mobilebert/tokenization_mobilebert.py
+++ b/src/transformers/models/mobilebert/tokenization_mobilebert.py
@@ -359,7 +359,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/mobilebert/tokenization_mobilebert.py
+++ b/src/transformers/models/mobilebert/tokenization_mobilebert.py
@@ -356,6 +356,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/mobilebert/tokenization_mobilebert.py
+++ b/src/transformers/models/mobilebert/tokenization_mobilebert.py
@@ -317,8 +317,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -328,7 +326,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -337,7 +334,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -360,9 +356,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -452,7 +446,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/mobilebert/tokenization_mobilebert.py
+++ b/src/transformers/models/mobilebert/tokenization_mobilebert.py
@@ -314,20 +314,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -346,7 +360,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -374,7 +390,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -436,7 +452,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/mpnet/tokenization_mpnet.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet.py
@@ -345,8 +345,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -356,7 +354,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -365,7 +362,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -388,9 +384,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -480,7 +474,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/mpnet/tokenization_mpnet.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet.py
@@ -384,6 +384,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/mpnet/tokenization_mpnet.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet.py
@@ -387,7 +387,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/mpnet/tokenization_mpnet.py
+++ b/src/transformers/models/mpnet/tokenization_mpnet.py
@@ -342,20 +342,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -374,7 +388,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -402,7 +418,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -464,7 +480,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/openai/tokenization_openai.py
+++ b/src/transformers/models/openai/tokenization_openai.py
@@ -71,20 +71,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -103,7 +117,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -131,7 +147,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -193,7 +209,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/openai/tokenization_openai.py
+++ b/src/transformers/models/openai/tokenization_openai.py
@@ -74,8 +74,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -85,7 +83,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -94,7 +91,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -117,9 +113,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -209,7 +203,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/openai/tokenization_openai.py
+++ b/src/transformers/models/openai/tokenization_openai.py
@@ -113,6 +113,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/openai/tokenization_openai.py
+++ b/src/transformers/models/openai/tokenization_openai.py
@@ -116,7 +116,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/prophetnet/tokenization_prophetnet.py
+++ b/src/transformers/models/prophetnet/tokenization_prophetnet.py
@@ -117,7 +117,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/prophetnet/tokenization_prophetnet.py
+++ b/src/transformers/models/prophetnet/tokenization_prophetnet.py
@@ -72,20 +72,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -104,7 +118,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -132,7 +148,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -194,7 +210,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/prophetnet/tokenization_prophetnet.py
+++ b/src/transformers/models/prophetnet/tokenization_prophetnet.py
@@ -75,8 +75,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -86,7 +84,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -95,7 +92,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -118,9 +114,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -210,7 +204,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/prophetnet/tokenization_prophetnet.py
+++ b/src/transformers/models/prophetnet/tokenization_prophetnet.py
@@ -114,6 +114,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/retribert/tokenization_retribert.py
+++ b/src/transformers/models/retribert/tokenization_retribert.py
@@ -333,20 +333,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -365,7 +379,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -393,7 +409,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -455,7 +471,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/retribert/tokenization_retribert.py
+++ b/src/transformers/models/retribert/tokenization_retribert.py
@@ -375,6 +375,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/retribert/tokenization_retribert.py
+++ b/src/transformers/models/retribert/tokenization_retribert.py
@@ -378,7 +378,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/retribert/tokenization_retribert.py
+++ b/src/transformers/models/retribert/tokenization_retribert.py
@@ -336,8 +336,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -347,7 +345,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -356,7 +353,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -379,9 +375,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -471,7 +465,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/roc_bert/tokenization_roc_bert.py
+++ b/src/transformers/models/roc_bert/tokenization_roc_bert.py
@@ -973,6 +973,9 @@ class RoCBertBasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/roc_bert/tokenization_roc_bert.py
+++ b/src/transformers/models/roc_bert/tokenization_roc_bert.py
@@ -931,20 +931,34 @@ class RoCBertBasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -963,7 +977,9 @@ class RoCBertBasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -991,7 +1007,7 @@ class RoCBertBasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -1053,7 +1069,7 @@ class RoCBertBasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/roc_bert/tokenization_roc_bert.py
+++ b/src/transformers/models/roc_bert/tokenization_roc_bert.py
@@ -976,7 +976,6 @@ class RoCBertBasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/roc_bert/tokenization_roc_bert.py
+++ b/src/transformers/models/roc_bert/tokenization_roc_bert.py
@@ -934,8 +934,6 @@ class RoCBertBasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -945,7 +943,6 @@ class RoCBertBasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -954,7 +951,6 @@ class RoCBertBasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -977,9 +973,7 @@ class RoCBertBasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -1069,7 +1063,7 @@ class RoCBertBasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/roformer/tokenization_roformer.py
+++ b/src/transformers/models/roformer/tokenization_roformer.py
@@ -152,7 +152,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/roformer/tokenization_roformer.py
+++ b/src/transformers/models/roformer/tokenization_roformer.py
@@ -107,20 +107,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -139,7 +153,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -167,7 +183,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -229,7 +245,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/roformer/tokenization_roformer.py
+++ b/src/transformers/models/roformer/tokenization_roformer.py
@@ -149,6 +149,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/roformer/tokenization_roformer.py
+++ b/src/transformers/models/roformer/tokenization_roformer.py
@@ -110,8 +110,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -121,7 +119,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -130,7 +127,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -153,9 +149,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -245,7 +239,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/squeezebert/tokenization_squeezebert.py
+++ b/src/transformers/models/squeezebert/tokenization_squeezebert.py
@@ -373,7 +373,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/src/transformers/models/squeezebert/tokenization_squeezebert.py
+++ b/src/transformers/models/squeezebert/tokenization_squeezebert.py
@@ -331,8 +331,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -342,7 +340,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -351,7 +348,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -374,9 +370,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -466,7 +460,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/squeezebert/tokenization_squeezebert.py
+++ b/src/transformers/models/squeezebert/tokenization_squeezebert.py
@@ -328,20 +328,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -360,7 +374,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -388,7 +404,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -450,7 +466,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/squeezebert/tokenization_squeezebert.py
+++ b/src/transformers/models/squeezebert/tokenization_squeezebert.py
@@ -370,6 +370,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -2097,6 +2097,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -2055,20 +2055,34 @@ class BasicTokenizer(object):
         strip_accents (`bool`, *optional*):
             Whether or not to strip all accents. If this option is not specified, then it will be determined by the
             value for `lowercase` (as in the original BERT).
+        do_split_on_punc (`bool`, *optional*, defaults to `True`):
+            In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
+            the full context of the words, such as contractions.
+        remove_control_chars (`bool`, *optional*, defaults to `True`):
+            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
-    def __init__(self, do_lower_case=True, never_split=None, tokenize_chinese_chars=True, strip_accents=None):
+    def __init__(
+        self,
+        do_lower_case=True,
+        never_split=None,
+        tokenize_chinese_chars=True,
+        strip_accents=None,
+        do_split_on_punc=True,
+        remove_control_chars=True,
+    ):
         if never_split is None:
             never_split = []
         self.do_lower_case = do_lower_case
         self.never_split = set(never_split)
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
+        self.do_split_on_punc = do_split_on_punc
+        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
-        Basic Tokenization of a piece of text. Split on "white spaces" only, for sub-word tokenization, see
-        WordPieceTokenizer.
+        Basic Tokenization of a piece of text. For sub-word tokenization, see WordPieceTokenizer.
 
         Args:
             never_split (`List[str]`, *optional*)
@@ -2087,7 +2101,9 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        orig_tokens = whitespace_tokenize(text)
+        # prevents treating the same character with different unicode codepoints as different characters
+        unicode_normalized_text = unicodedata.normalize("NFC", text)
+        orig_tokens = whitespace_tokenize(unicode_normalized_text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -2115,7 +2131,7 @@ class BasicTokenizer(object):
 
     def _run_split_on_punc(self, text, never_split=None):
         """Splits punctuation on a piece of text."""
-        if never_split is not None and text in never_split:
+        if not self.do_split_on_punc or (never_split is not None and text in never_split):
             return [text]
         chars = list(text)
         i = 0
@@ -2177,7 +2193,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or _is_control(char):
+            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -2058,8 +2058,6 @@ class BasicTokenizer(object):
         do_split_on_punc (`bool`, *optional*, defaults to `True`):
             In some instances we want to skip the basic punctuation splitting so that later tokenization can capture
             the full context of the words, such as contractions.
-        remove_control_chars (`bool`, *optional*, defaults to `True`):
-            Whether to allow or remove control characers, as some vocabs includes them.
     """
 
     def __init__(
@@ -2069,7 +2067,6 @@ class BasicTokenizer(object):
         tokenize_chinese_chars=True,
         strip_accents=None,
         do_split_on_punc=True,
-        remove_control_chars=True,
     ):
         if never_split is None:
             never_split = []
@@ -2078,7 +2075,6 @@ class BasicTokenizer(object):
         self.tokenize_chinese_chars = tokenize_chinese_chars
         self.strip_accents = strip_accents
         self.do_split_on_punc = do_split_on_punc
-        self.remove_control_chars = remove_control_chars
 
     def tokenize(self, text, never_split=None):
         """
@@ -2101,9 +2097,7 @@ class BasicTokenizer(object):
         # words in the English Wikipedia.).
         if self.tokenize_chinese_chars:
             text = self._tokenize_chinese_chars(text)
-        # prevents treating the same character with different unicode codepoints as different characters
-        unicode_normalized_text = unicodedata.normalize("NFC", text)
-        orig_tokens = whitespace_tokenize(unicode_normalized_text)
+        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:
@@ -2193,7 +2187,7 @@ class BasicTokenizer(object):
         output = []
         for char in text:
             cp = ord(char)
-            if cp == 0 or cp == 0xFFFD or (self.remove_control_chars and _is_control(char)):
+            if cp == 0 or cp == 0xFFFD or _is_control(char):
                 continue
             if _is_whitespace(char):
                 output.append(" ")

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -2100,7 +2100,6 @@ class BasicTokenizer(object):
         # prevents treating the same character with different unicode codepoints as different characters
         unicode_normalized_text = unicodedata.normalize("NFC", text)
         orig_tokens = whitespace_tokenize(unicode_normalized_text)
-        orig_tokens = whitespace_tokenize(text)
         split_tokens = []
         for token in orig_tokens:
             if token not in never_split:

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -189,15 +189,13 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(tokenizer.tokenize(text), expected)
 
     def test_basic_tokenizer_remove_control_chars_true(self):
-        tokenizer = BasicTokenizer(remove_control_chars=True)
-        # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
-        text = "\u200E\u200F"
+        tokenizer = BasicTokenizer()
+        text = "\u200E\u200F"  # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
         self.assertListEqual(tokenizer.tokenize(text), [])
 
     def test_basic_tokenizer_remove_control_chars_false(self):
         tokenizer = BasicTokenizer(remove_control_chars=False)
-        # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
-        text = "\u200E\u200F"
+        text = "\u200E\u200F"  # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
         self.assertListEqual(tokenizer.tokenize(text), ["\u200E\u200F"])
 
     def test_wordpiece_tokenizer(self):

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -182,6 +182,20 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]"), ["HeLLo", "!", "how", "Are", "yoU", "?", "[UNK]"]
         )
 
+    def test_basic_tokenizer_split_on_punc_or_pattern(self):
+        # # Split on punc
+        tokenizer = BasicTokenizer()
+        text = "a\n'll !!to?'d of, can't."
+        expected = ["a", "'", "ll", "!", "!", "to", "?", "'", "d", "of", ",", "can", "'", "t", "."]
+        self.assertListEqual(tokenizer.tokenize(text), expected)
+
+        # Split on patterns
+        pattern = r"(<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+)"
+        tokenizer = BasicTokenizer(pattern=pattern)
+        text = "a\n'll !!to?'d''d of, can't."
+        expected = ['a', "'ll", '!!', 'to', "?'", 'd', "''", 'd', 'of', ',', 'can', "'t", '.']
+        self.assertListEqual(tokenizer.tokenize(text), expected)
+
     def test_wordpiece_tokenizer(self):
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn", "##ing"]
 

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -182,19 +182,23 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             tokenizer.tokenize(" \tHeLLo!how  \n Are yoU? [UNK]"), ["HeLLo", "!", "how", "Are", "yoU", "?", "[UNK]"]
         )
 
-    def test_basic_tokenizer_split_on_punc_or_pattern(self):
-        # # Split on punc
+    def test_basic_tokenizer_splits_on_punctuation(self):
         tokenizer = BasicTokenizer()
         text = "a\n'll !!to?'d of, can't."
         expected = ["a", "'", "ll", "!", "!", "to", "?", "'", "d", "of", ",", "can", "'", "t", "."]
         self.assertListEqual(tokenizer.tokenize(text), expected)
 
-        # Split on patterns
-        pattern = r"(<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+)"
-        tokenizer = BasicTokenizer(pattern=pattern)
-        text = "a\n'll !!to?'d''d of, can't."
-        expected = ["a", "'ll", "!!", "to", "?'", "d", "''", "d", "of", ",", "can", "'t", "."]
-        self.assertListEqual(tokenizer.tokenize(text), expected)
+    def test_basic_tokenizer_remove_control_chars_true(self):
+        tokenizer = BasicTokenizer(remove_control_chars=True)
+        # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
+        text = "\u200E\u200F"
+        self.assertListEqual(tokenizer.tokenize(text), [])
+
+    def test_basic_tokenizer_remove_control_chars_false(self):
+        tokenizer = BasicTokenizer(remove_control_chars=False)
+        # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
+        text = "\u200E\u200F"
+        self.assertListEqual(tokenizer.tokenize(text), ["\u200E\u200F"])
 
     def test_wordpiece_tokenizer(self):
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn", "##ing"]

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -193,7 +193,7 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         pattern = r"(<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+)"
         tokenizer = BasicTokenizer(pattern=pattern)
         text = "a\n'll !!to?'d''d of, can't."
-        expected = ['a', "'ll", '!!', 'to', "?'", 'd', "''", 'd', 'of', ',', 'can', "'t", '.']
+        expected = ["a", "'ll", "!!", "to", "?'", "d", "''", "d", "of", ",", "can", "'t", "."]
         self.assertListEqual(tokenizer.tokenize(text), expected)
 
     def test_wordpiece_tokenizer(self):

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -188,16 +188,6 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         expected = ["a", "'", "ll", "!", "!", "to", "?", "'", "d", "of", ",", "can", "'", "t", "."]
         self.assertListEqual(tokenizer.tokenize(text), expected)
 
-    def test_basic_tokenizer_remove_control_chars_true(self):
-        tokenizer = BasicTokenizer()
-        text = "\u200E\u200F"  # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
-        self.assertListEqual(tokenizer.tokenize(text), [])
-
-    def test_basic_tokenizer_remove_control_chars_false(self):
-        tokenizer = BasicTokenizer(remove_control_chars=False)
-        text = "\u200E\u200F"  # \u200E: (left-to-right mark):w, \u200F: (right-to-left mark)
-        self.assertListEqual(tokenizer.tokenize(text), ["\u200E\u200F"])
-
     def test_wordpiece_tokenizer(self):
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn", "##ing"]
 

--- a/tests/models/clip/test_tokenization_clip.py
+++ b/tests/models/clip/test_tokenization_clip.py
@@ -106,6 +106,7 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 for unicode_seq in spaces_unicodes:
                     text_tokenized_s = tokenizer_s.tokenize(unicode_seq)
                     text_tokenized_r = tokenizer_r.tokenize(unicode_seq)
+
                     self.assertListEqual(text_tokenized_s, text_tokenized_r)
 
                 # Test that the tokenization is identical on unicode of line break type
@@ -117,7 +118,7 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     "\u000D",  # (carriage return, '\r')
                     "\u2028",  # (line separator)
                     "\u2029",  # (paragraph separator)
-                    # "\u0085",  # (next line)
+                    # "\u0085", # (next line)
                 ]
 
                 # The tokenization is not identical for the character "\u0085" (next line). The slow version using ftfy transforms

--- a/tests/models/clip/test_tokenization_clip.py
+++ b/tests/models/clip/test_tokenization_clip.py
@@ -74,6 +74,7 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         input_bpe_tokens = [10, 2, 16, 9, 3, 2, 16, 20]
         self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
 
+    @require_ftfy
     def test_check_encoding_slow_fast(self):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
             with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):

--- a/tests/models/clip/test_tokenization_clip.py
+++ b/tests/models/clip/test_tokenization_clip.py
@@ -74,14 +74,13 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         input_bpe_tokens = [10, 2, 16, 9, 3, 2, 16, 20]
         self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
 
-    @require_ftfy
     def test_check_encoding_slow_fast(self):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
             with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
                 tokenizer_s = self.tokenizer_class.from_pretrained(pretrained_name, **kwargs)
                 tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name, **kwargs)
 
-                text = "A\n'll 11p223RF☆ho!!to?'d'd''d of a cat"
+                text = "A\n'll 11p223RF☆ho!!to?'d'd''d of a cat to-$''d."
                 text_tokenized_s = tokenizer_s.tokenize(text)
                 text_tokenized_r = tokenizer_r.tokenize(text)
 
@@ -107,7 +106,6 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                 for unicode_seq in spaces_unicodes:
                     text_tokenized_s = tokenizer_s.tokenize(unicode_seq)
                     text_tokenized_r = tokenizer_r.tokenize(unicode_seq)
-
                     self.assertListEqual(text_tokenized_s, text_tokenized_r)
 
                 # Test that the tokenization is identical on unicode of line break type
@@ -119,10 +117,10 @@ class CLIPTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     "\u000D",  # (carriage return, '\r')
                     "\u2028",  # (line separator)
                     "\u2029",  # (paragraph separator)
-                    # "\u0085", # (next line)
+                    # "\u0085",  # (next line)
                 ]
 
-                # The tokenization is not identical for the character "\u0085" (next line). The slow version transforms
+                # The tokenization is not identical for the character "\u0085" (next line). The slow version using ftfy transforms
                 # it into the Horizontal Ellipsis character "…" ("\u2026") while the fast version transforms it into a
                 # space (and thus into an empty list).
 


### PR DESCRIPTION
# What does this PR do?

Note: The tests are failing because of repo-consistency, but I intentionally haven't made the change across the repo until we confirm what change we want to make. Will remove [Don't merge] tag once done.

This fixes an issue related to the BasicTokenizer.

Initially looked to fix #22166 by updating the _run_split_on_punc method in the BasicTokenizer to split apostrophes without starting a new word. In the issue, it was noted that apostrophes weren't being split properly as `should've` was being converted to `should`, `'`, and `ve` instead of `should` and `'ve`.

However, when adding testing it became apparent there are other cases where the BasicTokenizer is failing too, such as capturing '!!' as separate tokens with id 256 as opposed to one 748 token, which is in the [vocab](https://huggingface.co/openai/clip-vit-base-patch32/resolve/main/vocab.json).

To address these I modified `_run_split_on_punc` in the BasicTokenizer to also split on passed patterns and renamed it `_split_on_punc_or_pattern` and added tests for them. 


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
@ArthurZucker