### PR TITLE
Update PT/TF weight conversion after #24030

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -276,13 +276,13 @@ def load_pytorch_state_dict_in_tf2_model(
 
         # New `weight_norm` from https://github.com/huggingface/transformers/pull/24030
         key_components = key.split(".")
-        _name = None
+        name = None
         if key_components[-3::2] == ["parametrizations", "original0"]:
-            _name = key_components[-2] + "_g"
+            name = key_components[-2] + "_g"
         elif key_components[-3::2] == ["parametrizations", "original1"]:
-            _name = key_components[-2] + "_v"
-        if _name is not None:
-            key_components = key_components[:-3] + [_name]
+            name = key_components[-2] + "_v"
+        if name is not None:
+            key_components = key_components[:-3] + [name]
             new_key = ".".join(key_components)
 
         if new_key is None:
@@ -511,27 +511,27 @@ def load_tf2_state_dict_in_pytorch_model(pt_model, tf_state_dict, allow_missing_
             new_pt_params_dict[pt_weight_name] = loaded_pt_weights_data_ptr[pt_weight.data_ptr()]
             continue
 
-        _pt_weight_name = pt_weight_name
+        pt_weight_name_to_check = pt_weight_name
         # New `weight_norm` from https://github.com/huggingface/transformers/pull/24030
         key_components = pt_weight_name.split(".")
-        _name = None
+        name = None
         if key_components[-3::2] == ["parametrizations", "original0"]:
-            _name = key_components[-2] + "_g"
+            name = key_components[-2] + "_g"
         elif key_components[-3::2] == ["parametrizations", "original1"]:
-            _name = key_components[-2] + "_v"
-        if _name is not None:
-            key_components = key_components[:-3] + [_name]
-            _pt_weight_name = ".".join(key_components)
+            name = key_components[-2] + "_v"
+        if name is not None:
+            key_components = key_components[:-3] + [name]
+            pt_weight_name_to_check = ".".join(key_components)
 
         # Find associated numpy array in pytorch model state dict
-        if _pt_weight_name not in tf_weights_map:
+        if pt_weight_name_to_check not in tf_weights_map:
             if allow_missing_keys:
                 missing_keys_pt.append(pt_weight_name)
                 continue
 
             raise AttributeError(f"{pt_weight_name} not found in TF 2.0 model")
 
-        array, transpose = tf_weights_map[_pt_weight_name]
+        array, transpose = tf_weights_map[pt_weight_name_to_check]
 
         array = apply_transpose(transpose, array, pt_weight.shape, pt_to_tf=False)
 

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -273,6 +273,17 @@ def load_pytorch_state_dict_in_tf2_model(
             new_key = key.replace("running_var", "moving_variance")
         if "running_mean" in key:
             new_key = key.replace("running_mean", "moving_mean")
+
+        key_components = key.split(".")
+        _name = None
+        if key_components[-3::2] == ["parametrizations", "original0"]:
+            _name = key_components[-2] + "_g"
+        elif key_components[-3::2] == ["parametrizations", "original1"]:
+            _name = key_components[-2] + "_v"
+        if _name is not None:
+            key_components = key_components[:-3] + [_name]
+            new_key = ".".join(key_components)
+
         if new_key is None:
             new_key = key
         tf_keys_to_pt_keys[new_key] = key


### PR DESCRIPTION
# What does this PR do?

Update PT/TF weight conversion due to the change in #24030.

(can do PT/Flax too in the same PR, but request a review first anyway)

### Code snippet to show issues and verify this PR's effect

(Failing for `main + nightly torch`. Pass for `PR + nightly torch` and `main/PR + stable torch`) 
```python
import transformers

from transformers import TFWav2Vec2Model
from tests.models.wav2vec2.test_modeling_tf_wav2vec2 import TFWav2Vec2ModelTest

self = TFWav2Vec2ModelTest()
self.setUp()

model_class = TFWav2Vec2Model
allow_missing_keys = False

config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

pt_model_class_name = model_class.__name__[2:]  # Skip the "TF" at the beginning
pt_model_class = getattr(transformers, pt_model_class_name)

tf_model = model_class(config)
pt_model = pt_model_class(config)

tf_inputs_dict = self._prepare_for_class(inputs_dict, model_class)

# Check we can load pt model in tf and vice-versa with model => model functions
try:
    _tf_model = transformers.load_pytorch_model_in_tf2_model(
        tf_model, pt_model, tf_inputs=tf_inputs_dict, allow_missing_keys=allow_missing_keys
    )
except:
    _tf_model = None

try:
    _pt_model = transformers.load_tf2_model_in_pytorch_model(
        pt_model, tf_model, allow_missing_keys=allow_missing_keys
    )
except:
    _pt_model = None

if _tf_model is None:
    print("_tf_model fails")
else:
    print("_tf_model OK")

if _pt_model is None:
    print("_pt_model fails")
else:
    print("_pt_model OK")
```