### PR TITLE
Add  document-question-answering in task_summary

### DIFF
--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -237,7 +237,7 @@ score: 0.9327, start: 30, end: 54, answer: huggingface/transformers
 
 ### Docuement Question answering
 
-Document Question Answering is a task that answers natural language questions from a document. Unlike token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document Question Answering can be used to parse structured documents and extract key information from documents. For example total amount and change amount can be extracted from a receipt.
+Document Question answering is a task that answers natural language questions from a document. Unlike token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document Question answering can be used to parse structured documents and extract key information from documents. For example total amount and change amount can be extracted from a receipt.
 
 ```py
 >>> from transformers import pipeline
@@ -250,7 +250,7 @@ Document Question Answering is a task that answers natural language questions fr
 >>> doc_question_answerer = pipeline("document-question-answering", model="naver-clova-ix/donut-base-finetuned-docvqa")
 >>> preds = doc_question_answerer(
 ...     question="What is the total amount?",
-...     image=image
+...     image=image,
 ... )
 >>> preds
 [{'answer': '17,000'}]

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -237,7 +237,7 @@ score: 0.9327, start: 30, end: 54, answer: huggingface/transformers
 
 ### Document question answering
 
-Document Question answering is a task that answers natural language questions from a document. Unlike token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document Question answering can be used to parse structured documents and extract key information from documents. For example total amount and change amount can be extracted from a receipt.
+Document question answering is a task that answers natural language questions from a document. Unlike a token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document question answering can be used to parse structured documents and extract key information from documents. In the example below, the total amount and change due can be extracted from a receipt.
 
 ```py
 >>> from transformers import pipeline

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -235,27 +235,6 @@ There are two common types of question answering:
 score: 0.9327, start: 30, end: 54, answer: huggingface/transformers
 ```
 
-### Document question answering
-
-Document question answering is a task that answers natural language questions from a document. Unlike a token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document question answering can be used to parse structured documents and extract key information from documents. In the example below, the total amount and change due can be extracted from a receipt.
-
-```py
->>> from transformers import pipeline
->>> from PIL import Image
->>> import requests
-
->>> url = "https://datasets-server.huggingface.co/assets/hf-internal-testing/example-documents/--/hf-internal-testing--example-documents/test/2/image/image.jpg"
->>> image = Image.open(requests.get(url, stream=True).raw)
-
->>> doc_question_answerer = pipeline("document-question-answering", model="naver-clova-ix/donut-base-finetuned-docvqa")
->>> preds = doc_question_answerer(
-...     question="What is the total amount?",
-...     image=image,
-... )
->>> preds
-[{'answer': '17,000'}]
-```
-
 ### Summarization
 
 Summarization creates a shorter version of a text from a longer one while trying to preserve most of the meaning of the original document. Summarization is a sequence-to-sequence task; it outputs a shorter text sequence than the input. There are a lot of long-form documents that can be summarized to help readers quickly understand the main points. Legislative bills, legal and financial documents, patents, and scientific papers are a few examples of documents that could be summarized to save readers time and serve as a reading aid.
@@ -327,5 +306,30 @@ There are two types of language modeling:
       'token_str': ' platform',
       'sequence': 'Hugging Face is a community-based open-source platform for machine learning.'}]
     ```
