### PR TITLE
:bug: Handle empty gen_kwargs for seq2seq trainer prediction_step function

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -258,13 +258,8 @@ class Seq2SeqTrainer(Trainer):
         # Priority (handled in generate):
         # gen_kwargs > model.generation_config > default GenerationConfig()
 
-        if gen_kwargs:
-            # overriding gen_kwargs have been provided, use those
-            gen_kwargs = gen_kwargs.copy()
-        elif hasattr(self, "_gen_kwargs"):
+        if len(gen_kwargs) == 0 and hasattr(self, "_gen_kwargs"):
             gen_kwargs = self._gen_kwargs.copy()
-        else:
-            gen_kwargs = {}
 
         if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
             gen_kwargs["max_length"] = self.model.config.max_length

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -221,6 +221,7 @@ class Seq2SeqTrainer(Trainer):
         inputs: Dict[str, Union[torch.Tensor, Any]],
         prediction_loss_only: bool,
         ignore_keys: Optional[List[str]] = None,
+        **gen_kwargs,
     ) -> Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
         Perform an evaluation step on `model` using `inputs`.
@@ -237,6 +238,8 @@ class Seq2SeqTrainer(Trainer):
                 argument `labels`. Check your model's documentation for all accepted arguments.
             prediction_loss_only (`bool`):
                 Whether or not to return the loss only.
+            gen_kwargs:
+                Additional `generate` specific kwargs.
 
         Return:
             Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]: A tuple with the loss, logits and
@@ -254,7 +257,15 @@ class Seq2SeqTrainer(Trainer):
         # XXX: adapt synced_gpus for fairscale as well
         # Priority (handled in generate):
         # gen_kwargs > model.generation_config > default GenerationConfig()
-        gen_kwargs = self._gen_kwargs.copy()
+
+        if gen_kwargs:
+            # overriding gen_kwargs have been provided, use those
+            gen_kwargs = gen_kwargs.copy()
+        elif hasattr(self, "_gen_kwargs"):
+            gen_kwargs = self._gen_kwargs.copy()
+        else:
+            gen_kwargs = {}
+
         if gen_kwargs.get("max_length") is None and gen_kwargs.get("max_new_tokens") is None:
             gen_kwargs["max_length"] = self.model.config.max_length
         gen_kwargs["num_beams"] = (


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

All Trainers expose function `prediction_step`. For `Seq2SeqTrainer`, it seems like the `prediction_step` function is relying on availability of `_gen_kwargs` attribute, which will get set automatically, if `prediction_step` will get called from other functions like `predict` or `evaluate`. However, if someone calls `prediction_step` directly, then this field will not get set and currently will throw `AttributeError: 'Seq2SeqTrainer' object has no attribute '_gen_kwargs'`. 

In this PR, I am trying to resolve above issue by accepting `gen_kwargs` as an argument to `prediction_step` function, in addition to automatically get it from `self` if it has been set previously while falling back to empty `{}` in case its not set in either of those methods. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


cc: @sgugger