### PR TITLE
Use code on the Hub from another repo

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -667,6 +667,8 @@ class PretrainedConfig(PushToHubMixin):
         else:
             logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
 
+        if "auto_map" in config_dict and not is_local:
+            config_dict["auto_map"] = {k: (f"{pretrained_model_name_or_path}--{v}" if "--" not in v else v) for k, v in config_dict["auto_map"].items()}
         return config_dict, kwargs
 
     @classmethod

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -668,7 +668,10 @@ class PretrainedConfig(PushToHubMixin):
             logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
 
         if "auto_map" in config_dict and not is_local:
-            config_dict["auto_map"] = {k: (f"{pretrained_model_name_or_path}--{v}" if "--" not in v else v) for k, v in config_dict["auto_map"].items()}
+            config_dict["auto_map"] = {
+                k: (f"{pretrained_model_name_or_path}--{v}" if "--" not in v else v)
+                for k, v in config_dict["auto_map"].items()
+            }
         return config_dict, kwargs
 
     @classmethod

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -379,6 +379,12 @@ def get_class_from_dynamic_module(
     # module.
     cls = get_class_from_dynamic_module("sgugger/my-bert-model--modeling.MyBertModel", "sgugger/another-bert-model")
     ```"""
+    if revision is None:
+        logger.warning(
+            "Explicitly passing a `revision` is encouraged when loading a model with custom code to ensure"
+            " no malicious code has been contributed in a newer revision."
+        )
+
     # Catch the name of the repo if it's specified in `class_reference`
     if "--" in class_reference:
         repo_id, class_reference = class_reference.split("--")

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -462,13 +462,8 @@ class _BaseAutoModelClass:
                     "no malicious code has been contributed in a newer revision."
                 )
             class_ref = config.auto_map[cls.__name__]
-            if "--" in class_ref:
-                repo_id, class_ref = class_ref.split("--")
-            else:
-                repo_id = pretrained_model_name_or_path
-            module_file, class_name = class_ref.split(".")
             model_class = get_class_from_dynamic_module(
-                repo_id, module_file + ".py", class_name, **hub_kwargs, **kwargs
+                class_ref, pretrained_model_name_or_path, **hub_kwargs, **kwargs
             )
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -456,11 +456,6 @@ class _BaseAutoModelClass:
                     "on your local machine. Make sure you have read the code there to avoid malicious use, then set "
                     "the option `trust_remote_code=True` to remove this error."
                 )
-            if hub_kwargs.get("revision", None) is None:
-                logger.warning(
-                    "Explicitly passing a `revision` is encouraged when loading a model with custom code to ensure "
-                    "no malicious code has been contributed in a newer revision."
-                )
             class_ref = config.auto_map[cls.__name__]
             model_class = get_class_from_dynamic_module(
                 class_ref, pretrained_model_name_or_path, **hub_kwargs, **kwargs

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -403,8 +403,12 @@ class _BaseAutoModelClass:
                     "no malicious code has been contributed in a newer revision."
                 )
             class_ref = config.auto_map[cls.__name__]
+            if "--" in class_ref:
+                repo_id, class_ref = class_ref.split("--")
+            else:
+                repo_id = config.name_or_path
             module_file, class_name = class_ref.split(".")
-            model_class = get_class_from_dynamic_module(config.name_or_path, module_file + ".py", class_name, **kwargs)
+            model_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
             return model_class._from_config(config, **kwargs)
         elif type(config) in cls._model_mapping.keys():
             model_class = _get_model_class(config, cls._model_mapping)
@@ -458,11 +462,14 @@ class _BaseAutoModelClass:
                     "no malicious code has been contributed in a newer revision."
                 )
             class_ref = config.auto_map[cls.__name__]
+            if "--" in class_ref:
+                repo_id, class_ref = class_ref.split("--")
+            else:
+                repo_id = pretrained_model_name_or_path
             module_file, class_name = class_ref.split(".")
             model_class = get_class_from_dynamic_module(
-                pretrained_model_name_or_path, module_file + ".py", class_name, **hub_kwargs, **kwargs
+                repo_id, module_file + ".py", class_name, **hub_kwargs, **kwargs
             )
-            model_class.register_for_auto_class(cls.__name__)
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs
             )

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -924,11 +924,12 @@ class AutoConfig:
                     "ensure no malicious code has been contributed in a newer revision."
                 )
             class_ref = config_dict["auto_map"]["AutoConfig"]
+            if "--" in class_ref:
+                repo_id, class_ref = class_ref.split("--")
+            else:
+                repo_id = pretrained_model_name_or_path
             module_file, class_name = class_ref.split(".")
-            config_class = get_class_from_dynamic_module(
-                pretrained_model_name_or_path, module_file + ".py", class_name, **kwargs
-            )
-            config_class.register_for_auto_class()
+            config_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
             return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
         elif "model_type" in config_dict:
             config_class = CONFIG_MAPPING[config_dict["model_type"]]

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -924,12 +924,7 @@ class AutoConfig:
                     "ensure no malicious code has been contributed in a newer revision."
                 )
             class_ref = config_dict["auto_map"]["AutoConfig"]
-            if "--" in class_ref:
-                repo_id, class_ref = class_ref.split("--")
-            else:
-                repo_id = pretrained_model_name_or_path
-            module_file, class_name = class_ref.split(".")
-            config_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
+            config_class = get_class_from_dynamic_module(class_ref, pretrained_model_name_or_path, **kwargs)
             return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
         elif "model_type" in config_dict:
             config_class = CONFIG_MAPPING[config_dict["model_type"]]

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -918,11 +918,6 @@ class AutoConfig:
                     " repo on your local machine. Make sure you have read the code there to avoid malicious use, then"
                     " set the option `trust_remote_code=True` to remove this error."
                 )
-            if kwargs.get("revision", None) is None:
-                logger.warning(
-                    "Explicitly passing a `revision` is encouraged when loading a configuration with custom code to "
-                    "ensure no malicious code has been contributed in a newer revision."
-                )
             class_ref = config_dict["auto_map"]["AutoConfig"]
             config_class = get_class_from_dynamic_module(class_ref, pretrained_model_name_or_path, **kwargs)
             return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -333,11 +333,6 @@ class AutoFeatureExtractor:
                         "in that repo on your local machine. Make sure you have read the code there to avoid "
                         "malicious use, then set the option `trust_remote_code=True` to remove this error."
                     )
-                if kwargs.get("revision", None) is None:
-                    logger.warning(
-                        "Explicitly passing a `revision` is encouraged when loading a feature extractor with custom "
-                        "code to ensure no malicious code has been contributed in a newer revision."
-                    )
                 feature_extractor_class = get_class_from_dynamic_module(
                     feature_extractor_auto_map, pretrained_model_name_or_path, **kwargs
                 )

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -338,14 +338,8 @@ class AutoFeatureExtractor:
                         "Explicitly passing a `revision` is encouraged when loading a feature extractor with custom "
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
-
-                if "--" in feature_extractor_auto_map:
-                    repo_id, feature_extractor_auto_map = feature_extractor_auto_map.split("--")
-                else:
-                    repo_id = pretrained_model_name_or_path
-                module_file, class_name = feature_extractor_auto_map.split(".")
                 feature_extractor_class = get_class_from_dynamic_module(
-                    repo_id, module_file + ".py", class_name, **kwargs
+                    feature_extractor_auto_map, pretrained_model_name_or_path, **kwargs
                 )
             else:
                 feature_extractor_class = feature_extractor_class_from_name(feature_extractor_class)

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -339,11 +339,14 @@ class AutoFeatureExtractor:
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
 
+                if "--" in feature_extractor_auto_map:
+                    repo_id, feature_extractor_auto_map = feature_extractor_auto_map.split("--")
+                else:
+                    repo_id = pretrained_model_name_or_path
                 module_file, class_name = feature_extractor_auto_map.split(".")
                 feature_extractor_class = get_class_from_dynamic_module(
-                    pretrained_model_name_or_path, module_file + ".py", class_name, **kwargs
+                    repo_id, module_file + ".py", class_name, **kwargs
                 )
-                feature_extractor_class.register_for_auto_class()
             else:
                 feature_extractor_class = feature_extractor_class_from_name(feature_extractor_class)
 

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -355,11 +355,6 @@ class AutoImageProcessor:
                         "in that repo on your local machine. Make sure you have read the code there to avoid "
                         "malicious use, then set the option `trust_remote_code=True` to remove this error."
                     )
-                if kwargs.get("revision", None) is None:
-                    logger.warning(
-                        "Explicitly passing a `revision` is encouraged when loading a image processor with custom "
-                        "code to ensure no malicious code has been contributed in a newer revision."
-                    )
                 image_processor_class = get_class_from_dynamic_module(
                     image_processor_auto_map, pretrained_model_name_or_path, **kwargs
                 )

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -360,14 +360,8 @@ class AutoImageProcessor:
                         "Explicitly passing a `revision` is encouraged when loading a image processor with custom "
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
-
-                if "--" in image_processor_auto_map:
-                    repo_id, image_processor_auto_map = image_processor_auto_map.split("--")
-                else:
-                    repo_id = pretrained_model_name_or_path
-                module_file, class_name = image_processor_auto_map.split(".")
                 image_processor_class = get_class_from_dynamic_module(
-                    repo_id, module_file + ".py", class_name, **kwargs
+                    image_processor_auto_map, pretrained_model_name_or_path, **kwargs
                 )
             else:
                 image_processor_class = image_processor_class_from_name(image_processor_class)

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -361,11 +361,14 @@ class AutoImageProcessor:
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
 
+                if "--" in image_processor_auto_map:
+                    repo_id, image_processor_auto_map = image_processor_auto_map.split("--")
+                else:
+                    repo_id = pretrained_model_name_or_path
                 module_file, class_name = image_processor_auto_map.split(".")
                 image_processor_class = get_class_from_dynamic_module(
-                    pretrained_model_name_or_path, module_file + ".py", class_name, **kwargs
+                    repo_id, module_file + ".py", class_name, **kwargs
                 )
-                image_processor_class.register_for_auto_class()
             else:
                 image_processor_class = image_processor_class_from_name(image_processor_class)
 

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -254,11 +254,6 @@ class AutoProcessor:
                         "in that repo on your local machine. Make sure you have read the code there to avoid "
                         "malicious use, then set the option `trust_remote_code=True` to remove this error."
                     )
-                if kwargs.get("revision", None) is None:
-                    logger.warning(
-                        "Explicitly passing a `revision` is encouraged when loading a feature extractor with custom "
-                        "code to ensure no malicious code has been contributed in a newer revision."
-                    )
 
                 processor_class = get_class_from_dynamic_module(
                     processor_auto_map, pretrained_model_name_or_path, **kwargs

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -260,12 +260,9 @@ class AutoProcessor:
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
 
-                if "--" in processor_auto_map:
-                    repo_id, processor_auto_map = processor_auto_map.split("--")
-                else:
-                    repo_id = pretrained_model_name_or_path
-                module_file, class_name = processor_auto_map.split(".")
-                processor_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
+                processor_class = get_class_from_dynamic_module(
+                    processor_auto_map, pretrained_model_name_or_path, **kwargs
+                )
             else:
                 processor_class = processor_class_from_name(processor_class)
 

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -260,11 +260,12 @@ class AutoProcessor:
                         "code to ensure no malicious code has been contributed in a newer revision."
                     )
 
+                if "--" in processor_auto_map:
+                    repo_id, processor_auto_map = processor_auto_map.split("--")
+                else:
+                    repo_id = pretrained_model_name_or_path
                 module_file, class_name = processor_auto_map.split(".")
-                processor_class = get_class_from_dynamic_module(
-                    pretrained_model_name_or_path, module_file + ".py", class_name, **kwargs
-                )
-                processor_class.register_for_auto_class()
+                processor_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
             else:
                 processor_class = processor_class_from_name(processor_class)
 

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -670,11 +670,6 @@ class AutoTokenizer:
                         " repo on your local machine. Make sure you have read the code there to avoid malicious use,"
                         " then set the option `trust_remote_code=True` to remove this error."
                     )
-                if kwargs.get("revision", None) is None:
-                    logger.warning(
-                        "Explicitly passing a `revision` is encouraged when loading a model with custom code to ensure"
-                        " no malicious code has been contributed in a newer revision."
-                    )
 
                 if use_fast and tokenizer_auto_map[1] is not None:
                     class_ref = tokenizer_auto_map[1]

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -681,11 +681,12 @@ class AutoTokenizer:
                 else:
                     class_ref = tokenizer_auto_map[0]
 
+                if "--" in class_ref:
+                    repo_id, class_ref = class_ref.split("--")
+                else:
+                    repo_id = pretrained_model_name_or_path
                 module_file, class_name = class_ref.split(".")
-                tokenizer_class = get_class_from_dynamic_module(
-                    pretrained_model_name_or_path, module_file + ".py", class_name, **kwargs
-                )
-                tokenizer_class.register_for_auto_class()
+                tokenizer_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
 
             elif use_fast and not config_tokenizer_class.endswith("Fast"):
                 tokenizer_class_candidate = f"{config_tokenizer_class}Fast"

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -680,13 +680,7 @@ class AutoTokenizer:
                     class_ref = tokenizer_auto_map[1]
                 else:
                     class_ref = tokenizer_auto_map[0]
-
-                if "--" in class_ref:
-                    repo_id, class_ref = class_ref.split("--")
-                else:
-                    repo_id = pretrained_model_name_or_path
-                module_file, class_name = class_ref.split(".")
-                tokenizer_class = get_class_from_dynamic_module(repo_id, module_file + ".py", class_name, **kwargs)
+                tokenizer_class = get_class_from_dynamic_module(class_ref, pretrained_model_name_or_path, **kwargs)
 
             elif use_fast and not config_tokenizer_class.endswith("Fast"):
                 tokenizer_class_candidate = f"{config_tokenizer_class}Fast"

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -727,9 +727,8 @@ def pipeline(
                     " set the option `trust_remote_code=True` to remove this error."
                 )
             class_ref = targeted_task["impl"]
-            module_file, class_name = class_ref.split(".")
             pipeline_class = get_class_from_dynamic_module(
-                model, module_file + ".py", class_name, revision=revision, use_auth_token=use_auth_token
+                class_ref, model, revision=revision, use_auth_token=use_auth_token
             )
     else:
         normalized_task, targeted_task, task_options = check_task(task)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1817,6 +1817,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             cache_dir=cache_dir,
             local_files_only=local_files_only,
             _commit_hash=commit_hash,
+            _is_local=is_local,
             **kwargs,
         )
 
@@ -1831,6 +1832,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         cache_dir=None,
         local_files_only=False,
         _commit_hash=None,
+        _is_local=False,
         **kwargs,
     ):
         # We instantiate fast tokenizers based on a slow tokenizer if we don't have access to the tokenizer.json
@@ -1861,13 +1863,21 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             # First attempt. We get tokenizer_class from tokenizer_config to check mismatch between tokenizers.
             config_tokenizer_class = init_kwargs.get("tokenizer_class")
             init_kwargs.pop("tokenizer_class", None)
-            init_kwargs.pop("auto_map", None)
             saved_init_inputs = init_kwargs.pop("init_inputs", ())
             if not init_inputs:
                 init_inputs = saved_init_inputs
         else:
             config_tokenizer_class = None
             init_kwargs = init_configuration
+
+        if "auto_map" in init_kwargs and not _is_local:
+            new_auto_map = {}
+            for key, value in init_kwargs["auto_map"].items():
+                if isinstance(value, (list, tuple)):
+                    new_auto_map[key] = [f"{pretrained_model_name_or_path}--{v}" for v in value]
+                else:
+                    new_auto_map[key] = f"{pretrained_model_name_or_path}--{value}"
+            init_kwargs["auto_map"] = new_auto_map
 
         if config_tokenizer_class is None:
             from .models.auto.configuration_auto import AutoConfig  # tests_ignore

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -83,6 +83,7 @@ from .hub import (
     is_remote_url,
     move_cache,
     send_example_telemetry,
+    try_to_load_from_cache,
 )
 from .import_utils import (
     ENV_VARS_TRUE_AND_AUTO_VALUES,

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -298,6 +298,34 @@ class AutoModelTest(unittest.TestCase):
         for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
+    def test_from_pretrained_dynamic_model_distant_with_ref(self):
+        model = AutoModel.from_pretrained("hf-internal-testing/ref_to_test_dynamic_model", trust_remote_code=True)
+        self.assertEqual(model.__class__.__name__, "NewModel")
+
+        # Test model can be reloaded.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir)
+            reloaded_model = AutoModel.from_pretrained(tmp_dir, trust_remote_code=True)
+
+        self.assertEqual(reloaded_model.__class__.__name__, "NewModel")
+        for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
+            self.assertTrue(torch.equal(p1, p2))
+
+        # This one uses a relative import to a util file, this checks it is downloaded and used properly.
+        model = AutoModel.from_pretrained(
+            "hf-internal-testing/ref_to_test_dynamic_model_with_util", trust_remote_code=True
+        )
+        self.assertEqual(model.__class__.__name__, "NewModel")
+
+        # Test model can be reloaded.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir)
+            reloaded_model = AutoModel.from_pretrained(tmp_dir, trust_remote_code=True)
+
+        self.assertEqual(reloaded_model.__class__.__name__, "NewModel")
+        for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
+            self.assertTrue(torch.equal(p1, p2))
+
     def test_new_model_registration(self):
         AutoConfig.register("custom", CustomConfig)
 


### PR DESCRIPTION
# What does this PR do?

This makes it easier to maintain only one source of ground truth when using the code on the Hub feature by storing the repo ID on top of the module containing the class inside the config. Thus, when saving and re-pushing a model using code on the Hub, the code is not copied over anymore, but a reference to the original repo containing the code is put.

This might be breaking if some users relied on the code being copied over when `save_pretrained(xxx)` is executed. To enable that old behavior, one only needs to call the `register_for_auto_class` method:

```py
from transformers import AutoModel

model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model", trust_remote_code=True)
model.save_pretrained(some_path)
```
then some_path only contains the config and weights of the model. The config will contain links to the repo where the code of the model is defined (`hf-internal-testing/test_dynamic_model`) so that it can be reloaded via
```py
AutoModel.from_pretrained(some_path)
```

To get the custom code file copied other (behavior before this PR) just do:
```py
from transformers import AutoModel

model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model", trust_remote_code=True)
model.register_for_auto_class("AutoModel")
model.save_pretrained(some_path)
```
