### PR TITLE
Separate CircleCI cache between `main` and `pull` or other branches

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -106,9 +106,11 @@ class CircleCIJob:
             {
                 "restore_cache": {
                     "keys": [
-                        # Use the cache found in the `main` branch first. If not found, use the one given by `pull`
-                        f"v{self.cache_version}-{self.cache_name}-main-pip-" + '{{ checksum "setup.py" }}',
+                        # check the fully-matched cache first
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-" + '{{ checksum "setup.py" }}',
+                        # try the partially-matched cache from `main`
+                        f"v{self.cache_version}-{self.cache_name}-main-pip-",
+                        # try the general partially-matched cache
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-",
                     ]
                 }
@@ -116,7 +118,8 @@ class CircleCIJob:
             {
                 "restore_cache": {
                     "keys": [
-                        f"v{self.cache_version}-{self.cache_name}-main-site-packages-" + '{{ checksum "setup.py" }}',
+                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-" + '{{ checksum "setup.py" }}',
+                        f"v{self.cache_version}-{self.cache_name}-main-site-packages-",
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-",
                     ]
                 }

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -86,6 +86,11 @@ class CircleCIJob:
     def to_dict(self):
         env = COMMON_ENV_VARIABLES.copy()
         env.update(self.additional_env)
+
+        cache_branch_prefix = os.environ.get("CIRCLE_BRANCH", "pull")
+        if cache_branch_prefix != "main":
+            cache_branch_prefix = "pull"
+
         job = {
             "working_directory": self.working_directory,
             "docker": self.docker_image,
@@ -101,16 +106,16 @@ class CircleCIJob:
             {
                 "restore_cache": {
                     "keys": [
-                        f"v{self.cache_version}-{self.cache_name}-pip-" + '{{ checksum "setup.py" }}',
-                        f"v{self.cache_version}-{self.cache_name}-pip-",
+                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-" + '{{ checksum "setup.py" }}',
+                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-",
                     ]
                 }
             },
             {
                 "restore_cache": {
                     "keys": [
-                        f"v{self.cache_version}-{self.cache_name}-site-packages-" + '{{ checksum "setup.py" }}',
-                        f"v{self.cache_version}-{self.cache_name}-site-packages-",
+                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-" + '{{ checksum "setup.py" }}',
+                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-",
                     ]
                 }
             },
@@ -119,7 +124,7 @@ class CircleCIJob:
         steps.append(
             {
                 "save_cache": {
-                    "key": f"v{self.cache_version}-{self.cache_name}-pip-" + '{{ checksum "setup.py" }}',
+                    "key": f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-" + '{{ checksum "setup.py" }}',
                     "paths": ["~/.cache/pip"],
                 }
             }
@@ -127,7 +132,7 @@ class CircleCIJob:
         steps.append(
             {
                 "save_cache": {
-                    "key": f"v{self.cache_version}-{self.cache_name}-site-packages-" + '{{ checksum "setup.py" }}',
+                    "key": f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-" + '{{ checksum "setup.py" }}',
                     "paths": ["~/.pyenv/versions/"],
                 }
             }

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -106,6 +106,8 @@ class CircleCIJob:
             {
                 "restore_cache": {
                     "keys": [
+                        # Use the cache found in the `main` branch first. If not found, use the one given by `pull`
+                        f"v{self.cache_version}-{self.cache_name}-main-pip-" + '{{ checksum "setup.py" }}',
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-" + '{{ checksum "setup.py" }}',
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-pip-",
                     ]
@@ -114,7 +116,7 @@ class CircleCIJob:
             {
                 "restore_cache": {
                     "keys": [
-                        f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-" + '{{ checksum "setup.py" }}',
+                        f"v{self.cache_version}-{self.cache_name}-main-site-packages-" + '{{ checksum "setup.py" }}',
                         f"v{self.cache_version}-{self.cache_name}-{cache_branch_prefix}-site-packages-",
                     ]
                 }


### PR DESCRIPTION
# What does this PR do?

Keep the CircleCI cache running on `main` branch not affected by other branches/PR.

Reading the following by keeping in mind:
 - @lhoestq created a branch yesterday using `datasets 2.13.2.dev0`
 - @sgugger changed `setup.py` yesterday in the commit `4.32.0.dev0`
 - the cache used by @lhoestq 's branch is used on `main` in/after @sgugger 's commit.

Also: the CI triggered on `main` is much less frequently, so keeping its own cache from the pull events is fine (in terms of the cost)

Assume
  - someone changes `setup.py` to use a dev. version of a library, say `datasets` in a PR or a HF non-main branch
    - CI triggered + [precise] cache not found + [partial] cache found + cache updated with `datasets` dev. version
  - shortly, another person change `setup.py` (not necessary the same library involved) in another PR/branch and being merged
    - CI triggered+ [precise] cache not found + [partial] cache found: 
      - this could be the above one (depending the time gap)
      - `datasets` version remains `dev` if it has `datasets>=XXX` in `setup.py` in the merged PR
        - (as `dev` is newer version, so requirement already satisfied)
        - we get failures on `main` due to the `datasets dev` version, which should be avoided.


