### PR TITLE
Skip RWKV test in past CI

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -28,6 +28,7 @@ logger = logging.get_logger(__name__)
 
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
+is_torch_greater_or_equal_than_2_0 = parsed_torch_version_base >= version.parse("2.0")
 is_torch_greater_or_equal_than_1_10 = parsed_torch_version_base >= version.parse("1.10")
 is_torch_less_than_1_11 = parsed_torch_version_base < version.parse("1.11")
 

--- a/tests/models/rwkv/test_modeling_rwkv.py
+++ b/tests/models/rwkv/test_modeling_rwkv.py
@@ -261,7 +261,9 @@ class RwkvModelTester:
         return config, inputs_dict
 
 
-@unittest.skipIf(not is_torch_greater_or_equal_than_2_0, reason="See ")
+@unittest.skipIf(
+    not is_torch_greater_or_equal_than_2_0, reason="See https://github.com/huggingface/transformers/pull/24204"
+)
 @require_torch
 class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (RwkvModel, RwkvForCausalLM) if is_torch_available() else ()
@@ -422,7 +424,9 @@ class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
             self.assertIsNotNone(model)
 
 
-@unittest.skipIf(not is_torch_greater_or_equal_than_2_0, reason="See ")
+@unittest.skipIf(
+    not is_torch_greater_or_equal_than_2_0, reason="See https://github.com/huggingface/transformers/pull/24204"
+)
 @slow
 class RWKVIntegrationTests(unittest.TestCase):
     def setUp(self):

--- a/tests/models/rwkv/test_modeling_rwkv.py
+++ b/tests/models/rwkv/test_modeling_rwkv.py
@@ -34,6 +34,9 @@ if is_torch_available():
         RwkvForCausalLM,
         RwkvModel,
     )
+    from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_0
+else:
+    is_torch_greater_or_equal_than_2_0 = False
 
 
 class RwkvModelTester:
@@ -258,6 +261,7 @@ class RwkvModelTester:
         return config, inputs_dict
 
 
+@unittest.skipIf(not is_torch_greater_or_equal_than_2_0, reason="See ")
 @require_torch
 class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (RwkvModel, RwkvForCausalLM) if is_torch_available() else ()
@@ -418,6 +422,7 @@ class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
             self.assertIsNotNone(model)
 
 
+@unittest.skipIf(not is_torch_greater_or_equal_than_2_0, reason="See ")
 @slow
 class RWKVIntegrationTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# What does this PR do?

In the past CI with torch 13.1 (and older), RWKV tests fail.

- The first failure is

  ```bash
  test_model_parallelism

  (line 114)  RuntimeError: CUDA error: CUBLAS_STATUS_EXECUTION_FAILED when calling cublasSgemm( handle, opa, opb, m, n, k,   &alpha, a, lda, b, ldb, &beta, c, ldc)
  ```
  - this affects 1x more subsequential tests
  - skip this particular test will reduce a lot the number of failures.

- The docker env. of that past CI uses a base docker image shipped with `cuda 11.6`

- **In a docker image with cuda `11.8` but installing `torch==1.13+cu116`, no failure.**

Let's not take too much time on identifying what exactly cause the failure here, and just skip RWKV tests on past CI with torch < 2.0.

The goal is just to have a clean past CI report.