### PR TITLE
Fix counting in Slack report for some jobs

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -655,7 +655,7 @@ class Message:
                         job_result,
                         failures,
                         device,
-                        text=f"Number of failures: {sum(job_result['failed'].values())}",
+                        text=f'Number of failures: {job_result["failed"][device]}',
                     )
 
                     print("Sending the following reply")


### PR DESCRIPTION
# What does this PR do?

Fix counting in Slack report for some jobs.

### Context
For the additional jobs (i.e. not model testing jobs), the number of failed tests are being summed across over all machine types (single/multi - gpu). We have strange things like single gpu deepspeed CI has only 1 failure but 86 was shown on the report, see:


<img width="812" alt="image" src="https://user-images.githubusercontent.com/2521628/233582320-81c3b61d-add4-4ad5-b007-2522ad0f44b3.png">



