### PR TITLE
[`Pix2Struct`] Add conditional generation on docstring example

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1687,6 +1687,15 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel):
         >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         >>> print(generated_text)
         A stop sign is on a street corner.
+
+        >>> # conditional generation
+        >>> text = "A picture of"
+        >>> inputs = processor(text=text, images=image, return_tensors="pt", add_special_tokens=False)
+
+        >>> generated_ids = model.generate(**inputs, max_new_tokens=50)
+        >>> generated_text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+        >>> print(generated_text)
+        A picture of a stop sign with a red stop sign on it.
         ```
 
         Training:


### PR DESCRIPTION
# What does this PR do?

As discussed in https://github.com/huggingface/transformers/pull/23391#issuecomment-1549555750 - this PR adds an example for users to run conditional generation using pix2struct. In fact, users shouldn't add special tokens when pre-pending the text - therefore it should be explicitly mentioned in the docs (done on the aformentioned PR) but also on the example snippets.

cc @amyeroberts 
