### PR TITLE
Skip `test_onnx_runtime_optimize` for now

### DIFF
--- a/tests/test_modeling_tf_common.py
+++ b/tests/test_modeling_tf_common.py
@@ -330,6 +330,9 @@ class TFModelTesterMixin:
 
             self.assertEqual(len(incompatible_ops), 0, incompatible_ops)
 
+    # `tf2onnx` issue page: https://github.com/onnx/tensorflow-onnx/issues/2172
+    # TODO: undo skip once a fix is done in `tf2onnx`
+    @unittest.skip("`tf2onnx` broke with TF 2.13")
     @require_tf2onnx
     @slow
     def test_onnx_runtime_optimize(self):


### PR DESCRIPTION
# What does this PR do?

`tf2onnx` has issue with `TF 2.13`, so let's skip them for now.

Note we have delegated the (pytorch) ONNX tests to Optimum, see [here](https://github.com/huggingface/transformers/pull/24800#issuecomment-1634822781), and it's like we will do this for the TF ONNX tests too (once @michaelbenayoun confirms this).