### PR TITLE
Generate: prepare assisted generation for release

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1517,9 +1517,9 @@ class GenerationTesterMixin:
             for output in (output_greedy, output_assisted):
                 self._check_outputs(output, input_ids, model.config, use_cache=True)
 
-    def test_assisted_decoding_sample(self):
-        # Seeded assisted decoding will not match sample for the same seed, as there are >1 sampling steps per output
-        # token. As such, this test only checks that the output format is correct.
+    def test_assisted_decoding_matches_sample(self):
+        # Seeded assisted decoding will not match sample for the same seed, as the forward pass does not return the
+        # exact same logits (the forward pass of the main model, now with several tokens at once, has causal masking).
 
         for model_class in self.all_generative_model_classes:
             # won't fix: FSMT and Reformer have a different cache variable type (and format).

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1517,7 +1517,7 @@ class GenerationTesterMixin:
             for output in (output_greedy, output_assisted):
                 self._check_outputs(output, input_ids, model.config, use_cache=True)
 
-    def test_assisted_decoding_matches_sample(self):
+    def test_assisted_decoding_sample(self):
         # Seeded assisted decoding will not match sample for the same seed, as the forward pass does not return the
         # exact same logits (the forward pass of the main model, now with several tokens at once, has causal masking).
 


### PR DESCRIPTION
# What does this PR do?

This PR makes a few final adjustments to assisted generation before its release, including:
1. Merge previously named step 7 [the forward pass after matching with assistant tokens] into step 6 [slicing variables based on the number of matches] -- the variables are already computed in step 3 [selecting the model's next tokens based on the logits], so the code becomes more concise and it helps me explain what's going on more easily. See the (partially bugged) gif below, which is WIP for the blog post.
2. Swaps the order of step 6 [slicing variables] with step 5 [updating the number of candidates for the next iteration] -- makes more sense that the update step for the next iteration is the last one :)
3. Better variable names and improved comments (so the implementation becomes self-documenting)

![assisted_gen](https://user-images.githubusercontent.com/12240844/235239007-d9d0224a-063e-49f3-9c1f-6b90b818345e.gif)
