### PR TITLE
Add `torch_dtype` attribute

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2725,6 +2725,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
 
         model.is_loaded_in_8bit = load_in_8bit
+        model.torch_dtype = torch_dtype
 
         # make sure token embedding weights are still tied if needed
         model.tie_weights()


### PR DESCRIPTION
# What does this PR do?

Disclaimer: Maybe there is a more canonical way to retrieve the `torch_dtype` of a loaded model !

I propose to add the attribute `torch_dtype` inside `PreTrainedModel` so that it can be conveniently retrieved. Useful for example for `peft` where I see this solution as one of the possible solution to fix forward pass issues in half-precision for `PrefixTuning` models.

To provide more context, the prefix tuning models feed to the base model [new `past_key_values`](https://github.com/huggingface/peft/blob/main/src/peft/tuners/prefix_tuning.py#L103-L109). Those are computed by default in `float32` (and should always stay in `float32`). However, if the base model is in half-precision, the forward pass would fail (`dtype` mismatch errors). This PR would make the retrieving process of the base model's `dtype` super easy, thus handling this error.

cc @sgugger @pacman100 