### PR TITLE
Slow (i.e., Python) Tokenizer `batch_encode_plus` for Input as `List[PreTokenizedInput]` or `List[PreTokenizedInputPair]`

### DIFF
--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -728,7 +728,14 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
             elif is_split_into_words and not isinstance(ids_or_pair_ids[0], (list, tuple)):
                 ids, pair_ids = ids_or_pair_ids, None
             else:
-                ids, pair_ids = ids_or_pair_ids
+                if isinstance(ids_or_pair_ids, tuple):
+                    ids, pair_ids = ids_or_pair_ids
+                elif isinstance(ids_or_pair_ids, list):
+                    ids, pair_ids = ids_or_pair_ids, None
+                else:
+                    raise ValueError(
+                        "Input is not valid. Should be a list of strings, a list of list/tuple of strings or a list of list/tuple of integers."
+                    )
 
             first_ids = get_input_ids(ids)
             second_ids = get_input_ids(pair_ids) if pair_ids is not None else None


### PR DESCRIPTION
# What does this PR do?

Current `batch_encode_plus()` should support input type including`List[PreTokenizedInput]` and `List[PreTokenizedInputPair]` by doc. However, a simple example would incur the error:
```
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased', use_fast=False)
>>> tokenizer([['I', 'love', 'you'], ['I', 'love', 'you']])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/anaconda3/envs/fid-bert/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 2556, in __call__
    encodings = self._call_one(text=text, text_pair=text_pair, **all_kwargs)
  File "/home/ubuntu/anaconda3/envs/fid-bert/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 2642, in _call_one
    return self.batch_encode_plus(
  File "/home/ubuntu/anaconda3/envs/fid-bert/lib/python3.9/site-packages/transformers/tokenization_utils_base.py", line 2833, in batch_encode_plus
    return self._batch_encode_plus(
  File "/home/ubuntu/anaconda3/envs/fid-bert/lib/python3.9/site-packages/transformers/tokenization_utils.py", line 731, in _batch_encode_plus
    ids, pair_ids = ids_or_pair_ids
ValueError: too many values to unpack (expected 2)
```

The fixed version would properly tokenize such inputs without errors:
```
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased', use_fast=False)
>>> tokenizer([['I', 'love', 'you'], ['I', 'love', 'you']])
{'input_ids': [[101, 100, 2293, 2017, 102], [101, 100, 2293, 2017, 102]], 'token_type_ids': [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0]], 'attention_mask': [[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]]}
```

The "fast" tokenizer written by Rust should be fixed accordingly as well.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @younesbelkada 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
