### PR TITLE
Add Number Normalisation for SpeechT5

### DIFF
--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -17,7 +17,7 @@
 import re
 
 
-class NumberNormalizer:
+class EnglishNumberNormalizer:
     def __init__(self):
         self.ones = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
         self.teens = [
@@ -89,7 +89,26 @@ class NumberNormalizer:
             integer_part, decimal_part = n, "00"
 
         # Define a dictionary to map currency symbols to their names
-        currency_symbols = {"$": " dollars", "€": " euros", "£": " pounds", "¢": " cents"}
+        currency_symbols = {
+            "$": " dollars",
+            "€": " euros",
+            "£": " pounds",
+            "¢": " cents",
+            "¥": "Japanese Yen",
+            "₹": "Indian Rupee",
+            "₽": "Russian Ruble",
+            "฿": "Thai Baht",
+            "₺": "Turkish Lira",
+            "₴": "Ukrainian Hryvnia",
+            "₣": "Swiss Franc",
+            "₡": "Costa Rican Colon",
+            "₱": "Philippine Peso",
+            "₪": "Israeli New Shekel",
+            "₮": "Mongolian Tögrög",
+            "₩": "South Korean Won",
+            "₦": "Nigerian Naira",
+            "₫": "Vietnamese Đồng",
+        }
 
         # Extract currency symbol if present
         currency_symbol = ""

--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -187,8 +187,7 @@ class EnglishNumberNormalizer:
 
     def __call__(self, text):
         """
-        Convert numbers / number-like quantities in a string to their spelt-out
-        counterparts
+        Convert numbers / number-like quantities in a string to their spelt-out counterparts
         """
         pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\d+(?:\.\d{1,2})?%?)(?!\w)"
 

--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -48,6 +48,28 @@ class EnglishNumberNormalizer:
             "decillion",
         ]
 
+        # Define a dictionary to map currency symbols to their names
+        self.currency_symbols = {
+            "$": " dollars",
+            "€": " euros",
+            "£": " pounds",
+            "¢": " cents",
+            "¥": " japanese yen",
+            "₹": " indian rupees",
+            "₽": " russian rubles",
+            "฿": " thai baht",
+            "₺": " turkish liras",
+            "₴": " ukrainian hryvnia",
+            "₣": " swiss francs",
+            "₡": " costa rican colon",
+            "₱": " philippine peso",
+            "₪": " israeli shekels",
+            "₮": " mongolian tögrög",
+            "₩": " south korean won",
+            "₦": " nigerian naira",
+            "₫": " vietnamese Đồng",
+        }
+
     def spell_number(self, num):
         if num == 0:
             return "zero"
@@ -82,37 +104,18 @@ class EnglishNumberNormalizer:
 
         return " ".join(reversed(parts))
 
-    def convert(self, n):
-        if "." in n:
-            integer_part, decimal_part = n.split(".")
+    def convert(self, number):
+        """
+        Converts an individual number passed in string form to spelt-out form
+        """
+        if "." in number:
+            integer_part, decimal_part = number.split(".")
         else:
-            integer_part, decimal_part = n, "00"
-
-        # Define a dictionary to map currency symbols to their names
-        currency_symbols = {
-            "$": " dollars",
-            "€": " euros",
-            "£": " pounds",
-            "¢": " cents",
-            "¥": "Japanese Yen",
-            "₹": "Indian Rupee",
-            "₽": "Russian Ruble",
-            "฿": "Thai Baht",
-            "₺": "Turkish Lira",
-            "₴": "Ukrainian Hryvnia",
-            "₣": "Swiss Franc",
-            "₡": "Costa Rican Colon",
-            "₱": "Philippine Peso",
-            "₪": "Israeli New Shekel",
-            "₮": "Mongolian Tögrög",
-            "₩": "South Korean Won",
-            "₦": "Nigerian Naira",
-            "₫": "Vietnamese Đồng",
-        }
+            integer_part, decimal_part = number, "00"
 
         # Extract currency symbol if present
         currency_symbol = ""
-        for symbol, name in currency_symbols.items():
+        for symbol, name in self.currency_symbols.items():
             if integer_part.startswith(symbol):
                 currency_symbol = name
                 integer_part = integer_part[len(symbol) :]
