### PR TITLE
deepspeed z1/z2 state dict fix

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2739,11 +2739,9 @@ class Trainer:
                 if self.args.should_save:
                     self._save(output_dir, state_dict=state_dict)
         elif self.is_deepspeed_enabled:
-            from deepspeed.runtime.utils import clone_tensors_for_torch_save
-
             # this takes care of everything as long as we aren't under zero3
-            if self.args.should_save:
-                state_dict = clone_tensors_for_torch_save(self.deepspeed.module.state_dict())
+            if self.args.should_save and not is_deepspeed_zero3_enabled():
+                state_dict = self.accelerator.get_state_dict(self.deepspeed)
                 self._save(output_dir, state_dict=state_dict)
 
             if is_deepspeed_zero3_enabled():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2741,7 +2741,10 @@ class Trainer:
         elif self.is_deepspeed_enabled:
             # this takes care of everything as long as we aren't under zero3
             if self.args.should_save and not is_deepspeed_zero3_enabled():
+                if version.parse(accelerate_version) <= version.parse("0.20.3"):
+                    raise ValueError("Install Accelerate from main branch")
                 state_dict = self.accelerator.get_state_dict(self.deepspeed)
+
                 self._save(output_dir, state_dict=state_dict)
 
             if is_deepspeed_zero3_enabled():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2739,14 +2739,17 @@ class Trainer:
                 if self.args.should_save:
                     self._save(output_dir, state_dict=state_dict)
         elif self.is_deepspeed_enabled:
+            from deepspeed.runtime.utils import clone_tensors_for_torch_save
+
             # this takes care of everything as long as we aren't under zero3
             if self.args.should_save:
-                self._save(output_dir)
+                state_dict = clone_tensors_for_torch_save(self.deepspeed.module.state_dict())
+                self._save(output_dir, state_dict=state_dict)
 
             if is_deepspeed_zero3_enabled():
                 # It's too complicated to try to override different places where the weights dump gets
                 # saved, so since under zero3 the file is bogus, simply delete it. The user should
-                # either user deepspeed checkpoint to resume or to recover full weights use
+                # either use deepspeed checkpoint to resume or to recover full weights use
                 # zero_to_fp32.py stored in the checkpoint.
                 if self.args.should_save:
                     file = os.path.join(output_dir, WEIGHTS_NAME)


### PR DESCRIPTION
# What does this PR do?
1. Fixes https://github.com/huggingface/transformers/issues/22822
2. Should be merged after https://github.com/huggingface/accelerate/pull/1638

The fix in accelerate uses the `deepspeed.checkpoint.utils.clone_tensors_for_torch_save` which removes the bloated state_dict. In Trainer, we use `accelerator.get_state_dict` to get the resultant lean state dict when using DeepSpeed and the ZeRO stage is not 3. 

Also, a typo fix.