### PR TITLE
Fix `PvtModelIntegrationTest::test_inference_fp16`

### DIFF
--- a/tests/models/pvt/test_modeling_pvt.py
+++ b/tests/models/pvt/test_modeling_pvt.py
@@ -317,14 +317,13 @@ class PvtModelIntegrationTest(unittest.TestCase):
         r"""
         A small test to make sure that inference work in half precision without any problem.
         """
-        model = PvtForImageClassification.from_pretrained(
-            "Zetatech/pvt-tiny-224", torch_dtype=torch.float16, device_map="auto"
-        )
+        model = PvtForImageClassification.from_pretrained("Zetatech/pvt-tiny-224", torch_dtype=torch.float16)
+        model.to(torch_device)
         image_processor = PvtImageProcessor(size=224)
 
         image = prepare_img()
         inputs = image_processor(images=image, return_tensors="pt")
-        pixel_values = inputs.pixel_values.to(torch_device).astype(torch.float16)
+        pixel_values = inputs.pixel_values.to(torch_device, dtype=torch.float16)
 
         # forward pass to make sure inference works in fp16
         with torch.no_grad():


### PR DESCRIPTION
# What does this PR do?

Failing

```bash
FAILED tests/models/pvt/test_modeling_pvt.py::PvtModelIntegrationTest::test_inference_fp16 - ValueError: PvtForImageClassification does not support `device_map='auto'`. To implement support, the modelclass needs to implement the `_no_split_modules` attribute.
```

A fix for this test will fix the other 2 shown in the report (due to bad GPU state or something else)