### PR TITLE
updating _compute_mask_indices fn to work with torch compile

### DIFF
--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -251,8 +251,7 @@ def _compute_mask_indices(
         spec_aug_mask_idxs[spec_aug_mask_idxs > sequence_length - 1] = sequence_length - 1
 
     # scatter indices to mask
-    mask_values = torch.ones(spec_aug_mask_idxs.shape, dtype=torch.bool)
-    spec_aug_mask = spec_aug_mask.scatter(1, spec_aug_mask_idxs, mask_values)
+    spec_aug_mask.scatter_(1, spec_aug_mask_idxs, spec_aug_mask)
 
     return spec_aug_mask
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1502,7 +1502,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
 
         if mask_time_indices is not None:
             # apply SpecAugment along time axis with given mask_time_indices
-            hidden_size[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
+            hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
 
         elif self.config.mask_time_prob > 0 and self.training:
             mask_time_indices = _compute_mask_indices(

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1513,9 +1513,8 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
                 min_masks=self.config.mask_time_min_masks,
             )
             mask_time_indices = mask_time_indices.to(device=hidden_states.device)
-            temp_hidden_states = hidden_states.clone()
-            temp_hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
-            hidden_states = temp_hidden_states
+            expanded_embed = self.masked_spec_embed.unsqueeze(0).unsqueeze(0)
+            hidden_states = torch.where(mask_time_indices.unsqueeze(-1), expanded_embed, hidden_states)
 
         if self.config.mask_feature_prob > 0 and self.training:
             # generate indices & apply SpecAugment along feature axis

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -214,7 +214,7 @@ def _compute_mask_indices(
 
         # get random indices to mask
         spec_aug_mask_idx = torch.tensor(
-            random.sample(range(input_length - (mask_length - 1)), num_masked_span), dtype=torch.int64
+            random.sample(range(input_length - (mask_length - 1)), num_masked_span), dtype=torch.int32
         )
 
         # pick first sampled index that will serve as a dummy index to pad vector

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -201,7 +201,7 @@ def _compute_mask_indices(
 
     # SpecAugment mask to fill
     spec_aug_mask = torch.zeros((batch_size, sequence_length), dtype=torch.bool)
-    spec_aug_mask_idxs = torch.tensor([], dtype=torch.int64)
+    spec_aug_mask_idxs = torch.tensor([], dtype=torch.int32)
 
     max_num_masked_span = compute_num_masked_span(sequence_length)
 
@@ -251,7 +251,8 @@ def _compute_mask_indices(
         spec_aug_mask_idxs[spec_aug_mask_idxs > sequence_length - 1] = sequence_length - 1
 
     # scatter indices to mask
-    spec_aug_mask.scatter_(1, spec_aug_mask_idxs, spec_aug_mask)
+    mask_values = torch.ones(spec_aug_mask_idxs.shape, dtype=torch.bool)
+    spec_aug_mask.scatter_(1, spec_aug_mask_idxs, mask_values)
 
     return spec_aug_mask
 

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1502,9 +1502,7 @@ class Wav2Vec2Model(Wav2Vec2PreTrainedModel):
 
         if mask_time_indices is not None:
             # apply SpecAugment along time axis with given mask_time_indices
-            temp_hidden_states = hidden_states.clone()
-            temp_hidden_states[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
-            hidden_states = temp_hidden_states
+            hidden_size[mask_time_indices] = self.masked_spec_embed.to(hidden_states.dtype)
 
         elif self.config.mask_time_prob > 0 and self.training:
             mask_time_indices = _compute_mask_indices(

--- a/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -1245,7 +1245,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_length = 1
 
         mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-        mask = torch.from_numpy(mask).to(torch_device)
+        mask = mask.to(torch_device)
 
         self.assertListEqual(mask.sum(axis=-1).tolist(), [mask_prob * sequence_length for _ in range(batch_size)])
 
@@ -1264,7 +1264,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
 
         for _ in range(n_trials):
             mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-            mask = torch.from_numpy(mask).to(torch_device)
+            mask = mask.to(torch_device)
 
             num_masks = torch.sum(mask).item()
 
@@ -1286,7 +1286,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask_length = 4
 
         mask = _compute_mask_indices((batch_size, sequence_length), mask_prob, mask_length)
-        mask = torch.from_numpy(mask).to(torch_device)
+        mask = mask.to(torch_device)
 
         # because of overlap mask don't have to add up exactly to `mask_prob * sequence_length`, but have to be smaller or equal
         for batch_sum in mask.sum(axis=-1):
@@ -1304,7 +1304,7 @@ class Wav2Vec2UtilsTest(unittest.TestCase):
         mask = _compute_mask_indices(
             (batch_size, sequence_length), mask_prob, mask_length, attention_mask=attention_mask
         )
-        mask = torch.from_numpy(mask).to(torch_device)
+        mask = mask.to(torch_device)
 
         for batch_sum in mask.sum(axis=-1):
             self.assertTrue(int(batch_sum) <= mask_prob * sequence_length)


### PR DESCRIPTION
fixes #22849 

The inplace operations are replaced with out-of-place ones to fix the torch compile computational graph breakage.
This method converts the numpy operations to torch operations in _compute_mask_indices function.
The _compute_mask_indices is used when using SpecAugmentation in  wav2vec2 training.

@sanchit-gandhi 