### PR TITLE
[Image processors] Fix warnings

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -324,7 +324,7 @@ class AutoImageProcessor:
         if image_processor_class is None and image_processor_auto_map is None:
             feature_extractor_class = config_dict.pop("feature_extractor_type", None)
             if feature_extractor_class is not None:
-                logger.warning(
+                logger.info(
                     "Could not find image processor class in the image processor config or the model config. Loading"
                     " based on pattern matching with the model's feature extractor configuration."
                 )
@@ -332,7 +332,7 @@ class AutoImageProcessor:
             if "AutoFeatureExtractor" in config_dict.get("auto_map", {}):
                 feature_extractor_auto_map = config_dict["auto_map"]["AutoFeatureExtractor"]
                 image_processor_auto_map = feature_extractor_auto_map.replace("FeatureExtractor", "ImageProcessor")
-                logger.warning(
+                logger.info(
                     "Could not find image processor auto map in the image processor config or the model config."
                     " Loading based on pattern matching with the model's feature extractor configuration."
                 )

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -776,18 +776,12 @@ class DetrImageProcessor(BaseImageProcessor):
         if "pad_and_return_pixel_mask" in kwargs:
             do_pad = kwargs.pop("pad_and_return_pixel_mask")
 
-        if "max_size" in kwargs:
-            warnings.warn(
-                "The `max_size` parameter is deprecated and will be removed in v4.26. "
-                "Please specify in `size['longest_edge'] instead`.",
-                FutureWarning,
-            )
-            max_size = kwargs.pop("max_size")
-        else:
-            max_size = None if size is None else 1333
+        if "max_size" in kwargs and isinstance(size, int):
+            size = {"shortest_edge": size, "longest_edge": kwargs.pop("max_size")}
+        elif "max_size" in kwargs and isinstance(size, tuple):
+            size = {"width": size[0], "height": size[1]}
 
         size = size if size is not None else {"shortest_edge": 800, "longest_edge": 1333}
-        size = get_size_dict(size, max_size=max_size, default_to_square=False)
 
         super().__init__(**kwargs)
         self.format = format


### PR DESCRIPTION
# What does this PR do?

This PR aims to reduce the number of warnings shown to the user for 2 use cases:

- DETR and friends' `max_size` argument which is deprecated => if this gets approved, I'll run fix-copies to fix the other DETR-based models
- the pattern matching warning when a configuration doesn't have an image processor in the config