### PR TITLE
Generate: `ImageToTextPipeline` now supports generation kwargs

### DIFF
--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -61,7 +61,7 @@ class ImageToTextPipelineTests(unittest.TestCase):
         return pipe, examples
 
     def run_pipeline_test(self, pipe, examples):
-        outputs = pipe(examples)
+        outputs = pipe(examples, min_new_tokens=1, max_new_tokens=10)
         self.assertEqual(
             outputs,
             [


### PR DESCRIPTION
# What does this PR do?

As the title indicates -- previously the generation kwargs had to be passed as a separate dictionary, which was inconsistent with the other pipelines. 

This PR borrows code from the other pipelines, to allow things like `pipe(input, min_new_tokens=10)` (as opposed to `pipe(input, generate_kwargs={"min_new_tokens":10})`). It also updates the docs, which were slightly outdated.

Fixes #24836 