### PR TITLE
[`Tests`] Fix failing 8bit test

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -50,6 +50,9 @@ RUN python3 -m pip install --no-cache-dir bitsandbytes
 # Add auto-gptq for gtpq quantization testing
 RUN python3 -m pip install --no-cache-dir auto-gptq 
 
+# Add einops for additional model testing
+RUN python3 -m pip install --no-cache-dir einops
+
 # For bettertransformer + gptq 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/optimum@main#egg=optimum
 


### PR DESCRIPTION
# What does this PR do?

Fixes two failing tests in https://github.com/huggingface/transformers/actions/runs/5873964880/job/15928072870 

- `tests/quantization/bnb/test_mixed_int8.py::MixedInt8Test::test_get_keys_to_not_convert` & `tests/quantization/bnb/test_mixed_int8.py::MixedInt8GPT2Test::test_get_keys_to_not_convert`

Context: https://github.com/huggingface/transformers/pull/25105 added stronger checks to enable the correct quantization of models on the Hub. [Therefore it added a test that checks if `mpt-7b` is correctly quantized](https://github.com/huggingface/transformers/blob/main/tests/quantization/bnb/test_mixed_int8.py#L141). Since that model requires einops to be added as a dependency I propose to simply add einops in the docker image

cc @ydshieh 