### PR TITLE
Changed world_size() to get_world_size() bugfix

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1193,7 +1193,7 @@ class GenerationMixin:
         """
 
         if synced_gpus is None:
-            if is_deepspeed_zero3_enabled() and dist.world_size() > 1:
+            if is_deepspeed_zero3_enabled() and dist.get_world_size() > 1:
                 synced_gpus = True
             else:
                 synced_gpus = False


### PR DESCRIPTION
Edited one line in src/transormers/generation/utils.py. Changed dist.….world_size() to dist.get_world_size() since world_size() doesn't exist in pytorch.dist.

# What does this PR do?

Fixes # Pytorch 2 generation/utils.py , 'torch.distributed' has no attribute 'world_size' #22375
https://github.com/huggingface/transformers/issues/22375


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Library:

- generate: @gante

