### PR TITLE
Fix from_pretrained when model is instantiated on the meta device

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2935,10 +2935,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         unexpected_keys = list(set(loaded_keys) - set(expected_keys))
 
         # Some tensors maybe have been already filled by another key (tied weights).
-        existing_ptrs = {model_state_dict[k].data_ptr() for k in loaded_keys if k in model_state_dict}
-        missing_keys = [
-            k for k in missing_keys if k in model_state_dict and model_state_dict[k].data_ptr() not in existing_ptrs
-        ]
+        # TODO: Sylvain -> make this work even on meta device.
+        # existing_ptrs = {model_state_dict[k].data_ptr() for k in loaded_keys if k in model_state_dict}
+        # missing_keys = [
+        #     k for k in missing_keys if k in model_state_dict and model_state_dict[k].data_ptr() not in existing_ptrs
+        # ]
         # Some models may have keys that are not in the state by design, removing them before needlessly warning
         # the user.
         if cls._keys_to_ignore_on_load_missing is not None:


### PR DESCRIPTION
# What does this PR do?

#22437 broke the `from_pretrained` method whenever the model is instantiated on the meta device and the state dict passed is not complete (see [this issue](https://github.com/huggingface/accelerate/issues/1333) for one example).

Basically the check will remove all keys from `missing_keys` since all parameters on the meta device share the same data pointer. I had advocated to use another solution in that PR but the contributor did not listen

Since we rely on those `missing_keys` later on to re-initialize the weights that are not in the state dict, the model ends up with weights on the meta device.