### PR TITLE
Fix token pass

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1720,10 +1720,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 )
             token = use_auth_token
 
-        if token is not None:
-            # change to `token` in a follow-up PR
-            use_auth_token = token
-
         user_agent = {"file_type": "tokenizer", "from_auto_class": from_auto_class, "is_fast": "Fast" in cls.__name__}
         if from_pipeline is not None:
             user_agent["using_pipeline"] = from_pipeline

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1722,7 +1722,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         if token is not None:
             # change to `token` in a follow-up PR
-            kwargs["use_auth_token"] = token
+            use_auth_token = token
 
         user_agent = {"file_type": "tokenizer", "from_auto_class": from_auto_class, "is_fast": "Fast" in cls.__name__}
         if from_pipeline is not None:


### PR DESCRIPTION
# What does this PR do?

The `token` passed along in `PreTrainedTokenizerBase.from_pretrained` is passed along twice at the end: one time in the kwargs and one time as `use_auth_token`. This caused the speech examples to fail.