### PR TITLE
Fix path for dynamic module creation

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -59,7 +59,7 @@ def create_dynamic_module(name: Union[str, os.PathLike]):
     Creates a dynamic module in the cache directory for modules.
     """
     init_hf_modules()
-    dynamic_module_path = Path(HF_MODULES_CACHE) / name
+    dynamic_module_path = (Path(HF_MODULES_CACHE) / name).resolve()
     # If the parent module does not exist yet, recursively create it.
     if not dynamic_module_path.parent.exists():
         create_dynamic_module(dynamic_module_path.parent)


### PR DESCRIPTION
# What does this PR do?

If the user provides a custom cache folder, it might not be a fully expanded path, which then causes recursion errors when trying to create the dynamic module for code on the Hub. This PR fixes that.

Fixes #25396 