### PR TITLE
Better error message in `_prepare_output_docstrings`

### DIFF
--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -122,6 +122,11 @@ def _prepare_output_docstrings(output_type, config_class, min_indent=None):
     if i < len(lines):
         params_docstring = "\n".join(lines[(i + 1) :])
         params_docstring = _convert_output_args_doc(params_docstring)
+    else:
+        raise ValueError(
+            f"No `Args` or `Parameters` section is found in the docstring of `{output_type.__name__}`. Make sure it has"
+            "docstring and contain either `Args` or `Parameters`."
+        )
 
     # Add the return introduction
     full_output_type = f"{output_type.__module__}.{output_type.__name__}"


### PR DESCRIPTION
# What does this PR do?

Currently, if an output type has no docstring, or its docstring doesn't have `Args` or `Parameters`, we get an error 
```bash
  File "/transformers/src/transformers/utils/doc.py", line 137, in _prepare_output_docstrings
    full_output_type = f"{output_type.__module__}.{output_type.__name__}"
UnboundLocalError: local variable 'params_docstring' referenced before assignment
```
when `_prepare_output_docstrings` is called (for example, running a script that uses the relevant model).

This is not super informative what's wrong and what to fix.

This PR adds an error message to explain what's going on.