### PR TITLE
Editing issue with pickle def with lambda function

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -41,9 +41,9 @@ def get_constant_lambda(_=None):
             Placeholder to argument, used to consistency with args in LambdaLR
     
     Return:
-        1 : int - constanct lambda for constant scheduler
+        1 : int - constant lambda for constant scheduler
     """
-    
+
     return 1
 
 

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -32,6 +32,21 @@ from .utils.versions import require_version
 logger = logging.get_logger(__name__)
 
 
+def get_constant_lambda(_=None):
+    """
+    Return 1, independent from args.
+
+    Args:
+        _ ( *optional*, defaults to None):
+            Placeholder to argument, used to consistency with args in LambdaLR
+    
+    Return:
+        1 : int - constanct lambda for constant scheduler
+    """
+    
+    return 1
+
+
 def get_constant_schedule(optimizer: Optimizer, last_epoch: int = -1):
     """
     Create a schedule with a constant learning rate, using the learning rate set in optimizer.
@@ -46,7 +61,7 @@ def get_constant_schedule(optimizer: Optimizer, last_epoch: int = -1):
         `torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
     """
 
-    return LambdaLR(optimizer, lambda _: 1, last_epoch=last_epoch)
+    return LambdaLR(optimizer, get_constant_lambda, last_epoch=last_epoch)
 
 
 def get_reduce_on_plateau_schedule(optimizer: Optimizer):

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -32,17 +32,7 @@ from .utils.versions import require_version
 logger = logging.get_logger(__name__)
 
 
-def get_constant_lambda(_=None):
-    """
-    Return 1, independent from args.
-
-    Args:
-        _ ( *optional*, defaults to None):
-            Placeholder to argument, used to consistency with args in LambdaLR
-    
-    Return:
-        1 : int - constant lambda for constant scheduler
-    """
+def _get_constant_lambda(_=None):
 
     return 1
 
@@ -61,7 +51,7 @@ def get_constant_schedule(optimizer: Optimizer, last_epoch: int = -1):
         `torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
     """
 
-    return LambdaLR(optimizer, get_constant_lambda, last_epoch=last_epoch)
+    return LambdaLR(optimizer, _get_constant_lambda, last_epoch=last_epoch)
 
 
 def get_reduce_on_plateau_schedule(optimizer: Optimizer):

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -33,7 +33,6 @@ logger = logging.get_logger(__name__)
 
 
 def _get_constant_lambda(_=None):
-
     return 1
 
 


### PR DESCRIPTION
# What does this PR do?
In this PR, I address the problem of pickling the constant LR scheduler, which fails during the process (potentially during multi-GPU training, as observed in my case) due to the presence of a lambda function within it.

Fixes  #23865    (issue)
