### PR TITLE
Create overload signatures for cached_file

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -718,24 +718,34 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
                         "user_agent": user_agent,
                         "revision": revision,
                         "subfolder": subfolder,
-                        "_raise_exceptions_for_missing_entries": False,
                         "_commit_hash": commit_hash,
                     }
-                    resolved_archive_file = cached_file(pretrained_model_name_or_path, filename, **cached_file_kwargs)
+                    resolved_archive_file = cached_file(
+                        pretrained_model_name_or_path,
+                        filename,
+                        **cached_file_kwargs,
+                        _raise_exceptions_for_missing_entries=False,
+                    )
 
                     # Since we set _raise_exceptions_for_missing_entries=False, we don't get an expection but a None
                     # result when internet is up, the repo and revision exist, but the file does not.
                     if resolved_archive_file is None and filename == FLAX_WEIGHTS_NAME:
                         # Maybe the checkpoint is sharded, we try to grab the index name in this case.
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, FLAX_WEIGHTS_INDEX_NAME, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            FLAX_WEIGHTS_INDEX_NAME,
+                            **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True
                     # Maybe the checkpoint is pytorch sharded, we try to grab the pytorch index name in this case.
                     elif resolved_archive_file is None and from_pt:
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, WEIGHTS_INDEX_NAME, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            WEIGHTS_INDEX_NAME,
+                            **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2737,17 +2737,24 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                         "user_agent": user_agent,
                         "revision": revision,
                         "subfolder": subfolder,
-                        "_raise_exceptions_for_missing_entries": False,
                         "_commit_hash": commit_hash,
                     }
-                    resolved_archive_file = cached_file(pretrained_model_name_or_path, filename, **cached_file_kwargs)
+                    resolved_archive_file = cached_file(
+                        pretrained_model_name_or_path,
+                        filename,
+                        **cached_file_kwargs,
+                        _raise_exceptions_for_missing_entries=False,
+                    )
 
                     # Since we set _raise_exceptions_for_missing_entries=False, we don't get an exception but a None
                     # result when internet is up, the repo and revision exist, but the file does not.
                     if resolved_archive_file is None and filename == SAFE_WEIGHTS_NAME:
                         # Maybe the checkpoint is sharded, we try to grab the index name in this case.
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, SAFE_WEIGHTS_INDEX_NAME, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            SAFE_WEIGHTS_INDEX_NAME,
+                            **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True
@@ -2758,19 +2765,28 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                             # This repo has no safetensors file of any kind, we switch to TensorFlow.
                             filename = TF2_WEIGHTS_NAME
                             resolved_archive_file = cached_file(
-                                pretrained_model_name_or_path, TF2_WEIGHTS_NAME, **cached_file_kwargs
+                                pretrained_model_name_or_path,
+                                TF2_WEIGHTS_NAME,
+                                **cached_file_kwargs,
+                                _raise_exceptions_for_missing_entries=False,
                             )
                     if resolved_archive_file is None and filename == TF2_WEIGHTS_NAME:
                         # Maybe the checkpoint is sharded, we try to grab the index name in this case.
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, TF2_WEIGHTS_INDEX_NAME, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            TF2_WEIGHTS_INDEX_NAME,
+                            **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True
                     if resolved_archive_file is None and filename == WEIGHTS_NAME:
                         # Maybe the checkpoint is sharded, we try to grab the index name in this case.
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, WEIGHTS_INDEX_NAME, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            WEIGHTS_INDEX_NAME,
+                            **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2484,10 +2484,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         "user_agent": user_agent,
                         "revision": revision,
                         "subfolder": subfolder,
-                        "_raise_exceptions_for_missing_entries": False,
                         "_commit_hash": commit_hash,
                     }
-                    resolved_archive_file = cached_file(pretrained_model_name_or_path, filename, **cached_file_kwargs)
+                    resolved_archive_file = cached_file(
+                        pretrained_model_name_or_path,
+                        filename,
+                        **cached_file_kwargs,
+                        _raise_exceptions_for_missing_entries=False,
+                    )
 
                     # Since we set _raise_exceptions_for_missing_entries=False, we don't get an exception but a None
                     # result when internet is up, the repo and revision exist, but the file does not.
