### PR TITLE
🚨🚨🚨 Use default ignore index in Luke

### DIFF
--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -1298,7 +1298,7 @@ class LukeForMaskedLM(LukePreTrainedModel):
         self.lm_head = LukeLMHead(config)
         self.entity_predictions = EntityPredictionHead(config)
 
-        self.loss_fn = nn.CrossEntropyLoss(ignore_index=-1)
+        self.loss_fn = nn.CrossEntropyLoss()
 
         # Initialize weights and apply final processing
         self.post_init()


### PR DESCRIPTION
# What does this PR do?

As discussed in #22981, the `ignore_index` for Luke should be the same as all models in Transformers, even if it does not match the original authors implementation.

This is breaking but needed to align all models to have the same API.

Fixes #22981