### PR TITLE
Minor typo in pipeline FillMaskPipeline's documentation.

### DIFF
--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -234,7 +234,7 @@ class FillMaskPipeline(Pipeline):
             - **sequence** (`str`) -- The corresponding input with the mask token prediction.
             - **score** (`float`) -- The corresponding probability.
             - **token** (`int`) -- The predicted token id (to replace the masked one).
-            - **token** (`str`) -- The predicted token (to replace the masked one).
+            - **token_str** (`str`) -- The predicted token (to replace the masked one).
         """
         outputs = super().__call__(inputs, **kwargs)
         if isinstance(inputs, list) and len(inputs) == 1:


### PR DESCRIPTION
# What does this PR do?

Fixes a minor typo in the documentation for FillMaskPipeline.__call__().

## Before submitting
- [X ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@Narsil. @sgugger, @stevhliu and @MKhalusova