### PR TITLE
Pin numba for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ _deps = [
     "librosa",
     "nltk",
     "natten>=0.14.6",
+    "numba<0.57.0",  # Can be removed once unpinned.
     "numpy>=1.17",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
@@ -286,7 +287,8 @@ extras["sigopt"] = deps_list("sigopt")
 extras["integrations"] = extras["optuna"] + extras["ray"] + extras["sigopt"]
 
 extras["serving"] = deps_list("pydantic", "uvicorn", "fastapi", "starlette")
-extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer", "kenlm")
+# numba can be removed here once unpinned
+extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer", "kenlm", "numba")
 # `pip install ".[speech]"` is deprecated and `pip install ".[torch-speech]"` should be used instead
 extras["speech"] = deps_list("torchaudio") + extras["audio"]
 extras["torch-speech"] = deps_list("torchaudio") + extras["audio"]

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -36,6 +36,7 @@ deps = {
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6",
+    "numba": "numba<0.57.0",
     "numpy": "numpy>=1.17",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",


### PR DESCRIPTION
# What does this PR do?

Today's release of `numba` broke the audio feature extractors. Not sure if it's because of numba by itself or because it forces an update to Numpy 1.24. Will be investigated later by the audio team but in the meantime pinning `numba` to make `main` green.

cc @ydshieh @sanchit-gandhi for information, will merge this as soon as the CI is green.