### PR TITLE
Modify device_map behavior when loading a model using from_pretrained

### DIFF
--- a/docs/source/en/main_classes/quantization.mdx
+++ b/docs/source/en/main_classes/quantization.mdx
@@ -86,6 +86,7 @@ With this integration we were able to load large models on smaller devices and r
 <Tip warning={true}>
 
 Note that once a model has been loaded in 8-bit it is currently not possible to push the quantized weights on the Hub except if you use the latest `transformers` and `bitsandbytes`. Note also that you cannot train 8-bit weights as this is not supported yet. However you can use 8-bit models to train extra parameters, this will be covered in the next section.
+Note also that `device_map` is optional but setting `device_map = 'auto'` is prefered for inference as it will dispatch efficiently the model on the available ressources.
 
 </Tip>
 
@@ -162,9 +163,10 @@ You can load a quantized model from the Hub by using `from_pretrained` method. M
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-model = AutoModelForCausalLM.from_pretrained("{your_username}/bloom-560m-8bit")
+model = AutoModelForCausalLM.from_pretrained("{your_username}/bloom-560m-8bit", device_map="auto")
 ```
-Note that in this case, you don't need to specify the arguments `load_in_8bit=True` and `device_map="auto"`, but you need to make sure that `bitsandbytes` and `accelerate` are installed.
+Note that in this case, you don't need to specify the arguments `load_in_8bit=True`, but you need to make sure that `bitsandbytes` and `accelerate` are installed.
+Note also that `device_map` is optional but setting `device_map = 'auto'` is prefered for inference as it will dispatch efficiently the model on the available ressources.
 
 ### Advanced usecases
 
@@ -252,6 +254,8 @@ tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 With the official support of adapters in the Hugging Face ecosystem, you can fine-tune models that have been loaded in 8-bit. 
 This enables fine-tuning large models such as `flan-t5-large` or `facebook/opt-6.7b` in a single google Colab. Please have a look at [`peft`](https://github.com/huggingface/peft) library for more details.
+
+Note that you don't need to pass `device_map` when loading the model for training. It will automatically load your model on your GPU. You can also set the device map to a specific device if needed (e.g. `cuda:0`, `0`, `torch.device('cuda:0')`). Please note that `device_map=auto` should be used for inference only. 
 
 ### BitsAndBytesConfig
 

--- a/docs/source/en/perf_infer_gpu_one.mdx
+++ b/docs/source/en/perf_infer_gpu_one.mdx
@@ -65,6 +65,7 @@ from transformers import AutoModelForCausalLM
 model_name = "bigscience/bloom-2b5"
 model_8bit = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto", load_in_4bit=True)
 ```
