### PR TITLE
[WIP] Gradient Checkpointing: use_reentrant=False

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -574,6 +574,7 @@ class LlamaModel(LlamaPreTrainedModel):
                     attention_mask,
                     position_ids,
                     None,
+                    use_reentrant=False,
                 )
             else:
                 layer_outputs = decoder_layer(


### PR DESCRIPTION
# What does this PR do?

As per pytorch's [recommendation](https://github.com/pytorch/pytorch/blob/main/torch/utils/checkpoint.py#L418)

When using gradient checkpointing for models that allow them, torch.util.checkpoint recommends using
`use_reentrant=False``` as per [this note](https://github.com/pytorch/pytorch/blob/main/torch/utils/checkpoint.py#L336):

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

@ArthurZucker @sgugger 
