### PR TITLE
changed unused args from error to warning

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1137,7 +1137,7 @@ class GenerationMixin:
                 unused_model_args.append(key)
 
         if unused_model_args:
-            raise ValueError(
+            warnings.warn(
                 f"The following `model_kwargs` are not used by the model: {unused_model_args} (note: typos in the"
                 " generate arguments will also show up in this list)"
             )


### PR DESCRIPTION
the value error now breaks the code, while it can run perfectly without the unused arguments. This happens for example in https://huggingface.co/OpenAssistant/falcon-40b-sft-mix-1226/discussions/2

# What does this PR do?

Fixes issue referenced here: https://huggingface.co/OpenAssistant/falcon-40b-sft-mix-1226/discussions/2


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Library:


- generate: @gante


