### PR TITLE
Add support for non-rust implemented tokenization for `__getitem__` method.

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -233,11 +233,16 @@ class BatchEncoding(UserDict):
         etc.).
 
         If the key is an integer, get the `tokenizers.Encoding` for batch item with index `key`.
+
+        If the key is a slice, returns the value of the dict associated to `key` ('input_ids', 'attention_mask', etc.)
+        with the constraint of slice.
         """
         if isinstance(item, str):
             return self.data[item]
         elif self._encodings is not None:
             return self._encodings[item]
+        elif isinstance(item, slice):
+            return {key: self.data[key][slice] for key in self.data.keys()}
         else:
             raise KeyError(
                 "Indexing with integers (to access backend Encoding for a given batch index) "

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -245,8 +245,8 @@ class BatchEncoding(UserDict):
             return {key: self.data[key][slice] for key in self.data.keys()}
         else:
             raise KeyError(
-                "Indexing with integers (to access backend Encoding for a given batch index) "
-                "is not available when using Python based tokenizers"
+                "Invalid key. Only three types of key are available: "
+                "(1) string, (2) integers for backend Encoding, and (3) slices for data subsetting."
             )
 
     def __getattr__(self, item: str):


### PR DESCRIPTION
# Overview
This PR is going to add a support for the usage scenario of "getting a slice from the batch-tokenized sequences".

Without this PR, it seems to raise KeyError with the following message KeyError: 'Indexing with integers (to access backend Encoding for a given batch index) is not available when using Python based tokenizers'

P.S. The above scenario could be reproduced by using some models new uploaded but not support to Rust-implemented tokenization, such as fnlp/moss-moon-003-sft. Also we can run the following examplar script for reproducing this issue:

```python
# test script `/home/workspace/test.py` for this PR. 
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("fnlp/moss-moon-003-sft", trust_remote_code=True)
tok.add_special_tokens({"pad_token": "[PAD]"})

texts = ["Today is a good day!", "It's a good idea!", "How's going?"]
batch_tok = tok(texts, padding=True)
print(batch_tok[0:3])  # report `KeyError` here
```
# Error Message
```txt
Traceback (most recent call last):
  File "/home/workspace/test.py", line 8, in <module>
    print(batch_tok[0:3])  # report `KeyError` here
  File "/home/app/anaconda3/envs/test/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 242, in __getitem__
    raise KeyError(
KeyError: 'Indexing with integers (to access backend Encoding for a given batch index) is not available when using Python based tokenizers'
```

All in all, I think it seems useful to implement __getitem__ method behind it in Python side :)

Note that this PR is associative with the previous closed one. 
https://github.com/huggingface/transformers/pull/23645