### PR TITLE
[`Blip`] Fix slow tests and doctests with correct values

### DIFF
--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -1055,7 +1055,7 @@ class BlipForConditionalGeneration(BlipPreTrainedModel):
 
         >>> outputs = model.generate(**inputs)
         >>> print(processor.decode(outputs[0], skip_special_tokens=True))
-        two cats are laying on a couch
+        two cats sleeping on a couch
         ```
         """
 

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -1120,7 +1120,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         # Test output
         self.assertEqual(
             predictions[0].tolist(),
-            [30522, 1037, 3861, 1997, 1037, 2450, 3564, 2006, 1996, 3509, 2007, 2014, 3899, 102],
+            [30522, 1037, 3861, 1997, 1037, 2450, 1998, 2014, 3899, 2006, 1996, 3509, 102],
         )
 
     @require_torch_gpu
@@ -1148,7 +1148,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         # Test output
         self.assertEqual(
             predictions[0].tolist(),
-            [30522, 1037, 3861, 1997, 1037, 2450, 3564, 2006, 1996, 3509, 2007, 2014, 3899, 102],
+            [30522, 1037, 3861, 1997, 1037, 2450, 1998, 2014, 3899, 2006, 1996, 3509, 102],
         )
 
     def test_inference_vqa(self):
@@ -1176,7 +1176,7 @@ class BlipModelIntegrationTest(unittest.TestCase):
         out_itm = model(**inputs)
         out = model(**inputs, use_itm_head=False)
 
-        expected_scores = torch.Tensor([[0.9798, 0.0202]])
+        expected_scores = torch.Tensor([[0.0029, 0.9971]])
 
         self.assertTrue(torch.allclose(torch.nn.Softmax()(out_itm[0].cpu()), expected_scores, rtol=1e-3, atol=1e-3))
-        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5053]]), rtol=1e-3, atol=1e-3))
+        self.assertTrue(torch.allclose(out[0].cpu(), torch.Tensor([[0.5162]]), rtol=1e-3, atol=1e-3))


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/22625

In fact, the `num_attention_heads` of `BlipTextModel` should be 12 and not 8. Hence the models that are on the Hub were producing different logits / generations that the original implementation in some cases.

I made PRs on the Hub:

- https://huggingface.co/Salesforce/blip-itm-large-flickr/discussions/1
- https://huggingface.co/Salesforce/blip-itm-base-coco/discussions/3
- https://huggingface.co/Salesforce/blip-image-captioning-base/discussions/13
- https://huggingface.co/Salesforce/blip-image-captioning-large/discussions/8#642eed4cce2efe48a1aa1497
- https://huggingface.co/Salesforce/blip-vqa-base/discussions/3#642eed68ae8ae35b7a9bbb7f
- https://huggingface.co/Salesforce/blip-vqa-capfilt-large/discussions/5
- https://huggingface.co/Salesforce/blip-itm-large-flickr/discussions/3
- https://huggingface.co/Salesforce/blip-itm-large-coco/discussions/3

And tested them on the slow tests and doctests with `.from_pretrained(xxx, revision="refs/pr/xx")`, this PR fixes the slow tests and doctests with the correct values. Let's merge this PR and I'll merge the PRs that are on the Hub

cc @sgugger 
