### PR TITLE
[`pipeline`] revisit device check for pipeline

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -775,12 +775,19 @@ class Pipeline(_ScikitCompat):
         self.modelcard = modelcard
         self.framework = framework
 
-        if self.framework == "pt" and device is not None and not (isinstance(device, int) and device < 0):
+        # `accelerate` device map
+        hf_device_map = getattr(self.model, "hf_device_map", None)
+
+        # We shouldn't call `model.to()` for models loaded with accelerate
+        if (
+            self.framework == "pt"
+            and device is not None
+            and not (isinstance(device, int) and device < 0)
+            and hf_device_map is None
+        ):
             self.model.to(device)
 
         if device is None:
-            # `accelerate` device map
-            hf_device_map = getattr(self.model, "hf_device_map", None)
             if hf_device_map is not None:
                 # Take the first device used by `accelerate`.
                 device = next(iter(hf_device_map.values()))

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -778,13 +778,14 @@ class Pipeline(_ScikitCompat):
         # `accelerate` device map
         hf_device_map = getattr(self.model, "hf_device_map", None)
 
+        if hf_device_map is not None and device is not None:
+            raise ValueError(
+                "The model has been loaded with `accelerate` and therefore cannot be moved to a specific device. Please "
+                "discard the `device` argument when creating your pipeline object."
+            )
+
         # We shouldn't call `model.to()` for models loaded with accelerate
-        if (
-            self.framework == "pt"
-            and device is not None
-            and not (isinstance(device, int) and device < 0)
-            and hf_device_map is None
-        ):
+        if self.framework == "pt" and device is not None and not (isinstance(device, int) and device < 0):
             self.model.to(device)
 
         if device is None:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/23336#issuecomment-1657792271 

Currently `.to` is called to the model in pipeline even if the model is loaded with accelerate - which is a bad practice and can lead to unexpected behaviour if the model is loaded across multiple GPUs or offloaded to CPU/disk. 

This PR simply revisits the check for device assignment

Simple snippet to reproduce the issue:

```python 
from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer, pipeline
import torch

model_path="facebook/opt-350m"

config = AutoConfig.from_pretrained(model_path)
model = AutoModelForCausalLM.from_pretrained(model_path, load_in_8bit=True, device_map="auto")

tokenizer = AutoTokenizer.from_pretrained(model_path)
params = {
        "max_length":1024,
        "pad_token_id": 0, 
        "device_map":"auto", 
        "load_in_8bit": True,
        # "torch_dtype":"auto"
        }
pipe = pipeline(
    task="text-generation",
    model=model,
    tokenizer=tokenizer,
    device=0,
    model_kwargs=params,
)
```

cc @sgugger @Narsil 