### PR TITLE
CI 🚀 even more

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -579,7 +579,7 @@ def create_circleci_config(folder=None):
                 job.tests_to_run = [x for x in test_list_items if "/test_modeling_" not in x]
 
         # Since we filter tests above, we need to keep only those jobs that have tests to be run.
-        jobs = [x for x in jobs if len(x.tests_to_run) > 0]
+        jobs = [job for job in jobs if job.tests_to_run is not None and len(job.tests_to_run) > 0]
 
         extended_tests_to_run = set(test_list.split())
         # Extend the test files for cross test jobs

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -578,6 +578,9 @@ def create_circleci_config(folder=None):
             elif job.job_name == "tests_non_modeling":
                 job.tests_to_run = [x for x in test_list_items if "/test_modeling_" not in x]
 
+        # Since we filter tests above, we need to keep only those jobs that have tests to be run.
+        jobs = [x for x in jobs if len(x.tests_to_run) > 0]
+
         extended_tests_to_run = set(test_list.split())
         # Extend the test files for cross test jobs
         for job in jobs:

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -573,7 +573,7 @@ def create_circleci_config(folder=None):
             test_list_items += sorted([x for x in glob.glob("tests/models/*/**.py") if "test_" in x])
 
         for job in jobs:
-            if job.job_name in ["tests_torch", "tests_tf", "test_flax"]:
+            if job.job_name in ["tests_torch", "tests_tf", "tests_flax"]:
                 job.tests_to_run = [x for x in test_list_items if "/test_modeling_" in x]
             elif job.job_name == "tests_non_modeling":
                 job.tests_to_run = [x for x in test_list_items if "/test_modeling_" not in x]

--- a/tests/utils/test_add_new_model_like.py
+++ b/tests/utils/test_add_new_model_like.py
@@ -85,6 +85,7 @@ REPO_PATH = Path(transformers.__path__[0]).parent.parent
 @require_torch
 @require_tf
 @require_flax
+@unittest.skip("The file `add_new_model_like.py` requires an installation with `-e` flag.")
 class TestAddNewModelLike(unittest.TestCase):
     def init_file(self, file_name, content):
         with open(file_name, "w", encoding="utf-8") as f:


### PR DESCRIPTION
# What does this PR do?

A follow up of #25274:

- To reduce `torch_job` reaches `95%` RAM --> with this PR, it reaches only `82%`.
  - Also smaller RAM usage for: `tf_job`: `60%` | `flax_job`: `86%`
- Avoid the non-modeling files being tested redundantly
  - we save the timing for ~ 2 x 8 = 16 min.    

Now, all the jobs of the full suite CI runs < 10 minutes (except the new job `non_modeling_job`, but it takes ~2 min to restore the cache!)

<img width="206" alt="Screenshot 2023-08-03 081339" src="https://github.com/huggingface/transformers/assets/2521628/07a8b1b5-7521-4d8c-8d7e-11b176c427c4">
