### PR TITLE
Add GitForCausalLM model in VQA pipeline

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -844,6 +844,7 @@ MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         ("blip-2", "Blip2ForConditionalGeneration"),
+        ("git", "GitForCausalLM"),
         ("vilt", "ViltForQuestionAnswering"),
     ]
 )

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -121,6 +121,21 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         outputs = vqa_pipeline(image=image, question=question)
         self.assertEqual(outputs, [{"answer": ANY(str)}])
 
+    @require_torch
+    def test_small_model_pt_git(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="hf-internal-testing/tiny-random-GitForCausalLM")
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "How many cats are there?"
+
+        outputs = vqa_pipeline(image=image, question=question)
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(outputs, [[{"answer": ANY(str)}]] * 2)
+
     @slow
     @require_torch
     def test_large_model_pt(self):
@@ -170,6 +185,22 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
 
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
         self.assertEqual(outputs, [[{"answer": "two"}]] * 2)
+
+    @slow
+    @require_torch
+    def test_large_model_pt_git(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="microsoft/git-base-textvqa")
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "How many cats are there?"
+
+        outputs = vqa_pipeline(image=image, question=question)
+        self.assertEqual(outputs, [{"answer": "how many cats are there? 3"}])
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(outputs, [{"answer": "how many cats are there? 3"}])
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(outputs, [[{"answer": "how many cats are there? 3"}]] * 2)
 
     @require_tf
     @unittest.skip("Visual question answering not implemented in TF")


### PR DESCRIPTION
# What does this PR do?

Add GitForCausalLM model in VisualQuestionAnsweringPipeline.
Fixes part of #21110 and is based on #23348 #21227 .

## Who can review?

Hi @NielsRogge  what do you think of this??
Thanks!

## TODOs

- [x]  Add GIT model in VQA pipelines
- [x] Add tests
- [ ] Move custom preprocessing to the tokenizer/processor class (this shall be done in other PR, recommended in https://github.com/huggingface/transformers/pull/25509#issuecomment-1719288200)
- [ ] Update docs