### PR TITLE
Fix new line bug in chat mode for agents

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -264,9 +264,7 @@ class Agent:
         """
         prompt = self.format_prompt(task, chat_mode=True)
         result = self.generate_one(prompt, stop=["Human:", "====="])
-        self.chat_history = prompt + result
-        if not self.chat_history.endswith("\n"):
-            self.chat_history += "\n"
+        self.chat_history = prompt + result.strip() + "\n"
         explanation, code = clean_code_for_chat(result)
 
         print(f"==Explanation from the agent==\n{explanation}")


### PR DESCRIPTION
# What does this PR do?

Depending on the agent used we might get too many new lines here. Just stripping everything and adding the right amount fixes this.