### PR TITLE
change to suitable with half precision in tpu

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -645,6 +645,8 @@ class Trainer:
                         args.half_precision_backend = "cpu_amp"
                     else:
                         raise ValueError("Tried to use cpu amp but native cpu amp is not available")
+                elif args.device == torch.device('xla'):
+                    args.half_precision_backend = "cpu_amp"
                 else:
                     args.half_precision_backend = "cuda_amp"
 


### PR DESCRIPTION
I have made changes to your statement to make it suitable for a pull request on GitHub. Please review the following:

Description:
I am utilizing TPU for training and have observed that when setting the half_precision_backend to 'auto', it automatically assigns it as 'cuda_amp'. However, this causes a bug since there is no torch.cuda available on TPUs. To resolve this issue, I have implemented a conditional check where if the device is XLA (TPU), it will switch to 'cpu_amp' instead, and then avoid bug that call torch.cuda when using TPU.

However, it appears that this change has led to a decrease in TPU speed. I would appreciate it if you could review my modification and provide suggestions for improvements.