### PR TITLE
fix tied_params for meta tensor

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3072,9 +3072,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # id function doesn't work for meta tensor so we need this function
             tied_params = find_tied_parameters(model)
 
-        # These are all the pointers of shared tensors.
-        tied_params = [names for _, names in ptrs.items() if len(names) > 1]
-
         for group in tied_params:
             if remove_prefix_from_model:
                 group = [key[len(_prefix) :] if key.startswith(_prefix) else key for key in group]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3060,10 +3060,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         unexpected_keys = list(unexpected_keys - model_buffers)
 
         model.tie_weights()
-        ptrs = collections.defaultdict(list)
-        for name, tensor in model.state_dict().items():
-            id_tensor = id_tensor_storage(tensor) if tensor.device != torch.device("meta") else id(tensor)
-            ptrs[id_tensor].append(name)
+        if device_map is None:
+            ptrs = collections.defaultdict(list)
+            for name, tensor in model.state_dict().items():
+                id_tensor = id_tensor_storage(tensor)
+                ptrs[id_tensor].append(name)
+
+            # These are all the pointers of shared tensors.
+            tied_params = [names for _, names in ptrs.items() if len(names) > 1]
+        else:
+            # id function doesn't work for meta tensor so we need this function
+            tied_params = find_tied_parameters(model)
 
         # These are all the pointers of shared tensors.
         tied_params = [names for _, names in ptrs.items() if len(names) > 1]


### PR DESCRIPTION
# What does this PR do?
This PR fix the retrieval of `tied_params` when we load a model with accelerate. The issue was that we were not able to retrieve the tied parameters by using the `id` function to check equality between meta `tensor`. Instead, we use `find_tied_parameters` from accelerate library. 

Solves [#1772](https://github.com/huggingface/accelerate/issues/1772)