### PR TITLE
[NLLB-MoE] `model_type` update for auto mapping

### DIFF
--- a/src/transformers/models/nllb_moe/configuration_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/configuration_nllb_moe.py
@@ -125,7 +125,7 @@ class NllbMoeConfig(PretrainedConfig):
     >>> # Accessing the model configuration
     >>> configuration = model.config
     ```"""
-    model_type = "nllb_moe"
+    model_type = "nllb-moe"
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {"num_attention_heads": "encoder_attention_heads", "hidden_size": "d_model"}
 

--- a/tests/models/nllb_moe/test_modeling_nllb_moe.py
+++ b/tests/models/nllb_moe/test_modeling_nllb_moe.py
@@ -352,14 +352,14 @@ class NllbMoeModelIntegrationTests(unittest.TestCase):
 
     @cached_property
     def tokenizer(self):
-        return NllbTokenizer.from_pretrained("ArthurZ/random-nllb-moe-2-experts")
+        return NllbTokenizer.from_pretrained("hf-internal-testing/random-nllb-moe-2-experts")
 
     @cached_property
     def big_model(self):
         return NllbMoeForConditionalGeneration.from_pretrained("facebook/nllb-moe-54b")
 
     def inference_no_head(self):
-        model = NllbMoeModel.from_pretrained("ArthurZ/random-nllb-moe-2-experts").eval()
+        model = NllbMoeModel.from_pretrained("hf-internal-testing/random-nllb-moe-2-experts").eval()
         with torch.no_grad():
             output = model(**self.model_inputs)
         # fmt: off
@@ -380,7 +380,7 @@ class NllbMoeModelIntegrationTests(unittest.TestCase):
         and `transformers` implementation of NLLB-MoE transformers. We only check the logits
         of the second sample of the batch, as it is padded.
         """
-        model = NllbMoeForConditionalGeneration.from_pretrained("ArthurZ/random-nllb-moe-2-experts").eval()
+        model = NllbMoeForConditionalGeneration.from_pretrained("hf-internal-testing/random-nllb-moe-2-experts").eval()
         with torch.no_grad():
             output = model(**self.model_inputs)
 


### PR DESCRIPTION
# What does this PR do?
Changes the `model_type` to allow users using the `AutoModel` . 
While we are at it, also moved the testing model to `hf-internal-testing`
Fixes #22461 