### PR TITLE
🚨🚨🚨 Remove softmax for EfficientNetForImageClassification 🚨🚨🚨

### DIFF
--- a/src/transformers/models/efficientnet/modeling_efficientnet.py
+++ b/src/transformers/models/efficientnet/modeling_efficientnet.py
@@ -588,7 +588,6 @@ class EfficientNetForImageClassification(EfficientNetPreTrainedModel):
         # Classifier head
         self.dropout = nn.Dropout(p=config.dropout_rate)
         self.classifier = nn.Linear(config.hidden_dim, self.num_labels) if self.num_labels > 0 else nn.Identity()
-        self.classifier_act = nn.Softmax(dim=1)
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -620,7 +619,6 @@ class EfficientNetForImageClassification(EfficientNetPreTrainedModel):
         pooled_output = outputs.pooler_output if return_dict else outputs[1]
         pooled_output = self.dropout(pooled_output)
         logits = self.classifier(pooled_output)
-        logits = self.classifier_act(logits)
 
         loss = None
         if labels is not None:

--- a/tests/models/efficientnet/test_modeling_efficientnet.py
+++ b/tests/models/efficientnet/test_modeling_efficientnet.py
@@ -265,5 +265,5 @@ class EfficientNetModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size((1, 1000))
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([-0.2962,  0.4487,  0.4499]).to(torch_device)
+        expected_slice = torch.tensor([-0.2962, 0.4487, 0.4499]).to(torch_device)
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))

--- a/tests/models/efficientnet/test_modeling_efficientnet.py
+++ b/tests/models/efficientnet/test_modeling_efficientnet.py
@@ -265,5 +265,5 @@ class EfficientNetModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size((1, 1000))
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([0.0001, 0.0002, 0.0002]).to(torch_device)
+        expected_slice = torch.tensor([-0.2962,  0.4487,  0.4499]).to(torch_device)
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))


### PR DESCRIPTION
# What does this PR do?

 **\/!\ This is a breaking change /!\\** 

EfficientNet implementation erroneously added a softmax to the models logits in the classification head. This breaks with convention and [documentation](https://github.com/huggingface/transformers/blob/87c9d8a10f3935a46fc7b254d3bea97bca4bfcce/src/transformers/modeling_outputs.py#L1215) for the [model outputs](https://github.com/huggingface/transformers/blob/87c9d8a10f3935a46fc7b254d3bea97bca4bfcce/src/transformers/models/efficientnet/modeling_efficientnet.py#L623). 

This results in the very small probabilities seen in the hosted widgets on the checkpoints pages, as the logits effectively have softmax applied twice. 

<img width="1568" alt="image" src="https://github.com/huggingface/transformers/assets/22614925/111c8346-f679-4c2e-8800-b36cf5b385ff">


Most of the efficientnet checkpoints were downloaded < 100 times in the past month. However, [efficientnet-b7](https://huggingface.co/google/efficientnet-b7) is more popular with a few thousand downloads. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
