### PR TITLE
TensorFlow: additional missing `cmake` dependencies in CI

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -182,7 +182,7 @@ torch_and_tf_job = CircleCIJob(
     "torch_and_tf",
     additional_env={"RUN_PT_TF_CROSS_TESTS": True},
     install_steps=[
-        "sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng git-lfs",
+        "sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng git-lfs cmake",
         "git lfs install",
         "pip install --upgrade pip",
         "pip install .[sklearn,tf-cpu,torch,testing,sentencepiece,torch-speech,vision]",

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -319,6 +319,7 @@ examples_tensorflow_job = CircleCIJob(
     "examples_tensorflow",
     cache_name="tensorflow_examples",
     install_steps=[
+        "sudo apt-get -y update && sudo apt-get install -y cmake",
         "pip install --upgrade pip",
         "pip install .[sklearn,tensorflow,sentencepiece,testing]",
         "pip install -r examples/tensorflow/_tests_requirements.txt",
@@ -356,6 +357,7 @@ hub_job = CircleCIJob(
 onnx_job = CircleCIJob(
     "onnx",
     install_steps=[
+        "sudo apt-get -y update && sudo apt-get install -y cmake",
         "pip install --upgrade pip",
         "pip install .[torch,tf,testing,sentencepiece,onnxruntime,vision,rjieba]",
     ],


### PR DESCRIPTION
# What does this PR do?

Adds `cmake` to CI runs that depend on `transformers[tensorflow]`, on all missing cases.