### PR TITLE
Fix LR scheduler based on bs from auto bs finder

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1553,7 +1553,7 @@ class Trainer:
         # number of training epochs: num_train_epochs
         # number of training steps per epoch: num_update_steps_per_epoch
         # total number of training steps to execute: max_steps
-        total_train_batch_size = args.train_batch_size * args.gradient_accumulation_steps * args.world_size
+        total_train_batch_size = args._train_batch_size * args.gradient_accumulation_steps * args.world_size
 
         len_dataloader = None
         if has_length(train_dataloader):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1553,7 +1553,7 @@ class Trainer:
         # number of training epochs: num_train_epochs
         # number of training steps per epoch: num_update_steps_per_epoch
         # total number of training steps to execute: max_steps
-        total_train_batch_size = args._train_batch_size * args.gradient_accumulation_steps * args.world_size
+        total_train_batch_size = self._train_batch_size * args.gradient_accumulation_steps * args.world_size
 
         len_dataloader = None
         if has_length(train_dataloader):


### PR DESCRIPTION
# What does this PR do?

This PR presents an alternative to https://github.com/huggingface/transformers/pull/23038, since we can't actually modify the schedulers realistically in Accelerate, this sets the correct "total batch size" based on the new bs being used, which gets trickled down to the creation of the scheduler via max steps if applicable. We can't go further than this however, as modifying the scheduler further would allude to auto-gradient accumulation, which while good, should be done after this :) 

(and might be as simple as just modifying `self.accelerator.gradient_accumulation_steps`

