### PR TITLE
[`Llama2`] replace `self.pretraining_tp` with `self.config.pretraining_tp`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1252,6 +1252,40 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         pass
 
+    def disable_pretraining_tp(self):
+        r"""
+        For some setups, one might want to disable the tensor parallelism behavior
+        (e.g. when fine-tuning models with PEFT).
+        """
+        config = getattr(self, "config", None)
+        if config is not None and not hasattr(config, "pretraining_tp"):
+            raise ValueError("The config does not have the pretraining_tp attribute.")
+        else:
+            self._disable_pretraining_tp()
+
+    def _disable_pretraining_tp(self):
+        r"""
+        This method needs to be defined for each architecture that supports TP.
+        """
+        pass
+
+    def set_pretraining_tp(self, value):
+        r"""
+        This method is intended for users that want to enable back the tensor parallelism behavior
+        (e.g. after fine-tuning models with PEFT).
+        """
+        config = getattr(self, "config", None)
+        if config is not None and not hasattr(config, "pretraining_tp"):
+            raise ValueError("The config does not have the pretraining_tp attribute.")
+        else:
+            self._set_pretraining_tp(value)
+
+    def _set_pretraining_tp(self, value):
+        r"""
+        This method needs to be defined for each architecture that supports TP.
+        """
+        pass
+
     def _initialize_weights(self, module):
         """
         Initialize the weights if they are not already initialized.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1252,40 +1252,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         pass
 
-    def disable_pretraining_tp(self):
-        r"""
-        For some setups, one might want to disable the tensor parallelism behavior (e.g. when fine-tuning models with
-        PEFT).
-        """
-        config = getattr(self, "config", None)
-        if config is not None and not hasattr(config, "pretraining_tp"):
-            raise ValueError("The config does not have the pretraining_tp attribute.")
-        else:
-            self._disable_pretraining_tp()
-
-    def _disable_pretraining_tp(self):
-        r"""
-        This method needs to be defined for each architecture that supports TP.
-        """
-        pass
-
-    def set_pretraining_tp(self, value):
-        r"""
-        This method is intended for users that want to enable back the tensor parallelism behavior (e.g. after
-        fine-tuning models with PEFT).
-        """
-        config = getattr(self, "config", None)
-        if config is not None and not hasattr(config, "pretraining_tp"):
-            raise ValueError("The config does not have the pretraining_tp attribute.")
-        else:
-            self._set_pretraining_tp(value)
-
-    def _set_pretraining_tp(self, value):
-        r"""
-        This method needs to be defined for each architecture that supports TP.
-        """
-        pass
-
     def _initialize_weights(self, module):
         """
         Initialize the weights if they are not already initialized.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1254,8 +1254,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
     def disable_pretraining_tp(self):
         r"""
-        For some setups, one might want to disable the tensor parallelism behavior
-        (e.g. when fine-tuning models with PEFT).
+        For some setups, one might want to disable the tensor parallelism behavior (e.g. when fine-tuning models with
+        PEFT).
         """
         config = getattr(self, "config", None)
         if config is not None and not hasattr(config, "pretraining_tp"):
@@ -1271,8 +1271,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
     def set_pretraining_tp(self, value):
         r"""
-        This method is intended for users that want to enable back the tensor parallelism behavior
-        (e.g. after fine-tuning models with PEFT).
+        This method is intended for users that want to enable back the tensor parallelism behavior (e.g. after
+        fine-tuning models with PEFT).
         """
         config = getattr(self, "config", None)
         if config is not None and not hasattr(config, "pretraining_tp"):

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -475,6 +475,16 @@ class LlamaPreTrainedModel(PreTrainedModel):
         if isinstance(module, LlamaModel):
             module.gradient_checkpointing = value
 
