### PR TITLE
[`RWKV`] Rwkv fix for 8bit inference

### DIFF
--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -709,6 +709,7 @@ class RwkvModel(RwkvPreTrainedModel):
                         block.attention.output.weight.mul_(2 ** int(block_id // self.config.rescale_every))
                         block.feed_forward.value.weight.mul_(2 ** int(block_id // self.config.rescale_every))
                     else:
+                        # Deal with quantization statistics
                         if hasattr(block.attention.output.weight, "SCB"):
                             block.attention.output.weight.SCB.div_(2 ** int(block_id // self.config.rescale_every))
                             block.feed_forward.value.weight.SCB.div_(2 ** int(block_id // self.config.rescale_every))

--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -709,8 +709,12 @@ class RwkvModel(RwkvPreTrainedModel):
                         block.attention.output.weight.mul_(2 ** int(block_id // self.config.rescale_every))
                         block.feed_forward.value.weight.mul_(2 ** int(block_id // self.config.rescale_every))
                     else:
-                        block.attention.output.weight.div_(2 ** int(block_id // self.config.rescale_every))
-                        block.feed_forward.value.weight.div_(2 ** int(block_id // self.config.rescale_every))
+                        if hasattr(block.attention.output.weight, "SCB"):
+                            block.attention.output.weight.SCB.div_(2 ** int(block_id // self.config.rescale_every))
+                            block.feed_forward.value.weight.SCB.div_(2 ** int(block_id // self.config.rescale_every))
+                        else:
+                            block.attention.output.weight.div_(2 ** int(block_id // self.config.rescale_every))
+                            block.feed_forward.value.weight.div_(2 ** int(block_id // self.config.rescale_every))
 
         self.layers_are_rescaled = not self.training
 


### PR DESCRIPTION
# What does this PR do?

Fixes #23467

RWKV architecture scales down some linear layer weights with a certain factor at various stages for inference and training.
In the case of 8bit models, this leads to an error because the weight matrix is now an `int8` matrix. Therefore to apply the scaling one needs to scale the quantization statistics that are stored inside the `SCB` attribute.

cc @amyeroberts 

```python
from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
import torch

model_id = "RWKV/rwkv-4-1b5-pile"

model = AutoModelForCausalLM.from_pretrained(model_id, load_in_8bit=True, device_map={"":0})
tokenizer = AutoTokenizer.from_pretrained(model_id)

generation_config = GenerationConfig(max_new_tokens=20, pad_token_id=tokenizer.eos_token_id)
question = "Hello my name is"
inputs = tokenizer(question, return_tensors="pt").to(0)
output_int8 = model.generate((inputs["input_ids"]), generation_config=generation_config)
print(tokenizer.decode(output_int8[0], skip_special_tokens=True))
>>> Hello my name is John and I am a student at the University of Texas at Austin. I am a member of the

model_fp16 = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map={"":1})
output_fp16 = model_fp16.generate((inputs["input_ids"]), generation_config=generation_config)
print(tokenizer.decode(output_fp16[0], skip_special_tokens=True))
>>> Hello my name is John and I am a student at the University of South Florida. I am a member of the Alpha
```
