### PR TITLE
[lamaTokenizerFast] Update documentation

### DIFF
--- a/docs/source/en/model_doc/llama.mdx
+++ b/docs/source/en/model_doc/llama.mdx
@@ -65,6 +65,7 @@ This model was contributed by [zphang](https://huggingface.co/zphang) with contr
     - build_inputs_with_special_tokens
     - get_special_tokens_mask
     - create_token_type_ids_from_sequences
+    - update_post_processor
     - save_vocabulary
 
 ## LlamaModel

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -47,6 +47,12 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
     tokenizer.encode("Hello this is a test")
     >>> [1, 15043, 445, 338, 263, 1243]
     ```
+    
+    If you want to change the `bos_token` or the `eos_token`, make sure to specify them when initializing the model,
+    or call `tokenizer.update_post_processor()` to make sure that the post-processing is correctly done (otherwise the values
+    of the first token and final token of an encoded sequence will not be correct). For more details, checkout [post-processors]
+    (https://huggingface.co/docs/tokenizers/api/post-processors) documentation.
+    
 
     This tokenizer inherits from [`PreTrainedTokenizerFast`] which contains most of the main methods. Users should
     refer to this superclass for more information regarding those methods.
@@ -107,6 +113,9 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
         self.can_save_slow_tokenizer = False if not self.vocab_file else True
 
     def update_post_processor(self):
+        """
+        Updates the underlying post processor with the current `bos_token` and `eos_token`.
+        """
         bos = self.bos_token
         bos_token_id = self.bos_token_id
 

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -47,12 +47,12 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
     tokenizer.encode("Hello this is a test")
     >>> [1, 15043, 445, 338, 263, 1243]
     ```
-    
-    If you want to change the `bos_token` or the `eos_token`, make sure to specify them when initializing the model,
-    or call `tokenizer.update_post_processor()` to make sure that the post-processing is correctly done (otherwise the values
-    of the first token and final token of an encoded sequence will not be correct). For more details, checkout [post-processors]
-    (https://huggingface.co/docs/tokenizers/api/post-processors) documentation.
-    
+
+    If you want to change the `bos_token` or the `eos_token`, make sure to specify them when initializing the model, or
+    call `tokenizer.update_post_processor()` to make sure that the post-processing is correctly done (otherwise the
+    values of the first token and final token of an encoded sequence will not be correct). For more details, checkout
+    [post-processors] (https://huggingface.co/docs/tokenizers/api/post-processors) documentation.
+
 
     This tokenizer inherits from [`PreTrainedTokenizerFast`] which contains most of the main methods. Users should
     refer to this superclass for more information regarding those methods.


### PR DESCRIPTION
# What does this PR do?
Updates the documentation for llamaFast. 
I think that long term-wise it would make more sense that the rust tokenizer updates its internals if the specials tokens are updated as well, this would allow us to remove the python layer that takes care of it. 

Related to #23889 