### PR TITLE
inject automatic end of utterance tokens

### DIFF
--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -137,7 +137,6 @@ class IdeficsProcessor(ProcessorMixin):
         self.image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_TOKEN)
 
         print(self.image_processor.add_end_of_utterance_token)
-        # die
 
         self.add_end_of_utterance_token = add_end_of_utterance_token
         self.add_end_of_utterance_token = add_end_of_utterance_token
@@ -322,7 +321,6 @@ class IdeficsProcessor(ProcessorMixin):
 
             if debug is True:
                 print(f"{full_text=}")
-            # die
 
             image_objects = self.image_processor(image_objects, transform=transform)
 

--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -139,7 +139,6 @@ class IdeficsProcessor(ProcessorMixin):
         print(self.image_processor.add_end_of_utterance_token)
 
         self.add_end_of_utterance_token = add_end_of_utterance_token
-        self.add_end_of_utterance_token = add_end_of_utterance_token
 
         self.default_image_dims = (
             self.image_processor.image_num_channels,

--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -302,7 +302,7 @@ class IdeficsProcessor(ProcessorMixin):
                         image_objects.append(image)
                         last_was_image = True
                     else:
-                        # we add end_of_utterance_token between each subsequent text prompts (and at the very end)
+                        # we add end_of_utterance_token between each subsequent text prompts (but not at the last one!)
                         if add_end_of_utterance_token and last_was_text:
                             full_text += end_of_utterance_token
                         full_text += item
@@ -312,9 +312,6 @@ class IdeficsProcessor(ProcessorMixin):
                     full_text += image_tokens(last_was_image)
                     image_objects.append(item)
                     last_was_image = True
-
-            if add_end_of_utterance_token:
-                full_text += end_of_utterance_token
 
             if add_eos_token:
                 full_text += self.tokenizer.eos_token

--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -118,7 +118,7 @@ class IdeficsProcessor(ProcessorMixin):
         tokenizer (`LlamaTokenizerFast`):
             An instance of [`LlamaTokenizerFast`]. The tokenizer is a required input.
         image_size (`int`, *optional*, defaults to 224): Image size (assuming a square image)
-        add_end_of_utterance_token (`bool`, *optional*, defaults to `False`):
+        add_end_of_utterance_token (`bool`, *optional*, defaults to `True`):
             Whether to automatically add `<end_of_utterance>` after each prompt's text input (unless followed by an
             image). (provided by `preprocessing_config.json`)
     """


### PR DESCRIPTION
This adds a new feature:

For select models add `<end_of_utterance>` token at the end of each utterance.

The user can now easily break up their prompt and not need to worry about messing with tokens.

So for this prompt:

```
    [
        "User:",
        image,
        "Describe this image.",
        "Assistant: An image of two kittens in grass.",
        "User:",
        "https://hips.hearstapps.com/hmg-prod/images/dog-puns-1581708208.jpg",
        "Describe this image.",
        "Assistant:",
    ],
```

this new code with add_end_of_utterance_token=True will generate:

`full_text='<s>User:<fake_token_around_image><image><fake_token_around_image>Describe this image.<end_of_utterance>Assistant: An image of two kittens in grass.<end_of_utterance>User:<fake_token_around_image><image><fake_token_around_image>Describe this image.<end_of_utterance>Assistant:'
`
