### PR TITLE
Fix ConvNext V2 parameter naming issue

### DIFF
--- a/src/transformers/models/convnextv2/convert_convnextv2_to_pytorch.py
+++ b/src/transformers/models/convnextv2/convert_convnextv2_to_pytorch.py
@@ -99,6 +99,10 @@ def rename_key(name):
     if "stages" in name and "downsampling_layer" not in name:
         # stages.0.0. for instance should be renamed to stages.0.layers.0.
         name = name[: len("stages.0")] + ".layers" + name[len("stages.0") :]
+    if "gamma" in name:
+        name = name.replace("gamma", "weight")
+    if "beta" in name:
+        name = name.replace("beta", "bias")
     if "stages" in name:
         name = name.replace("stages", "encoder.stages")
     if "norm" in name:
@@ -152,14 +156,16 @@ def convert_convnextv2_checkpoint(checkpoint_url, pytorch_dump_folder_path, save
     for key in state_dict.copy().keys():
         val = state_dict.pop(key)
         state_dict[rename_key(key)] = val
+
     # add prefix to all keys expect classifier head
     for key in state_dict.copy().keys():
         val = state_dict.pop(key)
         if not key.startswith("classifier"):
             key = "convnextv2." + key
         state_dict[key] = val
-
+    
     # load HuggingFace model
+    print()
     model = ConvNextV2ForImageClassification(config)
     model.load_state_dict(state_dict)
     model.eval()

--- a/src/transformers/models/convnextv2/convert_convnextv2_to_pytorch.py
+++ b/src/transformers/models/convnextv2/convert_convnextv2_to_pytorch.py
@@ -156,16 +156,14 @@ def convert_convnextv2_checkpoint(checkpoint_url, pytorch_dump_folder_path, save
     for key in state_dict.copy().keys():
         val = state_dict.pop(key)
         state_dict[rename_key(key)] = val
-
     # add prefix to all keys expect classifier head
     for key in state_dict.copy().keys():
         val = state_dict.pop(key)
         if not key.startswith("classifier"):
             key = "convnextv2." + key
         state_dict[key] = val
-    
+
     # load HuggingFace model
-    print()
     model = ConvNextV2ForImageClassification(config)
     model.load_state_dict(state_dict)
     model.eval()

--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -100,14 +100,14 @@ class ConvNextV2GRN(nn.Module):
 
     def __init__(self, dim: int):
         super().__init__()
-        self.gamma = nn.Parameter(torch.zeros(1, 1, 1, dim))
-        self.beta = nn.Parameter(torch.zeros(1, 1, 1, dim))
+        self.weight = nn.Parameter(torch.zeros(1, 1, 1, dim))
+        self.bias = nn.Parameter(torch.zeros(1, 1, 1, dim))
 
     def forward(self, hidden_states: torch.FloatTensor) -> torch.FloatTensor:
         # Compute and normalize global spatial feature maps
         global_features = torch.norm(hidden_states, p=2, dim=(1, 2), keepdim=True)
         norm_features = global_features / (global_features.mean(dim=-1, keepdim=True) + 1e-6)
-        hidden_states = self.gamma * (hidden_states * norm_features) + self.beta + hidden_states
+        hidden_states = self.weight * (hidden_states * norm_features) + self.bias + hidden_states
 
         return hidden_states
 


### PR DESCRIPTION
# What does this PR do?
Renames gamma and beta parameters of the `ConvNextV2GRN` module, which caused the `save_pretrained` method to rename these parameters to weight and bias.

Existing checkpoints on the hub can be loaded without any warnings once the PR is merged.

Fixes #23090

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

