### PR TITLE
Revert "change version (#25387)"

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2883,10 +2883,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model = replace_with_bnb_linear(
                 model, modules_to_not_convert=modules_to_not_convert, quantization_config=quantization_config
             )
-            # training in 8-bit is only available in 0.37.0+ but a major bug in 8-bit optimizers was fixed in 0.41.1
+            # training in 8-bit is only available in 0.37.0+
             model._is_quantized_training_enabled = version.parse(
                 importlib.metadata.version("bitsandbytes")
-            ) >= version.parse("0.41.1")
+            ) >= version.parse("0.37.0")
 
             model.config.quantization_config = quantization_config
             model.is_8bit_serializable = is_8bit_serializable

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -404,7 +404,7 @@ class Trainer:
             else:
                 raise ValueError(
                     "The model you want to train is loaded in 8-bit precision.  if you want to fine-tune an 8-bit"
-                    " model, please make sure that you have installed `bitsandbytes>=0.41.1`. "
+                    " model, please make sure that you have installed `bitsandbytes>=0.37.0`. "
                 )
 
         # Setup Sharded DDP training


### PR DESCRIPTION
# What does this PR do?

This PR revert  #25387. As @younesbelkada  pointed [out](https://github.com/huggingface/transformers/pull/25387#pullrequestreview-1582170053), the training still works as expected if we don't use 8-bit optimizers. I will propose a fix in a follow-up PR. 
