### PR TITLE
Skip torchscript tests for `MusicgenForConditionalGeneration`

### DIFF
--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -506,6 +506,9 @@ class MusicgenTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     test_pruning = False  # training is not supported yet for MusicGen
     test_headmasking = False
     test_resize_embeddings = False
+    # not to test torchscript as the model tester doesn't prepare `input_values` and `padding_mask`
+    # (and `torchscript` hates `None` values).
+    test_torchscript = False
 
     def setUp(self):
         self.model_tester = MusicgenTester(self)


### PR DESCRIPTION
# What does this PR do?

This model class requires the model tester to prepare `input_values` and `padding_mask` for torchscript tests.
So far I think it is fine to skip it until we have high usage.
