### PR TITLE
Update test_image_processing_pix2struct.py

### DIFF
--- a/tests/models/pix2struct/test_image_processing_pix2struct.py
+++ b/tests/models/pix2struct/test_image_processing_pix2struct.py
@@ -65,7 +65,7 @@ class Pix2StructImageProcessingTester(unittest.TestCase):
         return {"do_normalize": self.do_normalize, "do_convert_rgb": self.do_convert_rgb}
 
     def prepare_dummy_image(self):
-        img_url = "https://www.ilankelman.org/stopsigns/australia.jpg"
+        img_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/australia.jpg"
         raw_image = Image.open(requests.get(img_url, stream=True).raw).convert("RGB")
         return raw_image
 
@@ -87,7 +87,6 @@ class Pix2StructImageProcessingTest(ImageProcessingSavingTestMixin, unittest.Tes
         self.assertTrue(hasattr(image_processor, "do_normalize"))
         self.assertTrue(hasattr(image_processor, "do_convert_rgb"))
 
-    @unittest.skip("fix me Younes.")
     def test_expected_patches(self):
         dummy_image = self.image_processor_tester.prepare_dummy_image()
 


### PR DESCRIPTION
# What does this PR do?

This PR should fix the failing test on `main`. 
The fix is to replace the previous image with the one I have uploaded on the Hub: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/australia.jpg

cc @sgugger 