### PR TITLE
Fix `is_vision_available`

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -546,7 +546,10 @@ def is_vision_available():
         try:
             package_version = importlib.metadata.version("Pillow")
         except importlib.metadata.PackageNotFoundError:
-            return False
+            try:
+                package_version = importlib.metadata.version("Pillow-SIMD")
+            except importlib.metadata.PackageNotFoundError:
+                return False
         logger.debug(f"Detected PIL version {package_version}")
     return _pil_available
 


### PR DESCRIPTION
# What does this PR do?

Fix #24845 

After #23163, we need an extra check if we want to support the use of `pillow-simd`.

