### PR TITLE
[WIP] Add state in segments id calculation

### DIFF
--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -672,7 +672,9 @@ def compute_segments(
     overlap_mask_area_threshold: float = 0.8,
     label_ids_to_fuse: Optional[Set[int]] = None,
     target_size: Tuple[int, int] = None,
+    class_segment_id_map: Optional[Dict[int, int]] = None,
 ):
+    class_segment_id_map = class_segment_id_map if class_segment_id_map is not None else {}
     height = mask_probs.shape[1] if target_size is None else target_size[0]
     width = mask_probs.shape[2] if target_size is None else target_size[1]
 
@@ -684,14 +686,13 @@ def compute_segments(
             mask_probs.unsqueeze(0), size=target_size, mode="bilinear", align_corners=False
         )[0]
 
-    current_segment_id = 0
+    current_segment_id = max(class_segment_id_map.values(), default=0)
 
     # Weigh each mask by its prediction score
     mask_probs *= pred_scores.view(-1, 1, 1)
     mask_labels = mask_probs.argmax(0)  # [height, width]
 
     # Keep track of instances of each class
-    stuff_memory_list: Dict[str, int] = {}
     for k in range(pred_labels.shape[0]):
         pred_class = pred_labels[k].item()
         should_fuse = pred_class in label_ids_to_fuse
@@ -702,8 +703,8 @@ def compute_segments(
         )
 
         if mask_exists:
-            if pred_class in stuff_memory_list:
-                current_segment_id = stuff_memory_list[pred_class]
+            if pred_class in class_segment_id_map:
+                current_segment_id = class_segment_id_map[pred_class]
             else:
                 current_segment_id += 1
 
@@ -719,9 +720,9 @@ def compute_segments(
                 }
             )
             if should_fuse:
-                stuff_memory_list[pred_class] = current_segment_id
+                class_segment_id_map[pred_class] = current_segment_id
 
-    return segmentation, segments
+    return segmentation, segments, class_segment_id_map
 
 
 class DetrImageProcessor(BaseImageProcessor):
@@ -801,6 +802,10 @@ class DetrImageProcessor(BaseImageProcessor):
         self.image_mean = image_mean if image_mean is not None else IMAGENET_DEFAULT_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_DEFAULT_STD
         self.do_pad = do_pad
+
+        # We use this to keep track of the segment id for each class. This ensure that once a segment id is assigned to a class,
+        # it remains consistent across batches
+        self._class_to_segment_id_map = {}
 
     @classmethod
     def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
@@ -1624,6 +1629,9 @@ class DetrImageProcessor(BaseImageProcessor):
         # Loop over items in batch size
         results: List[Dict[str, TensorType]] = []
 
