### PR TITLE
[check_config_docstrings.py] improve diagnostics

### DIFF
--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -85,9 +85,11 @@ def check_config_docstrings_have_checkpoints():
 
     if len(configs_without_checkpoint) > 0:
         message = "\n".join(sorted(configs_without_checkpoint))
-        raise ValueError(f"The following configurations don't contain any valid checkpoint:\n{message}\n\n"
-                        "Hint: ensure to include [foo/bar](https://huggingface.co/foo/bar) link pointing to "
-                         "one of the models of this architecture in the docstring of the config classes listed above.")
+        raise ValueError(
+            f"The following configurations don't contain any valid checkpoint:\n{message}\n\n"
+            "Hint: ensure to include [foo/bar](https://huggingface.co/foo/bar) link pointing to "
+            "one of the models of this architecture in the docstring of the config classes listed above."
+        )
 
 
 if __name__ == "__main__":

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -85,7 +85,9 @@ def check_config_docstrings_have_checkpoints():
 
     if len(configs_without_checkpoint) > 0:
         message = "\n".join(sorted(configs_without_checkpoint))
-        raise ValueError(f"The following configurations don't contain any valid checkpoint:\n{message}")
+        raise ValueError(f"The following configurations don't contain any valid checkpoint:\n{message}\n\n"
+                        "Hint: ensure to include [foo/bar](https://huggingface.co/foo/bar) link pointing to "
+                         "one of the models of this architecture in the docstring of the config classes listed above.")
 
 
 if __name__ == "__main__":

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -87,8 +87,9 @@ def check_config_docstrings_have_checkpoints():
         message = "\n".join(sorted(configs_without_checkpoint))
         raise ValueError(
             f"The following configurations don't contain any valid checkpoint:\n{message}\n\n"
-            "Hint: ensure to include [foo/bar](https://huggingface.co/foo/bar) link pointing to "
-            "one of the models of this architecture in the docstring of the config classes listed above."
+            "The requirements is to include a link pointing to one of the models of this architecture in the "
+            "docstring of the config classes listed above. The link should have be a markdown format like "
+            "[myorg/mymodel](https://huggingface.co/myorg/mymodel)."
         )
 
 

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -87,7 +87,7 @@ def check_config_docstrings_have_checkpoints():
         message = "\n".join(sorted(configs_without_checkpoint))
         raise ValueError(
             f"The following configurations don't contain any valid checkpoint:\n{message}\n\n"
-            "The requirements is to include a link pointing to one of the models of this architecture in the "
+            "The requirement is to include a link pointing to one of the models of this architecture in the "
             "docstring of the config classes listed above. The link should have be a markdown format like "
             "[myorg/mymodel](https://huggingface.co/myorg/mymodel)."
         )


### PR DESCRIPTION
It's difficult to know what to do when one gets an error:

```
python utils/check_config_docstrings.py

Traceback (most recent call last):
  File "utils/check_config_docstrings.py", line 92, in <module>
    check_config_docstrings_have_checkpoints()
  File "utils/check_config_docstrings.py", line 88, in check_config_docstrings_have_checkpoints
    raise ValueError(f"The following configurations don't contain any valid checkpoint:\n{message}")
ValueError: The following configurations don't contain any valid checkpoint:
IdeficsConfig

Exited with code exit status 1
```

After figuring out what it wants, proposing a better assert message.