### PR TITLE
[ `PreTrainedTokenizerFast`] Keep properties from fast tokenizer

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1523,7 +1523,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         self.model_max_length = model_max_length if model_max_length is not None else VERY_LARGE_INTEGER
 
         # Padding and truncation side are right by default and overridden in subclasses. If specified in the kwargs, it
-        # is changed.
+        # is changed. FIXME this does not work when initializing a fast from a fast
         self.padding_side = kwargs.pop("padding_side", self.padding_side)
         if self.padding_side not in ["right", "left"]:
             raise ValueError(

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1523,7 +1523,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         self.model_max_length = model_max_length if model_max_length is not None else VERY_LARGE_INTEGER
 
         # Padding and truncation side are right by default and overridden in subclasses. If specified in the kwargs, it
-        # is changed. FIXME this does not work when initializing a fast from a fast
+        # is changed.
         self.padding_side = kwargs.pop("padding_side", self.padding_side)
         if self.padding_side not in ["right", "left"]:
             raise ValueError(

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -132,6 +132,17 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
         self._decode_use_source_tokenizer = False
 
+        _truncation = self._tokenizer.truncation
+        if _truncation is not None:
+            self._tokenizer.no_truncation()
+            self._tokenizer.enable_truncation(**_truncation)
+        _padding = self._tokenizer.padding
+        if _padding is not None:
+            self._tokenizer.enable_padding(**_padding)
+            kwargs.update({"pad_token": _padding["pad_token"]})
+            kwargs.update({"padding_side": _padding["direction"]})
+            kwargs.update({"max_length": _padding["length"]})
+            kwargs.update({"pad_to_multiple_of": _padding["pad_to_multiple_of"]})
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
 
@@ -346,7 +357,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 the use of Tensor Cores on NVIDIA hardware with compute capability `>= 7.5` (Volta).
         """
         _truncation = self._tokenizer.truncation
+        print(f"_truncation: {_truncation}")
         _padding = self._tokenizer.padding
+        print(f"_padding: {_padding}")
         # Set truncation and padding on the backend tokenizer
         if truncation_strategy == TruncationStrategy.DO_NOT_TRUNCATE:
             if _truncation is not None:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -139,10 +139,11 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         _padding = self._tokenizer.padding
         if _padding is not None:
             self._tokenizer.enable_padding(**_padding)
-            kwargs.update({"pad_token": _padding["pad_token"]})
-            kwargs.update({"padding_side": _padding["direction"]})
-            kwargs.update({"max_length": _padding["length"]})
-            kwargs.update({"pad_to_multiple_of": _padding["pad_to_multiple_of"]})
+            kwargs.setdefault("pad_token", _padding["pad_token"])
+            kwargs.setdefault("padding_side", _padding["direction"])
+            kwargs.setdefault("max_length", _padding["length"])
+            kwargs.setdefault("pad_to_multiple_of", _padding["pad_to_multiple_of"])
+
         # We call this after having initialized the backend tokenizer because we update it.
         super().__init__(**kwargs)
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -136,6 +136,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         if _truncation is not None:
             self._tokenizer.no_truncation()
             self._tokenizer.enable_truncation(**_truncation)
+            kwargs.setdefault("max_length", _truncation["length"])
+            kwargs.setdefault("truncation_side", _truncation["direction"])
+
         _padding = self._tokenizer.padding
         if _padding is not None:
             self._tokenizer.enable_padding(**_padding)
@@ -358,9 +361,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
                 the use of Tensor Cores on NVIDIA hardware with compute capability `>= 7.5` (Volta).
         """
         _truncation = self._tokenizer.truncation
-        print(f"_truncation: {_truncation}")
         _padding = self._tokenizer.padding
-        print(f"_padding: {_padding}")
         # Set truncation and padding on the backend tokenizer
         if truncation_strategy == TruncationStrategy.DO_NOT_TRUNCATE:
             if _truncation is not None:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -133,16 +133,21 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         self._decode_use_source_tokenizer = False
 
         _truncation = self._tokenizer.truncation
+
         if _truncation is not None:
-            self._tokenizer.no_truncation()
             self._tokenizer.enable_truncation(**_truncation)
-            kwargs.setdefault("max_length", _truncation["length"])
+            kwargs.setdefault("max_length", _truncation["max_length"])
             kwargs.setdefault("truncation_side", _truncation["direction"])
+            kwargs.setdefault("stride", _truncation["stride"])
+            kwargs.setdefault("truncation_strategy", _truncation["strategy"])
+        else:
+            self._tokenizer.no_truncation()
 
         _padding = self._tokenizer.padding
         if _padding is not None:
             self._tokenizer.enable_padding(**_padding)
             kwargs.setdefault("pad_token", _padding["pad_token"])
+            kwargs.setdefault("pad_token_type_id", _padding["pad_type_id"])
             kwargs.setdefault("padding_side", _padding["direction"])
             kwargs.setdefault("max_length", _padding["length"])
             kwargs.setdefault("pad_to_multiple_of", _padding["pad_to_multiple_of"])

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -118,8 +118,8 @@ class PreTrainedTokenizationFastTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(
             tokenizer.padding,
             {
-                "length": None,
-                "pad_to_multiple_of": None,
+                "length": 512,
+                "pad_to_multiple_of": 64,
                 "pad_id": 0,
                 "pad_token": "<pad>",
                 "pad_type_id": 0,

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -139,7 +139,7 @@ class PreTrainedTokenizationFastTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertEqual(tok.init_kwargs["max_length"], 512)
             self.assertEqual(tok.init_kwargs["pad_to_multiple_of"], 8)
             # fmt: off
-            # self.assertEqual(tok(sentences), {'input_ids': [[8774, 6, 3, 63, 31, 1748, 55, 1, 0, 0, 0, 0,0, 0, 0, 0],[ 571, 33, 25, 3, 2, 3, 58, 290, 225, 59, 36, 136, 962, 269, 58, 1]], 'token_type_ids': [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], 'attention_mask': [[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]})
+            self.assertEqual(tok(sentences, padding = True), {'input_ids': [[8774, 6, 3, 63, 31, 1748, 55, 1, 0, 0, 0, 0,0, 0, 0, 0],[ 571, 33, 25, 3, 2, 3, 58, 290, 225, 59, 36, 136, 962, 269, 58, 1]], 'token_type_ids': [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], 'attention_mask': [[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]})
             # fmt: on
 
         tokenizer.enable_truncation(8, stride=0, strategy="longest_first", direction="right")
@@ -155,10 +155,11 @@ class PreTrainedTokenizationFastTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertEqual(tok.init_kwargs["truncation_strategy"], "longest_first")
             self.assertEqual(tok.init_kwargs["max_length"], 8)
             self.assertEqual(tok.init_kwargs["stride"], 0)
-            # should truncate by default
-            print(tok(sentences, return_tensors="pt"))
-
-            assert tok(sentences, return_tensors="pt")
+            # NOTE even if the model has a default max_length, it is not used...
+            # thus tok(sentences, truncation = True) does nothing and does not warn either
+            # fmt: off
+            self.assertEqual(tok(sentences, truncation = True, max_length = 8), {'input_ids': [[8774, 6, 3, 63, 31, 1748, 55, 1],[ 571, 33, 25, 3, 2, 3, 58, 1]], 'token_type_ids': [[0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0]], 'attention_mask': [[1, 1, 1, 1, 1, 1, 1, 1],[1, 1, 1, 1, 1, 1, 1, 1]]})
+            # fmt: on
 
 
 @require_tokenizers

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -111,6 +111,7 @@ class PreTrainedTokenizationFastTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_init_from_tokenizers_model(self):
         from tokenizers import Tokenizer
+
         sentences = ["Hello, y'all!", "How are you 😁 ?"]
 
         tokenizer = Tokenizer.from_pretrained("t5-base")


### PR DESCRIPTION
# What does this PR do?
Start a potential fix to #24179, ended up being releated to #24441, calling modifies the values of the underlying tokenizer, but never changes anything on the surface so will probably add some kind of warning in the documentation. 

TLDR; adds the possibility  of initialize a `PreTrainedTokenizerFast` from a `tokenizer.Tokenizer`, keeping the `padding` and `truncation` informations. 

