### PR TITLE
Support specifying revision in push_to_hub

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -32,6 +32,7 @@ import huggingface_hub
 import requests
 from huggingface_hub import (
     CommitOperationAdd,
+    create_branch,
     create_commit,
     create_repo,
     get_hf_file_metadata,
@@ -722,6 +723,7 @@ class PushToHubMixin:
         commit_message: Optional[str] = None,
         token: Optional[Union[bool, str]] = None,
         create_pr: bool = False,
+        revision: str = None,
     ):
         """
         Uploads all modified files in `working_dir` to `repo_id`, based on `files_timestamps`.
@@ -768,9 +770,17 @@ class PushToHubMixin:
                     CommitOperationAdd(path_or_fileobj=os.path.join(working_dir, file), path_in_repo=file)
                 )
 
+        if revision is not None:
+            create_branch(repo_id=repo_id, branch=revision, token=token, exist_ok=True)
+
         logger.info(f"Uploading the following files to {repo_id}: {','.join(modified_files)}")
         return create_commit(
-            repo_id=repo_id, operations=operations, commit_message=commit_message, token=token, create_pr=create_pr
+            repo_id=repo_id,
+            operations=operations,
+            commit_message=commit_message,
+            token=token,
+            create_pr=create_pr,
+            revision=revision,
         )
 
     def push_to_hub(
@@ -783,6 +793,7 @@ class PushToHubMixin:
         max_shard_size: Optional[Union[int, str]] = "10GB",
         create_pr: bool = False,
         safe_serialization: bool = False,
+        revision: str = None,
         **deprecated_kwargs,
     ) -> str:
         """
@@ -811,6 +822,8 @@ class PushToHubMixin:
                 Whether or not to create a PR with the uploaded files or directly commit.
             safe_serialization (`bool`, *optional*, defaults to `False`):
                 Whether or not to convert the model weights in safetensors format for safer serialization.
+            revision (`str`, *optional*):
+                Branch to push the uploaded files to.
 
         Examples:
 
@@ -886,6 +899,7 @@ class PushToHubMixin:
                 commit_message=commit_message,
                 token=token,
                 create_pr=create_pr,
+                revision=revision,
             )
 
 


### PR DESCRIPTION
Resolves https://github.com/huggingface/transformers/issues/22867 by adding revision to `create_commit` call and proactively creating the branch before committing.

Change hasn't been discussed or approved in an issue AFAIK.  Haven't written tests but happy to once the general approach is approved.  I've tested manually and the changes work.