### PR TITLE
[`core`] PEFT integration

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -423,6 +423,17 @@ onnx_job = CircleCIJob(
 )
 
 
+peft_job = CircleCIJob(
+    "peft",
+    install_steps=[
+        "sudo apt-get -y update && sudo apt-get install -y cmake",
+        "pip install --upgrade --upgrade-strategy eager pip",
+        "pip install -U --upgrade-strategy eager .[torch,testing,sentencepiece,vision,peft]",
+    ],
+    pytest_num_workers=1,
+)
+
+
 exotic_models_job = CircleCIJob(
     "exotic_models",
     install_steps=[
@@ -512,6 +523,7 @@ REGULAR_TESTS = [
     hub_job,
     onnx_job,
     exotic_models_job,
+    peft_job,
 ]
 EXAMPLES_TESTS = [
     examples_torch_job,

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -428,7 +428,7 @@ peft_job = CircleCIJob(
     install_steps=[
         "sudo apt-get -y update && sudo apt-get install -y cmake",
         "pip install --upgrade --upgrade-strategy eager pip",
-        "pip install -U --upgrade-strategy eager .[torch,testing,sentencepiece,vision,peft]",
+        "pip install -U --upgrade-strategy eager .[torch,testing,sentencepiece,peft]",
     ],
     pytest_num_workers=1,
     tests_to_run=[

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -431,6 +431,9 @@ peft_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager .[torch,testing,sentencepiece,vision,peft]",
     ],
     pytest_num_workers=1,
+    tests_to_run=[
+        "tests/peft_integration/test_peft_models.py"
+    ]
 )
 
 

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -42,6 +42,9 @@ RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
 
+# Add peft for PEFT integration
+RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/peft@main#egg=peft
+
 # Add bitsandbytes for mixed int8 testing
 RUN python3 -m pip install --no-cache-dir bitsandbytes
 

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -23,6 +23,8 @@
     title: Share your model
   - local: transformers_agents
     title: Agents
+  - local: peft
+    title: Load model adapters and train them with 🤗 PEFT
   title: Tutorials
 - sections:
   - sections:

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -14,19 +14,17 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Loading adapters using the 🤗 PEFT library
+# Load adapters with 🤗 PEFT
 
-*What are adapters and why are they are useful?*. If you are not familiar with adapters and Parameter-Efficient Fine Tuning (PEFT) approaches, we advise you to have a look at the introduction of the [🤗 PEFT announcement blogpost](https://huggingface.co/blog/peft).
+[Parameter-Efficient Fine Tuning (PEFT)](https://huggingface.co/blog/peft) methods aim to fine-tune a pretrained model while keeping the number of trainable parameters as low as possible. This is achieved by freezing the pretrained model and adding a small number of trainable parameters (the adapters) on top of it. The adapters are trained to learn task-specific information. This approach has been shown to be very memory-efficient with lower compute usage while producing results comparable to a fully fine-tuned model. 
 
-PEFT methods aims to fine-tune a pretrained model while keeping the number of trainable parameters as low as possible. This is achieved by freezing the pretrained model and adding a small number of trainable parameters (the adapters) on top of it. The adapters are then trained to learn the task-specific information. This approach has been shown to be very efficient in terms of memory and compute usage, while achieving competitive results compared to full fine-tuning. 
+Adapters trained with PEFT are also usually an order of magnitude smaller than the full model, making it convenient to share, store, and load them. In the image below, the adapter weights for a [`OPTForCausalLM`] model are stored on the Hub, and its weights are only ~6MB compared to the full size of the model weights, which can be ~700MB. 
 
-When training adapters with PEFT, you might want to save the trained adapter and share them with the community, usually the saved checkpoints are order of magnitude smaller than the full model. 
+<div class="flex justify-center">
+  <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/peft/PEFT-hub-screenshot.png"/>
+</div>
 
-| **Example screenshot of a PEFT adapter pushed on the Hub**                                           |
-|-----------------------------------------------------------------------------------------------------------------------------|
-| <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/peft/PEFT-hub-screenshot.png" width=200> | 
-
-Above is an example of what an adapter model would look like if correctly pushed on 🤗 Hub. The repo stores adapter weights of `OPTForCausalLM` model, that should have ~700MB of full model weights. As you can see from the screenshot, the adapter weights are only ~6MB, meaning the community can benefit from fine-tuned performance out of box and easily loading adapter weights.
+If you're interested in learning more about the 🤗 PEFT library, check out the [documentation](https://huggingface.co/docs/peft/index).
 
 ## Setup
 
@@ -41,6 +39,26 @@ If you want to try out the brand new features, you might be interested in instal
 ```bash
 pip install git+https://github.com/huggingface/peft.git
 ```
+
+## Load PEFT adapter
+
+To load and use a PEFT adapter model from 🤗 Transformers, make sure the Hub repository or local directory contains an `adapter_config.json` file and the adapter weights, as shown in the example image above. Then you can load the PEFT adapter model using the `AutoModelFor` class. For example, to load a PEFT adapter model for causal language modeling:
+
+1. specify the PEFT model id
+2. pass it to the [`AutoModelForCausalLM`] class
+
+```py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+peft_model_id = "ybelkada/opt-350m-lora"
+model = AutoModelForCausalLM.from_pretrained(peft_model_id)
+```
+
+<Tip>
+
+You can still load a PEFT adapter even if your model isn't an auto-mapped model as long as the Hub repository or your local directory contains an `adapter_config.json` file with the `base_model_name_or_path` key.
+
+</Tip>
 
 <!--
 

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -1,0 +1,53 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Loading adapters using the 🤗 PEFT library
+
+*What are adapters and why are they are useful?*. If you are not familiar with adapters and Parameter-Efficient Fine Tuning (PEFT) approaches, we advise you to have a look at the introduction of the [🤗 PEFT announcement blogpost](https://huggingface.co/blog/peft).
+
+PEFT methods aims to fine-tune a pretrained model while keeping the number of trainable parameters as low as possible. This is achieved by freezing the pretrained model and adding a small number of trainable parameters (the adapters) on top of it. The adapters are then trained to learn the task-specific information. This approach has been shown to be very efficient in terms of memory and compute usage, while achieving competitive results compared to full fine-tuning. 
+
+When training adapters with PEFT, you might want to save the trained adapter and share them with the community, usually the saved checkpoints are order of magnitude smaller than the full model. 
+
+| **Example screenshot of a PEFT adapter pushed on the Hub**                                           |
+|-----------------------------------------------------------------------------------------------------------------------------|
+| <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/peft/PEFT-hub-screenshot.png" width=200> | 
+
+Above is an example of what an adapter model would look like if correctly pushed on 🤗 Hub. The repo stores adapter weights of `OPTForCausalLM` model, that should have ~700MB of full model weights. As you can see from the screenshot, the adapter weights are only ~6MB, meaning the community can benefit from fine-tuned performance out of box and easily loading adapter weights.
+
+## Setup
+
+Get started by installing 🤗 PEFT:
+
+```bash
+pip install peft
+```
+
+If you want to try out the brand new features, you might be interesting in installing the library from source:
+
+```bash
+pip install git+https://github.com/huggingface/peft.git
+```
+
+<!--
+
+TODO: (@younesbelkada @stevhliu)
+
+-   From pretrained example - make sure to tell it works for auto mapping models + non-auto mapping models.
+-   Link to PEFT docs for further details
+-   Trainer integration - provide small snippets 
+-   8-bit / 4-bit examples ?
+-->

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -36,7 +36,7 @@ Get started by installing 🤗 PEFT:
 pip install peft
 ```
 
-If you want to try out the brand new features, you might be interesting in installing the library from source:
+If you want to try out the brand new features, you might be interested in installing the library from source:
 
 ```bash
 pip install git+https://github.com/huggingface/peft.git

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,7 @@ _deps = [
     "unidic_lite>=1.0.7",
     "urllib3<2.0.0",
     "uvicorn",
+    "peft>=0.4.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -293,6 +293,7 @@ extras["tf-speech"] = extras["audio"]
 extras["flax-speech"] = extras["audio"]
 extras["vision"] = deps_list("Pillow")
 extras["timm"] = deps_list("timm")
+extras["peft"] = deps_list("peft")
 extras["torch-vision"] = deps_list("torchvision") + extras["vision"]
 extras["natten"] = deps_list("natten")
 extras["codecarbon"] = deps_list("codecarbon")

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -88,4 +88,5 @@ deps = {
     "unidic_lite": "unidic_lite>=1.0.7",
     "urllib3": "urllib3<2.0.0",
     "uvicorn": "uvicorn",
+    "peft": "peft>=0.4.0",
 }

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2352,7 +2352,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_adapter_model_id = pretrained_model_name_or_path
 
                         logger.info(
-                            f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using the base model from {raw_adapter_config_dict['base_model_name_or_path']}"
+                            f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using" 
+                            f" the base model from {raw_adapter_config_dict['base_model_name_or_path']}"
                         )
                         pretrained_model_name_or_path = raw_adapter_config_dict["base_model_name_or_path"]
                     else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2975,6 +2975,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if is_peft_available() and is_adapter_file:
             from peft import PeftModel
 
+            # TODO: handle correctly PeftModel kwargs here
             model = PeftModel.from_pretrained(
                 model,
                 peft_adapter_model_id,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2192,15 +2192,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         kwargs.pop("peft_adapter_name", None)
         peft_adapter_model_id = kwargs.pop("_peft_adapter_model_id", None)
 
-        is_adapter_file = False
+        has_adapter_file = False
         if is_peft_available():
-            is_adapter_file = peft_adapter_model_id is not None
+            has_adapter_file = peft_adapter_model_id is not None
 
-        if is_adapter_file:
+        if has_adapter_file:
             logger.info(
-                "Found adapter file at {}. Automatically loading adapter model using the base model from {}".format(
-                    peft_adapter_model_id, pretrained_model_name_or_path
-                )
+                f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using the base model from {pretrained_model_name_or_path}"
             )
 
         if use_auth_token is not None:
@@ -2972,7 +2970,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 kwargs["skip_keys"] = model._skip_keys_device_placement
             dispatch_model(model, **kwargs)
 
-        if is_peft_available() and is_adapter_file:
+        if is_peft_available() and has_adapter_file:
             from peft import PeftModel
 
             # TODO: handle correctly PeftModel kwargs here

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2109,6 +2109,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             use_safetensors (`bool`, *optional*, defaults to `None`):
                 Whether or not to use `safetensors` checkpoints. Defaults to `None`. If not specified and `safetensors`
                 is not installed, it will be set to `False`.
+            peft_adapter_name (`str`, *optional*, defaults to `"default"`):
+                The default PEFT adapter name to load, in case the `pretrained_model_name_or_path` contains adapter
+                weights. The default adapter name (supported by PEFT library) is `"default"`.
+            _peft_adapter_model_id (`str`, *optional*, defaults to `None`):
+                The adapter model id retrieved by the `_BaseAutoModelClass` class in case users load the model through
+                auto mapping. This argument is exclusively created and passed by that class. Therefore, we advise users
+                to not manually pass this argumet unless they know what they are doing.
+
 
             kwargs (remaining dictionary of keyword arguments, *optional*):
                 Can be used to update the configuration object (after it being loaded) and initiate the model (e.g.,
@@ -2352,7 +2360,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_adapter_model_id = pretrained_model_name_or_path
 
                         logger.info(
-                            f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using" 
+                            f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using"
                             f" the base model from {raw_adapter_config_dict['base_model_name_or_path']}"
                         )
                         pretrained_model_name_or_path = raw_adapter_config_dict["base_model_name_or_path"]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2199,7 +2199,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if has_adapter_file:
             logger.info(
-                f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model using the base model from {pretrained_model_name_or_path}"
+                f"Found adapter file at {peft_adapter_model_id}. Automatically loading adapter model "
+                f"using the base model from {pretrained_model_name_or_path}"
             )
 
         if use_auth_token is not None:
@@ -2336,14 +2337,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not isinstance(config, PretrainedConfig):
             # In case users load models without auto mapping
             if is_peft_available() and peft_adapter_model_id is None:
-                raw_adapter_config_dict_path = cls._check_and_return_if_adapter_model(
+                raw_adapter_config_dict_path = cls._find_adapter_config_file(
                     pretrained_model_name_or_path,
                     revision=revision,
                     use_auth_token=use_auth_token,
                 )
 
                 if raw_adapter_config_dict_path is not None:
-                    raw_adapter_config_dict = json.load(open(raw_adapter_config_dict_path, "r"))
+                    with open(raw_adapter_config_dict_path, "r") as json_file:
+                        raw_adapter_config_dict = json.load(json_file)
 
                     if "base_model_name_or_path" in raw_adapter_config_dict:
                         has_adapter_file = True
@@ -3459,8 +3461,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         return error_msgs
 
     @classmethod
-    # Copied from transformers.models.auto.auto_factory._BaseAutoModelClass._check_and_return_if_adapter_model
-    def _check_and_return_if_adapter_model(
+    # Copied from transformers.models.auto.auto_factory._BaseAutoModelClass._find_adapter_config_file
+    def _find_adapter_config_file(
         cls,
         model_id: str,
         revision: str = None,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2189,7 +2189,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         subfolder = kwargs.pop("subfolder", "")
         commit_hash = kwargs.pop("_commit_hash", None)
         variant = kwargs.pop("variant", None)
-        kwargs.pop("peft_adapter_name", None)
+        peft_adapter_name = kwargs.pop("peft_adapter_name", "default")
         peft_adapter_model_id = kwargs.pop("_peft_adapter_model_id", None)
 
         has_adapter_file = False
@@ -2973,10 +2973,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if is_peft_available() and has_adapter_file:
             from peft import PeftModel
 
-            # TODO: handle correctly PeftModel kwargs here
             model = PeftModel.from_pretrained(
                 model,
                 peft_adapter_model_id,
+                adapter_name=peft_adapter_name,
+                device_map=device_map,
+                max_memory=max_memory,
+                offload_index=offload_index,
+                offload_dir=offload_folder,
+                subfolder=subfolder,
+                revision=revision,
+                cache_dir=cache_dir,
+                use_auth_token=use_auth_token,
             )
 
         if output_loading_info:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -549,24 +549,26 @@ class _BaseAutoModelClass:
         revision: str = None,
         use_auth_token: Optional[str] = None,
         commit_hash: Optional[str] = None,
-    ) -> bool:
+    ) -> Optional[str]:
         r"""
         Simply checks if the model stored on the Hub or locally is an adapter model or not
         """
         adapter_cached_filename = None
-        try:
+        if os.path.isdir(model_id):
+            list_remote_files = os.listdir(model_id)
+            if ADAPTER_CONFIG_NAME in list_remote_files:
+                adapter_cached_filename = os.path.join(model_id, ADAPTER_CONFIG_NAME)
+        else:
             adapter_cached_filename = cached_file(
                 model_id,
                 ADAPTER_CONFIG_NAME,
                 revision=revision,
                 use_auth_token=use_auth_token,
                 _commit_hash=commit_hash,
+                _raise_exceptions_for_missing_entries=False,
+                _raise_exceptions_for_connection_errors=False,
             )
-        except EnvironmentError:
-            if os.path.isdir(model_id):
-                list_remote_files = os.listdir(model_id)
-                if ADAPTER_CONFIG_NAME in list_remote_files:
-                    adapter_cached_filename = os.path.join(model_id, ADAPTER_CONFIG_NAME)
+
         return adapter_cached_filename
 
 

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -551,7 +551,8 @@ class _BaseAutoModelClass:
         commit_hash: Optional[str] = None,
     ) -> Optional[str]:
         r"""
-        Simply checks if the model stored on the Hub or locally is an adapter model or not
+        Simply checks if the model stored on the Hub or locally is an adapter model or not, return the path the the
+        adapter config file if it is, None otherwise.
         """
         adapter_cached_filename = None
         if os.path.isdir(model_id):

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -461,7 +461,7 @@ class _BaseAutoModelClass:
                 _ = kwargs.pop("torch_dtype")
 
             if is_peft_available():
-                raw_adapter_config_dict_path = cls._check_and_return_if_adapter_model(
+                raw_adapter_config_dict_path = cls._find_adapter_config_file(
                     pretrained_model_name_or_path,
                     revision=hub_kwargs.get("revision", None),
                     use_auth_token=hub_kwargs.get("use_auth_token", None),
@@ -543,7 +543,7 @@ class _BaseAutoModelClass:
         cls._model_mapping.register(config_class, model_class, exist_ok=exist_ok)
 
     @classmethod
-    def _check_and_return_if_adapter_model(
+    def _find_adapter_config_file(
         cls,
         model_id: str,
         revision: str = None,

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -374,7 +374,7 @@ def require_peft(test_case):
     These tests are skipped when PEFT isn't installed.
 
     """
-    return unittest.skipUnless(is_peft_available(), "test requires PyTorch")(test_case)
+    return unittest.skipUnless(is_peft_available(), "test requires PEFT")(test_case)
 
 
 def require_torchvision(test_case):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -68,6 +68,7 @@ from .utils import (
     is_onnx_available,
     is_optimum_available,
     is_pandas_available,
+    is_peft_available,
     is_phonemizer_available,
     is_pyctcdecode_available,
     is_pytesseract_available,
@@ -364,6 +365,16 @@ def require_torch(test_case):
 
     """
     return unittest.skipUnless(is_torch_available(), "test requires PyTorch")(test_case)
+
+
+def require_peft(test_case):
+    """
+    Decorator marking a test that requires PEFT.
+
+    These tests are skipped when PEFT isn't installed.
+
+    """
+    return unittest.skipUnless(is_peft_available(), "test requires PyTorch")(test_case)
 
 
 def require_torchvision(test_case):

--- a/tests/peft_integration/__init__.py
+++ b/tests/peft_integration/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/peft_integration/__init__.py
+++ b/tests/peft_integration/__init__.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/peft_integration/test_peft_models.py
+++ b/tests/peft_integration/test_peft_models.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import inspect
+import unittest
+
+from transformers import AutoModelForCausalLM, OPTForCausalLM
+from transformers.utils import is_peft_available, is_torch_available
+from transformers.testing_utils import require_peft, torch_device, require_torch, slow, require_torch_gpu
+
+if is_peft_available():
+    from peft import PeftModel
+
+if is_torch_available():
+    import torch
+
+@require_peft
+@require_torch
+@slow
+class PeftTesterMixin:
+    # one safetensors adapters and one pickle adapter
+    peft_test_model_ids = (
+        "peft-internal-testing/opt-350m-lora-pickle",
+        "peft-internal-testing/opt-350m-lora"
+    )
+    transformers_test_model_classes = (
+        AutoModelForCausalLM, 
+        OPTForCausalLM
+    )
+
+
+class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
+    r"""
+    A testing suite that makes sure that the PeftModel class is correctly integrated into the transformers library.
+
+    - test_peft_from_pretrained:
+        Tests if the peft model is correctly loaded through `from_pretrained` method
+    - test_peft_from_pretrained_kwargs:
+        Tests if the kwargs are correctly passed to the peft model
+    """
+    
+    def test_peft_from_pretrained(self):
+        r"""
+        Simple test that tests the basic usage of PEFT model through `from_pretrained`
+        """
+        for model_id in self.peft_test_model_ids:
+            for transformers_class in self.transformers_test_model_classes:
+                peft_model = transformers_class.from_pretrained(model_id).to(torch_device)
+                self.assertTrue(isinstance(peft_model, PeftModel))
+
+                # dummy generation
+                _ = peft_model.generate(input_ids=torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]]).to(torch_device))
+
+
+    @require_torch_gpu
+    def test_peft_from_pretrained_kwargs(self):
+        r"""
+        Simple test that tests the basic usage of PEFT model through `from_pretrained` + additional kwargs
+        and see if the integraiton behaves as expected.
+        """
+        for model_id in self.peft_test_model_ids:
+            for transformers_class in self.transformers_test_model_classes:
+                peft_model = transformers_class.from_pretrained(model_id, load_in_8bit=True, device_map="auto")
+                self.assertTrue(isinstance(peft_model, PeftModel))
+
+                module = inspect.getmodule(peft_model.base_model.model.model.decoder.layers[0].self_attn.v_proj.__class__)
+                
+                # Check that the converted linear layers are from PEFT library - which is different from the 
+                # `Linear8bitLt` class from bnb.
+                # here `module` should be `peft/src/peft/tuners/lora.py` thus contain the class `LoraModel`
+                self.assertTrue("LoraModel" in dir(module))
+
+                # dummy generation
+                _ = peft_model.generate(input_ids=torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]]).to(torch_device))


### PR DESCRIPTION
# What does this PR do?

This PR is an attempt to tightly integrate PEFT library with transformers, by offering users the ability to load PEFT models out of the box from `AutoModelForxxx.from_pretrained()` if the local directory or the Hub model id contains adapter weights and adapter config.

```python
import tempfile
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import AutoPeftModelForCausalLM

peft_model_id = "ybelkada/opt-350m-lora"
model = AutoModelForCausalLM.from_pretrained(peft_model_id)

with tempfile.TemporaryDirectory() as tmpdirname:
    peft_model = AutoPeftModelForCausalLM.from_pretrained(peft_model_id)
    peft_model.save_pretrained(tmpdirname)

    model = AutoModelForCausalLM.from_pretrained(tmpdirname)
    print(model)
``` 

Although this is similar to what have been introduced in https://github.com/huggingface/peft/pull/694 this PR offers a direct integration with transformers 

## TODOs:

- [x]  handle `PeftModel.from_pretrained(xxx)` kwargs
- [x] tests
- [x] docs (with the help of @stevhliu )

cc @sgugger @pacman100 @BenjaminBossan 