### PR TITLE
[`bnb`] fix bnb failing test

### DIFF
--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -384,9 +384,9 @@ class MixedInt8TestMultiGpu(BaseMixedInt8Test):
         Let's just try to load a model on 2 GPUs and see if it works. The model we test has ~2GB of total, 3GB should suffice
         """
 
-        memory_mapping = {0: "1GB", 1: "2GB"}
+        # memory_mapping = {0: "1GB", 1: "1GB"}
         model_parallel = AutoModelForCausalLM.from_pretrained(
-            self.model_name, load_in_8bit=True, max_memory=memory_mapping, device_map="auto"
+            self.model_name, load_in_8bit=True, device_map="balanced"
         )
 
         # Check correct device map

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -383,8 +383,7 @@ class MixedInt8TestMultiGpu(BaseMixedInt8Test):
         This tests that the model has been loaded and can be used correctly on a multi-GPU setup.
         Let's just try to load a model on 2 GPUs and see if it works. The model we test has ~2GB of total, 3GB should suffice
         """
-
-        # memory_mapping = {0: "1GB", 1: "1GB"}
+-
         model_parallel = AutoModelForCausalLM.from_pretrained(
             self.model_name, load_in_8bit=True, device_map="balanced"
         )

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -383,7 +383,7 @@ class MixedInt8TestMultiGpu(BaseMixedInt8Test):
         This tests that the model has been loaded and can be used correctly on a multi-GPU setup.
         Let's just try to load a model on 2 GPUs and see if it works. The model we test has ~2GB of total, 3GB should suffice
         """
--
+        
         model_parallel = AutoModelForCausalLM.from_pretrained(
             self.model_name, load_in_8bit=True, device_map="balanced"
         )

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -383,7 +383,7 @@ class MixedInt8TestMultiGpu(BaseMixedInt8Test):
         This tests that the model has been loaded and can be used correctly on a multi-GPU setup.
         Let's just try to load a model on 2 GPUs and see if it works. The model we test has ~2GB of total, 3GB should suffice
         """
-        
+
         model_parallel = AutoModelForCausalLM.from_pretrained(
             self.model_name, load_in_8bit=True, device_map="balanced"
         )


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/actions/runs/4538560416/jobs/7997676956

The PR https://github.com/huggingface/transformers/pull/22377 introduced the correct way to compute the device_map for int8 models to avoid issues in some corner cases. 

The `max_memory` argument was causing some issues and led to failing test due to the presence of a non-empty `special_dtypes`. Script to reproduce:

```python
import torch
from accelerate import init_empty_weights, infer_auto_device_map
from transformers import BloomForCausalLM, AutoConfig

config = AutoConfig.from_pretrained("bigscience/bloom-560m")

max_memory = {0: 1000000000, 1: 1000000000}

with init_empty_weights():
    model = BloomForCausalLM(config)

torch_dtype = torch.float16
modules_not_to_convert = ['transformer.word_embeddings', 'lm_head']
special_dtypes = {
    name: torch_dtype
    for name, _ in model.named_parameters()
    if any(m in name for m in modules_not_to_convert)
}

device_map = infer_auto_device_map(model, max_memory=max_memory, no_split_module_classes=['BloomBlock'], dtype=torch.int8, special_dtypes=special_dtypes)

print(set(device_map.values()))
```
I assume that the previous test was too much a corner case (with hardcoded `max_memory`), the correct fix should be just to use `balanced` in the `device_map` argument.

cc @sgugger 