### PR TITLE
[ASR Pipeline] Fix init with timestamps

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -439,25 +439,26 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 processed["stride"] = stride
             yield {"is_last": True, **processed, **extra}
 
-    def _forward(self, model_inputs, return_timestamps=None, generate_kwargs=None):
+    def _forward(self, model_inputs, return_timestamps=False, generate_kwargs=None):
         if generate_kwargs is None:
             generate_kwargs = {}
 
-        # Check whether we have a valid setting for return_timestamps and throw an error before we perform a forward pass
-        if self.type == "seq2seq" and return_timestamps:
-            raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
-        if self.type == "ctc_with_lm" and return_timestamps != "word":
-            raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
-        if self.type == "ctc" and return_timestamps not in ["char", "word"]:
-            raise ValueError(
-                "CTC can either predict character (char) level timestamps, or word level timestamps."
-                "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
-            )
-        if self.type == "seq2seq_whisper" and return_timestamps == "char":
-            raise ValueError(
-                "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
-                "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
-            )
+        if return_timestamps:
+            # Check whether we have a valid setting for return_timestamps and throw an error before we perform a forward pass
+            if self.type == "seq2seq" and return_timestamps:
+                raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
+            if self.type == "ctc_with_lm" and return_timestamps != "word":
+                raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
+            if self.type == "ctc" and return_timestamps not in ["char", "word"]:
+                raise ValueError(
+                    "CTC can either predict character (char) level timestamps, or word level timestamps."
+                    "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
+                )
+            if self.type == "seq2seq_whisper" and return_timestamps == "char":
+                raise ValueError(
+                    "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
+                    "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
+                )
 
         if return_timestamps and self.type == "seq2seq_whisper":
             generate_kwargs["return_timestamps"] = return_timestamps

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -322,20 +322,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         if decoder_kwargs is not None:
             postprocess_params["decoder_kwargs"] = decoder_kwargs
         if return_timestamps is not None:
-            if self.type == "seq2seq" and return_timestamps:
-                raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
-            if self.type == "ctc_with_lm" and return_timestamps != "word":
-                raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
-            if self.type == "ctc" and return_timestamps not in ["char", "word"]:
-                raise ValueError(
-                    "CTC can either predict character (char) level timestamps, or word level timestamps."
-                    "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
-                )
-            if self.type == "seq2seq_whisper" and return_timestamps == "char":
-                raise ValueError(
-                    "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
-                    "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
-                )
             forward_params["return_timestamps"] = return_timestamps
             postprocess_params["return_timestamps"] = return_timestamps
         if return_language is not None:
@@ -456,6 +442,23 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
     def _forward(self, model_inputs, return_timestamps=False, generate_kwargs=None):
         if generate_kwargs is None:
             generate_kwargs = {}
+
+        # Check whether we have a valid setting for return_timestamps and throw an error before we perform a forward pass
+        if self.type == "seq2seq" and return_timestamps:
+            raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
+        if self.type == "ctc_with_lm" and return_timestamps != "word":
+            raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
+        if self.type == "ctc" and return_timestamps not in ["char", "word"]:
+            raise ValueError(
+                "CTC can either predict character (char) level timestamps, or word level timestamps."
+                "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
+            )
+        if self.type == "seq2seq_whisper" and return_timestamps == "char":
+            raise ValueError(
+                "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
+                "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
+            )
+
         if return_timestamps and self.type == "seq2seq_whisper":
             generate_kwargs["return_timestamps"] = return_timestamps
             if return_timestamps == "word":
@@ -525,7 +528,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         # Optional return types
         optional = {}
 
-        if return_language is not None and self.type != "seq2seq_whisper":
+        if self.type != "seq2seq_whisper" and return_language is not None:
             raise ValueError("Only whisper can return language for now.")
 
         final_items = []

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -439,7 +439,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 processed["stride"] = stride
             yield {"is_last": True, **processed, **extra}
 
