### PR TITLE
Backbone add out indices

### DIFF
--- a/src/transformers/models/bit/configuration_bit.py
+++ b/src/transformers/models/bit/configuration_bit.py
@@ -130,7 +130,10 @@ class BitConfig(PretrainedConfig):
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
 
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/bit/configuration_bit.py
+++ b/src/transformers/models/bit/configuration_bit.py
@@ -63,11 +63,12 @@ class BitConfig(PretrainedConfig):
             The width factor for the model.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
     ```python
@@ -127,6 +128,18 @@ class BitConfig(PretrainedConfig):
         self.width_factor = width_factor
 
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -135,11 +148,12 @@ class BitConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
                 if idx >= len(self.stage_names):
                     raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices

--- a/src/transformers/models/bit/configuration_bit.py
+++ b/src/transformers/models/bit/configuration_bit.py
@@ -63,7 +63,11 @@ class BitConfig(PretrainedConfig):
             The width factor for the model.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
     ```python
@@ -98,6 +102,7 @@ class BitConfig(PretrainedConfig):
         output_stride=32,
         width_factor=1,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -131,3 +136,10 @@ class BitConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices

--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -850,6 +850,7 @@ class BitBackbone(BitPreTrainedModel, BackboneMixin):
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
         self.num_features = [config.embedding_size] + config.hidden_sizes
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
 
         # initialize weights and apply final processing
         self.post_init()

--- a/src/transformers/models/bit/modeling_bit.py
+++ b/src/transformers/models/bit/modeling_bit.py
@@ -850,7 +850,10 @@ class BitBackbone(BitPreTrainedModel, BackboneMixin):
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
         self.num_features = [config.embedding_size] + config.hidden_sizes
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
 
         # initialize weights and apply final processing
         self.post_init()

--- a/src/transformers/models/convnext/configuration_convnext.py
+++ b/src/transformers/models/convnext/configuration_convnext.py
@@ -119,8 +119,12 @@ class ConvNextConfig(PretrainedConfig):
         self.drop_path_rate = drop_path_rate
         self.image_size = image_size
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(self.depths) + 1)]
+
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/convnext/configuration_convnext.py
+++ b/src/transformers/models/convnext/configuration_convnext.py
@@ -66,11 +66,12 @@ class ConvNextConfig(PretrainedConfig):
             The drop rate for stochastic depth.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
     ```python
@@ -118,6 +119,17 @@ class ConvNextConfig(PretrainedConfig):
         self.drop_path_rate = drop_path_rate
         self.image_size = image_size
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(self.depths) + 1)]
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -126,13 +138,14 @@ class ConvNextConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
                 if idx >= len(self.stage_names):
                     raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices
 
 

--- a/src/transformers/models/convnext/configuration_convnext.py
+++ b/src/transformers/models/convnext/configuration_convnext.py
@@ -66,7 +66,11 @@ class ConvNextConfig(PretrainedConfig):
             The drop rate for stochastic depth.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
     ```python
@@ -97,6 +101,7 @@ class ConvNextConfig(PretrainedConfig):
         drop_path_rate=0.0,
         image_size=224,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -122,6 +127,13 @@ class ConvNextConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices
 
 
 class ConvNextOnnxConfig(OnnxConfig):

--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -487,6 +487,7 @@ class ConvNextBackbone(ConvNextPreTrainedModel, BackboneMixin):
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
         self.num_features = [config.hidden_sizes[0]] + config.hidden_sizes
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
 
         # Add layer norms to hidden states of out_features
         hidden_states_norms = {}

--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -487,7 +487,10 @@ class ConvNextBackbone(ConvNextPreTrainedModel, BackboneMixin):
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
         self.num_features = [config.hidden_sizes[0]] + config.hidden_sizes
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
 
         # Add layer norms to hidden states of out_features
         hidden_states_norms = {}

