### PR TITLE
Fix typo in doc comment of BitsAndBytesConfig

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -74,9 +74,9 @@ class BitsAndBytesConfig:
         bnb_4bit_compute_dtype (`torch.dtype` or str, *optional*, defaults to `torch.float32`):
             This sets the computational type which might be different than the input time. For example, inputs might be
             fp32, but computation can be set to bf16 for speedups.
-        bnb_4bit_quant_type (`str`, {fp4, fn4}, defaults to `fp4`):
+        bnb_4bit_quant_type (`str`, {fp4, nf4}, defaults to `fp4`):
             This sets the quantization data type in the bnb.nn.Linear4Bit layers. Options are FP4 and NF4 data types
-            which are specified by `fp4` or `fn4`.
+            which are specified by `fp4` or `nf4`.
         bnb_4bit_use_double_quant (`bool`, *optional*, defaults to `False`):
             This flag is used for nested quantization where the quantization constants from the first quantization are
             quantized again.


### PR DESCRIPTION
# What does this PR do?

Fix a typo in doc comments of `BitsAndBytesConfig` class.

It must be `nf4` instead of `fn4`.

Here is a comparison code in current main branch:

https://github.com/huggingface/transformers/blob/539e2281cd97c35ef4122757f26c88f44115fa94/src/transformers/utils/quantization_config.py#L166-L167

`qlora` implementations also uses `nf4`.

https://github.com/artidoro/qlora/blob/bdc655dfa71e5ef1553a078980fb5083c346a4cf/qlora.py#L138-L141

So I think it is better to fix doc, not a code.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger, @stevhliu @MKhalusova @younesbelkada and @sourabh112

Or @TimDettmers?
