### PR TITLE
Fix accelerate logger bug

### DIFF
--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -42,7 +42,7 @@ from transformers.utils.versions import importlib_metadata
 
 
 if is_accelerate_available():
-    from accelerate import Accelerator
+    from accelerate import PartialState
     from accelerate.logging import get_logger
 
     logger = get_logger(__name__)

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -46,7 +46,7 @@ if is_accelerate_available():
     from accelerate.logging import get_logger
 
     logger = get_logger(__name__)
-    _ = Accelerator()
+    _ = PartialState()
 
 if is_torch_available():
     import torch

--- a/tests/mixed_int8/test_mixed_int8.py
+++ b/tests/mixed_int8/test_mixed_int8.py
@@ -29,6 +29,7 @@ from transformers import (
     pipeline,
 )
 from transformers.testing_utils import (
+    is_accelerate_available,
     is_torch_available,
     require_accelerate,
     require_bitsandbytes,
@@ -39,6 +40,13 @@ from transformers.testing_utils import (
 )
 from transformers.utils.versions import importlib_metadata
 
+
+if is_accelerate_available():
+    from accelerate import Accelerator
+    from accelerate.logging import get_logger
+
+    logger = get_logger(__name__)
+    _ = Accelerator()
 
 if is_torch_available():
     import torch


### PR DESCRIPTION
# What does this PR do?

Fixes a slow test that requires accelerate t[hat is currently failing](https://github.com/huggingface/transformers/actions/runs/5035387610/jobs/9030918234) with the following error:

```bash
RuntimeError: You must initialize the accelerate state by calling either `PartialState()` or `Accelerator()` before using the logging utility.
```

I suspect this comes from https://github.com/huggingface/accelerate/pull/1446 
The fix seems to be to first initialize a dummy accelerator. However I couldn't reproduce the issue with a simpler snippet. It seems to appear only when a model is created together with CPU offloading + multi GPU. 

I tried this snippet:
```python
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "bigscience/bloom-1b7"

device_map = {
    "transformer.word_embeddings": 0,
    "transformer.word_embeddings_layernorm": 0,
    "lm_head": 0,
    "transformer.h.0": "cpu",
    "transformer.h.1": "cpu",
    "transformer.h.2": 0,
    "transformer.h.3": 0,
    "transformer.h.4": 0,
    "transformer.h.5": 0,
    "transformer.h.6": 0,
    "transformer.h.7": 0,
    "transformer.h.8": 0,
    "transformer.h.9": 1,
    "transformer.h.10": 0,
    "transformer.h.11": 1,
    "transformer.h.12": 0,
    "transformer.h.13": 0,
    "transformer.h.14": 1,
    "transformer.h.15": 0,
    "transformer.h.16": 0,
    "transformer.h.17": 1,
    "transformer.h.18": 1,
    "transformer.h.19": 0,
    "transformer.h.20": 1,
    "transformer.h.21": 1,
    "transformer.h.22": 0,
    "transformer.h.23": 0,
    "transformer.ln_f": 1,
}

model = AutoModelForCausalLM.from_pretrained(
    model_id,
    device_map=device_map,
)

tokenizer = AutoTokenizer.from_pretrained(model_id)

input_text = "hello"
encoded_input = tokenizer(input_text, return_tensors="pt")

# Check the exactness of the results
output_parallel = model.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
```
But it didn't raised any error, strangely, the error is only raised when the test is run.

I would appreciate any insight @muellerzr @sgugger 🙏 