### PR TITLE
Make (TF) CI faster (test only a random subset of model classes)

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -120,6 +120,10 @@ class TFModelTesterMixin:
     is_encoder_decoder = False
     has_attentions = True
 
+    def get_random_model_classes(self):
+        MAX_NUM_TO_TEST = 2
+        return random.sample(self.all_model_classes, k=MAX_NUM_TO_TEST)
+
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False) -> dict:
         inputs_dict = copy.deepcopy(inputs_dict)
 
@@ -341,7 +345,7 @@ class TFModelTesterMixin:
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             model = model_class(config)
             model.build()
 
@@ -689,7 +693,7 @@ class TFModelTesterMixin:
     def test_compile_tf_model(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             # Prepare our model
             model = model_class(config)
             # These are maximally general inputs for the model, with multiple None dimensions

--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -120,10 +120,6 @@ class TFModelTesterMixin:
     is_encoder_decoder = False
     has_attentions = True
 
-    def get_random_model_classes(self):
-        MAX_NUM_TO_TEST = 2
-        return random.sample(self.all_model_classes, k=MAX_NUM_TO_TEST)
-
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False) -> dict:
         inputs_dict = copy.deepcopy(inputs_dict)
 
@@ -345,7 +341,7 @@ class TFModelTesterMixin:
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             model = model_class(config)
             model.build()
 
@@ -693,7 +689,7 @@ class TFModelTesterMixin:
     def test_compile_tf_model(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             # Prepare our model
             model = model_class(config)
             # These are maximally general inputs for the model, with multiple None dimensions

--- a/tests/utils/test_modeling_tf_core.py
+++ b/tests/utils/test_modeling_tf_core.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import copy
 import os
-import random
 import tempfile
 from importlib import import_module
 from math import isnan
@@ -73,10 +72,6 @@ class TFCoreModelTesterMixin:
     test_head_masking = True
     is_encoder_decoder = False
 
-    def get_random_model_classes(self):
-        MAX_NUM_TO_TEST = 2
-        return random.sample(self.all_model_classes, k=MAX_NUM_TO_TEST)
-
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False) -> dict:
         inputs_dict = copy.deepcopy(inputs_dict)
 
@@ -116,7 +111,7 @@ class TFCoreModelTesterMixin:
     @slow
     def test_graph_mode(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             inputs = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
 
@@ -130,7 +125,7 @@ class TFCoreModelTesterMixin:
     @slow
     def test_xla_mode(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             inputs = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
 
@@ -145,7 +140,7 @@ class TFCoreModelTesterMixin:
     def test_xla_fit(self):
         # This is a copy of the test_keras_fit method, but we use XLA compilation instead of eager
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             model = model_class(config)
             if getattr(model, "hf_compute_loss", None):
                 # Test that model correctly compute the loss with kwargs
@@ -219,7 +214,7 @@ class TFCoreModelTesterMixin:
         encoder_seq_length = getattr(self.model_tester, "encoder_seq_length", self.model_tester.seq_length)
         encoder_key_length = getattr(self.model_tester, "key_length", encoder_seq_length)
 
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             class_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
             model.build()
@@ -274,7 +269,7 @@ class TFCoreModelTesterMixin:
         # try/finally block to ensure subsequent tests run in float32
         try:
             config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-            for model_class in self.get_random_model_classes():
+            for model_class in self.all_model_classes[:2]:
                 class_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
                 model = model_class(config)
                 outputs = model(class_inputs_dict)
@@ -357,7 +352,7 @@ class TFCoreModelTesterMixin:
     def test_graph_mode_with_inputs_embeds(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.get_random_model_classes():
+        for model_class in self.all_model_classes[:2]:
             model = model_class(config)
 
             inputs = copy.deepcopy(inputs_dict)

--- a/tests/utils/test_modeling_tf_core.py
+++ b/tests/utils/test_modeling_tf_core.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import copy
 import os
+import random
 import tempfile
 from importlib import import_module
 from math import isnan
@@ -72,6 +73,10 @@ class TFCoreModelTesterMixin:
     test_head_masking = True
     is_encoder_decoder = False
 
+    def get_random_model_classes(self):
+        MAX_NUM_TO_TEST = 2
+        return random.sample(self.all_model_classes, k=MAX_NUM_TO_TEST)
+
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False) -> dict:
         inputs_dict = copy.deepcopy(inputs_dict)
 
@@ -111,7 +116,7 @@ class TFCoreModelTesterMixin:
     @slow
     def test_graph_mode(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             inputs = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
 
@@ -125,7 +130,7 @@ class TFCoreModelTesterMixin:
     @slow
     def test_xla_mode(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             inputs = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
 
@@ -140,7 +145,7 @@ class TFCoreModelTesterMixin:
     def test_xla_fit(self):
         # This is a copy of the test_keras_fit method, but we use XLA compilation instead of eager
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             model = model_class(config)
             if getattr(model, "hf_compute_loss", None):
                 # Test that model correctly compute the loss with kwargs
@@ -214,7 +219,7 @@ class TFCoreModelTesterMixin:
         encoder_seq_length = getattr(self.model_tester, "encoder_seq_length", self.model_tester.seq_length)
         encoder_key_length = getattr(self.model_tester, "key_length", encoder_seq_length)
 
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             class_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
             model.build()
@@ -269,7 +274,7 @@ class TFCoreModelTesterMixin:
         # try/finally block to ensure subsequent tests run in float32
         try:
             config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-            for model_class in self.all_model_classes:
+            for model_class in self.get_random_model_classes():
                 class_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
                 model = model_class(config)
                 outputs = model(class_inputs_dict)
@@ -352,7 +357,7 @@ class TFCoreModelTesterMixin:
     def test_graph_mode_with_inputs_embeds(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
-        for model_class in self.all_model_classes:
+        for model_class in self.get_random_model_classes():
             model = model_class(config)
 
             inputs = copy.deepcopy(inputs_dict)


### PR DESCRIPTION
# What does this PR do?

Daily CI is currently running in 22h30m. @Rocketknight1 might have a way to bring it back to 19-20 hours.

For some tests, let's test only a (random) subset of the model classes 🙏 .

Here is the timing of some very slow tests currently:

```
398.44s call     tests/models/bert/test_modeling_tf_bert.py::TFBertModelTest::test_xla_fit
275.59s call     tests/models/bert/test_modeling_tf_bert.py::TFBertModelTest::test_saved_model_creation_extended
217.84s call     tests/models/bert/test_modeling_tf_bert.py::TFBertModelTest::test_compile_tf_model
106.25s call     tests/models/bert/test_tokenization_bert_tf.py::BertTokenizationTest::test_saved_model
77.69s call     tests/models/bert/test_modeling_tf_bert.py::TFBertModelTest::test_onnx_runtime_optimize
```
and
```
352.31s call     tests/models/bart/test_modeling_tf_bart.py::TFBartModelTest::test_saved_model_creation_extended
272.56s call     tests/models/bart/test_modeling_tf_bart.py::TFBartModelTest::test_compile_tf_model
270.84s call     tests/models/bart/test_modeling_tf_bart.py::TFBartModelTest::test_xla_fit
132.59s call     tests/models/bart/test_modeling_tf_bart.py::TFBartModelTest::test_onnx_runtime_optimize
```