### PR TITLE
Effectively allow `encoder_outputs` input to be a tuple in pix2struct

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1734,6 +1734,12 @@ class Pix2StructForConditionalGeneration(Pix2StructPreTrainedModel):
                 output_hidden_states=output_hidden_states,
                 return_dict=return_dict,
             )
+        elif return_dict and not isinstance(encoder_outputs, BaseModelOutput):
+            encoder_outputs = BaseModelOutput(
+                last_hidden_state=encoder_outputs[0],
+                hidden_states=encoder_outputs[1] if len(encoder_outputs) > 1 else None,
+                attentions=encoder_outputs[2] if len(encoder_outputs) > 2 else None,
+            )
 
         hidden_states = encoder_outputs[0]
 


### PR DESCRIPTION
Be consistent with the type hint https://github.com/huggingface/transformers/blob/fabe17a726bbf6081cfbcc975d8ac451a81f3e2d/src/transformers/models/pix2struct/modeling_pix2struct.py#L1656 (which should rather be `Optional[Union[Tuple[Tuple[torch.FloatTensor]], OrderedDict]]` IMO) and follow what is done with other architectures.

Otherwise, currently, with `return_dict=True`, an error is raised as we later try to access `encoder_outputs.last_hidden_state`: https://github.com/huggingface/transformers/blob/fabe17a726bbf6081cfbcc975d8ac451a81f3e2d/src/transformers/models/pix2struct/modeling_pix2struct.py#L1768-L1781

This is blocking for the ONNX export support.