### PR TITLE
Add the number of `model` test failures to slack CI report

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -193,8 +193,9 @@ class Message:
             "text": {
                 "type": "plain_text",
                 "text": (
-                    f"There were {self.n_failures} failures, out of {self.n_tests} tests.\nThe suite ran in"
-                    f" {self.time}."
+                    f"There were {self.n_failures} failures, out of {self.n_tests} tests.\n"
+                    f"Number of model failures: {self.n_model_failures}.\n"
+                    f"The suite ran in {self.time}."
                 ),
                 "emoji": True,
             },


### PR DESCRIPTION
# What does this PR do?

We decided to add deepspeed (nightly version) CI job to past CI in #22393. Also `accelerate` is installed with the `main` branch.
This makes the deepspeed CI job have quite a lot of failures most of the time. Sometimes we need to wait DS team for a fix, and sometimes a fix is required from HF.

**Let's add an information regarding `number of model test failures` (i.e. not counting deepspeed CI job's failures) to the Slack CI report**, so we have a number indicating the progress in past CI and make me feel a bit more of fulfillment 🙏 .