### PR TITLE
Save tokenizer and model config when training with FSDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2271,7 +2271,6 @@ class Trainer:
                     )
         if is_torch_tpu_available():
             xm.set_rng_state(checkpoint_rng_state["xla"])
-    
 
     def _save_checkpoint(self, model, trial, metrics=None):
         # In all cases, including ddp/dp/deepspeed, self.model is always a reference to the model we
@@ -2813,7 +2812,7 @@ class Trainer:
             self.tokenizer.save_pretrained(output_dir)
         if self.model.config is not None:
             self.model.config.save_pretrained(output_dir)
-    
+
     def _save(self, output_dir: Optional[str] = None, state_dict=None):
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir


### PR DESCRIPTION
# What does this PR do?

Currently when training models with FSDP the tokenizer and model config are not saved (at least using standard configs I have). This is especially bad when running a custom train.py that modifies the tokenizer and model before training. In that scenario there is no record of the new model config or tokenizer.

I have altered trainer.py to have a `_save_tokenizer_and_configs` method and added a call to this method in the model saving logic when FSDP is enabled.

If the team feels there could be better refactoring to handle this would be happy to discuss improvements to this PR!

Other note, to the best of my knowledge this is happening because when the logic flows to FSDP enabled it is just using the custom FSDP model saving and there is no logic for saving the other tokenizer and config info. If there is already a known config setting I'm missing that would fix this please let me know.

## Before submitting

I have not added any new tests.

## Who can review?

This involves modifications to the trainer so maybe @sgugger would be interested in reviewing?
