### PR TITLE
Add MobileVitV2 to doctests

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -75,7 +75,6 @@ IMAGE_PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("mgp-str", "ViTImageProcessor"),
         ("mobilenet_v1", "MobileNetV1ImageProcessor"),
         ("mobilenet_v2", "MobileNetV2ImageProcessor"),
-        ("mobilenet_v2", "MobileNetV2ImageProcessor"),
         ("mobilevit", "MobileViTImageProcessor"),
         ("mobilevit", "MobileViTImageProcessor"),
         ("mobilevitv2", "MobileViTImageProcessor"),

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -299,8 +299,8 @@ src/transformers/models/mobilevit/feature_extraction_mobilevit.py
 src/transformers/models/mobilevit/image_processing_mobilevit.py
 src/transformers/models/mobilevit/modeling_mobilevit.py
 src/transformers/models/mobilevit/modeling_tf_mobilevit.py
-src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
 src/transformers/models/mobilevitv2/configuration_mobilevitv2.py
+src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
 src/transformers/models/mpnet/tokenization_mpnet.py
 src/transformers/models/mpnet/tokenization_mpnet_fast.py
 src/transformers/models/musicgen/configuration_musicgen.py

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -299,6 +299,8 @@ src/transformers/models/mobilevit/feature_extraction_mobilevit.py
 src/transformers/models/mobilevit/image_processing_mobilevit.py
 src/transformers/models/mobilevit/modeling_mobilevit.py
 src/transformers/models/mobilevit/modeling_tf_mobilevit.py
+src/transformers/models/mobilevitv2/modeling_mobilevitv2.py
+src/transformers/models/mobilevitv2/configuration_mobilevitv2.py
 src/transformers/models/mpnet/tokenization_mpnet.py
 src/transformers/models/mpnet/tokenization_mpnet_fast.py
 src/transformers/models/musicgen/configuration_musicgen.py


### PR DESCRIPTION
# What does this PR do?

Adds MobileVitV2 to the doctests. The example snippet wasn't working because the model's config files pointed to an image processor that doesn't exist. This adds the models to the doctests so that this is caught. 

Also removes a duplicate line in image_processing_auto.py

Fixes #24763 (partially)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?