### PR TITLE
feat: add warning for using use_pretrained_backbone with from_pretrained

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2162,6 +2162,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         variant = kwargs.pop("variant", None)
         use_safetensors = kwargs.pop("use_safetensors", None if is_safetensors_available() else False)
 
+        if kwargs.get("use_pretrained_backbone") is not None:
+            logger.warning(
+                "The weights from using `use_pretrained_backbone` may be overriden when using `from_pretrained`."
+            )
+
         if is_bitsandbytes_available():
             is_8bit_serializable = version.parse(importlib_metadata.version("bitsandbytes")) > version.parse("0.37.2")
         else:


### PR DESCRIPTION
# What does this PR do?

This PR adds a warning when using `from_pretrained` and you also have `use_pretrained_backbone` enabled. `from_pretrained` will load its weights after the pretrained backbone is initialized meaning some weights may be unexpectedly overridden. I am not sure if this case is general enough to warrant a warning. The more general case would be if any weights are loaded before the `from_pretrained` weights. An additional feature would be to allow selectively loading weights using `from_pretrained`, but I understand if that use case is too esoteric. 

```
model = DetrForObjectDetection.from_pretrained(
    "facebook/detr-resnet-50",
    num_labels=len(categories.keys()),
    id2label=id2label,
    label2id=label2id,
    ignore_mismatched_sizes=True,
    num_queries=20,
    backbone="resnet50",
    use_pretrained_backbone=True,
    use_timm_backbone=True,    
)
```

For the scenario above, the `use_pretrained_backbone` will not have any effect as the `facebook/detr-resnet-50` weights will take precedent. 

## Who can review?

Perhaps this is the area of @sgugger or @amyeroberts 