### PR TITLE
[`Generate`] Add conditional generation for multimodal models

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1289,6 +1289,7 @@ class GenerationMixin:
                 device=inputs_tensor.device,
             )
 
+            # conditional generation for multi-modal models.
             if "input_ids" in model_kwargs and model_input_name == "pixel_values":
                 input_ids = torch.cat([input_ids, model_kwargs.pop("input_ids")], dim=-1)
         else:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1288,6 +1288,9 @@ class GenerationMixin:
                 model_kwargs=model_kwargs,
                 device=inputs_tensor.device,
             )
+
+            if "input_ids" in model_kwargs and model_input_name == "pixel_values":
+                input_ids = torch.cat([input_ids, model_kwargs.pop("input_ids")], dim=-1)
         else:
             input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
 


### PR DESCRIPTION
# Motivation

Some multi-modal models (precisely, image to text models) can perform better if conditional text is passed. This simply means that `input_ids` created by `_prepare_decoder_input_ids_for_generation` is concatenated with `input_ids` that is passed along `model_kwargs`.

This PR aims to add the support for this feature for `VisionEncoderDecoderModel`, precisely now this script should be able to run without any problem:

```python
import torch
import requests
from PIL import Image
from transformers import ViTFeatureExtractor, AutoTokenizer, VisionEncoderDecoderModel


loc = "ydshieh/vit-gpt2-coco-en"

feature_extractor = ViTFeatureExtractor.from_pretrained(loc)
tokenizer = AutoTokenizer.from_pretrained(loc)
model = VisionEncoderDecoderModel.from_pretrained(loc)
model.eval()


def predict(image, text):
    pixel_values = feature_extractor(images=image, return_tensors="pt").pixel_values
    input_ids = tokenizer(text, return_tensors="pt").input_ids

    with torch.no_grad():
        output_ids = model.generate(pixel_values, input_ids=input_ids, max_length=16, num_beams=4, return_dict_in_generate=True).sequences

    preds = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
    preds = [pred.strip() for pred in preds]

    return preds


# We will verify our results on an image of cute cats
url = "http://images.cocodataset.org/val2017/000000039769.jpg"
text = "an image of"
with Image.open(requests.get(url, stream=True).raw) as image:
    preds = predict(image, text)

print(preds)
>>> ['an image of two cats sleeping on a bed']
```

cc @gante 

Related: https://github.com/huggingface/transformers/pull/22423