### PR TITLE
Support GatedRepoError + use raise from

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -432,8 +432,8 @@ def cached_file(
     except GatedRepoError as e:
         raise EnvironmentError(
             "You are trying to access a gated repo.\nMake sure to request access at "
-            f"https://huggingface.co/{path_or_repo_id} and pass a token having permission to this repo with "
-            "`use_auth_token` or log in with `huggingface-cli login`."
+            f"https://huggingface.co/{path_or_repo_id} and pass a token having permission to this repo either "
+            "by logging in with `huggingface-cli login` or with `token=<your_token>`."
         ) from e
     except RepositoryNotFoundError as e:
         raise EnvironmentError(

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -433,14 +433,14 @@ def cached_file(
         raise EnvironmentError(
             "You are trying to access a gated repo.\nMake sure to request access at "
             f"https://huggingface.co/{path_or_repo_id} and pass a token having permission to this repo either "
-            "by logging in with `huggingface-cli login` or with `token=<your_token>`."
+            "by logging in with `huggingface-cli login` or by passing `token=<your_token>`."
         ) from e
     except RepositoryNotFoundError as e:
         raise EnvironmentError(
             f"{path_or_repo_id} is not a local folder and is not a valid model identifier "
-            "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
-            "pass a token having permission to this repo with `use_auth_token` or log in with "
-            "`huggingface-cli login`."
+            "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to pass a token "
+            "having permission to this repo either by logging in with `huggingface-cli login` or by passing "
+            "`token=<your_token>`"
         ) from e
     except RevisionNotFoundError as e:
         raise EnvironmentError(
@@ -621,8 +621,8 @@ def has_file(
         logger.error(e)
         raise EnvironmentError(
             f"{path_or_repo} is a gated repository. Make sure to request access at "
-            f"https://huggingface.co/{path_or_repo} and pass a token having permission to this repo with "
-            "`use_auth_token` or log in with `huggingface-cli login`."
+            f"https://huggingface.co/{path_or_repo} and pass a token having permission to this repo either by "
+            "logging in with `huggingface-cli login` or by passing `token=<your_token>`."
         ) from e
     except RepositoryNotFoundError as e:
         logger.error(e)

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -41,6 +41,7 @@ from huggingface_hub import (
 from huggingface_hub.file_download import REGEX_COMMIT_HASH, http_get
 from huggingface_hub.utils import (
     EntryNotFoundError,
+    GatedRepoError,
     LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
@@ -428,21 +429,26 @@ def cached_file(
             use_auth_token=use_auth_token,
             local_files_only=local_files_only,
         )
-
-    except RepositoryNotFoundError:
+    except GatedRepoError as e:
+        raise EnvironmentError(
+            "You are trying to access a gated repo.\nMake sure to request access at "
+            f"https://huggingface.co/{path_or_repo_id} and pass a token having permission to this repo with "
+            "`use_auth_token` or log in with `huggingface-cli login`."
+        ) from e
+    except RepositoryNotFoundError as e:
         raise EnvironmentError(
             f"{path_or_repo_id} is not a local folder and is not a valid model identifier "
             "listed on 'https://huggingface.co/models'\nIf this is a private repository, make sure to "
             "pass a token having permission to this repo with `use_auth_token` or log in with "
-            "`huggingface-cli login` and pass `use_auth_token=True`."
-        )
-    except RevisionNotFoundError:
+            "`huggingface-cli login`."
+        ) from e
+    except RevisionNotFoundError as e:
         raise EnvironmentError(
             f"{revision} is not a valid git identifier (branch name, tag name or commit id) that exists "
             "for this model name. Check the model page at "
             f"'https://huggingface.co/{path_or_repo_id}' for available revisions."
-        )
-    except LocalEntryNotFoundError:
+        ) from e
+    except LocalEntryNotFoundError as e:
         # We try to see if we have a cached version (not up to date):
         resolved_file = try_to_load_from_cache(path_or_repo_id, full_filename, cache_dir=cache_dir, revision=revision)
         if resolved_file is not None and resolved_file != _CACHED_NO_EXIST:
@@ -454,8 +460,8 @@ def cached_file(
             f" cached files and it looks like {path_or_repo_id} is not the path to a directory containing a file named"
             f" {full_filename}.\nCheckout your internet connection or see how to run the library in offline mode at"
             " 'https://huggingface.co/docs/transformers/installation#offline-mode'."
-        )
-    except EntryNotFoundError:
+        ) from e
+    except EntryNotFoundError as e:
         if not _raise_exceptions_for_missing_entries:
             return None
         if revision is None:
@@ -463,7 +469,7 @@ def cached_file(
         raise EnvironmentError(
             f"{path_or_repo_id} does not appear to have a file named {full_filename}. Checkout "
             f"'https://huggingface.co/{path_or_repo_id}/{revision}' for available files."
-        )
+        ) from e
     except HTTPError as err:
         # First we try to see if we have a cached version (not up to date):
         resolved_file = try_to_load_from_cache(path_or_repo_id, full_filename, cache_dir=cache_dir, revision=revision)
@@ -611,6 +617,13 @@ def has_file(
     try:
         hf_raise_for_status(r)
         return True
+    except GatedRepoError as e:
+        logger.error(e)
+        raise EnvironmentError(
+            f"{path_or_repo} is a gated repository. Make sure to request access at "
+            f"https://huggingface.co/{path_or_repo} and pass a token having permission to this repo with "
+            "`use_auth_token` or log in with `huggingface-cli login`."
+        ) from e
     except RepositoryNotFoundError as e:
         logger.error(e)
         raise EnvironmentError(f"{path_or_repo} is not a local folder or a valid repository name on 'https://hf.co'.")


### PR DESCRIPTION
(PR started after comment from @osanseviero [on slack](https://huggingface.slack.com/archives/C03V11RNS7P/p1690185858721759?thread_ts=1689956871.406059&cid=C03V11RNS7P) -private link)

This PR adds 2 things:
- raise a more custom error in case of `GatedRepoError` when downloading a file. `GatedRepoError` is a subclass of `RepoNotFoundError` in which the repo is actually found but user don't have access to it (the inheritance is there for backward compatibility)
- when raising a EnvironmentError in `utils/hub.py` I think it's best to use the Python's syntax `raise ... from ...`. This make debugging much easier for both users and maintainers.

At the moment `GatedRepoError` is triggered only if token is passed but a [PR is moon-landing](https://github.com/huggingface/moon-landing/pull/7106) (private link) is opened to also trigger a gated repo error for unauthenticated users.

**Note:** there might be some tests to adapt and I'm willing to do it once the logic is approved

(EDIT: I just checked and in the lowest version of `huggingface_hub` that is supported (0.14.1), GatedRepoError [already exists](https://github.com/huggingface/huggingface_hub/blob/v0.14.1/src/huggingface_hub/utils/_errors.py#L108) so no import issue to worry about)