### PR TITLE
Up pinned accelerate version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if stale_egg_info.exists():
 # 2. once modified, run: `make deps_table_update` to update src/transformers/dependency_versions_table.py
 _deps = [
     "Pillow",
-    "accelerate>=0.19.0",
+    "accelerate>=0.20.0",
     "av==9.2.0",  # Latest version of PyAV (10.0.0) has issues with audio stream.
     "beautifulsoup4",
     "black~=23.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -3,7 +3,7 @@
 # 2. run `make deps_table_update``
 deps = {
     "Pillow": "Pillow",
-    "accelerate": "accelerate>=0.19.0",
+    "accelerate": "accelerate>=0.20.0",
     "av": "av==9.2.0",
     "beautifulsoup4": "beautifulsoup4",
     "black": "black~=23.1",

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1668,9 +1668,9 @@ class TrainingArguments:
         requires_backends(self, ["torch"])
         logger.info("PyTorch: setting up devices")
         if not is_sagemaker_mp_enabled():
-            if not is_accelerate_available(check_partial_state=True):
+            if not is_accelerate_available(min_version="0.20.0"):
                 raise ImportError(
-                    "Using the `Trainer` with `PyTorch` requires `accelerate>=0.19.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
+                    "Using the `Trainer` with `PyTorch` requires `accelerate>=0.20.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
                 )
             AcceleratorState._reset_state(reset_partial_state=True)
         self.distributed_state = None

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -508,9 +508,9 @@ def is_protobuf_available():
     return importlib.util.find_spec("google.protobuf") is not None
 
 
-def is_accelerate_available(check_partial_state=False):
-    if check_partial_state:
-        return _accelerate_available and version.parse(_accelerate_version) >= version.parse("0.19.0")
+def is_accelerate_available(min_version: str = None):
+    if min_version is not None:
+        return _accelerate_available and version.parse(_accelerate_version) >= version.parse(min_version)
     return _accelerate_available
 
 


### PR DESCRIPTION
# What does this PR do?

Increases pinned accelerate version, and also let's the `is_accelerate_available` check see for a specific version, since now we care much more about just if `PartialState` is available.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger