### PR TITLE
Support shared tensors

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -309,7 +309,9 @@ def shard_checkpoint(
     current_block_size = 0
     total_size = 0
 
-    unique_storage_to_save = {(weight.storage().data_ptr(), weight.storage().nbytes()): key for key, weight in state_dict.items()}
+    unique_storage_to_save = {
+        (weight.storage().data_ptr(), weight.storage().nbytes()): key for key, weight in state_dict.items()
+    }
     key_to_block = {}
 
     for key in unique_storage_to_save.values():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -41,9 +41,10 @@ from .pytorch_utils import (  # noqa: F401
     Conv1D,
     apply_chunking_to_forward,
     find_pruneable_heads_and_indices,
+    id_tensor_storage,
     prune_conv1d_layer,
     prune_layer,
-    prune_linear_layer, id_tensor_storage,
+    prune_linear_layer,
 )
 from .utils import (
     DUMMY_INPUTS,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -309,7 +309,7 @@ def shard_checkpoint(
     current_block_size = 0
     total_size = 0
 
-    unique_storage_to_save = {weight.storage().data_ptr(): key for key, weight in state_dict.items()}
+    unique_storage_to_save = {(weight.storage().data_ptr(), weight.storage().nbytes()): key for key, weight in state_dict.items()}
     key_to_block = {}
 
     for key in unique_storage_to_save.values():
@@ -332,7 +332,8 @@ def shard_checkpoint(
 
     # Handle tensor that share same underlying storage as other tensors within `state_dict`
     for key, weight in state_dict.items():
-        unique_storage_key = unique_storage_to_save[weight.storage().data_ptr()]
+        storage = weight.storage()
+        unique_storage_key = unique_storage_to_save[(storage.data_ptr(), storage.nbytes())]
         if key == unique_storage_key:
             continue
         block_id = key_to_block[unique_storage_key]

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -277,3 +277,10 @@ def meshgrid(
         if indexing != "ij":
             raise ValueError('torch.meshgrid only supports `indexing="ij"` for torch<1.10.')
         return torch.meshgrid(*tensors)
+
+def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
+    """
+    Unique identifier to a tensor storage. This identifier is guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with non-overlapping lifetimes may have the same id.
+    """
+    storage = tensor.storage()
+    return tensor.device, storage.data_ptr(), storage.nbytes()

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -16,12 +16,10 @@ from typing import Callable, List, Optional, Set, Tuple, Union
 
 import torch
 from packaging import version
+from safetensors.torch import storage_ptr, storage_size
 from torch import nn
 
-from . import is_safetensors_available
 from .utils import logging
-
-from safetensors.torch import storage_ptr, storage_size
 
 
 ALL_LAYERNORM_LAYERS = [nn.LayerNorm]
@@ -284,10 +282,10 @@ def meshgrid(
 
 def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     """
-    Unique identifier to a tensor storage.
-    Multiple different tensors can share the same underlying storage. For example, "meta" tensors all share the same storage, and thus their identifier will all be equal.
-    This identifier is guaranteed to be unique and constant for this tensor's
-    storage during its lifetime. Two tensor storages with non-overlapping lifetimes may have the same id.
+    Unique identifier to a tensor storage. Multiple different tensors can share the same underlying storage. For
+    example, "meta" tensors all share the same storage, and thus their identifier will all be equal. This identifier is
+    guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with
+    non-overlapping lifetimes may have the same id.
 
     Warning
     """

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -18,7 +18,10 @@ import torch
 from packaging import version
 from torch import nn
 
+from . import is_safetensors_available
 from .utils import logging
+
+from safetensors.torch import storage_ptr, storage_size
 
 
 ALL_LAYERNORM_LAYERS = [nn.LayerNorm]
@@ -281,8 +284,11 @@ def meshgrid(
 
 def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     """
-    Unique identifier to a tensor storage. This identifier is guaranteed to be unique and constant for this tensor's
+    Unique identifier to a tensor storage.
+    Multiple different tensors can share the same underlying storage. For example, "meta" tensors all share the same storage, and thus their identifier will all be equal.
+    This identifier is guaranteed to be unique and constant for this tensor's
     storage during its lifetime. Two tensor storages with non-overlapping lifetimes may have the same id.
+
+    Warning
     """
-    storage = tensor.storage()
-    return tensor.device, storage.data_ptr(), storage.nbytes()
+    return tensor.device, storage_ptr(tensor), storage_size(tensor)

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -278,9 +278,11 @@ def meshgrid(
             raise ValueError('torch.meshgrid only supports `indexing="ij"` for torch<1.10.')
         return torch.meshgrid(*tensors)
 
+
 def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     """
-    Unique identifier to a tensor storage. This identifier is guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with non-overlapping lifetimes may have the same id.
+    Unique identifier to a tensor storage. This identifier is guaranteed to be unique and constant for this tensor's
+    storage during its lifetime. Two tensor storages with non-overlapping lifetimes may have the same id.
     """
     storage = tensor.storage()
     return tensor.device, storage.data_ptr(), storage.nbytes()

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -286,7 +286,5 @@ def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     example, "meta" tensors all share the same storage, and thus their identifier will all be equal. This identifier is
     guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with
     non-overlapping lifetimes may have the same id.
-
-    Warning
     """
     return tensor.device, storage_ptr(tensor), storage_size(tensor)


### PR DESCRIPTION
# What does this PR do?

- Fixes #23868

We can uniquely hash the storage by computing `data_ptr()` and `nbytes()` since storages are 1D contiguous buffers. We use that to find tensors that share the same storage. And if we do find them, we put those within the same "block" relying on underlying code to optimize serialization.
