### PR TITLE
Better error message when signal is not supported on OS

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -532,19 +532,27 @@ def resolve_trust_remote_code(trust_remote_code, model_name, has_local_code, has
         if has_local_code:
             trust_remote_code = False
         elif has_remote_code and TIME_OUT_REMOTE_CODE > 0:
-            signal.signal(signal.SIGALRM, _raise_timeout_error)
-            signal.alarm(TIME_OUT_REMOTE_CODE)
-            while trust_remote_code is None:
-                answer = input(
-                    f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
-                    f"the repository at https://hf.co/{model_name}. You can dismiss this prompt by passing "
-                    "`trust_remote_code=True`.\nDo you accept? [y/N] "
+            try:
+                signal.signal(signal.SIGALRM, _raise_timeout_error)
+                signal.alarm(TIME_OUT_REMOTE_CODE)
+                while trust_remote_code is None:
+                    answer = input(
+                        f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
+                        f"the repository at https://hf.co/{model_name}. You can dismiss this prompt by passing "
+                        "`trust_remote_code=True`.\nDo you accept? [y/N] "
+                    )
+                    if answer.lower() in ["yes", "y", "1"]:
+                        trust_remote_code = True
+                    elif answer.lower() in ["no", "n", "0", ""]:
+                        trust_remote_code = False
+                signal.alarm(0)
+            except AttributeError:
+                # OS which does not support signal.SIGALRM
+                raise ValueError(
+                    "Loading this model requires you to execute execute some code in that repo in that repo on your "
+                    "local machine. Make sure you have read the code there to avoid malicious use, then set the "
+                    "option `trust_remote_code=True` to remove this error."
                 )
-                if answer.lower() in ["yes", "y", "1"]:
-                    trust_remote_code = True
-                elif answer.lower() in ["no", "n", "0", ""]:
-                    trust_remote_code = False
-            signal.alarm(0)
         elif has_remote_code:
             # For the CI which puts the timeout at 0
             _raise_timeout_error(None, None)

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -549,9 +549,9 @@ def resolve_trust_remote_code(trust_remote_code, model_name, has_local_code, has
             except AttributeError:
                 # OS which does not support signal.SIGALRM
                 raise ValueError(
-                    "Loading this model requires you to execute execute some code in that repo in that repo on your "
-                    "local machine. Make sure you have read the code there to avoid malicious use, then set the "
-                    "option `trust_remote_code=True` to remove this error."
+                    "Loading this model requires you to execute execute some code in that repo on your local machine. "
+                    f"Make sure you have read the code at https://hf.co/{model_name} to avoid malicious use, then set "
+                    "the option `trust_remote_code=True` to remove this error."
                 )
         elif has_remote_code:
             # For the CI which puts the timeout at 0


### PR DESCRIPTION
# What does this PR do?

This PR adds a `try`/`except` block around the logic asking the user whether they want to execute the code on a distant repo when they don't set `trust_remote_code=True` to give a helpful error message.

Fixes #25029