### PR TITLE
Fix device placement for model-parallelism in generate for encoder/de…

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -616,6 +616,10 @@ class GenerationMixin:
     ) -> Dict[str, Any]:
         # 1. get encoder
         encoder = self.get_encoder()
+        # Compatibility with Accelerate big model inference: we need the encoder to outputs stuff on the same device
+        # as the inputs.
+        if hasattr(encoder, "_hf_hook"):
+            encoder._hf_hook.io_same_device = True
 
         # 2. Prepare encoder args and encoder kwargs from model kwargs.
         irrelevant_prefix = ["decoder_", "cross_attn", "use_cache"]
@@ -2317,6 +2321,7 @@ class GenerationMixin:
         unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
 
         this_peer_finished = False  # used by synced_gpus only
+        print({k: v.device if hasattr(v, "device") else v for k, v in model_kwargs.items()})
         while True:
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
@@ -2330,7 +2335,7 @@ class GenerationMixin:
 
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
-
+            print({k: v.device if hasattr(v, "device") else v for k, v in model_inputs.items()})
             # forward pass to get next token
             outputs = self(
                 **model_inputs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2321,7 +2321,6 @@ class GenerationMixin:
         unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
 
         this_peer_finished = False  # used by synced_gpus only
-        print({k: v.device if hasattr(v, "device") else v for k, v in model_kwargs.items()})
         while True:
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
@@ -2335,7 +2334,7 @@ class GenerationMixin:
 
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
-            print({k: v.device if hasattr(v, "device") else v for k, v in model_inputs.items()})
+
             # forward pass to get next token
             outputs = self(
                 **model_inputs,


### PR DESCRIPTION
…coders

When using model parallelism with encoder/decoder models, there is an issue in `generate` using the encoder in isolation. That encoder won't output logits on the same device as the inputs like the whole model does, and we get mismatched device errors.

Repro:
```py
from transformers import AutoModelForSeq2SeqLM

model = AutoModelForSeq2SeqLM.from_pretrained("facebook/nllb-200-distilled-600M", device_map="auto")
inputs = {"input_ids": torch.tensor([[256047, 94124, 248079, 15697, 248203, 2]], device=0), 'attention_mask': torch.tensor([[1, 1, 1, 1, 1, 1]], device=0), 'forced_bos_token_id': 256079}

model.generate(**inputs, max_length=4000)
```