### PR TITLE
Only add files with modification outside doc blocks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ _deps = [
     "psutil",
     "pyyaml>=5.1",
     "pydantic",
-    "pytest",
+    "pytest>=7.2.0",
     "pytest-timeout",
     "pytest-xdist",
     "python>=3.7.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -52,7 +52,7 @@ deps = {
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic",
-    "pytest": "pytest",
+    "pytest": "pytest>=7.2.0",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",
     "python": "python>=3.7.0",


### PR DESCRIPTION
# What does this PR do?

Add files for doctesting only when they have modifications outside docstrings.

(offline message from Sylvain)
> One small improvement I see is for the docstrings: for now the tests are launched on a file if we modify it, but I would only launch it if docstrings are modified (e.g. check the modifications are correct) to go faster. If changes in the code of a model file (for instance) trigger a doctest failure we will see it after. 