--- a/src/transformers/models/convnextv2/configuration_convnextv2.py
+++ b/src/transformers/models/convnextv2/configuration_convnextv2.py
@@ -58,7 +58,12 @@ class ConvNextV2Config(PretrainedConfig):
             The drop rate for stochastic depth.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
     ```python
@@ -88,6 +93,7 @@ class ConvNextV2Config(PretrainedConfig):
         drop_path_rate=0.0,
         image_size=224,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -103,6 +109,21 @@ class ConvNextV2Config(PretrainedConfig):
         self.drop_path_rate = drop_path_rate
         self.image_size = image_size
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(self.depths) + 1)]
+
+        if out_features is not None and out_indices is not None:
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -111,4 +132,12 @@ class ConvNextV2Config(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
         self.out_features = out_features
+        self.out_indices = out_indices

--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -510,6 +510,10 @@ class ConvNextV2Backbone(ConvNextV2PreTrainedModel, BackboneMixin):
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
         self.num_features = [config.hidden_sizes[0]] + config.hidden_sizes
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
 
         # Add layer norms to hidden states of out_features
         hidden_states_norms = {}

--- a/src/transformers/models/dinat/configuration_dinat.py
+++ b/src/transformers/models/dinat/configuration_dinat.py
@@ -72,7 +72,11 @@ class DinatConfig(PretrainedConfig):
             The initial value for the layer scale. Disabled if <=0.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
 
@@ -114,6 +118,7 @@ class DinatConfig(PretrainedConfig):
         layer_norm_eps=1e-5,
         layer_scale_init_value=0.0,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -148,3 +153,10 @@ class DinatConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices

--- a/src/transformers/models/dinat/configuration_dinat.py
+++ b/src/transformers/models/dinat/configuration_dinat.py
@@ -72,11 +72,12 @@ class DinatConfig(PretrainedConfig):
             The initial value for the layer scale. Disabled if <=0.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
 
@@ -144,6 +145,18 @@ class DinatConfig(PretrainedConfig):
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.layer_scale_init_value = layer_scale_init_value
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -152,11 +165,12 @@ class DinatConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
                 if idx >= len(self.stage_names):
                     raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices

--- a/src/transformers/models/dinat/configuration_dinat.py
+++ b/src/transformers/models/dinat/configuration_dinat.py
@@ -147,7 +147,10 @@ class DinatConfig(PretrainedConfig):
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
 
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -891,6 +891,7 @@ class DinatBackbone(DinatPreTrainedModel, BackboneMixin):
         self.encoder = DinatEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -891,7 +891,10 @@ class DinatBackbone(DinatPreTrainedModel, BackboneMixin):
         self.encoder = DinatEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features

--- a/src/transformers/models/maskformer/configuration_maskformer_swin.py
+++ b/src/transformers/models/maskformer/configuration_maskformer_swin.py
@@ -141,8 +141,12 @@ class MaskFormerSwinConfig(PretrainedConfig):
         # this indicates the channel dimension after the last stage of the model
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/maskformer/configuration_maskformer_swin.py
+++ b/src/transformers/models/maskformer/configuration_maskformer_swin.py
@@ -68,7 +68,11 @@ class MaskFormerSwinConfig(PretrainedConfig):
             The epsilon used by the layer normalization layers.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
 
@@ -110,6 +114,7 @@ class MaskFormerSwinConfig(PretrainedConfig):
         initializer_range=0.02,
         layer_norm_eps=1e-5,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -144,3 +149,10 @@ class MaskFormerSwinConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices

--- a/src/transformers/models/maskformer/modeling_maskformer_swin.py
+++ b/src/transformers/models/maskformer/modeling_maskformer_swin.py
@@ -859,7 +859,10 @@ class MaskFormerSwinBackbone(MaskFormerSwinPreTrainedModel, BackboneMixin):
         if "stem" in self.out_features:
             raise ValueError("This backbone does not support 'stem' in the `out_features`.")
 
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
         self.hidden_states_norms = nn.ModuleList([nn.LayerNorm(num_channels) for num_channels in self.channels])
 

--- a/src/transformers/models/maskformer/modeling_maskformer_swin.py
+++ b/src/transformers/models/maskformer/modeling_maskformer_swin.py
@@ -859,6 +859,7 @@ class MaskFormerSwinBackbone(MaskFormerSwinPreTrainedModel, BackboneMixin):
         if "stem" in self.out_features:
             raise ValueError("This backbone does not support 'stem' in the `out_features`.")
 
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
         self.hidden_states_norms = nn.ModuleList([nn.LayerNorm(num_channels) for num_channels in self.channels])
 

--- a/src/transformers/models/nat/configuration_nat.py
+++ b/src/transformers/models/nat/configuration_nat.py
@@ -141,8 +141,12 @@ class NatConfig(PretrainedConfig):
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.layer_scale_init_value = layer_scale_init_value
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/nat/configuration_nat.py
+++ b/src/transformers/models/nat/configuration_nat.py
@@ -70,11 +70,12 @@ class NatConfig(PretrainedConfig):
             The initial value for the layer scale. Disabled if <=0.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
 
@@ -140,6 +141,17 @@ class NatConfig(PretrainedConfig):
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.layer_scale_init_value = layer_scale_init_value
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -148,11 +160,12 @@ class NatConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
                 if idx >= len(self.stage_names):
                     raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices

--- a/src/transformers/models/nat/configuration_nat.py
+++ b/src/transformers/models/nat/configuration_nat.py
@@ -70,7 +70,11 @@ class NatConfig(PretrainedConfig):
             The initial value for the layer scale. Disabled if <=0.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
 
@@ -111,6 +115,7 @@ class NatConfig(PretrainedConfig):
         layer_norm_eps=1e-5,
         layer_scale_init_value=0.0,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -144,3 +149,10 @@ class NatConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices

--- a/src/transformers/models/nat/modeling_nat.py
+++ b/src/transformers/models/nat/modeling_nat.py
@@ -869,6 +869,7 @@ class NatBackbone(NatPreTrainedModel, BackboneMixin):
         self.encoder = NatEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features

--- a/src/transformers/models/nat/modeling_nat.py
+++ b/src/transformers/models/nat/modeling_nat.py
@@ -869,7 +869,10 @@ class NatBackbone(NatPreTrainedModel, BackboneMixin):
         self.encoder = NatEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features

--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -108,8 +108,12 @@ class ResNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.downsample_in_first_stage = downsample_in_first_stage
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -60,7 +60,11 @@ class ResNetConfig(PretrainedConfig):
             If `True`, the first stage will downsample the inputs using a `stride` of 2.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
     ```python
