### PR TITLE
To work out tokenization_utils_base.py:731 list to tensor so slow

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -728,7 +728,7 @@ class BatchEncoding(UserDict):
                     value = [value]
 
                 if not is_tensor(value):
-                    tensor = as_tensor(value)
+                    tensor = as_tensor(np.asarray(value))
 
                     # Removing this for now in favor of controlling the shape with `prepend_batch_axis`
                     # # at-least2d


### PR DESCRIPTION
tokenization_utils_base.py:731: UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.asarray() before converting to a tensor. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:230.)
Solved this problem to accelerate  list to tensor.