### PR TITLE
Seq2seq trainer generation config arg

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -33,24 +33,26 @@ logger = logging.get_logger(__name__)
 class Seq2SeqTrainer(Trainer):
     def __load_generation_config(self, gen_kwargs: Dict[str, Any]) -> Union[GenerationConfig, None]:
         """
-        Loads the `~generation.GenerationConfig` from the `generation_config_from_pretrained` arguments.
-        Priority: gen_kwargs > self.args.generation_config_from_pretrained (`Seq2SeqTrainingArguments`)
+        Loads a `~generation.GenerationConfig` from the `generation_config_from_pretrained` arguments. Priority:
+        gen_kwargs > self.args.generation_config_from_pretrained (`Seq2SeqTrainingArguments`)
+
         If no `generation_config_from_pretrained` has been provided, this method return None and in this case
         `generate` will fallback to `model.generation_config` or the default `~generation.GenerationConfig` values.
 
-        Priority: gen_kwargs > generation_config_from_pretrained > model.generation_config > default GenerationConfig
-        This is handled in `generate`, here we just create `~generation.GenerationConfig` from the
+        Priority: gen_kwargs > generation_config_from_pretrained > model.generation_config > default GenerationConfig.
+
+        This is handled in `generate`, here we just create a `~generation.GenerationConfig` from the
         `generation_config_from_pretrained` argument.
 
         Args:
-            gen_kwargs:
+            gen_kwargs (`Dict[str, Any]`):
                 Additional `generate` specific kwargs as a dictionary. If `generation_config_from_pretrained` is
-                provided, it will use this argument instead of the one from training arguments, and the entry will
-                be popped to not interfere when calling `generate`.
+                provided, it will use this argument in priority, and the entry will be popped to not interfere when
+                calling `generate`.
 
         Returns:
-            A `~generation.GenerationConfig` or None if no `generation_config_from_pretrained` has been provided in
-            `self.args` (`Seq2SeqTrainingArguments`).
+            A `~generation.GenerationConfig`, or `None` if no `generation_config_from_pretrained` has been provided in
+            `self.args` (`Seq2SeqTrainingArguments`) or `gen_kwargs`.
         """
         # Select the generation config argument
         if "generation_config_from_pretrained" in gen_kwargs:
@@ -231,8 +233,8 @@ class Seq2SeqTrainer(Trainer):
         # removed in https://github.com/huggingface/transformers/blob/98d88b23f54e5a23e741833f1e973fdf600cc2c5/src/transformers/generation/utils.py#L1183
         if self.model.generation_config._from_model_config:
             self.model.generation_config._from_model_config = False
-        # Retrieves GenerationConfig in case we did not provide a one to generate
-        # it used model.generation_config, or set the attribute if it didn't exist
+        # Retrieves GenerationConfig in case we did not provide one to generate.
+        # In this case, it used model.generation_config
         if gen_config is None:
             gen_config = model.generation_config
         # in case the batch is shorter than max length, the output should be padded

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -245,7 +245,7 @@ class Seq2SeqTrainer(Trainer):
             labels = inputs["labels"]
             if labels.shape[-1] < gen_config.max_length:
                 labels = self._pad_tensors_to_max_len(labels, gen_config.max_length)
-            elif labels.shape[-1] < gen_config.max_new_tokens + 1:
+            elif gen_config.max_new_tokens is not None and labels.shape[-1] < gen_config.max_new_tokens + 1:
                 labels = self._pad_tensors_to_max_len(labels, gen_config.max_new_tokens + 1)
         else:
             labels = None

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -103,10 +103,10 @@ class Seq2SeqTrainer(Trainer):
                 An optional prefix to be used as the metrics key prefix. For example the metrics "bleu" will be named
                 "eval_bleu" if the prefix is `"eval"` (default)
             max_length (`int`, *optional*):
-                 The maximum target length to use when predicting with the generate method.
+                The maximum target length to use when predicting with the generate method.
             num_beams (`int`, *optional*):
-                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
-                 beam search.
+                Number of beams for beam search that will be used when predicting with the generate method. 1 means no
+                beam search.
             gen_kwargs:
                 Additional `generate` specific kwargs.
 
