### PR TITLE
Return early once stop token is found.

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -491,5 +491,5 @@ class HfAgent(Agent):
         # Inference API returns the stop sequence
         for stop_seq in stop:
             if result.endswith(stop_seq):
-                result = result[: -len(stop_seq)]
+                return result[: -len(stop_seq)]
         return result


### PR DESCRIPTION
# What does this PR do?

Previously even after finding a stop token, other stop tokens were considered, which is unnecessary and slows down processing.

Currently, this unnecessary overhead is negligible since there are usually 2 stop tokens considered and they are fairly short, but in future it may become more expensive.
