### PR TITLE
Update error message when Accelerate isn't installed

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1611,7 +1611,7 @@ class TrainingArguments:
         logger.info("PyTorch: setting up devices")
         if not is_sagemaker_mp_enabled() and not is_accelerate_available(check_partial_state=True):
             raise ImportError(
-                "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install --upgrade accelerate`"
+                "Using the `Trainer` with `PyTorch` requires `accelerate>=0.19.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
             )
         if self.no_cuda:
             self.distributed_state = PartialState(cpu=True, backend=self.ddp_backend)

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -502,7 +502,7 @@ def is_protobuf_available():
 
 def is_accelerate_available(check_partial_state=False):
     if check_partial_state:
-        return _accelerate_available and version.parse(_accelerate_version) >= version.parse("0.17.0")
+        return _accelerate_available and version.parse(_accelerate_version) >= version.parse("0.19.0")
     return _accelerate_available
 
 


### PR DESCRIPTION
# What does this PR do?

This PR provides a bit more verbose error when `accelerate` isn't found on an install of `transformers`, as the `Trainer` (on PyTorch) requires Accelerate to be installed.

The error message was changed from:
```python
ImportError: Using the Trainer with PyTorch requires accelerate: Run pip install --upgrade accelerate
```
To be:
```python
Using the `Trainer` with `PyTorch` requires `accelerate>=0.19.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`
```

Fixes # (issue)

- https://github.com/huggingface/transformers/issues/23323


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik 

(@sgugger when you are back)
