### PR TITLE
[`SAM`] Fix sam slow test

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -760,7 +760,7 @@ class Pipeline(_ScikitCompat):
         framework: Optional[str] = None,
         task: str = "",
         args_parser: ArgumentHandler = None,
-        device: Union[int, str, "torch.device"] = None,
+        device: Union[int, "torch.device"] = None,
         torch_dtype: Optional[Union[str, "torch.dtype"]] = None,
         binary_output: bool = False,
         **kwargs,

--- a/tests/models/sam/test_modeling_sam.py
+++ b/tests/models/sam/test_modeling_sam.py
@@ -760,7 +760,9 @@ class SamModelIntegrationTest(unittest.TestCase):
         torch.testing.assert_allclose(iou_scores, EXPECTED_IOU, atol=1e-4, rtol=1e-4)
 
     def test_dummy_pipeline_generation(self):
-        generator = pipeline("mask-generation", model="facebook/sam-vit-base", device=torch_device)
+        generator = pipeline(
+            "mask-generation", model="facebook/sam-vit-base", device=0 if torch.cuda.is_available() else -1
+        )
         raw_image = prepare_image()
 
         _ = generator(raw_image, points_per_batch=64)


### PR DESCRIPTION
# What does this PR do?

Fixes SAM slow test, link to failing job: https://github.com/huggingface/transformers/actions/runs/5206799863

* Why this fix is relevant? 

Before the PR, it seems I was initalizing the pipeline in the wrong way. Passing a string to `device` argument of pipeline leads to an error. To reproduce:
```python
from transformers import pipeline

pipe = pipeline("text-generation", device="cuda")
pipe("Hello")
>>> ValueError: Expected a torch.device with a specified index or an integer, but got:cuda
```
That is yield here: https://github.com/huggingface/transformers/blob/847b47c0eed4e6ab904f584fb415e3d3a397867f/src/transformers/pipelines/base.py#L905 

Whereas the typehint of pipeline says: https://github.com/huggingface/transformers/blob/847b47c0eed4e6ab904f584fb415e3d3a397867f/src/transformers/pipelines/base.py#L763

The fix seems to be to pass an int for the device if cuda is available and -1 if not

cc @ydshieh 