### PR TITLE
Enable `ZeroShotAudioClassificationPipelineTests::test_small_model_pt`

### DIFF
--- a/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
@@ -27,8 +27,6 @@ class ZeroShotAudioClassificationPipelineTests(unittest.TestCase):
     # and only CLAP would be there for now.
     # model_mapping = {CLAPConfig: CLAPModel}
 
-    # TODO: fix me (ydshieh)
-    @unittest.skip("currently failing (probably due to `datasets` issue)")
     @require_torch
     def test_small_model_pt(self):
         audio_classifier = pipeline(


### PR DESCRIPTION
# What does this PR do?

This test was failing due to a dev version of `datasets` (created in another branch) being used in `main`. It's now resolved. 

Thank you @lhoestq for the investigation.