### PR TITLE
Skip keys not in the state dict when finding mismatched weights

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3158,6 +3158,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             mismatched_keys = []
             if ignore_mismatched_sizes:
                 for checkpoint_key in loaded_keys:
+                    # If the checkpoint is sharded, we may not have the key here.
+                    if checkpoint_key not in state_dict:
+                        continue
                     model_key = checkpoint_key
                     if remove_prefix_from_model:
                         # The model key starts with `prefix` but `checkpoint_key` doesn't so we add it.


### PR DESCRIPTION
# What does this PR do?

When looping through the keys in `find_mismatched_weights`, we loop through all the `loaded_keys` which are all the keys in the checkpoint. If the checkpoint is sharded, the `state_dict` passed won't contain all those keys, only a subset of them, so we need to skip the keys not present in the `state_dict`.

Fixes #24704 