### PR TITLE
Remove `pytest_options={"rA": None}` in CI

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -299,7 +299,6 @@ tf_job = CircleCIJob(
     ],
     parallelism=1,
     pytest_num_workers=6,
-    pytest_options={"rA": None},
 )
 
 
@@ -311,7 +310,6 @@ flax_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager .[flax,testing,sentencepiece,flax-speech,vision]",
     ],
     parallelism=1,
-    pytest_options={"rA": None},
 )
 
 
@@ -323,7 +321,6 @@ pipelines_torch_job = CircleCIJob(
         "pip install --upgrade --upgrade-strategy eager pip",
         "pip install -U --upgrade-strategy eager .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm,video]",
     ],
-    pytest_options={"rA": None},
     marker="is_pipeline_test",
 )
 
@@ -337,7 +334,6 @@ pipelines_tf_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager .[sklearn,tf-cpu,testing,sentencepiece,vision]",
         "pip install -U --upgrade-strategy eager tensorflow_probability",
     ],
-    pytest_options={"rA": None},
     marker="is_pipeline_test",
 )
 


### PR DESCRIPTION
# What does this PR do?

This option causes the (TF/Flax) jobs to spend 6-8 minutes (for a full set run) to prepare something for reporting after the actual tests are finished.

Taking [this TF job (nightly run)](https://app.circleci.com/pipelines/github/huggingface/transformers/69562/workflows/8fd9db08-9730-4d57-90b5-660c8a48a55c/jobs/872686/steps) for example, we can see the situation in the following screenshot

<img width="1044" alt="Screenshot 2023-08-02 132209" src="https://github.com/huggingface/transformers/assets/2521628/67e6bc89-d0d3-4d6a-9090-f3e1042be639">


Note that the torch job doesn't have this option, as it is removed ~ 3 years ago by Stas in #7995. Also, we still have all the reports we need in the artifact tab. (I don't remember the details about `-rA` though - Stas is the expert of this)