### PR TITLE
Fix `tests/repo_utils/test_get_test_info.py`

### DIFF
--- a/tests/repo_utils/test_get_test_info.py
+++ b/tests/repo_utils/test_get_test_info.py
@@ -45,7 +45,7 @@ class GetTestInfoTester(unittest.TestCase):
             "BlipTextImageModelTest": "BlipTextImageModelsModelTester",
             "BlipTextModelTest": "BlipTextModelTester",
             "BlipTextRetrievalModelTest": "BlipTextRetrievalModelTester",
-            "BlipVQAModelTest": "BlipModelTester",
+            "BlipVQAModelTest": "BlipVQAModelTester",
             "BlipVisionModelTest": "BlipVisionModelTester",
         }
 
@@ -71,7 +71,7 @@ class GetTestInfoTester(unittest.TestCase):
         EXPECTED_BLIP_MAPPING = {
             "BlipForConditionalGeneration": ["BlipTextImageModelTest"],
             "BlipForImageTextRetrieval": ["BlipTextRetrievalModelTest"],
-            "BlipForQuestionAnswering": ["BlipTextImageModelTest", "BlipVQAModelTest"],
+            "BlipForQuestionAnswering": ["BlipVQAModelTest"],
             "BlipModel": ["BlipModelTest"],
             "BlipTextModel": ["BlipTextModelTest"],
             "BlipVisionModel": ["BlipVisionModelTest"],
@@ -99,7 +99,7 @@ class GetTestInfoTester(unittest.TestCase):
         EXPECTED_BLIP_MAPPING = {
             "BlipForConditionalGeneration": ["BlipTextImageModelsModelTester"],
             "BlipForImageTextRetrieval": ["BlipTextRetrievalModelTester"],
-            "BlipForQuestionAnswering": ["BlipModelTester", "BlipTextImageModelsModelTester"],
+            "BlipForQuestionAnswering": ["BlipVQAModelTester"],
             "BlipModel": ["BlipModelTester"],
             "BlipTextModel": ["BlipTextModelTester"],
             "BlipVisionModel": ["BlipVisionModelTester"],


### PR DESCRIPTION
# What does this PR do?

3 tests break on `main` after #23153 (see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/64922/workflows/d53f3351-a1d1-4df5-9c8b-28c45fff4f09/jobs/805142)), but can't blame @younesbelkada as the tests are not triggered on PR CI, neither after being merged. But on nightly CircleCI run, failures are detected.