### PR TITLE
Skip `test_conditional_generation_pt_pix2struct` in Past CI (torch < 1.11)

### DIFF
--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -18,9 +18,22 @@ import requests
 
 from transformers import MODEL_FOR_VISION_2_SEQ_MAPPING, TF_MODEL_FOR_VISION_2_SEQ_MAPPING, is_vision_available
 from transformers.pipelines import pipeline
-from transformers.testing_utils import is_pipeline_test, require_tf, require_torch, require_vision, slow
+from transformers.testing_utils import (
+    is_pipeline_test,
+    is_torch_available,
+    require_tf,
+    require_torch,
+    require_vision,
+    slow,
+)
 
 from .test_pipelines_common import ANY
+
+
+if is_torch_available():
+    from transformers.pytorch_utils import is_torch_greater_or_equal_than_1_11
+else:
+    is_torch_greater_or_equal_than_1_11 = False
 
 
 if is_vision_available():
@@ -204,6 +217,9 @@ class ImageToTextPipelineTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             outputs = pipe([image, image], prompt=[prompt, prompt])
 
+    @unittest.skipIf(
+        not is_torch_greater_or_equal_than_1_11, reason="`Pix2StructImageProcessor` requires `torch>=1.11.0`."
+    )
     @slow
     @require_torch
     def test_conditional_generation_pt_pix2struct(self):


### PR DESCRIPTION
# What does this PR do?

Same as in #24270, but for a test inside pipeline test in `ImageToTextPipelineTests`.