### PR TITLE
[`core`] Add no split modules support for all models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2746,7 +2746,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if no_split_modules is None:
                 raise ValueError(
                     f"{model.__class__.__name__} does not support `device_map='{device_map}'`. To implement support, the model"
-                    "class needs to implement the `_no_split_modules` attribute."
+                    "class needs to implement the `_no_split_modules` attribute, or directly pass `no_split_modules` to "
+                    "`from_pretrained`."
                 )
             if device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Fixes: #23816 and other related issues

## Motivation

With the increase of the usage of code on the Hub features and more and more models pushed on that direction, I am convinced that it would be great to easily support accelerate loading of these models out of the box, without having to open PRs on the Hub and wait for authors approvals on each repo (as the changes needs to be duplicated across all repos, which can be redundant).

## Description

This PR addresses this, and adds support of `no_split_modules` on the `from_pretrained` method. Allowing superusers to load models using accelerate (for loading models in 8bit / 4bit for example), for models where the code is hosted on the Hub.

## To reproduce:

```python
from transformers import AutoModelForCausalLM, AutoTokenizer

model_name = 'mosaicml/mpt-7b-instruct'

tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b")
model = AutoModelForCausalLM.from_pretrained(
    model_name, 
    load_in_8bit=True,
    device_map="auto",
    no_split_modules=["MPTBlock"],
    trust_remote_code=True,
)

prompt = "What is the boiling point of Nitrogen?"

input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(0)
out = model.generate(input_ids)
print(tokenizer.decode(out[0], skip_special_tokens=True)) 
>>> What is the boiling point of Nitrogen?\n The boiling point of Nitrogen is 77.37
```

cc @ArthurZucker @sgugger 

Once the PoC approved, will add a section on the docs