### PR TITLE
[`WhisperTokenizer`]  Allow encoding timestamp tokens

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -311,6 +311,11 @@ class WhisperTokenizer(PreTrainedTokenizer):
         self.task = task
         self.predict_timestamps = predict_timestamps
 
+        # add the timestamp tokens for encoding
+        # self.sanitize_special_tokens()
+        # timestamps = ["<|%.2f|>" % (i * 0.02) for  i in range(1500 + 1)]
+        # self.add_tokens(timestamps)
+
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
         vocab.update(self.added_tokens_encoder)

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -157,6 +157,8 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
             add_prefix_space=add_prefix_space,
             **kwargs,
         )
+        # timestamps = ["<|%.2f|>" % (i * 0.02) for  i in range(1500 + 1)]
+        # self.add_tokens(timestamps)
 
         self.add_bos_token = kwargs.pop("add_bos_token", False)
 

--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -473,3 +473,16 @@ class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
 
         output = multilingual_tokenizer.decode(INPUT_TOKENS, output_offsets=True)["offsets"]
         self.assertEqual(output, [])
+
+    def test_timestamp_tokens(self):
+        multilingual_tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny")
+        timestamps = ["<|%.2f|>" % (i * 0.02) for  i in range(1500 + 1)]
+        multilingual_tokenizer.add_tokens(timestamps)
+        input_ids = multilingual_tokenizer.encode("<|0.00|>Hello!<|2.34|>", return_tensors = 'pt')
+        self.assertEqual(input_ids, [[50258, 50363, 50364, 15947,     0, 50481, 50257]])
+
+        multilingual_tokenizer = WhisperTokenizerFast.from_pretrained("openai/whisper-tiny")
+        input_ids = multilingual_tokenizer.encode("<|0.00|>Hello!<|2.34|>", return_tensors = 'pt')
+        timestamps = ["<|%.2f|>" % (i * 0.02) for  i in range(1500 + 1)]
+        multilingual_tokenizer.add_tokens(timestamps)
+        self.assertEqual(input_ids, [50258, 50363, 27, 91, 15, 13, 628, 91, 29, 15947, 0, 27, 91, 17, 13, 12249, 91, 29, 50257])


### PR DESCRIPTION
# What does this PR do?

Adresses #20225. Openai recently changed their tokenizer to allow encoding timestamp tokens as is (instead of splitting them). This is a breaking change because you can't encode them by splitting anymore, it will fail with the following error: 
```ptyhon 
ValueError: Encountered text corresponding to disallowed special token '<|7.86|>'.
If you want this text to be encoded as a special token, pass it to `allowed_special`, e.g. `allowed_special={'<|7.86|>', ...}`.
If you want this text to be encoded as normal text, disable the check for this token by passing `disallowed_special=(enc.special_tokens_set - {'<|7.86|>'})`.
To disable this check for all special tokens, pass `disallowed_special=()`.
```

This PR will have to wait before being merge. This is because the models on the hub need to be updated first otherwise the tests will be red. 
Moreover, `add_tokens` has to be fixed before that! 
Snipper showing why: 
```python 
from transformers import WhisperTokenizer, WhisperTokenizerFast, AddedToken
timestamps = [AddedToken("<|%.2f|>" % (i * 0.02), lstrip=False, rstrip=False) for  i in range(1500 + 1)]

from whisper.tokenizer import get_tokenizer
openai_tok = get_tokenizer(multilingual=True, language="en", task="transcribe")
model_path =f"openai/whisper-tiny"
slow = WhisperTokenizer.from_pretrained(model_path)
fast = WhisperTokenizerFast.from_pretrained(model_path)
slow.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
fast.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
slow.add_tokens(timestamps)
fast.add_tokens(timestamps)
```

The output from slow and fast is different. Fast matches the original implementation (not stripping spaces on the rigth and left) while slow does not. 

```python 
>>> openai_tok.encode("<|7.86|> Hey", allowed_special=set(openai_tok.special_tokens.keys()))
[50757, 1911]
>>> fast.encode('<|7.86|> Hey', add_special_tokens = False)
[50757, 1911]
>>> slow.encode('<|7.86|> Hey', add_special_tokens = False)
[50757, 7057]
```

script to update all models :
```python
from transformers import WhisperTokenizer, WhisperTokenizerFast, AddedToken
timestamps = [AddedToken("<|%.2f|>" % (i * 0.02), lstrip=False, rstrip=False) for  i in range(1500 + 1)]
models_ids = ["tiny","small","medium","base","large"]

from whisper.tokenizer import get_tokenizer
openai_tok = get_tokenizer(multilingual=True, language="en", task="transcribe")


openai_tok.encode("<|1.00|>", allowed_special=set(openai_tok.special_tokens.keys()))

for id in models_ids:
    model_path =f"openai/whisper-{id}"
    slow = WhisperTokenizer.from_pretrained(model_path)
    fast = WhisperTokenizerFast.from_pretrained(model_path)
    slow.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
    fast.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
    slow.add_tokens(timestamps)
    fast.add_tokens(timestamps)
    slow.push_to_hub(model_path, create_pr = True)
    fast.push_to_hub(model_path, create_pr = True)

    if id == "large":
        exit(0)

    model_path += '.en'
    slow = WhisperTokenizer.from_pretrained(model_path)
    fast = WhisperTokenizerFast.from_pretrained(model_path)
    slow.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
    fast.bos_token = AddedToken(slow.eos_token, lstrip=False, rstrip=False)
    slow.add_tokens(timestamps)
    fast.add_tokens(timestamps)
    slow.push_to_hub(model_path, create_pr = True)
    fast.push_to_hub(model_path, create_pr = True)


```