### PR TITLE
Fix `torch.fx` tests on nightly CI

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -1057,7 +1057,9 @@ class HFTracer(Tracer):
                 continue
             # We enforce that root must either be a PreTrainedModel or deserialized from a serialized traced model to
             # be able to use HFTracer._generate_dummy_input.
-            if isinstance(root, self.supported_archs) or any(type(root).__qualname__.startswith(x) for x in ["_deserialize_graph_module", "_CodeOnlyModule"]):
+            if isinstance(root, self.supported_archs) or any(
+                type(root).__qualname__.startswith(x) for x in ["_deserialize_graph_module", "_CodeOnlyModule"]
+            ):
                 inputs.update(self._generate_dummy_input(root, input_name, shape))
             else:
                 raise RuntimeError(

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -1057,8 +1057,8 @@ class HFTracer(Tracer):
                 continue
             # We enforce that root must either be a PreTrainedModel or deserialized from a serialized traced model to
             # be able to use HFTracer._generate_dummy_input.
-            if isinstance(root, self.supported_archs) or any(
-                type(root).__qualname__.startswith(x) for x in ["_deserialize_graph_module", "_CodeOnlyModule"]
+            if isinstance(root, self.supported_archs) or type(root).__qualname__.startswith(
+                ("_deserialize_graph_module", "_CodeOnlyModule")
             ):
                 inputs.update(self._generate_dummy_input(root, input_name, shape))
             else:

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -1057,9 +1057,7 @@ class HFTracer(Tracer):
                 continue
             # We enforce that root must either be a PreTrainedModel or deserialized from a serialized traced model to
             # be able to use HFTracer._generate_dummy_input.
-            if isinstance(root, self.supported_archs) or type(root).__qualname__.startswith(
-                "_deserialize_graph_module"
-            ):
+            if isinstance(root, self.supported_archs) or any(type(root).__qualname__.startswith(x) for x in ["_deserialize_graph_module", "_CodeOnlyModule"]):
                 inputs.update(self._generate_dummy_input(root, input_name, shape))
             else:
                 raise RuntimeError(


### PR DESCRIPTION
# What does this PR do?

There is a new `_CodeOnlyModule` type introduced in nightly torch (I have no idea about this). Need an update on our code to make `torch.fx` work for nightly (and future) torch.

Current error:

```
tests/models/layoutlm/test_modeling_layoutlm.py::LayoutLMModelTest::test_torch_fx
(line 753)  AssertionError: Couldn't serialize / deserialize the traced model: Could not generate input named bbox for because root is not a transformers.PreTrainedModel.
```