### PR TITLE
Fixed default config for `Pix2Struct` model to set `Pix2StructTextModel` to `is_decoder=True`

### DIFF
--- a/src/transformers/models/pix2struct/configuration_pix2struct.py
+++ b/src/transformers/models/pix2struct/configuration_pix2struct.py
@@ -118,6 +118,7 @@ class Pix2StructTextConfig(PretrainedConfig):
         pad_token_id=0,
         eos_token_id=1,
         tie_word_embeddings=False,
+        is_decoder=True,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -144,6 +145,7 @@ class Pix2StructTextConfig(PretrainedConfig):
             eos_token_id=eos_token_id,
             decoder_start_token_id=decoder_start_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            is_decoder=is_decoder,
             **kwargs,
         )
 


### PR DESCRIPTION
Previously, the `Pix2StructTextModel` was configured with `is_decoder=False` by default causing the attention mask used for self-attention to be non-causal and causing fine-tuning to fail.

As a fix, this PR adds `is_decoder=True` default kwarg to the `Pix2StructTextConfig` class in order to correctly configure the text model as a decoder. 

Fixes # 22903

@younesbelkada