### PR TITLE
Build with non Python files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE

--- a/Makefile
+++ b/Makefile
@@ -111,3 +111,10 @@ post-release:
 
 post-patch:
 	python utils/release.py --post_release --patch
+
+build-release:
+	rm -rf dist
+	rm -rf build
+	python setup.py bdist_wheel
+	python setup.py sdist
+	python utils/check_build.py

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ To create the package for pypi.
    Check you can run the following commands:
    python -c "from transformers import pipeline; classifier = pipeline('text-classification'); print(classifier('What a nice release'))"
    python -c "from transformers import *"
+   python utils/check_build.py --check_lib
 
    If making a patch release, double check the bug you are patching is indeed resolved.
 
@@ -441,7 +442,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
-    package_data={"transformers": ["*.cu", "*.cpp", "*.cuh", "*.h", "*.pyx"]},
+    package_data={"": ["**/*.cu", "**/*.cpp", "**/*.cuh", "**/*.h", "**/*.pyx"]},
     zip_safe=False,
     extras_require=extras,
     entry_points={"console_scripts": ["transformers-cli=transformers.commands.transformers_cli:main"]},

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,9 @@ To create the package for pypi.
 7. Build both the sources and the wheel. Do not change anything in setup.py between
    creating the wheel and the source distribution (obviously).
 
-   Clean up your build and dist folders (to avoid re-uploading oldies):
-   rm -rf dist
-   rm -rf build
+   Run `make build-release`. This will build the release and do some sanity checks for you. If this ends with an error
+   message, you need to fix things before going further.
 
-   For the wheel, run: "python setup.py bdist_wheel" in the top level directory.
-   (this will build a wheel for the python version you use to build it).
-
-   For the sources, run: "python setup.py sdist"
    You should now have a /dist directory with both .whl and .tar.gz source versions.
 
 8. Check that everything looks correct by uploading the package to the pypi test server:

--- a/utils/check_build.py
+++ b/utils/check_build.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+def test_custom_files_are_present():
+    transformers_path = Path.cwd() / "build/lib/transformers"
+    # Test all the extensions added in the setup
+    if not (transformers_path / "kernels/rwkv/wkv_cuda.cu").exists():
+        return False
+    if not (transformers_path / "kernels/rwkv/wkv_op.cpp").exists():
+        return False
+    if not (transformers_path / "models/deformable_detr/custom_kernel/ms_deform_attn.h").exists():
+        return False
+    if not (transformers_path / "models/deformable_detr/custom_kernel/cuda/ms_deform_im2col_cuda.cuh").exists():
+        return False
+    if not (transformers_path / "models/graphormer/algos_graphormer.pyx").exists():
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    if not test_custom_files_are_present():
+        raise ValueError(
+            "The built release does not contain the custom files. Fix this before going further!"
+        )

--- a/utils/check_build.py
+++ b/utils/check_build.py
@@ -12,27 +12,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import argparse
+import importlib
 from pathlib import Path
 
-def test_custom_files_are_present():
-    transformers_path = Path.cwd() / "build/lib/transformers"
+
+# Test all the extensions added in the setup
+FILES_TO_FIND = [
+    "kernels/rwkv/wkv_cuda.cu",
+    "kernels/rwkv/wkv_op.cpp",
+    "models/deformable_detr/custom_kernel/ms_deform_attn.h",
+    "models/deformable_detr/custom_kernel/cuda/ms_deform_im2col_cuda.cuh",
+    "models/graphormer/algos_graphormer.pyx",
+]
+
+
+def test_custom_files_are_present(transformers_path):
     # Test all the extensions added in the setup
-    if not (transformers_path / "kernels/rwkv/wkv_cuda.cu").exists():
-        return False
-    if not (transformers_path / "kernels/rwkv/wkv_op.cpp").exists():
-        return False
-    if not (transformers_path / "models/deformable_detr/custom_kernel/ms_deform_attn.h").exists():
-        return False
-    if not (transformers_path / "models/deformable_detr/custom_kernel/cuda/ms_deform_im2col_cuda.cuh").exists():
-        return False
-    if not (transformers_path / "models/graphormer/algos_graphormer.pyx").exists():
-        return False
+    for file in FILES_TO_FIND:
+        if not (transformers_path / file).exists():
+            return False
     return True
 
 
 if __name__ == "__main__":
-    if not test_custom_files_are_present():
-        raise ValueError(
-            "The built release does not contain the custom files. Fix this before going further!"
-        )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check_lib", action="store_true", help="Whether to check the build or the actual package.")
+    args = parser.parse_args()
+    if args.check_lib:
+        transformers_module = importlib.import_module("transformers")
+        transformers_path = Path(transformers_module.__file__).parent
+    else:
+        transformers_path = Path.cwd() / "build/lib/transformers"
+    if not test_custom_files_are_present(transformers_path):
+        raise ValueError("The built release does not contain the custom files. Fix this before going further!")


### PR DESCRIPTION
# What does this PR do?

It appears the non python files (such as CUDA kernesl) have disappeared from the built package once again. Fir some reason there were found before with just `*.extension`, but now need `**/*.extension` (although once found again I can remove the **).

This is all super brittle, so this PR also adds:
- a check that the build package contains the non-Python files before we upload it on testpypi
- a check that the library installed does contain the non-Python files before we upload it on pypi

Will make a patch after this is merged.