### PR TITLE
Handle padding warning in generation when using `inputs_embeds`

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1307,15 +1307,17 @@ class GenerationMixin:
 
         # decoder-only models should use left-padding for generation
         if not self.config.is_encoder_decoder:
-            if (
-                generation_config.pad_token_id is not None and (
+            if generation_config.pad_token_id is not None and (
                 # if `input_ids` was given, check if the last id in any sequence is `pad_token_id`
                 torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id) > 0
                 # If shape of `inputs_tensor` is (Batch, Sequence) then `input_ids` was given, else `inputs_embeds` was given
-                if len(inputs_tensor.shape) == 2 else
+                if len(inputs_tensor.shape) == 2
+                else
                 # if `inputs_embeds` was given, check if the last embed in any sequence is *all* zeros
-                torch.any(torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id, dim=1) == inputs_tensor.shape[2])
-            )):
+                torch.any(
+                    torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id, dim=1) == inputs_tensor.shape[2]
+                )
+            ):
                 logger.warning(
                     "A decoder-only architecture is being used, but right-padding was detected! For correct "
                     "generation results, please set `padding_side='left'` when initializing the tokenizer."

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1307,16 +1307,12 @@ class GenerationMixin:
 
         # decoder-only models should use left-padding for generation
         if not self.config.is_encoder_decoder:
-            if generation_config.pad_token_id is not None and (
-                # if `input_ids` was given, check if the last id in any sequence is `pad_token_id`
-                torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id) > 0
-                # If shape of `inputs_tensor` is (Batch, Sequence) then `input_ids` was given, else `inputs_embeds` was given
-                if len(inputs_tensor.shape) == 2
-                else
-                # if `inputs_embeds` was given, check if the last embed in any sequence is *all* zeros
-                torch.any(
-                    torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id, dim=1) == inputs_tensor.shape[2]
-                )
+            # If `input_ids` was given, check if the last id in any sequence is `pad_token_id`
+            # Note: If using, `inputs_embeds` this check does not work, because we want to be more hands-off.
+            if (
+                generation_config.pad_token_id is not None
+                and len(inputs_tensor.shape) == 2
+                and torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id) > 0
             ):
                 logger.warning(
                     "A decoder-only architecture is being used, but right-padding was detected! For correct "

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1291,7 +1291,6 @@ class GenerationMixin:
             inputs, generation_config.bos_token_id, model_kwargs
         )
         batch_size = inputs_tensor.shape[0]
-        using_inputs_embeds = len(inputs_tensor.shape) > 2
 
         # 4. Define other model kwargs
         model_kwargs["output_attentions"] = generation_config.output_attentions
@@ -1312,7 +1311,8 @@ class GenerationMixin:
                 generation_config.pad_token_id is not None and (
                 # if `input_ids` was given, check if the last id in any sequence is `pad_token_id`
                 torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id) > 0
-                if not using_inputs_embeds else
+                # If shape of `inputs_tensor` is (Batch, Sequence) then `input_ids` was given, else `inputs_embeds` was given
+                if len(inputs_tensor.shape) == 2 else
                 # if `inputs_embeds` was given, check if the last embed in any sequence is *all* zeros
                 torch.any(torch.sum(inputs_tensor[:, -1] == generation_config.pad_token_id, dim=1) == inputs_tensor.shape[2])
             )):


### PR DESCRIPTION
# What does this PR do?

Fixes: #23042
if `input_ids` was given, check if the last id in any sequence is `pad_token_id`
if `inputs_embeds` was given, check if the last embed in any sequence is *all* zeros

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? [Please add a link
      to it if that's the case.](https://github.com/huggingface/transformers/issues/23042)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
