### PR TITLE
Fix is_ninja_available()

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -450,9 +450,8 @@ def is_apex_available():
 
 def is_ninja_available():
     r"""
-    Code below comes from *torch.utils.cpp_extension.is_ninja_available()*
-    Returns `True` if the [ninja](https://ninja-build.org/) build system is
-    available on the system, `False` otherwise.
+    Code comes from *torch.utils.cpp_extension.is_ninja_available()*. Returns `True` if the
+    [ninja](https://ninja-build.org/) build system is available on the system, `False` otherwise.
     """
     try:
         subprocess.check_output("ninja --version".split())

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -449,13 +449,13 @@ def is_apex_available():
 
 
 def is_ninja_available():
-    r'''
+    r"""
     Code below comes from `torch.utils.cpp_extension.is_ninja_available()`
     Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
     available on the system, ``False`` otherwise.
-    '''
+    """
     try:
-        subprocess.check_output('ninja --version'.split())
+        subprocess.check_output("ninja --version".split())
     except Exception:
         return False
     else:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -450,9 +450,9 @@ def is_apex_available():
 
 def is_ninja_available():
     r"""
-    Code below comes from `torch.utils.cpp_extension.is_ninja_available()`
-    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
-    available on the system, ``False`` otherwise.
+    Code below comes from *torch.utils.cpp_extension.is_ninja_available()*
+    Returns `True` if the [ninja](https://ninja-build.org/) build system is
+    available on the system, `False` otherwise.
     """
     try:
         subprocess.check_output("ninja --version".split())

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -19,6 +19,7 @@ import importlib.util
 import json
 import os
 import shutil
+import subprocess
 import sys
 import warnings
 from collections import OrderedDict
@@ -94,7 +95,6 @@ _kenlm_available = _is_package_available("kenlm")
 _keras_nlp_available = _is_package_available("keras_nlp")
 _librosa_available = _is_package_available("librosa")
 _natten_available = _is_package_available("natten")
-_ninja_available = _is_package_available("ninja")
 _onnx_available = _is_package_available("onnx")
 _openai_available = _is_package_available("openai")
 _optimum_available = _is_package_available("optimum")
@@ -449,7 +449,17 @@ def is_apex_available():
 
 
 def is_ninja_available():
-    return _ninja_available
+    r'''
+    Code below comes from `torch.utils.cpp_extension.is_ninja_available()`
+    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
+    available on the system, ``False`` otherwise.
+    '''
+    try:
+        subprocess.check_output('ninja --version'.split())
+    except Exception:
+        return False
+    else:
+        return True
 
 
 def is_ipex_available():


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

i noticed that ninja cannot be detected by importlib because it is not a python package, so i fixed is_ninja_available() with an [implementation comes from pytorch](https://github.com/pytorch/pytorch/blob/4882cd08013733a5dbe299871ad7e974bce074b3/torch/utils/cpp_extension.py#L1629). 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
