### PR TITLE
added compiled model support for inference

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -27,8 +27,6 @@ from contextlib import contextmanager
 from os.path import abspath, exists
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
-from packaging import version
-
 from ..dynamic_module_utils import custom_object_save
 from ..feature_extraction_utils import PreTrainedFeatureExtractor
 from ..image_processing_utils import BaseImageProcessor

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1015,9 +1015,12 @@ class Pipeline(_ScikitCompat):
         raise NotImplementedError("postprocess not implemented")
 
     def get_inference_context(self):
+        inference_mode_supported = version.parse(version.parse(torch.__version__).base_version) >= version.parse("1.9.0")
+        model_was_not_compiled = version.parse(version.parse(torch.__version__).base_version) >= version.parse("2.0.0") \
+                                    and not isinstance(self.model, torch._dynamo.eval_frame.OptimizedModule) 
         inference_context = (
             torch.inference_mode
-            if version.parse(version.parse(torch.__version__).base_version) >= version.parse("1.9.0")
+            if inference_mode_supported and model_was_not_compiled
             else torch.no_grad
         )
         return inference_context

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1015,8 +1015,9 @@ class Pipeline(_ScikitCompat):
         raise NotImplementedError("postprocess not implemented")
 
     def get_inference_context(self):
-        inference_mode_supported = version.parse(version.parse(torch.__version__).base_version) >= version.parse("1.9.0")
-        model_was_not_compiled = version.parse(version.parse(torch.__version__).base_version) >= version.parse("2.0.0") \
+        torch_version = version.parse(torch.__version__).base_version
+        inference_mode_supported = version.parse(torch_version) >= version.parse("1.9.0")
+        model_was_not_compiled = version.parse(torch_version) >= version.parse("2.0.0") \
                                     and not isinstance(self.model, torch._dynamo.eval_frame.OptimizedModule) 
         inference_context = (
             torch.inference_mode

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1017,8 +1017,12 @@ class Pipeline(_ScikitCompat):
     def get_inference_context(self):
         torch_version = version.parse(torch.__version__).base_version
         inference_mode_supported = version.parse(torch_version) >= version.parse("1.9.0")
-        model_was_not_compiled = version.parse(torch_version) >= version.parse("2.0.0") \
-                                    and not isinstance(self.model, torch._dynamo.eval_frame.OptimizedModule) 
+        try:
+            from torch._dynamo.eval_frame import OptimizedModule
+        except ImportError:
+            model_was_not_compiled = True
+        else:
+            model_was_not_compiled = not isinstance(self.model, OptimizedModule)
         inference_context = (
             torch.inference_mode
             if inference_mode_supported and model_was_not_compiled

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1015,18 +1015,7 @@ class Pipeline(_ScikitCompat):
         raise NotImplementedError("postprocess not implemented")
 
     def get_inference_context(self):
-        torch_version = version.parse(torch.__version__).base_version
-        inference_mode_supported = version.parse(torch_version) >= version.parse("1.9.0")
-        try:
-            from torch._dynamo.eval_frame import OptimizedModule
-        except ImportError:
-            model_was_not_compiled = True
-        else:
-            model_was_not_compiled = not isinstance(self.model, OptimizedModule)
-        inference_context = (
-            torch.inference_mode if inference_mode_supported and model_was_not_compiled else torch.no_grad
-        )
-        return inference_context
+        return torch.no_grad
 
     def forward(self, model_inputs, **forward_params):
         with self.device_placement():

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1024,9 +1024,7 @@ class Pipeline(_ScikitCompat):
         else:
             model_was_not_compiled = not isinstance(self.model, OptimizedModule)
         inference_context = (
-            torch.inference_mode
-            if inference_mode_supported and model_was_not_compiled
-            else torch.no_grad
+            torch.inference_mode if inference_mode_supported and model_was_not_compiled else torch.no_grad
         )
         return inference_context
 


### PR DESCRIPTION
# What does this PR do?

Adds support for torch.compile-ed models in pipelines.

Basically, you cannot run torch.compile-ed model under `torch.inference_mode()` context and should use `torch.no_grad` instead

Examples:

<img width="1004" alt="image" src="https://github.com/huggingface/transformers/assets/22663468/04f0bde9-c7d0-4776-9fc4-bd224fadebce">

Here you see start of the super long traceback that ends with:
```
RuntimeError: Inference tensors do not track version counter.

While executing %getitem : [#users=1] = call_function[target=operator.getitem](args = (%attention_mask, 
(slice(None, None, None), None, None, slice(None, None, None))), kwargs = {})
Original traceback:
  File "/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/modeling_utils.py", line 890,
in get_extended_attention_mask
    extended_attention_mask = attention_mask[:, None, None, :]
 |   File 
"/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/models/bert/modeling_bert.py", line 
993, in forward
    extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape)
 |   File 
"/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/models/bert/modeling_bert.py", line 
1758, in forward
    outputs = self.bert(
```

and 

```
BackendCompilerFailed: debug_wrapper raised RuntimeError: Inference tensors do not track version counter.

While executing %getitem : [#users=1] = call_function[target=operator.getitem](args = (%attention_mask, 
(slice(None, None, None), None, None, slice(None, None, None))), kwargs = {})
Original traceback:
  File "/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/modeling_utils.py", line 890,
in get_extended_attention_mask
    extended_attention_mask = attention_mask[:, None, None, :]
 |   File 
"/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/models/bert/modeling_bert.py", line 
993, in forward
    extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape)
 |   File 
"/home/alexander/jupyter_server/.venv/lib/python3.8/site-packages/transformers/models/bert/modeling_bert.py", line 
1758, in forward
    outputs = self.bert(

```

Possible solution right now:

<img width="692" alt="image" src="https://github.com/huggingface/transformers/assets/22663468/f6b2c599-78b9-4e0c-89b7-31ded7532a52">

## Who can review?
@Narsil
