### PR TITLE
Enforce `max_memory` for device_map strategies

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2571,6 +2571,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     model,
                     dtype=torch_dtype,
                     low_zero=(device_map == "balanced_low_0"),
+                    max_memory=max_memory,
                     **kwargs,
                 )
             kwargs["max_memory"] = max_memory


### PR DESCRIPTION
# What does this PR do?

In #22271, by removing the `max_memory` from the kwargs before it gets passed to `get_balanced_memory`, I effectively made the `max_memory` argument ignored when `device_map` is `"auto"`, `"balanced"` or `"balanced_low_0"` (as was caught in the multi-GPU tests). This PR fixes that.