### PR TITLE
Fix test_modeling_mpt typo in model id

### DIFF
--- a/tests/models/mpt/test_modeling_mpt.py
+++ b/tests/models/mpt/test_modeling_mpt.py
@@ -95,7 +95,7 @@ class MptModelTester:
         self.pad_token_id = vocab_size - 1
 
     def get_large_model_config(self):
-        return MptConfig.from_pretrained("mosaicml/mpt-7")
+        return MptConfig.from_pretrained("mosaicml/mpt-7b")
 
     def prepare_config_and_inputs(self, gradient_checkpointing=False):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)


### PR DESCRIPTION
# What does this PR do?

Currently, the method `get_large_model_config` tries to download `mosaicml/mpt-7` model config, which is not found, rest of the file uses `mosaicml/mpt-7b`, which works. This seems like a typo.
## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker 
