### PR TITLE
Set can_generate for SpeechT5ForTextToSpeech

### DIFF
--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -2783,6 +2783,13 @@ class SpeechT5ForTextToSpeech(SpeechT5PreTrainedModel):
             encoder_attentions=outputs.encoder_attentions,
         )
 
+    def can_generate(self) -> bool:
+        """
+        Returns True. This model can `generate` and must therefore have this property set to True in order to be used
+        in the TTS pipeline.
+        """
+        return True
+
     @torch.no_grad()
     def generate(
         self,


### PR DESCRIPTION
# What does this PR do?

Following the [discussion](https://github.com/huggingface/transformers/pull/24952#discussion_r1293224895) on checking whether the generate or forward method will be used in the TTS pipeline, it makes sense to set `can_generate=True` for `SpeechT5ForTextToSpeech`, so that it's easier to check if it can generate.



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Before submitting
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? 

## Who can review?

Hey @sanchit-gandhi and @sgugger , what do you think of this??
Thanks!
