### PR TITLE
Make `RwkvModel` accept `attention_mask` but discard it internally

### DIFF
--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -565,6 +565,15 @@ RWKV_INPUTS_DOCSTRING = r"""
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
+        attention_mask (`torch.LongTensor` of shape `(batch_size, input_ids_length)`, *optional*):
+            Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+
+            This is currently not used by `RwkvModel`, but will be supported in the future.
+
+            [What are attention masks?](../glossary#attention-mask)
         inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
             Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
             is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
@@ -617,7 +626,7 @@ class RwkvModel(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this is currently not used, but maybe in the future
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         use_cache: Optional[bool] = None,
@@ -751,7 +760,7 @@ class RwkvForCausalLM(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this is currently not used, but maybe in the future
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         labels: Optional[torch.LongTensor] = None,

--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -617,22 +617,14 @@ class RwkvModel(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this argument is currently not used, but probably in the future
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        attention_mask: Optional[bool] = None,
     ) -> Union[Tuple, RwkvOutput]:
-        if attention_mask is not None:
-            logger.warning_once(
-                "`RwkvModel` doesn't use `attention_mask` but its `forward` method receives a value which is not "
-                "`None`. The inputs are likely prepared with a tokenizer that outputs `attention_mask`. This will be "
-                "discarded by setting the value to `None`."
-            )
-            attention_mask = None  # noqa
-
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -759,7 +751,7 @@ class RwkvForCausalLM(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this argument is currently not used, but probably in the future
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         labels: Optional[torch.LongTensor] = None,

--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -625,13 +625,13 @@ class RwkvModel(RwkvPreTrainedModel):
         return_dict: Optional[bool] = None,
         attention_mask: Optional[bool] = None,
     ) -> Union[Tuple, RwkvOutput]:
-
         if attention_mask is not None:
             logger.warning_once(
                 "`RwkvModel` doesn't use `attention_mask` but its `forward` method receives a value which is not "
                 "`None`. The inputs are likely prepared with a tokenizer that outputs `attention_mask`. This will be "
                 "discarded by setting the value to `None`."
             )
+            attention_mask = None  # noqa
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -623,7 +623,16 @@ class RwkvModel(RwkvPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        attention_mask: Optional[bool] = None,
     ) -> Union[Tuple, RwkvOutput]:
+
+        if attention_mask is not None:
+            logger.warning_once(
+                "`RwkvModel` doesn't use `attention_mask` but its `forward` method receives a value which is not "
+                "`None`. The inputs are likely prepared with a tokenizer that outputs `attention_mask`. This will be "
+                "discarded by setting the value to `None`."
+            )
+
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -617,7 +617,7 @@ class RwkvModel(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this argument is currently not used, but probably in the future
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this is currently not used, but maybe in the future
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         use_cache: Optional[bool] = None,
@@ -751,7 +751,7 @@ class RwkvForCausalLM(RwkvPreTrainedModel):
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this argument is currently not used, but probably in the future
+        attention_mask: Optional[torch.LongTensor] = None,  # noqa: this is currently not used, but maybe in the future
         inputs_embeds: Optional[torch.FloatTensor] = None,
         state: Optional[List[torch.FloatTensor]] = None,
         labels: Optional[torch.LongTensor] = None,


### PR DESCRIPTION
# What does this PR do?

`RwkvModel` doesn't accept `attention_mask` but the tokenizer (it is `GPTNeoXTokenizer` from the checkpoints) prepares this input. When I try to run the pipeline tests for this model, I get 
```bash
TypeError: forward() got an unexpected keyword argument 'attention_mask'
```

I see it would be quite annoying for people using this model with the default tokenizer. So it might be good to accept it then discard it internally with a warning.
(If `RwkvModel` had its own tokenizer class `RwkvTokenizer`, we could do this inside tokenizer class. But here is not the case)
