### PR TITLE
Avoid `GPT-2` daily CI job OOM (in TF tests)

### DIFF
--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -502,6 +502,7 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         self.config_tester = ConfigTester(self, config_class=GPT2Config, n_embd=37)
 
     def tearDown(self):
+        super().tearDown()
         # clean-up as much as possible GPU memory occupied by PyTorch
         gc.collect()
         torch.cuda.empty_cache()

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -15,6 +15,7 @@
 
 
 import datetime
+import gc
 import math
 import unittest
 
@@ -500,6 +501,11 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         self.model_tester = GPT2ModelTester(self)
         self.config_tester = ConfigTester(self, config_class=GPT2Config, n_embd=37)
 
+    def tearDown(self):
+        # clean-up as much as possible GPU memory occupied by PyTorch
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def test_config(self):
         self.config_tester.run_common_tests()
 
@@ -683,6 +689,12 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
 
 @require_torch
 class GPT2ModelLanguageGenerationTest(unittest.TestCase):
+    def tearDown(self):
+        super().tearDown()
+        # clean-up as much as possible GPU memory occupied by PyTorch
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def _test_lm_generate_gpt2_helper(
         self,
         gradient_checkpointing=False,


### PR DESCRIPTION
# What does this PR do?

Clear (as much as possible) GPU memory usage allocated by torch, so the TF tests (GPT-2) get more room and make @Rocketknight1 's life easier 😆.

Some (TF) tests get OOM after #23234.

Note, the changes in this PR are in torch test files instead of TF test files! This is similar to #16881, which has more details mentioned.

Running manually and all gpt2 tests pass now.
