### PR TITLE
[`Pix2Struct`] Fix pix2struct doctest

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1702,7 +1702,7 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel):
         >>> outputs = model(**inputs, labels=labels)
         >>> loss = outputs.loss
         >>> print(f"{loss.item():.5f}")
-        5.23973
+        4.58370
         ```"""
         use_cache = use_cache if use_cache is not None else self.config.text_config.use_cache
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

Fixes Pix2Struct doctest
Link to failing job: https://github.com/huggingface/transformers/actions/runs/4815336726/jobs/8573921590

With https://github.com/huggingface/transformers/pull/23004 being merged, the label smoothing of the loss function has been removed. Therefore the expected value of the loss function changed, leading to the failing doctest.

cc @ydshieh 
