### PR TITLE
Use native TF checkpoints for the BLIP TF tests

### DIFF
--- a/tests/models/blip/test_modeling_tf_blip.py
+++ b/tests/models/blip/test_modeling_tf_blip.py
@@ -317,10 +317,7 @@ class TFBlipTextModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            try:
-                model = TFBlipTextModel.from_pretrained(model_name)
-            except OSError:
-                model = TFBlipTextModel.from_pretrained(model_name)
+            model = TFBlipTextModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     def test_pt_tf_model_equivalence(self, allow_missing_keys=True):
@@ -747,10 +744,7 @@ class TFBlipTextImageModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            try:
-                model = TFBlipModel.from_pretrained(model_name)
-            except OSError:
-                model = TFBlipModel.from_pretrained(model_name)
+            model = TFBlipModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 

--- a/tests/models/blip/test_modeling_tf_blip.py
+++ b/tests/models/blip/test_modeling_tf_blip.py
@@ -189,10 +189,7 @@ class TFBlipVisionModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            try:
-                model = TFBlipVisionModel.from_pretrained(model_name)
-            except OSError:
-                model = TFBlipVisionModel.from_pretrained(model_name, from_pt=True)
+            model = TFBlipVisionModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 
@@ -323,7 +320,7 @@ class TFBlipTextModelTest(TFModelTesterMixin, unittest.TestCase):
             try:
                 model = TFBlipTextModel.from_pretrained(model_name)
             except OSError:
-                model = TFBlipTextModel.from_pretrained(model_name, from_pt=True)
+                model = TFBlipTextModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     def test_pt_tf_model_equivalence(self, allow_missing_keys=True):
@@ -432,7 +429,7 @@ class TFBlipModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = TFBlipModel.from_pretrained(model_name, from_pt=True)
+            model = TFBlipModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     def test_pt_tf_model_equivalence(self, allow_missing_keys=True):
@@ -635,7 +632,7 @@ class TFBlipTextRetrievalModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            model = TFBlipModel.from_pretrained(model_name, from_pt=True)
+            model = TFBlipModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     @unittest.skip(reason="Tested in individual model tests")
@@ -753,7 +750,7 @@ class TFBlipTextImageModelTest(TFModelTesterMixin, unittest.TestCase):
             try:
                 model = TFBlipModel.from_pretrained(model_name)
             except OSError:
-                model = TFBlipModel.from_pretrained(model_name, from_pt=True)
+                model = TFBlipModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
 
@@ -769,7 +766,7 @@ def prepare_img():
 @slow
 class TFBlipModelIntegrationTest(unittest.TestCase):
     def test_inference_image_captioning(self):
-        model = TFBlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-base", from_pt=True)
+        model = TFBlipForConditionalGeneration.from_pretrained("Salesforce/blip-image-captioning-base")
         processor = BlipProcessor.from_pretrained("Salesforce/blip-image-captioning-base")
         image = prepare_img()
 
@@ -796,7 +793,7 @@ class TFBlipModelIntegrationTest(unittest.TestCase):
         )
 
     def test_inference_vqa(self):
-        model = TFBlipForQuestionAnswering.from_pretrained("Salesforce/blip-vqa-base", from_pt=True)
+        model = TFBlipForQuestionAnswering.from_pretrained("Salesforce/blip-vqa-base")
         processor = BlipProcessor.from_pretrained("Salesforce/blip-vqa-base")
 
         image = prepare_img()
@@ -808,7 +805,7 @@ class TFBlipModelIntegrationTest(unittest.TestCase):
         self.assertEqual(out[0].numpy().tolist(), [30522, 1015, 102])
 
     def test_inference_itm(self):
-        model = TFBlipForImageTextRetrieval.from_pretrained("Salesforce/blip-itm-base-coco", from_pt=True)
+        model = TFBlipForImageTextRetrieval.from_pretrained("Salesforce/blip-itm-base-coco")
         processor = BlipProcessor.from_pretrained("Salesforce/blip-itm-base-coco")
 
         image = prepare_img()

--- a/tests/models/blip/test_modeling_tf_blip_text.py
+++ b/tests/models/blip/test_modeling_tf_blip_text.py
@@ -160,10 +160,7 @@ class BlipTextModelTest(TFModelTesterMixin, unittest.TestCase):
     @slow
     def test_model_from_pretrained(self):
         for model_name in TF_BLIP_PRETRAINED_MODEL_ARCHIVE_LIST[:1]:
-            try:
-                model = TFBlipTextModel.from_pretrained(model_name)
-            except OSError:
-                model = TFBlipTextModel.from_pretrained(model_name, from_pt=True)
+            model = TFBlipTextModel.from_pretrained(model_name)
             self.assertIsNotNone(model)
 
     def test_pt_tf_model_equivalence(self, allow_missing_keys=True):


### PR DESCRIPTION
Stop using `from_pt` now that the checkpoints have native TF weights