### PR TITLE
Fix a typo in HfAgent docstring.

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -430,7 +430,7 @@ class OpenAiAgent(Agent):
 
 class HfAgent(Agent):
     """
-    Agent that uses and inference endpoint to generate code.
+    Agent that uses an inference endpoint to generate code.
 
     Args:
         url_endpoint (`str`):


### PR DESCRIPTION
# What does this PR do?

Fixes a typo in HfAgent docstring.