### PR TITLE
[Trainer] Fix optimizer step on PyTorch TPU

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1859,6 +1859,7 @@ class Trainer:
                             self.scaler.step(self.optimizer)
                             self.scaler.update()
                         else:
+                            # tpu-comment: accelerate wrapped optimizers call xm.optimizer_step
                             self.optimizer.step()
                     elif self.do_grad_scaling:
                         scale_before = self.scaler.get_scale()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1859,7 +1859,7 @@ class Trainer:
                             self.scaler.step(self.optimizer)
                             self.scaler.update()
                         else:
-                            xm.optimizer_step(self.optimizer)
+                            self.optimizer.step()
                     elif self.do_grad_scaling:
                         scale_before = self.scaler.get_scale()
                         self.scaler.step(self.optimizer)


### PR DESCRIPTION
# What does this PR do?
Update optimizer step for TPUs to user `self.optimizer.step()` instead of `xm.optimizer_step(self.optimizer)`. 
AcceleratedOptimizer properly calls `xm.optimizer_step` on the optimizer (https://github.com/huggingface/accelerate/blob/main/src/accelerate/optimizer.py#L129). 

This fixes a bug in transformers/trainer.py when using Pytorch on TPUs:
File "/usr/local/lib/python3.8/dist-packages/torch_xla/core/xla_model.py", line 471, in _fetch_gradients for param_group in optimizer.getstate()['param_groups']: KeyError: 'param_groups'


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 

