### PR TITLE
Show a warning for missing attention masks when pad_token_id is not None

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3484,13 +3484,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if (attention_mask is not None) or (self.config.pad_token_id is None):
             return
 
-        if not hasattr(self, "warnings_issued"):
-            self.warnings_issued = {}
-        if self.warnings_issued.get("padding_and_no_attention_mask", False):
-            return
-
         # Check only the first and last input IDs to reduce overhead.
-        if self.config.pad_token_id in input_ids[:, -1] or self.config.pad_token_id in input_ids[:, 1]:
+        if self.config.pad_token_id in input_ids[:, [-1, 0]]:
             warn_string = (
                 "We strongly recommend passing in an `attention_mask` since your input_ids may be padded. See "
                 "https://huggingface.co/docs/transformers/troubleshooting"
@@ -3510,8 +3505,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     f"or the `sep_token_id` ({self.config.sep_token_id}), and your input is not padded."
                 )
 
-            logger.warning(warn_string)
-            self.warnings_issued["padding_and_no_attention_mask"] = True
+            logger.warning_once(warn_string)
 
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3477,6 +3477,42 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         return BetterTransformer.reverse(self)
 
+    def warn_if_padding_and_no_attention_mask(self, input_ids, attention_mask):
+        """
+        Shows a one-time warning if the input_ids appear to contain padding and no attention mask was given.
+        """
+        if (attention_mask is not None) or (self.config.pad_token_id is None):
+            return
+
+        if not hasattr(self, "warnings_issued"):
+            self.warnings_issued = {}
+        if self.warnings_issued.get("padding_and_no_attention_mask", False):
+            return
+
+        # Check only the first and last input IDs to reduce overhead.
+        if self.config.pad_token_id in input_ids[:, -1] or self.config.pad_token_id in input_ids[:, 1]:
+            warn_string = (
+                "We strongly recommend passing in an `attention_mask` since your input_ids may be padded. See "
+                "https://huggingface.co/docs/transformers/troubleshooting"
+                "#incorrect-output-when-padding-tokens-arent-masked."
+            )
+
+            # If the pad token is equal to either BOS, EOS, or SEP, we do not know whether the user should use an
+            # attention_mask or not. In this case, we should still show a warning because this is a rare case.
+            if (
+                (self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id)
+                or (self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id)
+                or (self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id)
+            ):
+                warn_string += (
+                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
+                    f"to the `bos_token_id` ({self.config.bos_token_id}), `eos_token_id` ({self.config.eos_token_id}), "
+                    f"or the `sep_token_id` ({self.config.sep_token_id}), and your input is not padded."
+                )
+
+            logger.warning(warn_string)
+            self.warnings_issued["padding_and_no_attention_mask"] = True
+
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)
 if PreTrainedModel.push_to_hub.__doc__ is not None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3477,47 +3477,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         return BetterTransformer.reverse(self)
 
-    def warn_if_no_attention_mask_when_pad_token_in_input_ids(self, input_ids, attention_mask):
-        if attention_mask is not None:
-            # No issues with attention_mask is defined.
-            return
-
-        if not hasattr(self, "warnings_issued"):
-            self.warnings_issued = {}
-
-        if self.warnings_issued.get("no_attention_mask_when_pad_token_in_input_ids", False):
-            # If warning has already been shown don't show again.
-            return
-
-        is_pad_token_in_input_ids = self.config.pad_token_id is not None and self.config.pad_token_id in input_ids
-        if is_pad_token_in_input_ids:
-            warn_string = (
-                "We strongly recommend passing in an `attention_mask` as one or more `pad_token_id`s were found in the "
-                "input IDs. Otherwise, the resulting attention weights may be incorrect."
-            )
-
-            # If <pad> is equal to either BOS, EOS, or SEP, we do not know whether the user should use an
-            # attention_mask or not. In this case, we should still show a warning because most models don't have
-            # <pad> == EOS or <pad> == BOS or <pad> == SEP.
-            if self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id:
-                warn_string += (
-                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
-                    f"to your `bos_token_id` ({self.config.bos_token_id}) and your input is not padded."
-                )
-            if self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id:
-                warn_string += (
-                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
-                    f"to your `eos_token_id` ({self.config.eos_token_id}) and your input is not padded."
-                )
-            if self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id:
-                warn_string += (
-                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
-                    f"to your `sep_token_id` ({self.config.sep_token_id}) and your input is not padded."
-                )
-
-            logger.warning(warn_string)
-            self.warnings_issued["no_attention_mask_when_pad_token_in_input_ids"] = True
-
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)
 if PreTrainedModel.push_to_hub.__doc__ is not None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3477,6 +3477,47 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         return BetterTransformer.reverse(self)
 
