### PR TITLE
Add `M2M100TokenizerFast` (+ convert_slow_tokenizer implementation)

### DIFF
--- a/docs/source/en/model_doc/m2m_100.md
+++ b/docs/source/en/model_doc/m2m_100.md
@@ -112,6 +112,10 @@ loss = model(**model_inputs).loss  # forward pass
     - create_token_type_ids_from_sequences
     - save_vocabulary
 
+## M2M100TokenizerFast
+
+[[autodoc]] M2M100TokenizerFast
+
 ## M2M100Model
 
 [[autodoc]] M2M100Model

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -824,6 +824,7 @@ else:
     _import_structure["models.llama"].append("LlamaTokenizerFast")
     _import_structure["models.longformer"].append("LongformerTokenizerFast")
     _import_structure["models.lxmert"].append("LxmertTokenizerFast")
+    _import_structure["models.m2m_100"].append("M2M100TokenizerFast")
     _import_structure["models.markuplm"].append("MarkupLMTokenizerFast")
     _import_structure["models.mbart"].append("MBartTokenizerFast")
     _import_structure["models.mbart50"].append("MBart50TokenizerFast")
@@ -4782,6 +4783,7 @@ if TYPE_CHECKING:
         from .models.llama import LlamaTokenizerFast
         from .models.longformer import LongformerTokenizerFast
         from .models.lxmert import LxmertTokenizerFast
+        from .models.m2m_100 import M2M100TokenizerFast
         from .models.markuplm import MarkupLMTokenizerFast
         from .models.mbart import MBartTokenizerFast
         from .models.mbart50 import MBart50TokenizerFast

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -830,6 +830,15 @@ class M2M100Converter(SpmConverter):
             raise Exception(
                 "You're trying to run a `Unigram` model but you're file was trained with a different algorithm"
             )
