### PR TITLE
Adds `TRANSFORMERS_TEST_DEVICE`

### DIFF
--- a/docs/source/en/testing.md
+++ b/docs/source/en/testing.md
@@ -511,6 +511,16 @@ from transformers.testing_utils import get_gpu_count
 n_gpu = get_gpu_count()  # works with torch and tf
 ```
 
+### Testing with a specific PyTorch backend
+
+To run the test suite on a specific torch backend add `TRANSFORMERS_TEST_DEVICE="$device"` where `$device` is the target backend. For example, to test on CPU only:
+```bash
+TRANSFORMERS_TEST_DEVICE="cpu" pytest tests/test_logging.py
+```
+
+This variable is useful for testing custom or less common PyTorch backends such as `mps`. It can also be used to achieve the same effect as `CUDA_VISIBLE_DEVICES` by targeting specific GPUs or testing in CPU-only mode.
+
+
 ### Distributed training
 
 `pytest` can't deal with distributed training directly. If this is attempted - the sub-processes don't do the right

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -620,7 +620,9 @@ if is_torch_available():
             # try creating device to see if provided device is valid
             _ = torch.device(torch_device)
         except RuntimeError as e:
-            raise RuntimeError(f"Unknown testing device specified by environment variable `TRANSFORMERS_TEST_DEVICE`: {torch_device}") from e
+            raise RuntimeError(
+                f"Unknown testing device specified by environment variable `TRANSFORMERS_TEST_DEVICE`: {torch_device}"
+            ) from e
     elif torch.cuda.is_available():
         torch_device = "cuda"
     elif _run_third_party_device_tests and is_torch_npu_available():

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -616,8 +616,11 @@ if is_torch_available():
 
     if "TRANSFORMERS_TEST_DEVICE" in os.environ:
         torch_device = os.environ["TRANSFORMERS_TEST_DEVICE"]
-        # try creating device to see if provided device is valid
-        _ = torch.device(torch_device)
+        try:
+            # try creating device to see if provided device is valid
+            _ = torch.device(torch_device)
+        except RuntimeError as e:
+            raise RuntimeError(f"Unknown testing device specified by environment variable `TRANSFORMERS_TEST_DEVICE`: {torch_device}") from e
     elif torch.cuda.is_available():
         torch_device = "cuda"
     elif _run_third_party_device_tests and is_torch_npu_available():

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -614,7 +614,15 @@ if is_torch_available():
     # Set env var CUDA_VISIBLE_DEVICES="" to force cpu-mode
     import torch
 
-    if torch.cuda.is_available():
+    if "TRANSFORMERS_TEST_DEVICE" in os.environ:
+        torch_device = os.environ["TRANSFORMERS_TEST_DEVICE"]
+        available_backends = ["cuda", "cpu", "mps"]
+        if torch_device not in available_backends:
+            raise ValueError(
+                f"unknown torch backend for transformers tests: {torch_device}. Available backends are:"
+                f" {available_backends}"
+            )
+    elif torch.cuda.is_available():
         torch_device = "cuda"
     elif _run_third_party_device_tests and is_torch_npu_available():
         torch_device = "npu"

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -616,12 +616,8 @@ if is_torch_available():
 
     if "TRANSFORMERS_TEST_DEVICE" in os.environ:
         torch_device = os.environ["TRANSFORMERS_TEST_DEVICE"]
-        available_backends = ["cuda", "cpu", "mps"]
-        if torch_device not in available_backends:
-            raise ValueError(
-                f"unknown torch backend for transformers tests: {torch_device}. Available backends are:"
-                f" {available_backends}"
-            )
+        # try creating device to see if provided device is valid
+        _ = torch.device(torch_device)
     elif torch.cuda.is_available():
         torch_device = "cuda"
     elif _run_third_party_device_tests and is_torch_npu_available():


### PR DESCRIPTION
Adds support for environment variable `TRANSFORMERS_TEST_DEVICE` to set device in use for running the test suite. This pattern is already in use in `diffusers`.

# What does this PR do?

Adds support for environment variable `TRANSFORMERS_TEST_DEVICE` to set device in use for running the test suite. This is a pattern already in use in [`diffusers`](https://github.com/huggingface/diffusers/blob/d93ca268938940839118fdb8d0cf4c1ca7a9fead/src/diffusers/utils/testing_utils.py#L45) which would be useful to have in transformers.

Additionally, I would like to propose removing the check on available backends, as is found in the diffusers version. I included it here to match diffusers, but it would be useful to remove it (for example, if testing new backends and the like). Let me know if that is okay and I will amend the PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger, git blame says you! :hugs: 
