### PR TITLE
Update check of core deps

### DIFF
--- a/src/transformers/dependency_versions_check.py
+++ b/src/transformers/dependency_versions_check.py
@@ -23,9 +23,21 @@ from .utils.versions import require_version, require_version_core
 # order specific notes:
 # - tqdm must be checked before tokenizers
 
-pkgs_to_check_at_runtime = "python tqdm regex requests packaging filelock numpy tokenizers".split()
-if sys.version_info < (3, 7):
-    pkgs_to_check_at_runtime.append("dataclasses")
+pkgs_to_check_at_runtime = [
+    "python",
+    "tqdm",
+    "regex",
+    "requests",
+    "packaging",
+    "filelock",
+    "numpy",
+    "tokenizers",
+    "huggingface-hub",
+    "safetensors",
+    "accelerate",
+    "pyyaml",
+]
+
 if sys.version_info < (3, 8):
     pkgs_to_check_at_runtime.append("importlib_metadata")
 
@@ -36,6 +48,14 @@ for pkg in pkgs_to_check_at_runtime:
             from .utils import is_tokenizers_available
 
             if not is_tokenizers_available():
+                continue  # not required, check version only if installed
+        elif pkg == "accelerate":
+            # must be loaded here, or else tqdm check may fail
+            from .utils import is_accelerate_available
+
+            # Maybe switch to is_torch_available in the future here so that Accelerate is hard dep of
+            # Transformers with PyTorch
+            if not is_accelerate_available():
                 continue  # not required, check version only if installed
 
         require_version_core(deps[pkg])


### PR DESCRIPTION
# What does this PR do?

This PR updates the check of core dependencies to:
- include all of them (huggingface_hub and safetensors were not tested)
- add Accelerate since we have a lot of issues with versions mismatch, with the work done on the Trainer

cc @ydshieh one of the lines removed here concerns the Python 3.6 but you should include the equivalent for your PR to drop Python 3.7