### PR TITLE
Support identity normalizer in SentencePiece model

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -547,8 +547,8 @@ class AlbertConverter(SpmConverter):
         if self.original_tokenizer.do_lower_case:
             list_normalizers.append(normalizers.Lowercase())
 
-        if proto.normalizer_spec.name != "identity":
-            precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
+        precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
+        if precompiled_charsmap:
             list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
         list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
         return normalizers.Sequence(list_normalizers)
@@ -800,7 +800,8 @@ class XLNetConverter(SpmConverter):
             list_normalizers.append(normalizers.Lowercase())
 
         precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
-        list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
+        if precompiled_charsmap:
+            list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
         list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
         return normalizers.Sequence(list_normalizers)
 
@@ -834,7 +835,8 @@ class RemBertConverter(SpmConverter):
             list_normalizers.append(normalizers.Lowercase())
 
         precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
-        list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
+        if precompiled_charsmap:
+            list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
         return normalizers.Sequence(list_normalizers)
 
     def post_processor(self):

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -547,8 +547,9 @@ class AlbertConverter(SpmConverter):
         if self.original_tokenizer.do_lower_case:
             list_normalizers.append(normalizers.Lowercase())
 
-        precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
-        list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
+        if proto.normalizer_spec.name != "identity":
+            precompiled_charsmap = proto.normalizer_spec.precompiled_charsmap
+            list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
         list_normalizers.append(normalizers.Replace(Regex(" {2,}"), " "))
         return normalizers.Sequence(list_normalizers)
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

SentencePiece can train a model with a specified normalizer (for example `normalization_rule_name="nfkc"`).
https://github.com/google/sentencepiece/blob/master/doc/normalization.md

However, no normalization is done with `normalization_rule_name="identity"`, and `proto.normalizer_spec.precompiled_charsmap` in the SentencePiece model is empty.
Loading this model with `AlbertTokenizerFast.from_pretrained` occurres the following error:

```
>>> tokenizer = AlbertTokenizerFast.from_pretrained('.')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 1804, in from_pretrained
    return cls._from_pretrained(
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 1959, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/models/albert/tokenization_albert_fast.py", line 148, in __init__
    super().__init__(
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/tokenization_utils_fast.py", line 114, in __init__
    fast_tokenizer = convert_slow_tokenizer(slow_tokenizer)
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/convert_slow_tokenizer.py", line 1162, in convert_slow_tokenizer
    return converter_class(transformer_tokenizer).converted()
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/convert_slow_tokenizer.py", line 503, in converted
    tokenizer.normalizer = self.normalizer(self.proto)
  File "/Users/nminami/.pyenv/versions/3.10.4/lib/python3.10/site-packages/transformers/convert_slow_tokenizer.py", line 535, in normalizer
    list_normalizers.append(normalizers.Precompiled(precompiled_charsmap))
Exception: Error while attempting to build Precompiled normalizer: Cannot parse precompiled_charsmap
```

This error is caused by passing empty bytes to `normalizers.Precompiled`. So, this PR prevents the problem to check `proto.normalizer_spec.name` before passing empty bytes.

## How to reproduce this problem

```
OS/Arch: macOS/Apple Silicon
Python 3.10.4 (main, Jun 26 2022, 22:29:49) [Clang 13.0.0 (clang-1300.0.27.3)] on darwin

protobuf==3.19.0
sentencepiece==0.1.97
transformers==4.28.1
```

Save SentencePiece model using [python/test/botchan.txt](https://github.com/google/sentencepiece/blob/master/python/test/botchan.txt).
```python
import sentencepiece as spm
spm.SentencePieceTrainer.train(input='python/test/botchan.txt', model_prefix='spiece', vocab_size=1000, normalization_rule_name='identity')
```

Read SentencePiece model using `AlbertTokenizerFast.from_pretrained`.
```python
from transformers import AlbertTokenizerFast
tokenizer = AlbertTokenizerFast.from_pretrained('.')
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
  - I think this is a bug fix. So, no documentation updates required.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
