### PR TITLE
Allow generic composite models to pass more kwargs

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1150,12 +1150,22 @@ class GenerationMixin:
 
         # Encoder-Decoder models may also need Encoder arguments from `model_kwargs`
         if self.config.is_encoder_decoder:
+            base_model = getattr(self, self.base_model_prefix, None)
+
             # allow encoder kwargs
-            encoder_model_args = set(inspect.signature(self.encoder.forward).parameters)
+            encoder = getattr(self, "encoder", None)
+            if encoder is None:
+                encoder = getattr(base_model, "encoder")
+
+            encoder_model_args = set(inspect.signature(encoder.forward).parameters)
             model_args |= encoder_model_args
 
             # allow decoder kwargs
-            decoder_model_args = set(inspect.signature(self.decoder.forward).parameters)
+            decoder = getattr(self, "decoder", None)
+            if decoder is None:
+                decoder = getattr(base_model, "decoder")
+
+            decoder_model_args = set(inspect.signature(decoder.forward).parameters)
             model_args |= {f"decoder_{x}" for x in decoder_model_args}
 
         for key, value in model_kwargs.items():

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1148,12 +1148,8 @@ class GenerationMixin:
         if "kwargs" in model_args or "model_kwargs" in model_args:
             model_args |= set(inspect.signature(self.forward).parameters)
 
-        # Generic composite models need information from its 2 components
-        if self.__class__.__name__ in {
-            "EncoderDecoderModel",
-            "VisionEncoderDecoderModel",
-            "SpeechEncoderDecoderModel",
-        }:
+        # Encoder-Decoder models may also need Encoder arguments from `model_kwargs`
+        if self.config.is_encoder_decoder:
             # allow encoder kwargs
             encoder_model_args = set(inspect.signature(self.encoder.forward).parameters)
             model_args |= encoder_model_args


### PR DESCRIPTION
# What does this PR do?

Generic composite models: `(Text|Vision|Speech)EncoderDecoder`: their `forward` don't have the full info. in their 2 components.

Fix #24919