### PR TITLE
Trainer: missing None check

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -281,7 +281,7 @@ class Seq2SeqTrainer(Trainer):
         # in case the batch is shorter than max length, the output should be padded
         if generated_tokens.shape[-1] < gen_config.max_length:
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_config.max_length)
-        elif generated_tokens.shape[-1] < gen_config.max_new_tokens + 1:
+        elif gen_config.max_new_tokens is not None and generated_tokens.shape[-1] < gen_config.max_new_tokens + 1:
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_config.max_new_tokens + 1)
 
         with torch.no_grad():


### PR DESCRIPTION
# What does this PR do?

Adds a missing `None` check. This is causing the example test to fail.