### PR TITLE
Add dropouts to GPT-NeoX

### DIFF
--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -59,7 +59,7 @@ class GPTNeoXConfig(PretrainedConfig):
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio probability of the attention score.
         hidden_dropout (`float`, *optional*, defaults to 0.0):
-            The dropout ratio of (1) the word embeddings, (2) the post-attention hidden states, and (3) the post-mlp 
+            The dropout ratio of (1) the word embeddings, (2) the post-attention hidden states, and (3) the post-mlp
             hidden states.
         classifier_dropout (`float`, *optional*, defaults to 0.1):
             Argument used when doing token classification, used in the model [`GPTNeoXForTokenClassification`].

--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -99,6 +99,8 @@ class GPTNeoXConfig(PretrainedConfig):
         hidden_act="gelu",
         rotary_pct=0.25,
         rotary_emb_base=10000,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
         classifier_dropout=0.1,
         max_position_embeddings=2048,
         initializer_range=0.02,
@@ -120,6 +122,8 @@ class GPTNeoXConfig(PretrainedConfig):
         self.hidden_act = hidden_act
         self.rotary_pct = rotary_pct
         self.rotary_emb_base = rotary_emb_base
+        self.attention_dropout = attention_dropout
+        self.hidden_dropout = hidden_dropout
         self.classifier_dropout = classifier_dropout
         self.initializer_range = initializer_range
         self.layer_norm_eps = layer_norm_eps

--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -56,6 +56,10 @@ class GPTNeoXConfig(PretrainedConfig):
             percentage of hidden dimensions to allocate to rotary embeddings
         rotary_emb_base (`int`, *optional*, defaults to 10000)
             base for computing rotary embeddings frequency
+        attention_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout ratio probability of the attention score.
+        hidden_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout ratio of (1) the word embeddings, (2) the post-attention hidden states, and (3) the post-mlp hidden states.
         classifier_dropout (`float`, *optional*, defaults to 0.1):
             Argument used when doing token classification, used in the model [`GPTNeoXForTokenClassification`].
 

--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -59,7 +59,8 @@ class GPTNeoXConfig(PretrainedConfig):
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio probability of the attention score.
         hidden_dropout (`float`, *optional*, defaults to 0.0):
-            The dropout ratio of (1) the word embeddings, (2) the post-attention hidden states, and (3) the post-mlp hidden states.
+            The dropout ratio of (1) the word embeddings, (2) the post-attention hidden states, and (3) the post-mlp 
+            hidden states.
         classifier_dropout (`float`, *optional*, defaults to 0.1):
             Argument used when doing token classification, used in the model [`GPTNeoXForTokenClassification`].
 

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -349,7 +349,7 @@ class GPTNeoXLayer(nn.Module):
             output_attentions=output_attentions,
         )
         attn_output = attention_layer_outputs[0]  # output_attn: attn_output, present, (attn_weights)
-        attn_output = self.post_attention_dropout(attn_dropout)
+        attn_output = self.post_attention_dropout(attn_output)
         outputs = attention_layer_outputs[1:]
 
         if self.use_parallel_residual:

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -114,6 +114,8 @@ class GPTNeoXAttention(nn.Module):
         self.query_key_value = nn.Linear(config.hidden_size, 3 * config.hidden_size)
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
 
+        self.attention_dropout = nn.Dropout(config.attention_dropout)
+
     def forward(
         self,
         hidden_states: torch.FloatTensor,
@@ -245,6 +247,8 @@ class GPTNeoXAttention(nn.Module):
         if head_mask is not None:
             attn_weights = attn_weights * head_mask
 
+        attn_weights = self.attention_dropout(attn_weights)
+
         attn_output = torch.matmul(attn_weights, value)
         return attn_output, attn_weights
 
@@ -320,6 +324,8 @@ class GPTNeoXLayer(nn.Module):
         self.use_parallel_residual = config.use_parallel_residual
         self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.post_attention_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.post_attention_dropout = nn.Dropout(config.hidden_dropout)
+        self.post_mlp_dropout = nn.Dropout(config.hidden_dropout)
         self.attention = GPTNeoXAttention(config)
         self.mlp = GPTNeoXMLP(config)
 
@@ -343,12 +349,14 @@ class GPTNeoXLayer(nn.Module):
             output_attentions=output_attentions,
         )
         attn_output = attention_layer_outputs[0]  # output_attn: attn_output, present, (attn_weights)
+        attn_output = self.post_attention_dropout(attn_dropout)
         outputs = attention_layer_outputs[1:]
 
         if self.use_parallel_residual:
             # pseudocode:
             # x = x + attn(ln1(x)) + mlp(ln2(x))
             mlp_output = self.mlp(self.post_attention_layernorm(hidden_states))
+            mlp_output = self.post_mlp_dropout(mlp_output)
             hidden_states = mlp_output + attn_output + hidden_states
         else:
             # pseudocode:
@@ -356,6 +364,7 @@ class GPTNeoXLayer(nn.Module):
             # x = x + mlp(ln2(x))
             attn_output = attn_output + hidden_states
             mlp_output = self.mlp(self.post_attention_layernorm(attn_output))
+            mlp_output = self.post_mlp_dropout(mlp_output)
             hidden_states = mlp_output + attn_output
 
         if use_cache:
@@ -429,6 +438,7 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
         self.config = config
 
         self.embed_in = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.emb_dropout = nn.Dropout(config.hidden_dropout)
         self.layers = nn.ModuleList([GPTNeoXLayer(config) for _ in range(config.num_hidden_layers)])
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
@@ -533,7 +543,7 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
         if inputs_embeds is None:
             inputs_embeds = self.embed_in(input_ids)
 
-        hidden_states = inputs_embeds
+        hidden_states = self.emb_dropout(inputs_embeds)
 
         if self.gradient_checkpointing and self.training:
             if use_cache:


### PR DESCRIPTION
# What does this PR do?

The current GPT-NeoX modeling code does not contain dropouts as in [the original EleutherAI/gpt-neox code](https://github.com/EleutherAI/gpt-neox/blob/main/megatron/model), possibly because that GPT-NeoX 20B, where the HF gpt-neox implementation was applied for the first time, has disabled all dropouts.

However, EleutherAI/gpt-neox does provide dropouts at several places.
* post-word-embedding dropout, [reference](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/word_embeddings.py#L156),
* attention score dropout, [reference](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L453C1-L453C1),
* post-attention dropout, [reference1](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L829-L834), [reference2](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L865-L870), [reference3](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L873-L880),
* post-mlp dropout, [reference1](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L839-L844), [reference2](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/model/transformer.py#L893-L898).

These dropouts can be turned on and help produce better fine-tuning performance.

This PR adds corresponding dropouts to the HF gpt_neox implementation. Following the original EleutherAI code, dropout probabilities are controlled by two config arguments:
* attention_dropout, which controls the probability of the attention score dropout, [reference](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/neox_arguments/neox_args.py#L911),
* hidden_dropout, which controls the probability of remaining dropouts, [reference](https://github.com/EleutherAI/gpt-neox/blob/2534e3d76e320aba095894e7dc2a4b416a1ac8df/megatron/neox_arguments/neox_args.py#L916).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Sorry that I am not sure whom to tag, so I am following the suggestion to tag text model people @ArthurZucker and @younesbelkada.
