### PR TITLE
Fix image segmentation tool bug

### DIFF
--- a/src/transformers/tools/image_segmentation.py
+++ b/src/transformers/tools/image_segmentation.py
@@ -44,7 +44,6 @@ class ImageSegmentationTool(PipelineTool):
         super().__init__(*args, **kwargs)
 
     def encode(self, image: "Image", label: str):
-        self.pre_processor.image_processor.size = {"width": image.size[0], "height": image.size[1]}
         return self.pre_processor(text=[label], images=[image], padding=True, return_tensors="pt")
 
     def forward(self, inputs):

--- a/tests/tools/test_image_segmentation.py
+++ b/tests/tools/test_image_segmentation.py
@@ -33,21 +33,21 @@ class ImageSegmentationToolTester(unittest.TestCase, ToolTesterMixin):
         self.remote_tool = load_tool("image-segmentation", remote=True)
 
     def test_exact_match_arg(self):
-        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png").resize((512, 512))
+        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png")
         result = self.tool(image, "cat")
         self.assertTrue(isinstance(result, Image.Image))
 
     def test_exact_match_arg_remote(self):
-        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png").resize((512, 512))
+        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png")
         result = self.remote_tool(image, "cat")
         self.assertTrue(isinstance(result, Image.Image))
 
     def test_exact_match_kwarg(self):
-        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png").resize((512, 512))
+        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png")
         result = self.tool(image=image, label="cat")
         self.assertTrue(isinstance(result, Image.Image))
 
     def test_exact_match_kwarg_remote(self):
-        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png").resize((512, 512))
+        image = Image.open(Path(get_tests_dir("fixtures/tests_samples/COCO")) / "000000039769.png")
         result = self.remote_tool(image=image, label="cat")
         self.assertTrue(isinstance(result, Image.Image))


### PR DESCRIPTION
# What does this PR do?

Currently tools using the ImageSegmentation tool fail because the parameters for the image processor are overridden with the input image dimensions. This results in incompatible input dimensions being passed to the model.

This PR removes this logic in the `encode` method and removes the resizing in the tests which only happened for the segmentation tool and hid the issue. 

Fixes #23328 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
