### PR TITLE
Don't use `LayoutLMv2` and `LayoutLMv3` in some pipeline tests

### DIFF
--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -273,32 +273,10 @@ class LayoutLMv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         {
             "document-question-answering": LayoutLMv2ForQuestionAnswering,
             "feature-extraction": LayoutLMv2Model,
-            "question-answering": LayoutLMv2ForQuestionAnswering,
-            "text-classification": LayoutLMv2ForSequenceClassification,
-            "token-classification": LayoutLMv2ForTokenClassification,
-            "zero-shot": LayoutLMv2ForSequenceClassification,
         }
         if is_torch_available()
         else {}
     )
-
-    # TODO: Fix the failed tests
-    def is_pipeline_test_to_skip(
-        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
-    ):
-        if pipeline_test_casse_name in [
-            "QAPipelineTests",
-            "TextClassificationPipelineTests",
-            "TokenClassificationPipelineTests",
-            "ZeroShotClassificationPipelineTests",
-        ]:
-            # `LayoutLMv2Config` was never used in pipeline tests (`test_pt_LayoutLMv2Config_XXX`) due to lack of tiny
-            # config. With new tiny model creation, it is available, but we need to fix the failed tests.
-            return True
-
-        return super().is_pipeline_test_to_skip(
-            pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
-        )
 
     def setUp(self):
         self.model_tester = LayoutLMv2ModelTester(self)

--- a/tests/models/layoutlmv3/test_modeling_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_modeling_layoutlmv3.py
@@ -289,10 +289,6 @@ class LayoutLMv3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         {
             "document-question-answering": LayoutLMv3ForQuestionAnswering,
             "feature-extraction": LayoutLMv3Model,
-            "question-answering": LayoutLMv3ForQuestionAnswering,
-            "text-classification": LayoutLMv3ForSequenceClassification,
-            "token-classification": LayoutLMv3ForTokenClassification,
-            "zero-shot": LayoutLMv3ForSequenceClassification,
         }
         if is_torch_available()
         else {}
@@ -302,6 +298,10 @@ class LayoutLMv3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
     ):
+        # `DocumentQuestionAnsweringPipeline` is expected to work with this model, but it combines the text and visual
+        # embedding along the sequence dimension (dim 1), which causes an error during post-processing as `p_mask` has
+        # the sequence dimension of the text embedding only.
+        # (see the line `embedding_output = torch.cat([embedding_output, visual_embeddings], dim=1)`)
         return True
 
     def setUp(self):

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -43,8 +43,10 @@ class QAPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_QUESTION_ANSWERING_MAPPING
     tf_model_mapping = TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING
 
-    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
-    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
+    if model_mapping is not None:
+        model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    if tf_model_mapping is not None:
+        tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     def get_test_pipeline(self, model, tokenizer, processor):
         if isinstance(model.config, LxmertConfig):

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -34,10 +34,17 @@ from transformers.testing_utils import (
 from .test_pipelines_common import ANY
 
 
+# These 2 model types require different inputs than those of the usual text models.
+_TO_SKIP = {"LayoutLMv2Config", "LayoutLMv3Config"}
+
+
 @is_pipeline_test
 class QAPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_QUESTION_ANSWERING_MAPPING
     tf_model_mapping = TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING
+
+    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     def get_test_pipeline(self, model, tokenizer, processor):
         if isinstance(model.config, LxmertConfig):

--- a/tests/pipelines/test_pipelines_text_classification.py
+++ b/tests/pipelines/test_pipelines_text_classification.py
@@ -25,10 +25,17 @@ from transformers.testing_utils import is_pipeline_test, nested_simplify, requir
 from .test_pipelines_common import ANY
 
 
+# These 2 model types require different inputs than those of the usual text models.
+_TO_SKIP = {"LayoutLMv2Config", "LayoutLMv3Config"}
+
+
 @is_pipeline_test
 class TextClassificationPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
     tf_model_mapping = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
+    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     @require_torch
     def test_small_model_pt(self):

--- a/tests/pipelines/test_pipelines_text_classification.py
+++ b/tests/pipelines/test_pipelines_text_classification.py
@@ -34,8 +34,10 @@ class TextClassificationPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
     tf_model_mapping = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
 
-    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
-    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
+    if model_mapping is not None:
+        model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    if tf_model_mapping is not None:
+        tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     @require_torch
     def test_small_model_pt(self):

--- a/tests/pipelines/test_pipelines_token_classification.py
+++ b/tests/pipelines/test_pipelines_token_classification.py
@@ -48,8 +48,10 @@ class TokenClassificationPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
     tf_model_mapping = TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
 
-    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
-    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
+    if model_mapping is not None:
+        model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    if tf_model_mapping is not None:
+        tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     def get_test_pipeline(self, model, tokenizer, processor):
         token_classifier = TokenClassificationPipeline(model=model, tokenizer=tokenizer)

--- a/tests/pipelines/test_pipelines_token_classification.py
+++ b/tests/pipelines/test_pipelines_token_classification.py
@@ -39,11 +39,17 @@ from .test_pipelines_common import ANY
 
 VALID_INPUTS = ["A simple string", ["list of strings", "A simple string that is quite a bit longer"]]
 
+# These 2 model types require different inputs than those of the usual text models.
+_TO_SKIP = {"LayoutLMv2Config", "LayoutLMv3Config"}
+
 
 @is_pipeline_test
 class TokenClassificationPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
     tf_model_mapping = TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
+
+    model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     def get_test_pipeline(self, model, tokenizer, processor):
         token_classifier = TokenClassificationPipeline(model=model, tokenizer=tokenizer)

--- a/tests/pipelines/test_pipelines_zero_shot.py
+++ b/tests/pipelines/test_pipelines_zero_shot.py
@@ -26,10 +26,19 @@ from transformers.testing_utils import is_pipeline_test, nested_simplify, requir
 from .test_pipelines_common import ANY
 
 
+# These 2 model types require different inputs than those of the usual text models.
+_TO_SKIP = {"LayoutLMv2Config", "LayoutLMv3Config"}
+
+
 @is_pipeline_test
 class ZeroShotClassificationPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
     tf_model_mapping = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
+    if model_mapping is not None:
+        model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ in _TO_SKIP}
+    if tf_model_mapping is not None:
+        tf_model_mapping = {config: model for config, model in tf_model_mapping.items() if config.__name__ in _TO_SKIP}
 
     def get_test_pipeline(self, model, tokenizer, processor):
         classifier = ZeroShotClassificationPipeline(


### PR DESCRIPTION
# What does this PR do?

These 2 models require **different input format** than those of usual text models. See the relevant code block at the end.
The offline discussion with @NielsRogge is that **these 2 models are only for DocQA pipeline**, despite they have implementations for different head tasks. 

Therefore, this PR **removes these 2 models from being tested (pipeline) in the first place**, instead of skipping them at later point.
**IMO, we should also remove these models being used in the pipeline classes (except DocQA)** if they are not going to work. But I don't do anything on this.

**`LayoutLMv3` with `DocumentQuestionAnsweringPipeline` (and the pipeline test) is still not working due to some issue. We need to discuss with @NielsRogge to see if it could be fixed, but it's out of this PR's scope.**

### relevant code block
https://github.com/huggingface/transformers/blob/daf53241d6276c0cd932ee8ce3e5b0a403f392b7/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py#L610-L625