### PR TITLE
Move back doctest instructions to setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,6 @@ line-length = 119
 lines-after-imports = 2
 known-first-party = ["transformers"]
 
-[tool.pytest]
-doctest_optionflags="NUMBER NORMALIZE_WHITESPACE ELLIPSIS"
+# This is ignored, maybe because of the header? If someone finds a fix, we can uncomment and remove setup.cfg
+# [tool.pytest]
+# doctest_optionflags="NUMBER NORMALIZE_WHITESPACE ELLIPSIS"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+doctest_optionflags=NUMBER NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
# What does this PR do?

As a result of #22539, the options we have for the doctests are now all ignored. This PR reverts the change for those and puts them back in `setup.cfg`.