### PR TITLE
Fix typing annotations for FSDP and DeepSpeed in TrainingArguments

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -976,7 +976,7 @@ class TrainingArguments:
             )
         },
     )
-    fsdp_config: Optional[Union[str, dict]] = field(
+    fsdp_config: Optional[Union[str, Dict]] = field(
         default=None,
         metadata={
             "help": (
@@ -994,7 +994,7 @@ class TrainingArguments:
             )
         },
     )
-    deepspeed: Optional[Union[str, dict]] = field(
+    deepspeed: Optional[Union[str, Dict]] = field(
         default=None,
         metadata={
             "help": (

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -976,12 +976,12 @@ class TrainingArguments:
             )
         },
     )
-    fsdp_config: Optional[str] = field(
+    fsdp_config: Optional[Union[str, dict]] = field(
         default=None,
         metadata={
             "help": (
-                "Config to be used with FSDP (Pytorch Fully Sharded  Data Parallel). The  value is either a"
-                "fsdp json config file (e.g., `fsdp_config.json`) or an already loaded  json file as `dict`."
+                "Config to be used with FSDP (Pytorch Fully Sharded  Data Parallel). The value is either a"
+                "fsdp json config file (e.g., `fsdp_config.json`) or an already loaded json file as `dict`."
             )
         },
     )
@@ -994,11 +994,11 @@ class TrainingArguments:
             )
         },
     )
-    deepspeed: Optional[str] = field(
+    deepspeed: Optional[Union[str, dict]] = field(
         default=None,
         metadata={
             "help": (
-                "Enable deepspeed and pass the path to deepspeed json config file (e.g. ds_config.json) or an already"
+                "Enable deepspeed and pass the path to deepspeed json config file (e.g. `ds_config.json`) or an already"
                 " loaded json file as a dict"
             )
         },


### PR DESCRIPTION
# What does this PR do?
According to the the docstrings and to the code, options `fsdp_config` and `deepspeed` of `TrainingArguments` accept dictionaries with configs for FSDP and DeepSpeed correspondingly. However, the typing annotations for both of them mention only `str` as valid arguments, which makes typing checkers fail when trying to pass a dictionary for these options.

This PR fixes the problem by making these options accept `Dict` as well, also fixing a couple of minor typos in their descriptions.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

@sgugger 