+Note that `device_map` is optional but setting `device_map = 'auto'` is prefered for inference as it will dispatch efficiently the model on the available ressources.
 
 ### Running FP4 models - multi GPU setup 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2197,7 +2197,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 device_map = {"": torch.device(device_map)}
             except RuntimeError:
                 raise ValueError(
-                    f"When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential' but found {device_map}"
+                    "When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or "
+                    f"'auto', 'balanced', 'balanced_low_0', 'sequential' but found {device_map}."
                 )
         elif isinstance(device_map, int):
             if device_map < 0:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2060,7 +2060,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 parameter/buffer name, once a given module name is inside, every submodule of it will be sent to the
                 same device. If we only pass the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"mps"`, or a GPU ordinal rank
                 like `1`) on which the model will be allocated, the device map will map the entire model to this
-                device. Passing device_map = 0 is the same as doing device_map = {"":"cuda:0"}
+                device. Passing `device_map = 0` means put the whole model on GPU 0.
 
                 To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For
                 more information about each option see [designing a device
@@ -2196,7 +2196,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             try: 
                 device_map = {"": torch.device(device_map)}
             except RuntimeError:
-                raise ValueError("When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential'") 
+                raise ValueError(f"When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential' but found {device_map}") 
         elif isinstance(device_map, int):
             if device_map < 0:
                 raise ValueError("You can't pass device_map as a negative int. If you want to put the model on the cpu, pass device_map = 'cpu' ")
@@ -2265,7 +2265,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if torch.cuda.is_available():
                     device_map = {"": torch.cuda.current_device()}
                 else:
-                    raise RuntimeError("No GPU found.")
+                    raise RuntimeError("No GPU found. A GPU is needed for quantization.")
                 logger.info(
                     "The device_map was not initialized."
                     "Setting device_map to {'':torch.cuda.current_device()}."

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -82,8 +82,8 @@ XLA_USE_BF16 = os.environ.get("XLA_USE_BF16", "0").upper()
 XLA_DOWNCAST_BF16 = os.environ.get("XLA_DOWNCAST_BF16", "0").upper()
 
 if is_accelerate_available():
+    from accelerate import Accelerator, dispatch_model, infer_auto_device_map, init_empty_weights
     from accelerate import __version__ as accelerate_version
-    from accelerate import dispatch_model, infer_auto_device_map, init_empty_weights
     from accelerate.utils import (
         find_tied_parameters,
         load_offloaded_weights,
@@ -1918,6 +1918,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return super().float(*args)
 
     @classmethod
+    def _get_current_device(cls):
+        r"""
+        Get the current device using the `Accelerate` object - We just return the process index of the `Accelerate`
+        object to handle corner cases when running scripts in distributed setups.
+
+        Returns:
+            current_device (`int`):
+                The current device index.
+        """
+        dummy_accelerator = Accelerator()
+        current_device = dummy_accelerator.process_index
+        return current_device
+
+    @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], *model_args, **kwargs):
         r"""
         Instantiate a pretrained pytorch model from a pre-trained model configuration.
@@ -2267,7 +2281,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             if device_map is None:
                 if torch.cuda.is_available():
-                    device_map = {"": torch.cuda.current_device()}
+                    current_device = cls._get_current_device()
+                    device_map = {"": current_device}
                 else:
                     raise RuntimeError("No GPU found. A GPU is needed for quantization.")
                 logger.info(
@@ -2340,15 +2355,19 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if load_in_8bit:
                 if torch_dtype is None:
                     torch_dtype = torch.float16
-                if device_map is None:
-                    device_map = {"": torch.cuda.current_device()}
-                    logger.info(
-                        "The device_map was not initialized."
-                        "Setting device_map to {'':torch.cuda.current_device()}."
-                        "If you want to use the model for inference, please set device_map ='auto' "
-                    )
-                    if low_cpu_mem_usage is None:
-                        low_cpu_mem_usage = True
+                if torch.cuda.is_available():
+                    current_device = cls._get_current_device()
+                    device_map = {"": current_device}
+                else:
+                    raise RuntimeError("No GPU found. A GPU is needed for quantization.")
+                logger.info(
+                    "The device_map was not initialized."
+                    "Setting device_map to {'':torch.cuda.current_device()}."
+                    "If you want to use the model for inference, please set device_map ='auto' "
+                )
+                if low_cpu_mem_usage is None:
+                    low_cpu_mem_usage = True
+
         elif not is_8bit_serializable and not load_in_8bit and hasattr(config, "quantization_config"):
             logger.warning(
                 "Detected the presence of a `quantization_config` attribute in the model's configuration but you don't have the correct"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2341,7 +2341,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if torch_dtype is None:
                     torch_dtype = torch.float16
                 if device_map is None:
-                    device_map = {"": torch.cuda.current_device()}
+                    if torch.cuda.is_available():
+                        device_map = {"": torch.cuda.current_device()}
+                    else:
+                        raise RuntimeError("No GPU found. A GPU is needed for quantization.")
                     logger.info(
                         "The device_map was not initialized."
                         "Setting device_map to {'':torch.cuda.current_device()}."
@@ -2349,6 +2352,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     )
                     if low_cpu_mem_usage is None:
                         low_cpu_mem_usage = True
+
         elif not is_8bit_serializable and not load_in_8bit and hasattr(config, "quantization_config"):
             logger.warning(
                 "Detected the presence of a `quantization_config` attribute in the model's configuration but you don't have the correct"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2193,10 +2193,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if isinstance(device_map, torch.device):
             device_map = {"": device_map}
         elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
-            device_map = {"": torch.device(device_map)}
+            try: 
+                device_map = {"": torch.device(device_map)}
+            except RuntimeError:
+                raise ValueError("When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential'") 
         elif isinstance(device_map, int):
             if device_map < 0:
-                device_map = {"": "cpu"}
+                raise ValueError("You can't pass device_map as a negative int. If you want to put the model on the cpu, pass device_map = 'cpu' ")
             else:
                 device_map = {"": device_map}
 
@@ -2259,10 +2262,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 torch_dtype = torch.float16
 
             if device_map is None:
-                device_map = {"": torch.cuda.current_device()}
-                logger.warning(
-                    "The device_map was not initialized. Setting device_map to {"
-                    ":torch.cuda.current_device()}."
+                if torch.cuda.is_available():
+                    device_map = {"": torch.cuda.current_device()}
+                else:
+                    raise RuntimeError("No GPU found.")
+                logger.info(
+                    "The device_map was not initialized."
+                    "Setting device_map to {'':torch.cuda.current_device()}."
                     "If you want to use the model for inference, please set device_map ='auto' "
                 )
                 if low_cpu_mem_usage is None:
@@ -2332,7 +2338,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     torch_dtype = torch.float16
                 if device_map is None:
                     device_map = {"": torch.cuda.current_device()}
-                    logger.warning(
+                    logger.info(
                         "The device_map was not initialized. Setting device_map to {"
                         ":torch.cuda.current_device()}."
                         "If you want to use the model for inference, please set device_map ='auto' "

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2193,13 +2193,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if isinstance(device_map, torch.device):
             device_map = {"": device_map}
         elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
-            try: 
+            try:
                 device_map = {"": torch.device(device_map)}
             except RuntimeError:
-                raise ValueError(f"When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential' but found {device_map}") 
+                raise ValueError(
+                    f"When passing device_map as a string, the value needs to be a device name (e.g. cpu, cuda:0) or 'auto', 'balanced', 'balanced_low_0', 'sequential' but found {device_map}"
+                )
         elif isinstance(device_map, int):
             if device_map < 0:
-                raise ValueError("You can't pass device_map as a negative int. If you want to put the model on the cpu, pass device_map = 'cpu' ")
+                raise ValueError(
+                    "You can't pass device_map as a negative int. If you want to put the model on the cpu, pass device_map = 'cpu' "
+                )
             else:
                 device_map = {"": device_map}
 
@@ -2339,8 +2343,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if device_map is None:
                     device_map = {"": torch.cuda.current_device()}
                     logger.info(
-                        "The device_map was not initialized. Setting device_map to {"
-                        ":torch.cuda.current_device()}."
+                        "The device_map was not initialized."
+                        "Setting device_map to {'':torch.cuda.current_device()}."
                         "If you want to use the model for inference, please set device_map ='auto' "
                     )
                     if low_cpu_mem_usage is None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2055,10 +2055,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 </Tip>
 
-            device_map (`str` or `Dict[str, Union[int, str, torch.device]]`, *optional*):
+            device_map (`str` or `Dict[str, Union[int, str, torch.device]]` or `int` or `torch.device`, *optional*):
                 A map that specifies where each submodule should go. It doesn't need to be refined to each
                 parameter/buffer name, once a given module name is inside, every submodule of it will be sent to the
-                same device.
+                same device. If we only pass the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"mps"`, or a GPU ordinal rank
+                like `1`) on which the model will be allocated, the device map will map the entire model to this
+                device. Passing device_map = 0 is the same as doing device_map = {"":"cuda:0"}
 
                 To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For
                 more information about each option see [designing a device
@@ -2186,6 +2188,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 "The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is"
                 " ignored."
             )