+        
+        tokenizer.add_special_tokens(
+            [
+                AddedToken(token)
+                for token, score in vocab_scores
+                if score == 0 or token in ("<s>", "<pad>", "</s>", "<unk>")
+            ]
+        )
+        
         return tokenizer
 
     def extract(self, vocab_scores=None) -> Tuple[Dict[str, int], List[Tuple]]:

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -845,7 +845,7 @@ class M2M100Converter(SpmConverter):
         order the merges with respect to the piece scores instead.
         """
         vocab_scores = self.vocab()
-        vocab = dict(x for x in vocab_scores)
+        vocab = dict(vocab_scores)
 
         # Merges
         merges = []

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -772,6 +772,52 @@ class NllbConverter(SpmConverter):
         )
 
 
+class M2M100Converter(SpmConverter):
+
+    def __init__(self, original_tokenizer):
+        self.original_vocab_file = original_tokenizer.vocab_file
+        self.original_bpe_model = self.original_vocab_file.replace('vocab.json', 'sentencepiece.bpe.model')
+
+        original_tokenizer.vocab_file = self.original_bpe_model
+        super().__init__(original_tokenizer)
+        original_tokenizer.vocab_file = self.original_vocab_file
+
+
+    def vocab(self, proto):
+        vocab = [
+            ("<s>", 0.0),
+            ("<pad>", 0.0),
+            ("</s>", 0.0),
+            ("<unk>", 0.0),
+        ]
+        vocab += [(piece.piece, piece.score) for piece in proto.pieces[3:]]
+        vocab += [
+            # fmt: off
+            ('__af__', 0.0), ('__am__', 0.0), ('__ar__', 0.0), ('__ast__', 0.0), ('__az__', 0.0), ('__ba__', 0.0), ('__be__', 0.0), ('__bg__', 0.0), ('__bn__', 0.0), ('__br__', 0.0), ('__bs__', 0.0), ('__ca__', 0.0), ('__ceb__', 0.0), ('__cs__', 0.0), ('__cy__', 0.0), ('__da__', 0.0), ('__de__', 0.0), ('__el__', 0.0), ('__en__', 0.0), ('__es__', 0.0), ('__et__', 0.0), ('__fa__', 0.0), ('__ff__', 0.0), ('__fi__', 0.0), ('__fr__', 0.0), ('__fy__', 0.0), ('__ga__', 0.0), ('__gd__', 0.0), ('__gl__', 0.0), ('__gu__', 0.0), ('__ha__', 0.0), ('__he__', 0.0), ('__hi__', 0.0), ('__hr__', 0.0), ('__ht__', 0.0), ('__hu__', 0.0), ('__hy__', 0.0), ('__id__', 0.0), ('__ig__', 0.0), ('__ilo__', 0.0), ('__is__', 0.0), ('__it__', 0.0), ('__ja__', 0.0), ('__jv__', 0.0), ('__ka__', 0.0), ('__kk__', 0.0), ('__km__', 0.0), ('__kn__', 0.0), ('__ko__', 0.0), ('__lb__', 0.0), ('__lg__', 0.0), ('__ln__', 0.0), ('__lo__', 0.0), ('__lt__', 0.0), ('__lv__', 0.0), ('__mg__', 0.0), ('__mk__', 0.0), ('__ml__', 0.0), ('__mn__', 0.0), ('__mr__', 0.0), ('__ms__', 0.0), ('__my__', 0.0), ('__ne__', 0.0), ('__nl__', 0.0), ('__no__', 0.0), ('__ns__', 0.0), ('__oc__', 0.0), ('__or__', 0.0), ('__pa__', 0.0), ('__pl__', 0.0), ('__ps__', 0.0), ('__pt__', 0.0), ('__ro__', 0.0), ('__ru__', 0.0), ('__sd__', 0.0), ('__si__', 0.0), ('__sk__', 0.0), ('__sl__', 0.0), ('__so__', 0.0), ('__sq__', 0.0), ('__sr__', 0.0), ('__ss__', 0.0), ('__su__', 0.0), ('__sv__', 0.0), ('__sw__', 0.0), ('__ta__', 0.0), ('__th__', 0.0), ('__tl__', 0.0), ('__tn__', 0.0), ('__tr__', 0.0), ('__uk__', 0.0), ('__ur__', 0.0), ('__uz__', 0.0), ('__vi__', 0.0), ('__wo__', 0.0), ('__xh__', 0.0), ('__yi__', 0.0), ('__yo__', 0.0), ('__zh__', 0.0), ('__zu__', 0.0)
+            # fmt: on
+        ]
+        return vocab
+
+    def unk_id(self, proto):
+        return 3
+
+    def post_processor(self):
+        return processors.TemplateProcessing(
+            single="__en__ $A </s>",
+            pair="__en__ $A $B </s>",
+            special_tokens=[
+                ("__en__", self.original_tokenizer.convert_tokens_to_ids("__en__")),
+                ("</s>", self.original_tokenizer.convert_tokens_to_ids("</s>")),
+            ],
+        )
+
+    def converted(self) -> Tokenizer:
+        self.original_tokenizer.vocab_file = self.original_bpe_model
+        conv = super().converted()
+        self.original_tokenizer.vocab_file = self.original_vocab_file
+        return conv
+
+
 class XLMRobertaConverter(SpmConverter):
     def vocab(self, proto):
         vocab = [
@@ -1278,6 +1324,7 @@ SLOW_TO_FAST_CONVERTERS = {
     "LongformerTokenizer": RobertaConverter,
     "LEDTokenizer": RobertaConverter,
     "LxmertTokenizer": BertConverter,
+    "M2M100Tokenizer": M2M100Converter,
     "MarkupLMTokenizer": MarkupLMConverter,
     "MBartTokenizer": MBartConverter,
     "MBart50Tokenizer": MBart50Converter,

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -775,9 +775,8 @@ class NllbConverter(SpmConverter):
 class M2M100Converter(SpmConverter):
     def __init__(self, original_tokenizer):
         self.original_vocab_file = original_tokenizer.vocab_file
-        self.original_bpe_model = self.original_vocab_file.replace("vocab.json", "sentencepiece.bpe.model")
 
-        original_tokenizer.vocab_file = self.original_bpe_model
+        original_tokenizer.vocab_file = self.original_vocab_file.replace("vocab.json", "sentencepiece.bpe.model")
         super().__init__(original_tokenizer)
         original_tokenizer.vocab_file = self.original_vocab_file
 
@@ -808,12 +807,6 @@ class M2M100Converter(SpmConverter):
                 ("</s>", self.original_tokenizer.convert_tokens_to_ids("</s>")),
             ],
         )
-
-    def converted(self) -> Tokenizer:
-        self.original_tokenizer.vocab_file = self.original_bpe_model
-        conv = super().converted()
-        self.original_tokenizer.vocab_file = self.original_vocab_file
-        return conv
 
     def tokenizer(self, proto):
         model_type = proto.trainer_spec.model_type

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -773,15 +773,13 @@ class NllbConverter(SpmConverter):
 
 
 class M2M100Converter(SpmConverter):
-
     def __init__(self, original_tokenizer):
         self.original_vocab_file = original_tokenizer.vocab_file
-        self.original_bpe_model = self.original_vocab_file.replace('vocab.json', 'sentencepiece.bpe.model')
+        self.original_bpe_model = self.original_vocab_file.replace("vocab.json", "sentencepiece.bpe.model")
 
         original_tokenizer.vocab_file = self.original_bpe_model
         super().__init__(original_tokenizer)
         original_tokenizer.vocab_file = self.original_vocab_file
-
 
     def vocab(self, proto):
         vocab = [

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -193,7 +193,13 @@ else:
             ),
             ("luke", ("LukeTokenizer", None)),
             ("lxmert", ("LxmertTokenizer", "LxmertTokenizerFast" if is_tokenizers_available() else None)),
-            ("m2m_100", ("M2M100Tokenizer" if is_sentencepiece_available() else None, None)),
+            (
+                "m2m_100",
+                (
+                    "M2M100Tokenizer" if is_sentencepiece_available() else None,
+                    "M2M100TokenizerFast" if is_tokenizers_available() else None,
+                ),
+            ),
             ("marian", ("MarianTokenizer" if is_sentencepiece_available() else None, None)),
             (
                 "mbart",

--- a/src/transformers/models/m2m_100/__init__.py
+++ b/src/transformers/models/m2m_100/__init__.py
@@ -35,6 +35,14 @@ else:
         "M2M100PreTrainedModel",
     ]
 
+try:
+    if not is_tokenizers_available():
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    pass
+else:
+    _import_structure["tokenization_m2m_100_fast"] = ["M2M100TokenizerFast"]
+
 
 if TYPE_CHECKING:
     from .configuration_m2m_100 import M2M_100_PRETRAINED_CONFIG_ARCHIVE_MAP, M2M100Config, M2M100OnnxConfig
@@ -52,6 +60,14 @@ if TYPE_CHECKING:
             M2M100Model,
             M2M100PreTrainedModel,
         )
+
+    try:
+        if not is_tokenizers_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        pass
+    else:
+        from .tokenization_m2m_100_fast import M2M100TokenizerFast
 
 
 else:

--- a/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
@@ -203,7 +203,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self._src_lang = new_src_lang
         self.set_src_lang_special_tokens(self._src_lang)
 
-    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast.build_inputs_with_special_tokens
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast.build_inputs_with_special_tokens with NLLB->M2M100
     def build_inputs_with_special_tokens(
         self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None
     ) -> List[int]:

--- a/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
@@ -36,22 +36,24 @@ logger = logging.get_logger(__name__)
 
 VOCAB_FILES_NAMES = {"vocab_file": "sentencepiece.bpe.model", "tokenizer_file": "tokenizer.json"}
 
+# TODO: Add m2m models
 PRETRAINED_VOCAB_FILES_MAP = {
-    "vocab_file": {
-        "facebook/nllb-200-distilled-600M": (
-            "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/sentencepiece.bpe.model"
-        ),
-    },
-    "tokenizer_file": {
-        "facebook/nllb-200-distilled-600M": (
-            "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/tokenizer.json"
-        ),
-    },
+    # "vocab_file": {
+    #     "facebook/nllb-200-distilled-600M": (
+    #         "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/sentencepiece.bpe.model"
+    #     ),
+    # },
+    # "tokenizer_file": {
+    #     "facebook/nllb-200-distilled-600M": (
+    #         "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/tokenizer.json"
+    #     ),
+    # },
 }
 
+# TODO: Add m2m models
 PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
-    "facebook/nllb-large-en-ro": 1024,
-    "facebook/nllb-200-distilled-600M": 1024,
+    # "facebook/nllb-large-en-ro": 1024,
+    # "facebook/nllb-200-distilled-600M": 1024,
 }
 
 # fmt: off
@@ -201,6 +203,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self._src_lang = new_src_lang
         self.set_src_lang_special_tokens(self._src_lang)
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast.build_inputs_with_special_tokens
     def build_inputs_with_special_tokens(
         self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None
     ) -> List[int]:
@@ -208,7 +211,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         Build model inputs from a sequence or a pair of sequence for sequence classification tasks by concatenating and
         adding special tokens. The special tokens depend on calling set_lang.
 
-        An NLLB sequence has the following format, where `X` represents the sequence:
+        An M2M100 sequence has the following format, where `X` represents the sequence:
 
         - `input_ids` (for encoder) `X [eos, src_lang_code]`
         - `decoder_input_ids`: (for decoder) `X [eos, tgt_lang_code]`
@@ -230,6 +233,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         # We don't expect to process pairs, but leave the pair logic for API consistency
         return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast._build_translation_inputs
     def _build_translation_inputs(
         self, raw_inputs, return_tensors: str, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
     ):
@@ -242,6 +246,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         inputs["forced_bos_token_id"] = tgt_lang_id
         return inputs
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast.prepare_seq2seq_batch
     def prepare_seq2seq_batch(
         self,
         src_texts: List[str],
@@ -254,12 +259,15 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self.tgt_lang = tgt_lang
         return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast._switch_to_input_mode
     def _switch_to_input_mode(self):
         return self.set_src_lang_special_tokens(self.src_lang)
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast._switch_to_target_mode
     def _switch_to_target_mode(self):
         return self.set_tgt_lang_special_tokens(self.tgt_lang)
 
+    # Copied from transformers.models.m2m_100.tokenization_m2m_100.M2M100Tokenizer.set_src_lang_special_tokens
     def set_src_lang_special_tokens(self, src_lang: str) -> None:
         """Reset the special tokens to the source lang setting. No prefix and suffix=[eos, src_lang_code]."""
         lang_token = self.get_lang_token(src_lang)
@@ -276,6 +284,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
             special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
         )
 
+    # Copied from transformers.models.m2m_100.tokenization_m2m_100.M2M100Tokenizer.set_tgt_lang_special_tokens
     def set_tgt_lang_special_tokens(self, tgt_lang: str) -> None:
         """Reset the special tokens to the target language setting. No prefix and suffix=[eos, tgt_lang_code]."""
         lang_token = self.get_lang_token(tgt_lang)
@@ -292,13 +301,16 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
             special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
         )
 
+    # Copied from transformers.models.m2m_100.tokenization_m2m_100.M2M100Tokenizer.get_lang_token
     def get_lang_token(self, lang: str) -> str:
         return self.lang_code_to_token[lang]
 
+    # Copied from transformers.models.m2m_100.tokenization_m2m_100.M2M100Tokenizer.get_lang_id
     def get_lang_id(self, lang: str) -> int:
         lang_token = self.get_lang_token(lang)
         return self.lang_token_to_id[lang_token]
 
+    # Copied from transformers.models.nllb.tokenization_nllb_fast.NllbTokenizerFast.save_vocabulary
     def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
         if not self.can_save_slow_tokenizer:
             raise ValueError(

--- a/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
@@ -1,0 +1,322 @@
+# coding=utf-8
+# Copyright 2022 The Facebook AI Research Team Authors and The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from shutil import copyfile
+from typing import Union, Dict, List, Optional, Tuple
+
+from tokenizers import processors
+
+from ...tokenization_utils import AddedToken, BatchEncoding
+from ...tokenization_utils_fast import PreTrainedTokenizerFast
+from ...utils import is_sentencepiece_available, logging
+
+
+if is_sentencepiece_available():
+    from .tokenization_m2m_100 import M2M100Tokenizer
+else:
+    M2M100Tokenizer = None
+
+
+logger = logging.get_logger(__name__)
+
+
+VOCAB_FILES_NAMES = {"vocab_file": "sentencepiece.bpe.model", "tokenizer_file": "tokenizer.json"}
+
+PRETRAINED_VOCAB_FILES_MAP = {
+    "vocab_file": {
+        "facebook/nllb-200-distilled-600M": (
+            "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/sentencepiece.bpe.model"
+        ),
+    },
+    "tokenizer_file": {
+        "facebook/nllb-200-distilled-600M": (
+            "https://huggingface.co/facebook/nllb-200-distilled-600M/resolve/main/tokenizer.json"
+        ),
+    },
+}
+
+PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES = {
+    "facebook/nllb-large-en-ro": 1024,
+    "facebook/nllb-200-distilled-600M": 1024,
+}
+
+# fmt: off
+FAIRSEQ_LANGUAGE_CODES = {
+    "m2m100": ["af", "am", "ar", "ast", "az", "ba", "be", "bg", "bn", "br", "bs", "ca", "ceb", "cs", "cy", "da", "de", "el", "en", "es", "et", "fa", "ff", "fi", "fr", "fy", "ga", "gd", "gl", "gu", "ha", "he", "hi", "hr", "ht", "hu", "hy", "id", "ig", "ilo", "is", "it", "ja", "jv", "ka", "kk", "km", "kn", "ko", "lb", "lg", "ln", "lo", "lt", "lv", "mg", "mk", "ml", "mn", "mr", "ms", "my", "ne", "nl", "no", "ns", "oc", "or", "pa", "pl", "ps", "pt", "ro", "ru", "sd", "si", "sk", "sl", "so", "sq", "sr", "ss", "su", "sv", "sw", "ta", "th", "tl", "tn", "tr", "uk", "ur", "uz", "vi", "wo", "xh", "yi", "yo", "zh", "zu"],
+    "wmt21": ['en', 'ha', 'is', 'ja', 'cs', 'ru', 'zh', 'de']
+}
+# fmt: on
+
+
+class M2M100TokenizerFast(PreTrainedTokenizerFast):
+    """
+    Construct a "fast" M2M100 tokenizer (backed by HuggingFace's *tokenizers* library). Based on
+    [BPE](https://huggingface.co/docs/tokenizers/python/latest/components.html?highlight=BPE#models).
+
+    This tokenizer inherits from [`PreTrainedTokenizerFast`] which contains most of the main methods. Users should
+    refer to this superclass for more information regarding those methods.
+
+    The tokenization method is `<tokens> <eos> <language code>` for source language documents, and `<language code>
+    <tokens> <eos>` for target language documents.
+
+    Examples:
+
+    ```python
+    >>> from transformers import M2M100TokenizerFast
+
+    >>> tokenizer = M2M100TokenizerFast.from_pretrained(
+    ...     "facebook/m2m100_418M", src_lang="en", tgt_lang="ro"
+    ... )
+    >>> src_text = " UN Chief Says There Is No Military Solution in Syria"
+    >>> tgt_text = "Şeful ONU declară că nu există o soluţie militară în Siria"
+    >>> inputs = tokenizer(src_text, text_target=tgt_text, return_tensors="pt")
+    ```
+
+    Args:
+        vocab_file (`str`):
+            Path to the vocabulary file.
+        bos_token (`str`, *optional*, defaults to `"<s>"`):
+            The beginning of sequence token that was used during pretraining. Can be used a sequence classifier token.
+
+            <Tip>
+
+            When building a sequence using special tokens, this is not the token that is used for the beginning of
+            sequence. The token used is the `cls_token`.
+
+            </Tip>
+
+        eos_token (`str`, *optional*, defaults to `"</s>"`):
+            The end of sequence token.
+
+            <Tip>
+
+            When building a sequence using special tokens, this is not the token that is used for the end of sequence.
+            The token used is the `sep_token`.
+
+            </Tip>
+
+        sep_token (`str`, *optional*, defaults to `"</s>"`):
+            The separator token, which is used when building a sequence from multiple sequences, e.g. two sequences for
+            sequence classification or for a text and a question for question answering. It is also used as the last
+            token of a sequence built with special tokens.
+        unk_token (`str`, *optional*, defaults to `"<unk>"`):
+            The unknown token. A token that is not in the vocabulary cannot be converted to an ID and is set to be this
+            token instead.
+        pad_token (`str`, *optional*, defaults to `"<pad>"`):
+            The token used for padding, for example when batching sequences of different lengths.
+        language_codes (`str`, *optional*, defaults to `"m2m100"`):
+            What language codes to use. Should be one of `"m2m100"` or `"wmt21"`.
+        tokenizer_file (`str`, *optional*):
+            The path to a tokenizer file to use instead of the vocab file.
+        src_lang (`str`, *optional*):
+            The language to use as source language for translation.
+        tgt_lang (`str`, *optional*):
+            The language to use as target language for translation.
+    """
+
+    vocab_files_names = VOCAB_FILES_NAMES
+    max_model_input_sizes = PRETRAINED_POSITIONAL_EMBEDDINGS_SIZES
+    pretrained_vocab_files_map = PRETRAINED_VOCAB_FILES_MAP
+    model_input_names = ["input_ids", "attention_mask"]
+    slow_tokenizer_class = M2M100Tokenizer
+
+    prefix_tokens: List[int] = []
+    suffix_tokens: List[int] = []
+
+    def __init__(
+        self,
+        vocab_file=None,
+        bos_token="<s>",
+        eos_token="</s>",
+        sep_token="</s>",
+        unk_token="<unk>",
+        pad_token="<pad>",
+        language_codes="m2m100",
+        src_lang=None,
+        tgt_lang=None,
+        num_madeup_words=8,
+        additional_special_tokens=None,
+        **kwargs,
+    ):
+
+        super().__init__(
+            vocab_file=vocab_file,
+            bos_token=bos_token,
+            eos_token=eos_token,
+            sep_token=sep_token,
+            unk_token=unk_token,
+            pad_token=pad_token,
+            language_codes=language_codes,
+            src_lang=src_lang,
+            tgt_lang=tgt_lang,
+            num_madeup_words=num_madeup_words,
+            **kwargs,
+        )
+
+        self.vocab_file = vocab_file
+        self.can_save_slow_tokenizer = bool(self.vocab_file)
+
+
+        fairseq_language_code = FAIRSEQ_LANGUAGE_CODES[language_codes]
+        self.lang_code_to_token = {lang_code: f"__{lang_code}__" for lang_code in fairseq_language_code}
+
+        _additional_special_tokens = list(self.lang_code_to_token.values())
+        if additional_special_tokens is not None:
+            # Only add those special tokens if they are not already there.
+            _additional_special_tokens.extend(
+                [t for t in additional_special_tokens if t not in _additional_special_tokens]
+            )
+
+        self.add_special_tokens({"additional_special_tokens": _additional_special_tokens})
+        self.lang_code_to_id = {
+            lang_code: self.convert_tokens_to_ids(token) for lang_code, token in self.lang_code_to_token.items()
+        }
+        self.lang_token_to_id = { 
+            token: self.convert_tokens_to_ids(token) for token in self.lang_code_to_token.values()
+        }
+
+        self._src_lang = src_lang if src_lang is not None else "en"
+        self.cur_lang_code = self.convert_tokens_to_ids(self._src_lang)
+        self.tgt_lang = tgt_lang
+        self.set_src_lang_special_tokens(self._src_lang)
+
+
+    @property
+    def src_lang(self) -> str:
+        return self._src_lang
+
+    @src_lang.setter
+    def src_lang(self, new_src_lang: str) -> None:
+        self._src_lang = new_src_lang
+        self.set_src_lang_special_tokens(self._src_lang)
+
+    def build_inputs_with_special_tokens(
+        self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None
+    ) -> List[int]:
+        """
+        Build model inputs from a sequence or a pair of sequence for sequence classification tasks by concatenating and
+        adding special tokens. The special tokens depend on calling set_lang.
+
+        An NLLB sequence has the following format, where `X` represents the sequence:
+
+        - `input_ids` (for encoder) `X [eos, src_lang_code]`
+        - `decoder_input_ids`: (for decoder) `X [eos, tgt_lang_code]`
+
+        BOS is never used. Pairs of sequences are not the expected use case, but they will be handled without a
+        separator.
+
+        Args:
+            token_ids_0 (`List[int]`):
+                List of IDs to which the special tokens will be added.
+            token_ids_1 (`List[int]`, *optional*):
+                Optional second list of IDs for sequence pairs.
+
+        Returns:
+            `List[int]`: list of [input IDs](../glossary#input-ids) with the appropriate special tokens.
+        """
+        if token_ids_1 is None:
+            return self.prefix_tokens + token_ids_0 + self.suffix_tokens
+        # We don't expect to process pairs, but leave the pair logic for API consistency
+        return self.prefix_tokens + token_ids_0 + token_ids_1 + self.suffix_tokens
+
+    def _build_translation_inputs(
+        self, raw_inputs, return_tensors: str, src_lang: Optional[str], tgt_lang: Optional[str], **extra_kwargs
+    ):
+        """Used by translation pipeline, to prepare inputs for the generate function"""
+        if src_lang is None or tgt_lang is None:
+            raise ValueError("Translation requires a `src_lang` and a `tgt_lang` for this model")
+        self.src_lang = src_lang
+        inputs = self(raw_inputs, add_special_tokens=True, return_tensors=return_tensors, **extra_kwargs)
+        tgt_lang_id = self.convert_tokens_to_ids(tgt_lang)
+        inputs["forced_bos_token_id"] = tgt_lang_id
+        return inputs
+
+    def prepare_seq2seq_batch(
+        self,
+        src_texts: List[str],
+        src_lang: str = "en",
+        tgt_texts: Optional[List[str]] = None,
+        tgt_lang: str = "fra_Latn",
+        **kwargs,
+    ) -> BatchEncoding:
+        self.src_lang = src_lang
+        self.tgt_lang = tgt_lang
+        return super().prepare_seq2seq_batch(src_texts, tgt_texts, **kwargs)
+
+    def _switch_to_input_mode(self):
+        return self.set_src_lang_special_tokens(self.src_lang)
+
+    def _switch_to_target_mode(self):
+        return self.set_tgt_lang_special_tokens(self.tgt_lang)
+
+    def set_src_lang_special_tokens(self, src_lang: str) -> None:
+        """Reset the special tokens to the source lang setting. No prefix and suffix=[eos, src_lang_code]."""
+        lang_token = self.get_lang_token(src_lang)
+        self.cur_lang_id = self.lang_token_to_id[lang_token]
+        self.prefix_tokens = [self.cur_lang_id]
+        self.suffix_tokens = [self.eos_token_id]
+
+        prefix_tokens_str = self.convert_ids_to_tokens(self.prefix_tokens)
+        suffix_tokens_str = self.convert_ids_to_tokens(self.suffix_tokens)
+
+        self._tokenizer.post_processor = processors.TemplateProcessing(
+            single=prefix_tokens_str + ["$A"] + suffix_tokens_str,
+            pair=prefix_tokens_str + ["$A", "$B"] + suffix_tokens_str,
+            special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
+        )
+
+    def set_tgt_lang_special_tokens(self, tgt_lang: str) -> None:
+        """Reset the special tokens to the target language setting. No prefix and suffix=[eos, tgt_lang_code]."""
+        lang_token = self.get_lang_token(tgt_lang)
+        self.cur_lang_id = self.lang_token_to_id[lang_token]
+        self.prefix_tokens = [self.cur_lang_id]
+        self.suffix_tokens = [self.eos_token_id]
+
+        prefix_tokens_str = self.convert_ids_to_tokens(self.prefix_tokens)
+        suffix_tokens_str = self.convert_ids_to_tokens(self.suffix_tokens)
+
+        self._tokenizer.post_processor = processors.TemplateProcessing(
+            single=prefix_tokens_str + ["$A"] + suffix_tokens_str,
+            pair=prefix_tokens_str + ["$A", "$B"] + suffix_tokens_str,
+            special_tokens=list(zip(prefix_tokens_str + suffix_tokens_str, self.prefix_tokens + self.suffix_tokens)),
+        )
+
+    def get_lang_token(self, lang: str) -> str:
+        return self.lang_code_to_token[lang]
+
+    def get_lang_id(self, lang: str) -> int:
+        lang_token = self.get_lang_token(lang)
+        return self.lang_token_to_id[lang_token]
+
+    def save_vocabulary(self, save_directory: str, filename_prefix: Optional[str] = None) -> Tuple[str]:
+        if not self.can_save_slow_tokenizer:
+            raise ValueError(
+                "Your fast tokenizer does not have the necessary information to save the vocabulary for a slow "
+                "tokenizer."
+            )
+
+        if not os.path.isdir(save_directory):
+            logger.error(f"Vocabulary path ({save_directory}) should be a directory.")
+            return
+        out_vocab_file = os.path.join(
+            save_directory, (filename_prefix + "-" if filename_prefix else "") + VOCAB_FILES_NAMES["vocab_file"]
+        )
+
+        if os.path.abspath(self.vocab_file) != os.path.abspath(out_vocab_file):
+            copyfile(self.vocab_file, out_vocab_file)
+
+        return (out_vocab_file,)

--- a/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
+++ b/src/transformers/models/m2m_100/tokenization_m2m_100_fast.py
@@ -152,7 +152,6 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         additional_special_tokens=None,
         **kwargs,
     ):
-
         super().__init__(
             vocab_file=vocab_file,
             bos_token=bos_token,
@@ -170,7 +169,6 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self.vocab_file = vocab_file
         self.can_save_slow_tokenizer = bool(self.vocab_file)
 
-
         fairseq_language_code = FAIRSEQ_LANGUAGE_CODES[language_codes]
         self.lang_code_to_token = {lang_code: f"__{lang_code}__" for lang_code in fairseq_language_code}
 
@@ -185,7 +183,7 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self.lang_code_to_id = {
             lang_code: self.convert_tokens_to_ids(token) for lang_code, token in self.lang_code_to_token.items()
         }
-        self.lang_token_to_id = { 
+        self.lang_token_to_id = {
             token: self.convert_tokens_to_ids(token) for token in self.lang_code_to_token.values()
         }
 
@@ -193,7 +191,6 @@ class M2M100TokenizerFast(PreTrainedTokenizerFast):
         self.cur_lang_code = self.convert_tokens_to_ids(self._src_lang)
         self.tgt_lang = tgt_lang
         self.set_src_lang_special_tokens(self._src_lang)
-
 
     @property
     def src_lang(self) -> str:

--- a/src/transformers/utils/dummy_tokenizers_objects.py
+++ b/src/transformers/utils/dummy_tokenizers_objects.py
@@ -247,6 +247,13 @@ class LxmertTokenizerFast(metaclass=DummyObject):
         requires_backends(self, ["tokenizers"])
 
 
+class M2M100TokenizerFast(metaclass=DummyObject):
+    _backends = ["tokenizers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tokenizers"])
+
+
 class MarkupLMTokenizerFast(metaclass=DummyObject):
     _backends = ["tokenizers"]
 

--- a/tests/models/m2m_100/test_tokenization_m2m_100.py
+++ b/tests/models/m2m_100/test_tokenization_m2m_100.py
@@ -17,7 +17,11 @@ import unittest
 from pathlib import Path
 from shutil import copyfile
 
-from transformers import M2M100Tokenizer, is_torch_available
+from transformers import (
+    M2M100Tokenizer,
+    M2M100TokenizerFast,
+    is_torch_available,
+)
 from transformers.testing_utils import (
     get_tests_dir,
     nested_simplify,
@@ -47,9 +51,11 @@ FR_CODE = 128028
 
 
 @require_sentencepiece
+@require_tokenizers
 class M2M100TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     tokenizer_class = M2M100Tokenizer
-    test_rust_tokenizer = False
+    rust_tokenizer_class = M2M100TokenizerFast
+    test_rust_tokenizer = True
     test_seq2seq = False
     test_sentencepiece = True
 


### PR DESCRIPTION
# What does this PR do?

Adds fast tokenizer support for `M2M100Tokenizer`. I also added a `convert_slow_tokenizer` config to support generating a tokenizer.json file. For example, the generated tokenizer files for [facebook/m2m100_418M](https://huggingface.co/facebook/m2m100_418M) can be found [here](https://huggingface.co/Xenova/m2m100_418M/tree/main).

The fast tokenizer format is needed for transformers.js (see [issue](https://github.com/xenova/transformers.js/issues/235) and [PR](https://github.com/xenova/transformers.js/pull/250)). This may or may not be super relevant (considering the models are quite old), but there was a feature request in transformers.js, and I needed to write this code to get it working - so I thought I might as well share here.

I have ran the tokenizer on a [variety of test cases](https://github.com/xenova/transformers.js/blob/main/tests/generate_tests.py#L24-L46), and it passes each one. Additionally, it fixes a bug/inconsistency with the slow tokenizer (actually found in all sentencepiece tokenizers), where whitespace after special tokens is removed. To make the test cases past, I just basically hardcoded a [fix](https://github.com/xenova/transformers.js/blob/58425088a42931306304fa38b4cb50b901a2eefa/tests/generate_tests.py#L120-L125) for it (for now at least).

### Example conversion code
```python
from transformers import convert_slow_tokenizer, AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained('Xenova/m2m100_418M', use_fast=False)
fast_tokenizer=convert_slow_tokenizer.convert_slow_tokenizer(tokenizer)
fast_tokenizer.save('tokenizer.json')
```

### Example usage code
```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained('Xenova/m2m100_418M', use_fast=False)
fast_tokenizer = AutoTokenizer.from_pretrained('Xenova/m2m100_418M', use_fast=True)
assert tokenizer('Hello world').input_ids == fast_tokenizer('Hello world').input_ids
```

NOTE: To get facebook/m2m100_418M working, we need to remove the `"tokenizer_file": null,` line from [tokenizer_config.json](https://huggingface.co/facebook/m2m100_418M/blob/main/tokenizer_config.json)


Fixes # (issue)

### TODO
- [ ] Unit tests
- [x] Other config files + docs as done with `NllbTokenizerFast`
- [ ] Check that *all* special tokens are added (including `</s>` and similar tokens)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?


Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
