### PR TITLE
Fix `_load_pretrained_model`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3026,7 +3026,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         unexpected_keys = list(set(loaded_keys) - set(expected_keys))
 
         if find_tied_parameters is not None:
-            model.tie_weights()
             tied_params = find_tied_parameters(model)
         else:
             tied_params = []


### PR DESCRIPTION
# What does this PR do ? 
Fixes the following test from my old PR Add check for tied parameters (#24029): 
`RUN_SLOW=1 python3 -m pytest -v tests/models/marian/test_modeling_marian.py::TestMarian_FI_EN_V2::test_batch_generation_en_fr`