### PR TITLE
Generate: deprecation timeline for parameterization though the model config

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -286,6 +286,8 @@ class GenerationConfig(PushToHubMixin):
 
         # The remaining attributes do not parametrize `.generate()`, but are informative and/or used by the the hub
         # interface.
+        # TODO (joao): remove `self._from_model_config` and associated code in v4.32, to finalize the transition
+        # from being able to parameterize generation through the model config
         self._from_model_config = kwargs.pop("_from_model_config", False)
         self._commit_hash = kwargs.pop("_commit_hash", None)
         self.transformers_version = kwargs.pop("transformers_version", __version__)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -317,7 +317,7 @@ class FlaxGenerationMixin:
                 if new_generation_config != self.generation_config:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
-                        " deprecated strategy to control generation and will be removed soon, in a future version."
+                        " deprecated strategy to control generation and will be removed soon, in v4.32."
                         " Please use a generation configuration file (see"
                         " https://huggingface.co/docs/transformers/main_classes/text_generation )"
                     )

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -744,7 +744,7 @@ class TFGenerationMixin:
                 if new_generation_config != self.generation_config:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
-                        " deprecated strategy to control generation and will be removed soon, in a future version."
+                        " deprecated strategy to control generation and will be removed soon, in v4.32."
                         " Please use a generation configuration file (see"
                         " https://huggingface.co/docs/transformers/main_classes/text_generation )"
                     )

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1260,7 +1260,7 @@ class GenerationMixin:
                 if new_generation_config != self.generation_config:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
-                        " deprecated strategy to control generation and will be removed soon, in a future version."
+                        " deprecated strategy to control generation and will be removed soon, in v4.32."
                         " Please use a generation configuration file (see"
                         " https://huggingface.co/docs/transformers/main_classes/text_generation )"
                     )

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -63,6 +63,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
         default=None,
         metadata={
             "help": (
+                "Deprecated, the use of `--generation_config` is preferred (will be removed in v4.32). "
                 "The `max_length` to use on each evaluation loop when `predict_with_generate=True`. Will default "
                 "to the `max_length` value of the model configuration."
             )
@@ -72,6 +73,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
         default=None,
         metadata={
             "help": (
+                "Deprecated, the use of `--generation_config` is preferred (will be removed in v4.32). "
                 "The `num_beams` to use on each evaluation loop when `predict_with_generate=True`. Will default "
                 "to the `num_beams` value of the model configuration."
             )


### PR DESCRIPTION
# What does this PR do?

We had a warning about deprecating the parameterization of `.generate()` through the model config, but there was no specific date. This PR makes it clear it will go away in `v4.32`.

The extra parameters and code to allow the old and the new way of parameterizing `.generate()` to live together are causing a myriad of issues, so let's get rid of them :)