### PR TITLE
Fallback for missing attribute `Parameter.ds_numel`

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1040,17 +1040,19 @@ def get_model_param_count(model, trainable_only=False):
     """
     Calculate model's total param count. If trainable_only is True then count only those requiring grads
     """
-    if is_deepspeed_zero3_enabled():
+    zero3_enabled = is_deepspeed_zero3_enabled()
+    total_params = 0
 
-        def numel(p):
-            return p.ds_numel
+    for p in model.parameters():
+        if trainable_only and p.requires_grad is False:
+            continue
 
-    else:
+        if zero3_enabled and hasattr(p, "ds_numel"):
+            total_params += p.ds_numel
+        else:
+            total_params += p.numel()
 
-        def numel(p):
-            return p.numel()
-
-    return sum(numel(p) for p in model.parameters() if not trainable_only or p.requires_grad)
+    return total_params
 
 
 def get_parameter_names(model, forbidden_layer_types):


### PR DESCRIPTION
#22193 added a parameter count for Deepspeed sharded models (i.e. using the `Parameter` attribute `ds_numel`). However, `Parameter` Tensors don't always have the `ds_numel` attribute (even when the model is sharded with Zero stage 3).

We can see how this is [alternatively handled in Deepspeed](https://github.com/microsoft/DeepSpeed/blob/ceccfa3ef68182384c6db1349fab43b9af3ed7f3/deepspeed/runtime/engine.py#L3220), by falling back to `Parameter.numel()` if `ds_numel` is not an attribute. I've added this fix to the function in question.

Fixes #24792

@stas00 @pacman100