### PR TITLE
[`TokenizerFast`] Fix setting prefix space in __init__

### DIFF
--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -131,10 +131,16 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             **kwargs,
         )
         pre_tok_state = json.loads(self.backend_tokenizer.pre_tokenizer.__getstate__())
-        if pre_tok_state.get("add_prefix_space", add_prefix_space) != add_prefix_space:
-            pre_tok_class = getattr(pre_tokenizers, pre_tok_state.pop("type"))
-            pre_tok_state["add_prefix_space"] = add_prefix_space
-            self.backend_tokenizer.pre_tokenizer = pre_tok_class(**pre_tok_state)
+
+        pre_tok_class = getattr(pre_tokenizers, pre_tok_state.pop("type"))
+        if pre_tok_class == "Sequence":
+            for pre_tok in pre_tok_state.get("pretokenizers"):
+                if hasattr(pre_tok, "add_prefix_space"):
+                    pre_tok["add_prefix_space"] = add_prefix_space
+        elif hasattr(pre_tok, "add_prefix_space"):
+            pre_tok["add_prefix_space"] = add_prefix_space
+
+        self.backend_tokenizer.pre_tokenizer = pre_tok_class(**pre_tok_state)
 
         self.add_prefix_space = add_prefix_space
 

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -128,12 +128,15 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
             **kwargs,
         )
-        # overwride add_prefix_space
         pre_tok_state = pickle.dumps(self.backend_tokenizer.pre_tokenizer)
+        decoder_state = pickle.dumps(self.backend_tokenizer.decoder)
+
         if add_prefix_space:
-            pre_tok_state = pre_tok_state.replace(b'"add_prefix_space":false',b'"add_prefix_space": true')
-            # TODO decoder should also be udpated to reflect this
+            pre_tok_state = pre_tok_state.replace(b'"add_prefix_space":false', b'"add_prefix_space": true')
+            decoder_state = pre_tok_state.replace(b'"add_prefix_space":false', b'"add_prefix_space": true')
         self.backend_tokenizer.pre_tokenizer = pickle.loads(pre_tok_state)
+        self.backend_tokenizer.decoder = pickle.loads(decoder_state)
+
         self.add_prefix_space = add_prefix_space
 
     def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -128,11 +128,10 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
             **kwargs,
         )
+        # overwride add_prefix_space
         pre_tok_state = pickle.dumps(self.backend_tokenizer.pre_tokenizer)
         if add_prefix_space:
-            pre_tok_state.replace(b'"add_prefix_space":false',b'"add_prefix_space":true')
-        else:
-            pre_tok_state.replace(b'"add_prefix_space":true',b'"add_prefix_space":false')
+            pre_tok_state = pre_tok_state.replace(b'"add_prefix_space":false',b'"add_prefix_space": true')
         self.backend_tokenizer.pre_tokenizer = pickle.loads(pre_tok_state)
         self.add_prefix_space = add_prefix_space
 

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -132,6 +132,7 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
         pre_tok_state = pickle.dumps(self.backend_tokenizer.pre_tokenizer)
         if add_prefix_space:
             pre_tok_state = pre_tok_state.replace(b'"add_prefix_space":false',b'"add_prefix_space": true')
+            # TODO decoder should also be udpated to reflect this
         self.backend_tokenizer.pre_tokenizer = pickle.loads(pre_tok_state)
         self.add_prefix_space = add_prefix_space
 

--- a/src/transformers/models/bloom/tokenization_bloom_fast.py
+++ b/src/transformers/models/bloom/tokenization_bloom_fast.py
@@ -128,6 +128,8 @@ class BloomTokenizerFast(PreTrainedTokenizerFast):
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
             **kwargs,
         )
+        # TODO @ArthurZucker this can only work one way for now, to update later-on. Tests should also properly
+        # check this as they were green before.
         pre_tok_state = pickle.dumps(self.backend_tokenizer.pre_tokenizer)
         decoder_state = pickle.dumps(self.backend_tokenizer.decoder)
 


### PR DESCRIPTION
# What does this PR do?
Fixes #24846. For Sequence tokenizer, the previous solution was never doing anything. 