### PR TITLE
Better test name and enable pipeline test for `pix2struct`

### DIFF
--- a/tests/models/pix2struct/test_modeling_pix2struct.py
+++ b/tests/models/pix2struct/test_modeling_pix2struct.py
@@ -394,8 +394,9 @@ class Pix2StructModelTester:
 
 
 @require_torch
-class Pix2StructModelTest(ModelTesterMixin, unittest.TestCase):
+class Pix2StructModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (Pix2StructForConditionalGeneration,) if is_torch_available() else ()
+    pipeline_model_mapping = {"image-to-text": Pix2StructForConditionalGeneration} if is_torch_available() else {}
     fx_compatible = False
     test_head_masking = False
     test_pruning = False

--- a/tests/models/pix2struct/test_modeling_pix2struct.py
+++ b/tests/models/pix2struct/test_modeling_pix2struct.py
@@ -354,7 +354,7 @@ class Pix2StructTextModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertIsNotNone(model)
 
 
-class Pix2StructTextImageModelsModelTester:
+class Pix2StructModelTester:
     def __init__(self, parent, text_kwargs=None, vision_kwargs=None, is_training=True):
         if text_kwargs is None:
             text_kwargs = {}
@@ -394,7 +394,7 @@ class Pix2StructTextImageModelsModelTester:
 
 
 @require_torch
-class Pix2StructTextImageModelTest(ModelTesterMixin, unittest.TestCase):
+class Pix2StructModelTest(ModelTesterMixin, unittest.TestCase):
     all_model_classes = (Pix2StructForConditionalGeneration,) if is_torch_available() else ()
     fx_compatible = False
     test_head_masking = False
@@ -404,7 +404,7 @@ class Pix2StructTextImageModelTest(ModelTesterMixin, unittest.TestCase):
     test_torchscript = False
 
     def setUp(self):
-        self.model_tester = Pix2StructTextImageModelsModelTester(self)
+        self.model_tester = Pix2StructModelTester(self)
 
     def test_model(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/pix2struct/test_modeling_pix2struct.py
+++ b/tests/models/pix2struct/test_modeling_pix2struct.py
@@ -35,6 +35,7 @@ from ...test_modeling_common import (
     ids_tensor,
     random_attention_mask,
 )
+from ...test_pipeline_mixin import PipelineTesterMixin
 
 
 if is_torch_available():


### PR DESCRIPTION
# What does this PR do?

In #24364, `pix2struct` test file didn't get `pipeline_model_mapping` being updated, due to the `heuristic` of finding a test class not working well (try to find the shortest test class name).

Let's try to give the test class a better/short/clear name, (despite we don't really have a base model), `Pix2StructModelTest` instead of `Pix2StructTextImageModelTest`.

This enables the script `add_pipeline_model_mapping_to_test.py` works for `pix2struct`, and then we get the pipeline test being run.