### PR TITLE
Generate: detect special architectures when loaded from PEFT

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4235,7 +4235,7 @@ class GenerationMixin:
         assistant_kv_indexing = (
             1
             if "bloom" in assistant_model.__class__.__name__.lower()
-            or "bloom" in assistant_model.config.architectures[0].lower()
+            or "bloom" in assistant_model.config.architectures.get(0, "").lower()
             else 0
         )
 
@@ -4518,7 +4518,7 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
             )
         past_key_values = tuple(new_past)
     # bloom is special
-    elif "bloom" in model.__class__.__name__.lower() or "bloom" in model.config.architectures[0].lower():
+    elif "bloom" in model.__class__.__name__.lower() or "bloom" in model.config.architectures.get(0, "").lower():
         for idx in range(len(past_key_values)):
             new_past.append(
                 (
@@ -4528,7 +4528,10 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
             )
         past_key_values = tuple(new_past)
     # gptbigcode is too
-    elif "gptbigcode" in model.__class__.__name__.lower() or "gptbigcode" in model.config.architectures[0].lower():
+    elif (
+        "gptbigcode" in model.__class__.__name__.lower()
+        or "gptbigcode" in model.config.architectures.get(0, "").lower()
+    ):
         if model.config.multi_query:
             for idx in range(len(past_key_values)):
                 past_key_values[idx] = past_key_values[idx][:, :maximum_length, :]

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4232,6 +4232,7 @@ class GenerationMixin:
 
         # other auxiliary variables
         max_len = stopping_criteria[0].max_length
+        assistant_kv_indexing = 1 if "bloom" in assistant_model.__class__.__name__.lower() or "bloom" in assistant_model.config.architectures[0].lower() else 0
 
         this_peer_finished = False  # used by synced_gpus only
         while True:
@@ -4247,7 +4248,6 @@ class GenerationMixin:
 
             # Assistant: main logic start
             cur_len = input_ids.shape[-1]
-            assistant_kv_indexing = 0 if "bloom" not in assistant_model.__class__.__name__.lower() else 1
 
             #  1. Forecast next N tokens using the assistant model. This `for` block can be replaced with a
             # `.generate()` call if we decide to add `past_key_values` as a possible output of generate, as we
@@ -4512,7 +4512,8 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
                 )
             )
         past_key_values = tuple(new_past)
-    elif "bloom" in model.__class__.__name__.lower():  # bloom is special
+    # bloom is special
+    elif "bloom" in model.__class__.__name__.lower() or "bloom" in model.config.architectures[0].lower():
         for idx in range(len(past_key_values)):
             new_past.append(
                 (
@@ -4521,7 +4522,8 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
                 )
             )
         past_key_values = tuple(new_past)
-    elif "gptbigcode" in model.__class__.__name__.lower():  # gptbigcode is too
+    # gptbigcode is too
+    elif "gptbigcode" in model.__class__.__name__.lower() or "gptbigcode" in model.config.architectures[0].lower():
         if model.config.multi_query:
             for idx in range(len(past_key_values)):
                 past_key_values[idx] = past_key_values[idx][:, :maximum_length, :]

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4235,7 +4235,10 @@ class GenerationMixin:
         assistant_kv_indexing = (
             1
             if "bloom" in assistant_model.__class__.__name__.lower()
-            or "bloom" in assistant_model.config.architectures.get(0, "").lower()
+            or (
+                assistant_model.config.architectures is not None
+                and "bloom" in assistant_model.config.architectures[0].lower()
+            )
             else 0
         )
 
@@ -4518,7 +4521,9 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
             )
         past_key_values = tuple(new_past)
     # bloom is special
-    elif "bloom" in model.__class__.__name__.lower() or "bloom" in model.config.architectures.get(0, "").lower():
+    elif "bloom" in model.__class__.__name__.lower() or (
+        model.config.architectures is not None and "bloom" in model.config.architectures[0].lower()
+    ):
         for idx in range(len(past_key_values)):
             new_past.append(
                 (
@@ -4528,9 +4533,8 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
             )
         past_key_values = tuple(new_past)
     # gptbigcode is too
-    elif (
-        "gptbigcode" in model.__class__.__name__.lower()
-        or "gptbigcode" in model.config.architectures.get(0, "").lower()
+    elif "gptbigcode" in model.__class__.__name__.lower() or (
+        model.config.architectures is not None and "gptbigcode" in model.config.architectures[0].lower()
     ):
         if model.config.multi_query:
             for idx in range(len(past_key_values)):

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4232,7 +4232,12 @@ class GenerationMixin:
 
         # other auxiliary variables
         max_len = stopping_criteria[0].max_length
-        assistant_kv_indexing = 1 if "bloom" in assistant_model.__class__.__name__.lower() or "bloom" in assistant_model.config.architectures[0].lower() else 0
+        assistant_kv_indexing = (
+            1
+            if "bloom" in assistant_model.__class__.__name__.lower()
+            or "bloom" in assistant_model.config.architectures[0].lower()
+            else 0
+        )
 
         this_peer_finished = False  # used by synced_gpus only
         while True:


### PR DESCRIPTION
# What does this PR do?

Fixes #23686 

As identified in [this comment](https://github.com/huggingface/transformers/issues/23686#issuecomment-1587285715), a PEFT-loaded BLOOM can't be used as an assistant with assisted generation.

BLOOM (and GPTBigCode) need special handling due to their different cache API, and the architecture detection code was incompatible with PEFT models. This PR adds the logic to detect these special architectures when loaded with PEFT.