### PR TITLE
Fix type annotation for deepspeed training arg

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1001,6 +1001,7 @@ class TrainingArguments:
             )
         },
     )
+    # Do not touch this type annotation or it will stop working in CLI
     fsdp_config: Optional[str] = field(
         default=None,
         metadata={
@@ -1019,7 +1020,8 @@ class TrainingArguments:
             )
         },
     )
-    deepspeed: Optional[Union[str, Dict]] = field(
+    # Do not touch this type annotation or it will stop working in CLI
+    deepspeed: Optional[str] = field(
         default=None,
         metadata={
             "help": (


### PR DESCRIPTION
# What does this PR do?

#24550 wanted to put a more exact type annotation for the deepspeed arg, which then makes that training arg fail in CLI commands. This PR reverts that part and adds a comment so we do not break this again.

Fixes #24974 