### PR TITLE
[`SAM`] Fixes pipeline and adds a dummy pipeline test

### DIFF
--- a/src/transformers/models/sam/image_processing_sam.py
+++ b/src/transformers/models/sam/image_processing_sam.py
@@ -934,7 +934,7 @@ def _generate_crop_boxes(
     cropped_images, point_grid_per_crop = _generate_crop_images(
         crop_boxes, image, points_grid, layer_idxs, target_size, original_size
     )
-
+    crop_boxes = np.array(crop_boxes)
     crop_boxes = crop_boxes.astype(np.float32)
     points_per_crop = np.array([point_grid_per_crop])
     points_per_crop = np.transpose(points_per_crop, axes=(0, 2, 1, 3))

--- a/tests/models/sam/test_modeling_sam.py
+++ b/tests/models/sam/test_modeling_sam.py
@@ -752,7 +752,7 @@ class SamModelIntegrationTest(unittest.TestCase):
         self.assertTrue(iou_scores.shape == (1, 3, 3))
         torch.testing.assert_allclose(iou_scores, EXPECTED_IOU, atol=1e-4, rtol=1e-4)
 
-    def test_simple_pipeline(self):
+    def test_dummy_pipeline_generation(self):
         generator = pipeline("mask-generation", model="facebook/sam-vit-base", device=torch_device)
         raw_image = prepare_image()
 

--- a/tests/models/sam/test_modeling_sam.py
+++ b/tests/models/sam/test_modeling_sam.py
@@ -20,7 +20,7 @@ import unittest
 
 import requests
 
-from transformers import SamConfig, SamMaskDecoderConfig, SamPromptEncoderConfig, SamVisionConfig
+from transformers import SamConfig, SamMaskDecoderConfig, SamPromptEncoderConfig, SamVisionConfig, pipeline
 from transformers.testing_utils import require_torch, slow, torch_device
 from transformers.utils import is_torch_available, is_vision_available
 
@@ -751,3 +751,9 @@ class SamModelIntegrationTest(unittest.TestCase):
         iou_scores = outputs.iou_scores.cpu()
         self.assertTrue(iou_scores.shape == (1, 3, 3))
         torch.testing.assert_allclose(iou_scores, EXPECTED_IOU, atol=1e-4, rtol=1e-4)
+
+    def test_simple_pipeline(self):
+        generator = pipeline("mask-generation", model="facebook/sam-vit-base", device=torch_device)
+        raw_image = prepare_image()
+
+        _ = generator(raw_image, points_per_batch=64)


### PR DESCRIPTION
# What does this PR do?

1- Fixes the automatic mask generation pipeline, currently on the main branch, the script below

```python
from transformers import pipeline
from PIL import Image
import requests

generator = pipeline("mask-generation", model="facebook/sam-vit-base", device=0)

img_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/car.jpg"
raw_image = Image.open(requests.get(img_url, stream=True).raw).convert("RGB")

outputs = generator(raw_image, points_per_batch=64)
```
is broken

2- Adds a dummy pipeline test. I know the pipelines are already tested in tests/pipeline but these tests are quite slow. I thought adding a small dummy pipeline test is easier for future contributors to make sure they will not break the pipeline without having to run the entire pipeline testing suite for SAM


cc @ArthurZucker @ydshieh @sgugger 