### PR TITLE
Fix issue introduced in PR #23163

### DIFF
--- a/src/transformers/onnx/config.py
+++ b/src/transformers/onnx/config.py
@@ -234,7 +234,7 @@ class OnnxConfig(ABC):
         if is_torch_available():
             from transformers.utils import get_torch_version
 
-            return get_torch_version() >= self.torch_onnx_minimum_version
+            return version.parse(get_torch_version()) >= self.torch_onnx_minimum_version
         else:
             return False
 

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from packaging import version
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
@@ -321,7 +322,7 @@ class OnnxExportTestCaseV2(TestCase):
         if is_torch_available():
             from transformers.utils import get_torch_version
 
-            if get_torch_version() < onnx_config.torch_onnx_minimum_version:
+            if version.parse(get_torch_version()) < onnx_config.torch_onnx_minimum_version:
                 pytest.skip(
                     "Skipping due to incompatible PyTorch version. Minimum required is"
                     f" {onnx_config.torch_onnx_minimum_version}, got: {get_torch_version()}"
@@ -364,7 +365,7 @@ class OnnxExportTestCaseV2(TestCase):
         if is_torch_available():
             from transformers.utils import get_torch_version
 
-            if get_torch_version() < onnx_config.torch_onnx_minimum_version:
+            if version.parse(get_torch_version()) < onnx_config.torch_onnx_minimum_version:
                 pytest.skip(
                     "Skipping due to incompatible PyTorch version. Minimum required is"
                     f" {onnx_config.torch_onnx_minimum_version}, got: {get_torch_version()}"

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -1,12 +1,12 @@
 import os
 import unittest
-from packaging import version
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
+from packaging import version
 from parameterized import parameterized
 
 from transformers import AutoConfig, PreTrainedTokenizerBase, is_tf_available, is_torch_available


### PR DESCRIPTION
# What does this PR do?

Fix issue introduced in PR #23163.

The previous `torch_version` is removed (which is not a string but a `version` type), and `get_torch_version()` is introduced and used (which is a string). In some places, it is compared against `self.torch_onnx_minimum_version` which is a string, and we know get on CI `TypeError: '<' not supported between instances of 'str' and 'Version'`.

This PR fixes this problem and avoid the > 1000 test failures.

(cc. @apbard FYI)