### PR TITLE
Add offload support to Bark

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1426,7 +1426,7 @@ class BarkModel(BarkPreTrainedModel):
         the next sub-model runs.
 
         Args:
-            gpu_id (`Optional[int]`, *optional*, defaults to 0):
+            gpu_id (`int`, *optional*, defaults to 0):
                 GPU id on which the sub-models will be loaded and offloaded.
         """
         if is_accelerate_available():

--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1572,7 +1572,7 @@ class BarkModel(BarkPreTrainedModel):
             **kwargs_fine,
         )
 
-        if hasattr(self, "fine_acoustics_hook") and self.fine_acoustics_hook is not None:
+        if getattr(self, "fine_acoustics_hook", None) is not None:
             # Manually offload fine_acoustics to CPU
             # and load codec_model to GPU
             # since bark doesn't use codec_model forward pass
@@ -1582,7 +1582,7 @@ class BarkModel(BarkPreTrainedModel):
         # 4. Decode the output and generate audio array
         audio = self.codec_decode(output)
 
-        if hasattr(self, "codec_model_hook") and self.codec_model_hook is not None:
+        if getattr(self, "codec_model_hook", None) is not None:
             # Offload codec_model to CPU
             self.codec_model_hook.offload()
 

--- a/tests/models/bark/test_modeling_bark.py
+++ b/tests/models/bark/test_modeling_bark.py
@@ -31,7 +31,8 @@ from transformers.models.bark.generation_configuration_bark import (
     BarkFineGenerationConfig,
     BarkSemanticGenerationConfig,
 )
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_gpu, slow, torch_device
+from transformers.trainer_utils import set_seed
 from transformers.utils import cached_property
 
 from ...generation.test_utils import GenerationTesterMixin
@@ -50,6 +51,8 @@ if is_torch_available():
         BarkProcessor,
         BarkSemanticModel,
     )
+
+set_seed(42)
 
 
 class BarkSemanticModelTester:
@@ -989,3 +992,42 @@ class BarkModelIntegrationTests(unittest.TestCase):
                 coarse_temperature=0.2,
                 fine_temperature=0.1,
             )
+
+    @require_torch_gpu
+    @slow
+    def test_generate_end_to_end_with_offload(self):
+        input_ids = self.inputs
+
+        with torch.no_grad():
+            # standard generation
+            output_with_no_offload = self.model.generate(**input_ids, do_sample=False, fine_temperature=None)
+
+            torch.cuda.empty_cache()
+
+            memory_before_offload = torch.cuda.memory_allocated()
+            model_memory_footprint = self.model.get_memory_footprint()
+
+            # activate cpu offload
+            self.model.enable_cpu_offload()
+
+            memory_after_offload = torch.cuda.memory_allocated()
+
+            # checks if the model have been offloaded
+
+            # CUDA memory usage after offload should be near 0, leaving room to small differences
+            room_for_difference = 1.1
+            self.assertGreater(
+                (memory_before_offload - model_memory_footprint) * room_for_difference, memory_after_offload
+            )
+
+            # checks if device is the correct one
+            self.assertEqual(self.model.device.type, torch_device)
+
+            # checks if hooks exist
+            self.assertTrue(hasattr(self.model.semantic, "_hf_hook"))
+
+            # output with cpu offload
+            output_with_offload = self.model.generate(**input_ids, do_sample=False, fine_temperature=None)
+
+        # checks if same output
+        self.assertListEqual(output_with_no_offload.tolist(), output_with_offload.tolist())

--- a/tests/models/bark/test_modeling_bark.py
+++ b/tests/models/bark/test_modeling_bark.py
@@ -32,7 +32,6 @@ from transformers.models.bark.generation_configuration_bark import (
     BarkSemanticGenerationConfig,
 )
 from transformers.testing_utils import require_torch, require_torch_gpu, slow, torch_device
-from transformers.trainer_utils import set_seed
 from transformers.utils import cached_property
 
 from ...generation.test_utils import GenerationTesterMixin
@@ -51,8 +50,6 @@ if is_torch_available():
         BarkProcessor,
         BarkSemanticModel,
     )
-
-set_seed(42)
 
 
 class BarkSemanticModelTester:


### PR DESCRIPTION
# What does this PR do?

Bark is a TTS model recently added by #24086. 

It is made of is of 4 main sub-models, which are sequentially called during generation (`BarkModel.generate`). When a sub-model is used, the other models remain unused, taking up a lot of space on the GPU.

This PR thus propose a simple, yet effective, handmade offloading of sub-models.

```python
from transformers import BarkModel, BarkProcessor

# no need to load the model onto GPU, it will be done inside the generate function
model = BarkModel.from_pretrained("suno/bark")
processor = BarkProcessor.from_pretrained("suno/bark")

# works if a GPU is available. Throws a warning if not, and uses default behavior.
device = "cuda"

# input must be put onto the right device, i.e onto the GPU.
input = processor("Hey, it's a test").to(device)

# one simple additional argument
output = model.generate(**input, offload_to_cpu = True)

# output is loaded onto GPU as well
```

With this PR, GPU footprint is around 60% lower, while being less than 10% slower, based on a benchmark I've done and that will be shared soon (`batch_size = 1` on a single TITAN RTX).


TODO:
- [x] write tests


## Who can review?

Hey @sanchit-gandhi and @amyeroberts, I'm tagging you because you were the ones reviewing  #24086 and because the changes are really small! 
I'm wondering whether the code I've written conforms to the transformer paradigm and whether I need to raise additional warnings or errors in extreme cases!
Many thanks!
