### PR TITLE
TF SAM memory reduction

### DIFF
--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -918,7 +918,6 @@ class TFSamVisionAttention(tf.keras.layers.Layer):
             )
         attn_weights = tf.nn.softmax(attn_weights, axis=-1)
 
-
         if training:
             attn_probs = tf.nn.dropout(attn_weights, rate=self.dropout)
         else:

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -916,7 +916,6 @@ class TFSamVisionAttention(tf.keras.layers.Layer):
             attn_weights = self.add_decomposed_rel_pos(
                 attn_weights, query, self.rel_pos_h, self.rel_pos_w, (height, width), (height, width)
             )
-        print(attn_weights.shape)
         attn_weights = tf.nn.softmax(attn_weights, axis=-1)
 
 

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -248,7 +248,6 @@ class TFSamAttention(tf.keras.layers.Layer):
         )  # batch_size * point_batch_size  x N_heads x N_tokens x N_tokens
         attn = attn / tf.math.sqrt(float(c_per_head))
         attn = tf.nn.softmax(attn, axis=-1)
-        breakpoint()
 
         # Get output
         out = tf.matmul(attn, value)

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -248,6 +248,7 @@ class TFSamAttention(tf.keras.layers.Layer):
         )  # batch_size * point_batch_size  x N_heads x N_tokens x N_tokens
         attn = attn / tf.math.sqrt(float(c_per_head))
         attn = tf.nn.softmax(attn, axis=-1)
+        breakpoint()
 
         # Get output
         out = tf.matmul(attn, value)
@@ -1155,7 +1156,7 @@ class TFSamPreTrainedModel(TFPreTrainedModel):
         """
         VISION_DUMMY_INPUTS = tf.random.uniform(
             shape=(
-                3,
+                1,
                 self.config.vision_config.num_channels,
                 self.config.vision_config.image_size,
                 self.config.vision_config.image_size,

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -248,6 +248,7 @@ class TFSamAttention(tf.keras.layers.Layer):
         )  # batch_size * point_batch_size  x N_heads x N_tokens x N_tokens
         attn = attn / tf.math.sqrt(float(c_per_head))
         attn = tf.nn.softmax(attn, axis=-1)
+        print(attn.shape)
 
         # Get output
         out = tf.matmul(attn, value)
@@ -918,6 +919,7 @@ class TFSamVisionAttention(tf.keras.layers.Layer):
             )
 
         attn_weights = tf.nn.softmax(attn_weights, axis=-1)
+
 
         if training:
             attn_probs = tf.nn.dropout(attn_weights, rate=self.dropout)

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -916,6 +916,7 @@ class TFSamVisionAttention(tf.keras.layers.Layer):
             attn_weights = self.add_decomposed_rel_pos(
                 attn_weights, query, self.rel_pos_h, self.rel_pos_w, (height, width), (height, width)
             )
+
         attn_weights = tf.nn.softmax(attn_weights, axis=-1)
 
         if training:

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -243,8 +243,6 @@ class TFSamAttention(tf.keras.layers.Layer):
 
         # SamAttention
         _, _, _, c_per_head = shape_list(query)
-        print(query.shape)
-        print(key.shape)
         attn = tf.matmul(
             query, tf.transpose(key, perm=[0, 1, 3, 2])
         )  # batch_size * point_batch_size  x N_heads x N_tokens x N_tokens
@@ -918,7 +916,7 @@ class TFSamVisionAttention(tf.keras.layers.Layer):
             attn_weights = self.add_decomposed_rel_pos(
                 attn_weights, query, self.rel_pos_h, self.rel_pos_w, (height, width), (height, width)
             )
-
+        print(attn_weights.shape)
         attn_weights = tf.nn.softmax(attn_weights, axis=-1)
 
 

--- a/src/transformers/models/sam/modeling_tf_sam.py
+++ b/src/transformers/models/sam/modeling_tf_sam.py
@@ -243,12 +243,13 @@ class TFSamAttention(tf.keras.layers.Layer):
 
         # SamAttention
         _, _, _, c_per_head = shape_list(query)
+        print(query.shape)
+        print(key.shape)
         attn = tf.matmul(
             query, tf.transpose(key, perm=[0, 1, 3, 2])
         )  # batch_size * point_batch_size  x N_heads x N_tokens x N_tokens
         attn = attn / tf.math.sqrt(float(c_per_head))
         attn = tf.nn.softmax(attn, axis=-1)
-        print(attn.shape)
 
         # Get output
         out = tf.matmul(attn, value)


### PR DESCRIPTION
Extremely small PR to use smaller dummy inputs to build SAM, which might help with memory issues on smaller devices.