### PR TITLE
Add PEFT support directly in transformers pipeline

### DIFF
--- a/docs/source/en/main_classes/pipelines.md
+++ b/docs/source/en/main_classes/pipelines.md
@@ -302,6 +302,56 @@ That should enable you to do all the custom code you want.
 
 [Implementing a new pipeline](../add_new_pipeline)
 
+## Integration with PEFT library
+
+You can use adapter models that have been trained using the PEFT library with the pipelines. Currently the supported tasks for adapters are:
+
+- `text-generation`
+- `text2text-generation`
+- `question-answering`
+- `token-classification`
+- `feature-extraction`
+
+Make sure to first install the PEFT library:
+
+```bash
+pip install peft
+```
+and double check that you have passed a valid Hub model name with PEFT adapters:
+```python
+from transformers import pipeline
+
+model_id = "ybelkada/opt-350m-lora"
+pipe = pipeline("text-generation", model=model_id)
+
+output = pipe("Hello")
+```
+Or a `PeftModel` to the pipeline:
+```python
+from transformers import pipeline, AutoTokenizer
+from peft import AutoPeftModelForCausalLM
+
+model_id = "ybelkada/opt-350m-lora"
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+peft_model = AutoPeftModelForCausalLM.from_pretrained(model_id)
+
+pipe = pipeline("text-generation", peft_model, tokenizer=tokenizer)
+
+output = pipe("Hello")
+```
+You can handle the key word arguments that you want to pass to a `PeftModel` by passing the argument `peft_model_kwargs` to the pipeline:
+
+```python
+from transformers import pipeline
+
+model_id = "ybelkada/opt-350m-lora"
+pipe = pipeline("text-generation", model=model_id, peft_model_kwargs={"adapter_name": "default"})
+
+output = pipe("Hello")
+```
+
+
 ## Audio
 
 Pipelines available for audio tasks include the following.

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -734,6 +734,10 @@ def pipeline(
 
     elif config is None and isinstance(model, str):
         if has_adapter_config:
+            logger.info(
+                f"Detected an adapter model in the specified path ({model}). Will use PEFT library to load the model."
+            )
+
             peft_config = PeftConfig.from_pretrained(model, **hub_kwargs)
             config = AutoConfig.from_pretrained(
                 peft_config.base_model_name_or_path, _from_pipeline=task, **hub_kwargs, **model_kwargs

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -711,6 +711,8 @@ def pipeline(
         try:
             list_remote_files = list_repo_files(model, revision=revision, use_auth_token=use_auth_token)
         except EntryNotFoundError:
+            if not os.path.isdir(model):
+                raise ValueError(f"Local file or directory {model} does not exist.")
             list_remote_files = os.listdir(model)
 
         has_adapter_config = "adapter_config.json" in list_remote_files

--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -17,12 +17,9 @@ from typing import Union
 import numpy as np
 import requests
 
-from ..utils import add_end_docstrings, is_torch_available, is_torchaudio_available, logging
+from ..utils import add_end_docstrings, is_torchaudio_available, logging
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
-
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -97,8 +94,6 @@ class AudioClassificationPipeline(Pipeline):
 
         if self.framework != "pt":
             raise ValueError(f"The {self.__class__} is only available in PyTorch.")
-
-        self.check_model_type(MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING)
 
     def __call__(
         self,

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_CTC_MAPPING, MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING
+    from ..models.auto.modeling_auto import MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING
 
 
 def rescale_stride(stride, ratio):
@@ -219,8 +219,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
 
         if self.framework == "tf":
             raise ValueError("The AutomaticSpeechRecognitionPipeline is only available in PyTorch.")
-
-        self.check_model_type(dict(MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING.items() + MODEL_FOR_CTC_MAPPING.items()))
 
     def __call__(
         self,

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -971,9 +971,7 @@ class Pipeline(_ScikitCompat):
         else:
             return inputs
 
-    def check_model_type(
-        self, supported_models: Union[List[str], dict], extra_custom_model_classes: Optional[dict] = None
-    ):
+    def check_model_type(self, supported_models: Union[List[str], dict]):
         """
         Check if the model class is in supported by the pipeline.
 
@@ -990,11 +988,6 @@ class Pipeline(_ScikitCompat):
                 else:
                     supported_models_names.append(model.__name__)
             supported_models = supported_models_names
-
-        if extra_custom_model_classes is not None and not isinstance(extra_custom_model_classes, list):
-            raise ValueError("extra_custom_models must be a list of model classes")
-        elif extra_custom_model_classes is not None:
-            supported_models = supported_models + [model_class.__name__ for model_class in extra_custom_model_classes]
 
         if self.model.__class__.__name__ not in supported_models:
             logger.error(

--- a/src/transformers/pipelines/depth_estimation.py
+++ b/src/transformers/pipelines/depth_estimation.py
@@ -14,7 +14,6 @@ if is_vision_available():
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import MODEL_FOR_DEPTH_ESTIMATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -48,7 +47,6 @@ class DepthEstimationPipeline(Pipeline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         requires_backends(self, "vision")
-        self.check_model_type(MODEL_FOR_DEPTH_ESTIMATION_MAPPING)
 
     def __call__(self, images: Union[str, List[str], "Image.Image", List["Image.Image"]], **kwargs):
         """

--- a/src/transformers/pipelines/document_question_answering.py
+++ b/src/transformers/pipelines/document_question_answering.py
@@ -37,7 +37,6 @@ if is_vision_available():
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING
 
 TESSERACT_LOADED = False
 if is_pytesseract_available():
@@ -142,7 +141,6 @@ class DocumentQuestionAnsweringPipeline(ChunkPipeline):
             if self.model.config.encoder.model_type != "donut-swin":
                 raise ValueError("Currently, the only supported VisionEncoderDecoder model is Donut")
         else:
-            self.check_model_type(MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING)
             if self.model.config.__class__.__name__ == "LayoutLMConfig":
                 self.model_type = ModelType.LayoutLM
             else:

--- a/src/transformers/pipelines/image_classification.py
+++ b/src/transformers/pipelines/image_classification.py
@@ -3,7 +3,6 @@ from typing import List, Union
 from ..utils import (
     add_end_docstrings,
     is_tf_available,
-    is_torch_available,
     is_vision_available,
     logging,
     requires_backends,
@@ -19,11 +18,8 @@ if is_vision_available():
 if is_tf_available():
     import tensorflow as tf
 
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING
     from ..tf_utils import stable_softmax
 
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -56,11 +52,6 @@ class ImageClassificationPipeline(Pipeline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         requires_backends(self, "vision")
-        self.check_model_type(
-            TF_MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING
-            if self.framework == "tf"
-            else MODEL_FOR_IMAGE_CLASSIFICATION_MAPPING
-        )
 
     def _sanitize_parameters(self, top_k=None):
         postprocess_params = {}

--- a/src/transformers/pipelines/image_segmentation.py
+++ b/src/transformers/pipelines/image_segmentation.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Union
 
 import numpy as np
 
-from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging, requires_backends
+from ..utils import add_end_docstrings, is_vision_available, logging, requires_backends
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
@@ -10,14 +10,6 @@ if is_vision_available():
     from PIL import Image
 
     from ..image_utils import load_image
-
-if is_torch_available():
-    from ..models.auto.modeling_auto import (
-        MODEL_FOR_IMAGE_SEGMENTATION_MAPPING,
-        MODEL_FOR_INSTANCE_SEGMENTATION_MAPPING,
-        MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING,
-        MODEL_FOR_UNIVERSAL_SEGMENTATION_MAPPING,
-    )
 
 
 logger = logging.get_logger(__name__)
@@ -71,14 +63,6 @@ class ImageSegmentationPipeline(Pipeline):
             raise ValueError(f"The {self.__class__} is only available in PyTorch.")
 
         requires_backends(self, "vision")
-        self.check_model_type(
-            dict(
-                MODEL_FOR_IMAGE_SEGMENTATION_MAPPING.items()
-                + MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING.items()
-                + MODEL_FOR_INSTANCE_SEGMENTATION_MAPPING.items()
-                + MODEL_FOR_UNIVERSAL_SEGMENTATION_MAPPING.items()
-            )
-        )
 
     def _sanitize_parameters(self, **kwargs):
         preprocess_kwargs = {}

--- a/src/transformers/pipelines/image_to_text.py
+++ b/src/transformers/pipelines/image_to_text.py
@@ -2,7 +2,6 @@ from typing import List, Union
 
 from ..utils import (
     add_end_docstrings,
-    is_tf_available,
     is_torch_available,
     is_vision_available,
     logging,
@@ -16,13 +15,9 @@ if is_vision_available():
 
     from ..image_utils import load_image
 
-if is_tf_available():
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_VISION_2_SEQ_MAPPING
-
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import MODEL_FOR_VISION_2_SEQ_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -54,9 +49,6 @@ class ImageToTextPipeline(Pipeline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         requires_backends(self, "vision")
-        self.check_model_type(
-            TF_MODEL_FOR_VISION_2_SEQ_MAPPING if self.framework == "tf" else MODEL_FOR_VISION_2_SEQ_MAPPING
-        )
 
     def _sanitize_parameters(self, max_new_tokens=None, generate_kwargs=None, prompt=None):
         forward_kwargs = {}

--- a/src/transformers/pipelines/mask_generation.py
+++ b/src/transformers/pipelines/mask_generation.py
@@ -14,7 +14,6 @@ from .base import PIPELINE_INIT_ARGS, ChunkPipeline
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import MODEL_FOR_MASK_GENERATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -95,8 +94,6 @@ class MaskGenerationPipeline(ChunkPipeline):
 
         if self.framework != "pt":
             raise ValueError(f"The {self.__class__} is only available in PyTorch.")
-
-        self.check_model_type(MODEL_FOR_MASK_GENERATION_MAPPING)
 
     def _sanitize_parameters(self, **kwargs):
         preprocess_kwargs = {}

--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -11,7 +11,6 @@ if is_vision_available():
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import MODEL_FOR_OBJECT_DETECTION_MAPPING, MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -53,9 +52,6 @@ class ObjectDetectionPipeline(Pipeline):
             raise ValueError(f"The {self.__class__} is only available in PyTorch.")
 
         requires_backends(self, "vision")
-        self.check_model_type(
-            dict(MODEL_FOR_OBJECT_DETECTION_MAPPING.items() + MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING.items())
-        )
 
     def _sanitize_parameters(self, **kwargs):
         postprocess_kwargs = {}

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -31,15 +31,11 @@ if TYPE_CHECKING:
 if is_tf_available():
     import tensorflow as tf
 
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING
-
     Dataset = None
 
 if is_torch_available():
     import torch
     from torch.utils.data import Dataset
-
-    from ..models.auto.modeling_auto import MODEL_FOR_QUESTION_ANSWERING_MAPPING
 
 
 def decode_spans(
@@ -268,9 +264,6 @@ class QuestionAnsweringPipeline(ChunkPipeline):
         )
 
         self._args_parser = QuestionAnsweringArgumentHandler()
-        self.check_model_type(
-            TF_MODEL_FOR_QUESTION_ANSWERING_MAPPING if self.framework == "tf" else MODEL_FOR_QUESTION_ANSWERING_MAPPING
-        )
 
     @staticmethod
     def create_sample(

--- a/src/transformers/pipelines/table_question_answering.py
+++ b/src/transformers/pipelines/table_question_answering.py
@@ -16,19 +16,10 @@ from .base import PIPELINE_INIT_ARGS, ArgumentHandler, Dataset, Pipeline, Pipeli
 if is_torch_available():
     import torch
 
-    from ..models.auto.modeling_auto import (
-        MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
-    )
 
 if is_tf_available() and is_tensorflow_probability_available():
     import tensorflow as tf
     import tensorflow_probability as tfp
-
-    from ..models.auto.modeling_tf_auto import (
-        TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
-        TF_MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING,
-    )
 
 
 class TableQuestionAnsweringArgumentHandler(ArgumentHandler):
@@ -121,17 +112,6 @@ class TableQuestionAnsweringPipeline(Pipeline):
     def __init__(self, args_parser=TableQuestionAnsweringArgumentHandler(), *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._args_parser = args_parser
-
-        self.check_model_type(
-            dict(
-                TF_MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING.items()
-                + TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items()
-            )
-            if self.framework == "tf"
-            else dict(
-                MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING.items() + MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING.items()
-            )
-        )
 
         self.aggregate = bool(getattr(self.model.config, "aggregation_labels", None)) and bool(
             getattr(self.model.config, "num_aggregation_labels", None)

--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -2,17 +2,13 @@ import enum
 import warnings
 
 from ..tokenization_utils import TruncationStrategy
-from ..utils import add_end_docstrings, is_tf_available, is_torch_available, logging
+from ..utils import add_end_docstrings, is_tf_available, logging
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
 if is_tf_available():
     import tensorflow as tf
 
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -63,12 +59,6 @@ class Text2TextGenerationPipeline(Pipeline):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.check_model_type(
-            TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-            if self.framework == "tf"
-            else MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
-        )
 
     def _sanitize_parameters(
         self,

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -8,10 +8,10 @@ from .base import PIPELINE_INIT_ARGS, GenericTensor, Pipeline
 
 
 if is_tf_available():
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+    pass
 
 if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+    pass
 
 
 def sigmoid(_outputs):
@@ -81,12 +81,6 @@ class TextClassificationPipeline(Pipeline):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-        self.check_model_type(
-            TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
-            if self.framework == "tf"
-            else MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
-        )
 
     def _sanitize_parameters(self, return_all_scores=None, function_to_apply=None, top_k="", **tokenizer_kwargs):
         # Using "" as default argument because we're going to use `top_k=None` in user code to declare

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -1,16 +1,12 @@
 import enum
 import warnings
 
-from .. import MODEL_FOR_CAUSAL_LM_MAPPING, TF_MODEL_FOR_CAUSAL_LM_MAPPING
-from ..utils import add_end_docstrings, is_peft_available, is_tf_available
+from ..utils import add_end_docstrings, is_tf_available
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
 if is_tf_available():
     import tensorflow as tf
-
-if is_peft_available():
-    from peft import PeftModelForCausalLM
 
 
 class ReturnType(enum.Enum):
@@ -64,15 +60,6 @@ class TextGenerationPipeline(Pipeline):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        models_mapping_to_check = (
-            TF_MODEL_FOR_CAUSAL_LM_MAPPING if self.framework == "tf" else MODEL_FOR_CAUSAL_LM_MAPPING
-        )
-        if self.framework == "pt" and is_peft_available():
-            extra_custom_model_classes = [PeftModelForCausalLM]
-        else:
-            extra_custom_model_classes = None
-
-        self.check_model_type(models_mapping_to_check, extra_custom_model_classes)
         if "prefix" not in self._preprocess_params:
             # This is very specific. The logic is quite complex and needs to be done
             # as a "default".

--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -9,17 +9,12 @@ from ..utils import (
     ExplicitEnum,
     add_end_docstrings,
     is_tf_available,
-    is_torch_available,
 )
 from .base import PIPELINE_INIT_ARGS, ArgumentHandler, ChunkPipeline, Dataset
 
 
 if is_tf_available():
     import tensorflow as tf
-
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
 
 
 class TokenClassificationArgumentHandler(ArgumentHandler):
@@ -134,11 +129,6 @@ class TokenClassificationPipeline(ChunkPipeline):
 
     def __init__(self, args_parser=TokenClassificationArgumentHandler(), *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.check_model_type(
-            TF_MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
-            if self.framework == "tf"
-            else MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING
-        )
 
         self._basic_tokenizer = BasicTokenizer(do_lower_case=False)
         self._args_parser = args_parser

--- a/src/transformers/pipelines/video_classification.py
+++ b/src/transformers/pipelines/video_classification.py
@@ -3,7 +3,7 @@ from typing import List, Union
 
 import requests
 
-from ..utils import add_end_docstrings, is_decord_available, is_torch_available, logging, requires_backends
+from ..utils import add_end_docstrings, is_decord_available, logging, requires_backends
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
@@ -11,9 +11,6 @@ if is_decord_available():
     import numpy as np
     from decord import VideoReader
 
-
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -34,7 +31,6 @@ class VideoClassificationPipeline(Pipeline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         requires_backends(self, "decord")
-        self.check_model_type(MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING)
 
     def _sanitize_parameters(self, top_k=None, num_frames=None, frame_sampling_rate=None):
         preprocess_params = {}

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging
+from ..utils import add_end_docstrings, is_vision_available, logging
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
@@ -8,9 +8,6 @@ if is_vision_available():
     from PIL import Image
 
     from ..image_utils import load_image
-
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -53,7 +50,6 @@ class VisualQuestionAnsweringPipeline(Pipeline):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.check_model_type(MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING)
 
     def _sanitize_parameters(self, top_k=None, padding=None, truncation=None, **kwargs):
         preprocess_params, postprocess_params = {}, {}

--- a/src/transformers/pipelines/zero_shot_image_classification.py
+++ b/src/transformers/pipelines/zero_shot_image_classification.py
@@ -4,7 +4,6 @@ from typing import List, Union
 from ..utils import (
     add_end_docstrings,
     is_tf_available,
-    is_torch_available,
     is_vision_available,
     logging,
     requires_backends,
@@ -17,11 +16,7 @@ if is_vision_available():
 
     from ..image_utils import load_image
 
-if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_ZERO_SHOT_IMAGE_CLASSIFICATION_MAPPING
-
 if is_tf_available():
-    from ..models.auto.modeling_tf_auto import TF_MODEL_FOR_ZERO_SHOT_IMAGE_CLASSIFICATION_MAPPING
     from ..tf_utils import stable_softmax
 
 logger = logging.get_logger(__name__)
@@ -65,11 +60,6 @@ class ZeroShotImageClassificationPipeline(Pipeline):
         super().__init__(**kwargs)
 
         requires_backends(self, "vision")
-        self.check_model_type(
-            TF_MODEL_FOR_ZERO_SHOT_IMAGE_CLASSIFICATION_MAPPING
-            if self.framework == "tf"
-            else MODEL_FOR_ZERO_SHOT_IMAGE_CLASSIFICATION_MAPPING
-        )
 
     def __call__(self, images: Union[str, List[str], "Image", List["Image"]], **kwargs):
         """

--- a/src/transformers/pipelines/zero_shot_object_detection.py
+++ b/src/transformers/pipelines/zero_shot_object_detection.py
@@ -14,7 +14,6 @@ if is_torch_available():
 
     from transformers.modeling_outputs import BaseModelOutput
 
-    from ..models.auto.modeling_auto import MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING
 
 logger = logging.get_logger(__name__)
 
@@ -60,7 +59,6 @@ class ZeroShotObjectDetectionPipeline(ChunkPipeline):
             raise ValueError(f"The {self.__class__} is only available in PyTorch.")
 
         requires_backends(self, "vision")
-        self.check_model_type(MODEL_FOR_ZERO_SHOT_OBJECT_DETECTION_MAPPING)
 
     def __call__(
         self,

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -68,6 +68,7 @@ from .utils import (
     is_onnx_available,
     is_optimum_available,
     is_pandas_available,
+    is_peft_available,
     is_phonemizer_available,
     is_pyctcdecode_available,
     is_pytesseract_available,
@@ -419,6 +420,13 @@ def require_torchaudio(test_case):
     Decorator marking a test that requires torchaudio. These tests are skipped when torchaudio isn't installed.
     """
     return unittest.skipUnless(is_torchaudio_available(), "test requires torchaudio")(test_case)
+
+
+def require_peft(test_case):
+    """
+    Decorator marking a test that requires PEFT. These tests are skipped when PEFT isn't installed.
+    """
+    return unittest.skipUnless(is_peft_available(), "test requires PEFT")(test_case)
 
 
 def require_tf(test_case):

--- a/tests/pipelines/test_pipelines_peft.py
+++ b/tests/pipelines/test_pipelines_peft.py
@@ -1,0 +1,148 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers.pipelines import pipeline
+from transformers.testing_utils import (
+    is_pipeline_test,
+    require_torch,
+    require_peft,
+    slow,
+)
+from transformers.utils import is_peft_available
+
+from .test_pipelines_common import ANY
+
+if is_peft_available():
+    from peft import PeftModel, AutoPeftModelForCausalLM
+
+@is_pipeline_test
+@slow
+@require_peft
+@require_torch
+class PeftIntegrationPipelineTests(unittest.TestCase):
+    r"""
+    Few tests to check if pipeline is compatible with PEFT models.
+    """
+    def test_pipeline_text_generation_with_kwargs(self):
+        model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
+        peft_model_kwargs = {"adapter_name": "default"}
+
+        pipe = pipeline("text-generation", model_id, peft_model_kwargs=peft_model_kwargs)
+        output = pipe("Hello, my name is ")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {"generated_text": ANY(str)},
+            ],
+        )
+
+    def test_pipeline_text_generation(self):
+        model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
+        tok_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
+
+        pipe = pipeline("text-generation", model_id)
+        output = pipe("Hello, my name is ")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {"generated_text": ANY(str)},
+            ],
+        )
+
+        # with an external model
+        peft_model = AutoPeftModelForCausalLM.from_pretrained(model_id)
+        pipe = pipeline("text-generation", peft_model, tokenizer=tok_id)
+        output = pipe("Hello, my name is ")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {"generated_text": ANY(str)},
+            ],
+        )
+    
+
+    def test_pipeline_question_answering(self):
+        model_id = "peft-internal-testing/tiny_OPTForQuestionAnswering-lora"
+
+        pipe = pipeline("question-answering", model_id)
+        output = pipe(
+            question=["What field is HuggingFace working ?", "In what field is HuggingFace ?"],
+            context=[
+                "HuggingFace is a startup based in New-York",
+                "HuggingFace is a startup founded in Paris",
+            ],
+        )
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {"answer": ANY(str), "start": ANY(int), "end": ANY(int), "score": ANY(float)},
+                {"answer": ANY(str), "start": ANY(int), "end": ANY(int), "score": ANY(float)},
+            ],
+        )
+
+    def test_pipeline_token_classification(self):
+        model_id = "peft-internal-testing/tiny_GPT2ForTokenClassification-lora"
+
+        pipe = pipeline("token-classification", model_id)
+        output = pipe("Hello")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {
+                    "entity": ANY(str),
+                    "score": ANY(float),
+                    "start": ANY(int),
+                    "end": ANY(int),
+                    "index": ANY(int),
+                    "word": ANY(str),
+                }
+                for i in range(len(output))
+            ],
+        )
+    
+    def test_pipeline_text2text_generation(self):
+        model_id = "peft-internal-testing/tiny_T5ForSeq2SeqLM-lora"
+
+        pipe = pipeline("text2text-generation", model_id)
+        output = pipe("Hello")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertEqual(
+            output,
+            [
+                {"generated_text": ANY(str)},
+            ],
+        )
+    
+
+    def test_pipeline_feature_extraction(self):
+        model_id = "peft-internal-testing/tiny_OPTForFeatureExtraction-lora"
+
+        pipe = pipeline("feature-extraction", model_id)
+        output = pipe("Hello")
+
+        self.assertTrue(isinstance(pipe.model, PeftModel))
+        self.assertTrue(isinstance(output, list) and isinstance(output[0], list) and isinstance(output[0][0], list) and isinstance(output[0][0][0], float))

--- a/tests/pipelines/test_pipelines_peft.py
+++ b/tests/pipelines/test_pipelines_peft.py
@@ -17,16 +17,18 @@ import unittest
 from transformers.pipelines import pipeline
 from transformers.testing_utils import (
     is_pipeline_test,
-    require_torch,
     require_peft,
+    require_torch,
     slow,
 )
 from transformers.utils import is_peft_available
 
 from .test_pipelines_common import ANY
 
+
 if is_peft_available():
-    from peft import PeftModel, AutoPeftModelForCausalLM
+    from peft import AutoPeftModelForCausalLM, PeftModel
+
 
 @is_pipeline_test
 @slow
@@ -36,6 +38,7 @@ class PeftIntegrationPipelineTests(unittest.TestCase):
     r"""
     Few tests to check if pipeline is compatible with PEFT models.
     """
+
     def test_pipeline_text_generation_with_kwargs(self):
         model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
         peft_model_kwargs = {"adapter_name": "default"}
@@ -78,7 +81,6 @@ class PeftIntegrationPipelineTests(unittest.TestCase):
                 {"generated_text": ANY(str)},
             ],
         )
-    
 
     def test_pipeline_question_answering(self):
         model_id = "peft-internal-testing/tiny_OPTForQuestionAnswering-lora"
@@ -122,7 +124,7 @@ class PeftIntegrationPipelineTests(unittest.TestCase):
                 for i in range(len(output))
             ],
         )
-    
+
     def test_pipeline_text2text_generation(self):
         model_id = "peft-internal-testing/tiny_T5ForSeq2SeqLM-lora"
 
@@ -136,7 +138,6 @@ class PeftIntegrationPipelineTests(unittest.TestCase):
                 {"generated_text": ANY(str)},
             ],
         )
