### PR TITLE
Add overloads for from_pretrained and from_dict on PretrainedConfig

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -397,7 +397,7 @@ class PretrainedConfig(PushToHubMixin):
         """
         `str`: Name or path to the pretrained checkpoint.
         """
-        return self._name_or_path
+        return getattr(self, "_name_or_path", "")
 
     @name_or_path.setter
     def name_or_path(self, value):

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -20,7 +20,7 @@ import os
 import re
 from functools import partial
 from pickle import UnpicklingError
-from typing import Any, Dict, Set, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Type, Union
 
 import flax.linen as nn
 import jax
@@ -163,18 +163,18 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
 
     Class attributes (overridden by derived classes):
 
-        - **config_class** ([`PretrainedConfig`]) -- A subclass of [`PretrainedConfig`] to use as configuration class
-          for this model architecture.
+        - **config_class** ([`Type[PretrainedConfig]`]) -- A subclass of [`PretrainedConfig`] to use as configuration
+          class for this model architecture.
         - **base_model_prefix** (`str`) -- A string indicating the attribute associated to the base model in derived
           classes of the same architecture adding modules on top of the base model.
         - **main_input_name** (`str`) -- The name of the principal input to the model (often `input_ids` for NLP
           models, `pixel_values` for vision models and `input_values` for speech models).
     """
-    config_class = None
-    base_model_prefix = ""
-    main_input_name = "input_ids"
-    _auto_class = None
-    _missing_keys = set()
+    config_class: Type[PretrainedConfig]
+    base_model_prefix: str = ""
+    main_input_name: str = "input_ids"
+    _auto_class: Optional[str] = None
+    _missing_keys: Set[str] = set()
 
     def __init__(
         self,

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -27,7 +27,7 @@ import re
 import warnings
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
 import h5py
 import numpy as np
@@ -1083,27 +1083,27 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     Class attributes (overridden by derived classes):
 
-        - **config_class** ([`PretrainedConfig`]) -- A subclass of [`PretrainedConfig`] to use as configuration class
-          for this model architecture.
+        - **config_class** ([`Type[PretrainedConfig]`]) -- A subclass of [`PretrainedConfig`] to use as configuration
+          class for this model architecture.
         - **base_model_prefix** (`str`) -- A string indicating the attribute associated to the base model in derived
           classes of the same architecture adding modules on top of the base model.
         - **main_input_name** (`str`) -- The name of the principal input to the model (often `input_ids` for NLP
           models, `pixel_values` for vision models and `input_values` for speech models).
     """
-    config_class = None
-    base_model_prefix = ""
-    main_input_name = "input_ids"
-    _auto_class = None
-    _using_dummy_loss = None
-    _label_to_output_map = None
+    config_class: Type[PretrainedConfig]
+    base_model_prefix: str = ""
+    main_input_name: str = "input_ids"
+    _auto_class: Optional[str] = None
+    _using_dummy_loss: bool = False
+    _label_to_output_map: Optional[Dict[str, str]] = None
 
     # a list of re pattern of tensor names to ignore from the model when loading the model weights
     # (and avoid unnecessary warnings).
-    _keys_to_ignore_on_load_missing = None
+    _keys_to_ignore_on_load_missing: Optional[List[str]] = None
     # a list of re pattern of tensor names to ignore from the weights when loading the model weights
     # (and avoid unnecessary warnings).
-    _keys_to_ignore_on_load_unexpected = None
-    _requires_load_weight_prefix = False
+    _keys_to_ignore_on_load_unexpected: Optional[List[str]] = None
+    _requires_load_weight_prefix: bool = False
 
     @property
     def dummy_inputs(self) -> Dict[str, tf.Tensor]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -25,7 +25,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 from packaging import version
@@ -1032,8 +1032,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
     Class attributes (overridden by derived classes):
 
-        - **config_class** ([`PretrainedConfig`]) -- A subclass of [`PretrainedConfig`] to use as configuration class
-          for this model architecture.
+        - **config_class** ([`Type[PretrainedConfig]`]) -- A subclass of [`PretrainedConfig`] to use as configuration
+          class for this model architecture.
         - **load_tf_weights** (`Callable`) -- A python *method* for loading a TensorFlow checkpoint in a PyTorch model,
           taking as arguments:
 
@@ -1047,27 +1047,27 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         - **main_input_name** (`str`) -- The name of the principal input to the model (often `input_ids` for NLP
           models, `pixel_values` for vision models and `input_values` for speech models).
     """
-    config_class = None
-    base_model_prefix = ""
-    main_input_name = "input_ids"
-    _auto_class = None
-    _no_split_modules = None
-    _skip_keys_device_placement = None
-    _keep_in_fp32_modules = None
+    config_class: Type[PretrainedConfig]
+    base_model_prefix: str = ""
+    main_input_name: str = "input_ids"
+    _auto_class: Optional[str] = None
+    _no_split_modules: Optional[List[str]] = None
+    _skip_keys_device_placement: Optional[str] = None
+    _keep_in_fp32_modules: Optional[List[str]] = None
 
     # a list of `re` patterns of `state_dict` keys that should be removed from the list of missing
     # keys we find (keys inside the model but not in the checkpoint) and avoid unnecessary warnings.
-    _keys_to_ignore_on_load_missing = None
+    _keys_to_ignore_on_load_missing: Optional[List[str]] = None
     # a list of `re` patterns of `state_dict` keys that should be removed from the list of
     # unexpected keys we find (keys inside the checkpoint but not the model) and avoid unnecessary
     # warnings.
-    _keys_to_ignore_on_load_unexpected = None
+    _keys_to_ignore_on_load_unexpected: Optional[List[str]] = None
     # a list of `state_dict` keys to ignore when saving the model (useful for keys that aren't
     # trained, but which are either deterministic or tied variables)
-    _keys_to_ignore_on_save = None
+    _keys_to_ignore_on_save: Optional[List[str]] = None
 
-    is_parallelizable = False
-    supports_gradient_checkpointing = False
+    is_parallelizable: bool = False
+    supports_gradient_checkpointing: bool = False
 
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Related #23980

this is part of a set of changes to improve the type checking in `PreTrainedModel.from_pretrained`

1. Pull `return_unused_kwargs` out of `kwargs` to create `overload`s for `PretrainedConfig.from_pretrained` & `PretrainedConfig.from_dict` for improved return typing
2. add type hints to class variables in `FlaxPreTrainedModel`, `TFPreTrainedModel`, and `PreTrainedModel` so that we can consume the above improvements

before:
<img width="656" alt="Screenshot 2023-06-03 at 10 48 18 PM" src="https://github.com/huggingface/transformers/assets/27844407/d435f97a-bd13-40e4-90f7-43287927aedb">

after:
<img width="660" alt="Screenshot 2023-06-03 at 10 47 31 PM" src="https://github.com/huggingface/transformers/assets/27844407/c0a9e781-6d42-4a44-a3be-ce05c1589b0c">


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Documentation: @sgugger, @stevhliu and @MKhalusova

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
