### PR TITLE
[safetensors] don't use in `torch<1.10`

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -577,10 +577,13 @@ def is_optimum_available():
 
 
 def is_safetensors_available():
-    if version.parse(_torch_version) >= version.parse("1.10"):
-        return importlib.util.find_spec("safetensors") is not None
+    if is_torch_available():
+        if version.parse(_torch_version) >= version.parse("1.10"):
+            return importlib.util.find_spec("safetensors") is not None
+        else:
+            return False
     else:
-        return False
+        return importlib.util.find_spec("safetensors") is not None
 
 
 def is_tokenizers_available():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -577,7 +577,10 @@ def is_optimum_available():
 
 
 def is_safetensors_available():
-    return importlib.util.find_spec("safetensors") is not None
+    if version.parse(_torch_version) >= version.parse("1.10"):
+        return importlib.util.find_spec("safetensors") is not None
+    else:
+        return False
 
 
 def is_tokenizers_available():


### PR DESCRIPTION
`safetensors` only seems to work with pt>=1.10. This PR fixes this breakage:

```
python -c 'import sys; from transformers import AutoModel; AutoModel.from_pretrained(sys.argv[1])'  "bigscience/bigscience-small-testing"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/nvme0/code/huggingface/transformers-master/src/transformers/models/auto/auto_factory.py", line 471, in from_pretrained
    return model_class.from_pretrained(
  File "/mnt/nvme0/code/huggingface/transformers-master/src/transformers/modeling_utils.py", line 2424, in from_pretrained
    state_dict = load_state_dict(resolved_archive_file)
  File "/mnt/nvme0/code/huggingface/transformers-master/src/transformers/modeling_utils.py", line 413, in load_state_dict
    return safe_load_file(checkpoint_file)
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/safetensors/torch.py", line 101, in load_file
    result[k] = f.get_tensor(k)
AttributeError: module 'torch' has no attribute 'frombuffer'
```