### PR TITLE
fix vit hybrid test

### DIFF
--- a/tests/models/vit_hybrid/test_modeling_vit_hybrid.py
+++ b/tests/models/vit_hybrid/test_modeling_vit_hybrid.py
@@ -281,7 +281,7 @@ class ViTModelIntegrationTest(unittest.TestCase):
 
         image = prepare_img()
 
-        inputs = image_processor(images=image, return_tensors="pt")
+        inputs = image_processor(images=image, return_tensors="pt").to(torch_device)
         outputs = model(**inputs)
         logits = outputs.logits
         # model predicts one of the 1000 ImageNet classes


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes a [test](https://github.com/huggingface/transformers/actions/runs/5503465492/job/14897632810). This bug was introduced by this [PR](https://github.com/huggingface/accelerate/pull/1648) on accelerate library. Basically, for single gpu setup, when we use device_map = 'auto', we don't add hooks to the model anymore. Hence, the test has been failing because we need to move the input to the right device. 