### PR TITLE
Skip `GPT-J` fx tests for torch < 1.12

### DIFF
--- a/tests/models/gptj/test_modeling_gptj.py
+++ b/tests/models/gptj/test_modeling_gptj.py
@@ -388,11 +388,15 @@ class GPTJModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_model_parallel = False
     test_head_masking = False
 
-    @unittest.skipIf(not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+")
+    @unittest.skipIf(
+        not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+."
+    )
     def test_torch_fx(self):
         super().test_torch_fx()
 
-    @unittest.skipIf(not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+")
+    @unittest.skipIf(
+        not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+."
+    )
     def test_torch_fx_output_loss(self):
         super().test_torch_fx_output_loss()
 

--- a/tests/models/gptj/test_modeling_gptj.py
+++ b/tests/models/gptj/test_modeling_gptj.py
@@ -37,6 +37,9 @@ if is_torch_available():
         GPTJForSequenceClassification,
         GPTJModel,
     )
+    from transformers.pytorch_utils import is_torch_greater_or_equal_than_1_12
+else:
+    is_torch_greater_or_equal_than_1_12 = False
 
 
 class GPTJModelTester:
@@ -384,6 +387,14 @@ class GPTJModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_missing_keys = False
     test_model_parallel = False
     test_head_masking = False
+
+    @unittest.skipIf(not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+")
+    def test_torch_fx(self):
+        super().test_torch_fx()
+
+    @unittest.skipIf(not is_torch_greater_or_equal_than_1_12, reason="PR #22069 made changes that require torch v1.12+")
+    def test_torch_fx_output_loss(self):
+        super().test_torch_fx_output_loss()
 
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(


### PR DESCRIPTION
# What does this PR do?

After #22069, the fx tests for gpt-j with torch < 1.12 gives an error
```bash
(line 941)  AssertionError: Couldn't trace module: 'len' is not supported in symbolic tracing by default. If you want this call to be recorded, please call torch.fx.wrap('len') at module scope
```
Guess it's best to skip in this case, as it works with recent torch versions.

