### PR TITLE
Skip failing `AlignModelTest::test_multi_gpu_data_parallel_forward`

### DIFF
--- a/tests/models/align/test_modeling_align.py
+++ b/tests/models/align/test_modeling_align.py
@@ -437,6 +437,10 @@ class AlignModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_model(*config_and_inputs)
 
+    @unittest.skip(reason="Start to fail after using torch `cu118`.")
+    def test_multi_gpu_data_parallel_forward(self):
+        super().test_multi_gpu_data_parallel_forward()
+
     @unittest.skip(reason="Hidden_states is tested in individual model tests")
     def test_hidden_states_output(self):
         pass


### PR DESCRIPTION
# What does this PR do?

`tests/models/align/test_modeling_align.py::AlignModelTest::test_multi_gpu_data_parallel_forward` starts to fail after we switch to `torch+cu118`. If I install back with `torch+cu117`, it passes again.

This test uses `torch.nn.DataParallel` which is not recommended (despite not deprecated yet). The error is pure CUDA thing for which I have no knowledge. Combing all the above facts + the usage of this model, let's just skip this particular test for `AlignModelTest`.

(This failing test cause the other 18 tests to fail due to the CUDA is in a bad state)

```bash
E       RuntimeError: Caught RuntimeError in replica 0 on device 0.
E       Original Traceback (most recent call last):
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/parallel/parallel_apply.py", line 64, in _worker
E           output = module(*input, **kwargs)
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
E           return forward_call(*args, **kwargs)
E         File "/transformers/src/transformers/models/align/modeling_align.py", line 1596, in forward
E           vision_outputs = self.vision_model(
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
E           return forward_call(*args, **kwargs)
E         File "/transformers/src/transformers/models/align/modeling_align.py", line 1395, in forward
E           embedding_output = self.embeddings(pixel_values)
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
E           return forward_call(*args, **kwargs)
E         File "/transformers/src/transformers/models/align/modeling_align.py", line 345, in forward
E           features = self.convolution(features)
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
E           return forward_call(*args, **kwargs)
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/conv.py", line 463, in forward
E           return self._conv_forward(input, self.weight, self.bias)
E         File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/conv.py", line 459, in _conv_forward
E           return F.conv2d(input, weight, bias, self.stride,
E       RuntimeError: GET was unable to find an engine to execute this computation
```