### PR TITLE
reset accelerate env variables after each test

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1339,6 +1339,11 @@ class TestCasePlus(unittest.TestCase):
             AcceleratorState._reset_state()
             PartialState._reset_state()
 
+            # delete all the env variables having `ACCELERATE` in them
+            for k in list(os.environ.keys()):
+                if "ACCELERATE" in k:
+                    del os.environ[k]
+
 
 def mockenv(**kwargs):
     """


### PR DESCRIPTION
# What does this PR do?

## Context:
For the failing tests in `test_trainer_ext`, the reason is given below:
1. These tests are run via following command:
```
python -m pytest -v --make-reports=multi-gpu_tests_torch_cuda_extensions_gpu tests/deepspeed tests/extended
```

2. Now, as DeepSpeed tests are run first, even though the AcceleratorState  is reset during teardown, the env variable set by Accelerate ACCELERATE_USE_DEEPSPEED  isn't deleted (if the test isn't a script run as a subprocess) and as such Accelerator object initialization in extended tests create DeepSpeedPlugin leading to them failing with - HFDeepSpeedPlugin raises config mismatch error

3. Simple reproducer:
```
cd transformers
export CUDA_VISIBLE_DEVICES="0,1"
export RUN_SLOW="yes"
pytest -sv tests/deepspeed/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_hf_ds_config_mismatch tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq
```

This PR fixes it by deleting all the env variables having `ACCELERATE` in them during test `tearDown`.