### PR TITLE
Fix convert_opt_original_pytorch_checkpoint_to_pytorch.py typo

### DIFF
--- a/src/transformers/models/opt/convert_opt_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/opt/convert_opt_original_pytorch_checkpoint_to_pytorch.py
@@ -55,9 +55,9 @@ def load_checkpoint(checkpoint_path):
 
     keys = list(sd.keys())
     for key in keys:
-        if ".qkj_proj." in key:
+        if ".qkv_proj." in key:
             value = sd[key]
-            # We split QKV in seperate Q,K,V
+            # We split QKV in separate Q,K,V
 
             q_name = key.replace(".qkv_proj.", ".q_proj.")
             k_name = key.replace(".qkv_proj.", ".k_proj.")


### PR DESCRIPTION
# What does this PR do?

`load_checkpoint()` silently fails because `".qkj_proj." in key` is always `False`, but will eventually cause an error at `model.load_state_dict(state_dict)`. This PR fixes the typo that causes this issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@patrickvonplaten 