### PR TITLE
[doc] `image_processing_vilt.py` wrong default documented

### DIFF
--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -307,7 +307,7 @@ class ViltImageProcessor(BaseImageProcessor):
         Args:
             images (`List[np.ndarray]`):
                 Batch of images to pad.
-            return_pixel_mask (`bool`, *optional*, defaults to `False`):
+            return_pixel_mask (`bool`, *optional*, defaults to `True`):
                 Whether to return the pixel mask.
             return_tensors (`str` or `TensorType`, *optional*):
                 The type of tensors to return. Can be one of:


### PR DESCRIPTION
Sync the doc with reality.

https://github.com/huggingface/transformers/blob/ee4250a35f3bd5e9a4379b4907b3d8f9d5d9523f/src/transformers/models/vilt/image_processing_vilt.py#L299

https://github.com/huggingface/transformers/blob/ee4250a35f3bd5e9a4379b4907b3d8f9d5d9523f/src/transformers/models/vilt/image_processing_vilt.py#L310