### PR TITLE
Fix `all_model_classes` in `FlaxBloomGenerationTest`

### DIFF
--- a/tests/models/bloom/test_modeling_flax_bloom.py
+++ b/tests/models/bloom/test_modeling_flax_bloom.py
@@ -198,7 +198,7 @@ class FlaxBloomModelTest(FlaxModelTesterMixin, unittest.TestCase, FlaxGeneration
 @slow
 @require_flax
 class FlaxBloomGenerationTest(unittest.TestCase):
-    all_model_classes = (FlaxBloomForCausalLM) if is_flax_available() else ()
+    all_model_classes = (FlaxBloomForCausalLM,) if is_flax_available() else ()
     all_generative_model_classes = () if is_flax_available() else ()
 
     def setUp(self):


### PR DESCRIPTION
# What does this PR do?

It should be a tuple (which requires the ending `,`)