### PR TITLE
improve from_pretrained for zero3 multi gpus mode

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -457,7 +457,11 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
             )
         return safe_load_file(checkpoint_file)
     try:
-        return torch.load(checkpoint_file, map_location="cpu")
+        if is_deepspeed_zero3_enabled() and torch.distributed.get_rank() > 0:
+            map_location = "meta"
+        else:
+            map_location = "cpu"
+        return torch.load(checkpoint_file, map_location=map_location)
     except Exception as e:
         try:
             with open(checkpoint_file) as f:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -29,7 +29,6 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
-import torch.distributed as dist
 from packaging import version
 from torch import Tensor, nn
 from torch.nn import CrossEntropyLoss
@@ -458,7 +457,7 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
             )
         return safe_load_file(checkpoint_file)
     try:
-        if is_deepspeed_zero3_enabled() and dist.is_initialized() and dist.get_rank() > 0:
+        if is_deepspeed_zero3_enabled() and torch.distributed.is_initialized() and torch.distributed.get_rank() > 0:
             map_location = "meta"
         else:
             map_location = "cpu"
@@ -540,7 +539,7 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):
                     # manager gathers (unpartitions) the params of the current layer, then loads from
                     # the state dict and then re-partitions them again
                     with deepspeed.zero.GatheredParameters(params_to_gather, modifier_rank=0):
-                        if dist.get_rank() == 0:
+                        if torch.distributed.get_rank() == 0:
                             module._load_from_state_dict(*args)
             else:
                 module._load_from_state_dict(*args)
@@ -1480,7 +1479,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             import deepspeed
 
             with deepspeed.zero.GatheredParameters(old_embeddings.weight, modifier_rank=0):
-                if dist.get_rank() == 0:
+                if torch.distributed.get_rank() == 0:
                     new_embeddings.weight.data[:n, :] = old_embeddings.weight.data[:n, :]
         else:
             new_embeddings.weight.data[:n, :] = old_embeddings.weight.data[:n, :]
@@ -1552,7 +1551,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             params = [old_lm_head.weight, old_lm_head.bias, new_lm_head.weight, new_lm_head.bias]
             with deepspeed.zero.GatheredParameters(params, modifier_rank=0):
-                if dist.get_rank() == 0:
+                if torch.distributed.get_rank() == 0:
                     # Copy old lm head weights to new lm head
                     if not transposed:
                         new_lm_head.weight.data[:num_tokens_to_copy, :] = old_lm_head.weight.data[


### PR DESCRIPTION
# Decrease RAM consumption during Deepspeed Zero 3 model initialisation with multiple GPUs.

This simple PR will save a ton of RAM in case with multi GPUs and Zero 3 Deepspeed scenario.

The idea is simple. We do not need to load checkpoints for all instances, because `deepspeed.zero.GatheredParameters` will copy weights from 0 rank.

## Issues

Related issue #12273

## Who can review?

- @stas00
- @pacman100