### PR TITLE
Fix `EncodecModelTest::test_multi_gpu_data_parallel_forward`

### DIFF
--- a/tests/models/encodec/test_modeling_encodec.py
+++ b/tests/models/encodec/test_modeling_encodec.py
@@ -73,7 +73,8 @@ class EncodecModelTester:
     def __init__(
         self,
         parent,
-        batch_size=13,
+        # `batch_size` needs to be an even number if the model has some outputs with batch dim != 0.
+        batch_size=12,
         num_channels=2,
         is_training=False,
         num_hidden_layers=4,


### PR DESCRIPTION
# What does this PR do?

`test_multi_gpu_data_parallel_forward` requires the batch size to be an even number if the batch dim is not at position 0 in the output shape.