### PR TITLE
[`NllbMoe`] Update code to properly support loss computation

### DIFF
--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -130,9 +130,6 @@ def load_balancing_loss_func(router_probs: torch.Tensor, expert_indices: torch.T
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
 
-    Adapted from transfomers.models.modeling_switch_transformers.load_balancing_loss_func with
-    SwitchTransformers->NllbMoeModel to support None
-
     See Switch Transformer (https://arxiv.org/abs/2101.03961) for more details. This function implements the loss
     function presented in equations (4) - (6) of the paper. It aims at penalizing cases where the routing between
     experts is too unbalanced.
@@ -1788,8 +1785,6 @@ class NllbMoeForConditionalGeneration(NllbMoePreTrainedModel):
         )
 
     def _unpack_router_logits(self, router_outputs):
-        # Adapted from transfomers.models.switch_transformers.SwitchTransformersForConditionalGeneration._unpack_router_logits
-        # to support None
         total_router_logits = []
         total_expert_indexes = []
         for router_output in router_outputs:

--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -130,8 +130,8 @@ def load_balancing_loss_func(router_probs: torch.Tensor, expert_indices: torch.T
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
 
-    Adapted from transfomers.models.modeling_switch_transformers.load_balancing_loss_func with SwitchTransformers->NllbMoeModel
-    to support None
+    Adapted from transfomers.models.modeling_switch_transformers.load_balancing_loss_func with
+    SwitchTransformers->NllbMoeModel to support None
 
     See Switch Transformer (https://arxiv.org/abs/2101.03961) for more details. This function implements the loss
     function presented in equations (4) - (6) of the paper. It aims at penalizing cases where the routing between
@@ -148,7 +148,7 @@ def load_balancing_loss_func(router_probs: torch.Tensor, expert_indices: torch.T
     """
     if router_probs is None:
         return 0
-    
+
     num_experts = router_probs.shape[-1]
 
     # cast the expert indices to int64, otherwise one-hot encoding will fail
@@ -706,6 +706,7 @@ class NllbMoeEncoderLayer(nn.Module):
         else:
             # router_states set to None to track which layers have None gradients.
             hidden_states, router_states = self.ffn(hidden_states), None
+
         hidden_states = self.ff_dropout(hidden_states)
 
         hidden_states = residual + hidden_states
@@ -837,6 +838,7 @@ class NllbMoeDecoderLayer(nn.Module):
             hidden_states, router_states = self.ffn(hidden_states, attention_mask)
         else:
             hidden_states, router_states = self.ffn(hidden_states), None
+
         hidden_states = self.ff_dropout(hidden_states)
 
         hidden_states = residual + hidden_states
@@ -1795,7 +1797,7 @@ class NllbMoeForConditionalGeneration(NllbMoePreTrainedModel):
                 router_logits, expert_indexes = router_output
                 total_router_logits.append(router_logits)
                 total_expert_indexes.append(expert_indexes)
-        
+
         total_router_logits = torch.cat(total_router_logits, dim=1) if len(total_router_logits) > 0 else None
         total_expert_indexes = torch.stack(total_expert_indexes, dim=1) if len(total_expert_indexes) > 0 else None
         return total_router_logits, total_expert_indexes

--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -130,6 +130,9 @@ def load_balancing_loss_func(router_probs: torch.Tensor, expert_indices: torch.T
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
 
+    Adapted from transfomers.models.modeling_switch_transformers.load_balancing_loss_func with SwitchTransformers->NllbMoeModel
+    to support None
+
     See Switch Transformer (https://arxiv.org/abs/2101.03961) for more details. This function implements the loss
     function presented in equations (4) - (6) of the paper. It aims at penalizing cases where the routing between
     experts is too unbalanced.
@@ -1782,8 +1785,9 @@ class NllbMoeForConditionalGeneration(NllbMoePreTrainedModel):
             decoder_router_logits=outputs.decoder_router_logits,
         )
 
-    # Copied from transfomers.models.switch_transformers.SwitchTransformersForConditionalGeneration._unpack_router_logits
     def _unpack_router_logits(self, router_outputs):
+        # Adapted from transfomers.models.switch_transformers.SwitchTransformersForConditionalGeneration._unpack_router_logits
+        # to support None
         total_router_logits = []
         total_expert_indexes = []
         for router_output in router_outputs:

--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -126,7 +126,6 @@ def create_position_ids_from_input_ids(input_ids, padding_idx, past_key_values_l
     return incremental_indices.long() + padding_idx
 
 
-# Copied from transformers.models.switch_transformers.modeling_switch_transformers.load_balancing_loss_func with SwitchTransformers->NllbMoeModel
 def load_balancing_loss_func(router_probs: torch.Tensor, expert_indices: torch.Tensor) -> float:
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
@@ -699,12 +698,11 @@ class NllbMoeEncoderLayer(nn.Module):
         residual = hidden_states
 
         hidden_states = self.ff_layer_norm(hidden_states)
-
-        router_states = None # set to None to track which layers have None gradients.
         if self.is_sparse:
             hidden_states, router_states = self.ffn(hidden_states, attention_mask)
         else:
-            hidden_states = self.ffn(hidden_states)
+            # router_states set to None to track which layers have None gradients.
+            hidden_states, router_states = self.ffn(hidden_states), None
         hidden_states = self.ff_dropout(hidden_states)
 
         hidden_states = residual + hidden_states
@@ -832,12 +830,10 @@ class NllbMoeDecoderLayer(nn.Module):
         residual = hidden_states
 
         hidden_states = self.ff_layer_norm(hidden_states)
-        
-        router_states = None
         if self.is_sparse:
             hidden_states, router_states = self.ffn(hidden_states, attention_mask)
         else:
-            hidden_states = self.ffn(hidden_states)
+            hidden_states, router_states = self.ffn(hidden_states), None
         hidden_states = self.ff_dropout(hidden_states)
 
         hidden_states = residual + hidden_states

--- a/tests/models/nllb_moe/test_modeling_nllb_moe.py
+++ b/tests/models/nllb_moe/test_modeling_nllb_moe.py
@@ -337,6 +337,15 @@ class NllbMoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         model.generate(input_ids, attention_mask=attention_mask)
         model.generate(num_beams=4, do_sample=True, early_stopping=False, num_return_sequences=3)
 
+    def test_get_loss(self):
+        config, input_dict = self.model_tester.prepare_config_and_inputs()
+        input_dict["output_router_logits"] = True
+        input_dict["labels"] = input_dict["input_ids"]
+        model = NllbMoeForConditionalGeneration(config).eval().to(torch_device)
+        out = model(**input_dict)
+        self.assertIsNotNone(out.loss)
+        self.assertIsNotNone(model(**input_dict)["encoder_router_logits"][1])
+        self.assertIsNotNone(model(**input_dict)["decoder_router_logits"][0])
 
 @require_torch
 @require_sentencepiece

--- a/tests/models/nllb_moe/test_modeling_nllb_moe.py
+++ b/tests/models/nllb_moe/test_modeling_nllb_moe.py
@@ -347,6 +347,7 @@ class NllbMoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         self.assertIsNotNone(model(**input_dict)["encoder_router_logits"][1])
         self.assertIsNotNone(model(**input_dict)["decoder_router_logits"][0])
 
+
 @require_torch
 @require_sentencepiece
 @require_tokenizers


### PR DESCRIPTION
# What does this PR do?
The code works in `Switch` because we decided to only return none `None` outputs, but it makes more sens to return None when the layers is not sparse. Otherwise finding the index of the layer that produced this might be impossible. 

fixes #24898
- TODO: 
- [x] Update Switch Transformers code as well
- [x] Add some tests