### PR TITLE
Experiment with static past key/value buffer

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -18,7 +18,7 @@
 # to defer the actual importing for when the objects are requested. This way `import transformers` provides the names
 # in the namespace without actually importing anything (and especially none of the backends).
 
-__version__ = "4.30.0.prealloc"
+__version__ = "4.31.0.dev0"
 
 from typing import TYPE_CHECKING
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -18,7 +18,7 @@
 # to defer the actual importing for when the objects are requested. This way `import transformers` provides the names
 # in the namespace without actually importing anything (and especially none of the backends).
 
-__version__ = "4.30.0.dev0"
+__version__ = "4.30.0.prealloc"
 
 from typing import TYPE_CHECKING
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -781,11 +781,10 @@ class GenerationMixin:
                     dim=-1,
                 )
 
-        if "past_index" in model_kwargs:
-            if model_kwargs["past_index"] is None:
-                raise ValueError("should not happen")
+        if model_kwargs["past_index"] is None:
+            raise ValueError("should not happen")
 
-            model_kwargs["past_index"] = model_kwargs["past_index"] + outputs.logits.shape[1]
+        model_kwargs["past_index"] = model_kwargs["past_index"] + outputs.logits.shape[1]
 
         return model_kwargs
 
@@ -2327,6 +2326,8 @@ class GenerationMixin:
         unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)
 
         this_peer_finished = False  # used by synced_gpus only
+
+        model_kwargs["past_index"] = torch.tensor(-1, dtype=torch.int32)
         while True:
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
@@ -2341,6 +2342,7 @@ class GenerationMixin:
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
+            """
             print("-----")
             for key, inp in model_inputs.items():
                 if isinstance(inp, torch.Tensor):
@@ -2354,6 +2356,7 @@ class GenerationMixin:
                             print("    ", key, inp_.shape)
                 else:
                     print(key, type(inp))
+            """
             # print(model_inputs["attention_mask"])
 
             # forward pass to get next token

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -754,7 +754,6 @@ class GenerationMixin:
         standardize_cache_format: bool = False,
     ) -> Dict[str, Any]:
         # update past_key_values
-        print("self.is_using_static_kv_cache", self.is_using_static_kv_cache)
         if not self.is_using_static_kv_cache:
             model_kwargs["past_key_values"] = self._extract_past_from_model_output(
                 outputs, standardize_cache_format=standardize_cache_format
@@ -783,7 +782,7 @@ class GenerationMixin:
                     dim=-1,
                 )
 
-        if self.use_static_kv_cache:
+        if self.is_using_static_kv_cache:
             if model_kwargs["past_index"] is None:
                 raise ValueError("should not happen")
 
@@ -2330,7 +2329,7 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
 
-        model_kwargs["past_index"] = 0
+        model_kwargs["past_index"] = 0  # TODO (felix) this should be removed or made more elegant
         while True:
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.
@@ -2346,21 +2345,19 @@ class GenerationMixin:
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
             """
-            print("-----")
-            for key, inp in model_inputs.items():
+            print("-----") for key, inp in model_inputs.items():
                 if isinstance(inp, torch.Tensor):
                     print(key, inp.shape)
                 elif isinstance(inp, tuple):
                     for inp_ in inp:
                         if isinstance(inp_, tuple):
                             for inp__ in inp_:
-                                print("    ", key, inp__.shape)
+                                print(" ", key, inp__.shape)
                         else:
-                            print("    ", key, inp_.shape)
+                            print(" ", key, inp_.shape)
                 else:
                     print(key, type(inp))
             """
-            # print(model_inputs["attention_mask"])
 
             # forward pass to get next token
             outputs = self(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -754,9 +754,10 @@ class GenerationMixin:
         standardize_cache_format: bool = False,
     ) -> Dict[str, Any]:
         # update past_key_values
-        # model_kwargs["past_key_values"] = self._extract_past_from_model_output(
-        #     outputs, standardize_cache_format=standardize_cache_format
-        # )
+        if not self.is_using_static_kv_cache:
+            model_kwargs["past_key_values"] = self._extract_past_from_model_output(
+                outputs, standardize_cache_format=standardize_cache_format
+            )
         if getattr(outputs, "state", None) is not None:
             model_kwargs["state"] = outputs.state
 
@@ -781,10 +782,11 @@ class GenerationMixin:
                     dim=-1,
                 )
 
