### PR TITLE
[DO NOT MERGE] Add Crop Transformation

### DIFF
--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -39,6 +39,7 @@ if is_vision_available():
         center_to_corners_format,
         convert_to_rgb,
         corners_to_center_format,
+        crop,
         get_resize_output_image_size,
         id_to_rgb,
         normalize,
@@ -305,6 +306,110 @@ class ImageTransformsTester(unittest.TestCase):
         cropped_image = center_crop(image, (300, 260), data_format="channels_last")
         self.assertIsInstance(cropped_image, np.ndarray)
         self.assertEqual(cropped_image.shape, (300, 260, 3))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+    def test_crop(self):
+        image = np.random.randint(0, 256, (3, 224, 224))
+
+        # Test that exception is raised if crop out of bounds and padding is not specified
+        with self.assertRaises(ValueError):
+            crop(image, 0, 0, 300, 300, data_format="channels_last")
+
+        # Crop box within the image bounds
+        # *-----------*
+        # |   +----+  |
+        # |   ||||||  |
+        # |   +----+  |
+        # |           |
+        # *-----------*
+        image = np.arange(3 * 10 * 10).reshape(3, 10, 10)
+        top, left, height, width = 2, 2, 4, 4
+        expected_image = image[:, top : top + height, left : left + width]
+        cropped_image = crop(image, top, left, height, width, padding=0)
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (3, 4, 4))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+        # Crop box outside the image bounds
+        # +-----------+
+        # |00000000000|
+        # |000*----*00|
+        # |000||||||00|
+        # |000*----*00|
+        # +-----------+
+        image = np.arange(1 * 10 * 10).reshape(1, 10, 10)
+        top, left, height, width = -2, -2, 12, 12
+        expected_image = np.zeros((12, 12, 1))
+        expected_image[2:12, 2:12, :] = image.transpose((1, 2, 0))
+        cropped_image = crop(image, top, left, height, width, padding=0, data_format="channels_last")
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (12, 12, 1))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+        # Negative top, left indices with box outside of images
+        # +-----+
+        # |55555|
+        # |55555|
+        # +-----+
+        #         *----*
+        #         ||||||
+        #         *----*
+        top, left, height, width = -2, -2, 2, 2
+        image = np.arange(10 * 10 * 1).reshape(10, 10, 1)
+        expected_image = np.full((1, 2, 2), 5)
+        cropped_image = crop(image, top, left, height, width, padding=5)
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (2, 2, 1))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+        # Positive top, left indices with box outside of image
+        # *----*
+        # ||||||
+        # *----*
+        #     +-----+
+        #     |00000|
+        #     |00000|
+        #     +-----+
+        top, left, height, width = 12, 8, 4, 4
+        image = np.arange(3 * 10 * 10).reshape(3, 10, 10)
+        expected_image = np.zeros((3, 4, 4))
+        cropped_image = crop(image, top, left, height, width, padding=0)
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (3, 4, 4))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+        # Negative top, left with image in bottom right corner
+        # +--------+
+        # |00000000|
+        # |0000*---|-*
+        # |0000|||||||
+        # +--------+ |
+        #      |||||||
+        #      *-----*
+        top, left, height, width = -2, -2, 6, 6
+        image = np.arange(10 * 10 * 3).reshape(10, 10, 3)
+        expected_image = np.zeros((3, 6, 6))
+        expected_image[:, 2:, 2:] = image.transpose(2, 0, 1)[:, :4, :4]
+        cropped_image = crop(image, top, left, height, width, padding=0, data_format="channels_first")
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (3, 6, 6))
+        self.assertTrue(np.allclose(cropped_image, expected_image))
+
+        # Positive top, left with image in top left corner
+        # *-----*
+        # |||||||
+        # ||+--------+
+        # |||||||0000|
+        # +-|---*0000|
+        #   |00000000|
+        #   +--------+
+        top, left, height, width = 2, 2, 4, 4
+        image = np.arange(10 * 10 * 1).reshape(10, 10, 1)
+        expected_image = np.zeros((4, 4, 1))
+        expected_image[:4, :4, :] = image[2:6, 2:6, :]
+        cropped_image = crop(image, top, left, height, width, padding=0)
+        self.assertIsInstance(cropped_image, np.ndarray)
+        self.assertEqual(cropped_image.shape, (4, 4, 1))
         self.assertTrue(np.allclose(cropped_image, expected_image))
 
     def test_center_to_corners_format(self):

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -323,11 +323,11 @@ class ImageTransformsTester(unittest.TestCase):
         # |           |
         # *-----------*
         image = np.arange(3 * 10 * 10).reshape(3, 10, 10)
