### PR TITLE
Adding more information in help parser on train_file and validation_file

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -82,10 +82,10 @@ def parse_args():
         help="The configuration name of the dataset to use (via the datasets library).",
     )
     parser.add_argument(
-        "--train_file", type=str, default=None, help="A csv or a json file containing the training data."
+        "--train_file", type=str, default=None, help="A csv, txt or a json file containing the training data."
     )
     parser.add_argument(
-        "--validation_file", type=str, default=None, help="A csv or a json file containing the validation data."
+        "--validation_file", type=str, default=None, help="A csv, txt or a json file containing the validation data."
     )
     parser.add_argument(
         "--validation_split_percentage",


### PR DESCRIPTION
I create a PR because I see that in train_file and validation_file help in the parser, the docs do not provide the full extension (csv, json and text but the current just have csv and json).

So I add it to have more information in the docs.

I want to cc @ArthurZucker to review this