### PR TITLE
Avoid import `sentencepiece_model_pb2` in `utils.__init__.py`

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -184,9 +184,6 @@ if is_protobuf_available():
         from . import sentencepiece_model_pb2
     else:
         from . import sentencepiece_model_pb2_new as sentencepiece_model_pb2
-else:
-    # just to get the expected `No module named 'google.protobuf'` error
-    from . import sentencepiece_model_pb2
 
 
 WEIGHTS_NAME = "pytorch_model.bin"


### PR DESCRIPTION
# What does this PR do?

Otherwise, trying to import anything from `utils` will fail if protobuf is not installed.

More details in the comment.