### PR TITLE
Added missing parenthesis in call to is_fsdp_enabled

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -468,7 +468,7 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
         return safe_load_file(checkpoint_file)
     try:
         if (
-            (is_deepspeed_zero3_enabled() or is_fsdp_enabled)
+            (is_deepspeed_zero3_enabled() or is_fsdp_enabled())
             and torch.distributed.is_initialized()
             and torch.distributed.get_rank() > 0
         ):


### PR DESCRIPTION
Calling function is_fsdp_enabled instead of checking if it is not None

# What does this PR do?
It adds the missing parenthesis

Fixes #25584

## Who can review?
@ArthurZucker @younesbelkada

