### PR TITLE
Add `ffmpeg` for `doc_test_job` on CircleCI

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -454,7 +454,7 @@ doc_test_job = CircleCIJob(
     "pr_documentation_tests",
     additional_env={"TRANSFORMERS_VERBOSITY": "error", "DATASETS_VERBOSITY": "error", "SKIP_CUDA_DOCTEST": "1"},
     install_steps=[
-        "sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng time",
+        "sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng time ffmpeg",
         "pip install --upgrade pip",
         "pip install -e .[dev]",
         "pip install git+https://github.com/huggingface/accelerate",


### PR DESCRIPTION
# What does this PR do?

Need this at least for `docs/source/en/task_summary.md`.

Otherwise, [job](https://app.circleci.com/pipelines/github/huggingface/transformers/66845/workflows/ae6bcd25-5071-4f48-a9ba-d446ae6e060f/jobs/833148) fails