### PR TITLE
Update language_modeling.py

### DIFF
--- a/src/transformers/data/datasets/language_modeling.py
+++ b/src/transformers/data/datasets/language_modeling.py
@@ -499,7 +499,25 @@ class TextDatasetForNextSentencePrediction(Dataset):
                         is_random_next = False
                         for j in range(a_end, len(current_chunk)):
                             tokens_b.extend(current_chunk[j])
+                    
+                    def truncate_seq_pair(tokens_a, tokens_b, max_num_tokens):
+                        """Truncates a pair of sequences to a maximum sequence length."""
+                        while True:
+                            total_length = len(tokens_a) + len(tokens_b)
+                            if total_length <= max_num_tokens:
+                                break
 
+                            trunc_tokens = tokens_a if len(tokens_a) > len(tokens_b) else tokens_b
+                            assert len(trunc_tokens) >= 1
+
+                            if random.random() < 0.5:
+                                del trunc_tokens[0]
+                            else:
+                                trunc_tokens.pop()
+                                
+                    #Call truncate_seq_pair function to truncate. This is necessary because in the end, chunk added can exceed the maximum length allowed for long documents.
+                    truncate_seq_pair(tokens_a, tokens_b, max_num_tokens)
+                    
                     if not (len(tokens_a) >= 1):
                         raise ValueError(f"Length of sequence a is {len(tokens_a)} which must be no less than 1")
                     if not (len(tokens_b) >= 1):


### PR DESCRIPTION
Title: Add truncate_seq_pair function to TextDatasetForNextSentencePrediction

Description:
This PR adds a `truncate_seq_pair()` function to the `TextDatasetForNextSentencePrediction` class, inside the `create_examples_from_document()` function. This function truncates the sequences if they exceed the maximum number of tokens, which is useful when dealing with very long input texts. By including this function, the generated examples will adhere to the maximum sequence length constraint, which is important for the proper functioning of the model during pre-training.

Fixes # (issue)

## Before submitting
- [x] I read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section.
- [x] I wrote any new necessary tests.

## Who can review?
- text models: @ArthurZucker and @younesbelkada
- tokenizers: @ArthurZucker
- trainer: @sgugger

Please let me know if there are any changes or improvements needed.