### PR TITLE
[docs] Audio task guides fixes

### DIFF
--- a/docs/source/en/tasks/asr.mdx
+++ b/docs/source/en/tasks/asr.mdx
@@ -282,7 +282,7 @@ At this point, only three steps remain:
 ...     args=training_args,
 ...     train_dataset=encoded_minds["train"],
 ...     eval_dataset=encoded_minds["test"],
-...     tokenizer=processor.feature_extractor,
+...     tokenizer=processor,
 ...     data_collator=data_collator,
 ...     compute_metrics=compute_metrics,
 ... )

--- a/docs/source/en/tasks/text-to-speech.mdx
+++ b/docs/source/en/tasks/text-to-speech.mdx
@@ -469,7 +469,7 @@ Instantiate the `Trainer` object  and pass the model, dataset, and data collator
 ...     train_dataset=dataset["train"],
 ...     eval_dataset=dataset["test"],
 ...     data_collator=data_collator,
-...     tokenizer=processor.tokenizer,
+...     tokenizer=processor,
 ... )
 ```
 


### PR DESCRIPTION
Related to https://github.com/huggingface/transformers/issues/23188 and https://github.com/huggingface/transformers/issues/23222

In the guide examples, only `feature_extractor` is passed to `Trainer`, so that's the only part of the processor that gets pushed to Hub. This PR fixes the docs to pass `processor` to Trainer as the `tokenizer` parameter, so both `feature_extractor` and `tokenizer` are saved. 
The behavior is confirmed with the ASR task guide example. We may also need to fix the example scripts. I'll look into it, and if a fix is needed, I'll create a separate PR. 