### PR TITLE
[`Nllb-Moe`] Fix nllb moe accelerate issue

### DIFF
--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -856,7 +856,7 @@ class NllbMoePreTrainedModel(PreTrainedModel):
     config_class = NllbMoeConfig
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["NllbMoeAttention"]
+    _no_split_modules = ["NllbMoeEncoderLayer", "NllbMoeDecoderLayer"]
 
     def _init_weights(self, module):
         """Initialize the weights"""


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/23385 

Before this PR, it seemed that `_no_split_modules` was not properly set. Due to the skip connections in `NllbMoeEncoderLayer` and `NllbMoeDecoderLayer` one needs to add these modules inside `_no_split_modules` instead of `NllbMoeAttention`.

All accelerate tests pass

cc @ArthurZucker @sgugger 
