### PR TITLE
Properly guard PyTorch stuff

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -40,6 +40,8 @@ if is_openai_available():
 if is_torch_available():
     from ..generation import StoppingCriteria, StoppingCriteriaList
     from ..models.auto import AutoModelForCausalLM
+else:
+    StoppingCriteria = object
 
 _tools_are_initialized = False
 

--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -24,9 +24,8 @@ from typing import Dict
 import requests
 from huggingface_hub import HfFolder, hf_hub_download, list_spaces
 
-from ..generation import StoppingCriteria, StoppingCriteriaList
 from ..models.auto import AutoModelForCausalLM, AutoTokenizer
-from ..utils import is_openai_available, logging
+from ..utils import is_openai_available, is_torch_available, logging
 from .base import TASK_MAPPING, TOOL_CONFIG_FILE, Tool, load_tool, supports_remote
 from .prompts import CHAT_MESSAGE_PROMPT, CHAT_PROMPT_TEMPLATE, RUN_PROMPT_TEMPLATE
 from .python_interpreter import evaluate
@@ -37,6 +36,9 @@ logger = logging.get_logger(__name__)
 
 if is_openai_available():
     import openai
+
+if is_torch_available():
+    from ..generation import StoppingCriteria, StoppingCriteriaList
 
 _tools_are_initialized = False
 

--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -24,7 +24,7 @@ from typing import Dict
 import requests
 from huggingface_hub import HfFolder, hf_hub_download, list_spaces
 
-from ..models.auto import AutoModelForCausalLM, AutoTokenizer
+from ..models.auto import AutoTokenizer
 from ..utils import is_openai_available, is_torch_available, logging
 from .base import TASK_MAPPING, TOOL_CONFIG_FILE, Tool, load_tool, supports_remote
 from .prompts import CHAT_MESSAGE_PROMPT, CHAT_PROMPT_TEMPLATE, RUN_PROMPT_TEMPLATE
@@ -39,6 +39,7 @@ if is_openai_available():
 
 if is_torch_available():
     from ..generation import StoppingCriteria, StoppingCriteriaList
+    from ..models.auto import AutoModelForCausalLM
 
 _tools_are_initialized = False
 


### PR DESCRIPTION
# What does this PR do?

#23438 accidentally broke main since the objects in `.generation` imported are only available when PyTorch is installed. This PR fixes that.