### PR TITLE
CI with `pytest_num_workers=8` for torch/tf jobs

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -285,7 +285,6 @@ torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager git+https://github.com/huggingface/accelerate",
     ],
     parallelism=1,
-    pytest_num_workers=3,
 )
 
 
@@ -298,7 +297,6 @@ tf_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager tensorflow_probability",
     ],
     parallelism=1,
-    pytest_num_workers=6,
 )
 
 


### PR DESCRIPTION
We set `pytest_num_workers` to `3` for `torch_job` and 6 for `tf_job` to avoid OOM. With the recent efforts of reducing model size in CI, we can actually set `pytest_num_workers=8`.

- The full suite: all 3 jobs (PT/TF/Flax): `12-15 minutes`
- On the latest nightly CI (without all PRs merged today): `PT: 37 min | TF: 25 min | Flax: 20 min)`

The `torch_job` reach `95%` of RAM (peak), and `tf_job` is at `80%` of RAM. The `torch_job` with `n8` is a bit dangerous, but I think I have a way to further improve things in follow PR(s).