### PR TITLE
Fix a tiny typo in `WhisperForConditionalGeneration::generate` docstring

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1519,10 +1519,10 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             return_timestamps (`bool`, *optional*):
                 Whether to return the timestamps with the text. This enables the `WhisperTimestampsLogitsProcessor`.
-            task (`bool`, *optional*):
+            task (`str`, *optional*):
                 Task to use for generation, either "translate" or "transcribe". The `model.config.forced_decoder_ids`
                 will be updated accordingly.
-            language (`bool`, *optional*):
+            language (`str`, *optional*):
                 Language token to use for generation, can be either in the form of `<|en|>`, `en` or `english`. You can
                 find all the possible language tokens in the `model.generation_config.lang_to_id` dictionary.
             is_multilingual (`bool`, *optional*):


### PR DESCRIPTION
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


@sanchit-gandhi 