### PR TITLE
extend the test files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,18 @@ jobs:
                   else
                       touch test_preparation/examples_test_list.txt
                   fi
+            - run: |
+                  if [ -f filtered_test_list_torch_and_tf.txt ]; then
+                      mv filtered_test_list_torch_and_tf.txt test_preparation/filtered_test_list_torch_and_tf.txt
+                  else
+                      touch test_preparation/filtered_test_list_torch_and_tf.txt
+                  fi
+            - run: |
+                  if [ -f filtered_test_list_torch_and_flax.txt ]; then
+                      mv filtered_test_list_torch_and_flax.txt test_preparation/filtered_test_list_torch_and_flax.txt
+                  else
+                      touch test_preparation/filtered_test_list_torch_and_flax.txt
+                  fi
             - store_artifacts:
                   path: test_preparation/test_list.txt
             - store_artifacts:
@@ -78,6 +90,10 @@ jobs:
             - run: cp test_preparation/generated_config.yml test_preparation/generated_config.txt
             - store_artifacts:
                   path: test_preparation/generated_config.txt
+            - store_artifacts:
+                  path: test_preparation/filtered_test_list_torch_and_tf.txt
+            - store_artifacts:
+                  path: test_preparation/filtered_test_list_torch_and_flax.txt
             - continuation/continue:
                   configuration_path: test_preparation/generated_config.yml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,10 @@ jobs:
                       touch test_preparation/examples_test_list.txt
                   fi
             - run: |
-                  if [ -f filtered_test_list_torch_and_tf.txt ]; then
-                      mv filtered_test_list_torch_and_tf.txt test_preparation/filtered_test_list_torch_and_tf.txt
+                  if [ -f filtered_test_list_cross_tests.txt ]; then
+                      mv filtered_test_list_cross_tests.txt test_preparation/filtered_test_list_cross_tests.txt
                   else
-                      touch test_preparation/filtered_test_list_torch_and_tf.txt
-                  fi
-            - run: |
-                  if [ -f filtered_test_list_torch_and_flax.txt ]; then
-                      mv filtered_test_list_torch_and_flax.txt test_preparation/filtered_test_list_torch_and_flax.txt
-                  else
-                      touch test_preparation/filtered_test_list_torch_and_flax.txt
+                      touch test_preparation/filtered_test_list_cross_tests.txt
                   fi
             - store_artifacts:
                   path: test_preparation/test_list.txt
@@ -91,9 +85,7 @@ jobs:
             - store_artifacts:
                   path: test_preparation/generated_config.txt
             - store_artifacts:
-                  path: test_preparation/filtered_test_list_torch_and_tf.txt
-            - store_artifacts:
-                  path: test_preparation/filtered_test_list_torch_and_flax.txt
+                  path: test_preparation/filtered_test_list_cross_tests.txt
             - continuation/continue:
                   configuration_path: test_preparation/generated_config.yml
 

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -447,6 +447,31 @@ def create_circleci_config(folder=None):
     if len(test_list) > 0:
         jobs.extend(REGULAR_TESTS)
 
+        # Extend the test files for cross test jobs
+        for job in jobs:
+            if job.job_name in ["tests_torch_and_tf", "tests_torch_and_flax"]:
+                extended_tests_to_run = set(test_list.split())
+                for test_path in copy.copy(extended_tests_to_run):
+                    dir_path, fn = os.path.split(test_path)
+                    if fn.startswith("test_modeling_tf_"):
+                        fn = fn.replace("test_modeling_tf_", "test_modeling_")
+                    elif fn.startswith("test_modeling_flax_"):
+                        fn = fn.replace("test_modeling_flax_", "test_modeling_")
+                    else:
+                        if job.job_name == "test_torch_and_tf":
+                            fn = fn.replace("test_modeling_", "test_modeling_tf_")
+                        elif job.job_name == "test_torch_and_flax":
+                            fn = fn.replace("test_modeling_", "test_modeling_flax_")
+                    new_test_file = str(os.path.join(dir_path, fn))
+                    if os.path.isfile(new_test_file):
+                        if new_test_file not in extended_tests_to_run:
+                            extended_tests_to_run.add(new_test_file)
+                job.tests_to_run = sorted(extended_tests_to_run)
+                fn = f'{job.job_name.replace("tests_", "filtered_test_list_")}.txt'
+                f_path = os.path.join(folder, fn)
+                with open(f_path, "w") as fp:
+                    fp.write(" ".join(job.tests_to_run))
+
     example_file = os.path.join(folder, "examples_test_list.txt")
     if os.path.exists(example_file) and os.path.getsize(example_file) > 0:
         jobs.extend(EXAMPLES_TESTS)

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -470,7 +470,7 @@ def create_circleci_config(folder=None):
         for job in jobs:
             if job.job_name in ["tests_torch_and_tf", "tests_torch_and_flax"]:
                 job.tests_to_run = extended_tests_to_run
-        fn = "filtered_test_list_cross_tests"
+        fn = "filtered_test_list_cross_tests.txt"
         f_path = os.path.join(folder, fn)
         with open(f_path, "w") as fp:
             fp.write(" ".join(extended_tests_to_run))


### PR DESCRIPTION
# What does this PR do?

Extend the test files in cross test CI job.

In #21023, flax bigbird modeling file is changed and the flax test file skips the pt/flax tests. However, the test fetcher is not designed to take into account the corresponding pytorch test file, and we have test failure in `main` on `nightly` run.

This PR extends the test files for `torch_and_tf` and `torch_and_flax` jobs to avoid such situation.

The effect could be seen in this run

https://app.circleci.com/pipelines/github/huggingface/transformers/63246/workflows/84722f3a-1259-4226-973d-267c74ca9aee/jobs/780372