### PR TITLE
Tests: disable `accelerate_tests` mark warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,7 +42,7 @@ def pytest_configure(config):
         "markers", "is_pipeline_test: mark test to run only when pipelines are tested"
     )
     config.addinivalue_line("markers", "is_staging_test: mark test to run only in the staging environment")
-    config.addinivalue_line("markers", "accelerate_tests: mark tests that require accelerate")
+    config.addinivalue_line("markers", "accelerate_tests: mark test that require accelerate")
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,7 @@ def pytest_configure(config):
         "markers", "is_pipeline_test: mark test to run only when pipelines are tested"
     )
     config.addinivalue_line("markers", "is_staging_test: mark test to run only in the staging environment")
+    config.addinivalue_line("markers", "accelerate_tests: mark tests that require accelerate")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
# What does this PR do?

Adds the `accelerate_tests` mark to `conftest.py`, so we don't get related warnings at test time. 

Here's a print screen before the fix:
<img width="1512" alt="Screenshot 2023-04-05 at 11 27 32" src="https://user-images.githubusercontent.com/12240844/230054803-cc95b93d-aab4-4133-baa8-7115760cd3ee.png">

And after the fix:
<img width="1512" alt="Screenshot 2023-04-05 at 11 27 53" src="https://user-images.githubusercontent.com/12240844/230054894-46a9435a-43be-4ef9-b111-92d664017d13.png">
