### PR TITLE
when resume from peft checkpoint, the model should be trainable

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2058,7 +2058,7 @@ class Trainer:
             # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
             if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
                 if os.path.exists(resume_from_checkpoint):
-                    model.load_adapter(resume_from_checkpoint, model.active_adapter)
+                    model.load_adapter(resume_from_checkpoint, model.active_adapter, is_trainable=True)
                 else:
                     logger.warning(
                         "The intermediate checkpoints of PEFT may not be saved correctly, "


### PR DESCRIPTION
model.training is false after model.load_adapter of peft. see https://github.com/huggingface/peft/blob/main/src/peft/peft_model.py#L402, default value of is_trainable is False

- trainer: @sgugger

