### PR TITLE
Encoder-Decoder: add informative exception when the decoder is not compatible

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -16,6 +16,7 @@
 
 
 import gc
+import inspect
 import os
 import tempfile
 import warnings
@@ -243,6 +244,13 @@ class EncoderDecoderModel(PreTrainedModel):
         if self.encoder.get_output_embeddings() is not None:
             raise ValueError(
                 f"The encoder {self.encoder} should not have a LM Head. Please use a model without LM Head"
+            )
+
+        decoder_signature = set(inspect.signature(self.decoder.forward).parameters.keys())
+        if "encoder_hidden_states" not in decoder_signature:
+            raise ValueError(
+                "The selected decoder is not prepared for the encoder hidden states to be passed. Please see the "
+                "following discussion on GitHub: https://github.com/huggingface/transformers/issues/23350"
             )
 
         # tie encoder, decoder weights if config set accordingly

--- a/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_tf_encoder_decoder.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """ Classes to support TF Encoder-Decoder architectures"""
 
-
+import inspect
 import re
 import warnings
 from typing import Optional, Tuple, Union
@@ -264,6 +264,13 @@ class TFEncoderDecoderModel(TFPreTrainedModel, TFCausalLanguageModelingLoss):
         if self.encoder.get_output_embeddings() is not None:
             raise ValueError(
                 f"The encoder {self.encoder} should not have a LM Head. Please use a model without LM Head"
+            )
+
+        decoder_signature = set(inspect.signature(self.decoder.call).parameters.keys())
+        if "encoder_hidden_states" not in decoder_signature:
+            raise ValueError(
+                "The selected decoder is not prepared for the encoder hidden states to be passed. Please see the "
+                "following discussion on GitHub: https://github.com/huggingface/transformers/issues/23350"
             )
 
     @property


### PR DESCRIPTION
# What does this PR do?

Related to https://github.com/huggingface/transformers/issues/23350

Many decoder models are not compatible with our `EncoderDecoder` structure (mostly because using the encoded hidden states appropriately requires extra code in the decoder model architecture itself). This PR adds an informative message in the presence of incompatible decoder models.