### PR TITLE
[`InstructBlip`] Add accelerate support for instructblip

### DIFF
--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1269,10 +1269,11 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
 
         if config.use_decoder_only_language_model:
             language_model = AutoModelForCausalLM.from_config(config.text_config)
-            self._no_split_modules.append("LlamaDecoderLayer")
         else:
             language_model = AutoModelForSeq2SeqLM.from_config(config.text_config)
-            self._no_split_modules.append("T5Block")
+
+        if language_model._no_split_modules is not None:
+            self._no_split_modules.extend(language_model._no_split_modules)
 
         self.language_model = language_model
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -282,12 +282,7 @@ class InstructBlipPreTrainedModel(PreTrainedModel):
         r"language_model.lm_head.weight",
     ]
     _keep_in_fp32_modules = ["wo"]
-    _no_split_modules = [
-        "InstructBlipAttention",
-        "T5Block",
-        "OPTDecoderLayer",
-        "InstructBlipQFormerMultiHeadAttention",
-    ]
+    _no_split_modules = ["InstructBlipAttention", "InstructBlipQFormerMultiHeadAttention"]
 
     # Copied from transformers.models.blip_2.modeling_blip_2.Blip2PreTrainedModel._init_weights with Blip2->InstructBlip
     def _init_weights(self, module):
@@ -1271,10 +1266,13 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         self.qformer = InstructBlipQFormerModel(config.qformer_config)
 
         self.language_projection = nn.Linear(config.qformer_config.hidden_size, config.text_config.hidden_size)
+
         if config.use_decoder_only_language_model:
             language_model = AutoModelForCausalLM.from_config(config.text_config)
+            self._no_split_modules.append("LlamaDecoderLayer")
         else:
             language_model = AutoModelForSeq2SeqLM.from_config(config.text_config)
+            self._no_split_modules.append("T5Block")
 
         self.language_model = language_model
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -281,8 +281,8 @@ class InstructBlipPreTrainedModel(PreTrainedModel):
         r"language_model.decoder.embed_tokens.weight",
         r"language_model.lm_head.weight",
     ]
-    _keep_in_fp32_modules = ["wo"]
     _no_split_modules = ["InstructBlipAttention", "InstructBlipQFormerMultiHeadAttention"]
+    _keep_in_fp32_modules = []
 
     # Copied from transformers.models.blip_2.modeling_blip_2.Blip2PreTrainedModel._init_weights with Blip2->InstructBlip
     def _init_weights(self, module):
@@ -1274,6 +1274,9 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
 
         if language_model._no_split_modules is not None:
             self._no_split_modules.extend(language_model._no_split_modules)
+
+        if language_model._keep_in_fp32_modules is not None:
+            self._keep_in_fp32_modules.extend(language_model._keep_in_fp32_modules)
 
         self.language_model = language_model
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -281,6 +281,7 @@ class InstructBlipPreTrainedModel(PreTrainedModel):
         r"language_model.decoder.embed_tokens.weight",
         r"language_model.lm_head.weight",
     ]
+    _keep_in_fp32_modules = ["wo"]
     _no_split_modules = [
         "InstructBlipAttention",
         "T5Block",

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -281,6 +281,12 @@ class InstructBlipPreTrainedModel(PreTrainedModel):
         r"language_model.decoder.embed_tokens.weight",
         r"language_model.lm_head.weight",
     ]
+    _no_split_modules = [
+        "InstructBlipAttention",
+        "T5Block",
+        "OPTDecoderLayer",
+        "InstructBlipQFormerMultiHeadAttention",
+    ]
 
     # Copied from transformers.models.blip_2.modeling_blip_2.Blip2PreTrainedModel._init_weights with Blip2->InstructBlip
     def _init_weights(self, module):
@@ -1422,7 +1428,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
 
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
-        attention_mask = torch.cat([language_model_attention_mask, attention_mask], dim=1)
+        attention_mask = torch.cat([language_model_attention_mask.to(attention_mask.device), attention_mask], dim=1)
 
         if self.config.use_decoder_only_language_model:
             outputs = self.language_model(


### PR DESCRIPTION
# What does this PR do?

As per title, let's make users benefit from 8bit / 4bit loading of instructblip models

cc @amyeroberts @sgugger @NielsRogge 

all `accelerate` tests pass for this model

As a side note, as instruct blip relies on flan-t5 as backbone for some models, therefore it is important to add
```python
_keep_in_fp32_modules = ["wo"]
```
To ensure inference stability in fp16 / int8 / fp4 