### PR TITLE
Update default values of bos/eos token ids in `CLIPTextConfig`

### DIFF
--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -105,6 +105,8 @@ class CLIPTextConfig(PretrainedConfig):
         attention_dropout=0.0,
         initializer_range=0.02,
         initializer_factor=1.0,
+        # This differs from `CLIPTokenizer`'s default and from openai/clip
+        # See https://github.com/huggingface/transformers/pull/24773#issuecomment-1632287538
         pad_token_id=1,
         bos_token_id=49406,
         eos_token_id=49407,

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -106,10 +106,16 @@ class CLIPTextConfig(PretrainedConfig):
         initializer_range=0.02,
         initializer_factor=1.0,
         pad_token_id=1,
-        bos_token_id=0,
-        eos_token_id=2,
+        bos_token_id=49406,
+        eos_token_id=49407,
         **kwargs,
     ):
+        # (TODO): remove this comment
+        #  we can't just reset `eos_token_id` to `vocab_size - 1`!
+        #    - we need to respect the value in the config file.
+        #    - (even if we want to reset, `eos_token_id` is not just `vocab_size - 1` when user adding more tokens)
+        #  Before all the config files on Hub repo. are updated, we can't use `config.eos_token_id` in the modeling.
+
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -112,12 +112,6 @@ class CLIPTextConfig(PretrainedConfig):
         eos_token_id=49407,
         **kwargs,
     ):
-        # (TODO): remove this comment
-        #  we can't just reset `eos_token_id` to `vocab_size - 1`!
-        #    - we need to respect the value in the config file.
-        #    - (even if we want to reset, `eos_token_id` is not just `vocab_size - 1` when user adding more tokens)
-        #  Before all the config files on Hub repo. are updated, we can't use `config.eos_token_id` in the modeling.
-
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 
         self.vocab_size = vocab_size


### PR DESCRIPTION
# What does this PR do?

Currently the default values are not the ones from the corresponding tokenizers.

See discussion in #24650

However, we can't use the `config.eos_token_id` in the modeling file (which is the ultimate goal in #24650) with only the change in this PR. We will have to update all the Hub repo. config files first 😢 . (Probably there is something easier to do)