+        # Cache to store class segment id map for each batch item
+        class_segment_id_map = self._class_to_segment_id_map()
+
         for i in range(batch_size):
             mask_probs_item, pred_scores_item, pred_labels_item = remove_low_and_no_objects(
                 mask_probs[i], pred_scores[i], pred_labels[i], threshold, num_labels
@@ -1638,7 +1646,7 @@ class DetrImageProcessor(BaseImageProcessor):
 
             # Get segmentation map and segment information of batch item
             target_size = target_sizes[i] if target_sizes is not None else None
-            segmentation, segments = compute_segments(
+            segmentation, segments, class_segment_id_map = compute_segments(
                 mask_probs=mask_probs_item,
                 pred_scores=pred_scores_item,
                 pred_labels=pred_labels_item,
@@ -1646,6 +1654,7 @@ class DetrImageProcessor(BaseImageProcessor):
                 overlap_mask_area_threshold=overlap_mask_area_threshold,
                 label_ids_to_fuse=[],
                 target_size=target_size,
+                class_segment_id_map=class_segment_id_map,
             )
 
             # Return segmentation map in run-length encoding (RLE) format
@@ -1653,6 +1662,9 @@ class DetrImageProcessor(BaseImageProcessor):
                 segmentation = convert_segmentation_to_rle(segmentation)
 
             results.append({"segmentation": segmentation, "segments_info": segments})
+
+        self._class_to_segment_id_map = class_segment_id_map
+
         return results
 
     # inspired by https://github.com/facebookresearch/detr/blob/master/models/segmentation.py#L241

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -201,7 +201,9 @@ def compute_segments(
     overlap_mask_area_threshold: float = 0.8,
     label_ids_to_fuse: Optional[Set[int]] = None,
     target_size: Tuple[int, int] = None,
+    class_segment_id_map: Optional[Dict[int, int]] = None,
 ):
+    class_segment_id_map = class_segment_id_map if class_segment_id_map is not None else {}
     height = mask_probs.shape[1] if target_size is None else target_size[0]
     width = mask_probs.shape[2] if target_size is None else target_size[1]
 
@@ -213,14 +215,13 @@ def compute_segments(
             mask_probs.unsqueeze(0), size=target_size, mode="bilinear", align_corners=False
         )[0]
 
-    current_segment_id = 0
+    current_segment_id = max(class_segment_id_map.values(), default=0)
 
     # Weigh each mask by its prediction score
     mask_probs *= pred_scores.view(-1, 1, 1)
     mask_labels = mask_probs.argmax(0)  # [height, width]
 
     # Keep track of instances of each class
-    stuff_memory_list: Dict[str, int] = {}
     for k in range(pred_labels.shape[0]):
         pred_class = pred_labels[k].item()
         should_fuse = pred_class in label_ids_to_fuse
@@ -231,8 +232,8 @@ def compute_segments(
         )
 
         if mask_exists:
-            if pred_class in stuff_memory_list:
-                current_segment_id = stuff_memory_list[pred_class]
+            if pred_class in class_segment_id_map:
+                current_segment_id = class_segment_id_map[pred_class]
             else:
                 current_segment_id += 1
 
@@ -248,9 +249,9 @@ def compute_segments(
                 }
             )
             if should_fuse:
-                stuff_memory_list[pred_class] = current_segment_id
+                class_segment_id_map[pred_class] = current_segment_id
 
-    return segmentation, segments
+    return segmentation, segments, class_segment_id_map
 
 
 # TODO: (Amy) Move to image_transforms

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -205,7 +205,9 @@ def compute_segments(
     overlap_mask_area_threshold: float = 0.8,
     label_ids_to_fuse: Optional[Set[int]] = None,
     target_size: Tuple[int, int] = None,
+    class_segment_id_map: Optional[Dict[int, int]] = None,
 ):
+    class_segment_id_map = class_segment_id_map if class_segment_id_map is not None else {}
     height = mask_probs.shape[1] if target_size is None else target_size[0]
     width = mask_probs.shape[2] if target_size is None else target_size[1]
 
@@ -217,14 +219,13 @@ def compute_segments(
             mask_probs.unsqueeze(0), size=target_size, mode="bilinear", align_corners=False
         )[0]
 
-    current_segment_id = 0
+    current_segment_id = max(class_segment_id_map.values(), default=0)
 
     # Weigh each mask by its prediction score
     mask_probs *= pred_scores.view(-1, 1, 1)
     mask_labels = mask_probs.argmax(0)  # [height, width]
 
     # Keep track of instances of each class
-    stuff_memory_list: Dict[str, int] = {}
     for k in range(pred_labels.shape[0]):
         pred_class = pred_labels[k].item()
         should_fuse = pred_class in label_ids_to_fuse
@@ -235,8 +236,8 @@ def compute_segments(
         )
 
         if mask_exists:
-            if pred_class in stuff_memory_list:
-                current_segment_id = stuff_memory_list[pred_class]
+            if pred_class in class_segment_id_map:
+                current_segment_id = class_segment_id_map[pred_class]
             else:
                 current_segment_id += 1
 
@@ -252,9 +253,9 @@ def compute_segments(
                 }
             )
             if should_fuse:
-                stuff_memory_list[pred_class] = current_segment_id
+                class_segment_id_map[pred_class] = current_segment_id
 
-    return segmentation, segments
+    return segmentation, segments, class_segment_id_map
 
 
 # TODO: (Amy) Move to image_transforms

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -202,7 +202,9 @@ def compute_segments(
     overlap_mask_area_threshold: float = 0.8,
     label_ids_to_fuse: Optional[Set[int]] = None,
     target_size: Tuple[int, int] = None,
+    class_segment_id_map: Optional[Dict[int, int]] = None,
 ):
