### PR TITLE
Skip `TFCvtModelTest::test_keras_fit_mixed_precision` for now

### DIFF
--- a/tests/models/cvt/test_modeling_tf_cvt.py
+++ b/tests/models/cvt/test_modeling_tf_cvt.py
@@ -186,6 +186,7 @@ class TFCvtModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     def test_keras_fit(self):
         super().test_keras_fit()
 
+    @unittest.skip(reason="Get `Failed to determine best cudnn convolution algo.` error after using TF 2.12+cuda 11.8")
     def test_keras_fit_mixed_precision(self):
         policy = tf.keras.mixed_precision.Policy("mixed_float16")
         tf.keras.mixed_precision.set_global_policy(policy)


### PR DESCRIPTION
# What does this PR do?

#23339 uses TF 2.12 with CUDA 11.8 (and CUDNN 8700). With those, the test
```bash
tests/models/cvt/test_modeling_tf_cvt.py::TFCvtModelTest::test_keras_fit_mixed_precision
```
gets
```bash
 tensorflow.python.framework.errors_impl.UnknownError: Failed to determine best cudnn convolution algorithm for:
```
and affect other two tests
```bash
FAILED tests/models/cvt/test_modeling_tf_cvt.py::TFCvtModelTest::test_pt_tf_model_equivalence - AssertionError: 0.007014513 not less than or equal to 1e-05 : outputs.last_hidden_state: Difference between torch and tf is 0.00701451301574707 (>= 1e-05).
FAILED tests/models/cvt/test_modeling_tf_cvt.py::TFCvtModelIntegrationTest::test_inference_image_classification_head - AssertionError: False is not true
```
**Those 2 tests will pass if `test_keras_fit_mixed_precision` is not run in the same pytest process.** (probably the GPU/CUDA/CUDNN is in bad states).

We will have to take a look and fix `test_keras_fit_mixed_precision`. But in the meantime, **let's skip it and not to affect the other 2 tests.**

@Rocketknight1 If you ever want to take a look this CUDA/CUDNN/TF issue. (Maybe better to open an issue in TF repo. but it may take 10 years to get a fix)