### PR TITLE
Place static llama variables for multigpu

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -558,6 +558,10 @@ class LlamaModel(LlamaPreTrainedModel):
 
             past_key_value = past_key_values[idx] if past_key_values is not None else None
 
+            layer_dev = next(decoder_layer.parameters()).device
+            attention_mask = attention_mask.to(layer_dev)
+            position_ids = position_ids.to(layer_dev)
+
             if self.gradient_checkpointing and self.training:
 
                 def create_custom_forward(module):


### PR DESCRIPTION

# What does this PR do?

When using accelerate, attention_mask and position_ids were being retransferred for every layer after the first device. This change transfers them once in advance.



## Who can review?

@ArthurZucker @pacman100

