### PR TITLE
Add a check in `ImageToTextPipeline._forward`

### DIFF
--- a/src/transformers/pipelines/image_to_text.py
+++ b/src/transformers/pipelines/image_to_text.py
@@ -145,7 +145,6 @@ class ImageToTextPipeline(Pipeline):
         return model_inputs
 
     def _forward(self, model_inputs, generate_kwargs=None):
-
         # Git model sets `model_inputs["input_ids"] = None` in `preprocess` (when `prompt=None`). In batch model, the
         # pipeline will group them into a list of `None`, which fail `_forward`. Avoid this by checking it first.
         if "input_ids" in model_inputs and type(model_inputs["input_ids"]) == list:

--- a/src/transformers/pipelines/image_to_text.py
+++ b/src/transformers/pipelines/image_to_text.py
@@ -147,9 +147,12 @@ class ImageToTextPipeline(Pipeline):
     def _forward(self, model_inputs, generate_kwargs=None):
         # Git model sets `model_inputs["input_ids"] = None` in `preprocess` (when `prompt=None`). In batch model, the
         # pipeline will group them into a list of `None`, which fail `_forward`. Avoid this by checking it first.
-        if "input_ids" in model_inputs and isinstance(model_inputs["input_ids"]), list):
-            if all(x is None for x in model_inputs["input_ids"]):
-                model_inputs["input_ids"] = None
+        if (
+            "input_ids" in model_inputs
+            and isinstance(model_inputs["input_ids"], list)
+            and all(x is None for x in model_inputs["input_ids"])
+        ):
+            model_inputs["input_ids"] = None
 
         if generate_kwargs is None:
             generate_kwargs = {}

--- a/src/transformers/pipelines/image_to_text.py
+++ b/src/transformers/pipelines/image_to_text.py
@@ -147,7 +147,7 @@ class ImageToTextPipeline(Pipeline):
     def _forward(self, model_inputs, generate_kwargs=None):
         # Git model sets `model_inputs["input_ids"] = None` in `preprocess` (when `prompt=None`). In batch model, the
         # pipeline will group them into a list of `None`, which fail `_forward`. Avoid this by checking it first.
-        if "input_ids" in model_inputs and type(model_inputs["input_ids"]) == list:
+        if "input_ids" in model_inputs and isinstance(model_inputs["input_ids"]), list):
             if all(x is None for x in model_inputs["input_ids"]):
                 model_inputs["input_ids"] = None
 

--- a/src/transformers/pipelines/image_to_text.py
+++ b/src/transformers/pipelines/image_to_text.py
@@ -145,6 +145,13 @@ class ImageToTextPipeline(Pipeline):
         return model_inputs
 
     def _forward(self, model_inputs, generate_kwargs=None):
+
+        # Git model sets `model_inputs["input_ids"] = None` in `preprocess` (when `prompt=None`). In batch model, the
+        # pipeline will group them into a list of `None`, which fail `_forward`. Avoid this by checking it first.
+        if "input_ids" in model_inputs and type(model_inputs["input_ids"]) == list:
+            if all(x is None for x in model_inputs["input_ids"]):
+                model_inputs["input_ids"] = None
+
         if generate_kwargs is None:
             generate_kwargs = {}
         # FIXME: We need to pop here due to a difference in how `generation.py` and `generation.tf_utils.py`

--- a/tests/models/git/test_modeling_git.py
+++ b/tests/models/git/test_modeling_git.py
@@ -390,15 +390,6 @@ class GitModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     fx_compatible = False
     test_torchscript = False
 
-    # `GitForCausalLM` doesn't fit into image-to-text pipeline. We might need to overwrite its `generate` function.
-    def is_pipeline_test_to_skip(
-        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
-    ):
-        if pipeline_test_casse_name == "ImageToTextPipelineTests":
-            return True
-
-        return False
-
     # special case for GitForCausalLM model
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = super()._prepare_for_class(inputs_dict, model_class, return_labels=return_labels)


### PR DESCRIPTION
# What does this PR do?

Inside `ImageToTextPipeline.preprocess`, we have 
```python
        if self.model.config.model_type == "git" and prompt is None:
            model_inputs["input_ids"] = None
```
So it may  happen with a list of `None` (for Git model), and the `_forward` fail.

This PR add a check and change the above case to a single `None` value to avoid failure.