### PR TITLE
Generate: Enable easier TextStreamer customization

### DIFF
--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -34,10 +34,6 @@ class BaseStreamer:
         """Function that is called by `.generate()` to signal the end of generation"""
         raise NotImplementedError()
 
-    def on_new_token(self, token: str, stream_end: bool = False):
-        """Callback function to signal the generation of a new token"""
-        pass
-
 
 class TextStreamer(BaseStreamer):
     """
@@ -92,7 +88,7 @@ class TextStreamer(BaseStreamer):
             printable_text = text[self.print_len : text.rfind(" ") + 1]
             self.print_len += len(printable_text)
 
-        self.on_new_token(printable_text)
+        self.on_finalized_text(printable_text)
 
     def end(self):
         """Flushes any remaining cache and prints a newline to stdout."""
@@ -106,10 +102,10 @@ class TextStreamer(BaseStreamer):
             printable_text = ""
 
         # Print a newline (and the remaining text, if any)
-        self.on_new_token(printable_text, stream_end=True)
+        self.on_finalized_text(printable_text, stream_end=True)
 
-    def on_new_token(self, token: str, stream_end: bool = False):
-        """Prints the new token to stdout."""
+    def on_finalized_text(self, token: str, stream_end: bool = False):
+        """Prints the new text to stdout."""
         print(token, flush=True, end="" if not stream_end else None)
 
 

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -34,6 +34,10 @@ class BaseStreamer:
         """Function that is called by `.generate()` to signal the end of generation"""
         raise NotImplementedError()
 
+    def on_new_token(self, token: str, stream_end: bool = False):
+        """Callback function to signal the generation of a new token"""
+        pass
+
 
 class TextStreamer(BaseStreamer):
     """
@@ -88,7 +92,7 @@ class TextStreamer(BaseStreamer):
             printable_text = text[self.print_len : text.rfind(" ") + 1]
             self.print_len += len(printable_text)
 
-        print(printable_text, flush=True, end="")
+        self.on_new_token(printable_text)
 
     def end(self):
         """Flushes any remaining cache and prints a newline to stdout."""
@@ -102,7 +106,11 @@ class TextStreamer(BaseStreamer):
             printable_text = ""
 
         # Print a newline (and the remaining text, if any)
-        print(printable_text, flush=True)
+        self.on_new_token(printable_text, stream_end=True)
+
+    def on_new_token(self, token: str, stream_end: bool = False):
+        """Prints the new token to stdout."""
+        print(token, flush=True, end="" if not stream_end else None)
 
 
 class TextIteratorStreamer(BaseStreamer):


### PR DESCRIPTION
# What does this PR do?

Minimally adapts recently integrated (https://github.com/huggingface/transformers/pull/22449) by adding a more obvious API hook for streaming tokens yet retains all the current semantics.

I am excited to use TextStreamer but I found the hook-in API not as intuitive as it could be if one needs to customize token printing. For example, I need to use specific colouring to print arriving tokens, yet achieving this without a complete TextStreamer rewrite is not as easy. We can easily create an obvious hook-in method:

```def on_new_token(self, token: str, stream_end: bool = False):```

This method is called by TextStreamer yet its subclasses can easily customize printing. The default implementation of on_new_token method simply prints tokens to stdout as it currently does. 

I don't foresee any major documentation updates as a consequence of this PR. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@gante @sgugger 