### PR TITLE
Avoid OOM in doctest CI

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1870,9 +1870,17 @@ def preprocess_string(string, skip_cuda_tests):
         ):
             is_cuda_found = True
             break
+
     modified_string = ""
     if not is_cuda_found:
         modified_string = "".join(codeblocks)
+
+        lines = modified_string.split("\n")
+        indent = len(lines[-1]) - len(lines[-1].lstrip())
+
+        cleanup = ">>> import gc; gc.collect()  # doctest: +IGNORE_RESULT"
+        modified_string += "\n" + " " * indent + cleanup
+
     return modified_string
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1875,11 +1875,12 @@ def preprocess_string(string, skip_cuda_tests):
     if not is_cuda_found:
         modified_string = "".join(codeblocks)
 
-        lines = modified_string.split("\n")
-        indent = len(lines[-1]) - len(lines[-1].lstrip())
+        if ">>>" in modified_string:
+            lines = modified_string.split("\n")
+            indent = len(lines[-1]) - len(lines[-1].lstrip())
 
-        cleanup = ">>> import gc; gc.collect()  # doctest: +IGNORE_RESULT"
-        modified_string += "\n" + " " * indent + cleanup
+            cleanup = ">>> import gc; gc.collect()  # doctest: +IGNORE_RESULT"
+            modified_string += "\n" + " " * indent + cleanup
 
     return modified_string
 


### PR DESCRIPTION
# What does this PR do?

This is done by inject `gc.collect()` to the source code during pytest/doctest collecting the test to run.