### PR TITLE
Update `WhisperForAudioClassification` doc example

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1778,7 +1778,7 @@ class WhisperForAudioClassification(WhisperPreTrainedModel):
         >>> predicted_class_ids = torch.argmax(logits).item()
         >>> predicted_label = model.config.id2label[predicted_class_ids]
         >>> predicted_label
-        'af_za'
+        'Afrikaans'
         ```"""
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions


### PR DESCRIPTION
# What does this PR do?

After the config file change in Hub commit `a7a63ecc2bd1015783dead844fced2af7531edd2` on `sanchit-gandhi/whisper-medium-fleurs-lang-id`, the doc example for `WhisperForAudioClassification` has to be updated.

Currently the test fails  due to a different expected output value.