### PR TITLE
Adds a FlyteCallback

### DIFF
--- a/docs/source/en/main_classes/callback.mdx
+++ b/docs/source/en/main_classes/callback.mdx
@@ -39,6 +39,7 @@ By default a [`Trainer`] will use the following callbacks:
   installed.
 - [`~integrations.ClearMLCallback`] if [clearml](https://github.com/allegroai/clearml) is installed.
 - [`~integrations.DagsHubCallback`] if [dagshub](https://dagshub.com/) is installed.
+- [`~integrations.FlyteCallback`] if [flyte](https://flyte.org/) is installed.
 
 The main class that implements callbacks is [`TrainerCallback`]. It gets the
 [`TrainingArguments`] used to instantiate the [`Trainer`], can access that
@@ -78,6 +79,8 @@ Here is the list of the available [`TrainerCallback`] in the library:
 [[autodoc]] integrations.ClearMLCallback
 
 [[autodoc]] integrations.DagsHubCallback
+
+[[autodoc]] integrations.FlyteCallback
 
 ## TrainerCallback
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -1550,13 +1550,15 @@ class FlyteCallback(TrainerCallback):
             Determines whether or not to save the training logs to the task's Flyte Deck.
 
         sync_checkpoints (bool, optional, defaults to `True`):
-            When set to True, checkpoints are synced to Flyte and can be used to resume training
-            in the case of an interruption.
+            When set to True, checkpoints are synced to Flyte and can be used to resume training in the case of an
+            interruption.
 
     Example:
         ```python
         # Note: This example skips over some setup steps for brevity.
         from flytekit import current_context, task
+
+
         @task
         def train_hf_transformer():
             cp = current_context().checkpoint
@@ -1564,14 +1566,14 @@ class FlyteCallback(TrainerCallback):
             output = trainer.train(resume_from_checkpoint=cp.restore())
         ```
     """
+
     def __init__(self, save_log_history: bool = True, sync_checkpoints: bool = True):
         super().__init__()
         if not is_flytekit_available():
-            raise ImportError(
-                "FlyteCallback requires flytekit to be installed. Run `pip install flytekit`."
-            )
+            raise ImportError("FlyteCallback requires flytekit to be installed. Run `pip install flytekit`.")
 
         from flytekit import current_context
+
         self.cp = current_context().checkpoint
         self.save_log_history = save_log_history
         self.sync_checkpoints = sync_checkpoints
@@ -1581,9 +1583,7 @@ class FlyteCallback(TrainerCallback):
             ckpt_dir = f"checkpoint-{state.global_step}"
             artifact_path = os.path.join(args.output_dir, ckpt_dir)
 
-            logger.info(
-                f"Saving checkpoint in {ckpt_dir} to Flyte. This may take time."
-            )
+            logger.info(f"Saving checkpoint in {ckpt_dir} to Flyte. This may take time.")
             self.cp.save(artifact_path)
 
     def on_train_end(self, args, state, control, **kwargs):

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 import numpy as np
 
 from . import __version__ as version
-from .utils import flatten_dict, is_datasets_available, is_torch_available, logging
+from .utils import flatten_dict, is_datasets_available, is_pandas_available, is_torch_available, logging
 from .utils.versions import importlib_metadata
 
 
@@ -144,6 +144,10 @@ def is_neptune_available():
 
 def is_codecarbon_available():
     return importlib.util.find_spec("codecarbon") is not None
+
+
+def is_flytekit_available():
+    return importlib.util.find_spec("flytekit") is not None
 
 
 def hp_params(trial):
@@ -1537,6 +1541,59 @@ class ClearMLCallback(TrainerCallback):
             self._clearml_task.update_output_model(artifact_path, iteration=state.global_step, auto_delete_file=False)
 
 
+class FlyteCallback(TrainerCallback):
+    """A [`TrainerCallback`] that sends the logs to [Flyte](https://flyte.org/).
+    NOTE: This callback only works within a Flyte task.
+
+    Args:
+        save_log_history (bool, optional, defaults to `True`):
+            Determines whether or not to save the training logs to the task's Flyte Deck.
+
+        sync_checkpoints (bool, optional, defaults to `True`):
+            When set to True, checkpoints are synced to Flyte and can be used to resume training
+            in the case of an interruption.
+
+    Example:
+        ```python
+        # Note: This example skips over some setup steps for brevity.
+        from flytekit import current_context, task
+        @task
+        def train_hf_transformer():
+            cp = current_context().checkpoint
+            trainer = Trainer(..., callbacks=[FlyteCallback()])
+            output = trainer.train(resume_from_checkpoint=cp.restore())
+        ```
+    """
+    def __init__(self, save_log_history: bool = True, sync_checkpoints: bool = True):
+        super().__init__()
+        if not is_flytekit_available():
+            raise ImportError(
+                "FlyteCallback requires flytekit to be installed. Run `pip install flytekit`."
+            )
+
+        from flytekit import current_context
+        self.cp = current_context().checkpoint
+        self.save_log_history = save_log_history
+        self.sync_checkpoints = sync_checkpoints
+
+    def on_save(self, args, state, control, **kwargs):
+        if self.sync_checkpoints and state.is_world_process_zero:
+            ckpt_dir = f"checkpoint-{state.global_step}"
+            artifact_path = os.path.join(args.output_dir, ckpt_dir)
+
+            logger.info(
+                f"Saving checkpoint in {ckpt_dir} to Flyte. This may take time."
+            )
+            self.cp.save(artifact_path)
+
+    def on_train_end(self, args, state, control, **kwargs):
+        if self.save_log_history and is_pandas_available():
+            import pandas as pd
+            from flytekit import Deck
+
+            Deck("Log History", pd.DataFrame(state.log_history).to_html())
+
+
 INTEGRATION_TO_CALLBACK = {
     "azure_ml": AzureMLCallback,
     "comet_ml": CometCallback,
@@ -1547,6 +1604,7 @@ INTEGRATION_TO_CALLBACK = {
     "codecarbon": CodeCarbonCallback,
     "clearml": ClearMLCallback,
     "dagshub": DagsHubCallback,
+    "flyte": FlyteCallback,
 }
 
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -1587,11 +1587,15 @@ class FlyteCallback(TrainerCallback):
             self.cp.save(artifact_path)
 
     def on_train_end(self, args, state, control, **kwargs):
-        if self.save_log_history and is_pandas_available():
+        if self.save_log_history:
             import pandas as pd
             from flytekit import Deck
 
-            Deck("Log History", pd.DataFrame(state.log_history).to_html())
+            if is_pandas_available():
+                Deck("Log History", pd.DataFrame(state.log_history).to_html())
+            else:
+                logger.warning("Install pandas for optimal Flyte log formatting.")
+                Deck("Log History", str(state.log_history))
 
 
 INTEGRATION_TO_CALLBACK = {

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -1552,10 +1552,10 @@ class FlyteCallback(TrainerCallback):
     NOTE: This callback only works within a Flyte task.
 
     Args:
-        save_log_history (bool, optional, defaults to `True`):
+        save_log_history (`bool`, *optional*, defaults to `True`):
             When set to True, the training logs are saved as a Flyte Deck.
 
-        sync_checkpoints (bool, optional, defaults to `True`):
+        sync_checkpoints (`bool`, *optional*, defaults to `True`):
             When set to True, checkpoints are synced with Flyte and can be used to resume training in the case of an
             interruption.
 

--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -1560,17 +1560,18 @@ class FlyteCallback(TrainerCallback):
             interruption.
 
     Example:
-        ```python
-        # Note: This example skips over some setup steps for brevity.
-        from flytekit import current_context, task
+
+    ```python
+    # Note: This example skips over some setup steps for brevity.
+    from flytekit import current_context, task
 
 
-        @task
-        def train_hf_transformer():
-            cp = current_context().checkpoint
-            trainer = Trainer(..., callbacks=[FlyteCallback()])
-            output = trainer.train(resume_from_checkpoint=cp.restore())
-        ```
+    @task
+    def train_hf_transformer():
+        cp = current_context().checkpoint
+        trainer = Trainer(..., callbacks=[FlyteCallback()])
+        output = trainer.train(resume_from_checkpoint=cp.restore())
+    ```
     """
 
     def __init__(self, save_log_history: bool = True, sync_checkpoints: bool = True):


### PR DESCRIPTION
# What does this PR do?
This PR adds a Flyte callback that integrates with Flyte's [intra-task checkpoints](https://docs.flyte.org/projects/cookbook/en/stable/auto/core/control_flow/checkpoint.html#why-intra-task-checkpoints) and [Flyte Decks](https://docs.flyte.org/projects/cookbook/en/latest/auto/core/flyte_basics/deck.html).

I raised this issue in order to get approval for this PR #23476 

I am using this [example](https://gist.github.com/peridotml/68f376f0f4fd1926fb0746daaeea09f8) to test on a flyte cluster. It uses Flyte's checkpointing system to restart from a hugging face checkpoint (see screenshots).
<img width="400" alt="Screenshot 2023-05-26 at 2 57 59 PM" src="https://github.com/huggingface/transformers/assets/106936600/5cf83157-cce0-4a2e-8a2f-cd1a72c65820">
<img width="400" alt="Screenshot 2023-05-26 at 2 58 14 PM" src="https://github.com/huggingface/transformers/assets/106936600/891d86e7-5885-4851-889f-e912d42f2902">

Once this is merged, I will add this and more to Flyte's documentation.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer: @stas00, Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
