### PR TITLE
override .cuda() to check if model is already quantized

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1912,6 +1912,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             mem = mem + mem_bufs
         return mem
 
+    def cuda(self, *args, **kwargs):
+        # Checks if the model has been loaded in 8-bit
+        if getattr(self, "is_quantized", False):
+            raise ValueError(
+                "Calling `cuda()` is not supported for `4-bit` or `8-bit` quantized models. Please use the model as it is, since the"
+                " model has already been set to the correct devices and casted to the correct `dtype`."
+            )
+        else:
+            return super().cuda(*args, **kwargs)
+
     def to(self, *args, **kwargs):
         # Checks if the model has been loaded in 8-bit
         if getattr(self, "is_quantized", False):


### PR DESCRIPTION
# What does this PR do?
This PR is a quick fix by adding .cuda() to prevent device casting after 8-bit quantization. Same spirit as #20409. @younesbelkada  @sgugger Would you please have a quick look .

It fixes the following unexpected error: 

### For reberta-large, output `nan` without raising an error
```python
from transformers import AutoTokenizer, AutoModelForMaskedLM
from transformers import AutoConfig
from transformers import pipeline


model_name = "roberta-large"  # or any other models

tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
config = AutoConfig.from_pretrained(
    model_name,
)

model = AutoModelForMaskedLM.from_pretrained(
    model_name, trust_remote_code=True, load_in_8bit=True, device_map="auto"
)
model.cuda()
unmasker = pipeline("fill-mask", model=model, tokenizer=tokenizer)
print(unmasker("Hello I'm a <mask> model."))

>>> [{'score': nan, 'token': 3, 'token_str': '<unk>', 'sequence': "Hello I'm a model."}, {'score': nan, 'token': 4, 'token_str': '.', 'sequence': "Hello I'm a. model."}, {'score': nan, 'token': 1, 'token_str': '<pad>', 'sequence': "Hello I'm a model."}, {'score': nan, 'token': 0, 'token_str': '<s>', 'sequence': "Hello I'm a model."}, {'score': nan, 'token': 2, 'token_str': '</s>', 'sequence': "Hello I'm a model."}] 
```
### for mpt, RuntimeError as follows
```python
from transformers import AutoTokenizer, AutoModelForCausalLM
from transformers import AutoConfig


model_name = "mosaicml/mpt-7b"

tokenizer = AutoTokenizer.from_pretrained(model_name)
config = AutoConfig.from_pretrained(model_name)

model = AutoModelForCausalLM.from_pretrained(
    model_name, load_in_4bit=True, device_map="auto"
)
model.cuda()
text = "Here is a recipe for vegan banana bread:\n"
input_ids = tokenizer.encode(text, return_tensors="pt").to("cuda:0")
output = model.generate(input_ids, max_length=100, do_sample=True)
response = tokenizer.decode(output[0])
print(response)
>>> output = torch.nn.functional.linear(A, F.dequantize_4bit(B, state).to(A.dtype).t(), bias)
>>> RuntimeError: mat1 and mat2 shapes cannot be multiplied (10x4096 and 1x25165824)
```
