### PR TITLE
[`logging.py`] set default `stderr`  path if `None`

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -85,6 +85,10 @@ def _configure_library_root_logger() -> None:
             # This library has already configured the library root logger.
             return
         _default_handler = logging.StreamHandler()  # Set sys.stderr as stream.
+        # set defaults based on https://github.com/pyinstaller/pyinstaller/issues/7334#issuecomment-1357447176
+        if sys.stderr is None:
+            sys.stderr = open(os.devnull, "w")
+
         _default_handler.flush = sys.stderr.flush
 
         # Apply our default configuration to the library root logger.


### PR DESCRIPTION
# What does this PR do?
Attempt to fix #24047

Thanks to contributors, seems like the issue [is known](https://github.com/pyinstaller/pyinstaller/issues/7334#issuecomment-1357447176). 
Though it is not entirely related to `transformers`, adding a safeguard seems like a good practice