### PR TITLE
Avoid some pipeline tasks to use `use_cache=True`

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -1,3 +1,4 @@
+import inspect
 import types
 import warnings
 from collections.abc import Iterable
@@ -509,6 +510,10 @@ class QuestionAnsweringPipeline(ChunkPipeline):
 
     def _forward(self, inputs):
         example = inputs["example"]
+        # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
+        model_forward = self.model.forward if self.framework == "pt" else self.model.call
+        if "use_cache" in inspect.signature(model_forward).parameters.keys():
+            model_inputs["use_cache"] = False
         model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
         output = self.model(**model_inputs)
         if isinstance(output, dict):

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -510,11 +510,11 @@ class QuestionAnsweringPipeline(ChunkPipeline):
 
     def _forward(self, inputs):
         example = inputs["example"]
+        model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
         # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
         model_forward = self.model.forward if self.framework == "pt" else self.model.call
         if "use_cache" in inspect.signature(model_forward).parameters.keys():
             model_inputs["use_cache"] = False
-        model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
         output = self.model(**model_inputs)
         if isinstance(output, dict):
             return {"start": output["start_logits"], "end": output["end_logits"], "example": example, **inputs}

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Dict
 
+import inspect
 import numpy as np
 
 from ..utils import ExplicitEnum, add_end_docstrings, is_tf_available, is_torch_available
@@ -179,6 +180,10 @@ class TextClassificationPipeline(Pipeline):
         return self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
 
     def _forward(self, model_inputs):
+        # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
+        model_forward = self.model.forward if self.framework == "pt" else self.model.call
+        if "use_cache" in inspect.signature(model_forward).parameters.keys():
+            model_inputs["use_cache"] = False
         return self.model(**model_inputs)
 
     def postprocess(self, model_outputs, function_to_apply=None, top_k=1, _legacy=True):

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -1,7 +1,7 @@
+import inspect
 import warnings
 from typing import Dict
 
-import inspect
 import numpy as np
 
 from ..utils import ExplicitEnum, add_end_docstrings, is_tf_available, is_torch_available

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import List, Union
 
 import numpy as np
@@ -221,6 +222,13 @@ class ZeroShotClassificationPipeline(ChunkPipeline):
         candidate_label = inputs["candidate_label"]
         sequence = inputs["sequence"]
         model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
+        # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
+        if hasattr(self.model, "forward") and "use_cache" in set(
+            inspect.signature(self.model.forward).parameters.keys()
+        ):
+            model_inputs["use_cache"] = False
+        elif hasattr(self.model, "call") and "use_cache" in set(inspect.signature(self.model.call).parameters.keys()):
+            model_inputs["use_cache"] = False
         outputs = self.model(**model_inputs)
 
         model_outputs = {

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -223,11 +223,8 @@ class ZeroShotClassificationPipeline(ChunkPipeline):
         sequence = inputs["sequence"]
         model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
         # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
-        if hasattr(self.model, "forward") and "use_cache" in set(
-            inspect.signature(self.model.forward).parameters.keys()
-        ):
-            model_inputs["use_cache"] = False
-        elif hasattr(self.model, "call") and "use_cache" in set(inspect.signature(self.model.call).parameters.keys()):
+        model_forward = self.model.forward if self.framework == "pt" else self.model.call
+        if "use_cache" in inspect.signature(model_forward).parameters.keys():
             model_inputs["use_cache"] = False
         outputs = self.model(**model_inputs)
 


### PR DESCRIPTION
# What does this PR do?

Fix  #24873

For example, we can pass `use_cache=True` (or set this in config) to `BartForSequenceClassification` and it will return `past_key_values` (although not useful to the task).

This is to respond to #24873, despite the memory issue reported there is not 100% for sure yet.
However, avoid using `cache` and not to let model returning `past_key_values` can avoid overhead like CPU/GPU communication (huge/many tensors).

In the code snippet I provided in #24873, there is a gain of 16.5% of running time.

We could probably extend this PR to other pipeline task classes.
