### PR TITLE
TEAMS: Add TensorFlow 2 Model Garden Conversion Script

### DIFF
--- a/src/transformers/models/electra/convert_teams_original_tf2_checkpoint_to_pytorch.py
+++ b/src/transformers/models/electra/convert_teams_original_tf2_checkpoint_to_pytorch.py
@@ -1,0 +1,293 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script converts a checkpoint from the "Training ELECTRA Augmented with Multi-word Selection" (TEAMS)
+implementation into a PyTorch-compatible ELECTRA model. The official implementation of "TEAMS" can be found in the
+TensorFlow Models Garden repository:
+
+https://github.com/tensorflow/models/tree/v2.9.2/official/projects/teams
+"""
+import argparse
+
+import tensorflow as tf
+import torch
+
+from transformers import ElectraConfig, ElectraForMaskedLM, ElectraForPreTraining
+from transformers.utils import logging
+
+
+logging.set_verbosity_info()
+
+
+def convert_checkpoint_to_pytorch(
+    tf_checkpoint_path: str, config_path: str, pytorch_dump_path: str, discriminator_or_generator: str
+):
+    def get_array(name: str):
+        name += "/.ATTRIBUTES/VARIABLE_VALUE"
+        array = tf.train.load_variable(tf_checkpoint_path, name)
+
+        if "kernel" in name:
+            array = array.transpose()
+
+        return torch.from_numpy(array)
+
+    def get_array_with_reshaping(name: str, orginal_shape):
+        name += "/.ATTRIBUTES/VARIABLE_VALUE"
+        array = tf.train.load_variable(tf_checkpoint_path, name)
+        array = array.reshape(orginal_shape)
+
+        if "kernel" in name:
+            array = array.transpose()
+
+        return torch.from_numpy(array)
+
+    config = ElectraConfig.from_pretrained(config_path)
+
+    if discriminator_or_generator == "generator":
+        model = ElectraForMaskedLM(config)
+    elif discriminator_or_generator == "discriminator":
+        model = ElectraForPreTraining(config)
+    else:
+        raise ValueError("The discriminator_or_generator argument should be either 'discriminator' or 'generator'")
+
+    model.electra.embeddings.word_embeddings.weight.data = get_array("model/masked_lm/embedding_table")
+    model.electra.embeddings.position_embeddings.weight.data = get_array(
+        "encoder/layer_with_weights-0/layer_with_weights-1/embeddings"
+    )
+    model.electra.embeddings.token_type_embeddings.weight.data = get_array(
+        "encoder/layer_with_weights-0/layer_with_weights-2/embeddings"
+    )
+    model.electra.embeddings.LayerNorm.weight.data = get_array(
+        "encoder/layer_with_weights-0/layer_with_weights-3/gamma"
+    )
+    model.electra.embeddings.LayerNorm.bias.data = get_array("encoder/layer_with_weights-0/layer_with_weights-3/beta")
+
+    if discriminator_or_generator == "generator":
+        model.generator_predictions.LayerNorm.weight.data = get_array("model/masked_lm/layer_norm/gamma")
+        model.generator_predictions.LayerNorm.bias.data = get_array("model/masked_lm/layer_norm/beta")
+
+        model.generator_predictions.dense.weight.data = get_array("model/masked_lm/dense/kernel")
+        model.generator_predictions.dense.bias.data = get_array("model/masked_lm/dense/bias")
+
+        model.generator_lm_head.weight.data = get_array("model/masked_lm/embedding_table")
+        model.generator_lm_head.bias.data = get_array("model/masked_lm/output_bias.Sbias")
+    else:
+        model.discriminator_predictions.dense.bias.data = get_array("model/discriminator_rtd_head/dense/bias")
+        model.discriminator_predictions.dense.weight.data = get_array("model/discriminator_rtd_head/dense/kernel")
+
+        model.discriminator_predictions.dense_prediction.bias.data = get_array(
+            "model/discriminator_rtd_head/rtd_head/bias"
+        )
+        model.discriminator_predictions.dense_prediction.weight.data = get_array(
+            "model/discriminator_rtd_head/rtd_head/kernel"
+        )
+
+    encoder_layer_end = config.num_hidden_layers
+
+    if discriminator_or_generator == "generator":
+        # Generator layers are shared in TEAMS model:
+        encoder_layer_end = config.num_hidden_layers // 2
+
+    for i in range(0, encoder_layer_end):
+        layer = model.electra.encoder.layer[i]
+
+        self_attn = layer.attention.self
+
+        self_attn.query.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_query_dense/kernel",
+            self_attn.query.weight.data.shape,
+        )
+        self_attn.query.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_query_dense/bias", self_attn.query.bias.data.shape
+        )
+
+        self_attn.key.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_key_dense/kernel", self_attn.key.weight.data.shape
+        )
+        self_attn.key.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_key_dense/bias", self_attn.key.bias.data.shape
+        )
+
+        self_attn.value.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_value_dense/kernel",
+            self_attn.value.weight.data.shape,
+        )
+        self_attn.value.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_value_dense/bias", self_attn.value.bias.data.shape
+        )
+
+        self_output = layer.attention.output
+
+        self_output.dense.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_output_dense/kernel",
+            self_output.dense.weight.data.shape,
+        )
+        self_output.dense.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer/_output_dense/bias",
+            self_output.dense.bias.data.shape,
+        )
+
+        self_output.LayerNorm.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer_norm/gamma", self_output.LayerNorm.weight.data.shape
+        )
+        self_output.LayerNorm.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_attention_layer_norm/beta", self_output.LayerNorm.bias.data.shape
+        )
+
+        intermediate = layer.intermediate
+
+        intermediate.dense.weight.data = get_array(f"encoder/layer_with_weights-{i + 1}/_intermediate_dense/kernel")
+        intermediate.dense.bias.data = get_array(f"encoder/layer_with_weights-{i + 1}/_intermediate_dense/bias")
+
+        electra_output = layer.output
+
+        electra_output.dense.weight.data = get_array(
+            f"encoder/layer_with_weights-{i + 1}/_output_dense/kernel"
+        )  # , electra_output.dense.weight.data.shape)
+        electra_output.dense.bias.data = get_array(
+            f"encoder/layer_with_weights-{i + 1}/_output_dense/bias"
+        )  # , electra_output.dense.bias.data.shape)
+
+        electra_output.LayerNorm.weight.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_output_layer_norm/gamma", electra_output.LayerNorm.weight.data.shape
+        )
+        electra_output.LayerNorm.bias.data = get_array_with_reshaping(
+            f"encoder/layer_with_weights-{i + 1}/_output_layer_norm/beta", electra_output.LayerNorm.bias.data.shape
+        )
+
+    if discriminator_or_generator == "generator":
+        for i in range(encoder_layer_end, config.num_hidden_layers):
+            layer = model.electra.encoder.layer[i]
+
+            self_attn = layer.attention.self
+
+            self_attn.query.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_query_dense/kernel",
+                self_attn.query.weight.data.shape,
+            )
+            self_attn.query.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_query_dense/bias",
+                self_attn.query.bias.data.shape,
+            )
+
+            self_attn.key.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_key_dense/kernel",
+                self_attn.key.weight.data.shape,
+            )
+            self_attn.key.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_key_dense/bias",
+                self_attn.key.bias.data.shape,
+            )
+
+            self_attn.value.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_value_dense/kernel",
+                self_attn.value.weight.data.shape,
+            )
+            self_attn.value.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_value_dense/bias",
+                self_attn.value.bias.data.shape,
+            )
+
+            self_output = layer.attention.output
+
+            self_output.dense.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_output_dense/kernel",
+                self_output.dense.weight.data.shape,
+            )
+            self_output.dense.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer/_output_dense/bias",
+                self_output.dense.bias.data.shape,
+            )
+
+            self_output.LayerNorm.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer_norm/gamma",
+                self_output.LayerNorm.weight.data.shape,
+            )
+            self_output.LayerNorm.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_attention_layer_norm/beta",
+                self_output.LayerNorm.bias.data.shape,
+            )
+
+            intermediate = layer.intermediate
+
+            intermediate.dense.weight.data = get_array(
+                f"model/generator_network/layer_with_weights-{i + 1}/_intermediate_dense/kernel"
+            )
+            intermediate.dense.bias.data = get_array(
+                f"model/generator_network/layer_with_weights-{i + 1}/_intermediate_dense/bias"
+            )
+
+            electra_output = layer.output
+
+            electra_output.dense.weight.data = get_array(
+                f"model/generator_network/layer_with_weights-{i + 1}/_output_dense/kernel"
+            )
+            electra_output.dense.bias.data = get_array(
+                f"model/generator_network/layer_with_weights-{i + 1}/_output_dense/bias"
+            )
+
+            electra_output.LayerNorm.weight.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_output_layer_norm/gamma",
+                electra_output.LayerNorm.weight.data.shape,
+            )
+            electra_output.LayerNorm.bias.data = get_array_with_reshaping(
+                f"model/generator_network/layer_with_weights-{i + 1}/_output_layer_norm/beta",
+                electra_output.LayerNorm.bias.data.shape,
+            )
+
+    # Export final model
+    model.save_pretrained(pytorch_dump_path)
+
+    # Integration test - should load without any errors ;)
+    if discriminator_or_generator == "generator":
+        loaded_model = ElectraForMaskedLM.from_pretrained(pytorch_dump_path)
+    else:
+        loaded_model = ElectraForPreTraining.from_pretrained(pytorch_dump_path)
+
+    print(loaded_model.eval())
+    print("Model conversion was done successfully!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tf_checkpoint_path", type=str, required=True, help="Path to the TensorFlow TEAMS checkpoint path."
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        required=True,
+        help="The config json file corresponding to the TEAMS model. This specifies the model architecture.",
+    )
+    parser.add_argument(
+        "--pytorch_dump_path",
+        type=str,
+        required=True,
+        help="Path to the output PyTorch model.",
+    )
+    parser.add_argument(
+        "--discriminator_or_generator",
+        default=None,
+        type=str,
+        required=True,
+        help=(
+            "Whether to export the generator or the discriminator. Should be a string, either 'discriminator' or "
+            "'generator'."
+        ),
+    )
+    args = parser.parse_args()
+    convert_checkpoint_to_pytorch(
+        args.tf_checkpoint_path, args.config_file, args.pytorch_dump_path, args.discriminator_or_generator
+    )


### PR DESCRIPTION
Hi,

with this PR a pretrained TEAMS model with TensorFlow Models Garden can be converted to an ELECTRA compatible model.

The TEAMS model was proposed in the "[Training ELECTRA Augmented with Multi-word Selection](https://aclanthology.org/2021.findings-acl.219.pdf) paper and accepted at ACL 2021:

> A new text encoder pre-training method is presented that improves ELECTRA based on multi-task learning and develops two techniques to effectively combine all pre- training tasks: using attention-based networks for task-specific heads, and sharing bottom layers of the generator and the discriminator.

The [TEAMS](https://github.com/tensorflow/models/tree/master/official/projects/teams) implementation can be found in the TensorFlow Models Garden repository.

Unfortunately, the authors did not release any pretrained models.

However, I pretrained a TEAMS model on [German Wikipedia](https://huggingface.co/gwlms/teams-base-dewiki-v1-generator) and release all checkpoints on the Hugging Face Model Hub. Additionally, the conversion script to integrate pretrained TEAMS into Transformers is included in this PR.

Closes #16466.

### Implementation Details

TEAMS use the same architecture as ELECTRA (just pretraining approach is different). ELECTRA in Transformers comes with two models: Generator and Discriminator.

In contrast to ELECTRA, the TEAMS generator use shared layers with discriminator:

```
Our study confirms this observation and finds that sharing some transformer layers of the generator
and discriminator and can further boost the model performance. More specifically, we design the
generator to have the same “width” (i.e., hidden size, intermediate size and number of heads) as the
discriminator and share the bottom half of all transformer layers between the generator and the
discriminator.
```

More precisely, the sharing of layers can be seen in the reference implementation:

https://github.com/tensorflow/models/blob/master/official/projects/teams/teams_task.py#L48

This shows, that the generator uses the first n layers from discriminator first (which is usually half size of specified total layers).

<img width="543" alt="Bildschirmfoto 2023-07-29 um 00 36 22" src="https://github.com/huggingface/transformers/assets/20651387/4ba96b79-0afe-4bc5-905a-b1941a4670b0">

### Retrieving TensorFlow 2 Checkpoints

In order to test the conversion script, the original TensorFlow 2 checkpoints need to be downloaded from Model Hub:

```bash
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-generator/resolve/main/ckpt-1000000.data-00000-of-00001
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-generator/resolve/main/ckpt-1000000.index
```

Additionally, to test the model locally, we need to download tokenizer:

```bash
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-generator/resolve/main/tokenizer_config.json
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-generator/resolve/main/vocab.txt
```

### Converting TEAMS Generator

After retrieving the original checkpoints, the generator configuration must be downloaded:

```bash
$ mkdir generator && cd $_
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-generator/resolve/main/config.json
$ cd ..
```

After that, the conversion script can be run to convert TEAMS (generator part) into ELECTRA generator:

```bash
$ python3 convert_teams_original_tf2_checkpoint_to_pytorch.py \
    --tf_checkpoint_path ckpt-1000000 \
    --config_file ./generator/config.json \
    --pytorch_dump_path ./exported-generator \
    --discriminator_or_generator generator
$ cp tokenizer_config.json exported-generator
$ cp vocab.txt exported-generator
```

The generator can be tested with masked lm pipeline to predict next work:

```python3
from transformers import pipeline

predictor = pipeline("fill-mask", model="./exported-generator", tokenizer="./exported-generator")
predictor("Die Hauptstadt von Finnland ist [MASK].")
```

The example German should predict the capital city of Finland, which is Helsinki:

```python
[{'score': 0.971819281578064,
  'token': 16014,
  'token_str': 'Helsinki',
  'sequence': 'Die Hauptstadt von Finnland ist Helsinki.'},
 {'score': 0.006745012942701578,
  'token': 12388,
  'token_str': 'Stockholm',
  'sequence': 'Die Hauptstadt von Finnland ist Stockholm.'},
 {'score': 0.003258457174524665,
  'token': 12227,
  'token_str': 'Finnland',
  'sequence': 'Die Hauptstadt von Finnland ist Finnland.'},
 {'score': 0.0025941277854144573,
  'token': 23596,
  'token_str': 'Tallinn',
  'sequence': 'Die Hauptstadt von Finnland ist Tallinn.'},
 {'score': 0.0014661155873909593,
  'token': 17408,
  'token_str': 'Riga',
  'sequence': 'Die Hauptstadt von Finnland ist Riga.'}]
```

### Converting TEAMS Discriminator

After retrieving the original checkpoints, the generator configuration must be downloaded:

```bash
$ mkdir discriminator && cd $_
$ wget https://huggingface.co/gwlms/teams-base-dewiki-v1-discriminator/resolve/main/config.json
$ cd ..
```

After that, the conversion script can be run to convert TEAMS (generator part) into ELECTRA generator:

```bash
$ python3 convert_teams_original_tf2_checkpoint_to_pytorch.py \
    --tf_checkpoint_path ckpt-1000000 \
    --config_file ./discriminator/config.json \
    --pytorch_dump_path ./exported-discriminator \
    --discriminator_or_generator discriminator
```

I made experiments on downstream tasks (such as NER or text classification) and the results are superior than to compared BERT models (original BERT and Token Dropping BERT).

Made with 🥨and ❤️.