### PR TITLE
MaskFormer post_process_instance_segmentation bug fix convert out side of loop

### DIFF
--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -1026,9 +1026,10 @@ class Mask2FormerImageProcessor(BaseImageProcessor):
                     )
                     current_segment_id += 1
                     instance_maps.append(pred_masks[j])
-                    # Return segmentation map in run-length encoding (RLE) format
-                    if return_coco_annotation:
-                        segmentation = convert_segmentation_to_rle(segmentation)
+
+            # Return segmentation map in run-length encoding (RLE) format
+            if return_coco_annotation:
+                segmentation = convert_segmentation_to_rle(segmentation)
 
             # Return a concatenated tensor of binary instance maps
             if return_binary_maps and len(instance_maps) != 0:

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -1081,9 +1081,10 @@ class MaskFormerImageProcessor(BaseImageProcessor):
                     )
                     current_segment_id += 1
                     instance_maps.append(pred_masks[j])
-                    # Return segmentation map in run-length encoding (RLE) format
-                    if return_coco_annotation:
-                        segmentation = convert_segmentation_to_rle(segmentation)
+
+            # Return segmentation map in run-length encoding (RLE) format
+            if return_coco_annotation:
+                segmentation = convert_segmentation_to_rle(segmentation)
 
             # Return a concatenated tensor of binary instance maps
             if return_binary_maps and len(instance_maps) != 0:


### PR DESCRIPTION
# What does this PR do?

Resolves a bug in post processing logic in MaskFormer and Mask2Former. 

If `return_coco_annotation` is set to `True` the generated segmentation map was converted to RLE before finishing iterating over all of the queries. This breaks the assumption that segmentation is an array of the same shape as `pred_masks` [here](https://github.com/huggingface/transformers/blob/e97deca9a3f4ddf2a6a44405ed928067d7b729f3/src/transformers/models/maskformer/image_processing_maskformer.py#L1073) in the for loop.

Fixes #25486 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
