### PR TITLE
Pin tensorflow-text to go with tensorflow

### DIFF
--- a/examples/tensorflow/_tests_requirements.txt
+++ b/examples/tensorflow/_tests_requirements.txt
@@ -1,4 +1,4 @@
-tensorflow<2.11
+tensorflow<2.12
 tensorboard
 scikit-learn
 seqeval

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,6 @@ if stale_egg_info.exists():
     )
     shutil.rmtree(stale_egg_info)
 
-# TensorFlow pin. When changing this value, update examples/tensorflow/_tests_requirements.txt accordingly
-_tf_pin = "<2.12"
 
 # IMPORTANT:
 # 1. all dependencies should be listed here with their version requirements if any
@@ -166,9 +164,10 @@ _deps = [
     "starlette",
     "sudachipy>=0.6.6",
     "sudachidict_core>=20220729",
-    f"tensorflow-cpu>=2.4,{_tf_pin}",
-    f"tensorflow>=2.4,{_tf_pin}",
-    f"tensorflow-text<{_tf_pin}",
+    # TensorFlow pin. When changing this value, update examples/tensorflow/_tests_requirements.txt accordingly
+    "tensorflow-cpu>=2.4,<2.12",
+    "tensorflow>=2.4,<2.12",
+    "tensorflow-text<2.12",
     "tf2onnx",
     "timeout-decorator",
     "timm",

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,8 @@ if stale_egg_info.exists():
     )
     shutil.rmtree(stale_egg_info)
 
+# TensorFlow pin. When changing this value, update examples/tensorflow/_tests_requirements.txt accordingly
+_tf_pin = "<2.12"
 
 # IMPORTANT:
 # 1. all dependencies should be listed here with their version requirements if any
@@ -164,9 +166,9 @@ _deps = [
     "starlette",
     "sudachipy>=0.6.6",
     "sudachidict_core>=20220729",
-    "tensorflow-cpu>=2.4,<2.12",
-    "tensorflow>=2.4,<2.12",
-    "tensorflow-text<2.12",
+    f"tensorflow-cpu>=2.4,{_tf_pin}",
+    f"tensorflow>=2.4,{_tf_pin}",
+    f"tensorflow-text<{_tf_pin}",
     "tf2onnx",
     "timeout-decorator",
     "timm",

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ _deps = [
     "sudachidict_core>=20220729",
     "tensorflow-cpu>=2.4,<2.12",
     "tensorflow>=2.4,<2.12",
-    "tensorflow-text",
+    "tensorflow-text<2.12",
     "tf2onnx",
     "timeout-decorator",
     "timm",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -72,7 +72,7 @@ deps = {
     "sudachidict_core": "sudachidict_core>=20220729",
     "tensorflow-cpu": "tensorflow-cpu>=2.4,<2.12",
     "tensorflow": "tensorflow>=2.4,<2.12",
-    "tensorflow-text": "tensorflow-text",
+    "tensorflow-text": "tensorflow-text<2.12",
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -72,7 +72,7 @@ deps = {
     "sudachidict_core": "sudachidict_core>=20220729",
     "tensorflow-cpu": "tensorflow-cpu>=2.4,<2.12",
     "tensorflow": "tensorflow>=2.4,<2.12",
-    "tensorflow-text": "tensorflow-text<2.12",
+    "tensorflow-text": "tensorflow-text<<2.12",
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -72,7 +72,7 @@ deps = {
     "sudachidict_core": "sudachidict_core>=20220729",
     "tensorflow-cpu": "tensorflow-cpu>=2.4,<2.12",
     "tensorflow": "tensorflow>=2.4,<2.12",
-    "tensorflow-text": "tensorflow-text<<2.12",
+    "tensorflow-text": "tensorflow-text<2.12",
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "timm": "timm",


### PR DESCRIPTION
# What does this PR do?

This PR pins `tensorflow-text` to go with TensorFlow, otherwise it tries to install the TF 2.12 which is not supported yet.