### PR TITLE
Docs: Update list of `report_to` logging integrations in docstring

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -507,8 +507,9 @@ class TrainingArguments:
             instance of `Dataset`.
         report_to (`str` or `List[str]`, *optional*, defaults to `"all"`):
             The list of integrations to report the results and logs to. Supported platforms are `"azure_ml"`,
-            `"clearml"`, `"codecarbon"`, `"comet_ml"`, `"dagshub"`, `"mlflow"`, `"neptune"`, `"tensorboard"`,
-            and `"wandb"`. Use `"all"` to report to all integrations installed, `"none"` for no integrations.
+            `"clearml"`, `"codecarbon"`, `"comet_ml"`, `"dagshub"`, `"flyte"`, `"mlflow"`, `"neptune"`,
+            `"tensorboard"`, and `"wandb"`. Use `"all"` to report to all integrations installed, `"none"` for no
+            integrations.
         ddp_find_unused_parameters (`bool`, *optional*):
             When using distributed training, the value of the flag `find_unused_parameters` passed to
             `DistributedDataParallel`. Will default to `False` if gradient checkpointing is used, `True` otherwise.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1055,7 +1055,7 @@ class TrainingArguments:
         default="length",
         metadata={"help": "Column name with precomputed lengths to use when grouping by length."},
     )
-    report_to: Optional[Union[str, List[str]]] = field(
+    report_to: Optional[List[str]] = field(
         default=None, metadata={"help": "The list of integrations to report the results and logs to."}
     )
     ddp_find_unused_parameters: Optional[bool] = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -507,8 +507,8 @@ class TrainingArguments:
             instance of `Dataset`.
         report_to (`str` or `List[str]`, *optional*, defaults to `"all"`):
             The list of integrations to report the results and logs to. Supported platforms are `"azure_ml"`,
-            `"comet_ml"`, `"mlflow"`, `"neptune"`, `"tensorboard"`,`"clearml"` and `"wandb"`. Use `"all"` to report to
-            all integrations installed, `"none"` for no integrations.
+            `"clearml"`, `"codecarbon"`, `"comet_ml"`, `"dagshub"`, `"mlflow"`, `"neptune"`, `"tensorboard"`,
+            and `"wandb"`. Use `"all"` to report to all integrations installed, `"none"` for no integrations.
         ddp_find_unused_parameters (`bool`, *optional*):
             When using distributed training, the value of the flag `find_unused_parameters` passed to
             `DistributedDataParallel`. Will default to `False` if gradient checkpointing is used, `True` otherwise.
@@ -1054,7 +1054,7 @@ class TrainingArguments:
         default="length",
         metadata={"help": "Column name with precomputed lengths to use when grouping by length."},
     )
-    report_to: Optional[List[str]] = field(
+    report_to: Optional[Union[str, List[str]]] = field(
         default=None, metadata={"help": "The list of integrations to report the results and logs to."}
     )
     ddp_find_unused_parameters: Optional[bool] = field(


### PR DESCRIPTION
# What does this PR do?

## Pull Request overview
* Add missing `dagshub`, `codecarbon` and `flyte` integrations to `TrainingArguments` docstring.
* Update `report_to` type hint to allow strings.

## Details
I also converted the ordering back to alphabetical. 

I considered using a typing `Literal` as the type hint to help users via their IDE, but I haven't implemented it here as to not clash with the existing style. 

## Before submitting
- [x] This PR fixes a typo or improves the docs

## Who can review?

@sgugger

- Tom Aarsen
