### PR TITLE
Generate: assisted generation with sample (take 2)

### DIFF
--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -361,11 +361,10 @@ To enable assisted decoding, set the `assistant_model` argument with a model.
 ['Alice and Bob are sitting in a bar. Alice is drinking a beer and Bob is drinking a']
 ```
 
-When using assisted decoding with sampling methods, the `assisted_keep_proba` argument will balance speed with
-pure sampling behavior. The greedily decoded candidate tokens whose main model's predicted probability are below
-this threshold are discarded, which force an anticipated sampling step. If `assisted_keep_proba` is set to 1.0,
-assisted decoding degenerates into a slow multinomial sampling. Conversely, if `assisted_keep_proba` is set to 0.0,
-the outcome will approximate an accelerated greedy decoding, with a few sampling steps in between.
+When using assisted decoding with sampling methods, you can use the `temperarure` argument to control the randomness
+just like in multinomial sampling. However, in assisted decoding, reducing the temperature will help improving latency.
+
+<!-- TODO: link the blog post again to explain why the tradeoff exists -->
 
 ```python
 >>> from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -379,7 +378,7 @@ the outcome will approximate an accelerated greedy decoding, with a few sampling
 
 >>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
 >>> assistant_model = AutoModelForCausalLM.from_pretrained(assistant_checkpoint)
->>> outputs = model.generate(**inputs, assistant_model=assistant_model, do_sample=True, assisted_keep_proba=0.1)
+>>> outputs = model.generate(**inputs, assistant_model=assistant_model, do_sample=True, temperature=0.5)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
-['Alice and Bob are in a room watching television. They are both on the same channel. Alice']
+["Alice and Bob are sitting on the sofa. Alice says, 'I'm going to my room"]
 ```

--- a/docs/source/en/generation_strategies.mdx
+++ b/docs/source/en/generation_strategies.mdx
@@ -333,15 +333,16 @@ This guide illustrates the main parameters that enable various decoding strategi
 [`generate`] method, which gives you even further control over the [`generate`] method's behavior.
 For the complete list of the available parameters, refer to the [API documentation](./main_classes/text_generation.mdx).
 
-### Assisted Generation
+### Assisted Decoding
 
-Assisted generation is a modification of the decoding strategies above that uses an assistant model with the same
-tokenizer (ideally a much smaller model) to speed up the decoding process. Currently only assisted greedy search is
-supported, and doesn't support batched inputs.
+Assisted decoding is a modification of the decoding strategies above that uses an assistant model with the same
+tokenizer (ideally a much smaller model) to greedily generate a few candidate tokens. The main model then validates
+the candidate tokens in a single forward pass, which speeds up the decoding process. Currently, only greedy search
+and sampling are supported with assisted decoding, and doesn't support batched inputs.
 
-<!-- TODO: add link to the blog post about assisted generation when it exists -->
+<!-- TODO: add link to the blog post about assisted decoding when it exists -->
 
-To enable assisted generation, set the `assistant_model` argument with a model.
+To enable assisted decoding, set the `assistant_model` argument with a model.
 
 ```python
 >>> from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -358,4 +359,27 @@ To enable assisted generation, set the `assistant_model` argument with a model.
 >>> outputs = model.generate(**inputs, assistant_model=assistant_model)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
 ['Alice and Bob are sitting in a bar. Alice is drinking a beer and Bob is drinking a']
+```
+
+When using assisted decoding with sampling methods, the `assisted_keep_proba` argument will balance speed with
+pure sampling behavior. The greedily decoded candidate tokens whose main model's predicted probability are below
+this threshold are discarded, which force an anticipated sampling step. If `assisted_keep_proba` is set to 1.0,
+assisted decoding degenerates into a slow multinomial sampling. Conversely, if `assisted_keep_proba` is set to 0.0,
+the outcome will approximate an accelerated greedy decoding, with a few sampling steps in between.
+
+```python
+>>> from transformers import AutoModelForCausalLM, AutoTokenizer
+
+>>> prompt = "Alice and Bob"
+>>> checkpoint = "EleutherAI/pythia-1.4b-deduped"
+>>> assistant_checkpoint = "EleutherAI/pythia-160m-deduped"
+
+>>> tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+>>> inputs = tokenizer(prompt, return_tensors="pt")
+
+>>> model = AutoModelForCausalLM.from_pretrained(checkpoint)
+>>> assistant_model = AutoModelForCausalLM.from_pretrained(assistant_checkpoint)
+>>> outputs = model.generate(**inputs, assistant_model=assistant_model, do_sample=True, assisted_keep_proba=0.1)
+>>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
+['Alice and Bob are in a room watching television. They are both on the same channel. Alice']
 ```

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -181,11 +181,6 @@ class GenerationConfig(PushToHubMixin):
             A list of pairs of integers which indicates a mapping from generation indices to token indices that will be
             forced before sampling. For example, `[[1, 123]]` means the second generated token will always be a token
             of index 123.
-        assisted_keep_proba (`float`, *optional*):
-            Used with assisted decoding. When `do_sample` is true, this controls the threshold at which the model will
-            resample candidate tokens. When the model's predicted probability for a candidate token is below this
-            threshold, the candidate token is invalidated and a sampling step. Decreasing this value will aproximate
-            the decoding process to greedy search, but it will be faster.
 
         > Parameters that define the output variables of `generate`
 
@@ -265,7 +260,6 @@ class GenerationConfig(PushToHubMixin):
         self.suppress_tokens = kwargs.pop("suppress_tokens", None)
         self.begin_suppress_tokens = kwargs.pop("begin_suppress_tokens", None)
         self.forced_decoder_ids = kwargs.pop("forced_decoder_ids", None)
-        self.assisted_keep_proba = kwargs.pop("assisted_keep_proba", 0.3)
 
         # Parameters that define the output variables of `generate`
         self.num_return_sequences = kwargs.pop("num_return_sequences", 1)
@@ -327,8 +321,6 @@ class GenerationConfig(PushToHubMixin):
         """
         if self.early_stopping not in {True, False, "never"}:
             raise ValueError(f"`early_stopping` must be a boolean or 'never', but is {self.early_stopping}.")
-        if self.assisted_keep_proba < 0.0 or self.assisted_keep_proba > 1.0:
-            raise ValueError(f"`assisted_keep_proba` must be between 0.0 and 1.0, but is {self.assisted_keep_proba}.")
 
     def save_pretrained(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4102,6 +4102,10 @@ class GenerationMixin:
             logits_processor (`LogitsProcessorList`, *optional*):
                 An instance of [`LogitsProcessorList`]. List of instances of class derived from [`LogitsProcessor`]
                 used to modify the prediction scores of the language modeling head applied at each generation step.
+            logits_warper (`LogitsProcessorList`, *optional*):
+                An instance of [`LogitsProcessorList`]. List of instances of class derived from [`LogitsWarper`] used
+                to warp the prediction score distribution of the language modeling head applied before multinomial
+                sampling at each generation step.
             stopping_criteria (`StoppingCriteriaList`, *optional*):
                 An instance of [`StoppingCriteriaList`]. List of instances of class derived from [`StoppingCriteria`]
                 used to tell if the generation loop should stop.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1457,13 +1457,13 @@ class GenerationTesterMixin:
             for output in (output_contrastive, output_generate):
                 self._check_outputs(output, input_ids, model.config, use_cache=True)
 
-    def test_assisted_greedy_search_matches_greedy_search(self):
+    def test_assisted_decoding_matches_greedy_search(self):
         # This test ensures that the assisted generation does not introduce output changes over greedy search.
         # It breaks the pattern in the tests above, for multiple reasons:
-        # - assisted_greedy_search, contrarily to the other methods, can't be called on its own (e.g. needs to
+        # - assisted_decoding, contrarily to the other methods, can't be called on its own (e.g. needs to
         # prepare the assistant encoder outputs in the main generate body);
-        # - assisted_greedy_search does not support `use_cache = False`
-        # - assisted_greedy_search does not support `batch_size > 1`
+        # - assisted_decoding does not support `use_cache = False`
+        # - assisted_decoding does not support `batch_size > 1`
 
         for model_class in self.all_generative_model_classes:
             # won't fix: FSMT and Reformer have a different cache variable type (and format).


### PR DESCRIPTION
# What does this PR do?

I was writing the blog post about assisted generation and realized that there is a much better way to solve the `do_sample=True` case 👀 Apologies for the repeated review request, but I believe this is a significant upgrade.

In a nutshell, the existing `temperature` argument provides a natural control mechanism for assisted generation with `do_sample=True`, when controlling how flat the distribution is at the sampling step. Lower temperature = high probability tokens become more likely to be sampled = more predictable = more likely to match the candidate tokens from the assistant model = assisted generation works faster.

Compared to the [other PR](https://github.com/huggingface/transformers/pull/22862), which was closed, this approach has the following pros and cons:
- Pros:
  - No new argument;
  - Behaves exactly like `.sample`, which users already understand well. No new heuristics;
  - As fast as the other method for similar randomness levels (see numbers below).
- Cons:
  - Internally, more than one sampling step will occur per output token. If we set a seed, the output will be different than `.sample`'s for the same seed. Not a deal breaker per se, but it means subtle bugs may be tough to catch.

## Performance numbers

  I've run the [benchmark](https://github.com/gante/huggingface-demos/tree/main/experiments/faster_generation) I've been running for assisted generation, but now for several `temperature` values. The values below are for `facebook/opt-6.7b` as the main model, `facebook/opt-125m` as the assistant model, running `.generate` starting from inputs taken from the C4 test set (i.e. quite random, the dataset I tested where assisted generation struggles the most), on a RTX3090. Note that most LLMs nowadays use temperature between 0.7 and 0.9.

TL;DR -- it's slower than greedy assisted generation, as it is expected, but it will still secure solid speedups e.g. with INT8.
  
<img width="418" alt="Screenshot 2023-04-23 at 14 58 10" src="https://user-images.githubusercontent.com/12240844/233844046-953999b7-3f9b-4f97-bab6-b4e4f50943ef.png">
  