### PR TITLE
Tied weights load

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3019,9 +3019,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         unexpected_keys = list(set(loaded_keys) - set(expected_keys))
 
         if is_accelerate_available():
+            model.tie_weights()
             tied_params = find_tied_parameters(model)
         else:
             tied_params = []
+
         _missing = []
         for k in missing_keys:
             found = False

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3267,7 +3267,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             missing_keys = [elem for elem in missing_keys if "SCB" not in elem]
 
         if len(unexpected_keys) > 0:
-            warner = logger.warn if model.__class__.__name__ in model.config.architectures else logger.info
+            archs = [] if model.config.architectures is None else model.config.architectures
+            warner = logger.warn if model.__class__.__name__ in archs else logger.info
             warner(
                 f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
                 f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1778,10 +1778,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             for names in shared_ptrs.values():
                 # Removing the keys which are declared as known duplicates on
                 # load. This allows to make sure the name which is kept is consistent.
-                if self._keys_to_ignore_on_load_missing is not None:
+                if self._tied_weights_keys is not None:
                     found = 0
                     for name in sorted(names):
-                        matches_pattern = any(re.search(pat, name) for pat in self._keys_to_ignore_on_load_missing)
+                        matches_pattern = any(re.search(pat, name) for pat in self._tied_weights_keys)
                         if matches_pattern and name in state_dict:
                             found += 1
                             if found < len(names):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3028,7 +3028,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             for group in tied_params:
                 if k in group:
                     found = True
-                    if len(group) > 2:
+                    if len(group) > 1:
                         group.remove(k)
                     else:
                         _missing.append(k)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -923,7 +923,7 @@ class ModelUtilsTest(TestCasePlus):
             # Loading the model with a new class, we don't get a warning for unexpected weights, just an info
             with CaptureLogger(logger) as cl:
                 _, loading_info = BaseModel.from_pretrained(tmp_dir, output_loading_info=True)
-            self.assertEqual(cl.out, "")
+            self.assertNotIn("were not used when initializing ModelWithHead", cl.out)
             self.assertEqual(
                 set(loading_info["unexpected_keys"]),
                 {"linear.weight", "linear.bias", "linear2.weight", "linear2.bias"},


### PR DESCRIPTION
# What does this PR do?

This continue cleaning up a bit the model loading by:
1. Using the new `_tied_weight_keys` class variable when deleting weights without warning for safetensors serialization
2. Fix the logic that deletes tied params in missing keys and add a test (which fails on main)
3. As discussed internally, use a logger.info for the unexepected keys warning when the class used to load the model does not match the class in the config.