@@ -2497,18 +2501,25 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             pretrained_model_name_or_path,
                             _add_variant(SAFE_WEIGHTS_INDEX_NAME, variant),
                             **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True
                         elif use_safetensors:
                             raise EnvironmentError(
-                                f" {_add_variant(SAFE_WEIGHTS_NAME, variant)} or {_add_variant(SAFE_WEIGHTS_INDEX_NAME, variant)} and thus cannot be loaded with `safetensors`. Please make sure that the model has been saved with `safe_serialization=True` or do not set `use_safetensors=True`."
+                                f"{_add_variant(SAFE_WEIGHTS_NAME, variant)} or "
+                                f"{_add_variant(SAFE_WEIGHTS_INDEX_NAME, variant)} and thus cannot be loaded with "
+                                "`safetensors`. Please make sure that the model has been saved with "
+                                "`safe_serialization=True` or do not set `use_safetensors=True`."
                             )
                         else:
                             # This repo has no safetensors file of any kind, we switch to PyTorch.
                             filename = _add_variant(WEIGHTS_NAME, variant)
                             resolved_archive_file = cached_file(
-                                pretrained_model_name_or_path, filename, **cached_file_kwargs
+                                pretrained_model_name_or_path,
+                                filename,
+                                **cached_file_kwargs,
+                                _raise_exceptions_for_missing_entries=False,
                             )
                     if resolved_archive_file is None and filename == _add_variant(WEIGHTS_NAME, variant):
                         # Maybe the checkpoint is sharded, we try to grab the index name in this case.
@@ -2516,6 +2527,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             pretrained_model_name_or_path,
                             _add_variant(WEIGHTS_INDEX_NAME, variant),
                             **cached_file_kwargs,
+                            _raise_exceptions_for_missing_entries=False,
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -23,7 +23,7 @@ import tempfile
 import traceback
 import warnings
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, overload
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -48,6 +48,7 @@ from huggingface_hub.utils import (
     hf_raise_for_status,
 )
 from requests.exceptions import HTTPError
+from typing_extensions import Literal
 
 from . import __version__, logging
 from .generic import working_or_temp_dir
