### PR TITLE
Udate link to RunHouse hardware setup documentation.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -104,7 +104,7 @@ for running remotely as well. You can easily customize the example used, command
 and type of compute hardware, and then run the script to automatically launch the example.
 
 You can refer to 
-[hardware setup](https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup)
+[hardware setup](https://runhouse-docs.readthedocs-hosted.com/en/latest/api/python/cluster.html#hardware-setup)
 for more information about hardware and dependency setup with Runhouse, or this
 [Colab tutorial](https://colab.research.google.com/drive/1sh_aNQzJX5BKAdNeXthTNGxKz7sM9VPc) for a more in-depth 
 walkthrough.

--- a/examples/run_on_remote.py
+++ b/examples/run_on_remote.py
@@ -21,7 +21,7 @@ import runhouse as rh
 
 
 if __name__ == "__main__":
-    # Refer to https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup for cloud access
+    # Refer to https://runhouse-docs.readthedocs-hosted.com/en/latest/api/python/cluster.html#hardware-setup for cloud access
     # setup instructions, if using on-demand hardware
 
     # If user passes --user <user> --host <host> --key_path <key_path> <example> <args>, fill them in as BYO cluster


### PR DESCRIPTION
# What does this PR do?

The [hardware setup](https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup) link gives a 404 error. Replaced with a [link](https://runhouse-docs.readthedocs-hosted.com/en/latest/api/python/cluster.html#hardware-setup) that points to the latest version of the RunHouse documentation.


## Before submitting
- [ X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



## Who can review?

Documentation: @dongreenberg, @sgugger, @stevhliu and @MKhalusova


