### PR TITLE
Fix `is_optimum_neuron_available`

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -98,7 +98,6 @@ _natten_available = _is_package_available("natten")
 _onnx_available = _is_package_available("onnx")
 _openai_available = _is_package_available("openai")
 _optimum_available = _is_package_available("optimum")
-_optimumneuron_available = _optimum_available and _is_package_available("optimum.neuron")
 _pandas_available = _is_package_available("pandas")
 _peft_available = _is_package_available("peft")
 _phonemizer_available = _is_package_available("phonemizer")
@@ -520,7 +519,7 @@ def is_optimum_available():
 
 
 def is_optimum_neuron_available():
-    return _optimumneuron_available
+    return _optimum_available and _is_package_available("optimum.neuron")
 
 
 def is_safetensors_available():


### PR DESCRIPTION
# What does this PR do?

#23163 introduced a new way for checking which seems to not work in this case. 
I get this when running `optimum-neuron`:

```
Please use the TrainiumTrainer from optimum[neuron] instead of the Transformers library to perform training on AWS Trainium instances. More information here: https://github.com/huggingface/o
ptimum-neuron  
```

It happens [here](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L82).
Basically it means that `optimum-neuron` is found to not be available, this PR fixes that.