### PR TITLE
auto move input to device of the first-layer if necessary

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1333,6 +1333,12 @@ class GenerationMixin:
         )
         batch_size = inputs_tensor.shape[0]
 
+        # Auto move input to the device of input_embedding weights if necessary
+        embedding_device = self.get_input_embeddings().weight.device
+        if inputs_tensor.device != embedding_device:
+            logger.info(f"Moving input tensor from device `{inputs_tensor.device}` to `{embedding_device}`")
+            inputs_tensor = inputs_tensor.to(self.get_input_embeddings().weight.device)
+
         # 4. Define other model kwargs
         model_kwargs["output_attentions"] = generation_config.output_attentions
         model_kwargs["output_hidden_states"] = generation_config.output_hidden_states


### PR DESCRIPTION
# What does this PR do?
This PR adds feature to model.generate()  to check if input_ids is at the same device of input_embeddings. 
If not, move input to the device rather than simply raising an error or warning.
It should be helpful when device_map="auto" or when there are multi-gpus to choose from, in which case we only need to worry about where to place to model. 

Hope it is acceptable. if not, I will close it.  


