### PR TITLE
Raise error if loss can't be calculated - ViT MIM 

### DIFF
--- a/src/transformers/models/vit/modeling_vit.py
+++ b/src/transformers/models/vit/modeling_vit.py
@@ -695,6 +695,13 @@ class ViTForMaskedImageModeling(ViTPreTrainedModel):
         ```"""
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
+        if bool_masked_pos is not None and (self.config.patch_size != self.config.encoder_stride):
+            raise ValueError(
+                "When `bool_masked_pos` is provided, `patch_size` must be equal to `encoder_stride` to ensure that "
+                "the reconstructed image has the same dimensions as the input."
+                f"Got `patch_size` = {self.config.patch_size} and `encoder_stride` = {self.config.encoder_stride}."
+            )
+
         outputs = self.vit(
             pixel_values,
             bool_masked_pos=bool_masked_pos,


### PR DESCRIPTION
# What does this PR do?

Currently, `ViTForMaskedImageModeling` will fail when calculating the reconstruction loss if a patch size other than 16 is chosen. This is because the decoder head is parametrized by `config.encoder_stride`, which controls the resolution of the upsampled image. 

By default, `config.patch_size = config.encoder_stride = 16`. If a user updates the patch size but not the encoder stride to match, the reconstructed image will have a different resolution. 

This PR adds a warning for the user before the forward pass, explaining why the loss calculation won't work.

Fixes #23832


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