-    def _forward(self, model_inputs, return_timestamps=False, generate_kwargs=None):
+    def _forward(self, model_inputs, return_timestamps=None, generate_kwargs=None):
         if generate_kwargs is None:
             generate_kwargs = {}
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -17,19 +17,24 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 import numpy as np
 import requests
 
+from ..modelcard import ModelCard
+from ..tokenization_utils import PreTrainedTokenizer
 from ..utils import is_torch_available, is_torchaudio_available, logging
 from .audio_utils import ffmpeg_read
-from .base import ChunkPipeline
+from .base import ArgumentHandler, ChunkPipeline, infer_framework_load_model
 
 
 if TYPE_CHECKING:
     from pyctcdecode import BeamSearchDecoderCTC
 
     from ..feature_extraction_sequence_utils import SequenceFeatureExtractor
+    from ..modeling_utils import PreTrainedModel
 
 logger = logging.get_logger(__name__)
 
 if is_torch_available():
+    import torch
+
     from ..models.auto.modeling_auto import MODEL_FOR_CTC_MAPPING_NAMES, MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES
 
 
@@ -194,14 +199,78 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
 
     def __init__(
         self,
-        feature_extractor: Union["SequenceFeatureExtractor", str],
-        *,
+        model: "PreTrainedModel",
+        feature_extractor: Union["SequenceFeatureExtractor", str] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
         decoder: Optional[Union["BeamSearchDecoderCTC", str]] = None,
+        modelcard: Optional[ModelCard] = None,
+        framework: Optional[str] = None,
+        task: str = "",
+        args_parser: ArgumentHandler = None,
+        device: Union[int, "torch.device"] = None,
+        torch_dtype: Optional[Union[str, "torch.dtype"]] = None,
+        binary_output: bool = False,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.feature_extractor = feature_extractor
+        if framework is None:
+            framework, model = infer_framework_load_model(model, config=model.config)
 
+        self.task = task
+        self.model = model
+        self.tokenizer = tokenizer
+        self.feature_extractor = feature_extractor
+        self.modelcard = modelcard
+        self.framework = framework
+
+        # `accelerate` device map
+        hf_device_map = getattr(self.model, "hf_device_map", None)
+
+        if hf_device_map is not None and device is not None:
+            raise ValueError(
+                "The model has been loaded with `accelerate` and therefore cannot be moved to a specific device. Please "
+                "discard the `device` argument when creating your pipeline object."
+            )
+
+        if self.framework == "tf":
+            raise ValueError("The AutomaticSpeechRecognitionPipeline is only available in PyTorch.")
+
+        # We shouldn't call `model.to()` for models loaded with accelerate
+        if device is not None and not (isinstance(device, int) and device < 0):
+            self.model.to(device)
+
+        if device is None:
+            if hf_device_map is not None:
+                # Take the first device used by `accelerate`.
+                device = next(iter(hf_device_map.values()))
+            else:
+                device = -1
+
+        if is_torch_available() and self.framework == "pt":
+            if isinstance(device, torch.device):
+                self.device = device
+            elif isinstance(device, str):
+                self.device = torch.device(device)
+            elif device < 0:
+                self.device = torch.device("cpu")
+            else:
+                self.device = torch.device(f"cuda:{device}")
+        else:
+            self.device = device if device is not None else -1
+        self.torch_dtype = torch_dtype
+        self.binary_output = binary_output
+
+        # Update config and generation_config with task specific parameters
+        task_specific_params = self.model.config.task_specific_params
+        if task_specific_params is not None and task in task_specific_params:
+            self.model.config.update(task_specific_params.get(task))
+            if self.model.can_generate():
+                self.model.generation_config.update(**task_specific_params.get(task))
+
+        self.call_count = 0
+        self._batch_size = kwargs.pop("batch_size", None)
+        self._num_workers = kwargs.pop("num_workers", None)
+
+        # set the model type so we can check we have the right pre- and post-processing parameters
         if self.model.config.model_type == "whisper":
             self.type = "seq2seq_whisper"
         elif self.model.__class__.__name__ in MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.values():
@@ -216,8 +285,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         else:
             self.type = "ctc"
 
-        if self.framework == "tf":
-            raise ValueError("The AutomaticSpeechRecognitionPipeline is only available in PyTorch.")
+        self._preprocess_params, self._forward_params, self._postprocess_params = self._sanitize_parameters(**kwargs)
 
         mapping = MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.copy()
         mapping.update(MODEL_FOR_CTC_MAPPING_NAMES)
@@ -322,6 +390,23 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         if decoder_kwargs is not None:
             postprocess_params["decoder_kwargs"] = decoder_kwargs
         if return_timestamps is not None:
+            # Check whether we have a valid setting for return_timestamps and throw an error before we perform a forward pass
+            if self.type == "seq2seq" and return_timestamps:
+                raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
+            if self.type == "ctc_with_lm" and return_timestamps != "word":
+                raise ValueError(
+                    "CTC with LM can only predict word level timestamps, set `return_timestamps='word'`"
+                )
+            if self.type == "ctc" and return_timestamps not in ["char", "word"]:
+                raise ValueError(
+                    "CTC can either predict character (char) level timestamps, or word level timestamps."
+                    "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
+                )
+            if self.type == "seq2seq_whisper" and return_timestamps == "char":
+                raise ValueError(
+                    "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
+                    "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
+                )
             forward_params["return_timestamps"] = return_timestamps
             postprocess_params["return_timestamps"] = return_timestamps
         if return_language is not None:
@@ -364,8 +449,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             extra = inputs
             inputs = _inputs
             if in_sampling_rate != self.feature_extractor.sampling_rate:
-                import torch
-
                 if is_torchaudio_available():
                     from torchaudio import functional as F
                 else:
@@ -442,23 +525,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
     def _forward(self, model_inputs, return_timestamps=False, generate_kwargs=None):
         if generate_kwargs is None:
             generate_kwargs = {}
-
-        if return_timestamps:
-            # Check whether we have a valid setting for return_timestamps and throw an error before we perform a forward pass
-            if self.type == "seq2seq" and return_timestamps:
-                raise ValueError("We cannot return_timestamps yet on non-CTC models apart from Whisper!")
-            if self.type == "ctc_with_lm" and return_timestamps != "word":
-                raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
-            if self.type == "ctc" and return_timestamps not in ["char", "word"]:
-                raise ValueError(
-                    "CTC can either predict character (char) level timestamps, or word level timestamps."
-                    "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
-                )
-            if self.type == "seq2seq_whisper" and return_timestamps == "char":
-                raise ValueError(
-                    "Whisper cannot return `char` timestamps, only word level or segment level timestamps. "
-                    "Use `return_timestamps='word'` or `return_timestamps=True` respectively."
-                )
 
         if return_timestamps and self.type == "seq2seq_whisper":
             generate_kwargs["return_timestamps"] = return_timestamps

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -350,6 +350,8 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("openai/whisper-tiny")
         feature_extractor = AutoFeatureExtractor.from_pretrained("openai/whisper-tiny")
 
+        dummy_speech = np.ones(100)
+
         pipe = pipeline(
             task="automatic-speech-recognition",
             model=model,
@@ -360,7 +362,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             return_timestamps=True,
         )
 
-        _ = pipe(np.ones(1000))
+        _ = pipe(dummy_speech)
 
         # word-level timestamps are accepted
         pipe = pipeline(
@@ -373,7 +375,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             return_timestamps="word",
         )
 
-        _ = pipe(np.ones(1000))
+        _ = pipe(dummy_speech)
 
         # char-level timestamps are not accepted
         with self.assertRaisesRegex(
@@ -391,7 +393,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
                 return_timestamps="char",
             )
 
-            _ = pipe(np.ones(1000))
+            _ = pipe(dummy_speech)
 
     @require_torch
     @slow


### PR DESCRIPTION
# What does this PR do?

The PR #25344 added checks for the setting of `return_timestamps` in the method `sanitize_paramters` - this works when the argument `return_timestamps` is passed in the forward pass:
```python
from transformers import pipeline
import numpy as np

pipe = pipeline("automatic-speech-recognition", model="openai/whisper-tiny")

dummy_speech = np.ones(100)
pipe(dummy_speech, return_timestamps=True)
```

But fails when the argument is passed in the init (thanks to @ydshieh for flagging):
```python
from transformers import pipeline
import numpy as np

pipe = pipeline("automatic-speech-recognition", model="openai/whisper-tiny", return_timestamps=True)
```

<details> 

<summary> Traceback: </summary>

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <ipython-input-2-d59778d5549a>:1 in <module>                                                     │
│                                                                                                  │
│ /Users/sanchitgandhi/transformers/src/transformers/pipelines/__init__.py:993 in pipeline         │
│                                                                                                  │
│   990 │   if device is not None:                                                                 │
│   991 │   │   kwargs["device"] = device                                                          │
│   992 │                                                                                          │
│ ❱ 993 │   return pipeline_class(model=model, framework=framework, task=task, **kwargs)           │
│   994                                                                                            │
│                                                                                                  │
│ /Users/sanchitgandhi/transformers/src/transformers/pipelines/automatic_speech_recognition.py:202 │
│ in __init__                                                                                      │
│                                                                                                  │
│   199 │   │   decoder: Optional[Union["BeamSearchDecoderCTC", str]] = None,                      │
│   200 │   │   **kwargs,                                                                          │
│   201 │   ):                                                                                     │
│ ❱ 202 │   │   super().__init__(**kwargs)                                                         │
│   203 │   │   self.feature_extractor = feature_extractor                                         │
│   204 │   │                                                                                      │
│   205 │   │   if self.model.config.model_type == "whisper":                                      │
│                                                                                                  │
│ /Users/sanchitgandhi/transformers/src/transformers/pipelines/base.py:822 in __init__             │
│                                                                                                  │
│    819 │   │   self.call_count = 0                                                               │
│    820 │   │   self._batch_size = kwargs.pop("batch_size", None)                                 │
│    821 │   │   self._num_workers = kwargs.pop("num_workers", None)                               │
│ ❱  822 │   │   self._preprocess_params, self._forward_params, self._postprocess_params = self._  │
│    823 │   │                                                                                     │
│    824 │   │   if self.image_processor is None and self.feature_extractor is not None:           │
│    825 │   │   │   if isinstance(self.feature_extractor, BaseImageProcessor):                    │
│                                                                                                  │
│ /Users/sanchitgandhi/transformers/src/transformers/pipelines/automatic_speech_recognition.py:326 │
│ in _sanitize_parameters                                                                          │
│                                                                                                  │
│   323 │   │   │   postprocess_params["decoder_kwargs"] = decoder_kwargs                          │
│   324 │   │   if return_timestamps is not None:                                                  │
│   325 │   │   │   # Check whether we have a valid setting for return_timestamps and throw an e   │
│ ❱ 326 │   │   │   if self.type == "seq2seq" and return_timestamps:                               │
│   327 │   │   │   │   raise ValueError("We cannot return_timestamps yet on non-CTC models apar   │
│   328 │   │   │   if self.type == "ctc_with_lm" and return_timestamps != "word":                 │
│   329 │   │   │   │   raise ValueError("CTC with LM can only predict word level timestamps, se   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'AutomaticSpeechRecognitionPipeline' object has no attribute 'type'
```

</details>

=> this is because we call `sanitise_parameters` in the `__init__`, but **before** the attribute `self.type` is set, so these checks fail

This PR moves these `return_timestamps` checks to the `_forward` method. They are safe to perform here (we have set `self.type`), and are still performed **before** we perform any forward pass, so the error is thrown earlier rather than later.