### PR TITLE
Skip `test_multi_gpu_data_parallel_forward` for `MobileViTV2ModelTest`

### DIFF
--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -19,7 +19,7 @@ import inspect
 import unittest
 
 from transformers import MobileViTV2Config
-from transformers.testing_utils import require_torch_multi_gpu, require_torch, require_vision, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_multi_gpu, require_vision, slow, torch_device
 from transformers.utils import cached_property, is_torch_available, is_vision_available
 
 from ...test_configuration_common import ConfigTester

--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -221,7 +221,7 @@ class MobileViTV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         pass
 
     @require_torch_multi_gpu
-    @unittest.skip(reason="Got `CUDA error: misaligned address`")
+    @unittest.skip(reason="Got `CUDA error: misaligned address` for tests after this one being run.")
     def test_multi_gpu_data_parallel_forward(self):
         pass
 

--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -19,7 +19,7 @@ import inspect
 import unittest
 
 from transformers import MobileViTV2Config
-from transformers.testing_utils import require_torch, require_vision, slow, torch_device
+from transformers.testing_utils import require_torch_multi_gpu, require_torch, require_vision, slow, torch_device
 from transformers.utils import cached_property, is_torch_available, is_vision_available
 
 from ...test_configuration_common import ConfigTester
@@ -218,6 +218,11 @@ class MobileViTV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
 
     @unittest.skip(reason="MobileViTV2 does not output attentions")
     def test_attention_outputs(self):
+        pass
+
+    @require_torch_multi_gpu
+    @unittest.skip(reason="Got `CUDA error: misaligned address`")
+    def test_multi_gpu_data_parallel_forward(self):
         pass
 
     def test_forward_signature(self):


### PR DESCRIPTION
# What does this PR do?

Skip `test_multi_gpu_data_parallel_forward` for `MobileViTV2ModelTest`.

This passes on CI, but the other 2x tests running after this one are all failing with `CUDA error: misaligned address`.

(Similar to #21991)