### PR TITLE
Relax `eos_token_id < 0` checks in `generate()` from `ValueError` to warning

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -111,7 +111,7 @@ class MinLengthLogitsProcessor(LogitsProcessor):
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            logger.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            logger.warning(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.min_length = min_length
         self.eos_token_id = eos_token_id
@@ -148,7 +148,7 @@ class MinNewTokensLengthLogitsProcessor(LogitsProcessor):
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            logger.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            logger.warning(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.prompt_length_to_skip = prompt_length_to_skip
         self.min_new_tokens = min_new_tokens

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -16,6 +16,7 @@
 import inspect
 import math
 from typing import Callable, Iterable, List, Optional, Tuple, Union
+import warnings
 
 import numpy as np
 import torch
@@ -106,12 +107,12 @@ class MinLengthLogitsProcessor(LogitsProcessor):
 
     def __init__(self, min_length: int, eos_token_id: Union[int, List[int]]):
         if not isinstance(min_length, int) or min_length < 0:
-            raise ValueError(f"`min_length` has to be a positive integer, but is {min_length}")
+            warnings.warn(f"`min_length` has to be a positive integer, but is {min_length}")
 
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            raise ValueError(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            warnings.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.min_length = min_length
         self.eos_token_id = eos_token_id
@@ -148,7 +149,7 @@ class MinNewTokensLengthLogitsProcessor(LogitsProcessor):
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            raise ValueError(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            warnings.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.prompt_length_to_skip = prompt_length_to_skip
         self.min_new_tokens = min_new_tokens

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -15,7 +15,6 @@
 
 import inspect
 import math
-import warnings
 from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -107,12 +106,12 @@ class MinLengthLogitsProcessor(LogitsProcessor):
 
     def __init__(self, min_length: int, eos_token_id: Union[int, List[int]]):
         if not isinstance(min_length, int) or min_length < 0:
-            warnings.warn(f"`min_length` has to be a positive integer, but is {min_length}")
+            raise ValueError(f"`min_length` has to be a non-negative integer, but is {min_length}")
 
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            warnings.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            logger.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.min_length = min_length
         self.eos_token_id = eos_token_id
@@ -149,7 +148,7 @@ class MinNewTokensLengthLogitsProcessor(LogitsProcessor):
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
         if not all([isinstance(i, int) for i in eos_token_id]) or any([i < 0 for i in eos_token_id]):
-            warnings.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
+            logger.warn(f"`eos_token_id` has to be a list of positive integers, but is {eos_token_id}")
 
         self.prompt_length_to_skip = prompt_length_to_skip
         self.min_new_tokens = min_new_tokens

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -15,8 +15,8 @@
 
 import inspect
 import math
-from typing import Callable, Iterable, List, Optional, Tuple, Union
 import warnings
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR relaxes a constraint that was introduced in eec46b4 to ensure `eos_token_id > 0` when `min_new_tokens > 0`. In particular, the current code would throw a `ValueError`:

```python
from transformers import pipeline

pipe = pipeline("text-generation")
pipe("Hello, my dog is cute.", min_new_tokens=4, eos_token_id=-1)
```

This isn't ideal as setting `eos_token_id=-1` is a handy trick to enable generating text past the EOS token. The current PR now returns a warning instead. I've also taken the liberty to relax the error on `min_length < 0` but let me know if that's not a good idea.

Internal Slack thread where this was discussed: https://huggingface.slack.com/archives/C01N44FJDHT/p1680175455762649


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
