### PR TITLE
Beam search type

### DIFF
--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -15,7 +15,7 @@
 
 from abc import ABC, abstractmethod
 from collections import UserDict
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -211,8 +211,7 @@ class BeamSearchScorer(BeamScorer):
         pad_token_id: Optional[int] = None,
         eos_token_id: Optional[Union[int, List[int]]] = None,
         beam_indices: Optional[torch.LongTensor] = None,
-    ) -> Tuple[torch.Tensor]:
-        print("Tupe here to be changed")
+    ) -> Dict[str,torch.Tensor]:
         cur_len = input_ids.shape[-1] + 1  # add up to the length which the next_scores is calculated on
         batch_size = len(self._beam_hyps)
         if not (batch_size == (input_ids.shape[0] // self.group_size)):

--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -211,7 +211,7 @@ class BeamSearchScorer(BeamScorer):
         pad_token_id: Optional[int] = None,
         eos_token_id: Optional[Union[int, List[int]]] = None,
         beam_indices: Optional[torch.LongTensor] = None,
-    ) -> Dict[str,torch.Tensor]:
+    ) -> Dict[str, torch.Tensor]:
         cur_len = input_ids.shape[-1] + 1  # add up to the length which the next_scores is calculated on
         batch_size = len(self._beam_hyps)
         if not (batch_size == (input_ids.shape[0] // self.group_size)):

--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -212,6 +212,7 @@ class BeamSearchScorer(BeamScorer):
         eos_token_id: Optional[Union[int, List[int]]] = None,
         beam_indices: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor]:
+        print("Tupe here to be changed")
         cur_len = input_ids.shape[-1] + 1  # add up to the length which the next_scores is calculated on
         batch_size = len(self._beam_hyps)
         if not (batch_size == (input_ids.shape[0] // self.group_size)):


### PR DESCRIPTION
# What does this PR do?




This PR fixes issue #22856 , which has a type mismatch between the returned value, and the type hinting in the  BeamSeachScorer, process function. Previously the type hint was set to a Tuple which was inconsistent with the returned Dict value. I've changed them to be consistent and ran the following test cases.

1. Performed print statements of the process annotations.
- Before changes return  type was typing.Tuple[torch.Tensor]}
- After changes return type was typing.Dict[str, torch.Tensor]

2. Ran PyTest for the test_beam_search.py with all 6 test cases passing. 


# Motivation and Context

To ensure high quality code within the HuggingFace repo.

## Who can review?
@gante 


