### PR TITLE
remove unnecessary print in gpt neox sequence classifier

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -863,7 +863,6 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
                     loss = loss_fct(pooled_logits, labels)
             elif self.config.problem_type == "single_label_classification":
                 loss_fct = CrossEntropyLoss()
-                print(pooled_logits.shape, labels.shape)
                 loss = loss_fct(pooled_logits.view(-1, self.num_labels), labels.view(-1))
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()


### PR DESCRIPTION
# What does this PR do?

Removes an unnecessary print from gpt neox's sequence classifier output which muffles unnecessary output that was likely used for debugging at one point. Before, training gpt neox as a sequence classifier would `print` the logit/label sizes every training step which is hard to muffle and generally not useful.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). **NA, original behaviour not documented**
- [ ] Did you write any new necessary tests? **NA, change too simple to require test**


## Who can review?

- text models: @ArthurZucker and @younesbelkada


