### PR TITLE
[MusicGen] Add streamer to generate

### DIFF
--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -2198,6 +2198,7 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
         logits_processor: Optional[LogitsProcessorList] = None,
         stopping_criteria: Optional[StoppingCriteriaList] = None,
         synced_gpus: Optional[bool] = None,
+        streamer: Optional["BaseStreamer"] = None,
         **kwargs,
     ):
         """
@@ -2238,6 +2239,9 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
                 generation config an error is thrown. This feature is intended for advanced users.
             synced_gpus (`bool`, *optional*, defaults to `False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
+            streamer (`BaseStreamer`, *optional*):
+                Streamer object that will be used to stream the generated sequences. Generated tokens are passed
+                through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
             kwargs (`Dict[str, Any]`, *optional*):
                 Ad hoc parametrization of `generate_config` and/or additional model-specific kwargs that will be
                 forwarded to the `forward` function of the model. If the model is an encoder-decoder model, encoder
@@ -2380,6 +2384,10 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
         # stash the delay mask so that we don't have to recompute in each forward pass
         model_kwargs["decoder_delay_pattern_mask"] = decoder_delay_pattern_mask
 
+        # input_ids are ready to be placed on the streamer (if used)
+        if streamer is not None:
+            streamer.put(input_ids.cpu())
+
         # 7. determine generation mode
         is_greedy_gen_mode = (
             (generation_config.num_beams == 1)
@@ -2428,6 +2436,7 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
                 output_scores=generation_config.output_scores,
                 return_dict_in_generate=generation_config.return_dict_in_generate,
                 synced_gpus=synced_gpus,
+                streamer=streamer,
                 **model_kwargs,
             )
 
@@ -2454,6 +2463,7 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
                 output_scores=generation_config.output_scores,
                 return_dict_in_generate=generation_config.return_dict_in_generate,
                 synced_gpus=synced_gpus,
+                streamer=streamer,
                 **model_kwargs,
             )
 

--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -18,7 +18,7 @@ import inspect
 import math
 import random
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -47,6 +47,9 @@ from ..auto.configuration_auto import AutoConfig
 from ..auto.modeling_auto import AutoModel
 from .configuration_musicgen import MusicgenConfig, MusicgenDecoderConfig
 
+
+if TYPE_CHECKING:
+    from ...generation.streamers import BaseStreamer
 
 logger = logging.get_logger(__name__)
 
@@ -1185,6 +1188,7 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel):
         logits_processor: Optional[LogitsProcessorList] = None,
         stopping_criteria: Optional[StoppingCriteriaList] = None,
         synced_gpus: Optional[bool] = None,
+        streamer: Optional["BaseStreamer"] = None,
         **kwargs,
     ):
         """
