### PR TITLE
[`SAM`] Change to `facebook/sam-vit-base`

### DIFF
--- a/src/transformers/models/sam/configuration_sam.py
+++ b/src/transformers/models/sam/configuration_sam.py
@@ -25,7 +25,7 @@ logger = logging.get_logger(__name__)
 SAM_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     "facebook/sam-vit-huge": "https://huggingface.co/facebook/sam-vit-huge/resolve/main/config.json",
     "facebook/sam-vit-large": "https://huggingface.co/facebook/sam-vit-large/resolve/main/config.json",
-    "facebook/sam-vit-big": "https://huggingface.co/facebook/sam-vit-big/resolve/main/config.json",
+    "facebook/sam-vit-base": "https://huggingface.co/facebook/sam-vit-base/resolve/main/config.json",
 }
 
 

--- a/src/transformers/models/sam/modeling_sam.py
+++ b/src/transformers/models/sam/modeling_sam.py
@@ -40,7 +40,7 @@ _CHECKPOINT_FOR_DOC = "facebook/sam-vit-huge"
 SAM_PRETRAINED_MODEL_ARCHIVE_LIST = [
     "facebook/sam-vit-huge",
     "facebook/sam-vit-large",
-    "facebook/sam-vit-big",
+    "facebook/sam-vit-base",
     # See all SAM models at https://huggingface.co/models?filter=sam
 ]
 


### PR DESCRIPTION
# What does this PR do?

Changes the checkpoint name to `sam-vit-base` instead of `sam-vit-big` which was slightly confusing for users. The checkpoints are sorted with their size

- `sam-vit-base`: 350MB
- `sam-vit-large`: 1GB
- `sam-vit-huge`: 2GB

Which now makes more sense. The repo on the Hub have been updated accordingly

cc @amyeroberts @ArthurZucker @sgugger 