### PR TITLE
Doc: NLP tasks between NLU and Text Generation

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -32,17 +32,22 @@
         title: Token classification
       - local: tasks/question_answering
         title: Question answering
-      - local: tasks/language_modeling
-        title: Causal language modeling
       - local: tasks/masked_language_modeling
         title: Masked language modeling
+      - local: tasks/multiple_choice
+        title: Multiple choice
+    title: Natural Language Understanding
+    isExpanded: false
+  - sections:
+      - local: tasks/language_modeling
+        title: Causal language modeling
       - local: tasks/translation
         title: Translation
       - local: tasks/summarization
         title: Summarization
-      - local: tasks/multiple_choice
-        title: Multiple choice
-    title: Natural Language Processing
+      - local: generation_strategies
+        title: Customize text generation strategy
+    title: Text Generation
     isExpanded: false
   - sections:
       - local: tasks/audio_classification
@@ -76,11 +81,6 @@
       - local: tasks/text-to-speech
         title: Text to speech
     title: Multimodal
-    isExpanded: false
-  - sections:
-      - local: generation_strategies
-        title: Customize text generation strategy
-    title: Generation
     isExpanded: false
   title: Task Guides
 - sections:

--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -19,8 +19,7 @@ State-of-the-art Machine Learning for [PyTorch](https://pytorch.org/), [TensorFl
 
 🤗 Transformers provides APIs and tools to easily download and train state-of-the-art pretrained models. Using pretrained models can reduce your compute costs, carbon footprint, and save you the time and resources required to train a model from scratch. These models support common tasks in different modalities, such as:
 
-🤖 **Natural Language Understanding**: text classification, named entity recognition, question answering, language modeling, and multiple choice.<br>
-📝 **Text Generation**: summarization, translation, and text generation.<br>
+📝 **Natural Language Processing**: text classification, named entity recognition, question answering, language modeling, summarization, translation, multiple choice, and text generation.<br>
 🖼️ **Computer Vision**: image classification, object detection, and segmentation.<br>
 🗣️ **Audio**: automatic speech recognition and audio classification.<br>
 🐙 **Multimodal**: table question answering, optical character recognition, information extraction from scanned documents, video classification, and visual question answering.

--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -19,7 +19,8 @@ State-of-the-art Machine Learning for [PyTorch](https://pytorch.org/), [TensorFl
 
 🤗 Transformers provides APIs and tools to easily download and train state-of-the-art pretrained models. Using pretrained models can reduce your compute costs, carbon footprint, and save you the time and resources required to train a model from scratch. These models support common tasks in different modalities, such as:
 
-📝 **Natural Language Processing**: text classification, named entity recognition, question answering, language modeling, summarization, translation, multiple choice, and text generation.<br>
+🤖 **Natural Language Understanding**: text classification, named entity recognition, question answering, language modeling, and multiple choice.<br>
+📝 **Text Generation**: summarization, translation, and text generation.<br>
 🖼️ **Computer Vision**: image classification, object detection, and segmentation.<br>
 🗣️ **Audio**: automatic speech recognition and audio classification.<br>
 🐙 **Multimodal**: table question answering, optical character recognition, information extraction from scanned documents, video classification, and visual question answering.


### PR DESCRIPTION
# What does this PR do?

As discussed [here](https://github.com/huggingface/transformers/pull/25240#issuecomment-1668029668), this PR splits the NLP task section in two:
- Moves generative tasks to the new text generation task section
- Renames NLP into NLU, which now holds non-generative tasks, for clarity

Related issue: #24575 