-        top, left, height, width = 2, 2, 4, 4
+        top, left, height, width = 2, 1, 4, 5
         expected_image = image[:, top : top + height, left : left + width]
-        cropped_image = crop(image, top, left, height, width, padding=0)
+        cropped_image = crop(image, top, left, height, width)
         self.assertIsInstance(cropped_image, np.ndarray)
-        self.assertEqual(cropped_image.shape, (3, 4, 4))
+        self.assertEqual(cropped_image.shape, (3, 4, 5))
         self.assertTrue(np.allclose(cropped_image, expected_image))
 
         # Crop box outside the image bounds
@@ -338,12 +338,12 @@ class ImageTransformsTester(unittest.TestCase):
         # |000*----*00|
         # +-----------+
         image = np.arange(1 * 10 * 10).reshape(1, 10, 10)
-        top, left, height, width = -2, -2, 12, 12
-        expected_image = np.zeros((12, 12, 1))
-        expected_image[2:12, 2:12, :] = image.transpose((1, 2, 0))
+        top, left, height, width = -2, -3, 12, 10
+        expected_image = np.zeros((12, 10, 1))
+        expected_image[2:12, 3:, :] = image.transpose((1, 2, 0))[:10, :7, :]
         cropped_image = crop(image, top, left, height, width, padding=0, data_format="channels_last")
         self.assertIsInstance(cropped_image, np.ndarray)
-        self.assertEqual(cropped_image.shape, (12, 12, 1))
+        self.assertEqual(cropped_image.shape, (12, 10, 1))
         self.assertTrue(np.allclose(cropped_image, expected_image))
 
         # Negative top, left indices with box outside of images
@@ -403,13 +403,13 @@ class ImageTransformsTester(unittest.TestCase):
         # +-|---*0000|
         #   |00000000|
         #   +--------+
-        top, left, height, width = 2, 2, 4, 4
+        top, left, height, width = 2, 0, 4, 5
         image = np.arange(10 * 10 * 1).reshape(10, 10, 1)
-        expected_image = np.zeros((4, 4, 1))
-        expected_image[:4, :4, :] = image[2:6, 2:6, :]
+        expected_image = np.zeros((4, 5, 1))
+        expected_image[:4, :5, :] = image[2:6, :5, :]
         cropped_image = crop(image, top, left, height, width, padding=0)
         self.assertIsInstance(cropped_image, np.ndarray)
-        self.assertEqual(cropped_image.shape, (4, 4, 1))
+        self.assertEqual(cropped_image.shape, (4, 5, 1))
         self.assertTrue(np.allclose(cropped_image, expected_image))
 
     def test_center_to_corners_format(self):


### PR DESCRIPTION
# What does this PR do?

Abstracts out cropping logic to be a more generic `crop` function which other, more specific cropping functions e.g. `center_crop` can call. 

Motivation: 
* The output of the CLIP feature extractor changed after #17628. This was due to a difference in how the `top` and `left` coordinates were calculated resulting in some values being off by one. 
* The original CLIP feature extractor matched the original implementation
* Having a more generic `crop` method enables each image processor to have its own center_crop logic with minimal code replication. 

[BEFORE MERGING]: Verify this doesn't have large impact on any popular CLIP dependant pipelines

Fixes #22505


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?