### PR TITLE
Give more memory in test_disk_offload

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2521,7 +2521,7 @@ class ModelTesterMixin:
             base_output = model(**inputs_dict_class)
 
             model_size = compute_module_sizes(model)[""]
-            max_size = int(self.model_split_percents[0] * model_size)
+            max_size = int(self.model_split_percents[1] * model_size)
             with tempfile.TemporaryDirectory() as tmp_dir:
                 model.cpu().save_pretrained(tmp_dir)
 


### PR DESCRIPTION
# What does this PR do?

Give more memory available in `disk_offload_test` by using the second split (0.7) instead of the first (0.5). I haven't tried all of them, but it seems to fix all the ones I tried. We will know more at the next GPU CI run.