### PR TITLE
Fix smdistributed check

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -118,7 +118,7 @@ if _sklearn_available:
         importlib_metadata.version("scikit-learn")
     except importlib_metadata.PackageNotFoundError:
         _sklearn_available = False
-_smdistributed_available = _is_package_available("smdistributed")
+_smdistributed_available = importlib.util.find_spec("smdistributed") is not None
 _soundfile_available = _is_package_available("soundfile")
 _spacy_available = _is_package_available("spacy")
 _sudachipy_available = _is_package_available("sudachipy")


### PR DESCRIPTION
# What does this PR do?

It turns out the `smdistributed` package does not have metadata so #23163 made this package always seem unavailable. This fixes it.