### PR TITLE
add pathname and line number to logging formatter in debug mode

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -95,6 +95,11 @@ def _configure_library_root_logger() -> None:
         library_root_logger = _get_library_root_logger()
         library_root_logger.addHandler(_default_handler)
         library_root_logger.setLevel(_get_default_logging_level())
+        # if logging level is debug, we add pathname and lineno to formatter for easy debugging
+        if _get_default_logging_level() == logging.DEBUG:
+            formatter = logging.Formatter("[%(levelname)s|%(pathname)s:%(lineno)s] %(asctime)s >> %(message)s")
+            _default_handler.setFormatter(formatter)
+
         library_root_logger.propagate = False
 
 

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -40,6 +40,7 @@ _lock = threading.Lock()
 _default_handler: Optional[logging.Handler] = None
 
 log_levels = {
+    "detail": logging.DEBUG,  # will also print filename and line number
     "debug": logging.DEBUG,
     "info": logging.INFO,
     "warning": logging.WARNING,
@@ -96,7 +97,7 @@ def _configure_library_root_logger() -> None:
         library_root_logger.addHandler(_default_handler)
         library_root_logger.setLevel(_get_default_logging_level())
         # if logging level is debug, we add pathname and lineno to formatter for easy debugging
-        if _get_default_logging_level() == logging.DEBUG:
+        if os.getenv("TRANSFORMERS_VERBOSITY", None) == "detail":
             formatter = logging.Formatter("[%(levelname)s|%(pathname)s:%(lineno)s] %(asctime)s >> %(message)s")
             _default_handler.setFormatter(formatter)
 


### PR DESCRIPTION
# What does this PR do?
This PR adds pathname and line number to logging formatter in debug mode
It make the debug much easier when setting `export TRANSFORMERS_VERBOSITY=debug`. 
It has no effect in other logging levels(info, warning, etc ). 

Hope this is acceptable. It's ok if not. 

before, there is no way to know where the logging comes from. 
```
loading file vocab.json
loading file merges.txt
loading file tokenizer.json
loading file added_tokens.json
loading file special_tokens_map.json
loading file tokenizer_config.json
```
after:
```
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file vocab.json
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file merges.txt
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file tokenizer.json
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file added_tokens.json
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file special_tokens_map.json
[INFO|/home/ranch/models/transformers/src/transformers/tokenization_utils_base.py:1842] 2023-07-31 17:59:45,311 >> loading file tokenizer_config.json
```
