### PR TITLE
[modelcard] add audio classification to task list

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -279,6 +279,7 @@ TASK_TAG_TO_NAME_MAPPING = {
     "translation": "Translation",
     "zero-shot-classification": "Zero Shot Classification",
     "automatic-speech-recognition": "Automatic Speech Recognition",
+    "audio-classification": "Audio Classification",
 }
 
 


### PR DESCRIPTION
# What does this PR do?

Adds audio classification to the modelcard tasks lists, thus enabling model cards to be created for this task (required for https://github.com/huggingface/audio-transformers-course/pull/46)