### PR TITLE
Suppress warnings from LUKE for unexpected keys

### DIFF
--- a/src/transformers/models/luke/modeling_luke.py
+++ b/src/transformers/models/luke/modeling_luke.py
@@ -902,6 +902,11 @@ class LukePreTrainedModel(PreTrainedModel):
     base_model_prefix = "luke"
     supports_gradient_checkpointing = True
     _no_split_modules = ["LukeAttention", "LukeEntityEmbeddings"]
+    _keys_to_ignore_on_load_unexpected = [
+        r"entity_predictions.*",
+        r"lm_head.*",
+        r"luke.encoder.layer.*.attention.self.*_query.*",
+    ]
 
     def _init_weights(self, module: nn.Module):
         """Initialize the weights"""


### PR DESCRIPTION
# What does this PR do?

Suppress the warnings when instantiating the LUKE models by adding `_keys_to_ignore_on_load_unexpected`.

## Promblem

Currently, when you instantiate certain LUKE models from the Hugging Face Hub, such as
```
from transformers import AutoModel
model = transformers.AutoModel.from_pretrained("studio-ousia/mluke-base-lite")
```
you receive a warning indicating that a bunch of weights were not loaded.
```
Some weights of the model checkpoint at studio-ousia/mluke-base-lite were not used when initializing LukeModel: [
'luke.encoder.layer.0.attention.self.w2e_query.weight', 'luke.encoder.layer.0.attention.self.w2e_query.bias', 
'luke.encoder.layer.0.attention.self.e2w_query.weight', 'luke.encoder.layer.0.attention.self.e2w_query.bias', 
'luke.encoder.layer.0.attention.self.e2e_query.weight', 'luke.encoder.layer.0.attention.self.e2e_query.bias', 
...]
```

This seems to depend on the logging setting and is observed on Google Colabo Notebooks.
https://colab.research.google.com/drive/1kYN3eGhx5tzEMnGkUz2jPsdmFyEBwxFA?usp=sharing

This behavior is expected since these weights are optional and only loaded when `use_entity_aware_attention` is set to `True`. However, it has caused confusion among users, as evidenced by the following issues:
https://github.com/studio-ousia/luke/issues/174
https://huggingface.co/studio-ousia/mluke-base/discussions/2#63be8cc6c26a8a4d713ee08a

## Solution

I added `_keys_to_ignore_on_load_unexpected` to `LukePreTrainedModel ` to ignore some unexpected keys in the pretrained weights.


