### PR TITLE
Update hyperparameter_search.py

### DIFF
--- a/src/transformers/hyperparameter_search.py
+++ b/src/transformers/hyperparameter_search.py
@@ -119,7 +119,9 @@ ALL_HYPERPARAMETER_SEARCH_BACKENDS = {
 
 
 def default_hp_search_backend() -> str:
-    available_backends = [backend for backend in ALL_HYPERPARAMETER_SEARCH_BACKENDS.values() if backend.is_available()]
+    available_backends = [
+        backend for backend in ALL_HYPERPARAMETER_SEARCH_BACKENDS.values() if backend().is_available()
+    ]
     if len(available_backends) > 0:
         name = available_backends[0].name
         if len(available_backends) > 1:

--- a/src/transformers/hyperparameter_search.py
+++ b/src/transformers/hyperparameter_search.py
@@ -40,7 +40,8 @@ class HyperParamSearchBackendBase:
     name: str
     pip_package: str = None
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         raise NotImplementedError
 
     def run(self, trainer, n_trials: int, direction: str, **kwargs):
@@ -63,7 +64,8 @@ class HyperParamSearchBackendBase:
 class OptunaBackend(HyperParamSearchBackendBase):
     name = "optuna"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return is_optuna_available()
 
     def run(self, trainer, n_trials: int, direction: str, **kwargs):
@@ -77,7 +79,8 @@ class RayTuneBackend(HyperParamSearchBackendBase):
     name = "ray"
     pip_package = "'ray[tune]'"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return is_ray_available()
 
     def run(self, trainer, n_trials: int, direction: str, **kwargs):
@@ -90,7 +93,8 @@ class RayTuneBackend(HyperParamSearchBackendBase):
 class SigOptBackend(HyperParamSearchBackendBase):
     name = "sigopt"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return is_sigopt_available()
 
     def run(self, trainer, n_trials: int, direction: str, **kwargs):
@@ -103,7 +107,8 @@ class SigOptBackend(HyperParamSearchBackendBase):
 class WandbBackend(HyperParamSearchBackendBase):
     name = "wandb"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return is_wandb_available()
 
     def run(self, trainer, n_trials: int, direction: str, **kwargs):
@@ -119,9 +124,7 @@ ALL_HYPERPARAMETER_SEARCH_BACKENDS = {
 
 
 def default_hp_search_backend() -> str:
-    available_backends = [
-        backend for backend in ALL_HYPERPARAMETER_SEARCH_BACKENDS.values() if backend().is_available()
-    ]
+    available_backends = [backend for backend in ALL_HYPERPARAMETER_SEARCH_BACKENDS.values() if backend.is_available()]
     if len(available_backends) > 0:
         name = available_backends[0].name
         if len(available_backends) > 1:


### PR DESCRIPTION
# What does this PR do?
1. PR #24384 results in many tests failing related to HP Search. https://huggingface.slack.com/archives/C02CH2YP4EQ/p1687823783572709
2. Error being `tests/deepspeed/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_hyperparameter_search
(line 122)  TypeError: is_available() missing 1 required positional argument: 'self'` when `default_hp_search_backend` is called.
3. This PR fixes it.

Tested this via:
```
export CUDA_VISIBLE_DEVICES="0"
export RUN_SLOW="yes"
export LOGLEVEL=INFO

cd transformers

pytest -sv tests/deepspeed/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_hyperparameter_search
```