### PR TITLE
Fix bug in slow tokenizer conversion, make it a lot faster

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -60,7 +60,7 @@ class SentencePieceExtractor:
                 piece_l, piece_r = merge[:index], merge[index:]
                 if piece_l in vocab and piece_r in vocab:
                     local.append((piece_l, piece_r, piece_score))
-            local = sorted(local, key=lambda x: vocab[x[0]])
+            local = sorted(local, key=lambda x: (vocab[x[0]], vocab[[x[1]]]))
             merges.extend(local)
 
         merges = sorted(merges, key=lambda val: val[2], reverse=reverse)

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -54,12 +54,15 @@ class SentencePieceExtractor:
 
         # Merges
         merges = []
-        for piece_l in vocab.keys():
-            for piece_r in vocab.keys():
-                merge = f"{piece_l}{piece_r}"
-                piece_score = vocab_scores.get(merge, None)
-                if piece_score:
-                    merges += [(piece_l, piece_r, piece_score)]
+        for merge, piece_score in vocab_scores.items():
+            local = []
+            for index in range(1, len(merge)):
+                piece_l, piece_r = merge[:index], merge[index:]
+                if piece_l in vocab and piece_r in vocab:
+                    local.append((piece_l, piece_r, piece_score))
+            local = sorted(local, key=lambda x: vocab[x[0]])
+            merges.extend(local)
+
         merges = sorted(merges, key=lambda val: val[2], reverse=reverse)
         merges = [(val[0], val[1]) for val in merges]
         return vocab, merges

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -60,7 +60,7 @@ class SentencePieceExtractor:
                 piece_l, piece_r = merge[:index], merge[index:]
                 if piece_l in vocab and piece_r in vocab:
                     local.append((piece_l, piece_r, piece_score))
-            local = sorted(local, key=lambda x: (vocab[x[0]], vocab[[x[1]]]))
+            local = sorted(local, key=lambda x: (vocab[x[0]], vocab[x[1]]))
             merges.extend(local)
 
         merges = sorted(merges, key=lambda val: val[2], reverse=reverse)


### PR DESCRIPTION
# What does this PR do?

The slow tokenizer conversion currently has a bug where merges with a score of 0 do not get used due to an erroneous check. The check simply tested truthiness, but was actually looking for a `None`. During fixing, I noticed that the code was also slow, so I made it a lot faster.

Fixes #24233

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker 
