### PR TITLE
[docs] Fix Agents and Tools docstring

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -248,7 +248,7 @@ class Agent:
                 Whether to just return code and not evaluate it.
             remote (`bool`, *optional*, defaults to `False`):
                 Whether or not to use remote tools (inference endpoints) instead of local ones.
-            kwargs:
+            kwargs (additional keyword arguments, *optional*):
                 Any keyword argument to send to the agent when evaluating the code.
 
         Example:
@@ -298,7 +298,7 @@ class Agent:
                 Whether to just return code and not evaluate it.
             remote (`bool`, *optional*, defaults to `False`):
                 Whether or not to use remote tools (inference endpoints) instead of local ones.
-            kwargs:
+            kwargs (additional keyword arguments, *optional*):
                 Any keyword argument to send to the agent when evaluating the code.
 
         Example:

--- a/src/transformers/tools/base.py
+++ b/src/transformers/tools/base.py
@@ -188,7 +188,7 @@ class Tool:
                 `huggingface-cli login` (stored in `~/.huggingface`).
             remote (`bool`, *optional*, defaults to `False`):
                 Whether to use your tool by downloading the model or (if it is available) with an inference endpoint.
-            kwargs:
+            kwargs (additional keyword arguments, *optional*):
                 Additional keyword arguments that will be split in two: all arguments relevant to the Hub (such as
                 `cache_dir`, `revision`, `subfolder`) will be used when downloading the files for your tool, and the
                 others will be passed along to its init.
@@ -438,7 +438,7 @@ class PipelineTool(Tool):
         token (`str`, *optional*):
             The token to use as HTTP bearer authorization for remote files. If unset, will use the token generated when
             running `huggingface-cli login` (stored in `~/.huggingface`).
-        hub_kwargs:
+        hub_kwargs (additional keyword arguments, *optional*):
             Any additional keyword argument to send to the methods that will load the data from the Hub.
     """
 
@@ -631,7 +631,7 @@ def load_tool(task_or_repo_id, model_repo_id=None, remote=False, token=None, **k
         token (`str`, *optional*):
             The token to identify you on hf.co. If unset, will use the token generated when running `huggingface-cli
             login` (stored in `~/.huggingface`).
-        kwargs:
+        kwargs (additional keyword arguments, *optional*):
             Additional keyword arguments that will be split in two: all arguments relevant to the Hub (such as
             `cache_dir`, `revision`, `subfolder`) will be used when downloading the files for your tool, and the others
             will be passed along to its init.


### PR DESCRIPTION
Fixes the `kwarg` argument in the docstring to include what to expect, otherwise the `kwarg` gets mixed into the argument above it (see [here](https://huggingface.co/docs/transformers/main_classes/agent#transformers.Agent.chat.remote) for example).