### PR TITLE
moved labels to the same device as logits for LILT model

### DIFF
--- a/src/transformers/models/lilt/modeling_lilt.py
+++ b/src/transformers/models/lilt/modeling_lilt.py
@@ -924,6 +924,8 @@ class LiltForSequenceClassification(LiltPreTrainedModel):
 
         loss = None
         if labels is not None:
+            # move labels to correct device to enable model parallelism
+            labels = labels.to(logits.device)
             if self.config.problem_type is None:
                 if self.num_labels == 1:
                     self.config.problem_type = "regression"
@@ -1046,6 +1048,8 @@ class LiltForTokenClassification(LiltPreTrainedModel):
 
         loss = None
         if labels is not None:
+            # move labels to correct device to enable model parallelism
+            labels = labels.to(logits.device)
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
 


### PR DESCRIPTION
# What does this PR do?

As suggested in the [#22561](https://github.com/huggingface/transformers/issues/22561)  moved labels to the same device as logits for the lilt model.

@sgugger pls review and merge it in the main branch.
