### PR TITLE
Fix Slack report for Nightly CI and Past CI

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -958,7 +958,7 @@ if __name__ == "__main__":
         "Torch CUDA extension tests": "run_tests_torch_cuda_extensions_gpu_test_reports",
     }
 
-    if ci_event == "push":
+    if ci_event in ["push", "Nightly CI"] or ci_event.startswith("Past CI"):
         del additional_files["Examples directory"]
         del additional_files["PyTorch pipelines"]
         del additional_files["TensorFlow pipelines"]


### PR DESCRIPTION
# What does this PR do?

For these 2 CI, so for we get 

```bash
Single |  Multi | Category
     0 |      0 | [Errored out] Examples directory
     0 |      0 | [Errored out] PyTorch pipelines
     0 |      0 | [Errored out] TensorFlow pipelines
     ...
```
But they don't have these 3 jobs in their workflow. We just need to update the notification script.