### PR TITLE
Bark: flexible generation config overload

### DIFF
--- a/src/transformers/models/bark/generation_configuration_bark.py
+++ b/src/transformers/models/bark/generation_configuration_bark.py
@@ -224,7 +224,7 @@ class BarkFineGenerationConfig(GenerationConfig):
         self.max_fine_input_length = max_fine_input_length
         self.n_fine_codebooks = n_fine_codebooks
 
-    def validate(self):
+    def validate(self, **kwargs):
         """
         Overrides GenerationConfig.validate because BarkFineGenerationConfig don't use any parameters outside
         temperature.


### PR DESCRIPTION
# What does this PR do?

Fixes the issue we are seeing in CI, by overloading `validate` is a much more flexible signature :)