### PR TITLE
Fix typo in Greedy Search Description

### DIFF
--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -149,7 +149,6 @@ Here, we'll show some of the parameters that control the decoding strategies and
 ### Greedy Search
 
 [`generate`] uses greedy search decoding by default so you don't have to pass any parameters to enable it. This means the parameters `num_beams` is set to 1 and `do_sample=False`.
-`do_sample=False`. Because it is a default strategy, you do not have to pass any parameters to `generate()` method to enable it.
 
 ```python
 >>> from transformers import AutoModelForCausalLM, AutoTokenizer


### PR DESCRIPTION
# What does this PR do?
There is a small typographical error in the documentation for Greedy Search.
Fixes #22335 


- [x] This PR fixes a typo.



## Who can review?

@sgugger 