@@ -1225,6 +1229,9 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel):
                 generation config an error is thrown. This feature is intended for advanced users.
             synced_gpus (`bool`, *optional*, defaults to `False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
+            streamer (`BaseStreamer`, *optional*):
+                Streamer object that will be used to stream the generated sequences. Generated tokens are passed
+                through `streamer.put(token_ids)` and the streamer is responsible for any further processing.
             kwargs (`Dict[str, Any]`, *optional*):
                 Ad hoc parametrization of `generate_config` and/or additional model-specific kwargs that will be
                 forwarded to the `forward` function of the model. If the model is an encoder-decoder model, encoder
@@ -1336,6 +1343,9 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel):
             max_length=generation_config.max_length,
         )
 
+        if streamer is not None:
+            streamer.put(input_ids.cpu())
+
         # stash the delay mask so that we don't have to recompute it in each forward pass
         model_kwargs["delay_pattern_mask"] = delay_pattern_mask
 
@@ -1387,6 +1397,7 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel):
                 output_scores=generation_config.output_scores,
                 return_dict_in_generate=generation_config.return_dict_in_generate,
                 synced_gpus=synced_gpus,
+                streamer=streamer,
                 **model_kwargs,
             )
 
@@ -1412,6 +1423,7 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel):
                 output_scores=generation_config.output_scores,
                 return_dict_in_generate=generation_config.return_dict_in_generate,
                 synced_gpus=synced_gpus,
+                streamer=streamer,
                 **model_kwargs,
             )
 

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -506,7 +506,7 @@ class MusicgenTester:
 class MusicgenStreamer(BaseStreamer):
     def __init__(
         self,
-        model: MusicgenForConditionalGeneration,
+        model: "MusicgenForConditionalGeneration",
         device: Optional[str] = None,
         play_steps: Optional[int] = 10,
         stride: Optional[int] = None,

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -17,9 +17,6 @@ import copy
 import inspect
 import math
 import unittest
-from queue import Queue
-from threading import Thread
-from typing import Optional
 
 import numpy as np
 
@@ -31,7 +28,6 @@ from transformers import (
     PretrainedConfig,
     T5Config,
 )
-from transformers.generation.streamers import BaseStreamer
 from transformers.testing_utils import is_torch_available, require_torch, slow, torch_device
 from transformers.utils import cached_property
 
@@ -459,10 +455,9 @@ class MusicgenTester:
         self.num_filters = num_filters
         self.codebook_size = codebook_size
 
-    def prepare_config_and_inputs(self, batch_size=None):
-        batch_size = batch_size if batch_size is not None else self.batch_size
-        input_ids = ids_tensor([batch_size, self.seq_length], self.vocab_size)
-        decoder_input_ids = ids_tensor([batch_size * self.num_codebooks, self.seq_length], self.vocab_size)
+    def prepare_config_and_inputs(self):
+        input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
+        decoder_input_ids = ids_tensor([self.batch_size * self.num_codebooks, self.seq_length], self.vocab_size)
 
         config = self.get_config()
         inputs_dict = prepare_musicgen_inputs_dict(config, input_ids, decoder_input_ids=decoder_input_ids)
@@ -501,126 +496,6 @@ class MusicgenTester:
     def prepare_config_and_inputs_for_common(self):
         config, inputs_dict = self.prepare_config_and_inputs()
         return config, inputs_dict
-
-
-class MusicgenStreamer(BaseStreamer):
-    def __init__(
-        self,
-        model: "MusicgenForConditionalGeneration",
-        device: Optional[str] = None,
-        play_steps: Optional[int] = 10,
-        stride: Optional[int] = None,
-        timeout: Optional[float] = None,
-    ):
-        """
-        Streamer that stores playback-ready audio in a queue, to be used by a downstream application as an iterator.
-        This is useful for applications that benefit from accessing the generated audio in a non-blocking way (e.g. in
-        an interactive Gradio demo).
-
-        Parameters:
-            model (`MusicgenForConditionalGeneration`):
-                The MusicGen model used to generate the audio waveform.
-            device (`str`, *optional*):
-                The torch device on which to run the computation. If `None`, will default to the device of the model.
-            play_steps (`int`, *optional*, defaults to 10):
-                The number of generation steps with which to return the generated audio array. Using fewer steps will
-                mean the first chunk is ready faster, but will require more codec decoding steps overall. This value
-                should be tuned to your device and latency requirements.
-            stride (`int`, *optional*):
-                The window (stride) between adjacent audio samples. Using a stride between adjacent audio samples reduces
-                the hard boundary between them, giving smoother playback. If `None`, will default to a value equivalent to
-                play_steps // 6 in the audio space.
-            timeout (`int`, *optional*):
-                The timeout for the audio queue. If `None`, the queue will block indefinitely. Useful to handle exceptions
-                in `.generate()`, when it is called in a separate thread.
-        """
-        self.decoder = model.decoder
-        self.audio_encoder = model.audio_encoder
-        self.generation_config = model.generation_config
-        self.device = device if device is not None else model.device
-
-        # variables used in the streaming process
-        self.play_steps = play_steps
-        if stride is not None:
-            self.stride = stride
-        else:
-            hop_length = np.prod(self.audio_encoder.config.upsampling_ratios)
-            self.stride = hop_length * (play_steps - self.decoder.num_codebooks) // 6
-        self.token_cache = None
-        self.to_yield = 0
-
-        # varibles used in the thread process
-        self.audio_queue = Queue()
-        self.stop_signal = None
-        self.timeout = timeout
-
-    def apply_delay_pattern_mask(self, input_ids):
-        # build the delay pattern mask for offsetting each codebook prediction by 1 (this behaviour is specific to MusicGen)
-        _, decoder_delay_pattern_mask = self.decoder.build_delay_pattern_mask(
-            input_ids[:, :1],
-            pad_token_id=self.generation_config.decoder_start_token_id,
-            max_length=input_ids.shape[-1],
-        )
-        # apply the pattern mask to the input ids
-        input_ids = self.decoder.apply_delay_pattern_mask(input_ids, decoder_delay_pattern_mask)
-
-        # revert the pattern delay mask by filtering the pad token id
-        input_ids = input_ids[input_ids != self.generation_config.pad_token_id].reshape(
-            1, self.decoder.num_codebooks, -1
-        )
-
-        # append the frame dimension back to the audio codes
-        input_ids = input_ids[None, ...]
-
-        # send the input_ids to the correct device
-        input_ids = input_ids.to(self.audio_encoder.device)
-
-        output_values = self.audio_encoder.decode(
-            input_ids,
-            audio_scales=[None],
-        )
-        audio_values = output_values.audio_values[0, 0]
-        return audio_values.cpu().float().numpy()
-
-    def put(self, value):
-        batch_size = value.shape[0] // self.decoder.num_codebooks
-        if batch_size > 1:
-            raise ValueError("MusicgenStreamer only supports batch size 1")
-
-        if self.token_cache is None:
-            self.token_cache = value
-        else:
-            self.token_cache = torch.concatenate([self.token_cache, value[:, None]], dim=-1)
-
-        if self.token_cache.shape[-1] % self.play_steps == 0:
-            audio_values = self.apply_delay_pattern_mask(self.token_cache)
-            self.on_finalized_audio(audio_values[self.to_yield : -self.stride])
-            self.to_yield += len(audio_values) - self.to_yield - self.stride
-
-    def end(self):
-        """Flushes any remaining cache and appends the stop symbol."""
-        if self.token_cache is not None:
-            audio_values = self.apply_delay_pattern_mask(self.token_cache)
-        else:
-            audio_values = np.zeros(self.to_yield)
-
-        self.on_finalized_audio(audio_values[self.to_yield :], stream_end=True)
-
-    def on_finalized_audio(self, audio: np.ndarray, stream_end: bool = False):
-        """Put the new audio in the queue. If the stream is ending, also put a stop signal in the queue."""
-        self.audio_queue.put(audio, timeout=self.timeout)
-        if stream_end:
-            self.audio_queue.put(self.stop_signal, timeout=self.timeout)
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        value = self.audio_queue.get(timeout=self.timeout)
-        if not isinstance(value, np.ndarray) and value == self.stop_signal:
-            raise StopIteration()
-        else:
-            return value
 
 
 @require_torch
@@ -1220,24 +1095,6 @@ class MusicgenTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             model.generate(
                 input_dict["input_ids"], attention_mask=input_dict["attention_mask"], do_sample=True, max_new_tokens=10
             )
-
-    def test_generate_streamer(self):
-        config, input_dict = self.model_tester.prepare_config_and_inputs(batch_size=1)
-        for model_class in self.greedy_sample_model_classes:
-            model = model_class(config).eval().to(torch_device)
-            streamer = MusicgenStreamer(model, device=torch_device, play_steps=5)
-
-            generation_kwargs = dict(
-                **input_dict,
-                streamer=streamer,
-                max_new_tokens=15,
-            )
-
-            thread = Thread(target=model.generate, kwargs=generation_kwargs)
-            thread.start()
-
-            for new_audio in streamer:
-                yield new_audio
 
 
 def get_bip_bip(bip_duration=0.125, duration=0.5, sample_rate=32000):

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -500,7 +500,6 @@ class MusicgenTester:
         return config, inputs_dict
 
 
-@require_torch
 class MusicgenStreamer(BaseStreamer):
     """
     Simple MusicGen streamer that prints audio values to stdout every `play_steps` decoding steps.
@@ -512,7 +511,7 @@ class MusicgenStreamer(BaseStreamer):
         The interval of decoding steps with which to print audio values to the stddout.
     """
 
-    def __init__(self, model: MusicgenForConditionalGeneration, play_steps: int = 10):
+    def __init__(self, model: "MusicgenForConditionalGeneration", play_steps: int = 10):
         self.decoder = model.decoder
         self.audio_encoder = model.audio_encoder
         self.generation_config = model.generation_config

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -500,6 +500,7 @@ class MusicgenTester:
         return config, inputs_dict
 
 
+@require_torch
 class MusicgenStreamer(BaseStreamer):
     """
     Simple MusicGen streamer that prints audio values to stdout every `play_steps` decoding steps.

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -529,7 +529,7 @@ class MusicgenStreamer(BaseStreamer):
             max_length=self.token_cache.shape[-1],
         )
         # apply the pattern mask to the input ids
-        input_ids = self.decoder.apply_delay_pattern_mask(self.token_cache, decoder_delay_pattern_mask)
+        input_ids = self.decoder.apply_delay_pattern_mask(input_ids, decoder_delay_pattern_mask)
 
         # revert the pattern delay mask by filtering the pad token id
         input_ids = input_ids[input_ids != self.generation_config.pad_token_id].reshape(
@@ -561,8 +561,11 @@ class MusicgenStreamer(BaseStreamer):
 
         if self.token_cache.shape[-1] % self.play_steps == 0:
             audio_values = self.apply_delay_pattern_mask(self.token_cache)
-            self.on_finalized_text(audio_values[self.to_print :])
-            self.to_print += len(audio_values) - self.to_print
+            # only print the newly generated audio values
+            audio_values = audio_values[self.to_print :]
+            self.on_finalized_text(audio_values)
+            # update our running total
+            self.to_print += len(audio_values)
 
     def end(self):
         """Flushes any remaining cache and prints a newline to stdout."""


### PR DESCRIPTION
# What does this PR do?

Adds the `streamer` to MusicGen's generate, along with an example test for returning chunks of numpy audio arrays _on-the-fly_ as they are generated.

Facilitates using MusicGen with streaming mode as per the Gradio update: https://github.com/gradio-app/gradio/pull/5077

cc @Vaibhavs10 @ylacombe @aliabid94 @abidlabs