+
+## Multimodal
+
+Multimodal tasks require a model to process multiple data types(text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing and postprocessing steps help the model convert all the data types into a similar form called embeddings(vectors). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
+
+### Document question answering
+
+Document question answering is a task that answers natural language questions from a document. Unlike a token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document question answering can be used to parse structured documents and extract key information from documents. In the example below, the total amount and change due can be extracted from a receipt.
+
+```py
+>>> from transformers import pipeline
+>>> from PIL import Image
+>>> import requests
+
+>>> url = "https://datasets-server.huggingface.co/assets/hf-internal-testing/example-documents/--/hf-internal-testing--example-documents/test/2/image/image.jpg"
+>>> image = Image.open(requests.get(url, stream=True).raw)
+
+>>> doc_question_answerer = pipeline("document-question-answering", model="naver-clova-ix/donut-base-finetuned-docvqa")
+>>> preds = doc_question_answerer(
+...     question="What is the total amount?",
+...     image=image,
+... )
+>>> preds
+[{'answer': '17,000'}]
+```
 
 Hopefully, this page has given you some more background information about all the types of tasks in each modality and the practical importance of each one. In the next [section](tasks_explained), you'll learn **how** 🤗 Transformers work to solve these tasks.

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -309,7 +309,7 @@ There are two types of language modeling:
 
 ## Multimodal
 
-Multimodal tasks require a model to process multiple data types(text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing and postprocessing steps help the model convert all the data types into a similar form called embeddings(vectors). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
+Multimodal tasks require a model to process multiple data types (text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing and postprocessing steps help the model convert all the data types into a similar form called embeddings (vectors or list of numbers that holds meaningful information about the data). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
 
 ### Document question answering
 

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -235,7 +235,7 @@ There are two common types of question answering:
 score: 0.9327, start: 30, end: 54, answer: huggingface/transformers
 ```
 
-### Docuement Question answering
+### Document question answering
 
 Document Question answering is a task that answers natural language questions from a document. Unlike token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document Question answering can be used to parse structured documents and extract key information from documents. For example total amount and change amount can be extracted from a receipt.
 

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -309,7 +309,9 @@ There are two types of language modeling:
 
 ## Multimodal
 
-Multimodal tasks require a model to process multiple data modalities (text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing steps help the model convert all the data types into a similar form called embeddings (vectors or list of numbers that holds meaningful information about the data). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
+Multimodal tasks require a model to process multiple data modalities (text, image, audio, video) to solve a particular problem. Image captioning is an example of a multimodal task where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. 
+
+Although multimodal models work with different data types, internally, the preprocessing steps help the model convert all the data types into embeddings (vectors or list of numbers that holds meaningful information about the data). For a task like image captioning, the model learns relationships between image embeddings and text embeddings.
 
 ### Document question answering
 

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -235,6 +235,27 @@ There are two common types of question answering:
 score: 0.9327, start: 30, end: 54, answer: huggingface/transformers
 ```
 
+### Docuement Question answering
+
+Document Question Answering is a task that answers natural language questions from a document. Unlike token-level question answering task which takes text as input, document question answering takes an image of a document as input along with a question about the document and returns an answer. Document Question Answering can be used to parse structured documents and extract key information from documents. For example total amount and change amount can be extracted from a receipt.
+
+```py
+>>> from transformers import pipeline
+>>> from PIL import Image
+>>> import requests
+
+>>> url = "https://datasets-server.huggingface.co/assets/hf-internal-testing/example-documents/--/hf-internal-testing--example-documents/test/2/image/image.jpg"
+>>> image = Image.open(requests.get(url, stream=True).raw)
+
+>>> doc_question_answerer = pipeline("document-question-answering", model="naver-clova-ix/donut-base-finetuned-docvqa")
+>>> preds = doc_question_answerer(
+...     question="What is the total amount?",
+...     image=image
+... )
+>>> preds
+[{'answer': '17,000'}]
+```
+
 ### Summarization
 
 Summarization creates a shorter version of a text from a longer one while trying to preserve most of the meaning of the original document. Summarization is a sequence-to-sequence task; it outputs a shorter text sequence than the input. There are a lot of long-form documents that can be summarized to help readers quickly understand the main points. Legislative bills, legal and financial documents, patents, and scientific papers are a few examples of documents that could be summarized to save readers time and serve as a reading aid.

--- a/docs/source/en/task_summary.mdx
+++ b/docs/source/en/task_summary.mdx
@@ -309,7 +309,7 @@ There are two types of language modeling:
 
 ## Multimodal
 
-Multimodal tasks require a model to process multiple data types (text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing and postprocessing steps help the model convert all the data types into a similar form called embeddings (vectors or list of numbers that holds meaningful information about the data). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
+Multimodal tasks require a model to process multiple data modalities (text, image, audio, video) to solve a particular problem. A simple example of a multimodal task could be image captioning where the model takes an image as input and outputs a sequence of text describing the image or some properties of the image. Although multimodal models seem to work with different data types internally the preprocessing steps help the model convert all the data types into a similar form called embeddings (vectors or list of numbers that holds meaningful information about the data). So the model learns relationships between sequence of patches (small chunks of images) of image embeddings and text embeddings to complete a task like image captioning.
 
 ### Document question answering
 

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -1328,7 +1328,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
 
     # Copied from transformers.models.deformable_detr.image_processing_deformable_detr.DeformableDetrImageProcessor.post_process_object_detection with DeformableDetr->ConditionalDetr
     def post_process_object_detection(
-        self, outputs, threshold: float = 0.5, target_sizes: Union[TensorType, List[Tuple]] = None
+        self, outputs, threshold: float = 0.5, target_sizes: Union[TensorType, List[Tuple]] = None, top_k: int = 100
     ):
         """
         Converts the raw output of [`ConditionalDetrForObjectDetection`] into final bounding boxes in (top_left_x,
@@ -1342,6 +1342,8 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
             target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
                 Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
                 (height, width) of each image in the batch. If left to None, predictions will not be resized.
+            top_k (`int`, *optional*, defaults to 100):
+                Keep only top k bounding boxes before filtering by thresholding.
 
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
@@ -1356,7 +1358,9 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
                 )
 
         prob = out_logits.sigmoid()
-        topk_values, topk_indexes = torch.topk(prob.view(out_logits.shape[0], -1), 100, dim=1)
+        prob = prob.view(out_logits.shape[0], -1)
+        k_value = min(top_k, prob.size(1))
+        topk_values, topk_indexes = torch.topk(prob, k_value, dim=1)
         scores = topk_values
         topk_boxes = torch.div(topk_indexes, out_logits.shape[2], rounding_mode="floor")
         labels = topk_indexes % out_logits.shape[2]

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -118,8 +118,9 @@ class DecisionTransformerGPT2Attention(nn.Module):
             torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)).view(
                 1, 1, max_positions, max_positions
             ),
+            persistent=False,
         )
-        self.register_buffer("masked_bias", torch.tensor(-1e4))
+        self.register_buffer("masked_bias", torch.tensor(-1e4), persistent=False)
 
         self.embed_dim = config.hidden_size
         self.num_heads = config.num_attention_heads
@@ -747,6 +748,7 @@ class DecisionTransformerPreTrainedModel(PreTrainedModel):
     main_input_name = "states"
     supports_gradient_checkpointing = False
     _keys_to_ignore_on_load_missing = [r"position_ids"]
+    _keys_to_ignore_on_load_unexpected = [r"h\.\d+\.attn\.masked_bias", r"h\.\d+\.attn\.bias"]
 
     def _init_weights(self, module):
         """Initialize the weights"""

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -131,8 +131,9 @@ class GPT2Attention(nn.Module):
             torch.tril(torch.ones((max_positions, max_positions), dtype=torch.bool)).view(
                 1, 1, max_positions, max_positions
             ),
+            persistent=False,
         )
-        self.register_buffer("masked_bias", torch.tensor(-1e4))
+        self.register_buffer("masked_bias", torch.tensor(-1e4), persistent=False)
 
         self.embed_dim = config.hidden_size
         self.num_heads = config.num_attention_heads
@@ -954,7 +955,8 @@ class GPT2Model(GPT2PreTrainedModel):
     GPT2_START_DOCSTRING,
 )
 class GPT2LMHeadModel(GPT2PreTrainedModel):
-    _keys_to_ignore_on_load_missing = [r"attn.masked_bias", r"attn.bias", r"lm_head.weight"]
+    _keys_to_ignore_on_load_missing = [r"lm_head.weight"]
+    _keys_to_ignore_on_load_unexpected = [r"h\.\d+\.attn\.masked_bias", r"h\.\d+\.attn\.bias"]
 
     def __init__(self, config):
         super().__init__(config)

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -400,6 +400,10 @@ class TFWhisperModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestC
 
             check_hidden_states_output(inputs_dict, config, model_class)
 
+    def check_pt_tf_outputs(self, tf_outputs, pt_outputs, model_class, tol=5e-5, name="outputs", attributes=None):
+        # We override with a slightly higher tol value, as test recently became flaky
+        super().check_pt_tf_outputs(tf_outputs, pt_outputs, model_class, tol, name, attributes)
+
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -824,6 +824,10 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
             self.assertTrue(models_equal)
 
+    def check_pt_tf_outputs(self, tf_outputs, pt_outputs, model_class, tol=5e-5, name="outputs", attributes=None):
+        # We override with a slightly higher tol value, as test recently became flaky
+        super().check_pt_tf_outputs(tf_outputs, pt_outputs, model_class, tol, name, attributes)
+
     @is_pt_flax_cross_test
     def test_equivalence_pt_to_flax(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

From issue #18926
This PR adds Document Question Answering summary to task_summary.mdx
It also provides an example using pipeline and this [model](https://huggingface.co/naver-clova-ix/donut-base-finetuned-docvqa)  

## Who can review?
@stevhliu 



