### PR TITLE
fixes issue when saving fsdp via accelerate's FSDP plugin

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2312,7 +2312,7 @@ class Trainer:
                     torch.save(self.scaler.state_dict(), os.path.join(output_dir, SCALER_NAME))
         elif self.args.should_save and not self.is_deepspeed_enabled:
             # deepspeed.save_checkpoint above saves model/optim/sched
-            if self.fsdp:
+            if self.fsdp and not self.is_fsdp_enabled:
                 torch.save(full_osd, os.path.join(output_dir, OPTIMIZER_NAME))
             else:
                 torch.save(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))


### PR DESCRIPTION
# What does this PR do?
1. Fixes https://github.com/huggingface/transformers/issues/24057#issuecomment-1595152783
2. When using Accelerate's integration for FSDP, fsdp_plugin saves the optimizer state under various configs such as Full_Dict, Sharded_Dict ... properly. For other cases such as with FSDP-XLA, the trainer's behaviour is unchanged.
