### PR TITLE
Regarding pix2struct's bugs in the attentions of the encoder's and decoder's outputs

### DIFF
--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1094,12 +1094,7 @@ class Pix2StructTextBlock(nn.Module):
             clamp_value = torch.finfo(hidden_states.dtype).max - 1000
             hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
-        outputs = (hidden_states,)
-
-        if use_cache:
-            outputs = outputs + (present_key_value_state,) + attention_outputs
-        else:
-            outputs = outputs + attention_outputs
+        outputs = (hidden_states, present_key_value_state) + attention_outputs
 
         return outputs
 
@@ -1530,9 +1525,6 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
 
             # layer_outputs is a tuple with:
             # hidden-states, key-value-states, (self-attention position bias), (self-attention weights), (cross-attention position bias), (cross-attention weights)
-            if use_cache is False:
-                layer_outputs = layer_outputs[:1] + (None,) + layer_outputs[1:]
-
             hidden_states, present_key_value_state = layer_outputs[:2]
 
             # We share the position biases between the layers - the first layer store them
@@ -1546,8 +1538,8 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
                 present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                all_attentions = all_attentions + (layer_outputs[2],)
-                all_cross_attentions = all_cross_attentions + (layer_outputs[3],)
+                all_attentions = all_attentions + (layer_outputs[3],)
+                all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -362,7 +362,10 @@ class Pix2StructVisionEncoder(nn.Module):
             hidden_states = layer_outputs[0]
 
             if output_attentions:
-                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+                if len(layer_outputs) >= 3:
+                    all_self_attentions = all_self_attentions + (layer_outputs[2],)
+                else:
+                    all_self_attentions = all_self_attentions + (None,)
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
@@ -1538,8 +1541,12 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
                 present_key_value_states = present_key_value_states + (present_key_value_state,)
 
             if output_attentions:
-                all_attentions = all_attentions + (layer_outputs[3],)
-                all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
+                if len(layer_outputs) >= 6:
+                    all_attentions = all_attentions + (layer_outputs[3],)
+                    all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
+                else:
+                    all_attentions = all_attentions + (None,)
+                    all_cross_attentions = all_cross_attentions + (None,)
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -365,7 +365,7 @@ class Pix2StructVisionEncoder(nn.Module):
                 if len(layer_outputs) >= 3:
                     all_self_attentions = all_self_attentions + (layer_outputs[2],)
                 else:
-                    all_self_attentions = all_self_attentions + (None,)
+                    all_self_attentions = all_self_attentions + (torch.zeros_like(layer_outputs[1]),)
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
@@ -1545,8 +1545,8 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
                     all_attentions = all_attentions + (layer_outputs[3],)
                     all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
                 else:
-                    all_attentions = all_attentions + (None,)
-                    all_cross_attentions = all_cross_attentions + (None,)
+                    all_attentions = all_attentions + (torch.zeros_like(layer_outputs[2]),)
+                    all_cross_attentions = all_cross_attentions + (torch.zeros_like(layer_outputs[3]),)
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -365,7 +365,7 @@ class Pix2StructVisionEncoder(nn.Module):
                 if len(layer_outputs) >= 3:
                     all_self_attentions = all_self_attentions + (layer_outputs[2],)
                 else:
-                    all_self_attentions = all_self_attentions + (torch.zeros_like(layer_outputs[1]),)
+                    all_self_attentions = all_self_attentions + (torch.zeros_like(layer_outputs[1], requires_grad=True),)
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
@@ -1545,8 +1545,8 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
                     all_attentions = all_attentions + (layer_outputs[3],)
                     all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
                 else:
-                    all_attentions = all_attentions + (torch.zeros_like(layer_outputs[2]),)
-                    all_cross_attentions = all_cross_attentions + (torch.zeros_like(layer_outputs[3]),)
+                    all_attentions = all_attentions + (torch.zeros_like(layer_outputs[2], requires_grad=True),)
+                    all_cross_attentions = all_cross_attentions + (torch.zeros_like(layer_outputs[3], requires_grad=True),)
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -365,7 +365,7 @@ class Pix2StructVisionEncoder(nn.Module):
                 if len(layer_outputs) >= 3:
                     all_self_attentions = all_self_attentions + (layer_outputs[2],)
                 else:
-                    all_self_attentions = all_self_attentions + (torch.zeros_like(layer_outputs[1], requires_grad=True),)
+                    all_self_attentions = all_self_attentions + (layer_outputs[1],)
 
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states,)
@@ -1545,8 +1545,8 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
                     all_attentions = all_attentions + (layer_outputs[3],)
                     all_cross_attentions = all_cross_attentions + (layer_outputs[5],)
                 else:
-                    all_attentions = all_attentions + (torch.zeros_like(layer_outputs[2], requires_grad=True),)
-                    all_cross_attentions = all_cross_attentions + (torch.zeros_like(layer_outputs[3], requires_grad=True),)
+                    all_attentions = all_attentions + (layer_outputs[2],)
+                    all_cross_attentions = all_cross_attentions + (layer_outputs[3],)
 
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.dropout(hidden_states)


### PR DESCRIPTION
This change addresses the following bug: incorrect indices were used for "all_attentions" ([link](https://github.com/huggingface/transformers/blob/539e2281cd97c35ef4122757f26c88f44115fa94/src/transformers/models/pix2struct/modeling_pix2struct.py#L1549)) and "all_cross_attentions" ([link](https://github.com/huggingface/transformers/blob/539e2281cd97c35ef4122757f26c88f44115fa94/src/transformers/models/pix2struct/modeling_pix2struct.py#L1550)) where the indices should have been 3 and 5, respectively, but the original code used 2 and 3.

code snippet:

```
from PIL import Image
import requests
from transformers import AutoProcessor, Pix2StructForConditionalGeneration

processor = AutoProcessor.from_pretrained("google/pix2struct-textcaps-base")
model = Pix2StructForConditionalGeneration.from_pretrained("google/pix2struct-textcaps-base")
url = "https://www.ilankelman.org/stopsigns/australia.jpg"
image = Image.open(requests.get(url, stream=True).raw)
inputs = processor(images=image, return_tensors="pt")

outputs = model(**inputs, decoder_input_ids=torch.tensor([[0]]), output_attentions=True)
print(outputs.cross_attentions[0].shape)
```

The shape of cross_attentions should be (batchsize, head num, text tokens, image tokens). After the modification, the shape is (1, 12, 1, 2048), which is correct. However, before the modification, the shape was (1, 12, 1, 1), which is clearly incorrect, as it represents the cross-attention between text and image.

The "attention" in the original code is also incorrect as it retrieves the position bias instead of the attention. Actually, there is a correct comment regarding this matter: [comment](https://github.com/huggingface/transformers/blob/539e2281cd97c35ef4122757f26c88f44115fa94/src/transformers/models/pix2struct/modeling_pix2struct.py#L1532) , but it is unclear why the subsequent code does not use the indices provided in the comment to retrieve the correct values.