### PR TITLE
Raise error if `stride` is too high in `TokenClassificationPipeline`

### DIFF
--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -69,7 +69,8 @@ class AggregationStrategy(ExplicitEnum):
         stride (`int`, *optional*):
             If stride is provided, the pipeline is applied on all the text. The text is split into chunks of size
             model_max_length. Works only with fast tokenizers and `aggregation_strategy` different from `NONE`. The
-            value of this argument defines the number of overlapping tokens between chunks.
+            value of this argument defines the number of overlapping tokens between chunks. In other words, the model
+            will shift forward by `tokenizer.model_max_length - stride` tokens each step.
         aggregation_strategy (`str`, *optional*, defaults to `"none"`):
             The strategy to fuse (or not) tokens based on the model prediction.
 

--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -191,6 +191,10 @@ class TokenClassificationPipeline(ChunkPipeline):
         if ignore_labels is not None:
             postprocess_params["ignore_labels"] = ignore_labels
         if stride is not None:
+            if stride >= self.tokenizer.model_max_length:
+                raise ValueError(
+                    "`stride` must be less than `tokenizer.model_max_length` (or even lower if the tokenizer adds special tokens)"
+                )
             if aggregation_strategy == AggregationStrategy.NONE:
                 raise ValueError(
                     "`stride` was provided to process all the text but `aggregation_strategy="


### PR DESCRIPTION
# What does this PR do?

Users were previously not given a warning if they initialized a `TokenClassificationPipeline` with too high a value for `stride` (`stride` is the value that determines how many tokens overlap between chunks if the user choose to split text into chunks).

Unfortunately, it's also possible for a `stride` to be too high if the tokenizer happens to introduce special tokens (e.g. `bert-base-cased` has a maximum length of `512`, but each window gets `2` special tokens, so the highest valid `stride` is `509`) , but there's apparently no easy way to check this in advance (i.e. before the tokenizer is run as part of the pipeline). I think it might be worth fixing the error message ("`pyo3_runtime.PanicException: assertion failed: stride < max_len`") when a tokenizer is called with too high a value of `stride`, to clarify to users that added special tokens subtract from the effective window size.

I also thought it was worth clarifying slightly the function of the `stride` parameter. The way `stride` works in the context of Huggingface tokenizers is almost the opposite of the way it works in many [other contexts](https://www.kaggle.com/code/ryanholbrook/the-sliding-window/tutorial).

Mostly fixes #22789.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who should review?

@Narsil 
