### PR TITLE
Correctly build models and import call_context for older TF versions

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -81,7 +81,7 @@ elif parse(tf.__version__).minor >= 11:
     from keras.engine.keras_tensor import KerasTensor
 else:
     from tensorflow.python.keras import backend as K
-    from tensorflow.python.keras.engine import call_context
+    from tensorflow.python.keras.engine.base_layer_utils import call_context
     from tensorflow.python.keras.engine.keras_tensor import KerasTensor
 
 
@@ -1156,8 +1156,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         if self.built or call_context().in_call:
             self.built = True
         else:
-            self(self.dummy_inputs, training=False)
             self.built = True
+            self(self.dummy_inputs, training=False)
 
     def __init__(self, config, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)


### PR DESCRIPTION
Our import for `call_context` was wrong for older TF versions - this unfortunately makes it quite hard to load models on older TF versions! This PR fixes it, and sorry about the issue!

Fixes #24133