### PR TITLE
Do not prepare lr scheduler as it as the right number of steps

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1747,9 +1747,7 @@ class Trainer:
 
         # prepare using `accelerator` prepare
         if use_accelerator_prepare:
-            model, self.optimizer, self.lr_scheduler = self.accelerator.prepare(
-                self.model, self.optimizer, self.lr_scheduler
-            )
+            model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
 
         if self.is_fsdp_enabled:
             self.model = model
@@ -1996,6 +1994,7 @@ class Trainer:
                         optimizer_was_run = scale_before <= scale_after
                     else:
                         self.optimizer.step()
+                        optimizer_was_run = not self.accelerator.optimizer_step_was_skipped
 
                     if optimizer_was_run:
                         # Delay optimizer scheduling until metrics are generated

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1994,6 +1994,7 @@ class Trainer:
                         optimizer_was_run = scale_before <= scale_after
                     else:
                         self.optimizer.step()
+                        # Comment
                         optimizer_was_run = not self.accelerator.optimizer_step_was_skipped
 
                     if optimizer_was_run:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1994,7 +1994,6 @@ class Trainer:
                         optimizer_was_run = scale_before <= scale_after
                     else:
                         self.optimizer.step()
-                        # Comment
                         optimizer_was_run = not self.accelerator.optimizer_step_was_skipped
 
                     if optimizer_was_run:


### PR DESCRIPTION
# What does this PR do?

Right now the LR scheduler is prepared by the Accelerate but it has a number of steps that already accounts for the number of processes. This results in the LR scheduler being stepp through num_processes too fast. This PR thus removes the lr_scheduler from the prepared objects.

Should fix #23986 