### PR TITLE
[HFTracer] Make embeddings ops take on the dtype of the weight

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -171,13 +171,13 @@ _SUPPORTED_MODELS = tuple(sorted(set(_REGULAR_SUPPORTED_MODELS + _SPECIAL_SUPPOR
 
 
 def torch_nn_embedding(self, input):
-    return torch.empty(*input.shape, self.weight.shape[-1], device="meta")
+    return torch.empty(*input.shape, self.weight.shape[-1], device="meta", dtype=self.weight.dtype)
 
 
 def torch_nn_functional_embedding(
     input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False
 ):
-    return torch.empty(*input.shape, weight.shape[-1], device="meta")
+    return torch.empty(*input.shape, weight.shape[-1], device="meta", dtype=self.weight.dtype)
 
 
 def torch_nn_layernorm(self, input):

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -177,7 +177,7 @@ def torch_nn_embedding(self, input):
 def torch_nn_functional_embedding(
     input, weight, padding_idx=None, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False
 ):
-    return torch.empty(*input.shape, weight.shape[-1], device="meta", dtype=self.weight.dtype)
+    return torch.empty(*input.shape, weight.shape[-1], device="meta", dtype=weight.dtype)
 
 
 def torch_nn_layernorm(self, input):


### PR DESCRIPTION
# What does this PR do?

Previously, `HFTracer` would assume a dtype of `torch.float32` as the output for `embedding` operators. This would cause issues downstream if you're tracing out a model that is initialized as e.g. `torch.bfloat16`. This makes it so that the embeddings ops outputs take on the dtype of the weight tensor