### PR TITLE
[`Trainer`] Fix `.to` call on 4bit models

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -493,7 +493,10 @@ class Trainer:
         self.eval_dataset = eval_dataset
         self.tokenizer = tokenizer
 
-        if self.place_model_on_device and not getattr(model, "is_loaded_in_8bit", False):
+        # Quantized models doesn't support `.to` operation.
+        if self.place_model_on_device and not (
+            getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
+        ):
             self._move_model_to_device(model, args.device)
 
         # Force n_gpu to 1 to avoid DataParallel as MP will manage the GPUs

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -494,9 +494,7 @@ class Trainer:
         self.tokenizer = tokenizer
 
         # Quantized models doesn't support `.to` operation.
-        if self.place_model_on_device and not (
-            getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-        ):
+        if self.place_model_on_device and not getattr(model, "is_quantized", False):
             self._move_model_to_device(model, args.device)
 
         # Force n_gpu to 1 to avoid DataParallel as MP will manage the GPUs


### PR DESCRIPTION
# What does this PR do?

Currently the Trainer fails when calling initializing it on some scenarios using 4bit models
In fact, the device placement is correctly skipped for 8bit models but needs to be skipped as well for 4bit models as the `to` operation is not supported for 4bit models as well. 
This PR adds a patch for that case 

cc @amyeroberts @lewtun 
