### PR TITLE
Make `framework` as class property

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -241,6 +241,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         """
         return cls(config, **kwargs)
 
+    @classmethod
     @property
     def framework(self) -> str:
         """

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -243,7 +243,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
 
     @classmethod
     @property
-    def framework(self) -> str:
+    def framework(cls) -> str:
         """
         :str: Identifies that this is a Flax model.
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1121,7 +1121,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
     @classmethod
     @property
-    def framework(self) -> str:
+    def framework(cls) -> str:
         """
         :str: Identifies that this is a TensorFlow model.
         """

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1119,6 +1119,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
                     )
         return dummies
 
+    @classmethod
     @property
     def framework(self) -> str:
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1077,8 +1077,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         return {"input_ids": torch.tensor(DUMMY_INPUTS)}
 
+    @classmethod
     @property
-    def framework(self) -> str:
+    def framework(cls) -> str:
         """
         :str: Identifies that this is a PyTorch model.
         """


### PR DESCRIPTION
# What does this PR do?

Similar to #24299, make this property at class level. (Not the most interesting/useful change though, I agree).

(This approach is a bit hacky but it works. Deprecated in python 3.11.)