### PR TITLE
Add bitsandbytes support for gpt2 models

### DIFF
--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -6,10 +6,12 @@ from packaging import version
 from ..utils import logging
 from .import_utils import importlib_metadata, is_accelerate_available, is_bitsandbytes_available
 
+
 if is_bitsandbytes_available():
     import bitsandbytes as bnb
     import torch
     import torch.nn as nn
+
     from ..pytorch_utils import Conv1D
 
 if is_accelerate_available():

--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -4,14 +4,13 @@ from copy import deepcopy
 from packaging import version
 
 from ..utils import logging
-from ..pytorch_utils import Conv1D
 from .import_utils import importlib_metadata, is_accelerate_available, is_bitsandbytes_available
-
 
 if is_bitsandbytes_available():
     import bitsandbytes as bnb
     import torch
     import torch.nn as nn
+    from ..pytorch_utils import Conv1D
 
 if is_accelerate_available():
     from accelerate import init_empty_weights

--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from packaging import version
 
 from ..utils import logging
+from ..pytorch_utils import Conv1D
 from .import_utils import importlib_metadata, is_accelerate_available, is_bitsandbytes_available
 
 
@@ -84,6 +85,11 @@ def set_module_quantized_tensor_to_device(module, tensor_name, device, value=Non
             else:
                 new_value = torch.tensor(value, device="cpu")
 
+            # Support models using `Conv1D` in place of `nn.Linear` (e.g. gpt2) by transposing the weight matrix prior to quantization.
+            # Since weights are saved in the correct "orientation", we skip transposing when loading.
+            if issubclass(module.source_cls, Conv1D) and fp16_statistics is None:
+                new_value = new_value.T
+
             kwargs = old_value.__dict__
             if is_8bit:
                 new_value = bnb.nn.Int8Params(new_value, requires_grad=False, **kwargs).to(device)
@@ -122,14 +128,20 @@ def _replace_with_bnb_linear(
             current_key_name = []
         current_key_name.append(name)
 
-        if isinstance(module, nn.Linear) and name not in modules_to_not_convert:
+        if (isinstance(module, nn.Linear) or isinstance(module, Conv1D)) and name not in modules_to_not_convert:
             # Check if the current key is not in the `modules_to_not_convert`
             if not any(key in ".".join(current_key_name) for key in modules_to_not_convert):
                 with init_empty_weights():
+                    if isinstance(module, Conv1D):
+                        in_features, out_features = module.weight.shape
+                    else:
+                        in_features = module.in_features
+                        out_features = module.out_features
+
                     if quantization_config.quantization_method() == "llm_int8":
                         model._modules[name] = bnb.nn.Linear8bitLt(
-                            module.in_features,
-                            module.out_features,
+                            in_features,
+                            out_features,
                             module.bias is not None,
                             has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
                             threshold=quantization_config.llm_int8_threshold,
@@ -143,14 +155,16 @@ def _replace_with_bnb_linear(
                             pass
                         else:
                             model._modules[name] = bnb.nn.Linear4bit(
-                                module.in_features,
-                                module.out_features,
+                                in_features,
+                                out_features,
                                 module.bias is not None,
                                 quantization_config.bnb_4bit_compute_dtype,
                                 compress_statistics=quantization_config.bnb_4bit_use_double_quant,
                                 quant_type=quantization_config.bnb_4bit_quant_type,
                             )
                             has_been_replaced = True
+                    # Store the module class in case we need to transpose the weight later
+                    model._modules[name].source_cls = type(module)
                     # Force requires grad to False to avoid unexpected errors
                     model._modules[name].requires_grad_(False)
         if len(list(module.children())) > 0:
@@ -200,7 +214,6 @@ def replace_with_bnb_linear(model, modules_to_not_convert=None, current_key_name
     if not has_been_replaced:
         logger.warning(
             "You are loading your model in 8bit or 4bit but no linear modules were found in your model."
-            " this can happen for some architectures such as gpt2 that uses Conv1D instead of Linear layers."
             " Please double check your model architecture, or submit an issue on github if you think this is"
             " a bug."
         )

--- a/tests/bnb/test_4bit.py
+++ b/tests/bnb/test_4bit.py
@@ -39,6 +39,12 @@ from transformers.testing_utils import (
 from transformers.utils.versions import importlib_metadata
 
 
+def get_some_linear_layer(model):
+    if model.config.model_type == "gpt2":
+        return model.transformer.h[0].mlp.c_fc
+    return model.transformer.h[0].mlp.dense_4h_to_h
+
+
 if is_torch_available():
     import torch
     import torch.nn as nn
@@ -136,7 +142,8 @@ class Bnb4BitTest(Base4bitTest):
         mem_4bit = self.model_4bit.get_memory_footprint()
 
         self.assertAlmostEqual(mem_fp16 / mem_4bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_4bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Params4bit)
+        linear = get_some_linear_layer(self.model_4bit)
+        self.assertTrue(linear.weight.__class__ == Params4bit)
 
     def test_linear_are_4bit(self):
         r"""

--- a/tests/bnb/test_4bit.py
+++ b/tests/bnb/test_4bit.py
@@ -83,6 +83,7 @@ class Base4bitTest(unittest.TestCase):
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John and I am a professional photographer. I")
     EXPECTED_OUTPUTS.add("Hello my name is John.\nI am a friend of your father.\n")
+    EXPECTED_OUTPUTS.add("Hello my name is John Doe, I am a student at the University")
     MAX_NEW_TOKENS = 10
 
     def setUp(self):
@@ -473,3 +474,8 @@ class Bnb4BitTestTraining(Base4bitTest):
                 self.assertTrue(module.adapter[1].weight.grad.norm().item() > 0)
             elif isinstance(module, nn.Embedding):
                 self.assertTrue(module.weight.grad is None)
+
+
+class Bnb4BitGPT2Test(Bnb4BitTest):
+    model_name = "gpt2-xl"
+    EXPECTED_RELATIVE_DIFFERENCE = 3.3191854854152187

--- a/tests/bnb/test_mixed_int8.py
+++ b/tests/bnb/test_mixed_int8.py
@@ -748,3 +748,79 @@ class MixedInt8TestTraining(BaseMixedInt8Test):
                 self.assertTrue(module.adapter[1].weight.grad.norm().item() > 0)
             elif isinstance(module, nn.Embedding):
                 self.assertTrue(module.weight.grad is None)
+
+
+class MixedInt8GPT2Test(MixedInt8Test):
+    model_name = "gpt2-xl"
+    MLP_FC_NAME = "c_fc"
+    EXPECTED_RELATIVE_DIFFERENCE = 1.8720077507258357
+    EXPECTED_OUTPUT = "Hello my name is John Doe, and I am a member of the"
+
+    def test_memory_footprint(self):
+        r"""
+        A simple test to check if the model conversion has been done correctly by checking on the
+        memory footprint of the converted model and the class type of the linear layers of the converted models
+        """
+        from bitsandbytes.nn import Int8Params
+
+        mem_fp16 = self.model_fp16.get_memory_footprint()
+        mem_8bit = self.model_8bit.get_memory_footprint()
+
+        self.assertAlmostEqual(mem_fp16 / mem_8bit, self.EXPECTED_RELATIVE_DIFFERENCE)
+        self.assertTrue(self.model_8bit.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
+
+    def test_int8_serialization(self):
+        r"""
+        Test whether it is possible to serialize a model in 8-bit.
+        """
+        from bitsandbytes.nn import Int8Params
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.model_8bit.save_pretrained(tmpdirname)
+
+            # check that the file `quantization_config` is present
+            config = AutoConfig.from_pretrained(tmpdirname)
+            self.assertTrue(hasattr(config, "quantization_config"))
+
+            model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname, load_in_8bit=True, device_map="auto")
+
+            self.assertTrue(model_from_saved.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
+            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.c_fc.weight, "SCB"))
+
+            # generate
+            encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
+            output_sequences = model_from_saved.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
+
+            self.assertEqual(
+                self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT
+            )
+
+    def test_int8_serialization_sharded(self):
+        r"""
+        Test whether it is possible to serialize a model in 8-bit - sharded version.
+        """
+        from bitsandbytes.nn import Int8Params
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.model_8bit.save_pretrained(tmpdirname, max_shard_size="200MB")
+
+            # check that the file `quantization_config` is present
+            config = AutoConfig.from_pretrained(tmpdirname)
+            self.assertTrue(hasattr(config, "quantization_config"))
+
+            model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname)
+
+            self.assertTrue(model_from_saved.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
+            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.c_fc.weight, "SCB"))
+
+            # generate
+            encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
+            output_sequences = model_from_saved.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
+
+            self.assertEqual(
+                self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT
+            )
+
+    def test_int8_from_pretrained(self):
+        # TODO: Test loading quantized gpt2 model from the hub.
+        pass

--- a/tests/bnb/test_mixed_int8.py
+++ b/tests/bnb/test_mixed_int8.py
@@ -41,6 +41,12 @@ from transformers.testing_utils import (
 from transformers.utils.versions import importlib_metadata
 
 
+def get_some_linear_layer(model):
+    if model.config.model_type == "gpt2":
+        return model.transformer.h[0].mlp.c_fc
+    return model.transformer.h[0].mlp.dense_4h_to_h
+
+
 if is_accelerate_available():
     from accelerate import PartialState
     from accelerate.logging import get_logger
@@ -142,7 +148,7 @@ class MixedInt8Test(BaseMixedInt8Test):
         mem_8bit = self.model_8bit.get_memory_footprint()
 
         self.assertAlmostEqual(mem_fp16 / mem_8bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+        self.assertTrue(get_some_linear_layer(self.model_8bit).weight.__class__ == Int8Params)
 
     def test_linear_are_8bit(self):
         r"""
@@ -292,8 +298,9 @@ class MixedInt8Test(BaseMixedInt8Test):
 
             model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname, load_in_8bit=True, device_map="auto")
 
-            self.assertTrue(model_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB"))
+            linear = get_some_linear_layer(model_from_saved)
+            self.assertTrue(linear.weight.__class__ == Int8Params)
+            self.assertTrue(hasattr(linear.weight, "SCB"))
 
             # generate
             encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
@@ -318,8 +325,9 @@ class MixedInt8Test(BaseMixedInt8Test):
 
             model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname)
 
-            self.assertTrue(model_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB"))
+            linear = get_some_linear_layer(model_from_saved)
+            self.assertTrue(linear.weight.__class__ == Int8Params)
+            self.assertTrue(hasattr(linear.weight, "SCB"))
 
             # generate
             encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
@@ -339,8 +347,9 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         model = AutoModelForCausalLM.from_pretrained(model_id)
 
-        self.assertTrue(model.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-        self.assertTrue(hasattr(model.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB"))
+        linear = get_some_linear_layer(model)
+        self.assertTrue(linear.weight.__class__ == Int8Params)
+        self.assertTrue(hasattr(linear.weight, "SCB"))
 
         # generate
         encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
@@ -752,74 +761,8 @@ class MixedInt8TestTraining(BaseMixedInt8Test):
 
 class MixedInt8GPT2Test(MixedInt8Test):
     model_name = "gpt2-xl"
-    MLP_FC_NAME = "c_fc"
     EXPECTED_RELATIVE_DIFFERENCE = 1.8720077507258357
     EXPECTED_OUTPUT = "Hello my name is John Doe, and I am a member of the"
-
-    def test_memory_footprint(self):
-        r"""
-        A simple test to check if the model conversion has been done correctly by checking on the
-        memory footprint of the converted model and the class type of the linear layers of the converted models
-        """
-        from bitsandbytes.nn import Int8Params
-
-        mem_fp16 = self.model_fp16.get_memory_footprint()
-        mem_8bit = self.model_8bit.get_memory_footprint()
-
-        self.assertAlmostEqual(mem_fp16 / mem_8bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_8bit.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
-
-    def test_int8_serialization(self):
-        r"""
-        Test whether it is possible to serialize a model in 8-bit.
-        """
-        from bitsandbytes.nn import Int8Params
-
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.model_8bit.save_pretrained(tmpdirname)
-
-            # check that the file `quantization_config` is present
-            config = AutoConfig.from_pretrained(tmpdirname)
-            self.assertTrue(hasattr(config, "quantization_config"))
-
-            model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname, load_in_8bit=True, device_map="auto")
-
-            self.assertTrue(model_from_saved.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.c_fc.weight, "SCB"))
-
-            # generate
-            encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
-            output_sequences = model_from_saved.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
-
-            self.assertEqual(
-                self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT
-            )
-
-    def test_int8_serialization_sharded(self):
-        r"""
-        Test whether it is possible to serialize a model in 8-bit - sharded version.
-        """
-        from bitsandbytes.nn import Int8Params
-
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.model_8bit.save_pretrained(tmpdirname, max_shard_size="200MB")
-
-            # check that the file `quantization_config` is present
-            config = AutoConfig.from_pretrained(tmpdirname)
-            self.assertTrue(hasattr(config, "quantization_config"))
-
-            model_from_saved = AutoModelForCausalLM.from_pretrained(tmpdirname)
-
-            self.assertTrue(model_from_saved.transformer.h[0].mlp.c_fc.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_from_saved.transformer.h[0].mlp.c_fc.weight, "SCB"))
-
-            # generate
-            encoded_input = self.tokenizer(self.input_text, return_tensors="pt")
-            output_sequences = model_from_saved.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
-
-            self.assertEqual(
-                self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT
-            )
 
     def test_int8_from_pretrained(self):
         # TODO: Test loading quantized gpt2 model from the hub.

--- a/tests/bnb/test_mixed_int8.py
+++ b/tests/bnb/test_mixed_int8.py
@@ -765,5 +765,5 @@ class MixedInt8GPT2Test(MixedInt8Test):
     EXPECTED_OUTPUT = "Hello my name is John Doe, and I am a member of the"
 
     def test_int8_from_pretrained(self):
-        # TODO: Test loading quantized gpt2 model from the hub.
+        # TODO @younesbelkada: Test loading quantized gpt2 model from the hub.
         pass


### PR DESCRIPTION
# What does this PR do?

The current bitsandbytes integration only supports models using [nn.Linear](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html#torch.nn.Linear), which excludes gpt2 and other models that instead use [Conv1D](https://github.com/huggingface/transformers/blob/68c92981ff2b804979d2e6107eeefe298d1e5183/src/transformers/pytorch_utils.py#L85). This PR enables loading/serialization of these models, as well as gpt2-xl tests for int8 and 4bit.

This is achieved by transposing the weight matrices of Conv1D layers before quantization.

Note: Following the suggestion in the bnb tests to use models with >1b params only leaves [gpt2-xl](https://huggingface.co/gpt2-xl), which is unfortunately a 6.4GB download due to being stored in float32.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@younesbelkada, @TimDettmers