### PR TITLE
Generate: increase left-padding test atol

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1597,7 +1597,6 @@ class GenerationTesterMixin:
                 attn_weights = out[attn_name] if attn_name == attention_names[0] else out[attn_name][-1]
                 self.assertEqual(sum([w.sum().item() for w in attn_weights]), 0.0)
 
-    @slow  # TODO (Joao): fix GPTBigCode
     def test_left_padding_compatibility(self):
         # The check done in this test is fairly difficult -- depending on the model architecture, passing the right
         # position index for the position embeddings can still result in a different output, due to numerical masking.
@@ -1637,7 +1636,7 @@ class GenerationTesterMixin:
                     position_ids.masked_fill_(padded_attention_mask == 0, 1)
                     model_kwargs["position_ids"] = position_ids
                 next_logits_with_padding = model(**model_kwargs).logits[:, -1, :]
-                if not torch.allclose(next_logits_wo_padding, next_logits_with_padding):
+                if not torch.allclose(next_logits_wo_padding, next_logits_with_padding, atol=1e-7):
                     no_failures = False
                     break
 


### PR DESCRIPTION
# What does this PR do?

As stated in #23437, `GPTBigCode` was failing the left padding test. Upon further investigation:
1. `GPTBigCode` is left padding compatible, it accepts `position_ids` and uses them correctly
2. The test is only failing on CPU
3. The diff extremely small...

...so I've raised `atol` to `1e-7` (instead of the default `1e-8`) 👀 With `1e-7`, we can still detect failing cases, like the ones skipped in #23437 