### PR TITLE
Muellerzr fix deepspeed

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1733,7 +1733,7 @@ class TrainingArguments:
             self.distributed_state is not None and self.distributed_state.distributed_type != DistributedType.NO
         ) or (self.distributed_state is None and self.local_rank != -1):
             return ParallelMode.DISTRIBUTED
-        elif self.n_gpu > 1:
+        elif self._n_gpu > 1:
             return ParallelMode.NOT_DISTRIBUTED
         else:
             return ParallelMode.NOT_PARALLEL

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1708,7 +1708,8 @@ class TrainingArguments:
         """
         requires_backends(self, ["torch"])
         # Make sure `self._n_gpu` is properly setup.
-        _ = self._setup_devices
+        if not hasattr(self, "_n_gpu"):
+            _ = self._setup_devices
         return self._n_gpu
 
     @property
@@ -1733,7 +1734,7 @@ class TrainingArguments:
             self.distributed_state is not None and self.distributed_state.distributed_type != DistributedType.NO
         ) or (self.distributed_state is None and self.local_rank != -1):
             return ParallelMode.DISTRIBUTED
-        elif self._n_gpu > 1:
+        elif self.n_gpu > 1:
             return ParallelMode.NOT_DISTRIBUTED
         else:
             return ParallelMode.NOT_PARALLEL


### PR DESCRIPTION
# What does this PR do?

This PR fixes the slow tests by avoiding a recursion issue with `self.n_gpus`. It has `self.n_gpu` first check to see if we've assigned/spawned `self._n_gpu`, and if not then call setup_devices. This let's us maintain the clean `ParallelMode.DISTRIBUTED` check, without needing the complex check block in `setup_devices`.

I've confirmed DeepSpeed tests pass.

If we'd rather not do this, then the logic at https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L1732-L1735 would need to be repeated (which can be done, just a bit messy)

Fixes # (issue)

Failing deepspeed tests on nightly


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger
