### PR TITLE
Support ratios for `logging_steps`, `eval_steps`, and `save_steps`

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1713,11 +1713,11 @@ class Trainer:
             )
         
         # Compute absolute values for logging, eval, and save if given as ratio
-        if args.logging_steps < 1:
+        if args.logging_steps and args.logging_steps < 1:
             args.logging_steps = math.ceil(max_steps * args.logging_steps)
-        if args.eval_steps < 1:
+        if args.eval_steps and args.eval_steps < 1:
             args.eval_steps = math.ceil(max_steps * args.eval_steps)
-        if args.save_steps < 1:
+        if args.save_steps and args.save_steps < 1:
             args.save_steps = math.ceil(max_steps * args.save_steps)
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1711,7 +1711,7 @@ class Trainer:
                 "args.max_steps must be set to a positive value if dataloader does not have a length, was"
                 f" {args.max_steps}"
             )
-        
+
         # Compute absolute values for logging, eval, and save if given as ratio
         if args.logging_steps and args.logging_steps < 1:
             args.logging_steps = math.ceil(max_steps * args.logging_steps)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1711,6 +1711,14 @@ class Trainer:
                 "args.max_steps must be set to a positive value if dataloader does not have a length, was"
                 f" {args.max_steps}"
             )
+        
+        # Compute absolute values for logging, eval, and save if given as ratio
+        if args.logging_steps < 1:
+            args.logging_steps = math.ceil(max_steps * args.logging_steps)
+        if args.eval_steps < 1:
+            args.eval_steps = math.ceil(max_steps * args.eval_steps)
+        if args.save_steps < 1:
+            args.save_steps = math.ceil(max_steps * args.save_steps)
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -251,7 +251,7 @@ class TrainingArguments:
 
         logging_first_step (`bool`, *optional*, defaults to `False`):
             Whether to log and evaluate the first `global_step` or not.
-        logging_steps (`float`, *optional*, defaults to 500):
+        logging_steps (`int` or `float`, *optional*, defaults to 500):
             Number of update steps between two logs if `logging_strategy="steps"`. Should be an integer or a float in
             range `[0,1)`. If smaller than 1, will be interpreted as ratio of total training steps.
         logging_nan_inf_filter (`bool`, *optional*, defaults to `True`):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -251,8 +251,9 @@ class TrainingArguments:
 
         logging_first_step (`bool`, *optional*, defaults to `False`):
             Whether to log and evaluate the first `global_step` or not.
-        logging_steps (`int`, *optional*, defaults to 500):
-            Number of update steps between two logs if `logging_strategy="steps"`.
+        logging_steps (`float`, *optional*, defaults to 500):
+            Number of update steps between two logs if `logging_strategy="steps"`. If smaller than 1, will be
+            interpreted as ratio of total training steps.
         logging_nan_inf_filter (`bool`, *optional*, defaults to `True`):
             Whether to filter `nan` and `inf` losses for logging. If set to `True` the loss of every step that is `nan`
             or `inf` is filtered and the average loss of the current logging window is taken instead.
@@ -270,8 +271,9 @@ class TrainingArguments:
                 - `"no"`: No save is done during training.
                 - `"epoch"`: Save is done at the end of each epoch.
                 - `"steps"`: Save is done every `save_steps`.
-        save_steps (`int`, *optional*, defaults to 500):
-            Number of updates steps before two checkpoint saves if `save_strategy="steps"`.
+        save_steps (`float`, *optional*, defaults to 500):
+            Number of updates steps before two checkpoint saves if `save_strategy="steps"`. If smaller than 1, will be
+            interpreted as ratio of total training steps.
         save_total_limit (`int`, *optional*):
             If a value is passed, will limit the total amount of checkpoints. Deletes the older checkpoints in
             `output_dir`.
