### PR TITLE
Fix lr scheduler not being reset on reruns

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -689,7 +689,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # Internal variables to keep track of the original batch size
-        self._train_batch_size = args.train_batch_size
+        self._train_batch_size = self.args.train_batch_size
 
         # very last
         self._memory_tracker.stop_and_update_metrics()
@@ -1504,7 +1504,7 @@ class Trainer:
             raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
         # This might change the seed so needs to run first.
         self._hp_search_setup(trial)
-        self._train_batch_size = args.train_batch_size
+        self._train_batch_size = self.args.train_batch_size
 
         # Model re-init
         model_reloaded = False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1547,7 +1547,6 @@ class Trainer:
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
         self.accelerator.free_memory()
-        # We need to reset the scheduler, as its parameters may be different on subsequent calls
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps
@@ -1615,6 +1614,8 @@ class Trainer:
             or is_sagemaker_mp_enabled()
             or self.fsdp is not None
         )
+        
+        # We need to reset the scheduler, as its parameters may be different on subsequent calls
         if self._created_lr_scheduler:
             self.lr_scheduler = None
             self._created_lr_scheduler = False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -688,8 +688,9 @@ class Trainer:
         self.can_return_loss = can_return_loss(self.model.__class__)
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
-        # Internal variables to keep track of the original batch size
+        # Internal variables to help with automatic batch size reduction
         self._train_batch_size = args.train_batch_size
+        self._created_lr_scheduler = False
 
         # very last
         self._memory_tracker.stop_and_update_metrics()
@@ -1150,6 +1151,7 @@ class Trainer:
                 num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 num_training_steps=num_training_steps,
             )
+            self._created_lr_scheduler = True
         return self.lr_scheduler
 
     def num_examples(self, dataloader: DataLoader) -> int:
@@ -1546,8 +1548,6 @@ class Trainer:
     ):
         self.accelerator.free_memory()
         # We need to reset the scheduler, as its parameters may be different on subsequent calls
-        if hasattr(self, "lr_scheduler"):
-            self.lr_scheduler = None
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps
@@ -1615,6 +1615,9 @@ class Trainer:
             or is_sagemaker_mp_enabled()
             or self.fsdp is not None
         )
+        if self._created_lr_scheduler:
+            self.lr_scheduler = None
+            self._created_lr_scheduler = False
 
         if self.is_deepspeed_enabled:
             self.optimizer, self.lr_scheduler = deepspeed_init(self, num_training_steps=max_steps)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -689,7 +689,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # Internal variables to keep track of the original per-device batch size
-        self._train_batch_size = args.train_batch_size // max(1, self.args.n_gpu)
+        self._train_batch_size = args.train_batch_size
 
         # very last
         self._memory_tracker.stop_and_update_metrics()
@@ -1504,7 +1504,7 @@ class Trainer:
             raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
         # This might change the seed so needs to run first.
         self._hp_search_setup(trial)
-        self._train_batch_size = args.train_batch_size // max(1, self.args.n_gpu)
+        self._train_batch_size = args.train_batch_size
 
         # Model re-init
         model_reloaded = False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -688,8 +688,8 @@ class Trainer:
         self.can_return_loss = can_return_loss(self.model.__class__)
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
-        # Internal variables to keep track of the original batch size
-        self._train_batch_size = args.train_batch_size
+        # Internal variables to keep track of the original per-device batch size
+        self._train_batch_size = args.train_batch_size / max(1, self.args.n_gpu)
 
         # very last
         self._memory_tracker.stop_and_update_metrics()
@@ -1504,7 +1504,7 @@ class Trainer:
             raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
         # This might change the seed so needs to run first.
         self._hp_search_setup(trial)
-        self._train_batch_size = self.args.train_batch_size
+        self._train_batch_size = args.train_batch_size / max(1, self.args.n_gpu)
 
         # Model re-init
         model_reloaded = False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1614,7 +1614,7 @@ class Trainer:
             or is_sagemaker_mp_enabled()
             or self.fsdp is not None
         )
-        
+
         # We need to reset the scheduler, as its parameters may be different on subsequent calls
         if self._created_lr_scheduler:
             self.lr_scheduler = None

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -688,7 +688,7 @@ class Trainer:
         self.can_return_loss = can_return_loss(self.model.__class__)
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
-        # Internal variables to keep track of the original per-device batch size
+        # Internal variables to keep track of the original batch size
         self._train_batch_size = args.train_batch_size
 
         # very last

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -689,7 +689,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # Internal variables to keep track of the original per-device batch size
-        self._train_batch_size = args.train_batch_size / max(1, self.args.n_gpu)
+        self._train_batch_size = args.train_batch_size // max(1, self.args.n_gpu)
 
         # very last
         self._memory_tracker.stop_and_update_metrics()
@@ -1504,7 +1504,7 @@ class Trainer:
             raise TypeError(f"train() received got unexpected keyword arguments: {', '.join(list(kwargs.keys()))}.")
         # This might change the seed so needs to run first.
         self._hp_search_setup(trial)
-        self._train_batch_size = args.train_batch_size / max(1, self.args.n_gpu)
+        self._train_batch_size = args.train_batch_size // max(1, self.args.n_gpu)
 
         # Model re-init
         model_reloaded = False
@@ -1545,6 +1545,9 @@ class Trainer:
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
     ):
         self.accelerator.free_memory()
+        # We need to reset the scheduler, as its parameters may be different on subsequent calls
+        if hasattr(self, "lr_scheduler"):
+            self.lr_scheduler = None
         self._train_batch_size = batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -689,7 +689,7 @@ class Trainer:
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # Internal variables to keep track of the original batch size
-        self._train_batch_size = self.args.train_batch_size
+        self._train_batch_size = args.train_batch_size
 
         # very last
         self._memory_tracker.stop_and_update_metrics()


### PR DESCRIPTION
# What does this PR do?

This PR ensures that a new learning rate scheduler is created each time we rerun the `inner_training_loop`, so that if we have an lr such as `linear`, a new LR is generated based on the new batch size and step count. I don't believe a new optimizer is needed here to be recreated, just the scheduler as adjusting the bs and lr *shouldn't* matter? But if we think it is we can go ahead and add a reset to the optimizer as well.

Fixes # (issue)

The true solution to https://github.com/huggingface/transformers/pull/24521

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger
