### PR TITLE
Generate: better warnings with pipelines

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -806,16 +806,9 @@ class Pipeline(_ScikitCompat):
         # Update config and generation_config with task specific parameters
         task_specific_params = self.model.config.task_specific_params
         if task_specific_params is not None and task in task_specific_params:
-            for attr_name, attr in task_specific_params.get(task).items():
-                if self.model.can_generate() and hasattr(self.model.generation_config, attr_name):
-                    setattr(self.model.generation_config, attr_name, attr)
-                else:
-                    setattr(self.model.config, attr_name, attr)
-
-        # If the model can generate, disables the flag for the legacy behavior check (generation can be parameterized
-        # from model.config), which can't happen in a pipeline
-        if self.model.can_generate():
-            self.model.generation_config._from_model_config = False
+            self.model.config.update(task_specific_params.get(task))
+            if self.model.can_generate():
+                self.model.generation_config.update(**task_specific_params.get(task))
 
         self.call_count = 0
         self._batch_size = kwargs.pop("batch_size", None)

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -273,7 +273,7 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
 
         if input_length < max_length:
             logger.warning(
-                f"Your max_length is set to {max_length}, but your input_length is only {input_length}. You might "
+                f"Your max_length is set to {max_length}, but your input_length is only {input_length}. Since this is a summarization task, where outputs shorter than the input are typically wanted, you might "
                 f"consider decreasing max_length manually, e.g. summarizer('...', max_length={input_length//2})"
             )
 

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -273,7 +273,8 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
 
         if input_length < max_length:
             logger.warning(
-                f"Your max_length is set to {max_length}, but your input_length is only {input_length}. Since this is a summarization task, where outputs shorter than the input are typically wanted, you might "
+                f"Your max_length is set to {max_length}, but your input_length is only {input_length}. Since this is "
+                "a summarization task, where outputs shorter than the input are typically wanted, you might "
                 f"consider decreasing max_length manually, e.g. summarizer('...', max_length={input_length//2})"
             )
 


### PR DESCRIPTION
# What does this PR do?

Addresses comments in https://github.com/huggingface/transformers/issues/23054

This PR adds the following enhancements to generate-related pipeline warnings:
1. Clarifies the `max_length` reduction suggestion in the summarization pipeline
2. Also pipes task-specific configuration to `generation_config` (when applicable), which fixes the warning about relying on `model.config` to parameterize `generate`