### PR TITLE
Fix ExponentialDecayLengthPenalty negative logits issue

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1315,7 +1315,7 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
     ```python
     >>> from transformers import AutoTokenizer, AutoModelForCausalLM, set_seed
 
-    >>> set_seed(0)
+    >>> set_seed(1)
     >>> model = AutoModelForCausalLM.from_pretrained("gpt2")
     >>> tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
@@ -1326,7 +1326,7 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
     >>> # see that the answer tends to end abruptly
     >>> outputs = model.generate(**inputs, do_sample=True, temperature=0.9, max_length=30, pad_token_id=50256)
     >>> print(tokenizer.batch_decode(outputs)[0])
-    Just wanted to let you know, I'm doing great, but my plan of getting to the bottom of this is to start with the data that we
+    Just wanted to let you know, I'm not even a lawyer. I'm a man. I have no real knowledge of politics. I'm a
 
     >>> # Generate sequences with exponential penalty, we add the exponential_decay_length_penalty=(start_index, decay_factor)
     >>> # We see that instead of cutting at max_tokens, the output comes to an end before (at 25 tokens) and with more meaning
@@ -1337,23 +1337,22 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
     ...     temperature=0.9,
     ...     max_length=30,
     ...     pad_token_id=50256,
-    ...     exponential_decay_length_penalty=(15, 1.5),
+    ...     exponential_decay_length_penalty=(15, 1.6),
     ... )
     >>> print(tokenizer.batch_decode(outputs)[0])
-    Just wanted to let you know, I can't guarantee it is a "proper" version, but it works fine<|endoftext|>
+    Just wanted to let you know, I've got a very cool t-shirt educating people on how to use the Internet<|endoftext|>
 
-    >>> # Generate sequences with smaller decay_factor
-    >>> # We see that this allows the output to be longer, but still improves the hard cutoff mid-sentence
+    >>> # Generate sequences with smaller decay_factor, still improving the hard cutoff mid-sentence
     >>> outputs = model.generate(
     ...     **inputs,
     ...     do_sample=True,
     ...     temperature=0.9,
     ...     max_length=30,
     ...     pad_token_id=50256,
-    ...     exponential_decay_length_penalty=(15, 1.01),
+    ...     exponential_decay_length_penalty=(15, 1.05),
     ... )
     >>> print(tokenizer.batch_decode(outputs)[0])
-    Just wanted to let you know, I've done a bunch of research into this, and you should check out the new page for more details.<|endoftext|>
+    Just wanted to let you know, I've been working on it for about 6 months and now it's in Alpha.<|endoftext|>
     ```
     """
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1326,20 +1326,34 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
     >>> # see that the answer tends to end abruptly
     >>> outputs = model.generate(**inputs, do_sample=True, temperature=0.9, max_length=30, pad_token_id=50256)
     >>> print(tokenizer.batch_decode(outputs)[0])
-    'Just wanted to let you know, I'm doing great, but my plan of getting to the bottom of this is to start with the data that we'
+    Just wanted to let you know, I'm doing great, but my plan of getting to the bottom of this is to start with the data that we
 
     >>> # Generate sequences with exponential penalty, we add the exponential_decay_length_penalty=(start_index, decay_factor)
     >>> # We see that instead of cutting at max_tokens, the output comes to an end before (at 25 tokens) and with more meaning
     >>> # What happens is that starting from `start_index` the EOS token score will be increased by decay_factor exponentially
-    >>> outputs = model.generate(**inputs, do_sample=True, temperature=0.9, max_length=30, pad_token_id=50256, exponential_decay_length_penalty=(15, 1.5))
+    >>> outputs = model.generate(
+    ...     **inputs,
+    ...     do_sample=True,
+    ...     temperature=0.9,
+    ...     max_length=30,
+    ...     pad_token_id=50256,
+    ...     exponential_decay_length_penalty=(15, 1.5),
+    ... )
     >>> print(tokenizer.batch_decode(outputs)[0])
-    'Just wanted to let you know, I can't guarantee it is a "proper" version, but it works fine<|endoftext|>'
+    Just wanted to let you know, I can't guarantee it is a "proper" version, but it works fine<|endoftext|>
 
     >>> # Generate sequences with smaller decay_factor
     >>> # We see that this allows the output to be longer, but still improves the hard cutoff mid-sentence
-    >>> outputs = model.generate(**inputs, do_sample=True, temperature=0.9, max_length=30, pad_token_id=50256, exponential_decay_length_penalty=(15, 1.01))
+    >>> outputs = model.generate(
+    ...     **inputs,
+    ...     do_sample=True,
+    ...     temperature=0.9,
+    ...     max_length=30,
+    ...     pad_token_id=50256,
+    ...     exponential_decay_length_penalty=(15, 1.01),
+    ... )
     >>> print(tokenizer.batch_decode(outputs)[0])
-    'Just wanted to let you know, I've done a bunch of research into this, and you should check out the new page for more details.<|endoftext|>'
+    Just wanted to let you know, I've done a bunch of research into this, and you should check out the new page for more details.<|endoftext|>
     ```
     """
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1327,7 +1327,9 @@ class ExponentialDecayLengthPenalty(LogitsProcessor):
         cur_len = input_ids.shape[-1]
         if cur_len > self.regulation_start:
             for i in self.eos_token_id:
