### PR TITLE
Fix `test_eos_token_id_int_and_list_top_k_top_sampling`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2508,19 +2508,21 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             "top_k": 10,
             "temperature": 0.7,
         }
-        expectation = 15
+        expectation = 20
 
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors="pt").to(torch_device)
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
 
-        torch.manual_seed(0)
+        # Only some seeds will work both on CPU/GPU for a fixed `expectation` value.
+        # The selected seed is not guaranteed to work on all torch versions.
+        torch.manual_seed(1)
         eos_token_id = 846
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))
 
-        torch.manual_seed(0)
+        torch.manual_seed(1)
         eos_token_id = [846, 198]
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2508,7 +2508,7 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             "top_k": 10,
             "temperature": 0.7,
         }
-        expectation = 20
+        expectation = 15
 
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""


### PR DESCRIPTION
# What does this PR do?

In #22204, I updated the expected value in `test_eos_token_id_int_and_list_top_k_top_sampling` to pass the `CircleCI`. However, the daily CI fails with that new value. It turns out that we need a seed that could give the same (generation) output (at minimum, the same output length) on both CPU/GPU machines. The difference is very likely coming from somehow larger numerical differences after certain generation steps.

### remark
With seed `0`, the output `generated_tokens[0]` is:
- `cpu`: `[ 40, 416,  79,  12, 230,  89, 231, 432, 301, 212, 933, 225,  33,  33,
        846]`
- `gpu`: `[ 40, 416,  79,  12, 230,  89, 231, 432, 301, 212, 933, 225, 476, 682,
        319, 832, 873, 853, 873, 832]`