### PR TITLE
Skip failing `ZeroShotAudioClassificationPipelineTests::test_small_model_pt` for now

### DIFF
--- a/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
@@ -27,6 +27,8 @@ class ZeroShotAudioClassificationPipelineTests(unittest.TestCase):
     # and only CLAP would be there for now.
     # model_mapping = {CLAPConfig: CLAPModel}
 
+    # TODO: fix me (ydshieh)
+    @unittest.skip("currently failing (probably due to `datasets` issue)")
     @require_torch
     def test_small_model_pt(self):
         audio_classifier = pipeline(


### PR DESCRIPTION
# What does this PR do?

Skip failing `ZeroShotAudioClassificationPipelineTests::test_small_model_pt` for now.

see [failing job](https://app.circleci.com/pipelines/github/huggingface/transformers/68367/workflows/0d616969-381a-4ce2-96f9-ec83b259df75/jobs/856192)

likely a `datasets` issue