+    class_segment_id_map = class_segment_id_map if class_segment_id_map is not None else {}
     height = mask_probs.shape[1] if target_size is None else target_size[0]
     width = mask_probs.shape[2] if target_size is None else target_size[1]
 
@@ -214,14 +216,13 @@ def compute_segments(
             mask_probs.unsqueeze(0), size=target_size, mode="bilinear", align_corners=False
         )[0]
 
-    current_segment_id = 0
+    current_segment_id = max(class_segment_id_map.values(), default=0)
 
     # Weigh each mask by its prediction score
     mask_probs *= pred_scores.view(-1, 1, 1)
     mask_labels = mask_probs.argmax(0)  # [height, width]
 
     # Keep track of instances of each class
-    stuff_memory_list: Dict[str, int] = {}
     for k in range(pred_labels.shape[0]):
         pred_class = pred_labels[k].item()
         should_fuse = pred_class in label_ids_to_fuse
@@ -232,8 +233,8 @@ def compute_segments(
         )
 
         if mask_exists:
-            if pred_class in stuff_memory_list:
-                current_segment_id = stuff_memory_list[pred_class]
+            if pred_class in class_segment_id_map:
+                current_segment_id = class_segment_id_map[pred_class]
             else:
                 current_segment_id += 1
 
@@ -249,9 +250,9 @@ def compute_segments(
                 }
             )
             if should_fuse:
-                stuff_memory_list[pred_class] = current_segment_id
+                class_segment_id_map[pred_class] = current_segment_id
 
-    return segmentation, segments
+    return segmentation, segments, class_segment_id_map
 
 
 # Copied from transformers.models.maskformer.image_processing_maskformer.convert_segmentation_map_to_binary_masks

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -599,7 +599,9 @@ def compute_segments(
     overlap_mask_area_threshold: float = 0.8,
     label_ids_to_fuse: Optional[Set[int]] = None,
     target_size: Tuple[int, int] = None,
+    class_segment_id_map: Optional[Dict[int, int]] = None,
 ):
+    class_segment_id_map = class_segment_id_map if class_segment_id_map is not None else {}
     height = mask_probs.shape[1] if target_size is None else target_size[0]
     width = mask_probs.shape[2] if target_size is None else target_size[1]
 
@@ -611,14 +613,13 @@ def compute_segments(
             mask_probs.unsqueeze(0), size=target_size, mode="bilinear", align_corners=False
         )[0]
 
-    current_segment_id = 0
+    current_segment_id = max(class_segment_id_map.values(), default=0)
 
     # Weigh each mask by its prediction score
     mask_probs *= pred_scores.view(-1, 1, 1)
     mask_labels = mask_probs.argmax(0)  # [height, width]
 
     # Keep track of instances of each class
-    stuff_memory_list: Dict[str, int] = {}
     for k in range(pred_labels.shape[0]):
         pred_class = pred_labels[k].item()
         should_fuse = pred_class in label_ids_to_fuse
@@ -629,8 +630,8 @@ def compute_segments(
         )
 
         if mask_exists:
-            if pred_class in stuff_memory_list:
-                current_segment_id = stuff_memory_list[pred_class]
+            if pred_class in class_segment_id_map:
+                current_segment_id = class_segment_id_map[pred_class]
             else:
                 current_segment_id += 1
 
@@ -646,9 +647,9 @@ def compute_segments(
                 }
             )
             if should_fuse:
-                stuff_memory_list[pred_class] = current_segment_id
+                class_segment_id_map[pred_class] = current_segment_id
 
-    return segmentation, segments
+    return segmentation, segments, class_segment_id_map
 
 
 class YolosImageProcessor(BaseImageProcessor):


### PR DESCRIPTION
# What does this PR do?

At the moment, when segments are calculated it's calculated on an image-per-image basis. This means  when predicting with certain models e.g. DETR, the segment id that each class corresponds can be different across each image in a batch and across batches. 

This PR adds a private attribute to the image processor class to store the class: to segment_id mapping as state. 

/!\ There is a possible breaking change, as `compute_segments` now returns 3 rather than two objects. 

Fixes #23461

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
