### PR TITLE
Pin rhoknp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ _deps = [
     "ray[tune]",
     "regex!=2019.12.17",
     "requests",
-    "rhoknp>=1.1.0",
+    "rhoknp>=1.1.0,<1.3.1",
     "rjieba",
     "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff>=0.0.241,<=0.0.259",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -58,7 +58,7 @@ deps = {
     "ray[tune]": "ray[tune]",
     "regex": "regex!=2019.12.17",
     "requests": "requests",
-    "rhoknp": "rhoknp>=1.1.0",
+    "rhoknp": "rhoknp>=1.1.0,<1.3.1",
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff>=0.0.241,<=0.0.259",


### PR DESCRIPTION
# What does this PR do?

The recent release of `rhoknp` breaks the BERT Japanese tests, so this PR pins it.