### PR TITLE
[DOCS] Add `NoRepeatNGramLogitsProcessor` Example for `LogitsProcessor` class

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -507,7 +507,7 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
      N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. Given a
      sentence: " She runs fast ", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation,
      avoiding repetitions of word sequences provides a more diverse output. This [`LogitsProcessor`] enforces no
-     repetition of n-grams by setting the scores of banned tokens to negative infinity (-float("inf")) which eliminates
+     repetition of n-grams by setting the scores of banned tokens to negative infinity which eliminates
      those tokens from consideration when further processing the scores.
      [Fairseq](https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345).
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,8 +439,8 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size=2 and prev_input_ids=tensor([[40, 2883, 2712, 4346]]). The output of generated ngrams look
-    like this {(40,): [2883], (2883,): [2712], (2712,): [4346]}.
+    Assume ngram_size=2 and prev_input_ids=tensor([[40, 2883, 2712, 4346]]). The output of generated ngrams look like
+    this {(40,): [2883], (2883,): [2712], (2712,): [4346]}.
 
     Args:
         ngram_size (`int`):

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -442,7 +442,7 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     for idx in range(num_hypos):
         gen_tokens = prev_input_ids[idx].tolist()
         generated_ngram = generated_ngrams[idx]
-        #Loop through each n-gram of size ngram_size in the list of tokens (gen_tokens)
+        # Loop through each n-gram of size ngram_size in the list of tokens (gen_tokens)
         for ngram in zip(*[gen_tokens[i:] for i in range(ngram_size)]):
             prev_ngram_tuple = tuple(ngram[:-1])
             generated_ngram[prev_ngram_tuple] = generated_ngram.get(prev_ngram_tuple, []) + [ngram[-1]]
