### PR TITLE
Hot Fix 

### DIFF
--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -21,6 +21,7 @@ jobs:
           pip install --upgrade pip
           pip install datasets pandas
           pip install .[torch,tf,flax]
+          pip install --upgrade pytest pytest-sugar
 
       - name: Update metadata
         run: |

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - update_transformers_metadata*
+      - hot_fix_badass
 
 jobs:
   build_and_package:


### PR DESCRIPTION
# What does this PR do?

Fix the failing GitHub Action `Update Transformers metadata` due to the missing `pytest` after PR #22987. But it's kind strange that a simple `from transformers.utils import direct_transformers_import` will need `pytest`. Maybe we need to re-think if to have `from .doctest_utils import HfDocTestParser` inside the file `transformers/utils/__init__.py`.