### PR TITLE
Docs: separate generate section

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -77,14 +77,17 @@
         title: Text to speech
     title: Multimodal
     isExpanded: false
+  - sections:
+      - local: generation_strategies
+        title: Customize text generation strategy
+    title: Generation
+    isExpanded: false
   title: Task Guides
 - sections:
     - local: fast_tokenizers
       title: Use fast tokenizers from 🤗 Tokenizers
     - local: multilingual
       title: Run inference with multilingual models
-    - local: generation_strategies
-      title: Customize text generation strategy
     - local: create_a_model
       title: Use model-specific APIs
     - local: custom_models


### PR DESCRIPTION
# What does this PR do?

A conclusion of the latest doc brainstorming section with @patrickvonplaten was that generate-related doc discoverability will become harder as we add more guides. The plan would envision a tutorial page and a few new developer guides -- in addition to the existing task pages, developer guide, and API reference.

As such, we converged on the need for a new doc section, under which most new docs will reside (see #24575 for the plan), with a focus on the first L of LLMs.

There is no section that would fit perfectly, this is (IMO) the best compromise: it contains a bit of "task", "developer guide", and "performance and scalability", but "task" is the most obvious place to look for this information 🤗 