### PR TITLE
Seq2SeqTrainer: use unwrapped model to retrieve the generation config

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -277,7 +277,7 @@ class Seq2SeqTrainer(Trainer):
             self.model.generation_config._from_model_config = False
 
         # Retrieves GenerationConfig from model.generation_config
-        gen_config = model.generation_config
+        gen_config = self.model.generation_config
         # in case the batch is shorter than max length, the output should be padded
         if generated_tokens.shape[-1] < gen_config.max_length:
             generated_tokens = self._pad_tensors_to_max_len(generated_tokens, gen_config.max_length)


### PR DESCRIPTION
# What does this PR do?

Addresses one of the issues in #22571

As the title indicates, changes the source of the generation config from `model` (wrapped model) to `self.model` (unwrapped model).