### PR TITLE
Fix how we detect the TF package

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -40,6 +40,8 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 # TODO: This doesn't work for all packages (`bs4`, `faiss`, etc.) Talk to Sylvain to see how to do with it better.
 def _is_package_available(pkg_name: str, return_version: bool = False) -> Union[Tuple[bool, str], bool]:
     # Check we're not importing a "pkg_name" directory somewhere but the actual library by trying to grab the version
+    # Note: _is_package_available("tensorflow") fails for tensorflow-cpu. Please test any changes to the line below
+    # with tensorflow-cpu to make sure it still works!
     package_exists = importlib.util.find_spec(pkg_name) is not None
     package_version = "N/A"
     if package_exists:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -147,7 +147,7 @@ if FORCE_TF_AVAILABLE in ENV_VARS_TRUE_VALUES:
     _tf_available = True
 else:
     if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VALUES:
-        _tf_available = _is_package_available("tensorflow")
+        _tf_available = importlib.util.find_spec("tensorflow") is not None
         if _tf_available:
             candidates = (
                 "tensorflow",

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -40,8 +40,6 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 # TODO: This doesn't work for all packages (`bs4`, `faiss`, etc.) Talk to Sylvain to see how to do with it better.
 def _is_package_available(pkg_name: str, return_version: bool = False) -> Union[Tuple[bool, str], bool]:
     # Check we're not importing a "pkg_name" directory somewhere but the actual library by trying to grab the version
-    # Note: _is_package_available("tensorflow") fails for tensorflow-cpu. Please test any changes to the line below
-    # with tensorflow-cpu to make sure it still works!
     package_exists = importlib.util.find_spec(pkg_name) is not None
     package_version = "N/A"
     if package_exists:
@@ -149,6 +147,8 @@ if FORCE_TF_AVAILABLE in ENV_VARS_TRUE_VALUES:
     _tf_available = True
 else:
     if USE_TF in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TORCH not in ENV_VARS_TRUE_VALUES:
+        # Note: _is_package_available("tensorflow") fails for tensorflow-cpu. Please test any changes to the line below
+        # with tensorflow-cpu to make sure it still works!
         _tf_available = importlib.util.find_spec("tensorflow") is not None
         if _tf_available:
             candidates = (


### PR DESCRIPTION
Our framework detection code calls `_is_package_available()` for TensorFlow, but this code fails when only the `tensorflow-cpu` package is present. The failure occurs because `importlib_metadata.version("tensorflow")` throws an error in the version detection branch of `_is_package_available` unless the core `tensorflow` package is installed.

I solved this by just calling `importlib.util.find_spec("tensorflow")` instead of `_is_package_available()`. However, we could also resolve this issue by rewriting `_is_package_available()` so that it only takes the version check branch when `return_version` is `True`. The `importlib_metadata.version()` call is only used to get the package version, but it causes the entire `_is_package_available()` call to fail if it can't find a version, even if the `importlib.util.find_spec()` call was a success.

ccing @sgugger because there's a `TODO` above that function [requesting his attention](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L40), so I'd like his input on the right approach here!

Fixes #24253 