### PR TITLE
Mark flaky tests

### DIFF
--- a/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_tf_wav2vec2.py
@@ -306,7 +306,7 @@ class TFWav2Vec2ModelTester:
         model = TFWav2Vec2ForCTC(config)
         input_lengths = tf.constant([input_values.shape[-1] // i for i in [4, 2, 1]])
         max_length_labels = model.wav2vec2._get_feat_extract_output_lengths(input_lengths)
-        labels = ids_tensor((input_values.shape[0], min(max_length_labels) - 1), model.config.vocab_size + 100)
+        labels = ids_tensor((input_values.shape[0], min(max_length_labels) - 1), model.config.vocab_size + 500)
         with pytest.raises(ValueError):
             model(input_values, labels=labels)
 

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -23,7 +23,7 @@ from requests import ReadTimeout
 from tests.pipelines.test_pipelines_document_question_answering import INVOICE_URL
 from transformers import is_torch_available, is_vision_available
 from transformers.image_utils import ChannelDimension, get_channel_dimension_axis, make_list_of_images
-from transformers.testing_utils import require_torch, require_vision
+from transformers.testing_utils import is_flaky, require_torch, require_vision
 
 
 if is_torch_available():
@@ -486,6 +486,7 @@ class LoadImageTester(unittest.TestCase):
 
         self.assertEqual(img_arr.shape, (1061, 750, 3))
 
+    @is_flaky()
     def test_load_img_url_timeout(self):
         with self.assertRaises(ReadTimeout):
             load_image(INVOICE_URL, timeout=0.001)


### PR DESCRIPTION
# What does this PR do?

Handles two tests which semi-regularly fail on CI runs

`tests/utils/test_image_utils.py::LoadImageTester::test_load_img_url_timeout`
- Mark with an is_flaky decorator

`tests/models/wav2vec2/test_modeling_tf_wav2vec2.py::TFWav2Vec2ModelTest::test_labels_out_of_vocab`
- Already has an is_flaky decorator
- Upped the vocab size being used when generating random ids tensor to increase probability of OOV error being hit 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?