### PR TITLE
Unpin numba

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,6 @@ _deps = [
     "librosa",
     "nltk",
     "natten>=0.14.6",
-    "numba<0.57.0",  # Can be removed once unpinned.
     "numpy>=1.17",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
@@ -286,8 +285,7 @@ extras["sigopt"] = deps_list("sigopt")
 extras["integrations"] = extras["optuna"] + extras["ray"] + extras["sigopt"]
 
 extras["serving"] = deps_list("pydantic", "uvicorn", "fastapi", "starlette")
-# numba can be removed here once unpinned
-extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer", "kenlm", "numba")
+extras["audio"] = deps_list("librosa", "pyctcdecode", "phonemizer", "kenlm")
 # `pip install ".[speech]"` is deprecated and `pip install ".[torch-speech]"` should be used instead
 extras["speech"] = deps_list("torchaudio") + extras["audio"]
 extras["torch-speech"] = deps_list("torchaudio") + extras["audio"]

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -37,7 +37,6 @@ deps = {
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6",
-    "numba": "numba<0.57.0",
     "numpy": "numpy>=1.17",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -158,7 +158,7 @@ class BatchFeature(UserDict):
         else:
 
             def as_tensor(value, dtype=None):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+                if isinstance(value, (list, tuple)) and isinstance(value[0], (list, tuple, np.ndarray)):
                     value_lens = [len(val) for val in value]
                     if len(set(value_lens)) > 1 and dtype is None:
                         # we have a ragged list so handle explicitly

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -158,11 +158,13 @@ class BatchFeature(UserDict):
         else:
 
             def as_tensor(value):
-                if isinstance(value, (list, tuple, np.ndarray)) and len(value) > 0:
+                if isinstance(value, (list, tuple)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
                     if len(np.unique(value_lens)) != 1:
                         # we have a ragged list so handle explicitly
                         value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                    else:
+                        value = np.asarray(value)
                 else:
                     value = np.asarray(value)
                 return value

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -156,7 +156,14 @@ class BatchFeature(UserDict):
             as_tensor = jnp.array
             is_tensor = is_jax_tensor
         else:
-            as_tensor = np.asarray
+            def as_tensor(value):
+                value_lens = [len(val) for val in value]
+                if len(np.unique(value_lens)) != 1:
+                    # we have a ragged list so handle explicitly
+                    value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                else:
+                    value = np.asarray(value)
+                return value
             is_tensor = is_numpy_array
 
         # Do the tensor conversion in batch

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -158,9 +158,9 @@ class BatchFeature(UserDict):
         else:
 
             def as_tensor(value, dtype=None):
-                if isinstance(value, (list, tuple)) and len(value) > 0 and not isinstance(value[0], np.ndarray):
+                if isinstance(value, (list, tuple)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
-                    if len(set(value_lens)) > 1:
+                    if len(set(value_lens)) > 1 and dtype is None:
                         # we have a ragged list so handle explicitly
                         value = as_tensor([np.asarray(val) for val in value], dtype=object)
                 return np.asarray(value, dtype=dtype)

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -158,10 +158,11 @@ class BatchFeature(UserDict):
         else:
 
             def as_tensor(value):
-                value_lens = [len(val) for val in value]
-                if len(np.unique(value_lens)) != 1:
-                    # we have a ragged list so handle explicitly
-                    value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                if isinstance(value, (list, tuple)) and len(value) > 0:
+                    value_lens = [len(val) for val in value]
+                    if len(np.unique(value_lens)) != 1:
+                        # we have a ragged list so handle explicitly
+                        value = np.asarray([np.asarray(val) for val in value], dtype=object)
                 else:
                     value = np.asarray(value)
                 return value

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -156,6 +156,7 @@ class BatchFeature(UserDict):
             as_tensor = jnp.array
             is_tensor = is_jax_tensor
         else:
+
             def as_tensor(value):
                 value_lens = [len(val) for val in value]
                 if len(np.unique(value_lens)) != 1:
@@ -164,6 +165,7 @@ class BatchFeature(UserDict):
                 else:
                     value = np.asarray(value)
                 return value
+
             is_tensor = is_numpy_array
 
         # Do the tensor conversion in batch

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -157,17 +157,13 @@ class BatchFeature(UserDict):
             is_tensor = is_jax_tensor
         else:
 
-            def as_tensor(value):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+            def as_tensor(value, dtype=None):
+                if isinstance(value, (list, tuple)) and len(value) > 0 and not isinstance(value[0], np.ndarray):
                     value_lens = [len(val) for val in value]
-                    if len(np.unique(value_lens)) != 1:
+                    if len(set(value_lens)) > 1:
                         # we have a ragged list so handle explicitly
-                        value = np.asarray([np.asarray(val) for val in value], dtype=object)
-                    else:
-                        value = np.asarray(value)
-                else:
-                    value = np.asarray(value)
-                return value
+                        value = as_tensor([np.asarray(val) for val in value], dtype=object)
+                return np.asarray(value, dtype=dtype)
 
             is_tensor = is_numpy_array
 

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -158,7 +158,7 @@ class BatchFeature(UserDict):
         else:
 
             def as_tensor(value):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+                if isinstance(value, (list, tuple, np.ndarray)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
                     if len(np.unique(value_lens)) != 1:
                         # we have a ragged list so handle explicitly

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -705,7 +705,16 @@ class BatchEncoding(UserDict):
             as_tensor = jnp.array
             is_tensor = is_jax_tensor
         else:
-            as_tensor = np.asarray
+
+            def as_tensor(value):
+                value_lens = [len(val) for val in value]
+                if len(np.unique(value_lens)) != 1:
+                    # we have a ragged list so handle explicitly
+                    value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                else:
+                    value = np.asarray(value)
+                return value
+
             is_tensor = is_numpy_array
 
         # Do the tensor conversion in batch

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -707,9 +707,9 @@ class BatchEncoding(UserDict):
         else:
 
             def as_tensor(value, dtype=None):
-                if isinstance(value, (list, tuple)) and len(value) > 0 and not isinstance(value[0], np.ndarray):
+                if isinstance(value, (list, tuple)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
-                    if len(set(value_lens)) > 1:
+                    if len(set(value_lens)) > 1 and dtype is None:
                         # we have a ragged list so handle explicitly
                         value = as_tensor([np.asarray(val) for val in value], dtype=object)
                 return np.asarray(value, dtype=dtype)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -707,10 +707,11 @@ class BatchEncoding(UserDict):
         else:
 
             def as_tensor(value):
-                value_lens = [len(val) for val in value]
-                if len(np.unique(value_lens)) != 1:
-                    # we have a ragged list so handle explicitly
-                    value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                if isinstance(value, (list, tuple)) and len(value) > 0:
+                    value_lens = [len(val) for val in value]
+                    if len(np.unique(value_lens)) != 1:
+                        # we have a ragged list so handle explicitly
+                        value = np.asarray([np.asarray(val) for val in value], dtype=object)
                 else:
                     value = np.asarray(value)
                 return value

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -706,17 +706,13 @@ class BatchEncoding(UserDict):
             is_tensor = is_jax_tensor
         else:
 
-            def as_tensor(value):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+            def as_tensor(value, dtype=None):
+                if isinstance(value, (list, tuple)) and len(value) > 0 and not isinstance(value[0], np.ndarray):
                     value_lens = [len(val) for val in value]
-                    if len(np.unique(value_lens)) != 1:
+                    if len(set(value_lens)) > 1:
                         # we have a ragged list so handle explicitly
-                        value = np.asarray([np.asarray(val) for val in value], dtype=object)
-                    else:
-                        value = np.asarray(value)
-                else:
-                    value = np.asarray(value)
-                return value
+                        value = as_tensor([np.asarray(val) for val in value], dtype=object)
+                return np.asarray(value, dtype=dtype)
 
             is_tensor = is_numpy_array
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -707,11 +707,13 @@ class BatchEncoding(UserDict):
         else:
 
             def as_tensor(value):
-                if isinstance(value, (list, tuple, np.ndarray)) and len(value) > 0:
+                if isinstance(value, (list, tuple)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
                     if len(np.unique(value_lens)) != 1:
                         # we have a ragged list so handle explicitly
                         value = np.asarray([np.asarray(val) for val in value], dtype=object)
+                    else:
+                        value = np.asarray(value)
                 else:
                     value = np.asarray(value)
                 return value

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -707,7 +707,7 @@ class BatchEncoding(UserDict):
         else:
 
             def as_tensor(value, dtype=None):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+                if isinstance(value, (list, tuple)) and isinstance(value[0], (list, tuple, np.ndarray)):
                     value_lens = [len(val) for val in value]
                     if len(set(value_lens)) > 1 and dtype is None:
                         # we have a ragged list so handle explicitly

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -707,7 +707,7 @@ class BatchEncoding(UserDict):
         else:
 
             def as_tensor(value):
-                if isinstance(value, (list, tuple)) and len(value) > 0:
+                if isinstance(value, (list, tuple, np.ndarray)) and len(value) > 0:
                     value_lens = [len(val) for val in value]
                     if len(np.unique(value_lens)) != 1:
                         # we have a ragged list so handle explicitly

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -705,16 +705,7 @@ class BatchEncoding(UserDict):
             as_tensor = jnp.array
             is_tensor = is_jax_tensor
         else:
-
-            def as_tensor(value):
-                value_lens = [len(val) for val in value]
-                if len(np.unique(value_lens)) != 1:
-                    # we have a ragged list so handle explicitly
-                    value = np.asarray([np.asarray(val) for val in value], dtype=object)
-                else:
-                    value = np.asarray(value)
-                return value
-
+            as_tensor = np.asarray
             is_tensor = is_numpy_array
 
         # Do the tensor conversion in batch

--- a/tests/models/realm/test_modeling_realm.py
+++ b/tests/models/realm/test_modeling_realm.py
@@ -392,7 +392,7 @@ class RealmModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 b"This is the fourth record.",
                 b"This is the fifth record.",
             ],
-            dtype=np.object,
+            dtype=object,
         )
         retriever = RealmRetriever(block_records, tokenizer)
         model = RealmForOpenQA(openqa_config, retriever)

--- a/tests/models/realm/test_retrieval_realm.py
+++ b/tests/models/realm/test_retrieval_realm.py
@@ -116,7 +116,7 @@ class RealmRetrieverTest(TestCase):
         retriever = self.get_dummy_retriever()
         tokenizer = retriever.tokenizer
 
-        retrieved_block_ids = np.array([0, 3], dtype=np.long)
+        retrieved_block_ids = np.array([0, 3], dtype="long")
         question_input_ids = tokenizer(["Test question"]).input_ids
         answer_ids = tokenizer(
             ["the fourth"],
@@ -151,7 +151,7 @@ class RealmRetrieverTest(TestCase):
         retriever = self.get_dummy_retriever()
         tokenizer = retriever.tokenizer
 
-        retrieved_block_ids = np.array([0, 3, 5], dtype=np.long)
+        retrieved_block_ids = np.array([0, 3, 5], dtype="long")
         question_input_ids = tokenizer(["Test question"]).input_ids
         answer_ids = tokenizer(
             ["the fourth", "longer longer"],

--- a/tests/models/realm/test_retrieval_realm.py
+++ b/tests/models/realm/test_retrieval_realm.py
@@ -100,7 +100,7 @@ class RealmRetrieverTest(TestCase):
                 b"This is the fifth record",
                 b"This is a longer longer longer record",
             ],
-            dtype=np.object,
+            dtype=object,
         )
         return block_records
 


### PR DESCRIPTION
# What does this PR do?

Numba was pinned to <0.57.0 in #23118 - this is because it forced an update of the numpy package to >= 1.24. From numpy >= 1.24, converting a ragged list to a numpy array requires the user to **explicitly** set `dtype=object` (before this happened automatically, but threw a deprecation warning).

This PR updates the feature extraction and tokenisation utils to explicitly specify `dtype=object` when converting ragged lists to numpy arrays.