### PR TITLE
Flax Refactor v2

### DIFF
--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -1026,6 +1026,12 @@ class FlaxModelTesterMixin:
             inputs = self._prepare_for_class(inputs_dict, model_class).copy()
             model(**inputs, params=params)
 
+            # test apply
+            apply_ready_modules = ["FlaxBertModule"]
+            module = model.module
+            if type(module).__name__ in apply_ready_modules:
+                module.apply({"params": params}, **inputs)
+
     def test_from_pretrained_with_no_automatic_init(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True


### PR DESCRIPTION
# What does this PR do?

Alternative to #22627. Instead of making `FlaxPretrainedModel` a Flax `Module`, this PR aims to make all inner `.module`s usable in a standalone way by moving any pre/posprocessing done by its `*Model` container into the Module itself.