-        if model_kwargs["past_index"] is None:
-            raise ValueError("should not happen")
+        if self.use_static_kv_cache:
+            if model_kwargs["past_index"] is None:
+                raise ValueError("should not happen")
 
-        model_kwargs["past_index"] = model_kwargs["past_index"] + outputs.logits.shape[1]
+            model_kwargs["past_index"] = model_kwargs["past_index"] + outputs.logits.shape[1]
 
         return model_kwargs
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2327,9 +2327,9 @@ class GenerationMixin:
         this_peer_finished = False  # used by synced_gpus only
 
         if getattr(self, "use_static_kv_cache", False):
-            model_kwargs["valid_past_index"] = 0
-        else:
             model_kwargs["valid_past_index"] = None
+        else:
+            model_kwargs["valid_past_index"] = 0
         
         while True:
             if synced_gpus:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2345,22 +2345,6 @@ class GenerationMixin:
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
-            """
-            print("-----")
-            for key, inp in model_inputs.items():
-                if isinstance(inp, torch.Tensor):
-                    print(key, inp.shape)
-                elif isinstance(inp, tuple):
-                    for inp_ in inp:
-                        if isinstance(inp_, tuple):
-                            for inp__ in inp_:
-                                print(" ", key, inp__.shape)
-                        else:
-                            print(" ", key, inp_.shape)
-                else:
-                    print(key, type(inp))
-            """
-
             # forward pass to get next token
             outputs = self(
                 **model_inputs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2327,7 +2327,7 @@ class GenerationMixin:
 
         this_peer_finished = False  # used by synced_gpus only
 
-        model_kwargs["past_index"] = torch.tensor(-1, dtype=torch.int32)
+        model_kwargs["past_index"] = 0
         while True:
             if synced_gpus:
                 # Under synced_gpus the `forward` call must continue until all gpus complete their sequence.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -754,6 +754,7 @@ class GenerationMixin:
         standardize_cache_format: bool = False,
     ) -> Dict[str, Any]:
         # update past_key_values
