### PR TITLE
Avoid sgugger become THE bot

### DIFF
--- a/.github/workflows/update_tiny_models.yml
+++ b/.github/workflows/update_tiny_models.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  TOKEN: ${{ secrets.SYLVAIN_HF_TOKEN }}
+  TOKEN: ${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }}
 
 jobs:
   update_tiny_models:


### PR DESCRIPTION
# What does this PR do?

With more and more such 
<img width="380" alt="Screenshot 2023-03-29 192000" src="https://user-images.githubusercontent.com/2521628/228618109-0f4f33d7-db0b-43a5-b425-7dac596448d3.png">
`sgugger` will become a bot one day soon (or at least Google will think `sgugger` is a bot).

Let's save them from becoming a bot.

------
Serious part: This is discussed offline

> Would be good to create HF-testing Bot user and use that token as people really think it's me updating those models :sweat_smile:

**I already set this secret in the repository.**