### PR TITLE
Fix flaky `test_for_warning_if_padding_and_no_attention_mask`

### DIFF
--- a/tests/models/bert/test_modeling_bert.py
+++ b/tests/models/bert/test_modeling_bert.py
@@ -584,6 +584,9 @@ class BertModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
 
         # Check for warnings if the attention_mask is missing.
         logger = logging.get_logger("transformers.modeling_utils")
+        # clear cache so we can test the warning is emitted (from `warning_once`).
+        logger.warning_once.cache_clear()
+
         with CaptureLogger(logger) as cl:
             model = BertModel(config=config)
             model.to(torch_device)


### PR DESCRIPTION
# What does this PR do?

This tests #24510. It fails a few times (on my PRs, and once in someone's PR), and now it fails on the latest daily CI.

This test is flaky because it test the functionality of `warn_if_padding_and_no_attention_mask` which uses `logger.warning_once(warn_string)` - this uses `@functools.lru_cache(None)`.

If there is any test that triggers this warning before `test_for_warning_if_padding_and_no_attention_mask`, the cache is produced, and we won't get the expected warning in `test_for_warning_if_padding_and_no_attention_mask` then it fails.