### PR TITLE
Use dict.items to avoid unnecessary lookups.

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -92,8 +92,7 @@ def _setup_default_tools():
     tools_module = main_module.tools
 
     remote_tools = get_remote_tools()
-    for task_name in TASK_MAPPING:
-        tool_class_name = TASK_MAPPING.get(task_name)
+    for task_name, tool_class_name in TASK_MAPPING.items():
         tool_class = getattr(tools_module, tool_class_name)
         description = tool_class.description
         HUGGINGFACE_DEFAULT_TOOLS[tool_class.name] = PreTool(task=task_name, description=description, repo_id=None)


### PR DESCRIPTION
# What does this PR do?

It's more efficient to iterate over key, value dict pairs instead of iterating over keys and performing value lookups on each iteration. It's also more idiomatic.