### PR TITLE
Add Blip2 model in VQA pipeline

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -839,6 +839,7 @@ MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
+        ("blip-2", "Blip2ForConditionalGeneration"),
         ("vilt", "ViltForQuestionAnswering"),
     ]
 )

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1789,13 +1789,6 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
             language_model_outputs=outputs,
         )
 
-    def can_generate(self) -> bool:
-        """
-        Returns True. This model can `generate` and must therefore have this property set to True in order to be used
-        in the visual-question-answering pipeline.
-        """
-        return True
-
     @torch.no_grad()
     def generate(
         self,

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1789,6 +1789,13 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
             language_model_outputs=outputs,
         )
 
+    def can_generate(self) -> bool:
+        """
+        Returns True. This model can `generate` and must therefore have this property set to True in order to be used
+        in the visual-question-answering pipeline.
+        """
+        return True
+
     @torch.no_grad()
     def generate(
         self,

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging
+from ..utils import ExplicitEnum, add_end_docstrings, is_torch_available, is_vision_available, logging
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
 
@@ -13,6 +13,11 @@ if is_torch_available():
     from ..models.auto.modeling_auto import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES
 
 logger = logging.get_logger(__name__)
+
+
+class ModelType(ExplicitEnum):
+    CLASSIFIER = "classifier"
+    GENERATIVE = "generative"
 
 
 @add_end_docstrings(PIPELINE_INIT_ARGS)
@@ -54,6 +59,11 @@ class VisualQuestionAnsweringPipeline(Pipeline):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.check_model_type(MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES)
+
+        if self.model.config.__class__.__name__ in ["Blip2Config"]:
+            self.model_type = ModelType.GENERATIVE
+        elif self.model.config.__class__.__name__ in ["ViltConfig"]:
+            self.model_type = ModelType.CLASSIFIER
 
     def _sanitize_parameters(self, top_k=None, padding=None, truncation=None, timeout=None, **kwargs):
         preprocess_params, postprocess_params = {}, {}
@@ -124,19 +134,28 @@ class VisualQuestionAnsweringPipeline(Pipeline):
         return model_inputs
 
     def _forward(self, model_inputs):
-        model_outputs = self.model(**model_inputs)
+        if self.model_type == ModelType.GENERATIVE:
+            model_outputs = self.model.generate(**model_inputs)
+        else:
+            model_outputs = self.model(**model_inputs)
         return model_outputs
 
     def postprocess(self, model_outputs, top_k=5):
-        if top_k > self.model.config.num_labels:
-            top_k = self.model.config.num_labels
-
-        if self.framework == "pt":
-            probs = model_outputs.logits.sigmoid()[0]
-            scores, ids = probs.topk(top_k)
+        if self.model_type == ModelType.GENERATIVE:
+            return [
+                {"answer": self.tokenizer.decode(output_ids, skip_special_tokens=True).strip()}
+                for output_ids in model_outputs
+            ]
         else:
-            raise ValueError(f"Unsupported framework: {self.framework}")
+            if top_k > self.model.config.num_labels:
+                top_k = self.model.config.num_labels
 
-        scores = scores.tolist()
-        ids = ids.tolist()
-        return [{"score": score, "answer": self.model.config.id2label[_id]} for score, _id in zip(scores, ids)]
+            if self.framework == "pt":
+                probs = model_outputs.logits.sigmoid()[0]
+                scores, ids = probs.topk(top_k)
+            else:
+                raise ValueError(f"Unsupported framework: {self.framework}")
+
+            scores = scores.tolist()
+            ids = ids.tolist()
+            return [{"score": score, "answer": self.model.config.id2label[_id]} for score, _id in zip(scores, ids)]

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -84,6 +84,33 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
             outputs, [{"score": ANY(float), "answer": ANY(str)}, {"score": ANY(float), "answer": ANY(str)}]
         )
 
