### PR TITLE
CTC example: updated trainer parameters to save tokenizer

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_ctc.py
@@ -705,7 +705,7 @@ def main():
         compute_metrics=compute_metrics,
         train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
         eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
-        tokenizer=feature_extractor,
+        tokenizer=processor,
     )
 
     # 8. Finally, we can start training


### PR DESCRIPTION
The current example only passes `feature_extractor` to `Trainer` and thus `tokenizer` is not saved and won't be pushed to Hub. This PR fixes this by passing the `processor` to `Trainer`. It can probably be refactored further to get the tokenizer and feature_extractor from the instantiated processor, but with regard to behavior, this small fix seems to address the problem.