-                scores[:, i] = scores[:, i] * pow(self.regulation_factor, cur_len - self.regulation_start)
+                penalty_idx = cur_len - self.regulation_start
+                # To support negative logits we compute the penalty of the absolute value and add to the original logit
+                scores[:, i] = scores[:, i] + torch.abs(scores[:, i]) * (pow(self.regulation_factor, penalty_idx) - 1)
         return scores
 
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1297,8 +1297,8 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
 
 class ExponentialDecayLengthPenalty(LogitsProcessor):
     r"""
-    [`LogitsProcessor`] that exponentially increases the score of the eos_token_id after start_index has been reached.
-    This allows generating shorter sequences without having a hard cutoff, allowing the eos_token to be predicted in a
+    [`LogitsProcessor`] that exponentially increases the score of the `eos_token_id` after `start_index` has been reached.
+    This allows generating shorter sequences without having a hard cutoff, allowing the `eos_token` to be predicted in a
     meaningful position.
 
     Args:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1297,9 +1297,9 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
 
 class ExponentialDecayLengthPenalty(LogitsProcessor):
     r"""
-    [`LogitsProcessor`] that exponentially increases the score of the `eos_token_id` after `start_index` has been reached.
-    This allows generating shorter sequences without having a hard cutoff, allowing the `eos_token` to be predicted in a
-    meaningful position.
+    [`LogitsProcessor`] that exponentially increases the score of the `eos_token_id` after `start_index` has been
+    reached. This allows generating shorter sequences without having a hard cutoff, allowing the `eos_token` to be
+    predicted in a meaningful position.
 
     Args:
         exponential_decay_length_penalty (`tuple(int, float)`):

--- a/tests/generation/test_logits_process.py
+++ b/tests/generation/test_logits_process.py
@@ -717,18 +717,23 @@ class LogitsProcessorTest(unittest.TestCase):
 
         # check that penalty is not applied before start
         scores = self._get_uniform_logits(batch_size, vocab_size)
-        scores_before_start = length_decay_processor(input_ids, scores)
+        scores_before_start = torch.clone(scores)  # clone scores as precessor updates them inplace
+        scores_before_start = length_decay_processor(input_ids, scores_before_start)
         self.assertListEqual(scores_before_start[:, eos_token_id].tolist(), scores[:, eos_token_id].tolist())
 
         # check that penalty is applied after start
         input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
         scores = self._get_uniform_logits(batch_size, vocab_size)
-        scores_after_start = length_decay_processor(input_ids, scores)
-        self.assertTrue(
-            torch.gt(
-                scores_after_start[penalty_start + 1 :, eos_token_id], scores[penalty_start + 1 :, eos_token_id]
-            ).all()
-        )
+        scores_after_start = torch.clone(scores)  # clone scores as precessor updates them inplace
+        scores_after_start = length_decay_processor(input_ids, scores_after_start)
+        self.assertTrue(torch.gt(scores_after_start[:, eos_token_id], scores[:, eos_token_id]).all())
+
+        # check the penalty increases negative scores
+        input_ids = ids_tensor((batch_size, 20), vocab_size=vocab_size)
+        scores = torch.neg(self._get_uniform_logits(batch_size, vocab_size))
+        scores_after_start = torch.clone(scores)  # clone scores as precessor updates them inplace
+        scores_after_start = length_decay_processor(input_ids, scores_after_start)
+        self.assertTrue(torch.gt(scores_after_start[:, eos_token_id], scores[:, eos_token_id]).all())
 
     def test_normalization(self):
         input_ids = None


### PR DESCRIPTION
# What does this PR do?

In cases where the model logits are negative, ExponentialDecayLengthPenalty decreases the score of eos_token_id instead of increasing it.
To fix this issue we compute the penalty of the absolute value and add it to the original score, as described in #25416
The test was updated to check for negative logits.

In addition, this PR updates the class documentation and adds examples, as part of #24783

Fixes #25416


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@gante 
