### PR TITLE
Debug example code for MegaForCausalLM

### DIFF
--- a/src/transformers/models/mega/modeling_mega.py
+++ b/src/transformers/models/mega/modeling_mega.py
@@ -1743,7 +1743,7 @@ class MegaForCausalLM(MegaPreTrainedModel):
         >>> config = AutoConfig.from_pretrained("mnaylor/mega-base-wikitext")
         >>> config.is_decoder = True
         >>> config.bidirectional = False
-        >>> model = MegaForCausalLM.from_pretrained("mnaylor/mega-base-wikitext", config=config)
+        >>> model = MegaForCausalLM.from_pretrained("mnaylor/mega-base-wikitext", config=config, ignore_mismatched_sizes=True)
 
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         >>> outputs = model(**inputs)

--- a/src/transformers/models/mega/modeling_mega.py
+++ b/src/transformers/models/mega/modeling_mega.py
@@ -1743,7 +1743,9 @@ class MegaForCausalLM(MegaPreTrainedModel):
         >>> config = AutoConfig.from_pretrained("mnaylor/mega-base-wikitext")
         >>> config.is_decoder = True
         >>> config.bidirectional = False
-        >>> model = MegaForCausalLM.from_pretrained("mnaylor/mega-base-wikitext", config=config, ignore_mismatched_sizes=True)
+        >>> model = MegaForCausalLM.from_pretrained(
+        ...     "mnaylor/mega-base-wikitext", config=config, ignore_mismatched_sizes=True
+        ... )
 
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         >>> outputs = model(**inputs)


### PR DESCRIPTION
set ignore_mismatched_sizes=True in model loading code for MegaForCausalLM so that the example code runs without errors.

# What does this PR do?

Fixes # 22974


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.  https://github.com/huggingface/transformers/issues/22974
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts