### PR TITLE
Generate: Load generation config when `device_map` is passed

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2966,7 +2966,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         model.eval()
 
         # If it is a model with generation capabilities, attempt to load the generation config
-        if model.can_generate():
+        if model.can_generate() and pretrained_model_name_or_path is not None:
             try:
                 model.generation_config = GenerationConfig.from_pretrained(
                     pretrained_model_name_or_path,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2991,7 +2991,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Dispatch model with hooks on all devices if necessary
         if device_map is not None:
             device_map_kwargs = {
-                "device_map": device_map, "offload_dir": offload_folder, "offload_index": offload_index
+                "device_map": device_map,
+                "offload_dir": offload_folder,
+                "offload_index": offload_index,
             }
             if "skip_keys" in inspect.signature(dispatch_model).parameters:
                 device_map_kwargs["skip_keys"] = model._skip_keys_device_placement

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2849,9 +2849,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "'sequential'."
                 )
 
-            kwargs = {"no_split_module_classes": no_split_modules}
+            device_map_kwargs = {"no_split_module_classes": no_split_modules}
             if "special_dtypes" in inspect.signature(infer_auto_device_map).parameters:
-                kwargs["special_dtypes"] = special_dtypes
+                device_map_kwargs["special_dtypes"] = special_dtypes
             elif len(special_dtypes) > 0:
                 logger.warning(
                     "This model has some weights that should be kept in higher precision, you need to upgrade "
@@ -2863,12 +2863,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     dtype=target_dtype,
                     low_zero=(device_map == "balanced_low_0"),
                     max_memory=max_memory,
-                    **kwargs,
+                    **device_map_kwargs,
                 )
-            kwargs["max_memory"] = max_memory
+            device_map_kwargs["max_memory"] = max_memory
             # Make sure tied weights are tied before creating the device map.
             model.tie_weights()
-            device_map = infer_auto_device_map(model, dtype=target_dtype, **kwargs)
+            device_map = infer_auto_device_map(model, dtype=target_dtype, **device_map_kwargs)
 
             if load_in_8bit or load_in_4bit:
                 # The LM head / tied weights or any last module can stay on disk / CPU
@@ -2982,7 +2982,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     _from_pipeline=from_pipeline,
                     **kwargs,
                 )
-            except (OSError, TypeError):
+            except OSError:
                 logger.info(
                     "Generation config file not found, using a generation config created from the model config."
                 )
@@ -2990,10 +2990,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Dispatch model with hooks on all devices if necessary
         if device_map is not None:
-            kwargs = {"device_map": device_map, "offload_dir": offload_folder, "offload_index": offload_index}
+            device_map_kwargs = {
+                "device_map": device_map, "offload_dir": offload_folder, "offload_index": offload_index
+            }
             if "skip_keys" in inspect.signature(dispatch_model).parameters:
-                kwargs["skip_keys"] = model._skip_keys_device_placement
-            dispatch_model(model, **kwargs)
+                device_map_kwargs["skip_keys"] = model._skip_keys_device_placement
+            dispatch_model(model, **device_map_kwargs)
 
         if output_loading_info:
             if loading_info is None:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1037,15 +1037,17 @@ class ModelUtilsTest(TestCasePlus):
             self.assertEqual(model.__class__.__name__, model_ref.__class__.__name__)
 
     def test_generation_config_is_loaded_with_model(self):
-        # Note: `hf-internal-testing/tiny-random-gpt2` has a `generation_config.json` containing a dummy
+        # Note: `joaogante/tiny-random-gpt2-with-generation-config` has a `generation_config.json` containing a dummy
         # `transformers_version` field set to `foo`
 
         # 1. Load without further parameters
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = AutoModelForCausalLM.from_pretrained("joaogante/tiny-random-gpt2-with-generation-config")
         self.assertEqual(model.generation_config.transformers_version, "foo")
 
         # 2. Load with `device_map`
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", device_map="auto")
+        model = AutoModelForCausalLM.from_pretrained(
+            "joaogante/tiny-random-gpt2-with-generation-config", device_map="auto"
+        )
         self.assertEqual(model.generation_config.transformers_version, "foo")
 
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1038,7 +1038,7 @@ class ModelUtilsTest(TestCasePlus):
 
     def test_generation_config_is_loaded_with_model(self):
         # Note: `joaogante/tiny-random-gpt2-with-generation-config` has a `generation_config.json` containing a dummy
-        # `transformers_version` field set to `foo`
+        # `transformers_version` field set to `foo`. If loading the file fails, this test also fails.
 
         # 1. Load without further parameters
         model = AutoModelForCausalLM.from_pretrained("joaogante/tiny-random-gpt2-with-generation-config")

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1037,8 +1037,8 @@ class ModelUtilsTest(TestCasePlus):
             self.assertEqual(model.__class__.__name__, model_ref.__class__.__name__)
 
     def test_generation_config_is_loaded_with_model(self):
-        # Note: `hf-internal-testing/tiny-random-gpt2` has a dummy `transformers_version` field set to `foo`,
-        # which is harmless and impossible to replicate unless it is loaded properly
+        # Note: `hf-internal-testing/tiny-random-gpt2` has a `generation_config.json` containing a dummy
+        # `transformers_version` field set to `foo`
 
         # 1. Load without further parameters
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1036,6 +1036,18 @@ class ModelUtilsTest(TestCasePlus):
 
             self.assertEqual(model.__class__.__name__, model_ref.__class__.__name__)
 
+    def test_generation_config_is_loaded_with_model(self):
+        # Note: `hf-internal-testing/tiny-random-gpt2` has a dummy `transformers_version` field set to `foo`,
+        # which is harmless and impossible to replicate unless it is loaded properly
+
+        # 1. Load without further parameters
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        self.assertEqual(model.generation_config.transformers_version, "foo")
+
+        # 2. Load with `device_map`
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", device_map="auto")
+        self.assertEqual(model.generation_config.transformers_version, "foo")
+
 
 @require_torch
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?

Thank you @RonanKMcGovern for reporting this issue.

In `PreTrainedModel.from_pretrained`, `kwargs` is getting redefined when `device_map` is passed ([here](https://github.com/huggingface/transformers/blob/944ddce8bfd09ebbbdc71fb1d116421db42149b2/src/transformers/modeling_utils.py#L2852)). Later on, when attempting to load the generation config, the original `kwargs` are expected. However, since `kwargs` was rewritten into something else and the resulting exception was being caught, loading the generation config was failing silently.

The fix is simple: don't rewrite `kwargs` :)

___________________________________
### Impact of this PR on Llama 2

⚠️ We may indeed need a patch to run llama 2 models with good default behavior -- users loading the model with `device_map="auto"` (which I suspect is the most common case) are not loading the generation config, resulting in poor default behavior.

Here is an example of a script whose behavior changes drastically after this PR:
```py
from transformers import AutoModelForCausalLM, AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf")
model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-chat-hf", device_map="auto", load_in_4bit=True)

# After this PR loads do_sample=True and max_length=4096, before do_sample=False and max_length=20
for i in range(10):
    inputs = tokenizer(["The quick brown"], return_tensors="pt").to("cuda")
    gen_out = model.generate(**inputs)
    print(tokenizer.decode(gen_out[0]))
```

___________________________________
### Retrocompatibility note
In the model `.from_pretrained`, the generation config needs to receive `kwargs` the same way the model config does. For retrocompatibility purposes, we need to accept things like

```py
model = AutoModelForCausalLM.from_pretrained("gpt2", temperature=0.9) 
```

and the extra parameter should be loaded in the generation config.