### PR TITLE
Pin `deepspeed` to `0.9.2` for now

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -393,7 +393,7 @@ jobs:
         working-directory: /workspace
         run: |
           python3 -m pip uninstall -y deepspeed
-          DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 DS_BUILD_UTILS=1 python3 -m pip install deepspeed --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check
+          DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 DS_BUILD_UTILS=1 python3 -m pip install deepspeed==0.9.2 --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check
 
       - name: NVIDIA-SMI
         run: |


### PR DESCRIPTION
# What does this PR do?

DeepSpeed 0.9.3 has some issue, and introduced many more failures. See for example [here](https://github.com/huggingface/transformers/actions/runs/5166856163/jobs/9307371184) and [there](https://github.com/huggingface/transformers/actions/runs/5166856163/jobs/9307371242).

Let's pin `deepspeed==0.9.2` for now 🙏 