### PR TITLE
Add `examples`  to tests to run when `setup.py` is modified

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -690,7 +690,7 @@ def infer_tests_to_run(output_file, diff_with_last_commit=False, filter_models=T
 
     # Grab the corresponding test files:
     if "setup.py" in modified_files:
-        test_files_to_run = ["tests"]
+        test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
     else:
         # All modified tests need to be run.


### PR DESCRIPTION
# What does this PR do?

#25095 modified `setup.py`, but `examples` job is not triggered, see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/70003/workflows/9d952427-a622-429d-8ad1-155b4523048b)

We should include it, right?