### PR TITLE
add __repr__  to the BitsAndBytesConfig class

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -272,6 +272,10 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
 
         return output
 
+    def __repr__(self):
+        config_dict = self.to_dict()
+        return f"{self.__class__.__name__} {json.dumps(config_dict, indent=2, sort_keys=True)}\n"
+
     def to_diff_dict(self) -> Dict[str, Any]:
         """
         Removes all attributes from config which correspond to the default config attributes for better readability and


### PR DESCRIPTION
# What does this PR do?

add __repr__  to the BitsAndBytesConfig class for better visualization and debugging
before 
```python
>>> print(bnb_config)
>>> BitsAndBytesConfig(quant_method=<QuantizationMethod.BITS_AND_BYTES: 'bitsandbytes'>)

```
after
```python
>>> print(bnb_config)
>>> BitsAndBytesConfig {
  "bnb_4bit_compute_dtype": "bfloat16",
  "bnb_4bit_quant_type": "nf4",
  "bnb_4bit_use_double_quant": true,
  "llm_int8_enable_fp32_cpu_offload": false,
  "llm_int8_has_fp16_weight": false,
  "llm_int8_skip_modules": null,
  "llm_int8_threshold": 6.0,
  "load_in_4bit": true,
  "load_in_8bit": false,
  "quant_method": "bitsandbytes"
}
```
