### PR TITLE
Adds LILT to models exportable with ONNX

### DIFF
--- a/src/transformers/models/lilt/__init__.py
+++ b/src/transformers/models/lilt/__init__.py
@@ -18,7 +18,7 @@ from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_torch_avail
 
 
 _import_structure = {
-    "configuration_lilt": ["LILT_PRETRAINED_CONFIG_ARCHIVE_MAP", "LiltConfig"],
+    "configuration_lilt": ["LILT_PRETRAINED_CONFIG_ARCHIVE_MAP", "LiltConfig", "LiltOnnxConfig"],
 }
 
 try:
@@ -37,7 +37,7 @@ else:
     ]
 
 if TYPE_CHECKING:
-    from .configuration_lilt import LILT_PRETRAINED_CONFIG_ARCHIVE_MAP, LiltConfig
+    from .configuration_lilt import LILT_PRETRAINED_CONFIG_ARCHIVE_MAP, LiltConfig, LiltOnnxConfig
 
     try:
         if not is_torch_available():

--- a/src/transformers/models/lilt/configuration_lilt.py
+++ b/src/transformers/models/lilt/configuration_lilt.py
@@ -167,14 +167,20 @@ class LiltOnnxConfig(OnnxConfig):
         tokenizer: PreTrainedTokenizer = None,
     ) -> Mapping[str, Any]:
         """
-        Args:
         Generate inputs to provide to the ONNX exporter for the specific framework
-            preprocessor: ([`PreTrainedTokenizerBase`], [`FeatureExtractionMixin`], or [`ImageProcessingMixin`]):
-                The preprocessor associated with this model configuration.
-            batch_size: The batch size (int) to export the model for (-1 means dynamic axis)
-            seq_length: The sequence length (int) to export the model for (-1 means dynamic axis)
-            is_pair: Indicate if the input is a pair (sentence 1, sentence 2)
-            framework: The framework (optional) the tokenizer will generate tensor for
+
+        Args:
+            preprocessor ([`ProcessorMixin`]):
+                The processor associated with this model configuration.
+            batch_size (`int`, *optional*, defaults to -1):
+                The batch size to export the model for (-1 means dynamic axis).
+            seq_length (`int`, *optional*, defaults to -1):
+                The sequence length to export the model for (-1 means dynamic axis).
+            is_pair (`bool`, *optional*, defaults to `False`):
+                Indicate if the input is a pair (sentence 1, sentence 2).
+            framework (`TensorType`, *optional*, defaults to `None`):
+                The framework (PyTorch or TensorFlow) that the processor will generate tensors for.
+
         Returns:
             Mapping[str, Tensor] holding the kwargs to provide to the model's forward function
         """

--- a/src/transformers/onnx/features.py
+++ b/src/transformers/onnx/features.py
@@ -363,6 +363,13 @@ class FeaturesManager:
         "levit": supported_features_mapping(
             "default", "image-classification", onnx_config_cls="models.levit.LevitOnnxConfig"
         ),
+        "lilt": supported_features_mapping(
+            "default",
+            "question-answering",
+            "sequence-classification",
+            "token-classification",
+            onnx_config_cls="models.lilt.LiltOnnxConfig",
+        ),
         "longt5": supported_features_mapping(
             "default",
             "default-with-past",

--- a/tests/onnx/test_onnx_v2.py
+++ b/tests/onnx/test_onnx_v2.py
@@ -194,6 +194,7 @@ PYTORCH_EXPORT_MODELS = {
     ("levit", "facebook/levit-128S"),
     ("layoutlm", "hf-internal-testing/tiny-random-LayoutLMModel"),
     ("layoutlmv3", "microsoft/layoutlmv3-base"),
+    ("lilt", "SCUT-DLVCLab/lilt-roberta-en-base"),
     ("longformer", "allenai/longformer-base-4096"),
     ("mobilebert", "hf-internal-testing/tiny-random-MobileBertModel"),
     ("mobilenet_v1", "google/mobilenet_v1_0.75_192"),


### PR DESCRIPTION
# What does this PR do?

Adds LILT to models exportable with ONNX

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
