### PR TITLE
Simplify update metadata job

### DIFF
--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - update_transformers_metadata
+      - update_transformers_metadata*
 
 jobs:
   build_and_package:

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Setup environment
         run: |
           pip install --upgrade pip
-          pip install pandas
-          pip install .[dev]
+          pip install datasets pandas
+          pip install .[torch tf flax]
 
       - name: Update metadata
         run: |

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup environment
         run: |
           pip install --upgrade pip
+          pip install datasets, huggingface_hub, pandas
           pip install .
 
       - name: Update metadata

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup environment
         run: |
           pip install --upgrade pip
-          pip install datasets, huggingface_hub, pandas
+          pip install datasets huggingface_hub pandas
           pip install .
 
       - name: Update metadata

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install datasets pandas
-          pip install .[torch tf flax]
+          pip install .[torch,tf,flax]
 
       - name: Update metadata
         run: |

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -16,25 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Load cached virtual environment
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/venv/
-          key: v3-metadata-${{ hashFiles('setup.py') }}
-
-      - name: Create virtual environment on cache miss
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          python -m venv ~/venv && . ~/venv/bin/activate
-          pip install --upgrade pip
-
       - name: Setup environment
         run: |
-          . ~/venv/bin/activate
-          pip install git+https://github.com/huggingface/transformers#egg=transformers[dev]
+          pip install --upgrade pip
+          pip install .
 
       - name: Update metadata
         run: |
-          . ~/venv/bin/activate
           python utils/update_metadata.py --token ${{ secrets.SYLVAIN_HF_TOKEN }} --commit_sha ${{ github.sha }}

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Setup environment
         run: |
           pip install --upgrade pip
-          pip install datasets huggingface_hub pandas
-          pip install .
+          pip install pandas
+          pip install .[dev]
 
       - name: Update metadata
         run: |


### PR DESCRIPTION
# What does this PR do?

This should fix the issue with the update metadata job on main. Simplify the job execution by removing the cached and just doing a pip install dev. Since it's running on main, we don't really care about the 2-3 minutes the cache would make us gain.