### PR TITLE
[`LlamaConfig`] Nit: pad token should be None by default

### DIFF
--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -116,7 +116,7 @@ class LlamaConfig(PretrainedConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-6,
         use_cache=True,
-        pad_token_id=0,
+        pad_token_id=None,
         bos_token_id=1,
         eos_token_id=2,
         pretraining_tp=1,

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -58,6 +58,7 @@ class LlamaModelTester:
         initializer_range=0.02,
         num_labels=3,
         num_choices=4,
+        pad_token_id=0,
         scope=None,
     ):
         self.parent = parent
@@ -81,6 +82,7 @@ class LlamaModelTester:
         self.initializer_range = initializer_range
         self.num_labels = num_labels
         self.num_choices = num_choices
+        self.pad_token_id = pad_token_id
         self.scope = scope
 
     def prepare_config_and_inputs(self):
@@ -120,6 +122,7 @@ class LlamaModelTester:
             type_vocab_size=self.type_vocab_size,
             is_decoder=False,
             initializer_range=self.initializer_range,
+            pad_token_id=self.pad_token_id
         )
 
     def create_and_check_model(

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -122,7 +122,7 @@ class LlamaModelTester:
             type_vocab_size=self.type_vocab_size,
             is_decoder=False,
             initializer_range=self.initializer_range,
-            pad_token_id=self.pad_token_id
+            pad_token_id=self.pad_token_id,
         )
 
     def create_and_check_model(


### PR DESCRIPTION
# What does this PR do?
Does not set the padding token as `0` is for the `unk_token`. Though Llama has bytefallback support, meaning most of the time the unkown token will not be form the input, it can generate the `<unk>` token (probably very rarely). The pad token is used in the embedding and the unk embedding is not None.

This should warn user that are doing `SequenceClassification` that the padding token is not set.