### PR TITLE
Generate: Add text streamer decoding options

### DIFF
--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -25,7 +25,6 @@ class BaseStreamer:
     """
     Base class from which `.generate()` streamers should inherit.
     """
-
     def put(self, value):
         """Function that is called by `.generate()` to push new tokens"""
         raise NotImplementedError()
@@ -42,6 +41,10 @@ class TextStreamer(BaseStreamer):
     Parameters:
         tokenizer (`AutoTokenizer`):
             The tokenized used to decode the tokens.
+        skip_prompt (`bool`, *optional*, defaults to `False`):
+            Whether to skip the prompt to `.generate()` or not. Useful e.g. for chatbots.
+        decode_kwargs (`dict`, *optional*):
+            Additional keyword arguments to pass to the tokenizer's `decode` method.
 
     Examples:
 
@@ -59,10 +62,12 @@ class TextStreamer(BaseStreamer):
         ```
     """
 
-    def __init__(self, tokenizer: "AutoTokenizer"):
+    def __init__(self, tokenizer: "AutoTokenizer", skip_prompt: bool = False, **decode_kwargs):
         self.tokenizer = tokenizer
         self.token_cache = []
         self.print_len = 0
+        self.skipt_prompt = skip_prompt
+        self.decode_kwargs = decode_kwargs
 
     def put(self, value):
         """
@@ -112,8 +117,8 @@ class TextStreamer(BaseStreamer):
 class TextIteratorStreamer(BaseStreamer):
     """
     Streamer that stores print-ready text in a queue, to be used by a downstream application as an iterator. This is
-    useful for applications that want to use the generated text in a non-blocking way (e.g. in an interactive Gradio
-    demo).
+    useful for applications that benefit from acessing the generated text in a non-blocking way (e.g. in an interactive
+    Gradio demo).
 
     Parameters:
         tokenizer (`AutoTokenizer`):

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -25,6 +25,7 @@ class BaseStreamer:
     """
     Base class from which `.generate()` streamers should inherit.
     """
+
     def put(self, value):
         """Function that is called by `.generate()` to push new tokens"""
         raise NotImplementedError()
@@ -64,10 +65,13 @@ class TextStreamer(BaseStreamer):
 
     def __init__(self, tokenizer: "AutoTokenizer", skip_prompt: bool = False, **decode_kwargs):
         self.tokenizer = tokenizer
+        self.skip_prompt = skip_prompt
+        self.decode_kwargs = decode_kwargs
+
+        # variables used in the streaming process
         self.token_cache = []
         self.print_len = 0
-        self.skipt_prompt = skip_prompt
-        self.decode_kwargs = decode_kwargs
+        self.next_tokens_are_prompt = True
 
     def put(self, value):
         """
@@ -78,11 +82,15 @@ class TextStreamer(BaseStreamer):
         elif len(value.shape) > 1:
             value = value[0]
 
+        if self.skip_prompt and self.next_tokens_are_prompt:
+            self.next_tokens_are_prompt = False
+            return
+
         # Add the new token to the cache and decodes the entire thing.
         self.token_cache.extend(value.tolist())
-        text = self.tokenizer.decode(self.token_cache)
+        text = self.tokenizer.decode(self.token_cache, **self.decode_kwargs)
 
-        # After symbol for a new line, we flush the cache.
+        # After the symbol for a new line, we flush the cache.
         if text.endswith("\n"):
             printable_text = text[self.print_len :]
             self.token_cache = []
@@ -99,22 +107,22 @@ class TextStreamer(BaseStreamer):
         """Flushes any remaining cache and prints a newline to stdout."""
         # Flush the cache, if it exists
         if len(self.token_cache) > 0:
-            text = self.tokenizer.decode(self.token_cache)
+            text = self.tokenizer.decode(self.token_cache, **self.decode_kwargs)
             printable_text = text[self.print_len :]
             self.token_cache = []
             self.print_len = 0
         else:
             printable_text = ""
 
-        # Print a newline (and the remaining text, if any)
+        self.next_tokens_are_prompt = True
         self.on_finalized_text(printable_text, stream_end=True)
 
-    def on_finalized_text(self, token: str, stream_end: bool = False):
-        """Prints the new text to stdout."""
-        print(token, flush=True, end="" if not stream_end else None)
+    def on_finalized_text(self, text: str, stream_end: bool = False):
+        """Prints the new text to stdout. If the stream is ending, also prints a newline."""
+        print(text, flush=True, end="" if not stream_end else None)
 
 
-class TextIteratorStreamer(BaseStreamer):
+class TextIteratorStreamer(TextStreamer):
     """
     Streamer that stores print-ready text in a queue, to be used by a downstream application as an iterator. This is
     useful for applications that benefit from acessing the generated text in a non-blocking way (e.g. in an interactive
@@ -123,6 +131,10 @@ class TextIteratorStreamer(BaseStreamer):
     Parameters:
         tokenizer (`AutoTokenizer`):
             The tokenized used to decode the tokens.
+        skip_prompt (`bool`, *optional*, defaults to `False`):
+            Whether to skip the prompt to `.generate()` or not. Useful e.g. for chatbots.
+        decode_kwargs (`dict`, *optional*):
+            Additional keyword arguments to pass to the tokenizer's `decode` method.
 
     Examples:
 
@@ -147,58 +159,23 @@ class TextIteratorStreamer(BaseStreamer):
         ```
     """
 
-    def __init__(self, tokenizer: "AutoTokenizer"):
-        self.tokenizer = tokenizer
-        self.token_cache = []
-        self.print_len = 0
-        self.queue = Queue()
+    def __init__(self, tokenizer: "AutoTokenizer", skip_prompt: bool = False, **decode_kwargs):
+        super().__init__(tokenizer, skip_prompt, **decode_kwargs)
+        self.text_queue = Queue()
         self.stop_signal = None
+
+    def on_finalized_text(self, text: str, stream_end: bool = False):
+        """Put the new text in the queue. If the stream is ending, also put a stop signal in the queue."""
+        self.text_queue.put(text)
+        if stream_end:
+            self.text_queue.put(self.stop_signal)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        value = self.queue.get()
+        value = self.text_queue.get()
         if value == self.stop_signal:
             raise StopIteration()
         else:
             return value
-
-    def put(self, value):
-        """
-        Recives tokens, decodes them, and pushes text to the queue as soon as it form entire words.
-        """
-        if len(value.shape) > 1 and value.shape[0] > 1:
-            raise ValueError("TextStreamer only supports batch size 1")
-        elif len(value.shape) > 1:
-            value = value[0]
-
-        # Add the new token to the cache and decodes the entire thing.
-        self.token_cache.extend(value.tolist())
-        text = self.tokenizer.decode(self.token_cache)
-
-        # After symbol for a new line, we flush the cache.
-        if text.endswith("\n"):
-            printable_text = text[self.print_len :]
-            self.token_cache = []
-            self.print_len = 0
-        # Otherwise, prints until the last space char (simple heuristic to avoid printing incomplete words,
-        # which may change with the subsequent token -- there are probably smarter ways to do this!)
-        else:
-            printable_text = text[self.print_len : text.rfind(" ") + 1]
-            self.print_len += len(printable_text)
-        self.queue.put(printable_text)
-
-    def end(self):
-        """Flushes any remaining cache and puts the stop signal in the queue."""
-        # Flush the cache, if it exists
-        if len(self.token_cache) > 0:
-            text = self.tokenizer.decode(self.token_cache)
-            printable_text = text[self.print_len :]
-            self.token_cache = []
-            self.print_len = 0
-        else:
-            printable_text = ""
-
-        self.queue.put(printable_text)
-        self.queue.put(self.stop_signal)  # Put the stop signal

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1303,7 +1303,7 @@ class GenerationMixin:
         else:
             input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
 
-        if streamer is not None:
+        if streamer is not None and not streamer.skip_prompt:
             streamer.put(input_ids.cpu())
 
         # 6. Prepare `max_length` depending on other stopping criteria.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1303,7 +1303,7 @@ class GenerationMixin:
         else:
             input_ids = inputs_tensor if model_input_name == "input_ids" else model_kwargs.pop("input_ids")
 
-        if streamer is not None and not streamer.skip_prompt:
+        if streamer is not None:
             streamer.put(input_ids.cpu())
 
         # 6. Prepare `max_length` depending on other stopping criteria.


### PR DESCRIPTION
# What does this PR do?

In advance of communicating the iterator streamer with Gradio demos, adds two important options:
1. option to skip the prompt in the streamer (e.g. for chatbots)
2. option to receive `decode()` kwargs (e.g. to skip special tokens)

It also makes use of the changes in #22516 to make the iterator streamer much more compact -- it is now a child class of the stdout streamer, with a few modifications.