### PR TITLE
save full_osd in fsdp mode

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2258,7 +2258,7 @@ class Trainer:
 
         if self.fsdp or self.is_fsdp_enabled:
             if self.is_fsdp_enabled:
-                save_fsdp_optimizer(
+                full_osd = save_fsdp_optimizer(
                     self.accelerator.state.fsdp_plugin, self.accelerator, self.optimizer, self.model, output_dir
                 )
             else:


### PR DESCRIPTION
Fixes a typo in which the variable full_osd is referenced before definition if run in fsdp mode. The fix allows model files to be saved when running in fsdp.

Links to issue: https://github.com/huggingface/transformers/issues/24057

Fixes # 24057
