### PR TITLE
[AutoModel] fix `torch_dtype=auto` in `from_pretrained`

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -451,7 +451,7 @@ class _BaseAutoModelClass:
 
             # if torch_dtype=auto was passed here, ensure to pass it on
             if kwargs_orig.get("torch_dtype", None) == "auto":
-                kwargs["torch_dtype"] = kwargs_orig["torch_dtype"]
+                kwargs["torch_dtype"] = "auto"
 
         if hasattr(config, "auto_map") and cls.__name__ in config.auto_map:
             if not trust_remote_code:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -449,7 +449,8 @@ class _BaseAutoModelClass:
                 **kwargs,
             )
 
-            # pass torch_dtype=auto to the class's from_pretrained if torch_dtype=auto was passed here torch_dtype wasn't in the config object
+            # pass torch_dtype=auto to the class's from_pretrained if torch_dtype=auto was passed
+            # here torch_dtype wasn't in the config object
             if kwargs.get("torch_dtype", None) is None and kwargs_copy.get("torch_dtype", None) == "auto":
                 kwargs["torch_dtype"] = kwargs_copy["torch_dtype"]
 

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -438,16 +438,21 @@ class _BaseAutoModelClass:
             kwargs_copy = copy.deepcopy(kwargs)
             # ensure not to pollute the config object with torch_dtype="auto" - since it's
             # meaningless in the context of the config object - torch.dtype values are acceptable
-            if kwargs_copy.get("torch_dtype", None) == "auto":
-                _ = kwargs_copy.pop("torch_dtype")
+            if kwargs.get("torch_dtype", None) == "auto":
+                _ = kwargs.pop("torch_dtype")
 
             config, kwargs = AutoConfig.from_pretrained(
                 pretrained_model_name_or_path,
                 return_unused_kwargs=True,
                 trust_remote_code=trust_remote_code,
                 **hub_kwargs,
-                **kwargs_copy,
+                **kwargs,
             )
+
+            # pass torch_dtype=auto to the class's from_pretrained if torch_dtype=auto was passed here torch_dtype wasn't in the config object
+            if kwargs.get("torch_dtype", None) is None and kwargs_copy.get("torch_dtype", None) == "auto":
+                kwargs["torch_dtype"] = kwargs_copy["torch_dtype"]
+
         if hasattr(config, "auto_map") and cls.__name__ in config.auto_map:
             if not trust_remote_code:
                 raise ValueError(

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -435,7 +435,7 @@ class _BaseAutoModelClass:
         ]
         hub_kwargs = {name: kwargs.pop(name) for name in hub_kwargs_names if name in kwargs}
         if not isinstance(config, PretrainedConfig):
-            kwargs_copy = copy.deepcopy(kwargs)
+            kwargs_orig = copy.deepcopy(kwargs)
             # ensure not to pollute the config object with torch_dtype="auto" - since it's
             # meaningless in the context of the config object - torch.dtype values are acceptable
             if kwargs.get("torch_dtype", None) == "auto":
@@ -449,10 +449,9 @@ class _BaseAutoModelClass:
                 **kwargs,
             )
 
-            # pass torch_dtype=auto to the class's from_pretrained if torch_dtype=auto was passed
-            # here torch_dtype wasn't in the config object
-            if kwargs.get("torch_dtype", None) is None and kwargs_copy.get("torch_dtype", None) == "auto":
-                kwargs["torch_dtype"] = kwargs_copy["torch_dtype"]
+            # if torch_dtype=auto was passed here, ensure to pass it on
+            if kwargs_orig.get("torch_dtype", None) == "auto":
+                kwargs["torch_dtype"] = kwargs_orig["torch_dtype"]
 
         if hasattr(config, "auto_map") and cls.__name__ in config.auto_map:
             if not trust_remote_code:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2920,6 +2920,12 @@ class ModelUtilsTest(TestCasePlus):
         model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype="auto")
         self.assertEqual(model.dtype, torch.float16)
 
+        # 3. now retest that AutoModel behaves the same wrt torch_dtype="auto" as T5ForConditionalGeneration
+        model = AutoModel.from_pretrained(model_path, torch_dtype="auto")
+        self.assertEqual(model.dtype, torch.float16)
+
+
+
         # test fp16 save_pretrained, loaded with the explicit fp16
         model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype=torch.float16)
         self.assertEqual(model.dtype, torch.float16)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2924,8 +2924,6 @@ class ModelUtilsTest(TestCasePlus):
         model = AutoModel.from_pretrained(model_path, torch_dtype="auto")
         self.assertEqual(model.dtype, torch.float16)
 
-
-
         # test fp16 save_pretrained, loaded with the explicit fp16
         model = T5ForConditionalGeneration.from_pretrained(model_path, torch_dtype=torch.float16)
         self.assertEqual(model.dtype, torch.float16)


### PR DESCRIPTION
This PR:

1. fixes the case of `torch_dtype=auto` in `AutoModel.from_pretrained` which got unintentionally stripped in https://github.com/huggingface/transformers/pull/21524 - now `torch_dtype=auto` gets always passed on to the  `from_pretrained` method of the resolved class.
2. adds a test

Fixes: https://github.com/huggingface/transformers/issues/23357