### PR TITLE
Fix `SpeechT5` doctests

### DIFF
--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -2728,7 +2728,7 @@ class SpeechT5ForTextToSpeech(SpeechT5PreTrainedModel):
         >>> # generate speech
         >>> speech = model.generate_speech(inputs["input_ids"], speaker_embeddings, vocoder=vocoder)
         >>> speech.shape
-        torch.Size([15872])
+        torch.Size([16384])
         ```
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -2956,7 +2956,7 @@ class SpeechT5ForSpeechToSpeech(SpeechT5PreTrainedModel):
         >>> # generate speech
         >>> speech = model.generate_speech(inputs["input_values"], speaker_embeddings, vocoder=vocoder)
         >>> speech.shape
-        torch.Size([77824])
+        torch.Size([78336])
         ```
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

PR #24434 changes `np.random.uniform(0, 1)` to `torch.rand([])`. In the forward method of `SpeechT5ForSpeechToSpeech` and `SpeechT5ForTextToSpeech`, the line `dropout_probability = torch.rand([])` is executed no matter if we are in training/inference mode. So the new change in #24434 will change the random sequences even we set a seed in the beginning of `generate`, and we get different outputs now.

Hence this PR updates the expected values for doctest.

**However, I believe we should only call `dropout_probability = torch.rand([])` under the condition of being in training mode.**
WDYT?