### PR TITLE
[`Hub`] Add `safe_serialization` in push_to_hub

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -740,6 +740,7 @@ class PushToHubMixin:
         use_auth_token: Optional[Union[bool, str]] = None,
         max_shard_size: Optional[Union[int, str]] = "10GB",
         create_pr: bool = False,
+        safe_serialization: bool = False,
         **deprecated_kwargs,
     ) -> str:
         """
@@ -767,6 +768,8 @@ class PushToHubMixin:
                 by a unit (like `"5MB"`).
             create_pr (`bool`, *optional*, defaults to `False`):
                 Whether or not to create a PR with the uploaded files or directly commit.
+            safe_serialization (`bool`, *optional*, defaults to `False`):
+                Whether or not to convert the model weights in safetensors format for safer serialization.
 
         Examples:
 
@@ -809,7 +812,7 @@ class PushToHubMixin:
             files_timestamps = self._get_files_timestamps(work_dir)
 
             # Save all files.
-            self.save_pretrained(work_dir, max_shard_size=max_shard_size)
+            self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
 
             return self._upload_modified_files(
                 work_dir,


### PR DESCRIPTION
# What does this PR do?

This PR adds the possibility to directly push safetensors weight on the Hub, as the `save_pretrained` method was called with default args and it is currently not possible to pass kwargs to use `safe_serialization=True`.

cc @sgugger @Narsil 

Related: https://github.com/huggingface/peft/pull/553

also cc @pacman100 