@@ -332,9 +334,10 @@ class TrainingArguments:
         dataloader_drop_last (`bool`, *optional*, defaults to `False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
-        eval_steps (`int`, *optional*):
+        eval_steps (`float`, *optional*):
             Number of update steps between two evaluations if `evaluation_strategy="steps"`. Will default to the same
-            value as `logging_steps` if not set.
+            value as `logging_steps` if not set. If smaller than 1, will be interpreted as ratio of total training
+            steps.
         dataloader_num_workers (`int`, *optional*, defaults to 0):
             Number of subprocesses to use for data loading (PyTorch only). 0 means that the data will be loaded in the
             main process.
@@ -721,13 +724,13 @@ class TrainingArguments:
         metadata={"help": "The logging strategy to use."},
     )
     logging_first_step: bool = field(default=False, metadata={"help": "Log the first global_step"})
-    logging_steps: int = field(default=500, metadata={"help": "Log every X updates steps."})
+    logging_steps: float = field(default=500, metadata={"help": "Log every X updates steps. If smaller than 1, will be interpreted as ratio of total training steps."})
     logging_nan_inf_filter: bool = field(default=True, metadata={"help": "Filter nan and inf losses for logging."})
     save_strategy: Union[IntervalStrategy, str] = field(
         default="steps",
         metadata={"help": "The checkpoint save strategy to use."},
     )
-    save_steps: int = field(default=500, metadata={"help": "Save checkpoint every X updates steps."})
+    save_steps: float = field(default=500, metadata={"help": "Save checkpoint every X updates steps. If smaller than 1, will be interpreted as ratio of total training steps."})
     save_total_limit: Optional[int] = field(
         default=None,
         metadata={
@@ -854,7 +857,7 @@ class TrainingArguments:
     dataloader_drop_last: bool = field(
         default=False, metadata={"help": "Drop the last incomplete batch if it is not divisible by the batch size."}
     )
-    eval_steps: Optional[int] = field(default=None, metadata={"help": "Run an evaluation every X steps."})
+    eval_steps: Optional[float] = field(default=None, metadata={"help": "Run an evaluation every X steps. If smaller than 1, will be interpreted as ratio of total training steps."})
     dataloader_num_workers: int = field(
         default=0,
         metadata={
@@ -1185,6 +1188,14 @@ class TrainingArguments:
         # logging_steps must be non-zero for logging_strategy that is other than 'no'
         if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps == 0:
             raise ValueError(f"logging strategy {self.logging_strategy} requires non-zero --logging_steps")
+        
+        if self.logging_steps > 1 and self.logging_steps != int(self.logging_steps):
+            raise ValueError(f"--logging_steps must be an integer if bigger than 1: {self.logging_steps}")
+        if self.eval_steps > 1 and self.eval_steps != int(self.eval_steps):
+            raise ValueError(f"--eval_steps must be an integer if bigger than 1: {self.eval_steps}")
+        if self.save_steps > 1 and self.save_steps != int(self.save_steps):
+            raise ValueError(f"--save_steps must be an integer if bigger than 1: {self.save_steps}")
+        
 
         # Sanity checks for load_best_model_at_end: we require save and eval strategies to be compatible.
         if self.load_best_model_at_end:
@@ -1194,6 +1205,20 @@ class TrainingArguments:
                     f"strategy: {self.evaluation_strategy}\n- Save strategy: {self.save_strategy}"
                 )
             if self.evaluation_strategy == IntervalStrategy.STEPS and self.save_steps % self.eval_steps != 0:
+                if self.eval_steps < 1 or self.save_steps < 1:
+                    if not (self.eval_steps < 1 and self.save_steps < 1):
+                        raise ValueError(
+                            "--load_best_model_at_end requires the saving steps to be a multiple of the evaluation "
+                            "steps, which cannot get guaranteed when mixing ratio and absolute steps for save_steps"
+                            f"{self.save_steps} and eval_steps {self.eval_steps}."
+                        )
+                    # Work around floating point precision issues
+                    LARGE_MULTIPLIER = 1_000_000 
+                    if (self.save_steps * LARGE_MULTIPLIER) % (self.eval_steps * LARGE_MULTIPLIER )!= 0:
+                        raise ValueError(
+                            "--load_best_model_at_end requires the saving steps to be a multiple of the evaluation "
+                            f"steps, but found {self.save_steps}, which is not a multiple of {self.eval_steps}."
+                        )
                 raise ValueError(
                     "--load_best_model_at_end requires the saving steps to be a round multiple of the evaluation "
                     f"steps, but found {self.save_steps}, which is not a round multiple of {self.eval_steps}."

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -271,7 +271,7 @@ class TrainingArguments:
                 - `"no"`: No save is done during training.
                 - `"epoch"`: Save is done at the end of each epoch.
                 - `"steps"`: Save is done every `save_steps`.
-        save_steps (`float`, *optional*, defaults to 500):
+        save_steps (`int` or `float`, *optional*, defaults to 500):
             Number of updates steps before two checkpoint saves if `save_strategy="steps"`. Should be an integer or a
             float in range `[0,1)`. If smaller than 1, will be interpreted as ratio of total training steps.
         save_total_limit (`int`, *optional*):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1189,11 +1189,11 @@ class TrainingArguments:
         if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps == 0:
             raise ValueError(f"logging strategy {self.logging_strategy} requires non-zero --logging_steps")
         
-        if self.logging_steps > 1 and self.logging_steps != int(self.logging_steps):
+        if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps > 1 and self.logging_steps != int(self.logging_steps):
             raise ValueError(f"--logging_steps must be an integer if bigger than 1: {self.logging_steps}")
-        if self.eval_steps > 1 and self.eval_steps != int(self.eval_steps):
+        if self.evaluation_strategy == IntervalStrategy.STEPS and self.eval_steps > 1 and self.eval_steps != int(self.eval_steps):
             raise ValueError(f"--eval_steps must be an integer if bigger than 1: {self.eval_steps}")
-        if self.save_steps > 1 and self.save_steps != int(self.save_steps):
+        if self.save_strategy == IntervalStrategy.STEPS and self.save_steps > 1 and self.save_steps != int(self.save_steps):
             raise ValueError(f"--save_steps must be an integer if bigger than 1: {self.save_steps}")
         
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -334,7 +334,7 @@ class TrainingArguments:
         dataloader_drop_last (`bool`, *optional*, defaults to `False`):
             Whether to drop the last incomplete batch (if the length of the dataset is not divisible by the batch size)
             or not.
-        eval_steps (`float`, *optional*):
+        eval_steps (`int` or `float`, *optional*):
             Number of update steps between two evaluations if `evaluation_strategy="steps"`. Will default to the same
             value as `logging_steps` if not set. Should be an integer or a float in range `[0,1)`. If smaller than 1,
             will be interpreted as ratio of total training steps.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -54,7 +54,6 @@ from .utils import (
 )
 from .utils.import_utils import is_optimum_neuron_available
 
-
 logger = logging.get_logger(__name__)
 log_levels = logging.get_log_levels_dict().copy()
 trainer_log_levels = dict(**log_levels, passive=-1)
@@ -1213,24 +1212,18 @@ class TrainingArguments:
         if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps == 0:
             raise ValueError(f"logging strategy {self.logging_strategy} requires non-zero --logging_steps")
 
-        if (
-            self.logging_strategy == IntervalStrategy.STEPS
-            and self.logging_steps > 1
-            and self.logging_steps != int(self.logging_steps)
-        ):
-            raise ValueError(f"--logging_steps must be an integer if bigger than 1: {self.logging_steps}")
-        if (
-            self.evaluation_strategy == IntervalStrategy.STEPS
-            and self.eval_steps > 1
-            and self.eval_steps != int(self.eval_steps)
-        ):
-            raise ValueError(f"--eval_steps must be an integer if bigger than 1: {self.eval_steps}")
-        if (
-            self.save_strategy == IntervalStrategy.STEPS
-            and self.save_steps > 1
-            and self.save_steps != int(self.save_steps)
-        ):
-            raise ValueError(f"--save_steps must be an integer if bigger than 1: {self.save_steps}")
+        if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps > 1:
+            if self.logging_steps != int(self.logging_steps):
+                raise ValueError(f"--logging_steps must be an integer if bigger than 1: {self.logging_steps}")
+            self.logging_steps = int(self.logging_steps)
+        if self.evaluation_strategy == IntervalStrategy.STEPS and self.eval_steps > 1:
+            if self.eval_steps != int(self.eval_steps):
+                raise ValueError(f"--eval_steps must be an integer if bigger than 1: {self.eval_steps}")
+            self.eval_steps = int(self.eval_steps)
+        if self.save_strategy == IntervalStrategy.STEPS and self.save_steps > 1:
+            if self.save_steps != int(self.save_steps):
+                raise ValueError(f"--save_steps must be an integer if bigger than 1: {self.save_steps}")
+            self.save_steps = int(self.save_steps)
 
         # Sanity checks for load_best_model_at_end: we require save and eval strategies to be compatible.
         if self.load_best_model_at_end:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -54,6 +54,7 @@ from .utils import (
 )
 from .utils.import_utils import is_optimum_neuron_available
 
+
 logger = logging.get_logger(__name__)
 log_levels = logging.get_log_levels_dict().copy()
 trainer_log_levels = dict(**log_levels, passive=-1)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #23171 

Adds support for *ratios* to the `logging_steps`, `eval_steps`, and `save_steps` arguments, i.e. if they are a float in range `[0,1)`, the steps are calculated as a ratio of total training steps.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger