### PR TITLE
Adapt find_tied_parameters to handle breaking change in Accelerate

### DIFF
--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -154,7 +154,12 @@ def get_keys_to_not_convert(model):
     tied_model = deepcopy(model)  # this has 0 cost since it is done inside `init_empty_weights` context manager`
     tied_model.tie_weights()
 
-    tied_keys = list(find_tied_parameters(tied_model).values())
+    tied_params = find_tied_parameters(tied_model)
+    # For compatibility with Accelerate < 0.18
+    if isinstance(tied_params, dict):
+        tied_keys = list(tied_params.values())
+    else:
+        tied_keys = sum([x[1:] for x in tied_params], [])
     has_tied_params = len(tied_keys) > 0
 
     # Check if it is a base model


### PR DESCRIPTION
# What does this PR do?

In the upcoming version of Accelerate, `find_tied_parameters` returns a list of list instead of dictionary. While there is a hack in place to make sure the code in Transformers keeps working, it is a hack so it would be best to change the way we handle the result of `find_tied_parameters`.

This PR does just that.