### PR TITLE
[Time Series] use mean scaler when scaling is a boolean True

### DIFF
--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -1632,10 +1632,6 @@ class AutoformerModel(AutoformerPreTrainedModel):
         log_abs_loc = loc.abs().log1p() if self.config.input_size == 1 else loc.squeeze(1).abs().log1p()
         log_scale = scale.log() if self.config.input_size == 1 else scale.squeeze(1).log()
         static_feat = torch.cat((log_abs_loc, log_scale), dim=1)
-        if static_feat.isnan().any():
-            import pdb
-
-            pdb.set_trace()
 
         if static_real_features is not None:
             static_feat = torch.cat((static_real_features, static_feat), dim=1)

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -1495,7 +1495,7 @@ class AutoformerModel(AutoformerPreTrainedModel):
     def __init__(self, config: AutoformerConfig):
         super().__init__(config)
 
-        if config.scaling == "mean" or config.scaling:
+        if config.scaling == "mean" or config.scaling is True:
             self.scaler = AutoformerMeanScaler(dim=1, keepdim=True)
         elif config.scaling == "std":
             self.scaler = AutoformerStdScaler(dim=1, keepdim=True)
@@ -1632,6 +1632,10 @@ class AutoformerModel(AutoformerPreTrainedModel):
         log_abs_loc = loc.abs().log1p() if self.config.input_size == 1 else loc.squeeze(1).abs().log1p()
         log_scale = scale.log() if self.config.input_size == 1 else scale.squeeze(1).log()
         static_feat = torch.cat((log_abs_loc, log_scale), dim=1)
+        if static_feat.isnan().any():
+            import pdb
+
+            pdb.set_trace()
 
         if static_real_features is not None:
             static_feat = torch.cat((static_real_features, static_feat), dim=1)

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -1504,7 +1504,7 @@ class InformerModel(InformerPreTrainedModel):
     def __init__(self, config: InformerConfig):
         super().__init__(config)
 
-        if config.scaling == "mean" or config.scaling:
+        if config.scaling == "mean" or config.scaling is True:
             self.scaler = InformerMeanScaler(dim=1, keepdim=True)
         elif config.scaling == "std":
             self.scaler = InformerStdScaler(dim=1, keepdim=True)

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1229,7 +1229,7 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
     def __init__(self, config: TimeSeriesTransformerConfig):
         super().__init__(config)
 
-        if config.scaling == "mean" or config.scaling:
+        if config.scaling == "mean" or config.scaling is True:
             self.scaler = TimeSeriesMeanScaler(dim=1, keepdim=True)
         elif config.scaling == "std":
             self.scaler = TimeSeriesStdScaler(dim=1, keepdim=True)


### PR DESCRIPTION
# What does this PR do?

Use the mean scaler when `scaling` is `True` or `"mean"`