### PR TITLE
Fix `torch_job` worker(s) crashing

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -285,6 +285,7 @@ torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager git+https://github.com/huggingface/accelerate",
     ],
     parallelism=1,
+    pytest_num_workers=6,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

CircleCI nightly run's `torch_job` has crashed worker(s). This is due to the change of num. of processes from `3` to `8` in #25274 for that job. This PR changes it to `6` to avoid this crash.

It seems `Oneformer` is the (only) test that uses a lot of memory and causes the crash.