### PR TITLE
Generate: GenerationConfig can overwrite attributes at from_pretrained time

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -288,7 +288,8 @@ class GenerationConfig(PushToHubMixin):
 
         # Additional attributes without default values
         if not self._from_model_config:
-            # we don't want to copy values from the model config if we're initializing a `GenerationConfig` from a model's default configuration file
+            # we don't want to copy values from the model config if we're initializing a `GenerationConfig` from a
+            # model's default configuration file
             for key, value in kwargs.items():
                 try:
                     setattr(self, key, value)
@@ -569,9 +570,9 @@ class GenerationConfig(PushToHubMixin):
         if "_commit_hash" in kwargs and "_commit_hash" in config_dict:
             kwargs["_commit_hash"] = config_dict["_commit_hash"]
 
-        # remove all the arguments that are in the config_dict
-
-        config = cls(**config_dict, **kwargs)
+        # The line below allows model-specific config to be loaded as well through kwargs, with safety checks.
+        # See https://github.com/huggingface/transformers/pull/21269
+        config = cls(**{**config_dict, **kwargs})
         unused_kwargs = config.update(**kwargs)
 
         logger.info(f"Generate config {config}")

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -93,6 +93,22 @@ class GenerationConfigTest(unittest.TestCase):
         generation_config = GenerationConfig.from_model_config(new_config)
         assert not hasattr(generation_config, "foo")  # no new kwargs should be initialized if from config
 
+    def test_kwarg_init(self):
+        """Tests that we can overwrite attributes at `from_pretrained` time."""
+        config = GenerationConfig(
+            do_sample=True,
+            temperature=0.7,
+            length_penalty=1.0,
+            bad_words_ids=[[1, 2, 3], [4, 5]],
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config.save_pretrained(tmp_dir)
+            loaded_config = GenerationConfig.from_pretrained(tmp_dir, temperature=1.0)
+
+        self.assertEqual(loaded_config.temperature, 1.0)
+        self.assertEqual(loaded_config.do_sample, True)
+        self.assertEqual(loaded_config.num_beams, 1)  # default value
+
 
 @is_staging_test
 class ConfigPushToHubTester(unittest.TestCase):

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -99,7 +99,7 @@ class GenerationConfigTest(unittest.TestCase):
         self.assertEqual(default_config.temperature, 1.0)
         self.assertEqual(default_config.do_sample, False)
         self.assertEqual(default_config.num_beams, 1)
-        
+
         config = GenerationConfig(
             do_sample=True,
             temperature=0.7,
@@ -109,7 +109,7 @@ class GenerationConfigTest(unittest.TestCase):
         self.assertEqual(config.temperature, 0.7)
         self.assertEqual(config.do_sample, True)
         self.assertEqual(config.num_beams, 1)
-                        
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             config.save_pretrained(tmp_dir)
             loaded_config = GenerationConfig.from_pretrained(tmp_dir, temperature=1.0)

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -95,12 +95,21 @@ class GenerationConfigTest(unittest.TestCase):
 
     def test_kwarg_init(self):
         """Tests that we can overwrite attributes at `from_pretrained` time."""
+        default_config = GenerationConfig()
+        self.assertEqual(default_config.temperature, 1.0)
+        self.assertEqual(default_config.do_sample, False)
+        self.assertEqual(default_config.num_beams, 1)
+        
         config = GenerationConfig(
             do_sample=True,
             temperature=0.7,
             length_penalty=1.0,
             bad_words_ids=[[1, 2, 3], [4, 5]],
         )
+        self.assertEqual(config.temperature, 0.7)
+        self.assertEqual(config.do_sample, True)
+        self.assertEqual(config.num_beams, 1)
+                        
         with tempfile.TemporaryDirectory() as tmp_dir:
             config.save_pretrained(tmp_dir)
             loaded_config = GenerationConfig.from_pretrained(tmp_dir, temperature=1.0)


### PR DESCRIPTION
# What does this PR do?

Fixes #24104

As with other configuration files, we should allow overwriting attributes at `from_pretrained` time. The latest change to the `GenerationConfig` loading code disallowed it -- this PR fixes it and adds a test.