@@ -463,7 +463,7 @@ def _calc_banned_ngram_tokens(
     if cur_len + 1 < ngram_size:
         # return no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
         return [[] for _ in range(num_hypos)]
-    # With an example of no_repeat_ngram =2, generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}. 
+    # With an example of no_repeat_ngram =2, generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}.
     # The key is a generated word and the value is a list of the next words observed.
     generated_ngrams = _get_ngrams(ngram_size, prev_input_ids, num_hypos)
     # list of tokens that are banned, eg: [[], [836], [], [], [4346]]
@@ -476,27 +476,26 @@ def _calc_banned_ngram_tokens(
 
 class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     r"""
-    N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. 
-    Given a sentence: " She runs fast ", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation, 
-    avoiding repetitions of word sequences provides a more diverse and coherent output.
-    This [`LogitsProcessor`] enforces no repetition of n-grams. See
+    N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. Given a sentence:
+    " She runs fast ", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation, avoiding
+    repetitions of word sequences provides a more diverse and coherent output. This [`LogitsProcessor`] enforces no
+    repetition of n-grams. See
     [Fairseq](https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345).
-    It calls the <_calc_banned_ngram_tokens> function to determine the banned tokens (n-grams) based on the current state of the generated sequences 
-    and the specified ngram_size. For each hypothesis, it sets the scores of banned tokens to negative infinity (-inf), effectively discouraging the model
-    from generating those tokens.
+    It calls the <_calc_banned_ngram_tokens> function to determine the banned tokens (n-grams) based on the current
+    state of the generated sequences and the specified ngram_size. For each hypothesis, it sets the scores of banned
+    tokens to negative infinity (-inf), effectively discouraging the model from generating those tokens.
 
-    <Note>
-    Use n-gram penalties with care.  For instance, penalizing 2-grams (bigrams) in an article about the city of New York might lead 
-    to undesirable outcomes where the city's name appears only once in the entire text. 
+    <Note> Use n-gram penalties with care. For instance, penalizing 2-grams (bigrams) in an article about the city of
+    New York might lead to undesirable outcomes where the city's name appears only once in the entire text.
     [Reference](https://huggingface.co/blog/how-to-generate)
-    
+
     Args:
         ngram_size (`int`):
             All ngrams of size `ngram_size` can only occur once.
-    
+
     Examples:
 
-    ```python
+    ```py
     >>> from transformers import GPT2Tokenizer, AutoModelForCausalLM
 
     >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
@@ -505,14 +504,12 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
 
     >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, early_stopping=True, output_scores = True)
     >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
-    >>> I enjoy watching football, but I'm not a fan of it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it.
+    I enjoy watching football, but I'm not a fan of it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it.
 
     >>> #Now let's add ngram size using <no_repeat_ngram_size> in model.generate. This should stop the repetitions in the output.
     >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, no_repeat_ngram_size=2, early_stopping=True, output_scores = True)
     >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
-    >>> I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. 
-    >>> I've been playing football for a long time and I   
-    
+    I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. I've been playing football for a long time and I 
     ```
     """
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,7 +439,7 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size=2 and prev_input_ids=tensor([[ 40, 2883, 2712, 4346]]). The output of generated ngrams look
+    Assume ngram_size=2 and prev_input_ids=tensor([[40, 2883, 2712, 4346]]). The output of generated ngrams look
     like this {(40,): [2883], (2883,): [2712], (2712,): [4346]}.
 
     Args:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -482,7 +482,6 @@ def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
 
     Returns:
         List of tokens that are banned.
-
     """
     # Before decoding the next token, prevent decoding of ngrams that have already appeared
     start_idx = cur_len + 1 - ngram_size
@@ -508,7 +507,7 @@ def _calc_banned_ngram_tokens(
 class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     r"""
     N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. Given the
-    sentence: "She runs fast", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation,
+    sentence: "She runs fast", the bi-grams (n=2) would be ("she", "runs") and ("runs", "fast"). In text generation,
     avoiding repetitions of word sequences provides a more diverse output. This [`LogitsProcessor`] enforces no
     repetition of n-grams by setting the scores of banned tokens to negative infinity which eliminates those tokens
     from consideration when further processing the scores.

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -438,6 +438,10 @@ class EtaLogitsWarper(LogitsWarper):
 
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
+    """
+    The key is a generated word and the value is a list of the next words observed.
+    With an example of no_repeat_ngram =2, generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}.
+    """
     generated_ngrams = [{} for _ in range(num_hypos)]
     for idx in range(num_hypos):
         gen_tokens = prev_input_ids[idx].tolist()
@@ -453,6 +457,7 @@ def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     # Before decoding the next token, prevent decoding of ngrams that have already appeared
     start_idx = cur_len + 1 - ngram_size
     ngram_idx = tuple(prev_input_ids[start_idx:cur_len].tolist())
+    # list of tokens that are banned, output eg: [[], [836], [], [], [4346]]
     return banned_ngrams.get(ngram_idx, [])
 
 
@@ -463,10 +468,7 @@ def _calc_banned_ngram_tokens(
     if cur_len + 1 < ngram_size:
         # return no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
         return [[] for _ in range(num_hypos)]
-    # With an example of no_repeat_ngram =2, generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}.
-    # The key is a generated word and the value is a list of the next words observed.
     generated_ngrams = _get_ngrams(ngram_size, prev_input_ids, num_hypos)
-    # list of tokens that are banned, eg: [[], [836], [], [], [4346]]
     banned_tokens = [
         _get_generated_ngrams(generated_ngrams[hypo_idx], prev_input_ids[hypo_idx], ngram_size, cur_len)
         for hypo_idx in range(num_hypos)
@@ -478,16 +480,17 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     r"""
     N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. Given a sentence:
     " She runs fast ", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation, avoiding
-    repetitions of word sequences provides a more diverse and coherent output. This [`LogitsProcessor`] enforces no
+    repetitions of word sequences provides a more diverse output. This [`LogitsProcessor`] enforces no
     repetition of n-grams. See
     [Fairseq](https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345).
-    It calls the <_calc_banned_ngram_tokens> function to determine the banned tokens (n-grams) based on the current
-    state of the generated sequences and the specified ngram_size. For each hypothesis, it sets the scores of banned
-    tokens to negative infinity (-inf), effectively discouraging the model from generating those tokens.
-
-    <Note> Use n-gram penalties with care. For instance, penalizing 2-grams (bigrams) in an article about the city of
+    
+    <Tip> 
+    
+    Use n-gram penalties with care. For instance, penalizing 2-grams (bigrams) in an article about the city of
     New York might lead to undesirable outcomes where the city's name appears only once in the entire text.
     [Reference](https://huggingface.co/blog/how-to-generate)
+
+    </Tip>
 
     Args:
         ngram_size (`int`):
@@ -502,16 +505,14 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
     >>> inputs = tokenizer(["I enjoy watching football"], return_tensors="pt")
 
-    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, early_stopping=True, output_scores=True)
-    >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
-    I enjoy watching football, but I'm not a fan of it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it.
+    >>> output = model.generate(**inputs, max_length=50)
+    >>> print(tokenizer.decode(output[0], skip_special_tokens=True))
+    "I enjoy playing football on the weekends, but I'm not a big fan of the idea of playing in the middle of the night. I'm not a big fan of the idea of playing in the middle of the night. I'm not a big"
 
     >>> # Now let's add ngram size using <no_repeat_ngram_size> in model.generate. This should stop the repetitions in the output.
-    >>> beam_output = model.generate(
-    ...     **inputs, max_length=50, num_beams=5, no_repeat_ngram_size=2, early_stopping=True, output_scores=True
-    ... )
-    >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
-    I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. I've been playing football for a long time and I
+    >>> output = model.generate(**inputs, max_length=50, no_repeat_ngram_size=2)
+    >>> print(tokenizer.decode(output[0], skip_special_tokens=True))
+   "I enjoy playing football on the weekends, but I'm not a big fan of the idea of playing in the middle of a game. I think it's a bit of an overreaction to the fact that we're playing a team that's playing"
     ```
     """
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,9 +439,9 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size =2 and input tokenized tensor([[ 40, 2883, 2712, 4346, 319, 262, 21511]]) The output of generated
-    ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}. (Note this is only a subset of the
-    dictionary to illustrate a simplified representation of the generated n-grams) The key is a generated word and the
+    Assume ngram_size =2 and input tokenized tensor([[ 40, 2883, 2712, 4346, 319, 262, 21511]]) 
+    The output of generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]} (Note this is only a subset of the
+    dictionary to illustrate a simplified representation of the generated n-grams). The key is a generated word and the
     value is a list of the next words observed.
 
     Args:
@@ -471,10 +471,14 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
 def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     """
     This function is responsible for determining the tokens that are banned for each hypothesis based on the previously
-    generated n-grams. generated_ngrams = { (40,): [2883, 1053], (2883,): [2712], (2712,): [4346] } prev_input_ids =
-    torch.tensor([[40, 2883, 2712, 4346, 319, 262, 21511]]) cur_len = 3 The function then calculates the banned tokens
-    for each index by looking at the last ngram_size - 1 tokens (excluding the last token) of the current hypothesis
-    and checking if they form an n-gram that exists in the banned_ngrams dictionary. In this case, start_idx = 2
+    generated n-grams. 
+    generated_ngrams = { (40,): [2883, 1053], (2883,): [2712], (2712,): [4346] } 
+    prev_input_ids = torch.tensor([[40, 2883, 2712, 4346, 319, 262, 21511]]) 
+    cur_len = 3 
+    The function then calculates the banned tokens for each index by looking at the last ngram_size - 1 tokens 
+    (excluding the last token) of the current hypothesis and checking if they form an n-gram that exists 
+    in the banned_ngrams dictionary. In this case, 
+    start_idx = 2
     ngram_idx = (2712,) which matches the key from the banned_ngrams list output returns: [4346]
 
     Args:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -468,13 +468,13 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
 def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     """
     Parameters:
-        banned_ngrams (dict):
+        banned_ngrams (`dict`):
             A dictionary containing previously generated n-grams for each hypothesis.
-        prev_input_ids (torch.Tensor):
-            A tensor containing tokenized input for each hypothesis in the current batch.
+        prev_input_ids (`torch.Tensor`):
+            A `tensor` containing tokenized input for each hypothesis in the current batch.
         ngram_size (int):
             `ngram_size` that can only occur once.
-        cur_len (int):
+        cur_len (`int`):
             The current length of the token sequences for which the n-grams are being checked.
 
     Returns:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,10 +439,10 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size =2 and input tokenized tensor([[ 40, 2883, 2712, 4346, 319, 262, 21511]]) 
-    The output of generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]} (Note this is only a subset of the
-    dictionary to illustrate a simplified representation of the generated n-grams). The key is a generated word and the
-    value is a list of the next words observed.
+    Assume ngram_size =2 and prev_input_ids= tensor([[ 40, 2883, 2712, 4346, 319, 262, 21511]]). The output of
+    generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]} (Note this is only a subset
+    of the dictionary to illustrate a simplified representation of the generated n-grams). The key is a generated word
+    and the value is a list of the next words observed.
 
     Args:
         ngram_size (`int`):
