### PR TITLE
Revert "Fix --bf16 option support for Neuron after PR #22300"

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -588,12 +588,7 @@ class Trainer:
 
         if args.fp16 or args.bf16:
             if args.half_precision_backend == "auto":
-                if is_torch_neuroncore_available():
-                    if args.fp16:
-                        raise ValueError("Tried to use `fp16` but this option is not yet supported on Neuron.")
-                    else:
-                        args.half_precision_backend = "cpu_amp"
-                elif args.device == torch.device("cpu"):
+                if args.device == torch.device("cpu"):
                     if args.fp16:
                         raise ValueError("Tried to use `fp16` but it is not supported on cpu")
                     elif _is_native_cpu_amp_available:


### PR DESCRIPTION
This reverts commit fd81746dbec5f17c8285a0fdc72ca4b4c025cc33.

# What does this PR do?

This reverts https://github.com/huggingface/transformers/pull/22307 as CPU AMP doesn't cause torch/xla to emit the correctly autocasted XLA HLO, while GPU AMP path correctly emits autocasted XLA HLO. We are left with "RuntimeError: No CUDA GPUs are available" as noted in the previous PR which can be workaround with "torch.cuda.is_bf16_supported = lambda: True".

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger
