### PR TITLE
Add dummy_inputs for pytorch_version of vision_models

### DIFF
--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -15,7 +15,7 @@
 """ PyTorch ConvNext model."""
 
 
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
@@ -298,6 +298,17 @@ class ConvNextPreTrainedModel(PreTrainedModel):
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, ConvNextEncoder):
             module.gradient_checkpointing = value
+
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
 
 
 CONVNEXT_START_DOCSTRING = r"""

--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -15,7 +15,7 @@
 """ PyTorch ConvNextV2 model."""
 
 
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
@@ -319,6 +319,17 @@ class ConvNextV2PreTrainedModel(PreTrainedModel):
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, ConvNextV2Encoder):
             module.gradient_checkpointing = value
+
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
 
 
 CONVNEXTV2_START_DOCSTRING = r"""

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ PyTorch ResNet model."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 import torch.utils.checkpoint
@@ -268,6 +268,17 @@ class ResNetPreTrainedModel(PreTrainedModel):
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, ResNetEncoder):
             module.gradient_checkpointing = value
+
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
 
 
 RESNET_START_DOCSTRING = r"""

--- a/src/transformers/models/segformer/modeling_segformer.py
+++ b/src/transformers/models/segformer/modeling_segformer.py
@@ -16,7 +16,7 @@
 
 
 import math
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
@@ -472,6 +472,17 @@ class SegformerPreTrainedModel(PreTrainedModel):
         elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
+
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
 
 
 SEGFORMER_START_DOCSTRING = r"""

--- a/src/transformers/models/vit/modeling_vit.py
+++ b/src/transformers/models/vit/modeling_vit.py
@@ -471,6 +471,17 @@ class ViTPreTrainedModel(PreTrainedModel):
         if isinstance(module, ViTEncoder):
             module.gradient_checkpointing = value
 
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
+
 
 VIT_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it

--- a/src/transformers/models/vit_hybrid/modeling_vit_hybrid.py
+++ b/src/transformers/models/vit_hybrid/modeling_vit_hybrid.py
@@ -490,6 +490,17 @@ class ViTHybridPreTrainedModel(PreTrainedModel):
         if isinstance(module, ViTHybridEncoder):
             module.gradient_checkpointing = value
 
+    @property
+    def dummy_inputs(self) -> Dict[str, torch.Tensor]:
+        """
+        Dummy inputs to build the network. Returns: `Dict[str, torch.Tensor]`: The dummy inputs.
+        """
+        VISION_DUMMY_INPUTS = torch.rand(
+            size=(3, self.config.num_channels, self.config.image_size, self.config.image_size),
+            dtype=torch.float32,
+        )
+        return {"pixel_values": VISION_DUMMY_INPUTS}
+
 
 VIT_START_DOCSTRING = r"""
     This model is a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass. Use it


### PR DESCRIPTION
# What does this PR do?
```
from transformers import ViTForImageClassification
from transformers.utils.fx import symbolic_trace

model = ViTForImageClassification.from_pretrained("google/vit-base-patch16-224")
traced = symbolic_trace(model)
```
```
Traceback (most recent call last):
  File "bug_check.py", line 5, in <module>
    traced = symbolic_trace(model)
  File "/opt/conda/lib/python3.8/site-packages/transformers/utils/fx.py", line 1214, in symbolic_trace
    concrete_args = get_concrete_args(model, input_names)
  File "/opt/conda/lib/python3.8/site-packages/transformers/utils/fx.py", line 1167, in get_concrete_args
    raise ValueError(
ValueError: The model does not have input(s) named: input_ids, expected a subset of the following: pixel_values, head_mask, labels, output_attentions, output_hidden_states, interpolate_pos_encoding, return_dict
```
When using transformers.utils.fx.symbolic_trace,
the pytorch version of vision models throws an error. This is because the default setting of dummy_inputs is "input_ids".

It doesn't matter in TEXT MODELS,
but this problem occurs because
VISION MODELS requires "pixel_values" as a base.

Added dummy_inputs to several PyTorch version models by referring to the dummy_inputs of the Tensorflow version model.

This change fixes the
convnext, convnextv2, resnet, segformer, vit, and vit_hybrid models.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@amyeroberts 