@@ -149,10 +149,10 @@ class Seq2SeqTrainer(Trainer):
                 An optional prefix to be used as the metrics key prefix. For example the metrics "bleu" will be named
                 "eval_bleu" if the prefix is `"eval"` (default)
             max_length (`int`, *optional*):
-                 The maximum target length to use when predicting with the generate method.
+                The maximum target length to use when predicting with the generate method.
             num_beams (`int`, *optional*):
-                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
-                 beam search.
+                Number of beams for beam search that will be used when predicting with the generate method. 1 means no
+                beam search.
             gen_kwargs:
                 Additional `generate` specific kwargs.
 

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -111,6 +111,11 @@ class Seq2SeqTrainer(Trainer):
         """
 
         self._gen_kwargs = gen_kwargs.copy()
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.args.generation_max_length
+        gen_kwargs["num_beams"] = (
+            gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
+        )
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
@@ -156,6 +161,11 @@ class Seq2SeqTrainer(Trainer):
         """
 
         self._gen_kwargs = gen_kwargs.copy()
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.args.generation_max_length
+        gen_kwargs["num_beams"] = (
+            gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
+        )
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def prediction_step(

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -31,62 +31,50 @@ logger = logging.get_logger(__name__)
 
 
 class Seq2SeqTrainer(Trainer):
-    def __load_generation_config(self, gen_kwargs: Dict[str, Any]) -> Union[GenerationConfig, None]:
+    def __init__(self, *args_, **kwargs):
+        super().__init__(*args_, **kwargs)
+
+        # Override self.model.generation_config if a GenerationConfig is specified in args.
+        # Priority: args.generation_config > model.generation_config > default GenerationConfig.
+        if self.args.generation_config is not None:
+            gen_config = self.load_generation_config(self.args.generation_config)
+            self.model.generation_config = gen_config
+
+    @staticmethod
+    def load_generation_config(gen_config_arg: Union[str, GenerationConfig]) -> GenerationConfig:
         """
-        Loads a `~generation.GenerationConfig` from the `generation_config_from_pretrained` arguments. Priority:
-        gen_kwargs > self.args.generation_config_from_pretrained (`Seq2SeqTrainingArguments`)
-
-        If no `generation_config_from_pretrained` has been provided, this method return None and in this case
-        `generate` will fallback to `model.generation_config` or the default `~generation.GenerationConfig` values.
-
-        Priority: gen_kwargs > generation_config_from_pretrained > model.generation_config > default GenerationConfig.
-
-        This is handled in `generate`, here we just create a `~generation.GenerationConfig` from the
-        `generation_config_from_pretrained` argument.
+        Loads a `~generation.GenerationConfig` from the `Seq2SeqTrainingArguments.generation_config` arguments.
 
         Args:
-            gen_kwargs (`Dict[str, Any]`):
-                Additional `generate` specific kwargs as a dictionary. If `generation_config_from_pretrained` is
-                provided, it will use this argument in priority, and the entry will be popped to not interfere when
-                calling `generate`.
+            gen_config_arg (`str` or [`~generation.GenerationConfig`]):
+                `Seq2SeqTrainingArguments.generation_config` argument.
 
         Returns:
-            A [`~generation.GenerationConfig`], or `None` if no `generation_config_from_pretrained` has been provided in
-            `self.args` (`Seq2SeqTrainingArguments`) or `gen_kwargs`.
+            A `~generation.GenerationConfig`.
         """
-        # Select the generation config argument
-        if "generation_config_from_pretrained" in gen_kwargs:
-            gen_config_arg = gen_kwargs.pop("generation_config_from_pretrained")
-        else:
-            gen_config_arg = self.args.generation_config_from_pretrained
-
-        # No gen config arg, returns None
-        if gen_config_arg is None:
-            return None
 
         # GenerationConfig provided, nothing to do
-        elif isinstance(gen_config_arg, GenerationConfig):
+        if isinstance(gen_config_arg, GenerationConfig):
             return deepcopy(gen_config_arg)
 
         # str or Path
+        pretrained_model_name = Path(gen_config_arg) if isinstance(gen_config_arg, str) else gen_config_arg
+        config_file_name = None
+
+        # Figuring if it is path pointing to a file, pointing to a directory or else a model id or URL
+        # This step is required in order to determine config_file_name
+        if pretrained_model_name.is_file():
+            config_file_name = pretrained_model_name.name
+            pretrained_model_name = pretrained_model_name.parent
+        # dir path
+        elif pretrained_model_name.is_dir():
+            pass
+        # model id or URL
         else:
-            pretrained_model_name = Path(gen_config_arg) if isinstance(gen_config_arg, str) else gen_config_arg
-            config_file_name = None
+            pretrained_model_name = gen_config_arg
 
-            # Figuring if it is path pointing to a file, pointing to a directory or else a model id or URL
-            # This step is required in order to determine config_file_name
-            if pretrained_model_name.is_file():
-                config_file_name = pretrained_model_name.name
-                pretrained_model_name = pretrained_model_name.parent
-            # dir path
-            elif pretrained_model_name.is_dir():
-                pass
-            # model id or URL
-            else:
-                pretrained_model_name = gen_config_arg
-
-            gen_config = GenerationConfig.from_pretrained(pretrained_model_name, config_file_name)
-            return gen_config
+        gen_config = GenerationConfig.from_pretrained(pretrained_model_name, config_file_name)
+        return gen_config
 
     def evaluate(
         self,
@@ -122,10 +110,7 @@ class Seq2SeqTrainer(Trainer):
             dictionary also contains the epoch number which comes from the training state.
         """
 
-        gen_kwargs = gen_kwargs.copy()
-        self._gen_config = self.__load_generation_config(gen_kwargs)
-        self._gen_kwargs = gen_kwargs
-
+        self._gen_kwargs = gen_kwargs.copy()
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
@@ -170,10 +155,7 @@ class Seq2SeqTrainer(Trainer):
               labels).
         """
 
-        gen_kwargs = gen_kwargs.copy()
-        self._gen_config = self.__load_generation_config(gen_kwargs)
-        self._gen_kwargs = gen_kwargs
-
+        self._gen_kwargs = gen_kwargs.copy()
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def prediction_step(
@@ -212,12 +194,15 @@ class Seq2SeqTrainer(Trainer):
         has_labels = "labels" in inputs
         inputs = self._prepare_inputs(inputs)
 
-        # Priority (handled in generate):
-        # gen_kwargs > generation_config_from_pretrained > model.generation_config > default GenerationConfig()
-        gen_config = self._gen_config
-        gen_kwargs = self._gen_kwargs.copy()
-
         # XXX: adapt synced_gpus for fairscale as well
+        # Priority (handled in generate):
+        # gen_kwargs > model.generation_config > default GenerationConfig()
+        gen_kwargs = self._gen_kwargs.copy()
+        if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
+            gen_kwargs["max_length"] = self.model.config.max_length
+        gen_kwargs["num_beams"] = (
+            gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.model.config.num_beams
+        )
         default_synced_gpus = True if is_deepspeed_zero3_enabled() else False
         gen_kwargs["synced_gpus"] = (
             gen_kwargs["synced_gpus"] if gen_kwargs.get("synced_gpus") is not None else default_synced_gpus
@@ -226,17 +211,16 @@ class Seq2SeqTrainer(Trainer):
         # TODO (Joao): the following line is needed to keep a consistent result on SQUAD. Ideally, we should not block
         # users from preparing a dataset with `decoder_input_ids`.
         inputs = {k: v for k, v in inputs.items() if k != "decoder_input_ids"}
-        generated_tokens = self.model.generate(**inputs, generation_config=gen_config, **gen_kwargs)
+        generated_tokens = self.model.generate(**inputs, **gen_kwargs)
 
         # Temporary hack to ensure the generation config is not initialized for each iteration of the evaluation loop
         # TODO: remove this hack when the legacy code that initializes generation_config from a model config is
         # removed in https://github.com/huggingface/transformers/blob/98d88b23f54e5a23e741833f1e973fdf600cc2c5/src/transformers/generation/utils.py#L1183
         if self.model.generation_config._from_model_config:
             self.model.generation_config._from_model_config = False
-        # Retrieves GenerationConfig in case we did not provide one to generate.
-        # In this case, it used model.generation_config
-        if gen_config is None:
-            gen_config = model.generation_config
+
+        # Retrieves GenerationConfig from model.generation_config
+        gen_config = model.generation_config
         # in case the batch is shorter than max length, the output should be padded
         if generated_tokens.shape[-1] < gen_config.max_length:
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_config.max_length)

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -102,6 +102,11 @@ class Seq2SeqTrainer(Trainer):
             metric_key_prefix (`str`, *optional*, defaults to `"eval"`):
                 An optional prefix to be used as the metrics key prefix. For example the metrics "bleu" will be named
                 "eval_bleu" if the prefix is `"eval"` (default)
+            max_length (`int`, *optional*):
+                 The maximum target length to use when predicting with the generate method.
+            num_beams (`int`, *optional*):
+                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
+                 beam search.
             gen_kwargs:
                 Additional `generate` specific kwargs.
 
@@ -110,12 +115,14 @@ class Seq2SeqTrainer(Trainer):
             dictionary also contains the epoch number which comes from the training state.
         """
 
-        self._gen_kwargs = gen_kwargs.copy()
+        gen_kwargs = gen_kwargs.copy()
         if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
             gen_kwargs["max_length"] = self.args.generation_max_length
         gen_kwargs["num_beams"] = (
             gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
         )
+        self._gen_kwargs = gen_kwargs
+
         return super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def predict(
@@ -141,6 +148,11 @@ class Seq2SeqTrainer(Trainer):
             metric_key_prefix (`str`, *optional*, defaults to `"eval"`):
                 An optional prefix to be used as the metrics key prefix. For example the metrics "bleu" will be named
                 "eval_bleu" if the prefix is `"eval"` (default)
+            max_length (`int`, *optional*):
+                 The maximum target length to use when predicting with the generate method.
+            num_beams (`int`, *optional*):
+                 Number of beams for beam search that will be used when predicting with the generate method. 1 means no
+                 beam search.
             gen_kwargs:
                 Additional `generate` specific kwargs.
 
@@ -160,12 +172,14 @@ class Seq2SeqTrainer(Trainer):
               labels).
         """
 
-        self._gen_kwargs = gen_kwargs.copy()
+        gen_kwargs = gen_kwargs.copy()
         if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
             gen_kwargs["max_length"] = self.args.generation_max_length
         gen_kwargs["num_beams"] = (
             gen_kwargs["num_beams"] if gen_kwargs.get("num_beams") is not None else self.args.generation_num_beams
         )
+        self._gen_kwargs = gen_kwargs
+
         return super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
 
     def prediction_step(

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -14,16 +14,21 @@
 
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
 from torch.utils.data import Dataset
 
+from .data.data_collator import DataCollator
 from .deepspeed import is_deepspeed_zero3_enabled
 from .generation.configuration_utils import GenerationConfig
+from .modeling_utils import PreTrainedModel
+from .tokenization_utils_base import PreTrainedTokenizerBase
 from .trainer import Trainer
-from .trainer_utils import PredictionOutput
+from .trainer_callback import TrainerCallback
+from .trainer_utils import EvalPrediction, PredictionOutput
+from .training_args import TrainingArguments
 from .utils import logging
 
 
@@ -31,8 +36,33 @@ logger = logging.get_logger(__name__)
 
 
 class Seq2SeqTrainer(Trainer):
-    def __init__(self, *args_, **kwargs):
-        super().__init__(*args_, **kwargs)
+    def __init__(
+        self,
+        model: Union[PreTrainedModel, nn.Module] = None,
+        args: TrainingArguments = None,
+        data_collator: Optional[DataCollator] = None,
+        train_dataset: Optional[Dataset] = None,
+        eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
+        tokenizer: Optional[PreTrainedTokenizerBase] = None,
+        model_init: Optional[Callable[[], PreTrainedModel]] = None,
+        compute_metrics: Optional[Callable[[EvalPrediction], Dict]] = None,
+        callbacks: Optional[List[TrainerCallback]] = None,
+        optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
+        preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+    ):
+        super().__init__(
+            model=model,
+            args=args,
+            data_collator=data_collator,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            tokenizer=tokenizer,
+            model_init=model_init,
+            compute_metrics=compute_metrics,
+            callbacks=callbacks,
+            optimizers=optimizers,
+            preprocess_logits_for_metrics=preprocess_logits_for_metrics,
+        )
 
         # Override self.model.generation_config if a GenerationConfig is specified in args.
         # Priority: args.generation_config > model.generation_config > default GenerationConfig.

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -51,7 +51,7 @@ class Seq2SeqTrainer(Trainer):
                 calling `generate`.
 
         Returns:
-            A `~generation.GenerationConfig`, or `None` if no `generation_config_from_pretrained` has been provided in
+            A [`~generation.GenerationConfig`], or `None` if no `generation_config_from_pretrained` has been provided in
             `self.args` (`Seq2SeqTrainingArguments`) or `gen_kwargs`.
         """
         # Select the generation config argument

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -39,12 +39,11 @@ class Seq2SeqTrainingArguments(TrainingArguments):
         predict_with_generate (`bool`, *optional*, defaults to `False`):
             Whether to use generate to calculate generative metrics (ROUGE, BLEU).
         generation_config_from_pretrained (`str` or `Path` or [`~trainer_utils.GenerationConfig`], *optional*):
-            Loading a [`~trainer_utils.GenerationConfig`] from the `from_pretrained` method.
-            This can be either:
+            Allows to load a [`~trainer_utils.GenerationConfig`] from the `from_pretrained` method. This can be either:
 
             - a string, the *model id* of a pretrained model configuration hosted inside a model repo on
-              huggingface.co. Valid model ids can be located at the root-level, like `bert-base-uncased`, or
-              namespaced under a user or organization name, like `dbmdz/bert-base-german-cased`.
+              huggingface.co. Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced
+              under a user or organization name, like `dbmdz/bert-base-german-cased`.
             - a path to a *directory* containing a configuration file saved using the
               [`~GenerationConfig.save_pretrained`] method, e.g., `./my_model_directory/`.
             - a [`~trainer_utils.GenerationConfig`] object.
@@ -57,6 +56,6 @@ class Seq2SeqTrainingArguments(TrainingArguments):
     generation_config_from_pretrained: Optional[Union[str, Path, GenerationConfig]] = field(
         default=None,
         metadata={
-            "help": "Model id, file path or url pointing to a GenerationConfig json file," "to use during prediction."
+            "help": "Model id, file path or url pointing to a GenerationConfig json file, to use during prediction."
         },
     )

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -14,8 +14,10 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
+from .generation.configuration_utils import GenerationConfig
 from .training_args import TrainingArguments
 from .utils import add_start_docstrings
 
@@ -36,33 +38,25 @@ class Seq2SeqTrainingArguments(TrainingArguments):
             for the training set.
         predict_with_generate (`bool`, *optional*, defaults to `False`):
             Whether to use generate to calculate generative metrics (ROUGE, BLEU).
-        generation_max_length (`int`, *optional*):
-            The `max_length` to use on each evaluation loop when `predict_with_generate=True`. Will default to the
-            `max_length` value of the model configuration.
-        generation_num_beams (`int`, *optional*):
-            The `num_beams` to use on each evaluation loop when `predict_with_generate=True`. Will default to the
-            `num_beams` value of the model configuration.
+        generation_config_from_pretrained (`str` or `Path` or [`~trainer_utils.GenerationConfig`], *optional*):
+            Loading a [`~trainer_utils.GenerationConfig`] from the `from_pretrained` method.
+            This can be either:
+
+            - a string, the *model id* of a pretrained model configuration hosted inside a model repo on
+              huggingface.co. Valid model ids can be located at the root-level, like `bert-base-uncased`, or
+              namespaced under a user or organization name, like `dbmdz/bert-base-german-cased`.
+            - a path to a *directory* containing a configuration file saved using the
+              [`~GenerationConfig.save_pretrained`] method, e.g., `./my_model_directory/`.
+            - a [`~trainer_utils.GenerationConfig`] object.
     """
 
     sortish_sampler: bool = field(default=False, metadata={"help": "Whether to use SortishSampler or not."})
     predict_with_generate: bool = field(
         default=False, metadata={"help": "Whether to use generate to calculate generative metrics (ROUGE, BLEU)."}
     )
-    generation_max_length: Optional[int] = field(
+    generation_config_from_pretrained: Optional[Union[str, Path, GenerationConfig]] = field(
         default=None,
         metadata={
-            "help": (
-                "The `max_length` to use on each evaluation loop when `predict_with_generate=True`. Will default "
-                "to the `max_length` value of the model configuration."
-            )
-        },
-    )
-    generation_num_beams: Optional[int] = field(
-        default=None,
-        metadata={
-            "help": (
-                "The `num_beams` to use on each evaluation loop when `predict_with_generate=True`. Will default "
-                "to the `num_beams` value of the model configuration."
-            )
+            "help": "Model id, file path or url pointing to a GenerationConfig json file," "to use during prediction."
         },
     )

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -46,7 +46,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
               under a user or organization name, like `dbmdz/bert-base-german-cased`.
             - a path to a *directory* containing a configuration file saved using the
               [`~GenerationConfig.save_pretrained`] method, e.g., `./my_model_directory/`.
-            - a [`~trainer_utils.GenerationConfig`] object.
+            - a [`~generation.GenerationConfig`] object.
     """
 
     sortish_sampler: bool = field(default=False, metadata={"help": "Whether to use SortishSampler or not."})

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -38,8 +38,14 @@ class Seq2SeqTrainingArguments(TrainingArguments):
             for the training set.
         predict_with_generate (`bool`, *optional*, defaults to `False`):
             Whether to use generate to calculate generative metrics (ROUGE, BLEU).
-        generation_config_from_pretrained (`str` or `Path` or [`~trainer_utils.GenerationConfig`], *optional*):
-            Allows to load a [`~trainer_utils.GenerationConfig`] from the `from_pretrained` method. This can be either:
+        generation_max_length (`int`, *optional*):
+            The `max_length` to use on each evaluation loop when `predict_with_generate=True`. Will default to the
+            `max_length` value of the model configuration.
+        generation_num_beams (`int`, *optional*):
+            The `num_beams` to use on each evaluation loop when `predict_with_generate=True`. Will default to the
+            `num_beams` value of the model configuration.
+        generation_config (`str` or `Path` or [`~generation.GenerationConfig`], *optional*):
+            Allows to load a [`~generation.GenerationConfig`] from the `from_pretrained` method. This can be either:
 
             - a string, the *model id* of a pretrained model configuration hosted inside a model repo on
               huggingface.co. Valid model ids can be located at the root-level, like `bert-base-uncased`, or namespaced
@@ -53,7 +59,25 @@ class Seq2SeqTrainingArguments(TrainingArguments):
     predict_with_generate: bool = field(
         default=False, metadata={"help": "Whether to use generate to calculate generative metrics (ROUGE, BLEU)."}
     )
-    generation_config_from_pretrained: Optional[Union[str, Path, GenerationConfig]] = field(
+    generation_max_length: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "The `max_length` to use on each evaluation loop when `predict_with_generate=True`. Will default "
+                "to the `max_length` value of the model configuration."
+            )
+        },
+    )
+    generation_num_beams: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "The `num_beams` to use on each evaluation loop when `predict_with_generate=True`. Will default "
+                "to the `num_beams` value of the model configuration."
+            )
+        },
+    )
+    generation_config: Optional[Union[str, Path, GenerationConfig]] = field(
         default=None,
         metadata={
             "help": "Model id, file path or url pointing to a GenerationConfig json file, to use during prediction."


### PR DESCRIPTION
# What does this PR do?

`Seq2SeqTrainer` can load a `GenerationConfig`, by calling the `from_pretrained` method. This is done with the `generation_config_from_pretrain` argument from `Seq2SeqTrainingArguments` (or in `kwargs` of the `Seq2SeqTrainer.evaluate` and `Seq2SeqTrainer.predict` methods).

At first, we though of using a `generation_config_file` argument (#22203). I thought it would be even more versatile to consider it as  a "from_pretrained" approach. Hence here `generation_config_from_pretrain` can also handle model ids and urls.

### Small suggestion

As `Seq2SeqTrainer` actually brings very few additional functionality or modifications, would directly including these in `Trainer` be a good idea ? (one trainer to rule them all 💍) 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Yes: #22203
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger @gante