### PR TITLE
Change `torch_dtype` to str when `saved_model=True` in `save_pretrained` for TF models

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2318,7 +2318,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             # will still be saved below this `if` block. (If we change it, things may break if the TF model is uploaded
             # to a Hub repo where a PT checkpoint is there that expects this attribute).
             # This logic is copied from `dict_torch_dtype_to_str` in `configuration_utils.py`.
-            if self.config.getattr("torch_dtype", None) is not None and not isinstance(self.config.torch_dtype, str):
+            if getattr(self.config, "torch_dtype", None) is not None and not isinstance(self.config.torch_dtype, str):
                 self.config.torch_dtype = str(self.config.torch_dtype).split(".")[1]
             if signatures is None:
                 if any(spec.dtype == tf.int32 for spec in self.serving.input_signature[0].values()):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2317,8 +2317,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             # Although TF doesn't care about this attribute, we can't just remove it or set it to `None`, as the config
             # will still be saved below this `if` block. (If we change it, things may break if the TF model is uploaded
             # to a Hub repo where a PT checkpoint is there that expects this attribute).
-            if self.config.get("torch_dtype", None) is not None and not isinstance(self.config["torch_dtype"], str):
-                self.config["torch_dtype"] = str(self.config["torch_dtype"]).split(".")[1]
+            # This logic is copied from `dict_torch_dtype_to_str` in `configuration_utils.py`.
+            if self.config.getattr("torch_dtype", None) is not None and not isinstance(self.config.torch_dtype, str):
+                self.config.torch_dtype = str(self.config.torch_dtype).split(".")[1]
             if signatures is None:
                 if any(spec.dtype == tf.int32 for spec in self.serving.input_signature[0].values()):
                     int64_spec = {

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2314,10 +2314,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
         if saved_model:
             # If `torch_dtype` is in the config with a torch dtype class as the value, we need to change it to string.
-            # Although TF doesn't care about this attribute, we can't just remove it or set it to `None`, as the config
-            # will still be saved below this `if` block. (If we change it, things may break if the TF model is uploaded
-            # to a Hub repo where a PT checkpoint is there that expects this attribute).
-            # This logic is copied from `dict_torch_dtype_to_str` in `configuration_utils.py`.
+            # (Although TF doesn't care about this attribute, we can't just remove it or set it to `None`.)
             if getattr(self.config, "torch_dtype", None) is not None and not isinstance(self.config.torch_dtype, str):
                 self.config.torch_dtype = str(self.config.torch_dtype).split(".")[1]
             if signatures is None:


### PR DESCRIPTION
# What does this PR do?

One issue in #22731 is: the config contains `torch_type` with a torch dtype class as value. Usually, our `save_pretrained` will take care of it. But when `saved_model=True` in `save_pretrained` for TF models, it is not handled, and TF/Keras complains about it.

See the first part in [this comment](https://github.com/huggingface/transformers/issues/22731#issuecomment-1506538658)