### PR TITLE
Fix: Seq2SeqTrainingArgs overriding to_dict for GenerationConfig json support

### DIFF
--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import logging
-from dataclasses import dataclass, field, fields
-from enum import Enum
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Union
 
@@ -91,15 +90,8 @@ class Seq2SeqTrainingArguments(TrainingArguments):
         serialization support). It obfuscates the token values by removing their value.
         """
         # filter out fields that are defined as field(init=False)
-        d = {field.name: getattr(self, field.name) for field in fields(self) if field.init}
-
+        d = super().to_dict()
         for k, v in d.items():
-            if isinstance(v, Enum):
-                d[k] = v.value
-            if isinstance(v, list) and len(v) > 0 and isinstance(v[0], Enum):
-                d[k] = [x.value for x in v]
-            if k.endswith("_token"):
-                d[k] = f"<{k.upper()}>"
             if isinstance(v, GenerationConfig):
                 d[k] = v.to_dict()
         return d


### PR DESCRIPTION
# What does this PR do?

`Seq2SeqTrainingArguments` override the `to_dict()` method from `TrainingArguments`.

This is a fix to #22831 (solution 2), solving an error that happened when saving to json a `Seq2SeqTrainingArguments` object with a `GenerationConfig` attribute.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? #22831
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger @gante 
