### PR TITLE
Fix `VisionTextDualEncoderIntegrationTest`

### DIFF
--- a/tests/models/vision_text_dual_encoder/test_modeling_flax_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_modeling_flax_vision_text_dual_encoder.py
@@ -366,7 +366,7 @@ class FlaxCLIPVisionBertModelTest(VisionTextDualEncoderMixin, unittest.TestCase)
 class FlaxVisionTextDualEncoderIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
-        model = FlaxVisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1)
+        model = FlaxVisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1.0)
         processor = VisionTextDualEncoderProcessor.from_pretrained("clip-italian/clip-italian")
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")

--- a/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_modeling_tf_vision_text_dual_encoder.py
@@ -398,7 +398,7 @@ class TFVisionTextDualEncoderIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
         model = TFVisionTextDualEncoderModel.from_pretrained(
-            "clip-italian/clip-italian", logit_scale_init_value=1, from_pt=True
+            "clip-italian/clip-italian", logit_scale_init_value=1.0, from_pt=True
         )
         processor = VisionTextDualEncoderProcessor.from_pretrained("clip-italian/clip-italian")
 

--- a/tests/models/vision_text_dual_encoder/test_modeling_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_modeling_vision_text_dual_encoder.py
@@ -497,7 +497,7 @@ class CLIPVisionBertModelTest(VisionTextDualEncoderMixin, unittest.TestCase):
 class VisionTextDualEncoderIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
-        model = VisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1)
+        model = VisionTextDualEncoderModel.from_pretrained("clip-italian/clip-italian", logit_scale_init_value=1.0)
         processor = VisionTextDualEncoderProcessor.from_pretrained("clip-italian/clip-italian")
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")


### PR DESCRIPTION
# What does this PR do?

Need a tiny update in the test files after the PR #24585

So far, CI gets errors like

```bash
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
```