### PR TITLE
Fix NameError `init_empty_weights` when importing Blip2Processor

### DIFF
--- a/src/transformers/deepspeed.py
+++ b/src/transformers/deepspeed.py
@@ -36,6 +36,7 @@ def is_deepspeed_available():
 
 if is_accelerate_available() and is_deepspeed_available():
     from accelerate.utils.deepspeed import HfDeepSpeedConfig as DeepSpeedConfig
+    from accelerate import init_empty_weights
 else:
     # Inherits from a dummy `object` if accelerate is not available, so that python succeeds to import this file.
     # Deepspeed glue code will never inherit this dummy object as it checks if accelerate is available.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2181,9 +2181,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
 
         if load_in_8bit:
-            if not (is_accelerate_available() and is_bitsandbytes_available()):
+            if not is_accelerate_available():
                 raise ImportError(
-                    "Using `load_in_8bit=True` requires Accelerate: `pip install accelerate` and the latest version of"
+                    "Using `load_in_8bit=True` requires Accelerate"
+                    " `pip install accelerate` "
+                )
+            if not is_bitsandbytes_available():
+                raise ImportError(
+                    "Using `load_in_8bit=True` requires the latest version of"
                     " bitsandbytes `pip install -i https://test.pypi.org/simple/ bitsandbytes` or"
                     " pip install bitsandbytes` "
                 )


### PR DESCRIPTION
## Context 
Was trying to run [https://huggingface.co/Salesforce/blip2-flan-t5-xl](https://huggingface.co/Salesforce/blip-image-captioning-base) in a colab notebook (after installing `accelerate`) and was getting an error when importing Blip2Processor:
```
NameError `init_empty_weights` is not defined
```
<img width="1285" alt="Screen Shot 2023-04-01 at 1 31 17 pm" src="https://user-images.githubusercontent.com/3723005/229265367-36eed050-b75b-4d06-b69b-f80a649e2d2e.png">

## Changes
Splitting out the if statements to check for `accelerate` and `bitsandbytes` separately seems to fix this problem, in `load_in_8bit` mode.

Applies a similar fix to the imports in `deepspeed.py`. This fixed the same error as above but in this conditional block, later in the file.
```
    if is_deepspeed_zero3_enabled():
        import deepspeed

        [logger.info](http://logger.info/)("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
        init_contexts = [deepspeed.zero.Init(config_dict_or_path=deepspeed_config())] + init_contexts
```

After these changes, I was able to import, Blip2Processor, Blip2ForConditionalGeneration on Colab :)