### PR TITLE
Pix2struct: doctest fix

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1700,8 +1700,8 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel):
         >>> # forward pass
         >>> outputs = model(**inputs, labels=labels)
         >>> loss = outputs.loss
-        >>> print(loss.item())
-        5.239729881286621
+        >>> print(f"{loss.item():.5f}")
+        5.23973
         ```"""
         use_cache = use_cache if use_cache is not None else self.config.text_config.use_cache
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

Fixes the failing doctest: different machines may produce minor FP32 differences. This PR formats the printed number to a few decimal places.