### PR TITLE
recommend DeepSpeed's Argument Parsing documentation

### DIFF
--- a/docs/source/en/main_classes/deepspeed.md
+++ b/docs/source/en/main_classes/deepspeed.md
@@ -168,6 +168,8 @@ If after trying everything suggested you still encounter build issues, please, p
 
 To deploy the DeepSpeed integration adjust the [`Trainer`] command line arguments to include a new argument `--deepspeed ds_config.json`, where `ds_config.json` is the DeepSpeed configuration file as
    documented [here](https://www.deepspeed.ai/docs/config-json/). The file naming is up to you.
+   It's recommended to use DeepSpeed's `add_config_arguments` utility to add the necessary command line arguments to your code.
+   For more information please see [DeepSpeed's Argument Parsing](https://deepspeed.readthedocs.io/en/latest/initialize.html#argument-parsing) doc.
 
 You can use a launcher of your choice here. You can continue using the pytorch launcher:
 


### PR DESCRIPTION
# What does this PR do?

Clarify how to properly set the arguments passed by `deepspeed` when running in CLI.

For example the following errors might be raised when running something like `deepspeed --num_gpus=2 fine-tune.py google/flan-t5-xxl` due to args passed by `deepspeed`:

```
usage: fine-tune.py [-h] model_id                                                                                                      
fine-tune.py: error: unrecognized arguments: --local_rank=0 --deepspeed llms/flan-t5-fp16-z3.json                                      
usage: fine-tune.py [-h] model_id                                                                                                      
fine-tune.py: error: unrecognized arguments: --local_rank=1 --deepspeed llms/flan-t5-fp16-z3.json
```



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@stas00 @sgugger 