+        print("self.is_using_static_kv_cache", self.is_using_static_kv_cache)
         if not self.is_using_static_kv_cache:
             model_kwargs["past_key_values"] = self._extract_past_from_model_output(
                 outputs, standardize_cache_format=standardize_cache_format

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2345,6 +2345,19 @@ class GenerationMixin:
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
+            for key, inp in model_inputs.items():
+                if isinstance(inp, torch.Tensor):
+                    print(key, inp.shape)
+                elif isinstance(inp, tuple):
+                    for inp_ in inp:
+                        if isinstance(inp_, torch.Tensor):
+                            print("    ", key, inp_.shape)
+                        else:
+                            for inp__ in inp_:
+                                print("    ", key, inp__.shape)
+                else:
+                    print(key, type(inp))
+
             # forward pass to get next token
             outputs = self(
                 **model_inputs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2327,9 +2327,9 @@ class GenerationMixin:
         this_peer_finished = False  # used by synced_gpus only
 
         if getattr(self, "use_static_kv_cache", False):
-            model_kwargs["valid_past_index"] = None
-        else:
             model_kwargs["valid_past_index"] = 0
+        else:
+            model_kwargs["valid_past_index"] = None
         
         while True:
             if synced_gpus:
@@ -2346,7 +2346,8 @@ class GenerationMixin:
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
             """
-            print("-----") for key, inp in model_inputs.items():
+            print("-----")
+            for key, inp in model_inputs.items():
                 if isinstance(inp, torch.Tensor):
                     print(key, inp.shape)
                 elif isinstance(inp, tuple):

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2345,6 +2345,7 @@ class GenerationMixin:
             # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
+            """
             for key, inp in model_inputs.items():
                 if isinstance(inp, torch.Tensor):
                     print(key, inp.shape)
@@ -2357,6 +2358,7 @@ class GenerationMixin:
                                 print("    ", key, inp__.shape)
                 else:
                     print(key, type(inp))
+            """
 
             # forward pass to get next token
             outputs = self(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1058,7 +1058,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     _no_split_modules = None
     _skip_keys_device_placement = None
     _keep_in_fp32_modules = None
-    _supports_static_kv_cache = False
 
     # a list of `re` patterns of `state_dict` keys that should be removed from the list of missing
     # keys we find (keys inside the model but not in the checkpoint) and avoid unnecessary warnings.
@@ -1072,6 +1071,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     _keys_to_ignore_on_save = None
 
     is_parallelizable = False
+    supports_static_kv_cache = False
     supports_gradient_checkpointing = False
 
     @property
@@ -1649,7 +1649,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Note that in other frameworks this feature can be referred to as "activation checkpointing" or "checkpoint
         activations".
         """
-        if self.supports_gradient_checkpointing:
+        if self.supports_static_kv_cache:
             self.apply(partial(self._set_gradient_checkpointing, value=False))
 
     @property

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1632,15 +1632,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             raise ValueError(f"{self.__class__.__name__} does not support gradient checkpointing.")
         self.apply(partial(self._set_gradient_checkpointing, value=True))
 
-    def static_kv_cache_enable(self):
+    def enable_static_kv_cache(self):
         """
         Enable static KV cache for generation - speedups generation a lot on PT eager
         """
         if not self.supports_static_kv_cache:
             raise ValueError(f"{self.__class__.__name__} does not support static kv cache.")
-        self.apply(partial(self._set_static_kv_cache, value=True))
+        self.use_static_kv_cache = True
 
-    def static_kv_cache_disable(self):
+    def disable_static_kv_cache(self):
         """
         Disable static KV cache for generation
         """
@@ -1666,14 +1666,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         activations".
         """
         return any(hasattr(m, "gradient_checkpointing") and m.gradient_checkpointing for m in self.modules())
-
-    @property
-    def is_using_static_kv_cache(self) -> bool:
-        """
-        Whether static KV cache is activated for this model or not.
-        """
-        # TODO (felix) this is likely extremely slow, and duplicate with use_static_kv_cache
-        return any(hasattr(m, "use_static_kv_cache") for m in self.modules())
 
     def save_pretrained(
         self,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1661,6 +1661,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         activations".
         """
         return any(hasattr(m, "gradient_checkpointing") and m.gradient_checkpointing for m in self.modules())
+    
+    @property
+    def is_using_static_kv_cache(self) -> bool:
+        """
+        Whether static KV cache is activated for this model or not.
+        """
+        return any(hasattr(m, "use_static_kv_cache") and m.gradient_checkpointing for m in self.modules())
 
     def save_pretrained(
         self,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1631,24 +1631,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not self.supports_gradient_checkpointing:
             raise ValueError(f"{self.__class__.__name__} does not support gradient checkpointing.")
         self.apply(partial(self._set_gradient_checkpointing, value=True))
-    
 
     def static_kv_cache_enable(self):
         """
-        Enable static KV cache for generation - speedups generation a lot on PT eager 
+        Enable static KV cache for generation - speedups generation a lot on PT eager
         """
         if not self.supports_static_kv_cache:
             raise ValueError(f"{self.__class__.__name__} does not support static kv cache.")
         self.apply(partial(self._set_static_kv_cache, value=True))
-    
 
     def static_kv_cache_disable(self):
         """
-        Disable static KV cache for generation 
+        Disable static KV cache for generation
         """
         if self.supports_static_kv_cache:
             self.apply(partial(self._set_static_kv_cache, value=False))
-
 
     def gradient_checkpointing_disable(self):
         """
@@ -1669,13 +1666,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         activations".
         """
         return any(hasattr(m, "gradient_checkpointing") and m.gradient_checkpointing for m in self.modules())
-    
+
     @property
     def is_using_static_kv_cache(self) -> bool:
         """
         Whether static KV cache is activated for this model or not.
         """
-        return any(hasattr(m, "use_static_kv_cache") and m.gradient_checkpointing for m in self.modules())
+        # TODO (felix) this is likely extremely slow, and duplicate with use_static_kv_cache
+        return any(hasattr(m, "use_static_kv_cache") for m in self.modules())
 
     def save_pretrained(
         self,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1637,9 +1637,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         Enable static KV cache for generation - speedups generation a lot on PT eager 
         """
-        if not self.supports_static_kv_generation:
+        if not self.supports_static_kv_cache:
             raise ValueError(f"{self.__class__.__name__} does not support static kv cache.")
         self.apply(partial(self._set_static_kv_cache, value=True))
+    
+
+    def static_kv_cache_disable(self):
+        """
+        Disable static KV cache for generation 
+        """
+        if self.supports_static_kv_cache:
+            self.apply(partial(self._set_static_kv_cache, value=False))
 
 
     def gradient_checkpointing_disable(self):
@@ -1649,7 +1657,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Note that in other frameworks this feature can be referred to as "activation checkpointing" or "checkpoint
         activations".
         """
-        if self.supports_static_kv_cache:
+        if self.supports_gradient_checkpointing:
             self.apply(partial(self._set_gradient_checkpointing, value=False))
 
     @property

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1637,7 +1637,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         Enable static KV cache for generation - speedups generation a lot on PT eager 
         """
-        if not self.supports_static_kv_generation:
+        if not self.supports_static_kv_cache:
             raise ValueError(f"{self.__class__.__name__} does not support static kv cache.")
         self.apply(partial(self._set_static_kv_cache, value=True))
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1058,6 +1058,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     _no_split_modules = None
     _skip_keys_device_placement = None
     _keep_in_fp32_modules = None
+    _supports_static_kv_cache = False
 
     # a list of `re` patterns of `state_dict` keys that should be removed from the list of missing
     # keys we find (keys inside the model but not in the checkpoint) and avoid unnecessary warnings.
@@ -1630,6 +1631,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not self.supports_gradient_checkpointing:
             raise ValueError(f"{self.__class__.__name__} does not support gradient checkpointing.")
         self.apply(partial(self._set_gradient_checkpointing, value=True))
+    
+
+    def static_kv_cache_enable(self):
+        """
+        Enable static KV cache for generation - speedups generation a lot on PT eager 
+        """
+        if not self.supports_static_kv_generation:
+            raise ValueError(f"{self.__class__.__name__} does not support static kv cache.")
+        self.apply(partial(self._set_static_kv_cache, value=True))
+
 
     def gradient_checkpointing_disable(self):
         """

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -319,20 +319,19 @@ class GPT2Attention(nn.Module):
 
         if getattr(self, "use_static_kv_cache", False):
             if past_index > 0:
-              upper = past_index + 1
-              layer_past[0][:, :, past_index:upper] = key  # slice to keep dimension info
-              layer_past[1][:, :, past_index:upper] = value
+                upper = past_index + 1
+                layer_past[0][:, :, past_index:upper] = key  # slice to keep dimension info
+                layer_past[1][:, :, past_index:upper] = value
 
-              # TODO: not sure this allocation is needed - maybe refactoring would be faster?
-              key = layer_past[0][:, :, :upper]
-              value = layer_past[1][:, :, :upper]          
+                # TODO: not sure this allocation is needed - maybe refactoring would be faster?
+                key = layer_past[0][:, :, :upper]
+                value = layer_past[1][:, :, :upper]          
             else:
                 prompt_length = key.shape[-2]
                 layer_past[0][:, :, :prompt_length] = key
                 layer_past[1][:, :, :prompt_length] = value
             # layer_past updated in place
             present = None
-
         else:
             if layer_past is not None:
                 past_key, past_value = layer_past
@@ -340,7 +339,7 @@ class GPT2Attention(nn.Module):
                 value = torch.cat((past_value, value), dim=-2)
             if use_cache is True:
                 present = (key, value)
-
+        
         if self.reorder_and_upcast_attn:
             attn_output, attn_weights = self._upcast_and_reordered_attn(query, key, value, attention_mask, head_mask)
         else:
@@ -468,7 +467,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["GPT2Block"]
     _skip_keys_device_placement = "past_key_values"
-    _supports_static_kv_cache = True
+    supports_static_kv_cache = True
 
     def __init__(self, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)
@@ -506,7 +505,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
     
     def _set_static_kv_cache(self, module, value=False):
         if isinstance(module, (GPT2Model, GPT2Attention)):
-            module.use_static_cache = value
+            module.use_static_kv_cache = value
 
 
 @dataclass
@@ -822,7 +821,7 @@ class GPT2Model(GPT2PreTrainedModel):
 
         if getattr(self, "use_static_kv_cache", False):
             if past_index == 0:
-              past_length = 0
+                past_length = 0
 
         else:
             if past_key_values is None:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -329,7 +329,7 @@ class GPT2Attention(nn.Module):
             layer_past[0][:, :, valid_past_index:upper] = key  # Slice to keep dimension info
             layer_past[1][:, :, valid_past_index:upper] = value
 
-            # TODO (felix) Not sure this allocation is needed - maybe refactoring would be faster?
+            # TODO (felix) Would removing these two lines help?
             key = layer_past[0][:, :, :upper]
             value = layer_past[1][:, :, :upper]
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1039,7 +1039,7 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         token_type_ids = kwargs.get("token_type_ids", None)
 
         valid_past_index = kwargs.get("valid_past_index", None)
-        step_uses_cache = (valid_past_index is None and past_key_values is not None) or valid_past_index > 0
+        step_uses_cache = (valid_past_index is None and past_key_values is not None) or (valid_past_index is not None and valid_past_index > 0)
 
         # only last token for inputs_ids if past is defined in kwargs
         if step_uses_cache:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -468,7 +468,7 @@ class GPT2PreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["GPT2Block"]
     _skip_keys_device_placement = "past_key_values"
-    _supports_static_kv_cache = True
+    supports_static_kv_cache = True
 
     def __init__(self, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1065,7 +1065,7 @@ class GPT2LMHeadModel(GPT2PreTrainedModel):
         else:
             model_inputs = {"input_ids": input_ids}
 
-        if valid_past_index >= 0 and past_key_values is None:
+        if valid_past_index is not None and past_key_values is None:
             raise ValueError("This shound not happen.")
 
         model_inputs.update(

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -181,44 +181,44 @@ class GPT2Attention(nn.Module):
         self.pruned_heads = self.pruned_heads.union(heads)
 
     def _attn(self, query, key, value, attention_mask=None, head_mask=None):
-        attn_weights = torch.matmul(query, key.transpose(-1, -2))
+        batch_size = query.shape[0]
 
-        if self.scale_attn_weights:
-            attn_weights = attn_weights / torch.full(
-                [], value.size(-1) ** 0.5, dtype=attn_weights.dtype, device=attn_weights.device
-            )
+        mask_value = torch.finfo(value.dtype).min
+        mask_value = torch.full([], mask_value, dtype=value.dtype)
 
-        # Layer-wise attention scaling
-        if self.scale_attn_by_inverse_layer_idx:
-            attn_weights = attn_weights / float(self.layer_idx + 1)
-
-        if not self.is_cross_attention:
-            # if only "normal" attention layer implements causal mask
+        dropout_p = self.dropout_prob_attn if self.training else 0.0
+        if batch_size == 1 or self.training:
+            if query.shape[2] > 1:
+                sdpa_result = torch.nn.functional.scaled_dot_product_attention(
+                    query, key, value, attn_mask=None, dropout_p=dropout_p, is_causal=True
+                )
+            else:
+                sdpa_result = torch.nn.functional.scaled_dot_product_attention(
+                    query, key, value, attn_mask=None, dropout_p=dropout_p, is_causal=False
+                )
+        else:
             query_length, key_length = query.size(-2), key.size(-2)
-            causal_mask = self.bias[:, :, key_length - query_length : key_length, :key_length]
-            mask_value = torch.finfo(attn_weights.dtype).min
-            # Need to be a tensor, otherwise we get error: `RuntimeError: expected scalar type float but found double`.
-            # Need to be on the same device, otherwise `RuntimeError: ..., x and y to be on the same device`
-            mask_value = torch.full([], mask_value, dtype=attn_weights.dtype).to(attn_weights.device)
-            attn_weights = torch.where(causal_mask, attn_weights.to(attn_weights.dtype), mask_value)
 
-        if attention_mask is not None:
-            # Apply the attention mask
-            attn_weights = attn_weights + attention_mask
+            # causal_mask is always [True, ..., True] otherwise, so executing this
+            # is unnecessary
+            if query_length > 1:
+                causal_mask = self.bias[:, :, key_length - query_length : key_length, :key_length].to(torch.bool)
 
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+                causal_mask = torch.where(causal_mask, 0, mask_value)
 
-        # Downcast (if necessary) back to V's dtype (if in mixed-precision) -- No-Op otherwise
-        attn_weights = attn_weights.type(value.dtype)
-        attn_weights = self.attn_dropout(attn_weights)
+                # torch.Tensor.expand does no memory copy
+                causal_mask = causal_mask.expand(batch_size, -1, -1, -1)
+                attention_mask = causal_mask + attention_mask
+
+            sdpa_result = torch.nn.functional.scaled_dot_product_attention(
+                query, key, value, attn_mask=attention_mask, dropout_p=dropout_p, is_causal=False
+            )
 
         # Mask heads if we want to
         if head_mask is not None:
-            attn_weights = attn_weights * head_mask
+            raise ValueError("not supported")
 
-        attn_output = torch.matmul(attn_weights, value)
-
-        return attn_output, attn_weights
+        return sdpa_result, None
 
     def _upcast_and_reordered_attn(self, query, key, value, attention_mask=None, head_mask=None):
         # Use `torch.baddbmm` (a bit more efficient w/ alpha param for scaling -- from Megatron-LM)


### PR DESCRIPTION
This PR is just to see if this could reside in transformers or not.

## Motivation

We suspect [the concatenations of the key/value buffer](https://github.com/huggingface/transformers/blob/ba695c1efd55091e394eb59c90fb33ac3f9f0d41/src/transformers/models/gpt2/modeling_gpt2.py#L321-L322) at each generation step to be expensive. The idea is to modify the buffer in place after a unique allocation.

FasterTransformer [does preallocate the kv cache](https://github.com/NVIDIA/FasterTransformer/blob/c6e8f60ec40da218804a60e6aa986903e7fa8594/src/fastertransformer/models/decoding/Decoding.cc#L83C9-L84) (among others). Preallocating may also help `torch.compile` according to @Chillee, although I don't quite get why yet (there are still dynamic shapes in the model itself, so why care about model I/O static shapes?).

For reference: https://huggingface.slack.com/archives/C055NT312LW/p1683038064467109 & https://huggingface.slack.com/archives/C055NT312LW/p1685570357532069

## Current (ugly) workflow

Very temporary

```python
cache_size = max_new_tokens

past_key_values = tuple([
    tuple([torch.empty(
        batch_size,
        model.config.n_head,
        cache_size,
        model.config.n_embd // model.config.n_head,  # head dimension
        dtype=dtype,
        device=device
    ) for _ in range(2)])

model.enable_static_kv_cache()
res = model.generate(
    **inputs,
    num_beams=1,
    min_new_tokens=max_new_tokens,
    max_new_tokens=max_new_tokens,
    past_key_values=past_key_values
)
```

## Results

Some optimizations may still be missing - right now in small model / small batch size setting this is not interesting.

Results are with PyTorch 2.0.1 eager.

Script: https://github.com/fxmarty/transformers-preallocate-kv-cache/blob/main/run.py
Raw results: https://docs.google.com/spreadsheets/d/15P1o9vDcXOSeLAwLUWiqXQatHxtQYBa_xcyLZanOjQQ/edit?usp=sharing

![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/19db7654-819d-4939-8306-e0b3e5691af5)
![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/0dd50f85-a3a0-4571-aa80-2a748b9c9942)
![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/3a1e6efb-2358-40f4-bf8e-d09261296fd5)
![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/adc4ec1c-529c-44b6-8e77-105b788e222a)
![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/e41bc4ca-1d3b-4625-9ec6-283b1442420b)
![image](https://github.com/fxmarty/transformers-preallocate-kv-cache/assets/9808326/48294201-9798-4083-9776-3ef4dbd6ca12)

## Misc

The current implementation of `valid_past_index` being `Optional[int]` is quite debatable and may hamper readability.

I'm also not sure whether adding methods in `PreTrainedModel` that are specific to decoders is OK?

Missing test right now is to generate a sequence length shorter than the KV buffer.

Some todos:
- [ ] `past_key_values` buffer should be initialized in the background, instead of requiring the user to initialize it himself and requiring to pass `generate(**inputs, past_key_values=past_key_values)` (as currently).
- [ ] Current implementation is likely to break with `accelerate` with naive pipeline parallelism, as the buffer is currently initialized on a single device
- [ ] Preallocated kv cache still does not help with small models / batch size.
- [ ] Support an iterative buffer, e.g. that auto-extends each 512 tokens, instead of initializing a buffer of size `max_new_tokens`. This may help reducing memory usage (and speed? probably not).
- [ ] Implement tests
- [ ] Should this be in optimum or transformers?
- [ ] Support all (is it possible?) decoding strategies, instead of currently only `greedy_search`
- [ ] Have it work with cross-attention
- [ ] Preallocate `attention_mask` as well
- [ ] Test on CPU as well