### PR TITLE
add cleanlab to awesome-transformers tools list

### DIFF
--- a/awesome-transformers.md
+++ b/awesome-transformers.md
@@ -584,7 +584,7 @@ Keywords: Active Learning, Research, Labeling
 
 ## [cleanlab](https://github.com/cleanlab/cleanlab)
 
-[cleanlab](https://github.com/cleanlab/cleanlab) is the standard data-centric AI package for data quality and machine learning with messy, real-world data and labels. For {text,image,tabular,audio,...} datasets, you can use cleanlab to automatically: detect data issues (outliers, label errors, near duplicates, etc), train robust ML models, infer consensus + annotator-quality for multi-annotator data, suggest data to (re)label next (active learning).
+[cleanlab](https://github.com/cleanlab/cleanlab) is the standard data-centric AI package for data quality and machine learning with messy, real-world data and labels. For text, image, tabular, audio (among others) datasets, you can use cleanlab to automatically: detect data issues (outliers, label errors, near duplicates, etc), train robust ML models, infer consensus + annotator-quality for multi-annotator data, suggest data to (re)label next (active learning).
 
 Keywords: Data-Centric AI, Data Quality, Noisy Labels, Outlier Detection, Active Learning  
 

--- a/awesome-transformers.md
+++ b/awesome-transformers.md
@@ -586,3 +586,5 @@ Keywords: Active Learning, Research, Labeling
 
 [cleanlab](https://github.com/cleanlab/cleanlab) is the standard data-centric AI package for data quality and machine learning with messy, real-world data and labels. For {text,image,tabular,audio,...} datasets, you can use cleanlab to automatically: detect data issues (outliers, label errors, near duplicates, etc), train robust ML models, infer consensus + annotator-quality for multi-annotator data, suggest data to (re)label next (active learning).
 
+Keywords: Data-Centric AI, Data Quality, Noisy Labels, Outlier Detection, Active Learning  
+

--- a/awesome-transformers.md
+++ b/awesome-transformers.md
@@ -582,3 +582,7 @@ Keywords: IR, Information Retrieval, Dense, Sparse
 
 Keywords: Active Learning, Research, Labeling
 
+## [cleanlab](https://github.com/cleanlab/cleanlab)
+
+[cleanlab](https://github.com/cleanlab/cleanlab) is the standard data-centric AI package for data quality and machine learning with messy, real-world data and labels. For {text,image,tabular,audio,...} datasets, you can use cleanlab to automatically: detect data issues (outliers, label errors, near duplicates, etc), train robust ML models, infer consensus + annotator-quality for multi-annotator data, suggest data to (re)label next (active learning).
+


### PR DESCRIPTION
This PR adds the cleanlab package to the awesome-transformers list.  

cleanlab uses **transformers** & Hugging Face in all sorts of ways. Here's a couple of them:
- [tutorial for text data with **transformers**](https://docs.cleanlab.ai/stable/tutorials/datalab/text.html)
- [active learning with **transformers**](https://github.com/cleanlab/examples/blob/master/active_learning_transformers/active_learning.ipynb)
- [auditing data in the  **datasets** format](https://github.com/cleanlab/examples/blob/master/datalab_image_classification/datalab.ipynb), which is now the [primary data format](https://docs.cleanlab.ai/stable/cleanlab/datalab/datalab.html) supported by cleanlab
- [how to wrap a **transformers** model to be sklearn compatible](https://github.com/cleanlab/examples/blob/master/transformer_sklearn/transformer_sklearn.ipynb)

I'm not sure which reviewer is most appropriate, but perhaps one of the listed documentation reviewers: 
@sgugger, @stevhliu or @MKhalusova

