### PR TITLE
Don't hard error when cache version can't be converted to int

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -1082,7 +1082,10 @@ if not os.path.isfile(cache_version_file):
     cache_version = 0
 else:
     with open(cache_version_file) as f:
-        cache_version = int(f.read())
+        try:
+            cache_version = int(f.read())
+        except ValueError:
+            cache_version = 0
 
 cache_is_not_empty = os.path.isdir(TRANSFORMERS_CACHE) and len(os.listdir(TRANSFORMERS_CACHE)) > 0
 


### PR DESCRIPTION
# What does this PR do?

As reported in #22412 if the string stored in the cache version file is not an int, all import from the Transformers library will fail. This PR adds more safeguards.