@@ -471,15 +471,11 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
 def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     """
     This function is responsible for determining the tokens that are banned for each hypothesis based on the previously
-    generated n-grams. 
-    generated_ngrams = { (40,): [2883, 1053], (2883,): [2712], (2712,): [4346] } 
-    prev_input_ids = torch.tensor([[40, 2883, 2712, 4346, 319, 262, 21511]]) 
-    cur_len = 3 
-    The function then calculates the banned tokens for each index by looking at the last ngram_size - 1 tokens 
-    (excluding the last token) of the current hypothesis and checking if they form an n-gram that exists 
-    in the banned_ngrams dictionary. In this case, 
-    start_idx = 2
-    ngram_idx = (2712,) which matches the key from the banned_ngrams list output returns: [4346]
+    generated n-grams. Let's consider generated_ngrams = { (40,): [2883, 1053], (2883,): [2712], (2712,): [4346] },
+    prev_input_ids = torch.tensor([[40, 2883, 2712, 4346, 319, 262, 21511]]), cur_len = 3. The function then calculates
+    the banned tokens for each index by looking at the last ngram_size - 1 tokens (excluding the last token) of the
+    current hypothesis and checking if they form an n-gram that exists in the banned_ngrams dictionary. In this case,
+    start_idx = 2 ngram_idx = (2712,) which matches the key from the banned_ngrams list output returns: [4346]
 
     Args:
         banned_ngrams (`dict`):

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,7 +439,7 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size =2 and prev_input_ids=tensor([[ 40, 2883, 2712, 4346]]). The output of generated ngrams look
+    Assume ngram_size=2 and prev_input_ids=tensor([[ 40, 2883, 2712, 4346]]). The output of generated ngrams look
     like this {(40,): [2883], (2883,): [2712], (2712,): [4346]}.
 
     Args:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -502,14 +502,16 @@ class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
     >>> inputs = tokenizer(["I enjoy watching football"], return_tensors="pt")
 
-    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, early_stopping=True, output_scores = True)
+    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, early_stopping=True, output_scores=True)
     >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
     I enjoy watching football, but I'm not a fan of it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it.
 
-    >>> #Now let's add ngram size using <no_repeat_ngram_size> in model.generate. This should stop the repetitions in the output.
-    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, no_repeat_ngram_size=2, early_stopping=True, output_scores = True)
+    >>> # Now let's add ngram size using <no_repeat_ngram_size> in model.generate. This should stop the repetitions in the output.
+    >>> beam_output = model.generate(
+    ...     **inputs, max_length=50, num_beams=5, no_repeat_ngram_size=2, early_stopping=True, output_scores=True
+    ... )
     >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
-    I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. I've been playing football for a long time and I 
+    I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. I've been playing football for a long time and I
     ```
     """
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -439,15 +439,14 @@ class EtaLogitsWarper(LogitsWarper):
 
 def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     """
-    Assume ngram_size=2 and prev_input_ids=tensor([[list of generated tokens]]). The output of generated ngrams look
-    like this {(generated word #1,): [tokenized list of next words observed], (generated word #2,): [tokenized list of
-    next words observed] }.
+    Assume ngram_size =2 and prev_input_ids=tensor([[ 40, 2883, 2712, 4346]]). The output of generated ngrams look
+    like this {(40,): [2883], (2883,): [2712], (2712,): [4346]}.
 
     Args:
         ngram_size (`int`):
-            `ngram_size` that can only occur once.
+            The number sequential tokens taken as a group which may only occur once before being banned.
         prev_input_ids (`torch.Tensor`):
-            A tensor containing tokenized input for each hypothesis.
+           Generated token ids for the current hypothesis.
         num_hypos (`int`):
             The number of hypotheses for which n-grams need to be generated.
 
@@ -469,15 +468,15 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
 
 def _get_generated_ngrams(banned_ngrams, prev_input_ids, ngram_size, cur_len):
     """
