### PR TITLE
Fix link displayed for custom tools

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -318,7 +318,7 @@ def get_cached_module_file(
 
     if len(new_files) > 0:
         new_files = "\n".join([f"- {f}" for f in new_files])
-        repo_type_str = "" if repo_type is None else f"{repo_type}/"
+        repo_type_str = "" if repo_type is None else f"{repo_type}s/"
         url = f"https://huggingface.co/{repo_type_str}{pretrained_model_name_or_path}"
         logger.warning(
             f"A new version of the following files was downloaded from {url}:\n{new_files}"


### PR DESCRIPTION
# What does this PR do?

This fixes the link displayed when a custom tool downloads code files from the Hub.