@@ -139,38 +142,22 @@ class EnglishNumberNormalizer:
             integer_part = integer_part.replace("%", "")
             decimal_part = decimal_part.replace("%", "")
 
-        print(integer_part, decimal_part)
-
-        # integer_part = re.sub(r"\D", "", integer_part)
         integer_part = integer_part.zfill(3 * ((len(integer_part) - 1) // 3 + 1))
 
         parts = []
-        units = [
-            "",
-            "thousand",
-            "million",
-            "billion",
-            "trillion",
-            "quadrillion",
-            "quintillion",
-            "sextillion",
-            "septillion",
-            "octillion",
-            "nonillion",
-            "decillion",
-        ]
-
         for i in range(0, len(integer_part), 3):
             chunk = int(integer_part[i : i + 3])
             if chunk > 0:
                 part = self.spell_number(chunk)
-                unit = units[len(integer_part[i:]) // 3 - 1]
+                unit = self.thousands[len(integer_part[i:]) // 3 - 1]
                 if unit:
                     part += " " + unit
                 parts.append(part)
 
         spelled_integer = " ".join(parts)
 
+        # Format the spelt-out number based on conditions, such as:
+        # If it has decimal parts, currency symbol, minus prefix, etc
         if decimal_part == "00":
             return (
                 f"{minus_prefix}{spelled_integer}{percent_suffix}{currency_symbol}"
@@ -189,7 +176,8 @@ class EnglishNumberNormalizer:
         """
         Convert numbers / number-like quantities in a string to their spelt-out counterparts
         """
-        pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\d+(?:\.\d{1,2})?%?)(?!\w)"
+        # Form part of the pattern for all currency symbols
+        pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\¥?\₹?\₽?\฿?\₺?\₴?\₣?\₡?\₱?\₪?\₮?\₩?\₦?\₫?\d+(?:\.\d{1,2})?%?)(?!\w)"
 
         # Use regex to find and replace numbers in the text
         converted_text = re.sub(pattern, lambda match: self.convert(match.group(1)), text)

--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -1,0 +1,180 @@
+# coding=utf-8
+# Copyright 2023 The Facebook Inc. and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Number Normalizer class for SpeechT5."""
+
+import re
+
+
+class NumberNormalizer:
+    def __init__(self):
+        self.ones = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
+        self.teens = [
+            "",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+        ]
+        self.tens = ["", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"]
+        self.thousands = [
+            "",
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+            "quadrillion",
+            "quintillion",
+            "sextillion",
+            "septillion",
+            "octillion",
+            "nonillion",
+            "decillion",
+        ]
+
+    def spell_number(self, num):
+        if num == 0:
+            return "zero"
+
+        parts = []
+        for i in range(0, len(self.thousands)):
+            if num % 1000 != 0:
+                part = ""
+                hundreds = num % 1000 // 100
+                tens_units = num % 100
+
+                if hundreds > 0:
+                    part += self.ones[hundreds] + " hundred"
+                    if tens_units > 0:
+                        part += " and "
+
+                if tens_units > 10 and tens_units < 20:
+                    part += self.teens[tens_units - 10]
+                else:
+                    tens_digit = self.tens[tens_units // 10]
+                    ones_digit = self.ones[tens_units % 10]
+                    if tens_digit:
+                        part += tens_digit
+                    if ones_digit:
+                        if tens_digit:
+                            part += " "
+                        part += ones_digit
+
+                parts.append(part)
+
+            num //= 1000
+
+        return " ".join(reversed(parts))
+
+    def convert(self, n):
+        if "." in n:
+            integer_part, decimal_part = n.split(".")
+        else:
+            integer_part, decimal_part = n, "00"
+
+        # Define a dictionary to map currency symbols to their names
+        currency_symbols = {"$": " dollars", "€": " euros", "£": " pounds", "¢": " cents"}
+
+        # Extract currency symbol if present
+        currency_symbol = ""
+        for symbol, name in currency_symbols.items():
+            if integer_part.startswith(symbol):
+                currency_symbol = name
+                integer_part = integer_part[len(symbol) :]
+                break
+
+            if integer_part.startswith("-"):
+                if integer_part[1:].startswith(symbol):
+                    currency_symbol = name
+                    integer_part = "-" + integer_part[len(symbol) + 1 :]
+                    break
+
+        # Extract 'minus' prefix for negative numbers
+        minus_prefix = ""
+        if integer_part.startswith("-"):
+            minus_prefix = "minus "
+            integer_part = integer_part[1:]
+        elif integer_part.startswith("minus"):
+            minus_prefix = "minus "
+            integer_part = integer_part[len("minus") :]
+
+        percent_suffix = ""
+        if "%" in integer_part or "%" in decimal_part:
+            percent_suffix = " percent"
+            integer_part = integer_part.replace("%", "")
+            decimal_part = decimal_part.replace("%", "")
+
+        print(integer_part, decimal_part)
+
+        # integer_part = re.sub(r"\D", "", integer_part)
+        integer_part = integer_part.zfill(3 * ((len(integer_part) - 1) // 3 + 1))
+
+        parts = []
+        units = [
+            "",
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+            "quadrillion",
+            "quintillion",
+            "sextillion",
+            "septillion",
+            "octillion",
+            "nonillion",
+            "decillion",
+        ]
+
+        for i in range(0, len(integer_part), 3):
+            chunk = int(integer_part[i : i + 3])
+            if chunk > 0:
+                part = self.spell_number(chunk)
+                unit = units[len(integer_part[i:]) // 3 - 1]
+                if unit:
+                    part += " " + unit
+                parts.append(part)
+
+        spelled_integer = " ".join(parts)
+
+        if decimal_part == "00":
+            return (
+                f"{minus_prefix}{spelled_integer}{percent_suffix}{currency_symbol}"
+                if minus_prefix or currency_symbol
+                else f"{spelled_integer}{percent_suffix}"
+            )
+        else:
+            spelled_decimal = " ".join([self.spell_number(int(digit)) for digit in decimal_part])
+            return (
+                f"{minus_prefix}{spelled_integer} point {spelled_decimal}{percent_suffix}{currency_symbol}"
+                if minus_prefix or currency_symbol
+                else f"{minus_prefix}{spelled_integer} point {spelled_decimal}{percent_suffix}"
+            )
+
+    def __call__(self, text):
+        """
+        Convert numbers / number-like quantities in a string to their spelt-out
+        counterparts
+        """
+        pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\d+(?:\.\d{1,2})?%?)(?!\w)"
+
+        # Use regex to find and replace numbers in the text
+        converted_text = re.sub(pattern, lambda match: self.convert(match.group(1)), text)
+        converted_text = re.sub(" +", " ", converted_text)
+
+        return converted_text

--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2023 The Facebook Inc. and The HuggingFace Inc. team. All rights reserved.
+# Copyright 2023 The Fairseq Authors, Microsoft Research, and the HuggingFace Inc. team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,12 +49,15 @@ class EnglishNumberNormalizer:
         ]
 
         # Define a dictionary to map currency symbols to their names
+        # Top most traded currencies according to
+        # https://en.wikipedia.org/wiki/Template:Most_traded_currencies
         self.currency_symbols = {
             "$": " dollars",
             "€": " euros",
             "£": " pounds",
             "¢": " cents",
             "¥": " japanese yen",
+            "﷼": " saudi riyal",
             "₹": " indian rupees",
             "₽": " russian rubles",
             "฿": " thai baht",
@@ -177,7 +180,10 @@ class EnglishNumberNormalizer:
         Convert numbers / number-like quantities in a string to their spelt-out counterparts
         """
         # Form part of the pattern for all currency symbols
-        pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\¥?\₹?\₽?\฿?\₺?\₴?\₣?\₡?\₱?\₪?\₮?\₩?\₦?\₫?\d+(?:\.\d{1,2})?%?)(?!\w)"
+        pattern = r"(?<!\w)(-?\$?\€?\£?\¢?\¥?\₹?\₽?\฿?\₺?\₴?\₣?\₡?\₱?\₪?\₮?\₩?\₦?\₫?\﷼?\d+(?:\.\d{1,2})?%?)(?!\w)"
+
+        # Find and replace commas in numbers (15,000 -> 15000, etc)
+        text = re.sub(r"(\d+,\d+)", lambda match: match.group(1).replace(",", ""), text)
 
         # Use regex to find and replace numbers in the text
         converted_text = re.sub(pattern, lambda match: self.convert(match.group(1)), text)

--- a/src/transformers/models/speecht5/processing_speecht5.py
+++ b/src/transformers/models/speecht5/processing_speecht5.py
@@ -15,7 +15,6 @@
 """Speech processor class for SpeechT5."""
 
 from ...processing_utils import ProcessorMixin
-from .number_normalizer import EnglishNumberNormalizer
 
 
 class SpeechT5Processor(ProcessorMixin):
@@ -66,7 +65,6 @@ class SpeechT5Processor(ProcessorMixin):
         text_target = kwargs.pop("text_target", None)
         audio_target = kwargs.pop("audio_target", None)
         sampling_rate = kwargs.pop("sampling_rate", None)
-        normalize = kwargs.pop("normalize", None)
 
         if audio is not None and text is not None:
             raise ValueError(
@@ -84,8 +82,6 @@ class SpeechT5Processor(ProcessorMixin):
         if audio is not None:
             inputs = self.feature_extractor(audio, *args, sampling_rate=sampling_rate, **kwargs)
         elif text is not None:
-            if normalize:
-                text = self._normalize(text)
             inputs = self.tokenizer(text, **kwargs)
         else:
             inputs = None
@@ -94,8 +90,6 @@ class SpeechT5Processor(ProcessorMixin):
             targets = self.feature_extractor(audio_target=audio_target, *args, sampling_rate=sampling_rate, **kwargs)
             labels = targets["input_values"]
         elif text_target is not None:
-            if normalize:
-                text_target = self._normalize(text_target)
             targets = self.tokenizer(text_target, **kwargs)
             labels = targets["input_ids"]
         else:
@@ -186,11 +180,3 @@ class SpeechT5Processor(ProcessorMixin):
         the docstring of this method for more information.
         """
         return self.tokenizer.decode(*args, **kwargs)
-
-    def _normalize(self, text: str):
-        """
-        Normalizes a given string using the 'EnglishNumberNormalizer' class, which converts numeric elements in english
-        text.
-        """
-        normalizer = EnglishNumberNormalizer()
-        return normalizer(text)

--- a/src/transformers/models/speecht5/processing_speecht5.py
+++ b/src/transformers/models/speecht5/processing_speecht5.py
@@ -189,8 +189,8 @@ class SpeechT5Processor(ProcessorMixin):
 
     def _normalize(self, text: str):
         """
-        Normalizes a given string using the 'EnglishNumberNormalizer' class, which converts numeric elements in
-        english text.
+        Normalizes a given string using the 'EnglishNumberNormalizer' class, which converts numeric elements in english
+        text.
         """
         normalizer = EnglishNumberNormalizer()
         return normalizer(text)

--- a/src/transformers/models/speecht5/processing_speecht5.py
+++ b/src/transformers/models/speecht5/processing_speecht5.py
@@ -15,6 +15,7 @@
 """Speech processor class for SpeechT5."""
 
 from ...processing_utils import ProcessorMixin
+from .number_normalizer import EnglishNumberNormalizer
 
 
 class SpeechT5Processor(ProcessorMixin):
@@ -65,6 +66,7 @@ class SpeechT5Processor(ProcessorMixin):
         text_target = kwargs.pop("text_target", None)
         audio_target = kwargs.pop("audio_target", None)
         sampling_rate = kwargs.pop("sampling_rate", None)
+        normalize = kwargs.pop("normalize", None)
 
         if audio is not None and text is not None:
             raise ValueError(
@@ -82,6 +84,8 @@ class SpeechT5Processor(ProcessorMixin):
         if audio is not None:
             inputs = self.feature_extractor(audio, *args, sampling_rate=sampling_rate, **kwargs)
         elif text is not None:
+            if normalize:
+                text = self._normalize(text)
             inputs = self.tokenizer(text, **kwargs)
         else:
             inputs = None
@@ -90,6 +94,8 @@ class SpeechT5Processor(ProcessorMixin):
             targets = self.feature_extractor(audio_target=audio_target, *args, sampling_rate=sampling_rate, **kwargs)
             labels = targets["input_values"]
         elif text_target is not None:
+            if normalize:
+                text_target = self._normalize(text_target)
             targets = self.tokenizer(text_target, **kwargs)
             labels = targets["input_ids"]
         else:
@@ -180,3 +186,11 @@ class SpeechT5Processor(ProcessorMixin):
         the docstring of this method for more information.
         """
         return self.tokenizer.decode(*args, **kwargs)
+
+    def _normalize(self, text: str):
+        """
+        Normalizes a given string using the 'EnglishNumberNormalizer' class, which converts numeric elements in
+        english text.
+        """
+        normalizer = EnglishNumberNormalizer()
+        return normalizer(text)

--- a/src/transformers/models/speecht5/tokenization_speecht5.py
+++ b/src/transformers/models/speecht5/tokenization_speecht5.py
@@ -65,7 +65,7 @@ class SpeechT5Tokenizer(PreTrainedTokenizer):
             token instead.
         pad_token (`str`, *optional*, defaults to `"<pad>"`):
             The token used for padding, for example when batching sequences of different lengths.
-        normalize (`bool`, *optional*, defaults to `True`):
+        normalize (`bool`, *optional*, defaults to `False`):
             Whether to convert numeric quantities in the text to their spelt-out english counterparts.
         sp_model_kwargs (`dict`, *optional*):
             Will be passed to the `SentencePieceProcessor.__init__()` method. The [Python wrapper for
@@ -100,7 +100,7 @@ class SpeechT5Tokenizer(PreTrainedTokenizer):
         eos_token="</s>",
         unk_token="<unk>",
         pad_token="<pad>",
-        normalize=True,
+        normalize=False,
         sp_model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:

--- a/src/transformers/models/speecht5/tokenization_speecht5.py
+++ b/src/transformers/models/speecht5/tokenization_speecht5.py
@@ -111,6 +111,7 @@ class SpeechT5Tokenizer(PreTrainedTokenizer):
             eos_token=eos_token,
             unk_token=unk_token,
             pad_token=pad_token,
+            normalize=normalize,
             sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )

--- a/tests/models/speecht5/test_tokenization_speecht5.py
+++ b/tests/models/speecht5/test_tokenization_speecht5.py
@@ -64,11 +64,11 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         return text, ids
 
     def test_tokenizer_normalization(self):
-        tokenizer = self.get_tokenizer()
-        input_text, output_text = self.get_numeric_input_output_texts()
-        input_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(input_text))
-        output_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(output_text))
-        self.assertListEqual(input_ids, output_ids)
+        tokenizer = self.get_tokenizer(normalize=True)
+        input_text, expected_text = self.get_numeric_input_output_texts()
+        input_ids = tokenizer.encode(input_text)
+        output_text = tokenizer.decode(input_ids, skip_special_tokens=True)
+        self.assertEqual(output_text, expected_text)
 
     def test_convert_token_and_id(self):
         """Test ``_convert_token_to_id`` and ``_convert_id_to_token``."""
@@ -149,7 +149,7 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         pass
 
     def test_full_tokenizer(self):
-        tokenizer = self.get_tokenizer()
+        tokenizer = self.get_tokenizer(normalize=True)
 
         tokens = tokenizer.tokenize("This is a test")
         # fmt: off

--- a/tests/models/speecht5/test_tokenization_speecht5.py
+++ b/tests/models/speecht5/test_tokenization_speecht5.py
@@ -64,6 +64,7 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         return text, ids
 
     def test_tokenizer_normalization(self):
+        tokenizer = self.get_tokenizer()
         input_text, output_text = self.get_numeric_input_output_texts()
         input_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(input_text))
         output_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(output_text))
@@ -164,20 +165,20 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             tokens,
             # fmt: off
-            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, 'n', 'i', 'n', 'e', 't', 'y', SPIECE_UNDERLINE, 't', 'w', 'o', SPIECE_UNDERLINE, 't', 'h', 'o', 'u', 's', 'a', 'n', 'd', SPIECE_UNDERLINE, ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
+            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, 'n', 'i', 'n', 'e', 't', 'y', SPIECE_UNDERLINE, 't', 'w', 'o', SPIECE_UNDERLINE, 't', 'h', 'o', 'u', 's', 'a', 'n', 'd', ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
             # fmt: on
         )
 
         ids = tokenizer.convert_tokens_to_ids(tokens)
         # fmt: off
-        self.assertListEqual(ids, [4, 30, 4, 20, 7, 12, 4, 25, 8, 13, 9, 4, 10, 9, 4, 3, 23, 4, 7, 9, 14, 4, 6, 11, 10, 12, 4, 10, 12, 4, 19, 7, 15, 12, 73, 26])
+        self.assertListEqual(ids, [4, 30, 4, 20, 7, 12, 4, 25, 8, 13, 9, 4, 10, 9, 4, 9, 10, 9, 5, 6, 22, 4, 6, 20, 8, 4, 6, 11, 8, 16, 12, 7, 9, 14, 23, 4, 7, 9, 14, 4, 6, 11, 10, 12, 4, 10, 12, 4, 19, 7, 15, 12, 73, 26])
         # fmt: on
 
         back_tokens = tokenizer.convert_ids_to_tokens(ids)
         self.assertListEqual(
             back_tokens,
             # fmt: off
-            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, '<unk>', ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
+            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, 'n', 'i', 'n', 'e', 't', 'y', SPIECE_UNDERLINE, 't', 'w', 'o', SPIECE_UNDERLINE, 't', 'h', 'o', 'u', 's', 'a', 'n', 'd', ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
             # fmt: on
         )
 

--- a/tests/models/speecht5/test_tokenization_speecht5.py
+++ b/tests/models/speecht5/test_tokenization_speecht5.py
@@ -52,11 +52,22 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         output_text = "this is a test"
         return input_text, output_text
 
+    def get_numeric_input_output_texts(self):
+        input_text = "I have $123.45 and owe €59.78. My balance is -₴876.90 and have 73% stocks in my company which equals to ₦72649201"
+        output_text = "I have one hundred and twenty three point four five dollars and owe fifty nine point seven eight euros. My balance is minus eight hundred and seventy six point nine zero ukrainian hryvnia and have seventy three percent stocks in my company which equals to seventy two million six hundred and forty nine thousand two hundred and one nigerian naira"
+        return input_text, output_text
+
     def get_clean_sequence(self, tokenizer, with_prefix_space=False, max_length=20, min_length=5):
         input_text, output_text = self.get_input_output_texts(tokenizer)
         ids = tokenizer.encode(output_text, add_special_tokens=False)
         text = tokenizer.decode(ids, clean_up_tokenization_spaces=False)
         return text, ids
+
+    def test_tokenizer_normalization(self):
+        input_text, output_text = self.get_numeric_input_output_texts()
+        input_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(input_text))
+        output_ids = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(output_text))
+        self.assertListEqual(input_ids, output_ids)
 
     def test_convert_token_and_id(self):
         """Test ``_convert_token_to_id`` and ``_convert_id_to_token``."""
@@ -153,7 +164,7 @@ class SpeechT5TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             tokens,
             # fmt: off
-            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, '92000', ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
+            [SPIECE_UNDERLINE, 'I', SPIECE_UNDERLINE, 'w', 'a', 's', SPIECE_UNDERLINE, 'b', 'o', 'r', 'n', SPIECE_UNDERLINE, 'i', 'n', SPIECE_UNDERLINE, 'n', 'i', 'n', 'e', 't', 'y', SPIECE_UNDERLINE, 't', 'w', 'o', SPIECE_UNDERLINE, 't', 'h', 'o', 'u', 's', 'a', 'n', 'd', SPIECE_UNDERLINE, ',', SPIECE_UNDERLINE, 'a', 'n', 'd', SPIECE_UNDERLINE, 't', 'h', 'i', 's', SPIECE_UNDERLINE, 'i', 's', SPIECE_UNDERLINE, 'f', 'a', 'l', 's', 'é', '.']
             # fmt: on
         )
 


### PR DESCRIPTION
# What does this PR do?
This PR will add number normalisation for SpeechT5. Currently, SpeechT5 cannot read numbers, as described in #23480.

Fixes #23480

# Cases covered so far
- [x] Integer number normalisation
- [x] Floating point number normalisation
- [x] Currency normalisation
	- [x] US Dollar `$`
	- [x] cents `¢`
	- [x] Euro `€`
	- [x] Sterling Pound `£`
	- [x] Yen `¥`
	- [x] Other major currency symbols
- [x] Percents `%` 
- [x] Negative numbers (starting with `-`)
- [x] Numbers from 0 to Decillion
- [x] Any combination of those stated and ticked above

## Who can review?
@sanchit-gandhi 