### PR TITLE
Fix device issue in `SwitchTransformers`

### DIFF
--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -800,6 +800,9 @@ class SwitchTransformersBlock(nn.Module):
         else:
             router_tuple = (torch.tensor([0]),)
 
+        # Send elements in `router_tuple` to the correct device (due to the above if/else statement)
+        router_tuple = tuple(x.to(hidden_states.device) for x in router_tuple)
+
         # clamp inf values to enable fp16 training
         if hidden_states.dtype == torch.float16 and torch.isinf(hidden_states).any():
             clamp_value = torch.finfo(hidden_states.dtype).max - 1000

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -798,10 +798,7 @@ class SwitchTransformersBlock(nn.Module):
         if isinstance(hidden_states, tuple):
             hidden_states, router_tuple = hidden_states
         else:
-            router_tuple = (torch.tensor([0]),)
-
-        # Send elements in `router_tuple` to the correct device (due to the above if/else statement)
-        router_tuple = tuple(x.to(hidden_states.device) for x in router_tuple)
+            router_tuple = (torch.tensor([0], device=hidden_states.device),)
 
         # clamp inf values to enable fp16 training
         if hidden_states.dtype == torch.float16 and torch.isinf(hidden_states).any():


### PR DESCRIPTION
# What does this PR do?

Need a tiny fix after #24300.

Currently, we have a failure


```bash

self = <tests.models.switch_transformers.test_modeling_switch_transformers.SwitchTransformersEncoderOnlyModelTest testMethod=test_multi_gpu_data_parallel_forward>

    @staticmethod
    def forward(ctx, target_device, dim, *inputs):
>       assert all(i.device.type != 'cpu' for i in inputs), (
            'Gather function not implemented for CPU tensors'
        )
E       AssertionError: Gather function not implemented for CPU tensors

/usr/local/lib/python3.8/dist-packages/torch/nn/parallel/_functions.py:56: AssertionError
```