-    
 
     def test_pipeline_feature_extraction(self):
         model_id = "peft-internal-testing/tiny_OPTForFeatureExtraction-lora"
@@ -145,4 +146,9 @@ class PeftIntegrationPipelineTests(unittest.TestCase):
         output = pipe("Hello")
 
         self.assertTrue(isinstance(pipe.model, PeftModel))
-        self.assertTrue(isinstance(output, list) and isinstance(output[0], list) and isinstance(output[0][0], list) and isinstance(output[0][0][0], float))
+        self.assertTrue(
+            isinstance(output, list)
+            and isinstance(output[0], list)
+            and isinstance(output[0][0], list)
+            and isinstance(output[0][0][0], float)
+        )


### PR DESCRIPTION
# What does this PR do?

Replaces https://github.com/huggingface/peft/pull/585 

After discussing with @LysandreJik I made this PoC PR to see whether it is simpler to add PEFT support directly in transformers and centralize all sort of pipelines in transformers pipeline. In the future, we can concentrate the efforts on diffusers side to add PEFT support there as well.

Do not merge before the next PEFT release

Currently the API looks as follows:

```python
from transformers import pipeline 

peft_model_id = "ybelkada/opt-350m-lora"
pipe = pipeline("text-generation", peft_model_id)
print(pipe("hello"))

pipe = pipeline("text-generation", peft_model_id, peft_model_kwargs={"adapter_name": "default"})
print(pipe("hello"))

local_peft_pipeline_path = "./test_lora_pipeline"
pipe.model.save_pretrained(local_peft_pipeline_path)

pipe = pipeline("text-generation", local_peft_pipeline_path)
print(pipe("hello"))
```

## TODOS:

- [ ] seq2seq generation
- [ ] seq classification
- [ ] Add check with task_type
- [ ] add clean tests
- [ ] update docs