### PR TITLE
Fix confusing `transformers` installation in CI

### DIFF
--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -115,7 +115,7 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
@@ -176,7 +176,7 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
@@ -225,7 +225,7 @@ jobs:
         working-directory: /workspace/transformers
         run: git fetch && git checkout ${{ github.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /workspace/transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 

--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -115,6 +115,10 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
 
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
       - name: NVIDIA-SMI
         run: |
           nvidia-smi
@@ -172,6 +176,10 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
 
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
       - name: NVIDIA-SMI
         run: |
           nvidia-smi
@@ -216,6 +224,10 @@ jobs:
       - name: Update clone
         working-directory: /workspace/transformers
         run: git fetch && git checkout ${{ github.sha }}
+
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
       - name: Remove cached torch extensions
         run: rm -rf /github/home/.cache/torch_extensions/

--- a/.github/workflows/self-nightly-scheduled.yml
+++ b/.github/workflows/self-nightly-scheduled.yml
@@ -226,7 +226,7 @@ jobs:
         run: git fetch && git checkout ${{ github.sha }}
 
       - name: Reinstall transformers in edit mode (removed the one during docker image build)
-        working-directory: /transformers
+        working-directory: /workspace/transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
       - name: Remove cached torch extensions

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -111,7 +111,7 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ inputs.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
@@ -187,7 +187,7 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ inputs.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
@@ -263,7 +263,7 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
 
-      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 

--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -111,6 +111,10 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ inputs.sha }}
 
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -183,6 +187,10 @@ jobs:
         working-directory: /transformers
         run: git fetch && git checkout ${{ inputs.sha }}
 
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -254,6 +262,10 @@ jobs:
       - name: Update clone
         working-directory: /transformers
         run: git fetch && git checkout ${{ github.sha }}
+
+      - name: Reinstall transformers in edit mode (removed the one during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
       - name: Install
         working-directory: /transformers


### PR DESCRIPTION
# What does this PR do?

As mentioned in [this comment](https://github.com/huggingface/transformers/pull/23277#issuecomment-1544080975), the `transformers` in CI runs is not the same one installed during docker image build.

Furthermore, for past CI, we didn't update the docker image daily (there is no need to update the fixed 3rd-packages environment), but the `transformers` code is the latest one being test against. We get 
```bash
E   ImportError: cannot import name 'HfDoctestModule' from 'transformers.testing_utils'
```
as the `transformers` is the one during docker image build (months ago) which has no `HfDoctestModule` at the time.

To avoid and fix all such super confusing failures in the future, it's better to install the `transformers` again in the edit mode in the workflow files.

I don't change the daily CI workflow file yet in this PR -  I would wait this PR showing the change actually fix issues.