### PR TITLE
Update `(TF)SamModelIntegrationTest`

### DIFF
--- a/tests/models/sam/test_modeling_tf_sam.py
+++ b/tests/models/sam/test_modeling_tf_sam.py
@@ -428,8 +428,9 @@ def prepare_dog_img():
     return raw_image
 
 
+@require_tf
 @slow
-class SamModelIntegrationTest(unittest.TestCase):
+class TFSamModelIntegrationTest(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         # clean-up as much as possible GPU memory occupied by PyTorch


### PR DESCRIPTION
# What does this PR do?

- Add `require_tf`: otherwise, past CI's torch job  (with only torch installed) will fail for this test class
- Add `TF` prefix: as usual convention