### PR TITLE
skip `test_run_squad_no_trainer` for now

### DIFF
--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import sys
 import tempfile
+import unittest
 from unittest import mock
 
 import torch
@@ -176,6 +177,7 @@ class ExamplesTestsNoTrainer(TestCasePlus):
         self.assertTrue(os.path.exists(os.path.join(tmp_dir, "epoch_0")))
         self.assertTrue(os.path.exists(os.path.join(tmp_dir, "ner_no_trainer")))
 
+    @unittest.skip(reason="Fix me @zack")
     @mock.patch.dict(os.environ, {"WANDB_MODE": "offline"})
     def test_run_squad_no_trainer(self):
         tmp_dir = self.get_auto_remove_tmp_dir()


### PR DESCRIPTION
# What does this PR do?

Skip `test_run_squad_no_trainer` for now, as it is failing on `main`.