+    @require_torch
+    def test_small_model_pt_blip2(self):
+        vqa_pipeline = pipeline(
+            "visual-question-answering", model="hf-internal-testing/tiny-random-Blip2ForConditionalGeneration"
+        )
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "How many cats are there?"
+
+        outputs = vqa_pipeline(image=image, question=question)
+
+        self.assertEqual(
+            outputs,
+            [{"answer": ANY(str)}],
+        )
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(
+            outputs,
+            [{"answer": ANY(str)}],
+        )
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(
+            outputs,
+            [[{"answer": ANY(str)}]] * 2,
+        )
+
     @slow
     @require_torch
     def test_large_model_pt(self):
@@ -107,6 +134,35 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [[{"score": 0.8799, "answer": "2"}, {"score": 0.296, "answer": "1"}]] * 2,
+        )
+
+    @slow
+    @require_torch
+    def test_large_model_pt_blip2(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="Salesforce/blip2-opt-2.7b")
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "Question: how many cats are there? Answer:"
+
+        outputs = vqa_pipeline(image=image, question=question)
+
+        self.assertEqual(
+            outputs,
+            [{"answer": "two"}],
+        )
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(
+            outputs,
+            [{"answer": "two"}],
+        )
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(
+            outputs,
+            [
+                [{"answer": "two"}],
+            ]
+            * 2,
         )
 
     @require_tf

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -21,6 +21,7 @@ from transformers.testing_utils import (
     nested_simplify,
     require_tf,
     require_torch,
+    require_torch_gpu,
     require_vision,
     slow,
 )
@@ -137,7 +138,7 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         )
 
     @slow
-    @require_torch
+    @require_torch_gpu
     def test_large_model_pt_blip2(self):
         vqa_pipeline = pipeline("visual-question-answering", model="Salesforce/blip2-opt-2.7b")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -100,23 +100,13 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         question = "How many cats are there?"
 
         outputs = vqa_pipeline(image=image, question=question)
-
-        self.assertEqual(
-            outputs,
-            [{"answer": ANY(str)}],
-        )
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
 
         outputs = vqa_pipeline({"image": image, "question": question})
-        self.assertEqual(
-            outputs,
-            [{"answer": ANY(str)}],
-        )
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
 
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
-        self.assertEqual(
-            outputs,
-            [[{"answer": ANY(str)}]] * 2,
-        )
+        self.assertEqual(outputs, [[{"answer": ANY(str)}]] * 2)
 
         vqa_pipeline = pipeline(
             "visual-question-answering",
@@ -129,11 +119,7 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         self.assertEqual(vqa_pipeline.model.vision_model.dtype, torch.float16)
 
         outputs = vqa_pipeline(image=image, question=question)
-
-        self.assertEqual(
-            outputs,
-            [{"answer": ANY(str)}],
-        )
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
 
     @slow
     @require_torch
@@ -177,26 +163,13 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         question = "Question: how many cats are there? Answer:"
 
         outputs = vqa_pipeline(image=image, question=question)
-
-        self.assertEqual(
-            outputs,
-            [{"answer": "two"}],
-        )
+        self.assertEqual(outputs, [{"answer": "two"}])
 
         outputs = vqa_pipeline({"image": image, "question": question})
-        self.assertEqual(
-            outputs,
-            [{"answer": "two"}],
-        )
+        self.assertEqual(outputs, [{"answer": "two"}])
 
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
-        self.assertEqual(
-            outputs,
-            [
-                [{"answer": "two"}],
-            ]
-            * 2,
-        )
+        self.assertEqual(outputs, [[{"answer": "two"}]] * 2)
 
     @require_tf
     @unittest.skip("Visual question answering not implemented in TF")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Add Blip2ForConditionalGeneration model in VisualQuestionAnsweringPipeline.
Fixes part of #21110 and is based on #23348 #21227 .


## Who can review?

Hi @NielsRogge  what do you think of this??
Thanks!

## TODOs
- [x] add Blip2 model in VQA pipeline 
- [x] use require_torch_gpu in test
- [x] use can_generate in vqa pipeline for Blip2ForConditionalGeneration
- [x] use float16 in the test_large_model_pt_blip2
- [ ] check if it is necessary to cast the input in torch.float16 inside _forward