### PR TITLE
Skip `test_contrastive_generate` for `TFXLNet`

### DIFF
--- a/tests/models/xlnet/test_modeling_tf_xlnet.py
+++ b/tests/models/xlnet/test_modeling_tf_xlnet.py
@@ -365,6 +365,11 @@ class TFXLNetModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_head_masking = False
     test_onnx = False
 
+    # TODO (joao): fix this if possible
+    @unittest.skip("XLNet has special cache mechanism and is currently not working with contrastive generation")
+    def test_contrastive_generate(self):
+        super().test_contrastive_generate()
+
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name

--- a/tests/models/xlnet/test_modeling_tf_xlnet.py
+++ b/tests/models/xlnet/test_modeling_tf_xlnet.py
@@ -365,10 +365,11 @@ class TFXLNetModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_head_masking = False
     test_onnx = False
 
-    # TODO (joao): fix this if possible
+    # Note that `TFXLNetModelTest` is not a subclass of `GenerationTesterMixin`, so no contrastive generation tests
+    # from there is run against `TFXLNetModel`.
     @unittest.skip("XLNet has special cache mechanism and is currently not working with contrastive generation")
-    def test_contrastive_generate(self):
-        super().test_contrastive_generate()
+    def test_xla_generate_contrastive(self):
+        super().test_xla_generate_contrastive()
 
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(


### PR DESCRIPTION
# What does this PR do?

This model has special cache mechanism and `test_contrastive_generate` fails for more than 8 month. When I remove the argument `penalty_alpha` from the kwargs, it is able to generate something.

