### PR TITLE
[`Doctest`] Fix pix2struct doctest

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1702,7 +1702,7 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel):
         >>> outputs = model(**inputs, labels=labels)
         >>> loss = outputs.loss
         >>> print(f"{loss.item():.5f}")
-        4.58370
+        5.95566
         ```"""
         use_cache = use_cache if use_cache is not None else self.config.text_config.use_cache
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

Link to failing job: https://github.com/huggingface/transformers/actions/runs/4867713745/jobs/8680544136

This PR fixes the current failing doctest for pix2struct. https://github.com/huggingface/transformers/pull/23051 fixed the issues related with pix2struct and training by changing the way attention masks are computed. Naturally this has changed the value of the expected loss function in the docstring

cc @ydshieh 