### PR TITLE
Fix `save_cache` version in `config.yml`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: pip install .[all,quality]
             - save_cache:
-                  key: v0.5-code_quality-{{ checksum "setup.py" }}
+                  key: v0.6-code_quality-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
             - run:
@@ -174,7 +174,7 @@ jobs:
             - run: pip install --upgrade pip
             - run: pip install .[all,quality]
             - save_cache:
-                  key: v0.5-repository_consistency-{{ checksum "setup.py" }}
+                  key: v0.6-repository_consistency-{{ checksum "setup.py" }}
                   paths:
                       - '~/.cache/pip'
             - run:


### PR DESCRIPTION
# What does this PR do?

In #22204, I changed the `restore_cache` to `v0.6` but forgot to change `save_cache`. In consequence, no cache is saved/loaded, and the 2 jobs spend 5 minutes to install things:

<img width="716" alt="Screenshot 2023-06-22 101905" src="https://github.com/huggingface/transformers/assets/2521628/c796d958-ef9c-4066-bb46-3009be7a8fcc">


This PR fixes this and save money/credit we spend on CircleCI .... Please don't punish me 😭 