### PR TITLE
Docs fix: Multinomial sampling decoding needs "num_beams=1", since by default it is usually not 1.

### DIFF
--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -216,11 +216,11 @@ We pride ourselves on being the best in the business and our customer service is
 ### Multinomial sampling
 
 As opposed to greedy search that always chooses a token with the highest probability as the
-next token, multinomial sampling randomly selects the next token based on the probability distribution over the entire
+next token, multinomial sampling (also called ancestral sampling) randomly selects the next token based on the probability distribution over the entire
 vocabulary given by the model. Every token with a non-zero probability has a chance of being selected, thus reducing the
 risk of repetition.
 
-To enable multinomial sampling set `do_sample=True`.
+To enable multinomial sampling set `do_sample=True` and `num_beams=1`.
 
 ```python
 >>> from transformers import AutoTokenizer, AutoModelForCausalLM
@@ -232,7 +232,7 @@ To enable multinomial sampling set `do_sample=True`.
 >>> prompt = "Today was an amazing day because"
 >>> inputs = tokenizer(prompt, return_tensors="pt")
 
->>> outputs = model.generate(**inputs, do_sample=True, max_new_tokens=100)
+>>> outputs = model.generate(**inputs, do_sample=True, num_beams=1, max_new_tokens=100)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['Today was an amazing day because we are now in the final stages of our trip to New York City which was very tough. \
 It is a difficult schedule and a challenging part of the year but still worth it. I have been taking things easier and \


### PR DESCRIPTION
# Fix error in docs: multinomial sampling decoding strategy

As indicated in the library source code:
https://github.com/huggingface/transformers/blob/228792a9dc0c36f1e82ab441e1b1991d116ee0a0/src/transformers/generation/utils.py#LL1364-L1367

Multinomial sampling needs `num_beams=1`. However, this is not indicated in the docs, potentially leading to execute beam-search multinomial sampling instead of the intended multinomial sampling.

This deviation from the expected behaviour happens quite often, since a lot of models have in their `generation_config.json` the parameter `num_beams` set to something higher than 1. This happens, for example, in the majority of top translation models from the Hub.

Also, I have included "ancestral sampling" as another name for multinomial sampling, since it is the most common name in the decoding algorithms literature.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



## Who can review?

Original authors of this piece of documentation: @gante, @sgugger, @stevhliu and @MKhalusova 