-    Determines the banned tokens for each hypothesis based on previously generated n-grams.
+    Determines the banned tokens for the current hypothesis based on previously generated n-grams.
 
     Args:
         banned_ngrams (`dict`):
             A dictionary containing previously generated n-grams for each hypothesis.
         prev_input_ids (`torch.Tensor`):
-            A `tensor` containing tokenized input for each hypothesis in the current batch.
+            Generated token ids for the current hypothesis.
         ngram_size (`int`):
-            `ngram_size` that can only occur once.
+            The number sequential tokens taken as a group which may only occur once before being banned.
         cur_len (`int`):
             The current length of the token sequences for which the n-grams are being checked.
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -442,6 +442,7 @@ def _get_ngrams(ngram_size: int, prev_input_ids: torch.Tensor, num_hypos: int):
     for idx in range(num_hypos):
         gen_tokens = prev_input_ids[idx].tolist()
         generated_ngram = generated_ngrams[idx]
+        #Loop through each n-gram of size ngram_size in the list of tokens (gen_tokens)
         for ngram in zip(*[gen_tokens[i:] for i in range(ngram_size)]):
             prev_ngram_tuple = tuple(ngram[:-1])
             generated_ngram[prev_ngram_tuple] = generated_ngram.get(prev_ngram_tuple, []) + [ngram[-1]]
