### PR TITLE
Fix Past CI not running against the latest `main`

### DIFF
--- a/.github/workflows/self-nightly-past-ci-caller.yml
+++ b/.github/workflows/self-nightly-past-ci-caller.yml
@@ -30,6 +30,7 @@ jobs:
     with:
       framework: pytorch
       version: "1.13"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_pytorch_1-12:
@@ -40,6 +41,7 @@ jobs:
     with:
       framework: pytorch
       version: "1.12"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_pytorch_1-11:
@@ -50,6 +52,7 @@ jobs:
     with:
       framework: pytorch
       version: "1.11"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_pytorch_1-10:
@@ -60,6 +63,7 @@ jobs:
     with:
       framework: pytorch
       version: "1.10"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_pytorch_1-9:
@@ -70,6 +74,7 @@ jobs:
     with:
       framework: pytorch
       version: "1.9"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-11:
@@ -80,6 +85,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.11"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-10:
@@ -90,6 +96,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.10"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-9:
@@ -100,6 +107,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.9"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-8:
@@ -110,6 +118,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.8"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-7:
@@ -120,6 +129,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.7"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-6:
@@ -130,6 +140,7 @@ jobs:
     with:
       framework: tensorflow
       version: "2.6"
+      sha: ${{ github.sha }}
     secrets: inherit
 
   run_past_ci_tensorflow_2-5:
@@ -140,4 +151,5 @@ jobs:
     with:
       framework: tensorflow
       version: "2.5"
+      sha: ${{ github.sha }}
     secrets: inherit


### PR DESCRIPTION
# What does this PR do?

Fix Past CI not running against the latest `main`. See comment in the changes.