### PR TITLE
Fix a `BridgeTower` test

### DIFF
--- a/tests/models/bridgetower/test_modeling_bridgetower.py
+++ b/tests/models/bridgetower/test_modeling_bridgetower.py
@@ -627,7 +627,8 @@ class BridgeTowerModelTrainingTest(unittest.TestCase):
         non_used_layer_names = ["text_model.pooler"]
         if model_class == BridgeTowerForMaskedLM:
             non_used_layer_names = non_used_layer_names + [
-                "cross_modal_image_layers.5",
+                # This number `1` actually depends on the number of layers in `cross_modal_image_layers` (by minus 1)
+                "cross_modal_image_layers.1",
                 "cross_modal_image_pooler",
                 "cross_modal_text_pooler",
             ]


### PR DESCRIPTION
# What does this PR do?

A fix is required after #23029.

So far on main, an error is given

```bash
tests/models/bridgetower/test_modeling_bridgetower.py::BridgeTowerModelTrainingTest::test_training
(line 656)  AssertionError: unexpectedly None : Gradients should not be None - got None for bridgetower.cross_modal_image_layers.1.attention.self.query.weight
```