### PR TITLE
Fix the expected error in `test_offline_mode_pipeline_exception`

### DIFF
--- a/tests/utils/test_offline.py
+++ b/tests/utils/test_offline.py
@@ -176,7 +176,7 @@ socket.socket = offline_socket
         self.assertEqual(result.returncode, 1, result.stderr)
         self.assertIn(
             "You cannot infer task automatically within `pipeline` when using offline mode",
-            result.stderr.decode().replace("\n", "")
+            result.stderr.decode().replace("\n", ""),
         )
 
     @require_torch

--- a/tests/utils/test_offline.py
+++ b/tests/utils/test_offline.py
@@ -175,7 +175,8 @@ socket.socket = offline_socket
         result = subprocess.run(cmd, env=env, check=False, capture_output=True)
         self.assertEqual(result.returncode, 1, result.stderr)
         self.assertIn(
-            "You cannot infer task automatically within `pipeline` when using offline mode", result.stderr.decode()
+            "You cannot infer task automatically within `pipeline` when using offline mode",
+            result.stderr.decode().replace("\n", "")
         )
 
     @require_torch


### PR DESCRIPTION
# What does this PR do?

The expected error becomes `RuntimeError: You cannot infer task automatically within `pipeline` when using \noffline mode\n` since April 18, i.e. with 2 extra `\n`. It's not very clear where this change comes from, probably just the format thing from the `subprocess`.

Strangely, if I run the command in that test like below, there is no extra newline.

```bash
HF_HOME=/mnt/cache TRANSFORMERS_IS_CI=yes  TRANSFORMERS_OFFLINE=1 python3 temp.py
```
with temp.py
```python
from transformers import pipeline

mname = "hf-internal-testing/tiny-random-bert"
pipe = pipeline(model=mname)
```