### PR TITLE
Make `AutoFormer` work with previous torch version

### DIFF
--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
+import torch.utils.checkpoint
 from torch import nn
 
 from ...activations import ACT2FN


### PR DESCRIPTION
# What does this PR do?

Without `import torch.utils.checkpoint` (which we have in other files, like `Bart`), with torch 1.13, we got an error

(running `RUN_SLOW=1 python3 -m pytest -v tests/models/autoformer/test_modeling_autoformer.py::AutoformerModelTest::test_training_gradient_checkpointing`)

```bash
>                   layer_outputs = torch.utils.checkpoint.checkpoint(
                        create_custom_forward(encoder_layer),
                        hidden_states,
                        attention_mask,
                        (head_mask[idx] if head_mask is not None else None),
                    )
E                   AttributeError: module 'torch.utils' has no attribute 'checkpoint'
```

Let's make it work with previous torch version(s) ❤️ .