### PR TITLE
TF safetensors reduced mem usage

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -286,8 +286,8 @@ def load_pytorch_state_dict_in_tf2_model(
         pt_state_dict[new_key] = pt_state_dict.pop(old_key)
 
     # Matt: All TF models store the actual model stem in a MainLayer class, including the base model.
-    # In PT, the derived models (with heads) use the base model class as the stem instead, and the base model
-    # just contains the stem itself, and there is no MainLayer class. This means that TF base classes have one
+    # In PT, the derived models (with heads) use the base model class as the stem instead,
+    # and there is no MainLayer class. This means that TF base classes have one
     # extra layer in their weight names, corresponding to the MainLayer class. This code block compensates for that.
     start_prefix_to_remove = ""
     if not any(s.startswith(tf_model.base_model_prefix) for s in pt_state_dict.keys()):

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -248,7 +248,8 @@ def load_pytorch_state_dict_in_tf2_model(
     tf_to_pt_weight_rename=None,
     ignore_mismatched_sizes=False,
 ):
-    """Load a pytorch state_dict in a TF 2.0 model."""
+    """Load a pytorch state_dict in a TF 2.0 model. pt_state_dict can be either an actual dict or a lazy-loading
+    safetensors archive created with the safe_open() function."""
     import tensorflow as tf
     from packaging.version import parse
 
@@ -267,8 +268,7 @@ def load_pytorch_state_dict_in_tf2_model(
             tf_model(tf_inputs, training=False)  # Make sure model is built
     # Adapt state dict - TODO remove this and update the AWS weights files instead
     # Convert old format to new format if needed from a PyTorch state_dict
-    old_keys = []
-    new_keys = []
+    tf_keys_to_pt_keys = {}
     for key in pt_state_dict.keys():
         new_key = None
         if "gamma" in key:
@@ -279,24 +279,21 @@ def load_pytorch_state_dict_in_tf2_model(
             new_key = key.replace("running_var", "moving_variance")
         if "running_mean" in key:
             new_key = key.replace("running_mean", "moving_mean")
-        if new_key:
-            old_keys.append(key)
-            new_keys.append(new_key)
-    for old_key, new_key in zip(old_keys, new_keys):
-        pt_state_dict[new_key] = pt_state_dict.pop(old_key)
+        if new_key is None:
+            new_key = key
+        tf_keys_to_pt_keys[new_key] = key
 
     # Matt: All TF models store the actual model stem in a MainLayer class, including the base model.
     # In PT, the derived models (with heads) use the base model class as the stem instead,
     # and there is no MainLayer class. This means that TF base classes have one
     # extra layer in their weight names, corresponding to the MainLayer class. This code block compensates for that.
     start_prefix_to_remove = ""
-    if not any(s.startswith(tf_model.base_model_prefix) for s in pt_state_dict.keys()):
+    if not any(s.startswith(tf_model.base_model_prefix) for s in tf_keys_to_pt_keys.keys()):
         start_prefix_to_remove = tf_model.base_model_prefix + "."
 
     symbolic_weights = tf_model.trainable_weights + tf_model.non_trainable_weights
     tf_loaded_numel = 0
-    weight_value_tuples = []
-    all_pytorch_weights = set(pt_state_dict.keys())
+    all_pytorch_weights = set(tf_keys_to_pt_keys.keys())
     missing_keys = []
     mismatched_keys = []
     for symbolic_weight in symbolic_weights:
@@ -311,7 +308,7 @@ def load_pytorch_state_dict_in_tf2_model(
             name = tf_to_pt_weight_rename(name)
 
         # Find associated numpy array in pytorch model state dict
-        if name not in pt_state_dict:
+        if name not in tf_keys_to_pt_keys:
             if allow_missing_keys:
                 missing_keys.append(name)
                 continue
@@ -320,9 +317,9 @@ def load_pytorch_state_dict_in_tf2_model(
                 if any(re.search(pat, name) is not None for pat in tf_model._keys_to_ignore_on_load_missing):
                     continue
             raise AttributeError(f"{name} not found in PyTorch model")
-
+        state_dict_name = tf_keys_to_pt_keys[name]
         try:
-            array = apply_transpose(transpose, pt_state_dict[name], symbolic_weight.shape)
+            array = apply_transpose(transpose, pt_state_dict[state_dict_name], symbolic_weight.shape)
         except tf.errors.InvalidArgumentError as e:
             if not ignore_mismatched_sizes:
                 error_msg = str(e)
@@ -331,15 +328,13 @@ def load_pytorch_state_dict_in_tf2_model(
                 )
                 raise tf.errors.InvalidArgumentError(error_msg)
             else:
-                mismatched_keys.append((name, pt_state_dict[name].shape, symbolic_weight.shape))
+                mismatched_keys.append((name, pt_state_dict[state_dict_name].shape, symbolic_weight.shape))
                 continue
 
         tf_loaded_numel += tensor_size(array)
 
-        weight_value_tuples.append((symbolic_weight, array))
+        K.set_value(symbolic_weight, array)
         all_pytorch_weights.discard(name)
-
-    K.batch_set_value(weight_value_tuples)
 
     logger.info(f"Loaded {tf_loaded_numel:,} parameters in the TF 2.0 model.")
 

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -341,6 +341,7 @@ def load_pytorch_state_dict_in_tf2_model(
         tf_loaded_numel += tensor_size(array)
 
         K.set_value(symbolic_weight, array)
+        del array  # Immediately free memory to keep peak usage as low as possible
         all_pytorch_weights.discard(name)
 
     logger.info(f"Loaded {tf_loaded_numel:,} parameters in the TF 2.0 model.")

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -295,10 +295,7 @@ def load_pytorch_state_dict_in_tf2_model(
     all_pytorch_weights = set(tf_keys_to_pt_keys.keys())
     missing_keys = []
     mismatched_keys = []
-    if hasattr(pt_state_dict, "get_tensor"):
-        is_safetensor_archive = True
-    else:
-        is_safetensor_archive = False
+    is_safetensor_archive = hasattr(pt_state_dict, "get_tensor")
     for symbolic_weight in symbolic_weights:
         sw_name = symbolic_weight.name
         name, transpose = convert_tf_weight_name_to_pt_weight_name(

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -332,7 +332,7 @@ def load_pytorch_state_dict_in_tf2_model(
                 )
                 raise tf.errors.InvalidArgumentError(error_msg)
             else:
-                mismatched_keys.append((name, array, symbolic_weight.shape))
+                mismatched_keys.append((name, array.shape, symbolic_weight.shape))
                 continue
 
         tf_loaded_numel += tensor_size(array)

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -2895,13 +2895,13 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         if safetensors_from_pt:
             from .modeling_tf_pytorch_utils import load_pytorch_state_dict_in_tf2_model
 
-            with safe_open(resolved_archive_file, framework="tf") as state_dict:
+            with safe_open(resolved_archive_file, framework="tf") as safetensors_archive:
                 # Load from a PyTorch checkpoint
                 # We load in TF format here because PT weights often need to be transposed, and this is much
                 # faster on GPU. Loading as numpy and transposing on CPU adds several seconds to load times.
                 return load_pytorch_state_dict_in_tf2_model(
                     model,
-                    state_dict,
+                    safetensors_archive,
                     tf_inputs=False,  # No need to build the model again
                     allow_missing_keys=True,
                     output_loading_info=output_loading_info,

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1002,10 +1002,8 @@ def load_tf_weights_from_safetensors(model, resolved_archive_file, ignore_mismat
     # Read the safetensors file
     with safe_open(resolved_archive_file, framework="np") as safetensors_archive:
         mismatched_layers = []
-
         weight_names = [format_weight_name(w.name, _prefix=_prefix) for w in model.weights]
         loaded_weight_names = list(safetensors_archive.keys())
-
         # Find the missing layers from the high level list of layers
         missing_layers = list(set(weight_names) - set(loaded_weight_names))
         # Find the unexpected layers from the high level list of layers

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -999,7 +999,7 @@ def load_tf_weights_from_h5(model, resolved_archive_file, ignore_mismatched_size
 
 def load_tf_weights_from_safetensors(model, resolved_archive_file, ignore_mismatched_sizes=False, _prefix=None):
     # Read the safetensors file
-    with safe_open(resolved_archive_file, framework="np") as safetensors_archive:
+    with safe_open(resolved_archive_file, framework="tf") as safetensors_archive:
         mismatched_layers = []
         weight_names = [format_weight_name(w.name, _prefix=_prefix) for w in model.weights]
         loaded_weight_names = list(safetensors_archive.keys())
@@ -2853,7 +2853,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
         safetensors_from_pt = False
         if filename == SAFE_WEIGHTS_NAME:
-            with safe_open(resolved_archive_file, framework="np") as f:
+            with safe_open(resolved_archive_file, framework="tf") as f:
                 safetensors_metadata = f.metadata()
             if safetensors_metadata is None or safetensors_metadata.get("format") not in ["pt", "tf", "flax"]:
                 raise OSError(


### PR DESCRIPTION
When we load safetensors files in TF, the entire safetensors state dict is materialized on GPU alongside the randomly initialized weights. This inflates our memory usage during loading a lot, up to about 2X - 2.5X the amount we actually need.

This PR grabs tensors iteratively from the underlying safetensors archives and assigns them. ~It's working for TF-formatted safetensors archives right now, and I'll add torch-format support next.~ Now supports PT and TF formatted archives! Load times still seem very quick for me locally, so I don't think this negatively impacts anything!

Fixes #24393 