### PR TITLE
Improve typing for bitsandbytes util

### DIFF
--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union

--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 if is_bitsandbytes_available():
     import bitsandbytes as bnb
     import torch  # noqa: F811
-    import torch.nn as nn
+    import torch.nn as nn  # noqa: F811
 
 if is_accelerate_available():
     from accelerate import init_empty_weights

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -183,6 +183,13 @@ class BitsAndBytesConfig:
     ) -> Tuple[Self, Dict[str, Any]]:  # type: ignore[valid-type]
         ...
 
+    @overload
+    @classmethod
+    def from_dict(
+        cls, config_dict: Dict[str, Any], return_unused_kwargs: bool, **kwargs: Any
+    ) -> Union[Self, Tuple[Self, Dict[str, Any]]]:  # type: ignore[valid-type]
+        ...
+
     @classmethod
     def from_dict(
         cls, config_dict: Dict[str, Any], return_unused_kwargs: bool, **kwargs: Any

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -18,9 +18,10 @@ import copy
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Union
+from typing import Any, Dict, Tuple, Union, overload
 
 from packaging import version
+from typing_extensions import Literal, Self
 
 from ..utils import is_torch_available, logging
 from ..utils.import_utils import importlib_metadata
@@ -168,8 +169,24 @@ class BitsAndBytesConfig:
         else:
             return None
 
+    @overload
     @classmethod
-    def from_dict(cls, config_dict, return_unused_kwargs, **kwargs):
+    def from_dict(
+        cls, config_dict: Dict[str, Any], return_unused_kwargs: Literal[False], **kwargs: Any
+    ) -> Self:  # type: ignore[valid-type]
+        ...
+
+    @overload
+    @classmethod
+    def from_dict(
+        cls, config_dict: Dict[str, Any], return_unused_kwargs: Literal[True], **kwargs: Any
+    ) -> Tuple[Self, Dict[str, Any]]:  # type: ignore[valid-type]
+        ...
+
+    @classmethod
+    def from_dict(
+        cls, config_dict: Dict[str, Any], return_unused_kwargs: bool, **kwargs: Any
+    ) -> Union[Self, Tuple[Self, Dict[str, Any]]]:  # type: ignore[valid-type]
         """
         Instantiates a [`BitsAndBytesConfig`] from a Python dictionary of parameters.
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Related #23980

this is part of a set of changes to improve the type checking in `PreTrainedModel.from_pretrained`

1. we add the beginnings of a `TypedDict` as a template for improving the inferred types of the `from_pretrained` `kwargs`
2. add type hints to the `bitsandbytes` util and refactor some signatures and typing based on usage
3. improve type hints of `BitsAndBytesConfig.from_dict`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Documentation: @sgugger, @stevhliu and @MKhalusova

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
