### PR TITLE
Prevent ZeroDivisionError on `trainer.evaluate` if model and dataset are tiny 

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -350,6 +350,8 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None):
     """
     runtime = time.time() - start_time
     result = {f"{split}_runtime": round(runtime, 4)}
+    if runtime == 0:
+        return result
     if num_samples is not None:
         samples_per_second = num_samples / runtime
         result[f"{split}_samples_per_second"] = round(samples_per_second, 3)


### PR DESCRIPTION
Closes #24048

Hello!

## Pull Request overview
* Prevent ZeroDivisionError on `trainer.evaluate` if model and dataset are tiny 

## Details
Please see #24048 for details.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Tests would be quite flaky for this.


## Who can review?

@sgugger, @younesbelkada 

- Tom Aarsen