+    def warn_if_no_attention_mask_when_pad_token_in_input_ids(self, input_ids, attention_mask):
+        if attention_mask is not None:
+            # No issues with attention_mask is defined.
+            return
+
+        if not hasattr(self, "warnings_issued"):
+            self.warnings_issued = {}
+
+        if self.warnings_issued.get("no_attention_mask_when_pad_token_in_input_ids", False):
+            # If warning has already been shown don't show again.
+            return
+
+        is_pad_token_in_input_ids = self.config.pad_token_id is not None and self.config.pad_token_id in input_ids
+        if is_pad_token_in_input_ids:
+            warn_string = (
+                "We strongly recommend passing in an `attention_mask` as one or more `pad_token_id`s were found in the "
+                "input IDs. Otherwise, the resulting attention weights may be incorrect."
+            )
+
+            # If <pad> is equal to either BOS, EOS, or SEP, we do not know whether the user should use an
+            # attention_mask or not. In this case, we should still show a warning because most models don't have
+            # <pad> == EOS or <pad> == BOS or <pad> == SEP.
+            if self.config.bos_token_id is not None and self.config.bos_token_id == self.config.pad_token_id:
+                warn_string += (
+                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
+                    f"to your `bos_token_id` ({self.config.bos_token_id}) and your input is not padded."
+                )
+            if self.config.eos_token_id is not None and self.config.eos_token_id == self.config.pad_token_id:
+                warn_string += (
+                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
+                    f"to your `eos_token_id` ({self.config.eos_token_id}) and your input is not padded."
+                )
+            if self.config.sep_token_id is not None and self.config.sep_token_id == self.config.pad_token_id:
+                warn_string += (
+                    f"\nYou may ignore this warning if your `pad_token_id` ({self.config.pad_token_id}) is identical "
+                    f"to your `sep_token_id` ({self.config.sep_token_id}) and your input is not padded."
+                )
+
+            logger.warning(warn_string)
+            self.warnings_issued["no_attention_mask_when_pad_token_in_input_ids"] = True
+
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)
 if PreTrainedModel.push_to_hub.__doc__ is not None:

