### PR TITLE
Fix `MaskFormerModelIntegrationTest` OOM

### DIFF
--- a/tests/models/maskformer/test_modeling_maskformer.py
+++ b/tests/models/maskformer/test_modeling_maskformer.py
@@ -539,7 +539,7 @@ class MaskFormerModelIntegrationTest(unittest.TestCase):
         image_processor = self.default_image_processor
 
         inputs = image_processor(
-            [np.zeros((3, 800, 1333)), np.zeros((3, 800, 1333))],
+            [np.zeros((3, 400, 333)), np.zeros((3, 400, 333))],
             segmentation_maps=[np.zeros((384, 384)).astype(np.float32), np.zeros((384, 384)).astype(np.float32)],
             return_tensors="pt",
         )


### PR DESCRIPTION
# What does this PR do?

The change in #25297 has some effect of increased memory usage, and `tests/models/maskformer/test_modeling_maskformer.py::MaskFormerModelIntegrationTest::test_with_segmentation_maps_and_loss` starts to fail when `MaskFormerModelIntegrationTest` is run as a whole.

This PR changes the image size in `MaskFormerModelIntegrationTest` to avoid OOM.