@@ -233,7 +234,7 @@ def extract_commit_hash(resolved_file: Optional[str], commit_hash: Optional[str]
 def try_to_load_from_cache(
     repo_id: str,
     filename: str,
-    cache_dir: Union[str, Path, None] = None,
+    cache_dir: Optional[Union[str, os.PathLike]] = None,
     revision: Optional[str] = None,
     repo_type: Optional[str] = None,
 ) -> Optional[str]:
@@ -243,12 +244,12 @@ def try_to_load_from_cache(
     This function will not raise any exception if the file in not cached.
 
     Args:
-        cache_dir (`str` or `os.PathLike`):
-            The folder where the cached files lie.
         repo_id (`str`):
             The ID of the repo on huggingface.co.
         filename (`str`):
             The filename to look for inside `repo_id`.
+        cache_dir (`str` or `os.PathLike`):
+            The folder where the cached files lie.
         revision (`str`, *optional*):
             The specific model version to use. Will default to `"main"` if it's not provided and no `commit_hash` is
             provided either.
@@ -297,6 +298,94 @@ def try_to_load_from_cache(
     return cached_file if os.path.isfile(cached_file) else None
 
 
+@overload
+def cached_file(
+    path_or_repo_id: Union[str, os.PathLike],
+    filename: str,
+    cache_dir: Optional[Union[str, os.PathLike]] = ...,
+    force_download: bool = ...,
+    resume_download: bool = ...,
+    proxies: Optional[Dict[str, str]] = ...,
+    use_auth_token: Optional[Union[bool, str]] = ...,
+    revision: Optional[str] = ...,
+    local_files_only: bool = ...,
+    subfolder: str = ...,
+    repo_type: Optional[str] = ...,
+    user_agent: Optional[Union[str, Dict[str, str]]] = ...,
+    *,
+    _raise_exceptions_for_missing_entries: Literal[True] = ...,
+    _raise_exceptions_for_connection_errors: Literal[True] = ...,
+    _commit_hash: Optional[str] = ...,
+) -> str:
+    ...
+
+
+@overload
+def cached_file(
+    path_or_repo_id: Union[str, os.PathLike],
+    filename: str,
+    cache_dir: Optional[Union[str, os.PathLike]] = ...,
+    force_download: bool = ...,
+    resume_download: bool = ...,
+    proxies: Optional[Dict[str, str]] = ...,
+    use_auth_token: Optional[Union[bool, str]] = ...,
+    revision: Optional[str] = ...,
+    local_files_only: bool = ...,
+    subfolder: str = ...,
+    repo_type: Optional[str] = ...,
+    user_agent: Optional[Union[str, Dict[str, str]]] = ...,
+    *,
+    _raise_exceptions_for_missing_entries: Literal[True] = ...,
+    _raise_exceptions_for_connection_errors: bool,
+    _commit_hash: Optional[str] = ...,
+) -> Optional[str]:
+    ...
+
+
+@overload
+def cached_file(
+    path_or_repo_id: Union[str, os.PathLike],
+    filename: str,
+    cache_dir: Optional[Union[str, os.PathLike]] = ...,
+    force_download: bool = ...,
+    resume_download: bool = ...,
+    proxies: Optional[Dict[str, str]] = ...,
+    use_auth_token: Optional[Union[bool, str]] = ...,
+    revision: Optional[str] = ...,
+    local_files_only: bool = ...,
+    subfolder: str = ...,
+    repo_type: Optional[str] = ...,
+    user_agent: Optional[Union[str, Dict[str, str]]] = ...,
+    *,
+    _raise_exceptions_for_missing_entries: bool,
+    _raise_exceptions_for_connection_errors: Literal[True] = ...,
+    _commit_hash: Optional[str] = ...,
+) -> Optional[str]:
+    ...
+
+
+@overload
+def cached_file(
+    path_or_repo_id: Union[str, os.PathLike],
+    filename: str,
+    cache_dir: Optional[Union[str, os.PathLike]] = ...,
+    force_download: bool = ...,
+    resume_download: bool = ...,
+    proxies: Optional[Dict[str, str]] = ...,
+    use_auth_token: Optional[Union[bool, str]] = ...,
+    revision: Optional[str] = ...,
+    local_files_only: bool = ...,
+    subfolder: str = ...,
+    repo_type: Optional[str] = ...,
+    user_agent: Optional[Union[str, Dict[str, str]]] = ...,
+    *,
+    _raise_exceptions_for_missing_entries: bool,
+    _raise_exceptions_for_connection_errors: bool,
+    _commit_hash: Optional[str] = ...,
+) -> Optional[str]:
+    ...
+
+
 def cached_file(
     path_or_repo_id: Union[str, os.PathLike],
     filename: str,
@@ -310,10 +399,11 @@ def cached_file(
     subfolder: str = "",
     repo_type: Optional[str] = None,
     user_agent: Optional[Union[str, Dict[str, str]]] = None,
+    *,
     _raise_exceptions_for_missing_entries: bool = True,
     _raise_exceptions_for_connection_errors: bool = True,
     _commit_hash: Optional[str] = None,
-):
+) -> Optional[str]:
     """
     Tries to locate a file in a local folder and repo, downloads and cache it if necessary.
 
@@ -558,7 +648,7 @@ def get_file_from_repo(
     )
 
 
-def download_url(url, proxies=None):
+def download_url(url: str, proxies: Optional[Dict[str, str]] = None) -> str:
     """
     Downloads a given url in a temporary file. This function is not safe to use in multiple processes. Its only use is
     for deprecated behavior allowing to download config/models with a single url instead of using the Hub.


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Related #23980

this is part of a set of changes to improve the type checking in `PreTrainedModel.from_pretrained`. This PR specifically

1. creates `overload` signatures for `cached_file` s.t. when you pass in `_raise_exceptions_for_missing_entries` or `_raise_exceptions_for_connection_errors` either implicitly or explicitly (except via `dict` unpacking), we can get the actual correct return type

I asked on the `pyright` discussions to understand pyright's limitations regarding dict unpacking: https://github.com/microsoft/pyright/discussions/5231 ([addressed!](https://github.com/microsoft/pyright/commit/d345e20ebf5fb1d9e322aa3560187571a7f8cf16)) but I think this will only really benefit us if the `dict` isn't just `dict[str, Any]`, which they generally are in the places where we were attempting to perform `dict` unpacking. IMO manually passing it in in the few places where we were doing unpacking isn't really a big deal

before:
<img width="514" alt="Screenshot 2023-06-03 at 11 09 07 PM" src="https://github.com/huggingface/transformers/assets/27844407/255a4b07-7b15-41e9-97e9-041c5dc8146b">
<img width="567" alt="Screenshot 2023-06-03 at 11 09 45 PM" src="https://github.com/huggingface/transformers/assets/27844407/f3a23532-894d-4b6a-a061-bc320b88e648">

after:
<img width="489" alt="Screenshot 2023-06-03 at 11 11 47 PM" src="https://github.com/huggingface/transformers/assets/27844407/d6a1dd36-4d35-4d26-9d93-ab308b55b85b">
<img width="510" alt="Screenshot 2023-06-03 at 11 10 11 PM" src="https://github.com/huggingface/transformers/assets/27844407/e4f2c6e6-f128-47e2-ae94-85e0a5a1ba81">



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Documentation: @sgugger, @stevhliu and @MKhalusova

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
