### PR TITLE
Fix bug in perplexity guide calculations and update perplexity numbers. Fixes #22348

### DIFF
--- a/docs/source/en/perplexity.mdx
+++ b/docs/source/en/perplexity.mdx
@@ -115,11 +115,10 @@ for begin_loc in tqdm(range(0, seq_len, stride)):
     with torch.no_grad():
         outputs = model(input_ids, labels=target_ids)
 
-        # loss is calculated using CrossEntropyLoss which averages over input tokens.
-        # Multiply it with trg_len to get the summation instead of average.
-        # We will take average over all the tokens to get the true average
-        # in the last step of this example.
-        neg_log_likelihood = outputs.loss * trg_len
+        # loss is calculated using CrossEntropyLoss which averages over valid labels
+        # N.B. the model only calculates loss over trg_len - 1 labels, because it internally shifts the labels
+        # to the left by 1.
+        neg_log_likelihood = outputs.loss
 
     nlls.append(neg_log_likelihood)
 
@@ -127,14 +126,14 @@ for begin_loc in tqdm(range(0, seq_len, stride)):
     if end_loc == seq_len:
         break
 
-ppl = torch.exp(torch.stack(nlls).sum() / end_loc)
+ppl = torch.exp(torch.stack(nlls).mean())
 ```
 
 Running this with the stride length equal to the max input length is equivalent to the suboptimal, non-sliding-window
 strategy we discussed above. The smaller the stride, the more context the model will have in making each prediction,
 and the better the reported perplexity will typically be.
 
-When we run the above with `stride = 1024`, i.e. no overlap, the resulting PPL is `19.64`, which is about the same
+When we run the above with `stride = 1024`, i.e. no overlap, the resulting PPL is `19.44`, which is about the same
 as the `19.93` reported in the GPT-2 paper. By using `stride = 512` and thereby employing our striding window
-strategy, this jumps down to `16.44`. This is not only a more favorable score, but is calculated in a way that is
+strategy, this jumps down to `16.45`. This is not only a more favorable score, but is calculated in a way that is
 closer to the true autoregressive decomposition of a sequence likelihood.


### PR DESCRIPTION
# What does this PR do?

This pull request fixes the bug mentioned in issue #22348 relating to the Perplexity concept guide in the English documentation.

It removes the multiplication by `trg_len` (which was incorrect), and uses `mean` outside the loop instead of sum and division.  This both fixes the bug and simplifies the code.

I've updated the comments in the example code to reflect the changes, as well as leaving a note about the sub-optimal nature of the code.

N.B. This pull request does not touch the documentation in other languages besides English.

N.B. These changes are based on my understanding of perplexity and how the Transformers library works.  I'm not an expert.

Finally, the perplexity numbers were updated based on the new code.  I ran the example on my machine to get those new numbers.  My setup:

```
PyTorch Version: 2.0.0
GPU: NVIDIA GeForce RTX 3090
CUDA Version: 11.7
CUDA Device Capability: (8, 6)
CUDA Toolkit Version: 11
Transformers Version: 4.27.2
```


Fixes #22348


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 
