### PR TITLE
Fix `MobileViTV2` checkpoint name

### DIFF
--- a/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
+++ b/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
@@ -49,16 +49,16 @@ logger = logging.get_logger(__name__)
 _CONFIG_FOR_DOC = "MobileViTV2Config"
 
 # Base docstring
-_CHECKPOINT_FOR_DOC = "shehan97/mobilevitv2-1.0-imagenet1k-256"
+_CHECKPOINT_FOR_DOC = "apple/mobilevitv2-1.0-imagenet1k-256"
 _EXPECTED_OUTPUT_SHAPE = [1, 512, 8, 8]
 
 # Image classification docstring
-_IMAGE_CLASS_CHECKPOINT = "shehan97/mobilevitv2-1.0-imagenet1k-256"
+_IMAGE_CLASS_CHECKPOINT = "apple/mobilevitv2-1.0-imagenet1k-256"
 _IMAGE_CLASS_EXPECTED_OUTPUT = "tabby, tabby cat"
 
 
 MOBILEVITV2_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "shehan97/mobilevitv2-1.0-imagenet1k-256"
+    "apple/mobilevitv2-1.0-imagenet1k-256"
     # See all MobileViTV2 models at https://huggingface.co/models?filter=mobilevitv2
 ]
 

--- a/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
+++ b/src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
@@ -49,16 +49,16 @@ logger = logging.get_logger(__name__)
 _CONFIG_FOR_DOC = "MobileViTV2Config"
 
 # Base docstring
-_CHECKPOINT_FOR_DOC = "apple/mobilevitv2-1.0-imagenet1k-256"
+_CHECKPOINT_FOR_DOC = "shehan97/mobilevitv2-1.0-imagenet1k-256"
 _EXPECTED_OUTPUT_SHAPE = [1, 512, 8, 8]
 
 # Image classification docstring
-_IMAGE_CLASS_CHECKPOINT = "apple/mobilevitv2-1.0-imagenet1k-256"
+_IMAGE_CLASS_CHECKPOINT = "shehan97/mobilevitv2-1.0-imagenet1k-256"
 _IMAGE_CLASS_EXPECTED_OUTPUT = "tabby, tabby cat"
 
 
 MOBILEVITV2_PRETRAINED_MODEL_ARCHIVE_LIST = [
-    "apple/mobilevitv2-1.0-imagenet1k-256"
+    "shehan97/mobilevitv2-1.0-imagenet1k-256"
     # See all MobileViTV2 models at https://huggingface.co/models?filter=mobilevitv2
 ]
 

--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -306,14 +306,14 @@ class MobileViTV2ModelIntegrationTest(unittest.TestCase):
     @cached_property
     def default_image_processor(self):
         return (
-            MobileViTImageProcessor.from_pretrained("shehan97/mobilevitv2-1.0-imagenet1k-256")
+            MobileViTImageProcessor.from_pretrained("apple/mobilevitv2-1.0-imagenet1k-256")
             if is_vision_available()
             else None
         )
 
     @slow
     def test_inference_image_classification_head(self):
-        model = MobileViTV2ForImageClassification.from_pretrained("shehan97/mobilevitv2-1.0-imagenet1k-256").to(
+        model = MobileViTV2ForImageClassification.from_pretrained("apple/mobilevitv2-1.0-imagenet1k-256").to(
             torch_device
         )
 


### PR DESCRIPTION
# What does this PR do?

For `tests/models/mobilevitv2/test_modeling_mobilevitv2.py::MobileViTV2ModelTest::test_model_from_pretrained`,  we get
```bash
(line 433)  OSError: apple/mobilevitv2-1.0-imagenet1k-256 is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
```

This PR changes the checkpoint name to avoid this failure.

**Question**: Should we upload the model to `apple/mobilevitv2-1.0-imagenet1k-256` and change all checkpoint names in the code to `apple/mobilevitv2-1.0-imagenet1k-256`?

cc @shehanmunasinghe 