+
+        # change device_map into a map if we passed an int, a str or a torch.device
+        if isinstance(device_map, torch.device):
+            device_map = {"": device_map.index}
+        elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
+            device_map = {"": torch.device(device_map).index}
+        elif isinstance(device_map, int):
+            if device_map < 0:
+                device_map = {"": "cpu"}
+            else:
+                device_map = {"": device_map}
+
         if device_map is not None:
             if low_cpu_mem_usage is None:
                 low_cpu_mem_usage = True
@@ -2226,12 +2240,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "`quantization_config` argument at the same time."
                 )
 
-            # in the case a user loads an 8bit model from the Hub and assigns a new quantization_config
-            if device_map is None:
-                device_map = "auto"
-                if low_cpu_mem_usage is None:
-                    low_cpu_mem_usage = True
-
         if load_in_8bit or load_in_4bit:
             if not (is_accelerate_available() and is_bitsandbytes_available()):
                 raise ImportError(
@@ -2251,10 +2259,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 torch_dtype = torch.float16
 
             if device_map is None:
-                raise ValueError(
-                    "A device map needs to be passed to run convert models into 8-bit and 4-bit formats. Please run"
-                    "`.from_pretrained` with `device_map='auto'`"
+                device_map = {"": torch.cuda.current_device()}
+                logger.warning(
+                    "The device_map was not initialized. Setting device_map to {"
+                    ":torch.cuda.current_device()}."
+                    "If you want to use the model for inference, please set device_map ='auto' "
                 )
+                if low_cpu_mem_usage is None:
+                    low_cpu_mem_usage = True
+
             if from_tf or from_flax:
                 raise ValueError(
                     "Converting into 4-bit or 8-bit weights from tf/flax weights is currently not supported, please make"
@@ -2318,10 +2331,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if torch_dtype is None:
                     torch_dtype = torch.float16
                 if device_map is None:
-                    device_map = "auto"
-
-                if low_cpu_mem_usage is None:
-                    low_cpu_mem_usage = True
+                    device_map = {"": torch.cuda.current_device()}
+                    logger.warning(
+                        "The device_map was not initialized. Setting device_map to {"
+                        ":torch.cuda.current_device()}."
+                        "If you want to use the model for inference, please set device_map ='auto' "
+                    )
+                    if low_cpu_mem_usage is None:
+                        low_cpu_mem_usage = True
         elif not is_8bit_serializable and not load_in_8bit and hasattr(config, "quantization_config"):
             logger.warning(
                 "Detected the presence of a `quantization_config` attribute in the model's configuration but you don't have the correct"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2191,9 +2191,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):
-            device_map = {"": device_map.index}
+            device_map = {"": device_map}
         elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
-            device_map = {"": torch.device(device_map).index}
+            device_map = {"": torch.device(device_map)}
         elif isinstance(device_map, int):
             if device_map < 0:
                 device_map = {"": "cpu"}

--- a/tests/bitsandbytes/test_4bit.py
+++ b/tests/bitsandbytes/test_4bit.py
@@ -429,7 +429,9 @@ class Bnb4BitTestTraining(Base4bitTest):
             return
 
         # Step 1: freeze all parameters
-        model = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_4bit=True, device_map="auto")
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_4bit=True)
+
+        self.assertEqual(set(model.hf_device_map.values()), {torch.cuda.current_device()})
 
         for param in model.parameters():
             param.requires_grad = False  # freeze the model - train adapters later

--- a/tests/bitsandbytes/test_mixed_int8.py
+++ b/tests/bitsandbytes/test_mixed_int8.py
@@ -684,7 +684,9 @@ class MixedInt8TestTraining(BaseMixedInt8Test):
             return
 
         # Step 1: freeze all parameters
-        model = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_8bit=True, device_map="auto")
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, load_in_8bit=True)
+
+        self.assertEqual(set(model.hf_device_map.values()), {torch.cuda.current_device()})
 
         for param in model.parameters():
             param.requires_grad = False  # freeze the model - train adapters later


### PR DESCRIPTION
# What does this PR do?

Change how `device_map` works in the `from_pretrained` function when we load the model: 
- Training setup: we don't need to pass the `device_map` anymore ('cpu' by default or torch.cuda.local_device() for 4/8 bit model) or we can set `device_map` to the device we want our whole model to be placed on('cpu', 'cuda:0', 0, `torch.device('cpu')`...). 
- Inference setup: pass custom device_map or device_map in `["auto", "balanced", "balanced_low_0", "sequential"]`

Fixes [1412](https://github.com/huggingface/accelerate/issues/1412)

## Who can review?

@sgugger @younesbelkada 
