### PR TITLE
fix gptj could not jit.trace in GPU

### DIFF
--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -212,7 +212,7 @@ class GPTJAttention(nn.Module):
         key = self._split_heads(key, self.num_attention_heads, self.head_dim, True)
         value = self._split_heads(value, self.num_attention_heads, self.head_dim, False)
 
-        if is_torch_fx_proxy(position_ids):
+        if is_torch_fx_proxy(position_ids) or torch.jit.is_tracing():
             # The logic to conditionally copy to GPU could not be traced, so we do this
             # every time in the torch.fx case
             embed_positions = get_embed_positions(self.embed_positions, position_ids)


### PR DESCRIPTION
# What does this PR do?
fix the jit failure issue for gptj

Fixes # (issue)
jit.trace for gptj fail in RTX8000
error like
ERROR: Tensor-valued Constant nodes differed in value across invocations. This often indicates that the tracer has encountered untraceable code.
        Node:
                %192 : Tensor = prim::Constant[value=<Tensor>](), scope: __module.transformer/__module.transformer.h.0/__module.transformer.h.0.attn # /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py:190:0
        Source Location:
                /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py(190): _get_embed_positions
                /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py(220): forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1488): _slow_forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1501): _call_impl
                /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py(309): forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1488): _slow_forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1501): _call_impl
                /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py(688): forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1488): _slow_forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1501): _call_impl
                /skyrex01/wangyi/transformers/src/transformers/models/gptj/modeling_gptj.py(853): forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1488): _slow_forward
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/nn/modules/module.py(1501): _call_impl
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/jit/_trace.py(1056): trace_module
                /skyrex05/wangyi/miniconda3/envs/deepspeed/lib/python3.9/site-packages/torch/jit/_trace.py(794): trace
                /skyrex01/wangyi/transformers/examples/pytorch/text-generation/run_generation.py(412): main
                /skyrex01/wangyi/transformers/examples/pytorch/text-generation/run_generation.py(458): <module>
        Comparison exception:   The values for attribute 'device' do not match: cpu != cuda:0.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sgugger
 -->
