### PR TITLE
Generate: return `past_key_values`

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -109,8 +109,8 @@ class GreedySearchDecoderOnlyOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -153,8 +153,8 @@ class ContrastiveSearchEncoderDecoderOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -193,8 +193,8 @@ class ContrastiveSearchDecoderOnlyOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -240,8 +240,8 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -280,8 +280,8 @@ class SampleDecoderOnlyOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -328,8 +328,8 @@ class SampleEncoderDecoderOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -372,8 +372,8 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -427,8 +427,8 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -473,8 +473,8 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -527,8 +527,8 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
             Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
             tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
-            `config.is_encoder_decoder=True` 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+            `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2081,8 +2081,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2094,7 +2092,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2195,8 +2192,6 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
-                if output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             # Replicates the new past_key_values to match the `top_k` candidates
             new_key_values = []
@@ -2399,7 +2394,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return ContrastiveSearchDecoderOnlyOutput(
@@ -2407,7 +2402,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return input_ids
@@ -2542,8 +2537,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2555,7 +2548,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2615,8 +2607,6 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
-                if output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             # argmax
             next_tokens = torch.argmax(next_tokens_scores, dim=-1)
@@ -2665,7 +2655,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return GreedySearchDecoderOnlyOutput(
@@ -2673,7 +2663,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return input_ids
@@ -2828,8 +2818,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2841,7 +2829,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2903,8 +2890,6 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
-                if output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             # sample
             probs = nn.functional.softmax(next_token_scores, dim=-1)
@@ -2954,7 +2939,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return SampleDecoderOnlyOutput(
@@ -2962,7 +2947,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return input_ids
@@ -3112,8 +3097,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3138,7 +3121,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3241,8 +3223,6 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if return_dict_in_generate and output_past_key_values:
-                    past_key_values += (model_kwargs["past"],)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3282,7 +3262,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -3292,7 +3272,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return sequence_outputs["sequences"]
@@ -3453,8 +3433,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3474,7 +3452,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3577,8 +3554,6 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if return_dict_in_generate and output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3618,7 +3593,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return BeamSampleDecoderOnlyOutput(
@@ -3628,7 +3603,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return sequence_outputs["sequences"]
@@ -3782,8 +3757,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3813,7 +3786,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3965,8 +3937,6 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
-                if return_dict_in_generate and output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             # increase cur_len
             cur_len = cur_len + 1
@@ -4004,7 +3974,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -4014,7 +3984,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return sequence_outputs["sequences"]
@@ -4175,8 +4145,6 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
-        use_cache = model_kwargs.get("use_cache")
-        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -4201,7 +4169,6 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
-        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -4306,8 +4273,6 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if return_dict_in_generate and output_past_key_values:
-                    past_key_values += (outputs.past_key_values,)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -4346,7 +4311,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -4356,12 +4321,11 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=past_key_values,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return sequence_outputs["sequences"]
 
-    # --------------------------------------------------------------------------------------------- missing this one
     def assisted_decoding(
         self,
         input_ids: torch.LongTensor,
@@ -4763,6 +4727,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
             else:
                 return GreedySearchDecoderOnlyOutput(
@@ -4770,6 +4735,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=model_kwargs.get("past_key_values"),
                 )
         else:
             return input_ids

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -104,12 +104,19 @@ class GreedySearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
     scores: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -140,6 +147,12 @@ class ContrastiveSearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -149,6 +162,7 @@ class ContrastiveSearchEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -169,15 +183,22 @@ class ContrastiveSearchDecoderOnlyOutput(ModelOutput):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, num_heads, generated_length, sequence_length)`.
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is
-        passed or when `config.output_hidden_states=True`):
+            passed or when `config.output_hidden_states=True`): Tuple (one element for each generated token) of tuples
+            (one element for each layer of the decoder) of `torch.FloatTensor` of shape `(batch_size, generated_length,
+            hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
     scores: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -211,6 +232,12 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -220,6 +247,7 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -243,12 +271,19 @@ class SampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(num_return_sequences*batch_size, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
     scores: Optional[Tuple[torch.FloatTensor]] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -283,6 +318,12 @@ class SampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -292,6 +333,7 @@ class SampleEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -319,6 +361,12 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -327,6 +375,7 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
     beam_indices: Optional[torch.LongTensor] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -366,6 +415,12 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -377,6 +432,7 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -404,6 +460,12 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -412,6 +474,7 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
     beam_indices: Optional[torch.LongTensor] = None
     attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 @dataclass
@@ -450,6 +513,12 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
+            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
+            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
+            encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -461,6 +530,7 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
     decoder_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     cross_attentions: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
     decoder_hidden_states: Optional[Tuple[Tuple[torch.FloatTensor]]] = None
+    past_key_values: Optional[Tuple[Tuple[Tuple[torch.FloatTensor]]]] = None
 
 
 GreedySearchOutput = Union[GreedySearchEncoderDecoderOutput, GreedySearchDecoderOnlyOutput]
@@ -2011,6 +2081,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2022,6 +2094,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2122,6 +2195,8 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
+                if output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             # Replicates the new past_key_values to match the `top_k` candidates
             new_key_values = []
@@ -2324,6 +2399,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return ContrastiveSearchDecoderOnlyOutput(
@@ -2331,6 +2407,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return input_ids
@@ -2465,6 +2542,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2476,6 +2555,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2535,6 +2615,8 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
+                if output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             # argmax
             next_tokens = torch.argmax(next_tokens_scores, dim=-1)
@@ -2583,6 +2665,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return GreedySearchDecoderOnlyOutput(
@@ -2590,6 +2673,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return input_ids
@@ -2744,6 +2828,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -2755,6 +2841,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -2816,6 +2903,8 @@ class GenerationMixin:
                         if self.config.is_encoder_decoder
                         else (outputs.hidden_states,)
                     )
+                if output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             # sample
             probs = nn.functional.softmax(next_token_scores, dim=-1)
@@ -2865,6 +2954,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return SampleDecoderOnlyOutput(
@@ -2872,6 +2962,7 @@ class GenerationMixin:
                     scores=scores,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return input_ids
@@ -3021,6 +3112,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3045,6 +3138,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3147,6 +3241,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if return_dict_in_generate and output_past_key_values:
+                    past_key_values += (model_kwargs["past"],)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3186,6 +3282,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -3195,6 +3292,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return sequence_outputs["sequences"]
@@ -3355,6 +3453,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3374,6 +3474,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3476,6 +3577,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if return_dict_in_generate and output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3515,6 +3618,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return BeamSampleDecoderOnlyOutput(
@@ -3524,6 +3628,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return sequence_outputs["sequences"]
@@ -3677,6 +3782,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -3706,6 +3813,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -3857,6 +3965,8 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
+                if return_dict_in_generate and output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             # increase cur_len
             cur_len = cur_len + 1
@@ -3894,6 +4004,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -3903,6 +4014,7 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return sequence_outputs["sequences"]
@@ -4063,6 +4175,8 @@ class GenerationMixin:
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
         )
+        use_cache = model_kwargs.get("use_cache")
+        output_past_key_values = use_cache if use_cache is not None else getattr(self.config, "use_cache", False)
         return_dict_in_generate = (
             return_dict_in_generate
             if return_dict_in_generate is not None
@@ -4087,6 +4201,7 @@ class GenerationMixin:
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
+        past_key_values = () if (return_dict_in_generate and output_past_key_values) else None
 
         # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
@@ -4191,6 +4306,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if return_dict_in_generate and output_past_key_values:
+                    past_key_values += (outputs.past_key_values,)
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -4229,6 +4346,7 @@ class GenerationMixin:
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
             else:
                 return BeamSearchDecoderOnlyOutput(
@@ -4238,10 +4356,12 @@ class GenerationMixin:
                     beam_indices=sequence_outputs["beam_indices"],
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
+                    past_key_values=past_key_values,
                 )
         else:
             return sequence_outputs["sequences"]
 
+    # --------------------------------------------------------------------------------------------- missing this one
     def assisted_decoding(
         self,
         input_ids: torch.LongTensor,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -104,12 +104,13 @@ class GreedySearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -147,12 +148,13 @@ class ContrastiveSearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -186,12 +188,13 @@ class ContrastiveSearchDecoderOnlyOutput(ModelOutput):
             passed or when `config.output_hidden_states=True`): Tuple (one element for each generated token) of tuples
             (one element for each layer of the decoder) of `torch.FloatTensor` of shape `(batch_size, generated_length,
             hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -232,12 +235,13 @@ class GreedySearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -271,12 +275,13 @@ class SampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(num_return_sequences*batch_size, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -318,12 +323,13 @@ class SampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_return_sequences, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -361,12 +367,13 @@ class BeamSearchDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -415,12 +422,13 @@ class BeamSearchEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams*num_return_sequences, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -460,12 +468,13 @@ class BeamSampleDecoderOnlyOutput(ModelOutput):
         hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None
@@ -513,12 +522,13 @@ class BeamSampleEncoderDecoderOutput(ModelOutput):
         decoder_hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
             `torch.FloatTensor` of shape `(batch_size*num_beams, generated_length, hidden_size)`.
-        past_key_values (`tuple(tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
-            tuples (two elements, key tensor and value tensor). The second Tuple is of length `config.n_layers`, with
-            each tuple having 2 tensors of shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and
-            optionally if `config.is_encoder_decoder=True` 2 additional tensors of shape `(batch_size, num_heads,
-            encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            NOTE: some models have a different `past_key_values` format, confirm with the model's documentation.
+            Usually a Tuple (one element for each layer of the decoder) of tuples (two elements, key tensor and value
+            tensor). The first Tuple is of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and optionally if
+            `config.is_encoder_decoder=True` 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
     """
 
     sequences: torch.LongTensor = None

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2402,7 +2402,7 @@ class GenerationMixin:
                 for layer in model_kwargs["past_key_values"]:
                     layer_past_key_values = []
                     for item in layer:
-                        layer_past_key_values.append(item[:, :, :-1, :])
+                        layer_past_key_values.append(item[..., :-1, :])
                     past_key_values.append(tuple(layer_past_key_values))
                 model_kwargs["past_key_values"] = tuple(past_key_values)
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1892,7 +1892,7 @@ class GenerationTesterMixin:
         # 2. some old models still return `output.past_key_values` even without `use_cache=True`
         if use_cache:
             past_key_values = output.past_key_values
-            past_sequence_length = gen_len - 1 if config.is_encoder_decoder else seq_length + gen_len - 1
+            past_sequence_length = output.sequences.shape[-1] - 1
             self._check_past_key_values_for_generate(
                 num_sequences_in_output,
                 past_key_values,

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1891,7 +1891,7 @@ class GenerationTesterMixin:
         # 1. Its inner sequence length is with respect to the inputs of the latest forward pass, hence the "-1"
         # 2. Some old models still return `output.past_key_values` even without `use_cache=True`
         # 3. TODO (joao): A few models have different formats, skipping those until the cache refactor is complete
-        models_without_standard_cache = ("bloom", "ctrl", "fsmt", "gpt_bigcode", "mega", "reformer")
+        models_without_standard_cache = ("bloom", "ctrl", "fsmt", "gptbigcode", "mega", "reformer")
         has_standard_cache = not any(
             model_name in config.__class__.__name__.lower() for model_name in models_without_standard_cache
         )

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1892,10 +1892,11 @@ class GenerationTesterMixin:
         # 2. some old models still return `output.past_key_values` even without `use_cache=True`
         if use_cache:
             past_key_values = output.past_key_values
+            past_sequence_length = gen_len - 1 if config.is_encoder_decoder else seq_length + gen_len - 1
             self._check_past_key_values_for_generate(
                 num_sequences_in_output,
                 past_key_values,
-                seq_length=gen_len + seq_length - 1,
+                seq_length=past_sequence_length,
                 config=config,
             )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1887,12 +1887,13 @@ class GenerationTesterMixin:
                 use_cache=use_cache,
             )
 
-        # Past Key Value States
+        # Past Key Value States -- note that its inner sequence length is with respect to the inputs of the latest
+        # forward pass, hence the "-1"
         past_key_values = output.past_key_values
         self._check_past_key_values_for_generate(
             num_sequences_in_output,
             past_key_values,
-            seq_length=seq_length,
+            seq_length=gen_len + seq_length - 1,
             config=config,
         )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1961,9 +1961,7 @@ class GenerationTesterMixin:
             [encoder_expected_shape] * len(hidden_states),
         )
 
-    def _check_past_key_values_for_generate(
-        self, batch_size, past_key_values, seq_len, config, num_beam_groups=1
-    ):
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_len, config, num_beam_groups=1):
         if config.use_cache is False:
             self.assertIsNone(past_key_values)
             return

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1887,6 +1887,17 @@ class GenerationTesterMixin:
                 use_cache=use_cache,
             )
 
+        # Past Key Value States
+        past_key_values = output.past_key_values
+        min_length = 1 if config.is_encoder_decoder else seq_length
+        self._check_past_key_values_for_generate(
+            num_sequences_in_output,
+            past_key_values,
+            min_length=min_length,
+            max_length=output.sequences.shape[-1],
+            config=config,
+        )
+
     def _check_scores(self, batch_size, scores, length, config):
         expected_shape = (batch_size, config.vocab_size)
         self.assertIsInstance(scores, tuple)
@@ -1951,6 +1962,39 @@ class GenerationTesterMixin:
             [layer_hidden_states.shape for layer_hidden_states in hidden_states],
             [encoder_expected_shape] * len(hidden_states),
         )
+
+    def _check_past_key_values_for_generate(
+        self, batch_size, past_key_values, min_length, max_length, config, num_beam_groups=1
+    ):
+        if config.use_cache is False:
+            self.assertIsNone(past_key_values)
+            return
+
+        self.assertIsInstance(past_key_values, tuple)
+        self.assertListEqual(
+            [isinstance(iter_past_key_values, tuple) for iter_past_key_values in past_key_values],
+            [True] * len(past_key_values),
+        )
+        self.assertEqual(len(past_key_values), (max_length - min_length) * num_beam_groups)
+
+        for idx, iter_past_key_values in enumerate(past_key_values):
+            seq_len = min_length + idx
+            # (batch, head, seq_length, head_features)
+            expected_shape = (
+                batch_size * num_beam_groups,
+                config.num_attention_heads,
+                seq_len,
+                config.hidden_size // config.num_attention_heads,
+            )
+            # check shape key, value
+            self.assertListEqual(
+                [layer_past_key_values[0].shape for layer_past_key_values in iter_past_key_values],
+                [expected_shape] * len(iter_past_key_values),
+            )
+            self.assertListEqual(
+                [layer_past_key_values[1].shape for layer_past_key_values in iter_past_key_values],
+                [expected_shape] * len(iter_past_key_values),
+            )
 
     def _check_sequence_inside_sequence(self, tensor_1, tensor_2):
         # check if tensor_1 inside tensor_2 or tensor_2 inside tensor_1.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1961,7 +1961,7 @@ class GenerationTesterMixin:
             [encoder_expected_shape] * len(hidden_states),
         )
 
-    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_len, config, num_beam_groups=1):
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config, num_beam_groups=1):
         if config.use_cache is False:
             self.assertIsNone(past_key_values)
             return
@@ -1976,7 +1976,7 @@ class GenerationTesterMixin:
         expected_shape = (
             batch_size * num_beam_groups,
             config.num_attention_heads,
-            seq_len,
+            seq_length,
             config.hidden_size // config.num_attention_heads,
         )
         # check shape key, value

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1822,6 +1822,53 @@ class GenerationTesterMixin:
                 outputs_from_embeds_wo_ids[:, 1:].tolist(),
             )
 
+    def test_generate_continue_from_past_key_values(self):
+        # Tests that we can continue generating from past key values, returned from a previous `generate` call
+        for model_class in self.all_generative_model_classes:
+            config, inputs_ids, _, _ = self._get_input_ids_and_config()
+
+            # If it doesn't support cache, pass the test
+            if not hasattr(config, "use_cache"):
+                return
+            config.use_cache = True
+
+            model = model_class(config).to(torch_device)
+            model.eval()
+
+            # If "past_key_values" is not returned, pass the test (e.g. RWKV uses a different cache name and format)
+            outputs = model(inputs_ids)
+            if "past_key_values" not in outputs:
+                return
+
+            # Let's force it to always generate to max length
+            config.pad_token_id = config.eos_token_id = -1
+
+            # Traditional way of generating text, with `return_dict_in_generate` to return the past key values
+            outputs = model.generate(inputs_ids, do_sample=False, max_new_tokens=10, return_dict_in_generate=True)
+
+            # Let's generate again, but passing the past key values in between (9 + 1 = 10 tokens)
+            outputs_cached = model.generate(
+                inputs_ids, do_sample=False, max_new_tokens=9, return_dict_in_generate=True
+            )
+            outputs_cached = model.generate(
+                outputs_cached.sequences,  # continue from the 9 tokens generated previously
+                do_sample=False,
+                past_key_values=outputs_cached.past_key_values,
+                max_new_tokens=1,
+                return_dict_in_generate=True,
+            )
+
+            # The two sets should be equal to each other
+            self.assertListEqual(outputs.sequences.tolist(), outputs_cached.sequences.tolist())
+            for layer_idx in range(len(outputs_cached.past_key_values)):
+                for kv_idx in range(len(outputs_cached.past_key_values[layer_idx])):
+                    self.assertTrue(
+                        torch.allclose(
+                            outputs.past_key_values[layer_idx][kv_idx],
+                            outputs_cached.past_key_values[layer_idx][kv_idx],
+                        )
+                    )
+
     def _check_outputs(self, output, input_ids, config, use_cache=False, num_return_sequences=1):
         batch_size, seq_length = input_ids.shape
         num_sequences_in_output = batch_size * num_return_sequences

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1889,12 +1889,10 @@ class GenerationTesterMixin:
 
         # Past Key Value States
         past_key_values = output.past_key_values
-        min_length = 1 if config.is_encoder_decoder else seq_length
         self._check_past_key_values_for_generate(
             num_sequences_in_output,
             past_key_values,
-            min_length=min_length,
-            max_length=output.sequences.shape[-1],
+            seq_length=seq_length,
             config=config,
         )
 
@@ -1964,7 +1962,7 @@ class GenerationTesterMixin:
         )
 
     def _check_past_key_values_for_generate(
-        self, batch_size, past_key_values, min_length, max_length, config, num_beam_groups=1
+        self, batch_size, past_key_values, seq_len, config, num_beam_groups=1
     ):
         if config.use_cache is False:
             self.assertIsNone(past_key_values)
@@ -1975,26 +1973,23 @@ class GenerationTesterMixin:
             [isinstance(iter_past_key_values, tuple) for iter_past_key_values in past_key_values],
             [True] * len(past_key_values),
         )
-        self.assertEqual(len(past_key_values), (max_length - min_length) * num_beam_groups)
 
-        for idx, iter_past_key_values in enumerate(past_key_values):
-            seq_len = min_length + idx
-            # (batch, head, seq_length, head_features)
-            expected_shape = (
-                batch_size * num_beam_groups,
-                config.num_attention_heads,
-                seq_len,
-                config.hidden_size // config.num_attention_heads,
-            )
-            # check shape key, value
-            self.assertListEqual(
-                [layer_past_key_values[0].shape for layer_past_key_values in iter_past_key_values],
-                [expected_shape] * len(iter_past_key_values),
-            )
-            self.assertListEqual(
-                [layer_past_key_values[1].shape for layer_past_key_values in iter_past_key_values],
-                [expected_shape] * len(iter_past_key_values),
-            )
+        # (batch, head, seq_length, head_features)
+        expected_shape = (
+            batch_size * num_beam_groups,
+            config.num_attention_heads,
+            seq_len,
+            config.hidden_size // config.num_attention_heads,
+        )
+        # check shape key, value
+        self.assertListEqual(
+            [layer_past_key_values[0].shape for layer_past_key_values in past_key_values],
+            [expected_shape] * len(past_key_values),
+        )
+        self.assertListEqual(
+            [layer_past_key_values[1].shape for layer_past_key_values in past_key_values],
+            [expected_shape] * len(past_key_values),
+        )
 
     def _check_sequence_inside_sequence(self, tensor_1, tensor_2):
         # check if tensor_1 inside tensor_2 or tensor_2 inside tensor_1.


### PR DESCRIPTION
# What does this PR do?

Enables returning `past_key_values` from `generate`, if `return_dict_in_generate=True` (otherwise only the generated `input_ids` are returned) and `use_cache=True` (otherwise there is no cache to return ;) ).

In more abstract terms, this enables features like:
1. continuing a given generation without having the more expensive prefill step -- like in multi-turn conversations
2. exploring the KV values without having to place a breakpoint in `generate` 👀 🐛 

The added code for the feature is minimal, so most of the PR is docs and tests 🤗  

Fixes #24841 