### PR TITLE
Be nice to TF

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -272,6 +272,7 @@ tf_job = CircleCIJob(
         "pip install tensorflow_probability",
     ],
     parallelism=1,
+    pytest_num_workers=7,
     pytest_options={"rA": None},
 )
 

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -272,7 +272,7 @@ tf_job = CircleCIJob(
         "pip install tensorflow_probability",
     ],
     parallelism=1,
-    pytest_num_workers=7,
+    pytest_num_workers=6,
     pytest_options={"rA": None},
 )
 


### PR DESCRIPTION
# What does this PR do?

... and to @Rocketknight1 

To be serious: to avoid OOM issue introduced in #23234. Note `torch_job` use `pytest_num_workers=3`.

See [this comment](https://github.com/huggingface/transformers/pull/24071#issuecomment-1580778679). 