### PR TITLE
Clean up disk sapce during docker image build for `transformers-pytorch-gpu`

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -176,6 +176,16 @@ jobs:
     if: inputs.image_postfix != '-push-ci'
     runs-on: ubuntu-latest
     steps:
+      - name: Cleanup disk
+        run: |
+          sudo ls -l /usr/local/lib/
+          sudo ls -l /usr/share/
+          sudo du -sh /usr/local/lib/
+          sudo du -sh /usr/share/
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo du -sh /usr/local/lib/
+          sudo du -sh /usr/share/
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
# What does this PR do?

PyTorch pipeline CI job start to fail due to 
```bash
 ImportError: accelerate>=0.20.3 is required for a normal functioning of this module, but found accelerate==0.20.2.
Try: pip install transformers -U or pip install -e '.[dev]' if you're working with git main
```

**The root cause is: docker image for this job failed to build due to disk space issue**
```bash
RROR: Could not install packages due to an OSError: [Errno 28] No space left on device
```

As usual, let's us save Space!