### PR TITLE
Fix a minor bug in CI slack report

### DIFF
--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -57,9 +57,9 @@ def get_last_daily_ci_reports(artifact_names, output_dir, token):
 
     results = {}
     for artifact_name in artifact_names:
-        results[artifact_name] = {}
         artifact_zip_path = os.path.join(output_dir, f"{artifact_name}.zip")
         if os.path.isfile(artifact_zip_path):
+            results[artifact_name] = {}
             with zipfile.ZipFile(artifact_zip_path) as z:
                 for filename in z.namelist():
                     if not os.path.isdir(filename):

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -423,8 +423,8 @@ class Message:
                 artifact_names=artifact_names, output_dir=output_dir, token=os.environ["ACCESS_REPO_INFO_TOKEN"]
             )
 
-            # The last run doesn't produce `test_failure_tables` (by some issues or have no model failure at all)
-            if len(prev_tables) > 0:
+            # if the last run produces artifact named `test_failure_tables`
+            if "test_failure_tables" in prev_tables and "model_failures_report.txt" in prev_tables["test_failure_tables"]:
                 # Compute the difference of the previous/current (model failure) table
                 prev_model_failures = prev_tables["test_failure_tables"]["model_failures_report.txt"]
                 entries_changed = self.compute_diff_for_failure_reports(model_failures_report, prev_model_failures)

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -424,7 +424,10 @@ class Message:
             )
 
             # if the last run produces artifact named `test_failure_tables`
-            if "test_failure_tables" in prev_tables and "model_failures_report.txt" in prev_tables["test_failure_tables"]:
+            if (
+                "test_failure_tables" in prev_tables
+                and "model_failures_report.txt" in prev_tables["test_failure_tables"]
+            ):
                 # Compute the difference of the previous/current (model failure) table
                 prev_model_failures = prev_tables["test_failure_tables"]["model_failures_report.txt"]
                 entries_changed = self.compute_diff_for_failure_reports(model_failures_report, prev_model_failures)


### PR DESCRIPTION
# What does this PR do?

#22798 added code to show the difference between 2 CI runs. However, the previous CI run(s) may not yet produced the artifact `test_failure_tables`, and we got `KeyError: 'model_failures_report.txt'` in the last run.

This PR adds some check.