### PR TITLE
TensorBoard callback no longer adds hparams

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -639,9 +639,6 @@ class TensorBoardCallback(TrainerCallback):
                 if hasattr(model, "config") and model.config is not None:
                     model_config_json = model.config.to_json_string()
                     self.tb_writer.add_text("model_config", model_config_json)
-            # Version of TensorBoard coming from tensorboardX does not have this method.
-            if hasattr(self.tb_writer, "add_hparams"):
-                self.tb_writer.add_hparams(args.to_sanitized_dict(), metric_dict={})
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         if not state.is_world_process_zero:


### PR DESCRIPTION
# What does this PR do?
The `TensorBoardCallback.on_train_begin` function calls `add_hparams` with an empty `metric_dict` parameter, meaning that the only information that is logged is from `args.sanitized_dict()`. This is duplicated information from the previous `self.tb_writer.add_text("args", args.to_json_string())`. As a result, the `add_hparams` call is unnecessary and this PR removes it. 

Adjacently fixes https://github.com/huggingface/transformers/issues/21821. 

I'm aware of the following TensorBoard related documentation:
- https://huggingface.co/docs/hub/tensorboard
- https://huggingface.co/docs/transformers/main/en/main_classes/callback#transformers.integrations.TensorBoardCallback

None of these docs need to be updated in this PR. 

A sanity check test:
```python
"""
Minimal replication of https://github.com/huggingface/transformers/issues/21821
"""
from os import listdir
from shutil import rmtree

from transformers import TrainingArguments
from transformers.integrations import TensorBoardCallback


output_dir = "output_dir"

args = TrainingArguments(output_dir=output_dir, logging_dir=output_dir)

def has_extra_file():
    return len(listdir(output_dir)) > 1


class DummyControl:
    should_training_stop = None


class DummyState:
    is_world_process_zero = True
    is_hyper_param_search = False


class NoHParamsTensorBoardCallback(TensorBoardCallback):
    # This is a copy of `TensorBoardCallback.on_train_begin` unless specified otherwise
    def on_train_begin(self, args, state, control, **kwargs):
        if not state.is_world_process_zero:
            return

        log_dir = None

        if state.is_hyper_param_search:
            trial_name = state.trial_name
            if trial_name is not None:
                log_dir = os.path.join(args.logging_dir, trial_name)

        if self.tb_writer is None:
            self._init_summary_writer(args, log_dir)

        if self.tb_writer is not None:
            self.tb_writer.add_text("args", args.to_json_string())
            if "model" in kwargs:
                model = kwargs["model"]
                if hasattr(model, "config") and model.config is not None:
                    model_config_json = model.config.to_json_string()
                    self.tb_writer.add_text("model_config", model_config_json)

            ###########################
            # START no hparams call
            ###########################

            # Original code:
            # # Version of TensorBoard coming from tensorboardX does not have this method.
            # if hasattr(self.tb_writer, "add_hparams"):
            #     self.tb_writer.add_hparams(args.to_sanitized_dict(), metric_dict={})

            ###########################
            # END no hparams call
            ###########################


rmtree(output_dir, ignore_errors=True)
TensorBoardCallback().on_train_begin(args, DummyState(), DummyControl())
print(f"With the call to `add_hparams`, has extra file is {has_extra_file()}")

rmtree(output_dir, ignore_errors=True)
NoHParamsTensorBoardCallback().on_train_begin(args, DummyState(), DummyControl())
print(f"WithOUT the call to `add_hparams`, has extra file is {has_extra_file()}")

rmtree(output_dir, ignore_errors=True)  # Cleanup

```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
Anyone in the community is free to review the PR once the tests have passed. 
