### PR TITLE
Remove decoder_input_ids from RAG dummy inputs

### DIFF
--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -34,7 +34,13 @@ from ...modeling_tf_utils import (
     shape_list,
     unpack_inputs,
 )
-from ...utils import ModelOutput, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
+from ...utils import (
+    DUMMY_INPUTS,
+    ModelOutput,
+    add_start_docstrings_to_model_forward,
+    logging,
+    replace_return_docstrings,
+)
 from .configuration_rag import RagConfig
 from .retrieval_rag import RagRetriever
 
@@ -230,10 +236,7 @@ class TFRagPreTrainedModel(TFPreTrainedModel):
 
     @property
     def dummy_inputs(self):
-        dummies = super().dummy_inputs
-        # RAG doesn't actually need decoder inputs to build its weights
-        dummies = {key: val for key, val in dummies.items() if not key.startswith("decoder")}
-        return dummies
+        return {"input_ids": tf.constant(DUMMY_INPUTS)}
 
     @classmethod
     def from_pretrained_question_encoder_generator(

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -228,6 +228,12 @@ class TFRagPreTrainedModel(TFPreTrainedModel):
     base_model_prefix = "rag"
     _keys_to_ignore_on_load_missing = [r"position_ids"]
 
+    @property
+    def dummy_inputs(self):
+        dummies = super().dummy_inputs
+        dummies = {key: val for key, val in dummies.items() if not key.startswith("decoder")}
+        return dummies
+
     @classmethod
     def from_pretrained_question_encoder_generator(
         cls,

--- a/src/transformers/models/rag/modeling_tf_rag.py
+++ b/src/transformers/models/rag/modeling_tf_rag.py
@@ -231,6 +231,7 @@ class TFRagPreTrainedModel(TFPreTrainedModel):
     @property
     def dummy_inputs(self):
         dummies = super().dummy_inputs
+        # RAG doesn't actually need decoder inputs to build its weights
         dummies = {key: val for key, val in dummies.items() if not key.startswith("decoder")}
         return dummies
 

--- a/tests/models/rag/test_modeling_tf_rag.py
+++ b/tests/models/rag/test_modeling_tf_rag.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import json
 import os
 import shutil
@@ -904,6 +905,7 @@ class TFRagModelIntegrationTests(unittest.TestCase):
 
     @slow
     def test_rag_sequence_generate_batch_from_context_input_ids(self):
+        gc.collect()
         tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
         retriever = RagRetriever.from_pretrained(
             "facebook/rag-sequence-nq", index_name="exact", use_dummy_dataset=True


### PR DESCRIPTION
cc @ydshieh 

The old RAG dummy inputs didn't have `decoder_input_ids` but the new ones do - this seems like the most likely cause of the memory blowup, because RAG probably does a lot of weird retrieval stuff.