### PR TITLE
🚨🚨🚨 [`Blip`] remove labels masking

### DIFF
--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -1218,8 +1218,6 @@ class BlipForQuestionAnswering(BlipPreTrainedModel):
         if labels is not None and decoder_input_ids is None:
             # get decoder inputs from shifting lm labels to the right - this is used in training mode
             decoder_input_ids = self._shift_right(labels)
-            # replace possible -100 values in labels by `pad_token_id`
-            labels = labels.masked_fill(labels == self.decoder_pad_token_id, -100)
 
         answer_output = self.text_decoder(
             input_ids=decoder_input_ids,

--- a/src/transformers/models/blip/modeling_tf_blip.py
+++ b/src/transformers/models/blip/modeling_tf_blip.py
@@ -1452,8 +1452,6 @@ class TFBlipForQuestionAnswering(TFBlipPreTrainedModel):
         if labels is not None and decoder_input_ids is None:
             # get decoder inputs from shifting lm labels to the right - this is used in training mode
             decoder_input_ids = self._shift_right(labels)
-            # replace possible -100 values in labels by `pad_token_id`
-            labels = tf.where(labels == self.decoder_pad_token_id, -100, labels)
 
         answer_output = self.text_decoder(
             input_ids=decoder_input_ids,


### PR DESCRIPTION
# What does this PR do?

Addresses https://github.com/huggingface/transformers/pull/23004#issuecomment-1523776082

This PR aims to harmonize the training procedure for most of recent additions in `transformers`. It should be users' responsibility to fill_mask the padding tokens of the labels with the correct value. This PR addresses the issue that was raised by other architectures such as Luke or Pix2Struct

However I realize that even if this patch is applied, we still mask fill the labels with -100 [here](https://github.com/huggingface/transformers/blob/9435cc6670b7b8656b33e8ff28d3bbe9bafbca9d/src/transformers/models/blip/modeling_blip.py#L1133), similarly as in [T5](https://github.com/huggingface/transformers/blob/9435cc6670b7b8656b33e8ff28d3bbe9bafbca9d/src/transformers/models/t5/modeling_t5.py#L868)

I would love your feedback on this, @amyeroberts !
