### PR TITLE
fix(integrations): store serialized `TrainingArgs` to `wandb.config` without sanitization.

### DIFF
--- a/src/transformers/integrations.py
+++ b/src/transformers/integrations.py
@@ -716,7 +716,7 @@ class WandbCallback(TrainerCallback):
             logger.info(
                 'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
             )
-            combined_dict = {**args.to_sanitized_dict()}
+            combined_dict = {**args.to_dict()}
 
             if hasattr(model, "config") and model.config is not None:
                 model_config = model.config.to_dict()


### PR DESCRIPTION
Allows resuming training runs when  reusing the wandb config.

# What does this PR do?

Currently the `WandbLogger` uses the `to_sanitized_dict()` method in `TrainingArguments` to serialize the training hyperparameters. This converts nested objects and `NoneType` objects to `str` for safe serialization.  However, using the stored config when resuming a training run leads to issues while initializing the `TrainingArguments` from the `wandb.run.config`. This PR fixes this by instead using the `to_dict` method to serialize the `TrainingArguments`. The resulting dictionary can be stored in the `wandb.config` and reused to resume training runs. 


## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?

## Who can review?


- trainer: @sgugger , @pacman100 