@@ -89,6 +93,7 @@ class ResNetConfig(PretrainedConfig):
         hidden_act="relu",
         downsample_in_first_stage=False,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -111,6 +116,13 @@ class ResNetConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+        self.out_indices = out_indices
 
 
 class ResNetOnnxConfig(OnnxConfig):

--- a/src/transformers/models/resnet/configuration_resnet.py
+++ b/src/transformers/models/resnet/configuration_resnet.py
@@ -60,11 +60,12 @@ class ResNetConfig(PretrainedConfig):
             If `True`, the first stage will downsample the inputs using a `stride` of 2.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
     ```python
@@ -107,6 +108,17 @@ class ResNetConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.downsample_in_first_stage = downsample_in_first_stage
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -115,13 +127,14 @@ class ResNetConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
                 if idx >= len(self.stage_names):
                     raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices
 
 

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -437,7 +437,10 @@ class ResNetBackbone(ResNetPreTrainedModel, BackboneMixin):
         self.encoder = ResNetEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embedding_size] + config.hidden_sizes
 
         # initialize weights and apply final processing

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -437,6 +437,7 @@ class ResNetBackbone(ResNetPreTrainedModel, BackboneMixin):
         self.encoder = ResNetEncoder(config)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embedding_size] + config.hidden_sizes
 
         # initialize weights and apply final processing

--- a/src/transformers/models/swin/configuration_swin.py
+++ b/src/transformers/models/swin/configuration_swin.py
@@ -83,11 +83,12 @@ class SwinConfig(PretrainedConfig):
             Factor to increase the spatial resolution by in the decoder head for masked image modeling.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
-            `output_indices` instead.
+            (depending on how many stages the model has). If unset and `out_indices` is set, will default to the
+            corresponding stages. If unset and `out_indices` is unset, will default to the last stage.
         out_indices (`List[int]`, *optional*):
             If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
-            many stages the model has). Will default to the last stage if unset.
+            many stages the model has). If unset and `out_features` is set, will default to the corresponding stages.
+            If unset and `out_features` is unset, will default to the last stage.
 
     Example:
 
@@ -157,6 +158,17 @@ class SwinConfig(PretrainedConfig):
         # this indicates the channel dimension after the last stage of the model
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+        if out_features is not None and out_indices is not None:
+            raise ValueError("Cannot set both `out_features` and `out_indices`")
+
+        if out_features is None and out_indices is not None:
+            out_features = [self.stage_names[idx] for idx in out_indices]
+        elif out_features is not None and out_indices is None:
+            out_indices = [self.stage_names.index(feature) for feature in out_features]
+        elif out_features is None and out_indices is None:
+            out_features = [self.stage_names[-1]]
+            out_indices = [len(self.stage_names) - 1]
+
         if out_features is not None:
             if not isinstance(out_features, list):
                 raise ValueError("out_features should be a list")
@@ -165,15 +177,14 @@ class SwinConfig(PretrainedConfig):
                     raise ValueError(
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
-        self.out_features = out_features
         if out_indices is not None:
             if not isinstance(out_indices, (list, tuple)):
                 raise ValueError("out_indices should be a list or tuple")
             for idx in out_indices:
-                if idx not in range(len(self.stage_names)):
-                    raise ValueError(
-                        f"Index {idx} is not a valid index. Valid indices are {list(range(len(self.stage_names)))}"
-                    )
+                if idx >= len(self.stage_names):
+                    raise ValueError(f"Index {idx} is not a valid index for a list of length {len(self.stage_names)}")
+
+        self.out_features = out_features
         self.out_indices = out_indices
 
 

--- a/src/transformers/models/swin/configuration_swin.py
+++ b/src/transformers/models/swin/configuration_swin.py
@@ -83,7 +83,11 @@ class SwinConfig(PretrainedConfig):
             Factor to increase the spatial resolution by in the decoder head for masked image modeling.
         out_features (`List[str]`, *optional*):
             If used as backbone, list of features to output. Can be any of `"stem"`, `"stage1"`, `"stage2"`, etc.
-            (depending on how many stages the model has). Will default to the last stage if unset.
+            (depending on how many stages the model has). Will default to the last stage if unset. Deprecated: use
+            `output_indices` instead.
+        out_indices (`List[int]`, *optional*):
+            If used as backbone, list of indices of features to output. Can be any of 0, 1, 2, etc. (depending on how
+            many stages the model has). Will default to the last stage if unset.
 
     Example:
 
@@ -126,6 +130,7 @@ class SwinConfig(PretrainedConfig):
         layer_norm_eps=1e-5,
         encoder_stride=32,
         out_features=None,
+        out_indices=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -161,6 +166,15 @@ class SwinConfig(PretrainedConfig):
                         f"Feature {feature} is not a valid feature name. Valid names are {self.stage_names}"
                     )
         self.out_features = out_features
+        if out_indices is not None:
+            if not isinstance(out_indices, (list, tuple)):
+                raise ValueError("out_indices should be a list or tuple")
+            for idx in out_indices:
+                if idx not in range(len(self.stage_names)):
+                    raise ValueError(
+                        f"Index {idx} is not a valid index. Valid indices are {list(range(len(self.stage_names)))}"
+                    )
+        self.out_indices = out_indices
 
 
 class SwinOnnxConfig(OnnxConfig):

--- a/src/transformers/models/swin/configuration_swin.py
+++ b/src/transformers/models/swin/configuration_swin.py
@@ -158,8 +158,12 @@ class SwinConfig(PretrainedConfig):
         # this indicates the channel dimension after the last stage of the model
         self.hidden_size = int(embed_dim * 2 ** (len(depths) - 1))
         self.stage_names = ["stem"] + [f"stage{idx}" for idx in range(1, len(depths) + 1)]
+
         if out_features is not None and out_indices is not None:
-            raise ValueError("Cannot set both `out_features` and `out_indices`")
+            if len(out_features) != len(out_indices):
+                raise ValueError("out_features and out_indices should have the same length if both are set")
+            elif out_features != [self.stage_names[idx] for idx in out_indices]:
+                raise ValueError("out_features and out_indices should correspond to the same stages if both are set")
 
         if out_features is None and out_indices is not None:
             out_features = [self.stage_names[idx] for idx in out_indices]

--- a/src/transformers/models/swin/modeling_swin.py
+++ b/src/transformers/models/swin/modeling_swin.py
@@ -1255,6 +1255,7 @@ class SwinBackbone(SwinPreTrainedModel, BackboneMixin):
         self.encoder = SwinEncoder(config, self.embeddings.patch_grid)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
+        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features

--- a/src/transformers/models/swin/modeling_swin.py
+++ b/src/transformers/models/swin/modeling_swin.py
@@ -1255,7 +1255,10 @@ class SwinBackbone(SwinPreTrainedModel, BackboneMixin):
         self.encoder = SwinEncoder(config, self.embeddings.patch_grid)
 
         self.out_features = config.out_features if config.out_features is not None else [self.stage_names[-1]]
-        self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
+        if config.out_indices is not None:
+            self.out_indices = config.out_indices
+        else:
+            self.out_indices = tuple(i for i, layer in enumerate(self.stage_names) if layer in self.out_features)
         self.num_features = [config.embed_dim] + [int(config.embed_dim * 2**i) for i in range(len(config.depths))]
 
         # Add layer norms to hidden states of out_features


### PR DESCRIPTION
# What does this PR do?

Add out_indices as a way to specify which feature maps are returned in the backbone.

This isn't strictly necessary for cross loading timm backbones and is an optional design choice. 

Reasoning:
* Greater compatibility between timm and transformer models when loading with `AutoBackbone`. For the same model e.g. `microsoft/resnet-50` and `resnet50`, the stage names are different, whereas the layer index is the same. `out_indices=(1,)` means the same for both model. whereas selecting features requires knowing one uses `layer1` and the other uses `stage1`.
* `out_features` requires knowing the names of the layers in order select which layers you want and is more prone to errors with typos
* `out_indices` is the param used in timm. Once advantage of `out_indices` is that you can do negative indexing easily. For example, to get the last two feature maps, you need only pass `out_indices=(-2, -1)`.

Outstanding question on whether both `out_features` and `out_indices` should exist at the same time.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
