### PR TITLE
Update rescale tests - cast to float after rescaling to reflect #25229

### DIFF
--- a/tests/models/efficientnet/test_image_processing_efficientnet.py
+++ b/tests/models/efficientnet/test_image_processing_efficientnet.py
@@ -201,9 +201,9 @@ class EfficientNetImageProcessorTest(ImageProcessingSavingTestMixin, unittest.Te
         image_processor = self.image_processing_class(**self.image_processor_dict)
 
         rescaled_image = image_processor.rescale(image, scale=1 / 255)
-        expected_image = image.astype(np.float32) * (2 / 255.0) - 1
+        expected_image = (image * (2 / 255.0)).astype(np.float32) - 1
         self.assertTrue(np.allclose(rescaled_image, expected_image))
 
         rescaled_image = image_processor.rescale(image, scale=1 / 255, offset=False)
-        expected_image = image.astype(np.float32) / 255.0
+        expected_image = (image / 255.0).astype(np.float32)
         self.assertTrue(np.allclose(rescaled_image, expected_image))

--- a/tests/models/vivit/test_image_processing_vivit.py
+++ b/tests/models/vivit/test_image_processing_vivit.py
@@ -220,9 +220,9 @@ class VivitImageProcessingTest(ImageProcessingSavingTestMixin, unittest.TestCase
         image_processor = self.image_processing_class(**self.image_processor_dict)
 
         rescaled_image = image_processor.rescale(image, scale=1 / 255)
-        expected_image = image.astype(np.float32) * (2 / 255.0) - 1
+        expected_image = (image * (2 / 255.0)).astype(np.float32) - 1
         self.assertTrue(np.allclose(rescaled_image, expected_image))
 
         rescaled_image = image_processor.rescale(image, scale=1 / 255, offset=False)
-        expected_image = image.astype(np.float32) / 255.0
+        expected_image = (image / 255.0).astype(np.float32)
         self.assertTrue(np.allclose(rescaled_image, expected_image))


### PR DESCRIPTION
# What does this PR do?

In #25229 - the casting to float was moved back to after rescaling. This wasn't reflected in the specific rescaling tests for EfficientNet and ViVit, resulting in failing tests. 

This PR resolves this. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
