### PR TITLE
[`8bit`] Fix 8bit corner case with Blip2 8bit

### DIFF
--- a/src/transformers/utils/bitsandbytes.py
+++ b/src/transformers/utils/bitsandbytes.py
@@ -273,7 +273,7 @@ def get_keys_to_not_convert(model):
         return []
 
     # otherwise they have an attached head
-    list_modules = list(model.named_children())
+    list_modules = list(model.named_parameters())
     list_last_module = [list_modules[-1][0]]
 
     # add last module together with tied weights


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/25011
Fixes https://github.com/huggingface/transformers/issues/25026

https://github.com/huggingface/transformers/pull/24095/ introduced a new check for retrieving the list of modules that are not needed to be quantized (e.g. LM head). While it works perfectly fine for text models, when using `model.named_children()`, the last element of that list would be the entire `language_model` module for `Blip2` models. This lead to the entire language model not being converted in 8bit by `replace_bnb_linear` method, leading to an 8bit bnb weight forced to be loaded on a `nn.Linear` module, hence the error. 

The fix is to use `model.named_parameters()` to correctly get the last parameter (usually the lm_head) and not the last children

cc @sgugger 

Will mark as ready for review once the slow tests are green
