### PR TITLE
Marian: post-hack-fix correction

### DIFF
--- a/tests/models/marian/test_modeling_marian.py
+++ b/tests/models/marian/test_modeling_marian.py
@@ -438,7 +438,11 @@ class MarianIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(self.model.device, model_inputs.input_ids.device)
         generated_ids = self.model.generate(
-            model_inputs.input_ids, attention_mask=model_inputs.attention_mask, num_beams=2, max_length=128
+            model_inputs.input_ids,
+            attention_mask=model_inputs.attention_mask,
+            num_beams=2,
+            max_length=128,
+            renormalize_logits=True,
         )
         generated_words = self.tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         return generated_words

--- a/tests/models/marian/test_modeling_marian.py
+++ b/tests/models/marian/test_modeling_marian.py
@@ -442,7 +442,7 @@ class MarianIntegrationTest(unittest.TestCase):
             attention_mask=model_inputs.attention_mask,
             num_beams=2,
             max_length=128,
-            renormalize_logits=True,
+            renormalize_logits=True,  # Marian should always renormalize its logits. See #25459
         )
         generated_words = self.tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         return generated_words


### PR DESCRIPTION
# What does this PR do?

### Context
#25294 removes a Marian-only hack, where the `logits` of the `pad_token_id` were being set to `-inf` before the `logsoftmax`. This was perceived as safe to do, as `bad_word_ids` is set to the `pad_token_id` in Marian. `bad_word_ids` sets the scores (i.e. after `logsoftmax`) to `-inf`

### Why was that a problem?
The changed position of the operation (setting to `-inf` before/after `logsoftmax`) meant that the log probabilities after the `logsoftmax` were now NOT summing to 1, i.e. not normalized. Since beam search selects the beams with the highest scores, this meant that the higher `logits[:, pad_token_id]` were before being set to `-inf`, the higher distribution shift would be observed due to the lack of normalization.

This issue materializes as minor output differences, as seen in our CI, and minor performance degradation, as discussed in #4290

### Do we have to revert the PR and reintroduce the hack?
No 🙌  Long after the hack in #4290 was introduced, we have added a flag to renormalize the scores after applying the logits processors, which happens after the `logsoftmax`. Applying this flag is equivalent to applying the hack.

⚠️ This means that Marian's generation configs should be updated with this flag as well, in addition to this PR (assuming it is accepted :) )

👉 all `slow` tests are back to green after this change.