+    def _disable_pretraining_tp(self):
+        for _, module in self.named_modules():
+            if isinstance(module, (LlamaAttention, LlamaMLP)):
+                module.pretraining_tp = 1
+
+    def _set_pretraining_tp(self, value):
+        for _, module in self.named_modules():
+            if isinstance(module, (LlamaAttention, LlamaMLP)):
+                module.pretraining_tp = value
+
 
 LLAMA_INPUTS_DOCSTRING = r"""
     Args:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -191,7 +191,7 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids):
 class LlamaMLP(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.pretraining_tp = config.pretraining_tp
+        self.config = config
         self.hidden_size = config.hidden_size
         self.intermediate_size = config.intermediate_size
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
@@ -200,17 +200,21 @@ class LlamaMLP(nn.Module):
         self.act_fn = ACT2FN[config.hidden_act]
 
     def forward(self, x):
-        if self.pretraining_tp > 1:
-            slice = self.intermediate_size // self.pretraining_tp
+        if self.config.pretraining_tp > 1:
+            slice = self.intermediate_size // self.config.pretraining_tp
             gate_proj_slices = self.gate_proj.weight.split(slice, dim=0)
             up_proj_slices = self.up_proj.weight.split(slice, dim=0)
             down_proj_slices = self.down_proj.weight.split(slice, dim=1)
 
-            gate_proj = torch.cat([F.linear(x, gate_proj_slices[i]) for i in range(self.pretraining_tp)], dim=-1)
-            up_proj = torch.cat([F.linear(x, up_proj_slices[i]) for i in range(self.pretraining_tp)], dim=-1)
+            gate_proj = torch.cat(
+                [F.linear(x, gate_proj_slices[i]) for i in range(self.config.pretraining_tp)], dim=-1
+            )
+            up_proj = torch.cat([F.linear(x, up_proj_slices[i]) for i in range(self.config.pretraining_tp)], dim=-1)
 
             intermediate_states = (self.act_fn(gate_proj) * up_proj).split(slice, dim=2)
-            down_proj = [F.linear(intermediate_states[i], down_proj_slices[i]) for i in range(self.pretraining_tp)]
+            down_proj = [
+                F.linear(intermediate_states[i], down_proj_slices[i]) for i in range(self.config.pretraining_tp)
+            ]
             down_proj = sum(down_proj)
         else:
             down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
@@ -241,7 +245,6 @@ class LlamaAttention(nn.Module):
         self.head_dim = self.hidden_size // self.num_heads
         self.num_key_value_heads = config.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
-        self.pretraining_tp = config.pretraining_tp
         self.max_position_embeddings = config.max_position_embeddings
 
         if (self.head_dim * self.num_heads) != self.hidden_size:
@@ -286,19 +289,21 @@ class LlamaAttention(nn.Module):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         bsz, q_len, _ = hidden_states.size()
 
-        if self.pretraining_tp > 1:
-            key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.pretraining_tp
-            query_slices = self.q_proj.weight.split((self.num_heads * self.head_dim) // self.pretraining_tp, dim=0)
+        if self.config.pretraining_tp > 1:
+            key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.config.pretraining_tp
+            query_slices = self.q_proj.weight.split(
+                (self.num_heads * self.head_dim) // self.config.pretraining_tp, dim=0
+            )
             key_slices = self.k_proj.weight.split(key_value_slicing, dim=0)
             value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
 
-            query_states = [F.linear(hidden_states, query_slices[i]) for i in range(self.pretraining_tp)]
+            query_states = [F.linear(hidden_states, query_slices[i]) for i in range(self.config.pretraining_tp)]
             query_states = torch.cat(query_states, dim=-1)
 
-            key_states = [F.linear(hidden_states, key_slices[i]) for i in range(self.pretraining_tp)]
+            key_states = [F.linear(hidden_states, key_slices[i]) for i in range(self.config.pretraining_tp)]
             key_states = torch.cat(key_states, dim=-1)
 
-            value_states = [F.linear(hidden_states, value_slices[i]) for i in range(self.pretraining_tp)]
+            value_states = [F.linear(hidden_states, value_slices[i]) for i in range(self.config.pretraining_tp)]
             value_states = torch.cat(value_states, dim=-1)
 
         else:
@@ -355,10 +360,10 @@ class LlamaAttention(nn.Module):
         attn_output = attn_output.transpose(1, 2).contiguous()
         attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
 
-        if self.pretraining_tp > 1:
-            attn_output = attn_output.split(self.hidden_size // self.pretraining_tp, dim=2)
-            o_proj_slices = self.o_proj.weight.split(self.hidden_size // self.pretraining_tp, dim=1)
-            attn_output = sum([F.linear(attn_output[i], o_proj_slices[i]) for i in range(self.pretraining_tp)])
+        if self.config.pretraining_tp > 1:
+            attn_output = attn_output.split(self.hidden_size // self.config.pretraining_tp, dim=2)
+            o_proj_slices = self.o_proj.weight.split(self.hidden_size // self.config.pretraining_tp, dim=1)
+            attn_output = sum([F.linear(attn_output[i], o_proj_slices[i]) for i in range(self.config.pretraining_tp)])
         else:
             attn_output = self.o_proj(attn_output)
 
@@ -474,16 +479,6 @@ class LlamaPreTrainedModel(PreTrainedModel):
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, LlamaModel):
             module.gradient_checkpointing = value
-
-    def _disable_pretraining_tp(self):
-        for _, module in self.named_modules():
-            if isinstance(module, (LlamaAttention, LlamaMLP)):
-                module.pretraining_tp = 1
-
-    def _set_pretraining_tp(self, value):
-        for _, module in self.named_modules():
-            if isinstance(module, (LlamaAttention, LlamaMLP)):
-                module.pretraining_tp = value
 
 
 LLAMA_INPUTS_DOCSTRING = r"""
