### PR TITLE
Add `OwlViTForObjectDetection` to `MODEL_FOR_OBJECT_DETECTION`

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -612,6 +612,7 @@ MODEL_FOR_OBJECT_DETECTION_MAPPING_NAMES = OrderedDict(
         ("deformable_detr", "DeformableDetrForObjectDetection"),
         ("deta", "DetaForObjectDetection"),
         ("detr", "DetrForObjectDetection"),
+        ("owlvit", "OwlViTForObjectDetection"),
         ("table-transformer", "TableTransformerForObjectDetection"),
         ("yolos", "YolosForObjectDetection"),
     ]


### PR DESCRIPTION
# What does this PR do?

~~This seems a miss, but need @NielsRogge to make sure.~~

well, he told me

> it's not a bug, it's intended. OWL-ViT can be loaded using the AutoModelForZeroShotObjectDetectionModel class (few that's a long name)