@@ -462,9 +463,10 @@ def _calc_banned_ngram_tokens(
     if cur_len + 1 < ngram_size:
         # return no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
         return [[] for _ in range(num_hypos)]
-
+    # With an example of no_repeat_ngram =2, generated ngrams look like this {(40,): [2883, 1053], (2883,): [2712], (2712,): [4346]}. 
+    # The key is a generated word and the value is a list of the next words observed.
     generated_ngrams = _get_ngrams(ngram_size, prev_input_ids, num_hypos)
-
+    # list of tokens that are banned, eg: [[], [836], [], [], [4346]]
     banned_tokens = [
         _get_generated_ngrams(generated_ngrams[hypo_idx], prev_input_ids[hypo_idx], ngram_size, cur_len)
         for hypo_idx in range(num_hypos)
@@ -474,12 +476,44 @@ def _calc_banned_ngram_tokens(
 
 class NoRepeatNGramLogitsProcessor(LogitsProcessor):
     r"""
-    [`LogitsProcessor`] that enforces no repetition of n-grams. See
+    N-grams are groups of "n" consecutive words, characters, or tokens taken from a sequence of text. 
+    Given a sentence: " She runs fast ", the bi-grams (n = 2) would be ("she","runs") and ("runs","fast"). In text generation, 
+    avoiding repetitions of word sequences provides a more diverse and coherent output.
+    This [`LogitsProcessor`] enforces no repetition of n-grams. See
     [Fairseq](https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345).
+    It calls the <_calc_banned_ngram_tokens> function to determine the banned tokens (n-grams) based on the current state of the generated sequences 
+    and the specified ngram_size. For each hypothesis, it sets the scores of banned tokens to negative infinity (-inf), effectively discouraging the model
+    from generating those tokens.
 
+    <Note>
+    Use n-gram penalties with care.  For instance, penalizing 2-grams (bigrams) in an article about the city of New York might lead 
+    to undesirable outcomes where the city's name appears only once in the entire text. 
+    [Reference](https://huggingface.co/blog/how-to-generate)
+    
     Args:
         ngram_size (`int`):
             All ngrams of size `ngram_size` can only occur once.
+    
+    Examples:
+
+    ```python
+    >>> from transformers import GPT2Tokenizer, AutoModelForCausalLM
+
+    >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
+    >>> tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+    >>> inputs = tokenizer(["I enjoy watching football"], return_tensors="pt")
+
+    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, early_stopping=True, output_scores = True)
+    >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
+    >>> I enjoy watching football, but I'm not a fan of it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it. I don't like it.
+
+    >>> #Now let's add ngram size using <no_repeat_ngram_size> in model.generate. This should stop the repetitions in the output.
+    >>> beam_output = model.generate(**inputs, max_length=50, num_beams=5, no_repeat_ngram_size=2, early_stopping=True, output_scores = True)
+    >>> print(tokenizer.decode(beam_output[0], skip_special_tokens=True))
+    >>> I enjoy watching football, but I don't think I'm going to be able to do it in the NFL. "I'm not sure if I want to play football or not. 
+    >>> I've been playing football for a long time and I   
+    
+    ```
     """
 
     def __init__(self, ngram_size: int):


### PR DESCRIPTION
# What does this PR do?

This PR adds an example to the docstring of `NoRepeatNGramLogitsProcessor` and edits the docstring description of the same.
This is with reference to #24783 and is part of the #24575 

Fixes # (issue)
#24783

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).


## Who can review?

@gante @sgugger 

### Additional Notes:

In comparison with [TFNoRepeatNGramLogitsProcessor](https://github.com/huggingface/transformers/blob/05cda5df3405e6a2ee4ecf8f7e1b2300ebda472e/src/transformers/generation/tf_logits_process.py#L388), I noticed that the required functions `_get_ngrams`, `_get_generated_ngrams`, and `_calc_banned_ngram_tokens` were outside the class. Is this expected?

