### PR TITLE
Clarify batch size displayed when using DataParallel

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1680,7 +1680,9 @@ class Trainer:
         logger.info("***** Running training *****")
         logger.info(f"  Num examples = {num_examples:,}")
         logger.info(f"  Num Epochs = {num_train_epochs:,}")
-        logger.info(f"  Instantaneous batch size per device = {self._train_batch_size:,}")
+        logger.info(f"  Instantaneous batch size per device = {self.args.per_device_train_batch_size:,}")
+        if self.args.per_device_train_batch_size != self._train_batch_size:
+            logger.info(f"  Training with DataParallel so batch size has been adjusted to: {self._train_batch_size:,}")
         logger.info(f"  Total train batch size (w. parallel, distributed & accumulation) = {total_train_batch_size:,}")
         logger.info(f"  Gradient Accumulation steps = {args.gradient_accumulation_steps}")
         logger.info(f"  Total optimization steps = {max_steps:,}")


### PR DESCRIPTION
# What does this PR do?

As pointed out in #24345, the batch size displayed when using `DataParallel` is unclear, this PR fixes that.

Fixes #24345