### PR TITLE
Generate: faster `can_generate` check on TF and Flax

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -474,7 +474,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
         # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation
-        if "GenerationMixin" in str(self.prepare_inputs_for_generation):
+        if "GenerationMixin" in str(self.prepare_inputs_for_generation.__func__):
             return False
         return True
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1243,7 +1243,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
         # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation
-        if "GenerationMixin" in str(self.prepare_inputs_for_generation):
+        if "GenerationMixin" in str(self.prepare_inputs_for_generation.__func__):
             return False
         return True
 


### PR DESCRIPTION
# What does this PR do?

Same as https://github.com/huggingface/transformers/pull/22643, but on TF and Flax.

[This comment](https://github.com/huggingface/transformers/pull/22643#issuecomment-1501033074) shows that it reduces the exec time of this line from 1-500 ms to <0.01 ms