### PR TITLE
Revert "Only add files with modification outside doc blocks"

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -225,23 +225,10 @@ def get_diff_for_py_and_mdx_files(repo, base_commit, commits):
     for commit in commits:
         for diff_obj in commit.diff(base_commit):
             # We always add new python files
-            if diff_obj.change_type in ["A"] and (diff_obj.b_path.endswith(".py") or diff_obj.b_path.endswith(".mdx")):
-                code_diff.append(diff_obj.b_path)
-            # Now for modified files
-            elif (
-                diff_obj.change_type in ["M", "R"]
-                and diff_obj.b_path.endswith(".py")
-                or diff_obj.b_path.endswith(".mdx")
+            if diff_obj.change_type in ["A", "M", "R"] and (
+                diff_obj.b_path.endswith(".py") or diff_obj.b_path.endswith(".mdx")
             ):
-                # In case of renames, we'll look at the tests using both the old and new name.
-                if diff_obj.a_path != diff_obj.b_path:
-                    code_diff.extend([diff_obj.a_path, diff_obj.b_path])
-                else:
-                    # Otherwise, we check modifications are in code and not docstrings.
-                    if diff_is_docstring_only(repo, commit, diff_obj.b_path):
-                        print(f"Ignoring diff in {diff_obj.b_path} as it only concerns docstrings or comments.")
-                    else:
-                        code_diff.append(diff_obj.a_path)
+                code_diff.append(diff_obj.b_path)
 
     return code_diff
 


### PR DESCRIPTION
Reverts huggingface/transformers#23327.

I apologize, but I read Sylvain's messge too quickly and got it completely wrong.
> for now the tests are launched on a file if we modify it, but I would only launch it if docstrings are modified (e.g. check the modifications are correct) to go faster.

That merged PR did the converse instead: it adds a test file if only docstring (instead of only code) are modified.

I will need to create sth like `diff_is_code_only`.
