### PR TITLE
OPT/BioGPT: Improved attention mask shape exception

### DIFF
--- a/src/transformers/models/biogpt/modeling_biogpt.py
+++ b/src/transformers/models/biogpt/modeling_biogpt.py
@@ -107,7 +107,14 @@ class BioGptLearnedPositionalEmbedding(nn.Embedding):
         positions = (torch.cumsum(attention_mask, dim=1).type_as(attention_mask) * attention_mask).long() - 1
 
         # cut positions if `past_key_values_length` is > 0
-        positions = positions[:, past_key_values_length:]
+        if past_key_values_length > 0:
+            if attention_mask.shape[1] <= past_key_values_length:
+                raise ValueError(
+                    f"The sequence length within `past_key_values` ({past_key_values_length}) must be smaller than "
+                    f"the attention mask length ({attention_mask.shape[1]}). Usually, the attention mask has shape "
+                    "`[batch_size, curent inputs length + past inputs length]`."
+                )
+            positions = positions[:, past_key_values_length:]
 
         return super().forward(positions + self.offset)
 

--- a/src/transformers/models/biogpt/modeling_biogpt.py
+++ b/src/transformers/models/biogpt/modeling_biogpt.py
@@ -107,14 +107,7 @@ class BioGptLearnedPositionalEmbedding(nn.Embedding):
         positions = (torch.cumsum(attention_mask, dim=1).type_as(attention_mask) * attention_mask).long() - 1
 
         # cut positions if `past_key_values_length` is > 0
-        if past_key_values_length > 0:
-            if attention_mask.shape[1] <= past_key_values_length:
-                raise ValueError(
-                    f"The sequence length within `past_key_values` ({past_key_values_length}) must be smaller than "
-                    f"the attention mask length ({attention_mask.shape[1]}). Usually, the attention mask has shape "
-                    "`[batch_size, curent inputs length + past inputs length]`."
-                )
-            positions = positions[:, past_key_values_length:]
+        positions = positions[:, past_key_values_length:]
 
         return super().forward(positions + self.offset)
 
@@ -553,6 +546,12 @@ class BioGptModel(BioGptPreTrainedModel):
 
         if attention_mask is None:
             attention_mask = torch.ones(inputs_embeds.shape[:2], dtype=torch.bool, device=inputs_embeds.device)
+        elif attention_mask.shape[1] != past_key_values_length + input_shape[1]:
+            raise ValueError(
+                f"The provided attention mask has length {attention_mask.shape[1]}, but its length should be "
+                f"{past_key_values_length + input_shape[1]} (sum of the lengths of current and past inputs)"
+            )
+
         # embed positions
         positions = self.embed_positions(attention_mask, past_key_values_length)
 

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -115,7 +115,14 @@ class OPTLearnedPositionalEmbedding(nn.Embedding):
         positions = (torch.cumsum(attention_mask, dim=1).type_as(attention_mask) * attention_mask).long() - 1
 
         # cut positions if `past_key_values_length` is > 0
-        positions = positions[:, past_key_values_length:]
+        if past_key_values_length > 0:
+            if attention_mask.shape[1] <= past_key_values_length:
+                raise ValueError(
+                    f"The sequence length within `past_key_values` ({past_key_values_length}) must be smaller than "
+                    f"the attention mask length ({attention_mask.shape[1]}). Usually, the attention mask has shape "
+                    "`[batch_size, curent inputs length + past inputs length]`."
+                )
+            positions = positions[:, past_key_values_length:]
 
         return super().forward(positions + self.offset)
 

--- a/src/transformers/models/opt/modeling_tf_opt.py
+++ b/src/transformers/models/opt/modeling_tf_opt.py
@@ -646,7 +646,7 @@ class TFOPTDecoder(tf.keras.layers.Layer):
         if attention_mask is None:
             attention_mask = tf.ones(inputs_embeds.shape[:2], dtype=tf.bool)
         else:
-            tf.debugging.assert_less_equal(
+            tf.debugging.assert_equal(
                 attention_mask.shape[1],
                 past_key_values_length + input_shape[1],
                 message=(

--- a/src/transformers/models/opt/modeling_tf_opt.py
+++ b/src/transformers/models/opt/modeling_tf_opt.py
@@ -109,7 +109,17 @@ class TFOPTLearnedPositionalEmbedding(TFSharedEmbeddings):
         positions = tf.math.cumsum(attention_mask, axis=1) * attention_mask - 1
 
         # cut positions if `past_key_values_length` is > 0
-        positions = positions[:, past_key_values_length:]
+        if past_key_values_length > 0:
+            tf.debugging.assert_less_equal(
+                attention_mask.shape[1],
+                past_key_values_length,
+                message=(
+                    f"The sequence length within `past_key_values` ({past_key_values_length}) must be smaller than "
+                    f"the attention mask length ({attention_mask.shape[1]}). Usually, the attention mask has shape "
+                    "`[batch_size, curent inputs length + past inputs length]`."
+                ),
+            )
+            positions = positions[:, past_key_values_length:]
 
         return super().call(positions + self.offset)
 


### PR DESCRIPTION
# What does this PR do?

Related exception: #23197

Currently, in OPT/BioGPT, if we don't pass an attention mask or if we pass an attention mask with a wrong shape, an exception will be printed in the attention layer: `Attention mask should be of size {(bsz, 1, tgt_len, src_len)}, but is {attention_mask.size()}`. This exception has the following problems:
1. It checks the expanded attention mask, not the attention mask as set by the user (or the default). Even as a maintainer, I can't immediately decode the error message, as I would need to know how the mask is expanded for the model in question.
2. If there is a bug computing `bsz`, `tgt_len`, or `src_len`, the exception will be misleading.

In #23197 we found that when the length of `past_key_values` is equal to the length of the `attention_mask`, `tgt_len` and `src_len` will be wrong (in at least these 2 models), triggering the exception with an incorrect message. This PR solves both issues: it prevents the incorrect computation of `tgt_len` and `src_len` by checking the shape of `attention_mask` in the main model class, printing a user-friendly message.

If this PR gets approved, I will add a similar check to the other models.