### PR TITLE
Upgrade safetensors version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ _deps = [
     "ruff>=0.0.241,<=0.0.259",
     "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses",
-    "safetensors>=0.2.1",
+    "safetensors>=0.3.1",
     "sagemaker>=2.31.0",
     "scikit-learn",
     "sentencepiece>=0.1.91,!=0.1.92",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -65,7 +65,7 @@ deps = {
     "ruff": "ruff>=0.0.241,<=0.0.259",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
-    "safetensors": "safetensors>=0.2.1",
+    "safetensors": "safetensors>=0.3.1",
     "sagemaker": "sagemaker>=2.31.0",
     "scikit-learn": "scikit-learn",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",


### PR DESCRIPTION
# What does this PR do?

Upgrades `safetensors` version in the requirements to avoid the following error message:
(I had 0.3.0)

```python
src/transformers/models/gpt2/modeling_gpt2.py:38: in <module>
    from ...modeling_utils import PreTrainedModel, SequenceSummary
src/transformers/modeling_utils.py:40: in <module>
    from .pytorch_utils import (  # noqa: F401
src/transformers/pytorch_utils.py:19: in <module>
    from safetensors.torch import storage_ptr, storage_size
E   ImportError: cannot import name 'storage_ptr' from 'safetensors.torch' (/home/zach_mueller_huggingface_co/miniconda3/envs/accelerate/lib/python3.9/site-packages/safetensors/torch.py)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 