@@ -740,7 +735,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.model = LlamaModel(config)
-        self.pretraining_tp = config.pretraining_tp
         self.vocab_size = config.vocab_size
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
@@ -826,9 +820,9 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if self.pretraining_tp > 1:
-            lm_head_slices = self.lm_head.weight.split(self.vocab_size // self.pretraining_tp, dim=0)
-            logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.pretraining_tp)]
+        if self.config.pretraining_tp > 1:
+            lm_head_slices = self.lm_head.weight.split(self.vocab_size // self.config.pretraining_tp, dim=0)
+            logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
             logits = torch.cat(logits, dim=-1)
         else:
             logits = self.lm_head(hidden_states)


### PR DESCRIPTION
# What does this PR do?

Llama-2 (and also in the past Bloom) has introduced a new attribute in the config file `pretraining_tp` to mimic the behaviour of the original model at inference. Therefore, inside some layers the TP paradigm is "reproduced" by manually simulating the TP paradigm, see for example: https://github.com/huggingface/transformers/blob/476be08c4aa96f8c1cae4200d2677bbe8f12cf80/src/transformers/models/llama/modeling_llama.py#L291 

![Screenshot from 2022-04-22 15-55-48](https://user-images.githubusercontent.com/49240599/164728838-3f78585b-1018-4366-a499-95133fdeaa89.png)

In fact this can lead to unexpected behaviour to users, especially for peft library: (related: https://github.com/huggingface/peft/issues/726) (currently it is not possible to finetune llama-2 models with `pretraining_tp > 1`) 

```bash
  File "/home/younes_huggingface_co/code/transformers/src/transformers/models/llama/modeling_llama.py", line 209, in forward
    gate_proj = torch.cat([F.linear(x, gate_proj_slices[i]) for i in range(self.pretraining_tp)], dim=-1)
  File "/home/younes_huggingface_co/code/transformers/src/transformers/models/llama/modeling_llama.py", line 209, in <listcomp>
    gate_proj = torch.cat([F.linear(x, gate_proj_slices[i]) for i in range(self.pretraining_tp)], dim=-1)
RuntimeError: mat1 and mat2 shapes cannot be multiplied (2048x5120 and 1x6912)
```

I would argue that these slight numerical differences are ok to have in the context of training, thus we should let users the possibility to disable this behaviour, at their own risk. This PR fixes this and proposes to add a new method `disable_pretraining_tp` to disable that behavior. I also added a method to revert the TP behavior in case users want to revert that after training.

On par with: https://github.com/huggingface/peft/pull/728 

cc @ArthurZucker @sgugger @pacman100 @BenjaminBossan