### PR TITLE
Hardware Auto-Setup for Tutorials and Examples

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -30,6 +30,8 @@
       title: Train with a script
     - local: sagemaker
       title: Run training on Amazon SageMaker
+    - local: launch_auto_hardware
+      title: Run training or inference on remote hardware (auto setup)
     - local: converting_tensorflow_models
       title: Converting from TensorFlow checkpoints
     - local: serialization

--- a/docs/source/en/launch_auto_hardware.mdx
+++ b/docs/source/en/launch_auto_hardware.mdx
@@ -10,12 +10,12 @@ specific language governing permissions and limitations under the License.
 # Run Training or Inference on Remote Hardware (with Auto Setup)
 
 This page demonstrates how to run model training or inference on remote, self-hosted hardware, with automatic
-dependency and environment setup. You can develop fully locally on a Colab or local Python script, while execution
-a remote cluster to take advantage of accelerators like GPUs or TPUs.
+dependency and environment setup, via [Runhouse](https://github.com/run-house/runhouse). You can develop fully
+locally on a Colab or local Python script, while executing on a remote cluster to take advantage of
+accelerators like GPUs or TPUs.
 
 Remote hardware includes both on-demand clusters through cloud providers and existing clusters with SSH credentials.
-
-This tutorial is also available as a Colab [here]().
+For more info, see the [Runhouse compute overview](https://runhouse-docs.readthedocs-hosted.com/en/latest/overview/compute.html).
 
 ## Instantiate Remote Cluster
 

--- a/docs/source/en/launch_auto_hardware.mdx
+++ b/docs/source/en/launch_auto_hardware.mdx
@@ -70,7 +70,7 @@ To set up the hardware environment to be able to seamlessly run the distributed 
 necessary for running the training function with accelerate.
 
 ```python
-reqs = ['./', 'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
+reqs = ['./', 'transformers', 'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
 ```
 
 Then, we can create a callable to launch our training function, setting the hardware/system that it is intended to be run on,

--- a/docs/source/en/launch_auto_hardware.mdx
+++ b/docs/source/en/launch_auto_hardware.mdx
@@ -1,0 +1,92 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Run Training or Inference on Remote Hardware (with Auto Setup)
+
+This page demonstrates how to run model training or inference on remote, self-hosted hardware, with automatic
+dependency and environment setup. You can develop fully locally on a Colab or local Python script, while execution
+a remote cluster to take advantage of accelerators like GPUs or TPUs.
+
+Remote hardware includes both on-demand clusters through cloud providers and existing clusters with SSH credentials.
+
+This tutorial is also available as a Colab [here]().
+
+## Instantiate Remote Cluster
+
+Install Runhouse, which is used for creating a local Cluster object and sending remote function calls.
+
+```python
+import runhouse as rh
+```
+
+### On-Demand Clusters (AWS, Azure, GCP, LambdaLabs)
+
+On-Demand clusters are cloud clusters that are spun up/down automatically for you.
+For instructions on setting up cloud access for on-demand clusters, please refer to
+[Hardware Setup](https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup).
+
+```python
+# Single GPU
+gpu = rh.cluster(name="rh-cluster", instance_type="V100:1", provider="cheapest").up_if_not()
+# Multi GPU
+# gpu = rh.cluster(name="rh-cluster", instance_type="V100:4", provider="cheapest").up_if_not()
+gpu.keep_warm(60)  # automatically terminate gpu after this long of inactivity (-1 to disable)
+```
+
+### On-Premise Cluster
+
+To instantiate a BYO or on-prem cluster, you will need to provide the IP addresses and SSH credentials as follows.
+
+```python
+gpu = rh.cluster(
+    ips=["<ip of the cluster>"], ssh_creds={"ssh_user": "...", "ssh_private_key": "<path_to_key>"}, name="rh-a10x"
+)
+```
+
+# Inference
+
+We'll start with inference. Below, we're defining an inference function to run on the remote hardware.
+
+Load and initialize the gpt2 model and tokenizer, and then run inference on a sample input.
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+def gpt2(prompt, *args):
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    model = AutoModelForCausalLM.from_pretrained("gpt2")
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+    output = model.generate(input_ids, max_length=100, do_sample=True)
+    return tokenizer.decode(output[0], skip_special_tokens=True)
+```
+
+To set up the hardware environment to be able to seamlessly run the distributed launch function, first define the dependencies
+necessary for running the training function with accelerate.
+
+```python
+reqs = ['./', 'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
+```
+
+Then, we can create a callable to launch our training function, setting the hardware/system that it is intended to be run on,
+as well as the requirements for running the function.
+
+```python
+gpt2_gpu = rh.function(fn=gpt2).to(system=gpu, reqs=reqs)
+```
+
+Now we just call it.
+
+```python
+output = gpt2_gpu("Hello, I'm a language model, and I")
+print(output)
+```
+
+## Training
+
+# TODO

--- a/examples/README.md
+++ b/examples/README.md
@@ -99,7 +99,11 @@ and run the example command as usual afterward.
 
 If you want to run the examples on a remote machine, you can use the `run_on_remote.py` script. It will optionally
 spin up that machine on-demand from a cloud provider, automatically install the required dependencies and 
-run the example on the remote machine. You can run it with the following command:
+run the example on the remote machine, via [Runhouse](https://github.com/run-house/runhouse). See the 
+[Runhouse compute overview](https://runhouse-docs.readthedocs-hosted.com/en/latest/overview/compute.html) for more 
+information about hardware and dependency setup. 
+
+You can run it with the following command:
 
 ```bash
 # First install runhouse:
@@ -113,7 +117,7 @@ python run_on_remote.py \
     --prompt "This is a test"
 
 # For byo (bring your own) cluster:
-python run_on_remote.py --host <cluster_ip> --user <user> --key_path <key_path> \
+python run_on_remote.py --host <cluster_ip> --user <ssh_user> --key_path <ssh_key_path> \
   --example <example> <args>
 
 # For on-demand instances

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,3 +94,31 @@ Alternatively, you can switch your cloned 🤗 Transformers to a specific versio
 git checkout tags/v3.5.1
 ```
 and run the example command as usual afterward.
+
+## Running the Examples on Remote Hardware (with Auto-Setup)
+
+If you want to run the examples on a remote machine, you can use the `run_on_remote.py` script. It will optionally
+spin up that machine on-demand from a cloud provider, automatically install the required dependencies and 
+run the example on the remote machine. You can run it with the following command:
+
+```bash
+# First install runhouse:
+pip install runhouse
+
+# For an on-demand V100 with whichever cloud provider you have configured:
+python run_on_remote.py \
+    --example pytorch/text-generation/run_generation.py \
+    --model_type=gpt2 \
+    --model_name_or_path=gpt2 \
+    --prompt "This is a test"
+
+# For byo (bring your own) cluster:
+python run_on_remote.py --host <cluster_ip> --user <user> --key_path <key_path> \
+  --example <example> <args>
+
+# For on-demand instances
+python run_on_remote.py --instance <instance> --provider <provider> \
+  --example <example> <args>
+```
+
+You can also adapt the script to your own needs.

--- a/examples/run_on_remote.py
+++ b/examples/run_on_remote.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import runhouse as rh
+
+if __name__ == "__main__":
+    # Refer to https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup for cloud access
+    # setup instructions, if using on-demand hardware
+
+    # If user passes --user <user> --host <host> --key_path <key_path> <example> <args>, fill them in as BYO cluster
+    # If user passes --instance <instance> --provider <provider> <example> <args>, fill them in as on-demand cluster
+    # Throw an error if user passes both BYO and on-demand cluster args
+    # Otherwise, use default values
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--user', type=str, default='ubuntu')
+    parser.add_argument('--host', type=str, default='localhost')
+    parser.add_argument('--key_path', type=str, default=None)
+    parser.add_argument('--instance', type=str, default='V100:1')
+    parser.add_argument('--provider', type=str, default='cheapest')
+    parser.add_argument('--use_spot', type=bool, default=False)
+    parser.add_argument('--example', type=str, default='pytorch/text-generation/run_generation.py')
+    args, unknown = parser.parse_known_args()
+    if args.host != 'localhost':
+        if args.instance != 'V100:1' or args.provider != 'cheapest':
+            raise ValueError('Cannot specify both BYO and on-demand cluster args')
+        cluster = rh.cluster(name='rh-cluster', ips=[args.host],
+                             ssh_creds={"ssh_user": args.user, "ssh_private_key": args.key_path})
+    else:
+        cluster = rh.cluster(name='rh-cluster',
+                             instance_type=args.instance,
+                             provider=args.provider,
+                             use_spot=args.use_spot)
+    example_dir = args.example.rsplit('/', 1)[0]
+
+    # Set up remote environment
+    cluster.install_packages(['pip:./'])  # Installs transformers from local source
+    # Note transformers is copied into the home directory on the remote machine, so we can install from there
+    cluster.run([f'pip install -r transformers/examples/{example_dir}/requirements.txt'])
+    cluster.run(['pip install torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117'])
+
+    # Run example. You can bypass the CLI wrapper and paste your own code here.
+    cluster.run([f'python transformers/examples/{args.example} {" ".join(shlex.quote(arg) for arg in unknown)}'])
+
+    # Alternatively, we can just import and run a training function (especially if there's no wrapper CLI):
+    # from my_script... import train
+    # reqs = ['pip:./', 'torch', 'datasets', 'accelerate', 'evaluate', 'tqdm', 'scipy', 'scikit-learn', 'tensorboard']
+    # launch_train_gpu = rh.function(fn=train,
+    #                                system=gpu,
+    #                                reqs=reqs,
+    #                                name='train_bert_glue')
+    #
+    # We can pass in arguments just like we would to a function:
+    # launch_train_gpu(num_epochs = 3, lr = 2e-5, seed = 42, batch_size = 16
+    #                  stream_logs=True)


### PR DESCRIPTION
# What does this PR do?

Discussed with @sgugger and @LysandreJik . This PR introduces auto-setup functionality for tutorials and examples (we are sending a parallel PR to accelerate, and maybe Diffusers and Spaces shortly). This allows users to run transformers code, tutorials, and scripts on self-hosted hardware (either their own instance or a cloud instances) including on-demand allocation of the hardware itself on AWS, GCP, Azure, or Lambda Labs, and installation of dependencies. This introduces a similar level of turnkey usage and reproducibility that users only typically expect in Colab, but for any type of hardware on any cloud (we've tested on Paperspace and Coreweave as well, allocating the instance in their UI and then plugging in the IP as a static cluster). Note that Runhouse OSS is facilitating the setup (via SkyPilot) and rpc, but users don't don't need to create a Runhouse account or anything like that, this is strictly inside their own cloud accounts with their own credentials (or using their IP and ssh creds without a cloud account).

This PR is WIP and seeking feedback. A few open questions:
1. launch_auto_hardware.mdx is structured to be like a notebook, but how do I make it have the "launch in colab" etc. buttons on the top right? (I'm happy to refactor it into an ipynb if needed)
2. launch_auto_hardware.mdx shows only inference. I think it could be valuable to make it mirror the initial PyTorch parts of [the yelp fine-tuning tutorial](https://huggingface.co/docs/transformers/training), to show preprocessing, training, and inference all on remote hardware. Does that make sense?
3. We're generally using the term "remote hardware" with "auto setup". Would it be better to say "self-hosted" or something like that (to avoid confusion with hosted solutions)?
4. Should we showcase more examples? Right now we show just a few but can add more if you think that's valuable (e.g. @sgugger mentioned showing TPUs before). We can also tailor the auto-setup scripts to different examples if desired, rather than the one-size fits all approach.

Thank you for your input on this so far!!


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).