### PR TITLE
add use_orig_params to fsdp with torch compile

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1442,9 +1442,7 @@ class Trainer:
         # Distributed training using PyTorch FSDP
         elif self.fsdp is not None:
             # Torch compile requires use_orig_params in FSDP
-            use_orig_params = False
-            if self.args.torch_compile and is_torch_compile_available():
-                use_orig_params = True
+            use_orig_params = self.args.torch_compile and is_torch_compile_available()
             if not self.args.fsdp_config["xla"]:
                 # PyTorch FSDP!
                 from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1441,6 +1441,10 @@ class Trainer:
                 ).to(self.args.device)
         # Distributed training using PyTorch FSDP
         elif self.fsdp is not None:
+            # Torch compile requires use_orig_params in FSDP
+            use_orig_params = False
+            if self.args.torch_compile and is_torch_compile_available():
+                use_orig_params = True
             if not self.args.fsdp_config["xla"]:
                 # PyTorch FSDP!
                 from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload, MixedPrecision
@@ -1494,6 +1498,7 @@ class Trainer:
                         auto_wrap_policy=auto_wrap_policy,
                         mixed_precision=mixed_precision_policy,
                         device_id=self.args.device,
+                        use_orig_params=use_orig_params,
                         **kwargs,
                     )
             else:
@@ -1536,6 +1541,7 @@ class Trainer:
                     model,
                     auto_wrap_policy=auto_wrap_policy,
                     auto_wrapper_callable=auto_wrapper_callable,
+                    use_orig_params=use_orig_params,
                     **fsdp_kwargs,
                 )
 


### PR DESCRIPTION
# What does this PR do?

The FSDP wrapper inside `trainer.py` needs to be initialized with `use_orig_params=True` for FSDP + `torch.compile` to work well together. Therefore, I added some code to check inside the relevant FSDP section if `torch_compile` is set to `True` to then add `use_orig_params` with the corresponding value to FSDP.

Fixes #23341

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger
@pacman100