### PR TITLE
Allow backbones not in backbones_supported - Maskformer Mask2Former

### DIFF
--- a/src/transformers/models/mask2former/configuration_mask2former.py
+++ b/src/transformers/models/mask2former/configuration_mask2former.py
@@ -170,10 +170,18 @@ class Mask2FormerConfig(PretrainedConfig):
                 use_absolute_embeddings=False,
                 out_features=["stage1", "stage2", "stage3", "stage4"],
             )
-        elif isinstance(backbone_config, dict):
-            backbone_model_type = backbone_config.get("model_type")
+
+        if isinstance(backbone_config, dict):
+            backbone_model_type = backbone_config.pop("model_type")
             config_class = CONFIG_MAPPING[backbone_model_type]
             backbone_config = config_class.from_dict(backbone_config)
+
+        # verify that the backbone is supported
+        if backbone_config.model_type not in self.backbones_supported:
+            logger.warning_once(
+                f"Backbone {backbone_config.model_type} is not a supported model and may not be compatible with Mask2Former. "
+                f"Supported model types: {','.join(self.backbones_supported)}"
+            )
 
         self.backbone_config = backbone_config
         self.feature_size = feature_size


### PR DESCRIPTION
# What does this PR do?

Updates configuration creation to allow backbone configs to be pased in which aren't listed in `backbones_supported` - downgrading the exception raised to a warning. 

Tested with:

```python
from transformers import (
    Mask2FormerConfig, 
    MaskFormerConfig, 
    Mask2FormerModel, 
    MaskFormerModel, 
    FocalNetConfig
)

# Test with a backbone not officially supported
backbone_config = FocalNetConfig(out_indices=(-2, -1))

maskformer_config = MaskFormerConfig(backbone_config=backbone_config)
model = MaskFormerModel(maskformer_config)

mask2former_config = Mask2FormerConfig(backbone_config=backbone_config)
model = Mask2FormerModel(mask2former_config)
```

Fixes #24244


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
