### PR TITLE
Make FlaxPreTrainedModel a Flax Module

### DIFF
--- a/src/transformers/models/bert/modeling_flax_bert.py
+++ b/src/transformers/models/bert/modeling_flax_bert.py
@@ -971,12 +971,12 @@ class FlaxBertPreTrainedModel(FlaxPreTrainedModel):
                 )
             
             # add updated cache to model output
-            if past_key_values is not None and return_dict:
-                outputs, past_key_values = outputs
-                outputs["past_key_values"] = unfreeze(past_key_values["cache"])
-            elif past_key_values is not None and not return_dict:
-                outputs, past_key_values = outputs
-                outputs = outputs[:1] + (unfreeze(past_key_values["cache"]),) + outputs[1:]
+            if past_key_values is not None:
+                outputs, updates = outputs
+                if return_dict:
+                    outputs["past_key_values"] = unfreeze(updates["cache"])
+                else:
+                    outputs = outputs[:1] + (unfreeze(updates["cache"]),) + outputs[1:]
         else:
             if params is not None:
                 raise ValueError(

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -1024,6 +1024,9 @@ class FlaxModelTesterMixin:
             # Check if we can do a forward pass
             inputs_dict["output_hidden_states"] = True
             inputs = self._prepare_for_class(inputs_dict, model_class).copy()
+            # test regular __call__ with params as input
+            model(**inputs, params=params)
+            # test using apply
             model.apply({"params": {"_module": params}}, **inputs)
 
     def test_from_pretrained_with_no_automatic_init(self):

--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -1024,7 +1024,7 @@ class FlaxModelTesterMixin:
             # Check if we can do a forward pass
             inputs_dict["output_hidden_states"] = True
             inputs = self._prepare_for_class(inputs_dict, model_class).copy()
-            model(**inputs, params=params)
+            model.apply({"params": {"_module": params}}, **inputs)
 
     def test_from_pretrained_with_no_automatic_init(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

WIP. Makes `FlaxPreTrainedModel` a `nn.Module` so Flax users can easily integrate it into other Flax networks or systems that expect Flax Modules. 

See for #22499 some discussion of the approach.
