### PR TITLE
Raise err if minimum Accelerate version isn't available

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1531,7 +1531,7 @@ class TrainingArguments:
     def _setup_devices(self) -> "torch.device":
         requires_backends(self, ["torch"])
         logger.info("PyTorch: setting up devices")
-        if not is_sagemaker_mp_enabled() and not is_accelerate_available(partial_state=True):
+        if not is_sagemaker_mp_enabled() and not is_accelerate_available(check_partial_state=True):
             raise ImportError(
                 "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install --upgrade accelerate`"
             )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1533,7 +1533,7 @@ class TrainingArguments:
         logger.info("PyTorch: setting up devices")
         if not is_sagemaker_mp_enabled() and not is_accelerate_available(partial_state=True):
             raise ImportError(
-                "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install accelerate>=0.17.0`"
+                "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install --upgrade accelerate`"
             )
         if self.no_cuda:
             self.distributed_state = PartialState(cpu=True)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1531,7 +1531,7 @@ class TrainingArguments:
     def _setup_devices(self) -> "torch.device":
         requires_backends(self, ["torch"])
         logger.info("PyTorch: setting up devices")
-        if not is_sagemaker_mp_enabled() and not is_accelerate_available():
+        if not is_sagemaker_mp_enabled() and not is_accelerate_available(partial_state=True):
             raise ImportError(
                 "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install accelerate>=0.17.0`"
             )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1531,6 +1531,10 @@ class TrainingArguments:
     def _setup_devices(self) -> "torch.device":
         requires_backends(self, ["torch"])
         logger.info("PyTorch: setting up devices")
+        if not is_sagemaker_mp_enabled() and not is_accelerate_available():
+            raise ImportError(
+                "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install accelerate>=0.17.0`"
+            )
         if self.no_cuda:
             self.distributed_state = PartialState(cpu=True)
             device = self.distributed_state.device

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -579,7 +579,7 @@ def is_accelerate_available(partial_state=False):
     accelerate_available = importlib.util.find_spec("accelerate") is not None
     if accelerate_available:
         if partial_state:
-            return importlib_metadata.version("accelerate") >= version.parse("0.17.0")
+            return version.parse(importlib_metadata.version("accelerate")) >= version.parse("0.17.0")
         else:
             return True
     else:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -578,7 +578,7 @@ def is_protobuf_available():
 def is_accelerate_available(check_partial_state=False):
     accelerate_available = importlib.util.find_spec("accelerate") is not None
     if accelerate_available:
-        if partial_state:
+        if check_partial_state:
             return version.parse(importlib_metadata.version("accelerate")) >= version.parse("0.17.0")
         else:
             return True

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -575,7 +575,7 @@ def is_protobuf_available():
     return importlib.util.find_spec("google.protobuf") is not None
 
 
-def is_accelerate_available(partial_state=False):
+def is_accelerate_available(check_partial_state=False):
     accelerate_available = importlib.util.find_spec("accelerate") is not None
     if accelerate_available:
         if partial_state:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -575,8 +575,15 @@ def is_protobuf_available():
     return importlib.util.find_spec("google.protobuf") is not None
 
 
-def is_accelerate_available():
-    return importlib.util.find_spec("accelerate") is not None
+def is_accelerate_available(partial_state=False):
+    accelerate_available = importlib.util.find_spec("accelerate") is not None
+    if accelerate_available:
+        if partial_state:
+            return importlib_metadata.version("accelerate") >= version.parse("0.17.0")
+        else:
+            return True
+    else:
+        return False
 
 
 def is_optimum_available():


### PR DESCRIPTION
# What does this PR do?

This PR will raise an explicit `ImportError` during `TrainingArguments` if `Accelerate` isn't installed (or isn't the required minimal version) and Accelerate is going to be utilized

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 