### PR TITLE
fix bugs with trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2850,6 +2850,7 @@ class Trainer:
             or self.is_fsdp_enabled
         ):
             if self.is_fsdp_enabled:
+                os.makedirs(output_dir, exist_ok=True)
                 self.accelerator.state.fsdp_plugin.save_model(self.accelerator, self.model, output_dir)
             else:
                 state_dict = self.model.state_dict()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1750,7 +1750,10 @@ class Trainer:
         # prepare using `accelerator` prepare
         if use_accelerator_prepare:
             if hasattr(self.lr_scheduler, "step"):
-                model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
+                if self.use_apex:
+                    model = self.accelerator.prepare(self.model)
+                else:
+                    model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
             else:
                 # to handle cases wherein we pass "DummyScheduler" such as when it is sopecified in DeepSpeed config.
                 model, self.optimizer, self.lr_scheduler = self.accelerator.prepare(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1755,7 +1755,7 @@ class Trainer:
                 else:
                     model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
             else:
-                # to handle cases wherein we pass "DummyScheduler" such as when it is sopecified in DeepSpeed config.
+                # to handle cases wherein we pass "DummyScheduler" such as when it is specified in DeepSpeed config.
                 model, self.optimizer, self.lr_scheduler = self.accelerator.prepare(
                     self.model, self.optimizer, self.lr_scheduler
                 )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1749,7 +1749,13 @@ class Trainer:
 
         # prepare using `accelerator` prepare
         if use_accelerator_prepare:
-            model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
+            if hasattr(self.lr_scheduler, "step"):
+                model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
+            else:
+                # to handle cases wherein we pass "DummyScheduler" such as when it is sopecified in DeepSpeed config.
+                model, self.optimizer, self.lr_scheduler = self.accelerator.prepare(
+                    self.model, self.optimizer, self.lr_scheduler
+                )
 
         if self.is_fsdp_enabled:
             self.model = model


### PR DESCRIPTION
# What does this PR do?
Context:
1. Issue 1 - Currently, when the lr_scheduler is specified in the deepspeed config file, we leverage a DummyScheduler to pass to the `accelerator.prepare` to get the correct scheduler post prepare call. A prior PR removed preparation of the lr_scheduler leading to a lot of DeepSpeed tests failing.
2. Issue 2 - when using apex we shouldn't be preparing optimizer else we get `AttributeError: 'AcceleratedOptimizer' object has no attribute '_amp_stash'`
3. Issue 3 - FSDP ckpt logic should create ckpt dir if not present. Fixes https://github.com/huggingface/transformers/issues/24130

This PR fixes the above issues. 