### PR TITLE
fix peft ckpts not being pushed to hub 

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3535,7 +3535,7 @@ class Trainer:
         # To avoid a new synchronization of all model weights, we just copy the file from the checkpoint folder
         modeling_files = [CONFIG_NAME, WEIGHTS_NAME, SAFE_WEIGHTS_NAME]
         if is_peft_available():
-            modeling_files.entend([ADAPTER_CONFIG_NAME, ADAPTER_WEIGHTS_NAME, ADAPTER_SAFE_WEIGHTS_NAME])
+            modeling_files.extend([ADAPTER_CONFIG_NAME, ADAPTER_WEIGHTS_NAME, ADAPTER_SAFE_WEIGHTS_NAME])
         for modeling_file in modeling_files:
             if os.path.isfile(os.path.join(checkpoint_folder, modeling_file)):
                 shutil.copy(os.path.join(checkpoint_folder, modeling_file), os.path.join(output_dir, modeling_file))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -119,6 +119,7 @@ from .trainer_utils import (
 )
 from .training_args import OptimizerNames, ParallelMode, TrainingArguments
 from .utils import (
+    ADAPTER_CONFIG_NAME,
     ADAPTER_SAFE_WEIGHTS_NAME,
     ADAPTER_WEIGHTS_NAME,
     CONFIG_NAME,
@@ -3533,6 +3534,8 @@ class Trainer:
         output_dir = self.args.output_dir
         # To avoid a new synchronization of all model weights, we just copy the file from the checkpoint folder
         modeling_files = [CONFIG_NAME, WEIGHTS_NAME, SAFE_WEIGHTS_NAME]
+        if is_peft_available():
+            modeling_files.entend([ADAPTER_CONFIG_NAME, ADAPTER_WEIGHTS_NAME, ADAPTER_SAFE_WEIGHTS_NAME])
         for modeling_file in modeling_files:
             if os.path.isfile(os.path.join(checkpoint_folder, modeling_file)):
                 shutil.copy(os.path.join(checkpoint_folder, modeling_file), os.path.join(output_dir, modeling_file))

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -178,6 +178,7 @@ from .import_utils import (
 
 WEIGHTS_NAME = "pytorch_model.bin"
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
+ADAPTER_CONFIG_NAME = "adapter_config.json"
 ADAPTER_WEIGHTS_NAME = "adapter_model.bin"
 ADAPTER_SAFE_WEIGHTS_NAME = "adapter_model.safetensors"
 TF2_WEIGHTS_NAME = "tf_model.h5"


### PR DESCRIPTION
# What does this PR do?

1. Currently, when ckpts are saved every `save_steps` and `push_to_hub=True`, PEFT ckpts aren't being pushed to hub.
Reason:
every `save_steps` , the ckpts are being written to local `checkpoint-xx` folders. Now, in the trainer's function `_push_from_checkpoint` , it will copy the model files from the latest ckpt folder `checkpoint-xx` to the `output_dir`  which gets pushed to the Hub. Note that the modeling_files doesn't have `ADAPTER_WEIGHTS_NAME`  or `ADAPTER_SAFE_WEIGHTS_NAME`  or `ADAPTER_CONFIG_NAME`  leading to them not being pushed.

This PR fixes it. 

cc @younesbelkada 