### PR TITLE
Enable tests to run on third-party devcies

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -90,7 +90,6 @@ from .utils import (
     is_torch_available,
     is_torch_bf16_cpu_available,
     is_torch_bf16_gpu_available,
-    is_torch_mps_available,
     is_torch_neuroncore_available,
     is_torch_npu_available,
     is_torch_tensorrt_fx_available,
@@ -615,8 +614,6 @@ if is_torch_available():
 
     if torch.cuda.is_available():
         torch_device = "cuda"
-    elif is_torch_mps_available():
-        torch_device = "mps"
     elif is_torch_npu_available():
         torch_device = "npu"
     else:

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -614,7 +614,7 @@ if is_torch_available():
 
     if torch.cuda.is_available():
         torch_device = "cuda"
-    elif is_torch_npu_available():
+    elif is_torch_npu_available() and bool(os.environ.get("TEST_ON_THIRD_PARTY_DEVICE", False)):
         torch_device = "npu"
     else:
         torch_device = "cpu"

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -175,6 +175,7 @@ _run_staging = parse_flag_from_env("HUGGINGFACE_CO_STAGING", default=False)
 _tf_gpu_memory_limit = parse_int_from_env("TF_GPU_MEMORY_LIMIT", default=None)
 _run_pipeline_tests = parse_flag_from_env("RUN_PIPELINE_TESTS", default=True)
 _run_tool_tests = parse_flag_from_env("RUN_TOOL_TESTS", default=False)
+_run_third_party_device_tests = parse_flag_from_env("RUN_THIRD_PARTY_DEVICE_TESTS", default=False)
 
 
 def is_pt_tf_cross_test(test_case):
@@ -614,7 +615,7 @@ if is_torch_available():
 
     if torch.cuda.is_available():
         torch_device = "cuda"
-    elif is_torch_npu_available() and bool(os.environ.get("TEST_ON_THIRD_PARTY_DEVICE", False)):
+    elif _run_third_party_device_tests and is_torch_npu_available():
         torch_device = "npu"
     else:
         torch_device = "cpu"

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -90,6 +90,7 @@ from .utils import (
     is_torch_available,
     is_torch_bf16_cpu_available,
     is_torch_bf16_gpu_available,
+    is_torch_mps_available,
     is_torch_neuroncore_available,
     is_torch_npu_available,
     is_torch_tensorrt_fx_available,
@@ -612,7 +613,14 @@ if is_torch_available():
     # Set env var CUDA_VISIBLE_DEVICES="" to force cpu-mode
     import torch
 
-    torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available():
+        torch_device = "cuda"
+    elif is_torch_mps_available():
+        torch_device = "mps"
+    elif is_torch_npu_available():
+        torch_device = "npu"
+    else:
+        torch_device = "cpu"
 else:
     torch_device = None
 


### PR DESCRIPTION
### What does this PR do?
It is crucial to enable unit tests to ensure the smooth integration of third-party devices. This PR enables ~~MPS and~~ NPU to reuse most existing test cases.