--- a/src/transformers/models/altclip/modeling_altclip.py
+++ b/src/transformers/models/altclip/modeling_altclip.py
@@ -1305,6 +1305,12 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/altclip/modeling_altclip.py
+++ b/src/transformers/models/altclip/modeling_altclip.py
@@ -1305,12 +1305,7 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -967,7 +967,12 @@ class BertModel(BertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            self.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask)
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -967,6 +967,7 @@ class BertModel(BertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            self.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -967,12 +967,7 @@ class BertModel(BertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/bridgetower/modeling_bridgetower.py
+++ b/src/transformers/models/bridgetower/modeling_bridgetower.py
@@ -1118,6 +1118,12 @@ class BridgeTowerTextModel(BridgeTowerPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/bridgetower/modeling_bridgetower.py
+++ b/src/transformers/models/bridgetower/modeling_bridgetower.py
@@ -1118,12 +1118,7 @@ class BridgeTowerTextModel(BridgeTowerPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/camembert/modeling_camembert.py
+++ b/src/transformers/models/camembert/modeling_camembert.py
@@ -842,12 +842,7 @@ class CamembertModel(CamembertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/camembert/modeling_camembert.py
+++ b/src/transformers/models/camembert/modeling_camembert.py
@@ -842,6 +842,12 @@ class CamembertModel(CamembertPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -1854,6 +1854,12 @@ class ClapTextModel(ClapPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -1854,12 +1854,7 @@ class ClapTextModel(ClapPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/data2vec/modeling_data2vec_text.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_text.py
@@ -791,6 +791,12 @@ class Data2VecTextModel(Data2VecTextPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/data2vec/modeling_data2vec_text.py
+++ b/src/transformers/models/data2vec/modeling_data2vec_text.py
@@ -791,12 +791,7 @@ class Data2VecTextModel(Data2VecTextPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -789,6 +789,12 @@ class RobertaModel(RobertaPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -789,12 +789,7 @@ class RobertaModel(RobertaPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -791,12 +791,7 @@ class XLMRobertaModel(XLMRobertaPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -791,6 +791,12 @@ class XLMRobertaModel(XLMRobertaPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -757,6 +757,12 @@ class XLMRobertaXLModel(XLMRobertaXLPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
+            if attention_mask is None and self.config.pad_token_id is not None:
+                logger.warning_once(
+                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
+                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
+                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
+                )
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -757,12 +757,7 @@ class XLMRobertaXLModel(XLMRobertaXLPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             input_shape = input_ids.size()
-            if attention_mask is None and self.config.pad_token_id is not None:
-                logger.warning_once(
-                    "We strongly recommend passing in an `attention_mask` when `pad_token_id` is not None. Otherwise, "
-                    "the resulting attention weights may be incorrect. See https://huggingface.co/docs/transformers/"
-                    "troubleshooting#incorrect-output-when-padding-tokens-arent-masked."
-                )
+            self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
         elif inputs_embeds is not None:
             input_shape = inputs_embeds.size()[:-1]
         else:

--- a/tests/models/bert/test_modeling_bert.py
+++ b/tests/models/bert/test_modeling_bert.py
@@ -573,6 +573,7 @@ class BertModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         config.pad_token_id = 0
 
         logger = logging.getLogger("transformers.models.bert.modeling_bert")
+        logger.warning_once.cache_clear()
 
         # Check for no warnings if the attention_mask is present.
         with CaptureLogger(logger) as cl:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -938,66 +938,6 @@ class ModelUtilsTest(TestCasePlus):
             self.assertIn("were not used when initializing ModelWithHead: ['added_key']", cl.out)
             self.assertEqual(loading_info["unexpected_keys"], ["added_key"])
 
-    def test_warn_if_no_attention_mask_when_pad_token_in_input_ids(self):
-        logger = logging.get_logger("transformers.modeling_utils")
-
-        with self.subTest("Ensure no warnings when pad_token_id is None."):
-            with CaptureLogger(logger) as cl:
-                config_no_pad_token = PretrainedConfig()
-                config_no_pad_token.pad_token_id = None
-                model = ModelWithHead(config_no_pad_token)
-                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
-
-        with self.subTest("Ensure no warnings when there is an attention_mask."):
-            with CaptureLogger(logger) as cl:
-                config = PretrainedConfig()
-                config.pad_token_id = 0
-                model = ModelWithHead(config)
-                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
-                attention_mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask)
-            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
-
-        with self.subTest("Ensure no warnings when there are no pad_token_ids in the input_ids."):
-            with CaptureLogger(logger) as cl:
-                config = PretrainedConfig()
-                config.pad_token_id = 0
-                model = ModelWithHead(config)
-                input_ids = torch.tensor([[1, 345, 232, 328, 740, 140, 1695, 69, 6078, 2341, 25]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
-
-        with self.subTest("Ensure warnings when there are pad_token_ids inside the input_ids."):
-            with CaptureLogger(logger) as cl:
-                config = PretrainedConfig()
-                config.pad_token_id = 0
-                model = ModelWithHead(config)
-                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-            self.assertIn("We strongly recommend passing in an `attention_mask`", cl.out)
-
-        with self.subTest("Ensure warnings are only shown once."):
-            with CaptureLogger(logger) as cl:
-                config = PretrainedConfig()
-                config.pad_token_id = 0
-                model = ModelWithHead(config)
-                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-            self.assertEqual(cl.out.count("We strongly recommend passing in an `attention_mask`"), 1)
-
-        with self.subTest("Ensure different warning when the pad_token_id is equal to the bos_token_id."):
-            with CaptureLogger(logger) as cl:
-                config = PretrainedConfig()
-                config.pad_token_id = 0
-                config.bos_token_id = config.pad_token_id
-                model = ModelWithHead(config)
-                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
-                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
-            self.assertIn("You may ignore this warning if your `pad_token_id`", cl.out)
-
     @require_torch_gpu
     @slow
     def test_pretrained_low_mem_new_config(self):

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -938,6 +938,66 @@ class ModelUtilsTest(TestCasePlus):
             self.assertIn("were not used when initializing ModelWithHead: ['added_key']", cl.out)
             self.assertEqual(loading_info["unexpected_keys"], ["added_key"])
 
+    def test_warn_if_no_attention_mask_when_pad_token_in_input_ids(self):
+        logger = logging.get_logger("transformers.modeling_utils")
+
+        with self.subTest("Ensure no warnings when pad_token_id is None."):
+            with CaptureLogger(logger) as cl:
+                config_no_pad_token = PretrainedConfig()
+                config_no_pad_token.pad_token_id = None
+                model = ModelWithHead(config_no_pad_token)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure no warnings when there is an attention_mask."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                attention_mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure no warnings when there are no pad_token_ids in the input_ids."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[1, 345, 232, 328, 740, 140, 1695, 69, 6078, 2341, 25]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure warnings when there are pad_token_ids inside the input_ids."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+            self.assertIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure warnings are only shown once."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+            self.assertEqual(cl.out.count("We strongly recommend passing in an `attention_mask`"), 1)
+
+        with self.subTest("Ensure different warning when the pad_token_id is equal to the bos_token_id."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                config.bos_token_id = config.pad_token_id
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_no_attention_mask_when_pad_token_in_input_ids(input_ids, attention_mask=None)
+            self.assertIn("You may ignore this warning if your `pad_token_id`", cl.out)
+
     @require_torch_gpu
     @slow
     def test_pretrained_low_mem_new_config(self):

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -938,6 +938,66 @@ class ModelUtilsTest(TestCasePlus):
             self.assertIn("were not used when initializing ModelWithHead: ['added_key']", cl.out)
             self.assertEqual(loading_info["unexpected_keys"], ["added_key"])
 
+    def test_warn_if_padding_and_no_attention_mask(self):
+        logger = logging.get_logger("transformers.modeling_utils")
+
+        with self.subTest("Ensure no warnings when pad_token_id is None."):
+            with CaptureLogger(logger) as cl:
+                config_no_pad_token = PretrainedConfig()
+                config_no_pad_token.pad_token_id = None
+                model = ModelWithHead(config_no_pad_token)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure no warnings when there is an attention_mask."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                attention_mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure no warnings when there are no pad_token_ids in the input_ids."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[1, 345, 232, 328, 740, 140, 1695, 69, 6078, 2341, 25]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+            self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure warnings when there are pad_token_ids inside the input_ids."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+            self.assertIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        with self.subTest("Ensure warnings are only shown once."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+            self.assertEqual(cl.out.count("We strongly recommend passing in an `attention_mask`"), 1)
+
+        with self.subTest("Ensure different warning when the pad_token_id is equal to the bos_token_id."):
+            with CaptureLogger(logger) as cl:
+                config = PretrainedConfig()
+                config.pad_token_id = 0
+                config.bos_token_id = config.pad_token_id
+                model = ModelWithHead(config)
+                input_ids = torch.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 0, 0]])
+                model.warn_if_padding_and_no_attention_mask(input_ids, attention_mask=None)
+            self.assertIn("You may ignore this warning if your `pad_token_id`", cl.out)
+
     @require_torch_gpu
     @slow
     def test_pretrained_low_mem_new_config(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #16136

Shows a one-time warning message when the pad_token_id is not None and no attention masks are given. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? #16136 
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@gante @ydshieh