### PR TITLE
Added tokenizer kwargs for fill mask pipeline

### DIFF
--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -93,7 +93,7 @@ class FillMaskPipeline(Pipeline):
     def preprocess(self, inputs, return_tensors=None, **preprocess_parameters) -> Dict[str, GenericTensor]:
         if return_tensors is None:
             return_tensors = self.framework
-        model_inputs = self.tokenizer(inputs, return_tensors=return_tensors)
+        model_inputs = self.tokenizer(inputs, return_tensors=return_tensors, **preprocess_parameters)
         self.ensure_exactly_one_mask_token(model_inputs)
         return model_inputs
 
@@ -198,7 +198,8 @@ class FillMaskPipeline(Pipeline):
         target_ids = np.array(target_ids)
         return target_ids
 
-    def _sanitize_parameters(self, top_k=None, targets=None):
+    def _sanitize_parameters(self, top_k=None, targets=None, **tokenizer_kwargs):
+        preprocess_params = tokenizer_kwargs
         postprocess_params = {}
 
         if targets is not None:
@@ -212,7 +213,7 @@ class FillMaskPipeline(Pipeline):
             raise PipelineException(
                 "fill-mask", self.model.base_model_prefix, "The tokenizer does not define a `mask_token`."
             )
-        return {}, {}, postprocess_params
+        return preprocess_params, {}, postprocess_params
 
     def __call__(self, inputs, *args, **kwargs):
         """


### PR DESCRIPTION
Added tokenizer kwargs for the fill mask pipeline, which enables to truncate/pad/specify max length etc for the tokenizer. Pipeline can be used as follows following the edit:

`from transformers import pipeline`
`fill_mask_pipeline = pipeline(`
`    'fill-mask', `
`    model=model, `
`    tokenizer=tokenizer, `
`    device=0`
`)`

`tokenizer_kwargs = {'truncation':True, 'max_length':2048}`
`output = fill_mask_pipeline("Text to predict <mask>", **tokenizer_kwargs)`
