### PR TITLE
fix get_keys_to_not_convert() to return correct modules for full precision inference

### DIFF
--- a/tests/bnb/test_mixed_int8.py
+++ b/tests/bnb/test_mixed_int8.py
@@ -133,20 +133,22 @@ class MixedInt8Test(BaseMixedInt8Test):
         from transformers import AutoModelForMaskedLM, Blip2ForConditionalGeneration, MptForCausalLM, OPTForCausalLM
         from transformers.utils.bitsandbytes import get_keys_to_not_convert
 
-        config = AutoConfig.from_pretrained("mosaicml/mpt-7b", trust_remote_code=True)
+        model_id = "mosaicml/mpt-7b"
+        config = AutoConfig.from_pretrained(
+            model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+        )
         with init_empty_weights():
             model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
         self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
-
-        config = AutoConfig.from_pretrained("mosaicml/mpt-7b")
+        # without trust_remote_code
+        config = AutoConfig.from_pretrained(model_id, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")
         with init_empty_weights():
             model = MptForCausalLM(config)
         # The order of the keys does not matter, so we sort them before comparing, same for the other tests.
         self.assertEqual(get_keys_to_not_convert(model).sort(), ["lm_head", "transformer.wte"].sort())
 
         model_id = "Salesforce/blip2-opt-2.7b"
-        config = AutoConfig.from_pretrained(model_id)
-
+        config = AutoConfig.from_pretrained(model_id, revision="1ef7f63a8f0a144c13fdca8103eb7b4691c74cec")
         with init_empty_weights():
             model = Blip2ForConditionalGeneration(config)
         self.assertEqual(
@@ -155,13 +157,13 @@ class MixedInt8Test(BaseMixedInt8Test):
         )
 
         model_id = "facebook/opt-350m"
-        config = AutoConfig.from_pretrained(model_id)
+        config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         with init_empty_weights():
             model = OPTForCausalLM(config)
         self.assertEqual(get_keys_to_not_convert(model).sort(), ["lm_head", "model.decoder.embed_tokens"].sort())
 
         model_id = "roberta-large"
-        config = AutoConfig.from_pretrained(model_id)
+        config = AutoConfig.from_pretrained(model_id, revision="716877d372b884cad6d419d828bac6c85b3b18d9")
         with init_empty_weights():
             model = AutoModelForMaskedLM.from_config(config)
         self.assertEqual(


### PR DESCRIPTION
# What does this PR do?
This PR fixes `get_keys_to_not_convert()` and returns the correct modules that should not be quantized for numerical stability reasons. 

For GPT2 and bloom, both the current(1st output) and new version(2nd output) work well.
GPT2
```
>>> filtered_module_names_old is ['transformer.wte', 'lm_head', 'lm_head'] # both are correct, duplicated though

>>>  filtered_module_names is ['lm_head', 'transformer.wte'] # both are correct
```
bloom
```
>>> filtered_module_names_old is ['lm_head', 'transformer.word_embeddings', 'lm_head'] # both are correct, duplicated though
>>> filtered_module_names is ['transformer.word_embeddings', 'lm_head'] # both are correct
```
But for ChatGLM and MPT(and possibly others), this PR finds the correct modules while the current code doesn't.
MPT
```
>>> filtered_module_names_old is ['transformer.wte', 'transformer.output_wte', 'transformer'] # this is wrong
>>> filtered_module_names is ['transformer.output_wte', 'transformer.wte'] # this is correct
```
ChatGLM2
```
>>> filtered_module_names_old is ['transformer'] # this is wrong
>>> filtered_module_names is ['transformer.output_layer'] # this is correct
```