### PR TITLE
fix executable batch size issue

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1645,6 +1645,7 @@ class Trainer:
     def _inner_training_loop(
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
+        self.accelerator.free_memory()
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1646,6 +1646,7 @@ class Trainer:
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
         self.accelerator.free_memory()
+        self.optimizer = self.lr_scheduler = None
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1646,7 +1646,6 @@ class Trainer:
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
         self.accelerator.free_memory()
-        self.optimizer = self.lr_scheduler = None
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps


### PR DESCRIPTION
# What does this PR do?
1. Fixes #24050 
2. Context: We weren't handling properly the `auto_find_batch_size=True` case. Here, we need to free all of the stored model references in the Accelerator each time as mentioned in the https://github.com/huggingface/accelerate/blob/main/examples/by_feature/automatic_gradient_accumulation.py
3. This PR does that.
