### PR TITLE
Register ModelOutput class with PyTorch's pytree

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -338,6 +338,21 @@ class ModelOutput(OrderedDict):
         return tuple(self[k] for k in self.keys())
 
 
+if is_torch_available():
+    """
+    By registering ModelOutput with pytorch's pytree implementation,
+    we ensure that code intending to loop over the elements (e.g. tensors) within arbitrarily
+    structured model outputs can do so without having to understand the structures.
+    """
+    import torch.utils._pytree
+
+    torch.utils._pytree._register_pytree_node(
+        ModelOutput,
+        torch.utils._pytree._dict_flatten,
+        lambda values, context: ModelOutput(torch.utils._pytree._dict_unflatten(values, context)),
+    )
+
+
 class ExplicitEnum(str, Enum):
     """
     Enum with more explicit error message for missing values.

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1879,6 +1879,13 @@ class ModelTesterMixin:
                 tf_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, tol=tol, name=name, attributes=attributes
             )
 
+            # ensure torch pytree flatten works with ModelOutput class (by default, without user having to register it)
+            flat_outs, _ = torch.utils._pytree.tree_flatten(pt_outputs)
+            self.check_pt_pytree_outputs(
+                pt_outputs.to_tuple(), flat_outs, model_class, tol=tol, name=name, attributes=attributes
+            )
+
+
         # Allow `list` (e.g. `TransfoXLModelOutput.mems` is a list of tensors.)
         elif type(tf_outputs) in [tuple, list]:
             self.assertEqual(type(tf_outputs), type(pt_outputs), f"{name}: Output types differ between TF and PyTorch")


### PR DESCRIPTION
Summary:
PyTree lets users flatten arbitrarily complex py data structures (e.g. ModelOutput) and operate over a flat list of their constituent parts.

Users could opt to register HF's ModelOutput with pytree manually and then use it, but many users would not know to do this or would be inconvenienced by it.

A common use case is to operate over all the tensors in a model's output.

Test Plan:
I've added a unit test but haven't run it locally (yet as it depends on PT and TF) - would check if CI runs it first.

Reviewers:

Subscribers:

Tasks:

Tags:

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
