### PR TITLE
add warning for 8bit optimizers

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -134,6 +134,7 @@ from .utils import (
     find_labels,
     is_accelerate_available,
     is_apex_available,
+    is_bitsandbytes_available,
     is_datasets_available,
     is_in_notebook,
     is_ipex_available,
@@ -1090,7 +1091,9 @@ class Trainer:
                 optimizer_kwargs.update(bnb_kwargs)
             except ImportError:
                 raise ValueError("Trainer tried to instantiate bnb optimizer but bnb is not installed!")
-            if version.parse(importlib.metadata.version("bitsandbytes")) < version.parse("0.41.1"):
+            if is_bitsandbytes_available() and version.parse(
+                importlib.metadata.version("bitsandbytes")
+            ) < version.parse("0.41.1"):
                 logger.warning(
                     "You are using 8-bit optimizers with a version of `bitsandbytes` < 0.41.1. "
                     "It is recommended to update your version as a major bug has been fixed in 8-bit optimizers."

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -20,6 +20,7 @@ import contextlib
 import copy
 import functools
 import glob
+import importlib.metadata
 import inspect
 import math
 import os
@@ -1089,6 +1090,11 @@ class Trainer:
                 optimizer_kwargs.update(bnb_kwargs)
             except ImportError:
                 raise ValueError("Trainer tried to instantiate bnb optimizer but bnb is not installed!")
+            if version.parse(importlib.metadata.version("bitsandbytes")) < version.parse("0.41.1"):
+                logger.warning(
+                    "You are using 8-bit optimizers with a version of `bitsandbytes` < 0.41.1. "
+                    "It is recommended to update your version as a major bug has been fixed in 8-bit optimizers."
+                )
         elif args.optim == OptimizerNames.ADAMW_ANYPRECISION:
             try:
                 from torchdistx.optimizers import AnyPrecisionAdamW


### PR DESCRIPTION
# What does this PR do ? 
This PR adds a log when 8-bit optimizers are used with a version of bitsandbytes < 0.41.1. We do that because a major bug was fixed for 8-bit optimizers as reported by [Tim](https://twitter.com/Tim_Dettmers/status/1687458541643390976). 