### PR TITLE
Fix floating point precision issue for RoPE

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -97,9 +97,7 @@ class GPTNeoXAttention(nn.Module):
             ),
         )
         self.register_buffer("masked_bias", torch.tensor(-1e9))
-        self.rotary_emb = RotaryEmbedding(
-            self.rotary_ndims, base=config.rotary_emb_base
-        )
+        self.rotary_emb = RotaryEmbedding(self.rotary_ndims, base=config.rotary_emb_base)
         self.register_buffer(
             "norm_factor",
             torch.sqrt(torch.tensor(self.head_size, dtype=torch.float32)).to(torch.get_default_dtype()),

--- a/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
+++ b/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
@@ -78,9 +78,7 @@ class GPTNeoXJapaneseAttention(nn.Module):
         self.head_size = self.hidden_size // self.num_attention_heads
 
         self.rotary_ndims = int(self.head_size * config.rotary_pct)
-        self.rotary_emb = RotaryEmbedding(
-            self.rotary_ndims, base=config.rotary_emb_base
-        )
+        self.rotary_emb = RotaryEmbedding(self.rotary_ndims, base=config.rotary_emb_base)
         self.max_positions = config.max_position_embeddings
         self.attention_dropout = nn.Dropout(config.attention_dropout)
         self.norm_factor = torch.sqrt(torch.tensor(self.head_size, dtype=torch.float32)).to(torch.get_default_dtype())

--- a/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
+++ b/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
@@ -79,7 +79,7 @@ class GPTNeoXJapaneseAttention(nn.Module):
 
         self.rotary_ndims = int(self.head_size * config.rotary_pct)
         self.rotary_emb = RotaryEmbedding(
-            self.rotary_ndims, config.max_position_embeddings, base=config.rotary_emb_base
+            self.rotary_ndims, base=config.rotary_emb_base
         )
         self.max_positions = config.max_position_embeddings
         self.attention_dropout = nn.Dropout(config.attention_dropout)
@@ -239,24 +239,18 @@ class GPTNeoXJapaneseAttention(nn.Module):
 
 # Copied from transformers.models.gpt_neox.modeling_gpt_neox.RotaryEmbedding
 class RotaryEmbedding(torch.nn.Module):
-    def __init__(self, dim, max_position_embeddings, base=10000, device=None):
+    def __init__(self, dim, base=10000, device=None):
         super().__init__()
         inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
-        self.register_buffer("inv_freq", inv_freq)
+        self.register_buffer("inv_freq", inv_freq.to(torch.get_default_dtype()))
 
-        # Build here to make `torch.jit.trace` work.
-        self.max_seq_len_cached = max_position_embeddings
-        t = torch.arange(self.max_seq_len_cached, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
-        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
-        # Different from paper, but it uses a different permutation in order to obtain the same calculation
-        emb = torch.cat((freqs, freqs), dim=-1)
-        self.cos_cached = emb.cos()[None, None, :, :]
-        self.sin_cached = emb.sin()[None, None, :, :]
+        self.max_seq_len_cached = -1
+        self.cos_cached = None
+        self.sin_cached = None
 
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
-        # This `if` block is unlikely to be run after we build sin/cos in `__init__`. Keep the logic here just in case.
-        if seq_len > self.max_seq_len_cached:
+        if self.max_seq_len_cached < 0 or seq_len > self.max_seq_len_cached:
             self.max_seq_len_cached = seq_len
             t = torch.arange(self.max_seq_len_cached, device=x.device, dtype=self.inv_freq.dtype)
             freqs = torch.einsum("i,j->ij", t, self.inv_freq)


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue of floating point precision in `RotaryEmbedding`.
The purpose of this PR is to fix inconsistency between GPT-Neo-X and HF Transformers, which is causing a model performance degradation.

## Issue

In the current implementation of `RotaryEmbedding`, `inv_freq` is first initialized by float32. 
This value is then used for initializing `cos_cached` and `sin_cached` by float32.
As a result, `cos_cached` and `sin_cached` remain float32 even if the model (including inv_freq) uses float16; this is because these two variables are not the target of dtype conversion of `half()` method
Note that there is also a recomputation logic for these two variables, but it is very unlikely to occur https://github.com/huggingface/transformers/blob/f67dac97bdc63874f2288546b3fa87e69d2ea1c8/src/transformers/models/gpt_neox/modeling_gpt_neox.py#L268

However, this implementation seems inconsistent to the one in the [EleutherAI/gpt-neox](https://github.com/EleutherAI/gpt-neox) library.
In their implementation, `cos_cached` and `sin_cached` are almost always recomputed in the [forward method](https://github.com/EleutherAI/gpt-neox/blob/23ad392fdfe0f0a22c986013013209a03b7c28a1/megatron/model/positional_embeddings.py#L51-L63).
Thus, dtype of `cos_cached` and `sin_cached` are always consistent to the dtype of inv_freq.

This inconsistency between two libraries (HF Transformers and GPT-Neo-X) causes the performance degradation of the model converted from gpt-neox.
For example, the perplexity score of the language model on Wikitext corpus is as follows:

- gpt-neo-x w/o conversion: 520.7840
- gpt-neo-x w/ conversion to HF format: 520.9911
- gpt-neo-x w/ conversion to HF format and this PR: 520.7840 

(Sorry that the perplexity value is really bad. I am reporting the performance of model trained on toy data for debugging purpose)

## Solution

I basically followed the previous PR https://github.com/huggingface/transformers/pull/22888 and made a similar fix.

## Possible Side Effect

In the original code, `cos_cashed` and `sin_cashed` are initialized in the model consturctor.
However, I had to move the initialization code to forward method.
Otherwise the library gave me the following error: "cos_vml_cpu" not implemented for 'Half'.
As a result, `torch.jit.trace` might be no longer available.
Since I am not sure what jit.trace is, I don't have any workaround for this.

## Similar Issues

- https://github.com/huggingface/transformers/pull/22888
- https://github.com/EleutherAI/gpt-neox/issues/873

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
  - I would really appreciate it if the reviewers could point out the missing tests.


## Who can review?

@ArthurZucker and @younesbelkada