### PR TITLE
Use small config for `OneFormerModelTest.test_model_with_labels`

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -285,7 +285,7 @@ torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager git+https://github.com/huggingface/accelerate",
     ],
     parallelism=1,
-    pytest_num_workers=6,
+    pytest_num_workers=8,
 )
 
 

--- a/tests/models/oneformer/test_modeling_oneformer.py
+++ b/tests/models/oneformer/test_modeling_oneformer.py
@@ -332,13 +332,13 @@ class OneFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
             "pixel_values": torch.randn((2, 3, *size), device=torch_device),
             "task_inputs": torch.randint(high=self.model_tester.vocab_size, size=(2, 77), device=torch_device).long(),
             "text_inputs": torch.randint(
-                high=self.model_tester.vocab_size, size=(2, 134, 77), device=torch_device
+                high=self.model_tester.vocab_size, size=(2, 6, 77), device=torch_device
             ).long(),
             "mask_labels": torch.randn((2, 150, *size), device=torch_device),
             "class_labels": torch.zeros(2, 150, device=torch_device).long(),
         }
 
-        config = OneFormerConfig()
+        config = self.model_tester.get_config()
         config.is_training = True
 
         model = OneFormerForUniversalSegmentation(config).to(torch_device)


### PR DESCRIPTION
# What does this PR do?

And now we can safely use `pytest_num_workers=8` for `torch_job`.

The [job run page](https://app.circleci.com/pipelines/github/huggingface/transformers/70121/workflows/759a5a5b-53d0-4641-ace8-136d972079ef/jobs/879218/resources): it shows a peak of 78%. Without this PR (and run with `n8`, we get crashed or ~97 peak RAM usage)



<img width="1112" alt="Screenshot 2023-08-08 170353" src="https://github.com/huggingface/transformers/assets/2521628/d4fbdeba-819a-4618-8b2a-c3eb3c5cd1bc">
 