### PR TITLE
Pin `Pillow` for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ if stale_egg_info.exists():
 # 1. all dependencies should be listed here with their version requirements if any
 # 2. once modified, run: `make deps_table_update` to update src/transformers/dependency_versions_table.py
 _deps = [
-    "Pillow",
+    "Pillow<10.0.0",
     "accelerate>=0.20.3",
     "av==9.2.0",  # Latest version of PyAV (10.0.0) has issues with audio stream.
     "beautifulsoup4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -2,7 +2,7 @@
 # 1. modify the `_deps` dict in setup.py
 # 2. run `make deps_table_update``
 deps = {
-    "Pillow": "Pillow",
+    "Pillow": "Pillow<10.0.0",
     "accelerate": "accelerate>=0.20.3",
     "av": "av==9.2.0",
     "beautifulsoup4": "beautifulsoup4",


### PR DESCRIPTION
# What does this PR do?

`Pillow 10.0.0` is out 2 days ago.

Our CI get errors (via the usage of `detectron2`):

```bash
...
/usr/local/lib/python3.8/dist-packages/detectron2/data/transforms/transform.py:36: in <module>
...
>       def __init__(self, src_rect, output_size, interp=Image.LINEAR, fill=0):
E       AttributeError: module 'PIL.Image' has no attribute 'LINEAR'
``` 

This is due to the previous deprecation and the removal now
```bash
<stdin>:1: DeprecationWarning: LINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use BILINEAR or Resampling.BILINEAR instead.
```

This PR pins `Pillow` for now until `detectron2` fixes it.
