### PR TITLE
Fix `RwkvModel`

### DIFF
--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -679,7 +679,7 @@ class RwkvModel(RwkvPreTrainedModel):
             all_hidden_states = all_hidden_states + (hidden_states,)
 
         if not return_dict:
-            return (hidden_states, state, all_hidden_states, all_self_attentions)
+            return tuple(x for x in [hidden_states, state, all_hidden_states, all_self_attentions] if x is not None)
 
         return RwkvOutput(
             last_hidden_state=hidden_states,


### PR DESCRIPTION
# What does this PR do?

The convention is to filter out the `None` value from the output tuple.

And without this, torchscript tests fail as it doesn't like `None` value.
