### PR TITLE
[Whisper] Fix word-level timestamps for audio < 30 seconds

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1606,7 +1606,8 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
                 `return_timestamps` option. To get word-level timestamps, use the tokenizer to group the tokens into
                 words.
             num_frames (`float`, *optional*):
-                The number of audio frames available in this chunk. This is only used when generating word-level timestamps.
+                The number of audio frames available in this chunk. This is only used when generating word-level
+                timestamps.
             kwargs (`Dict[str, Any]`, *optional*):
                 Ad hoc parametrization of `generate_config` and/or additional model-specific kwargs that will be
                 forwarded to the `forward` function of the model. If the model is an encoder-decoder model, encoder

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1742,6 +1742,9 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
             forced_decoder_ids = [(rank + 1, token) for rank, token in enumerate(forced_decoder_ids)]
             generation_config.forced_decoder_ids = forced_decoder_ids
 
+        if num_frames is not None:
+            generation_config.num_frames = num_frames
+
         if generation_config.return_timestamps:
             logits_processor = [WhisperTimeStampLogitsProcessor(generation_config)]
 
@@ -1768,6 +1771,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         )
 
         if return_token_timestamps and hasattr(generation_config, "alignment_heads"):
+            num_frames = getattr(generation_config, "num_frames", None)
             outputs["token_timestamps"] = self._extract_token_timestamps(
                 outputs, generation_config.alignment_heads, num_frames=num_frames
             )

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1606,7 +1606,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
                 `return_timestamps` option. To get word-level timestamps, use the tokenizer to group the tokens into
                 words.
             num_frames (`float`, *optional*):
-                The number of audio frames available in this chunk. This is only used generating word-level timestamps.
+                The number of audio frames available in this chunk. This is only used when generating word-level timestamps.
             kwargs (`Dict[str, Any]`, *optional*):
                 Ad hoc parametrization of `generate_config` and/or additional model-specific kwargs that will be
                 forwarded to the `forward` function of the model. If the model is an encoder-decoder model, encoder

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1768,7 +1768,9 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         )
 
         if return_token_timestamps and hasattr(generation_config, "alignment_heads"):
-            outputs["token_timestamps"] = self._extract_token_timestamps(outputs, generation_config.alignment_heads, num_frames=num_frames)
+            outputs["token_timestamps"] = self._extract_token_timestamps(
+                outputs, generation_config.alignment_heads, num_frames=num_frames
+            )
 
         return outputs
 
@@ -1819,7 +1821,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         weights = torch.stack([cross_attentions[l][:, h] for l, h in alignment_heads])
         weights = weights.permute([1, 0, 2, 3])
         if num_frames is not None:
-            weights = weights[..., :num_frames // 2]
+            weights = weights[..., : num_frames // 2]
 
         # Normalize and smoothen the weights.
         std, mean = torch.std_mean(weights, dim=-2, keepdim=True, unbiased=False)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -523,15 +523,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         if generate_kwargs is None:
             generate_kwargs = {}
 
-        if return_timestamps and self.type == "seq2seq_whisper":
-            generate_kwargs["return_timestamps"] = return_timestamps
-            if return_timestamps == "word":
-                generate_kwargs["return_token_timestamps"] = True
-
-                stride = model_inputs.get("stride")
-                if stride is not None:
-                    generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
-
+        attention_mask = model_inputs.pop("attention_mask", None)
+        stride = model_inputs.pop("stride", None)
         is_last = model_inputs.pop("is_last")
 
         if self.type in {"seq2seq", "seq2seq_whisper"}:
@@ -548,11 +541,15 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                     f"`input_features` or `input_values` key, but only has {model_inputs.keys()}"
                 )
 
-            # we need to pass `processed.get("attention_mask")` here since audio encoder
-            # attention mask  length is different from expected text decoder `encoder_attention_mask` length
-            # `generate` magic to create the mask automatically won't work, we basically need to help
-            # it here.
-            attention_mask = model_inputs.pop("attention_mask", None)
+            # custom processing for Whisper timestamps and word-level timestamps
+            if return_timestamps and self.type == "seq2seq_whisper":
+                generate_kwargs["return_timestamps"] = return_timestamps
+                if return_timestamps == "word":
+                    generate_kwargs["return_token_timestamps"] = True
+
+                    if stride is not None:
+                        generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
+
             tokens = self.model.generate(
                 encoder_outputs=encoder(inputs, attention_mask=attention_mask),
                 attention_mask=attention_mask,
@@ -563,14 +560,11 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             else:
                 out = {"tokens": tokens}
             if self.type == "seq2seq_whisper":
-                stride = model_inputs.pop("stride", None)
                 if stride is not None:
                     out["stride"] = stride
 
         else:
-            stride = model_inputs.pop("stride", None)
             input_values = model_inputs.pop("input_values")
-            attention_mask = model_inputs.pop("attention_mask", None)
             outputs = self.model(input_values=input_values, attention_mask=attention_mask)
             logits = outputs.logits
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -527,6 +527,11 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             generate_kwargs["return_timestamps"] = return_timestamps
             if return_timestamps == "word":
                 generate_kwargs["return_token_timestamps"] = True
+
+                stride = model_inputs.get("stride")
+                if stride is not None:
+                    generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
+
         is_last = model_inputs.pop("is_last")
 
         if self.type in {"seq2seq", "seq2seq_whisper"}:

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -299,6 +299,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer(filename)
         self.assertEqual(output, {"text": "A MAN SAID TO THE UNIVERSE SIR I EXIST"})
 
+    @slow
     @require_torch
     def test_return_timestamps_in_preprocess(self):
         pipe = pipeline(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -324,7 +324,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         pipe.model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
         res = pipe(sample["audio"]["array"], return_timestamps="word")
 
-        self.assertEqual.__self__.maxDiff = None
         # fmt: off
         self.assertEqual(
             res,
@@ -332,13 +331,13 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
                 "text": " Conquered returned to its place amidst the tents.",
                 "chunks": [
                     {"text": " Conquered", "timestamp": (0.5, 1.2)},
-                    {"text": " returned", "timestamp": (1.2, 1.62)},
-                    {"text": " to", "timestamp": (1.62, 1.88)},
-                    {"text": " its", "timestamp": (1.88, 2.02)},
-                    {"text": " place", "timestamp": (2.02, 2.3)},
-                    {"text": " amidst", "timestamp": (2.3, 2.84)},
-                    {"text": " the", "timestamp": (2.84, 2.98)},
-                    {"text": " tents.", "timestamp": (2.98, 3.5)},
+                    {"text": " returned", "timestamp": (1.2, 1.64)},
+                    {"text": " to", "timestamp": (1.64, 1.84)},
+                    {"text": " its", "timestamp": (1.84, 2.02)},
+                    {"text": " place", "timestamp": (2.02, 2.28)},
+                    {"text": " amidst", "timestamp": (2.28, 2.78)},
+                    {"text": " the", "timestamp": (2.78, 2.96)},
+                    {"text": " tents.", "timestamp": (2.96, 3.48)}],
                 ],
             },
         )

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -324,6 +324,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         pipe.model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
         res = pipe(sample["audio"]["array"], return_timestamps="word")
 
+        print(f'{res=}')
         # fmt: off
         self.assertEqual(
             res,

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -317,8 +317,8 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(
             res,
             {
-                "text": " Conchord returned to its place amidst the tents.",
-                "chunks": [{"timestamp": (0.0, 3.36), "text": " Conchord returned to its place amidst the tents."}],
+                "text": " Conquered returned to its place amidst the tents.",
+                "chunks": [{"timestamp": (0.0, 3.36), "text": " Conquered returned to its place amidst the tents."}],
             },
         )
         pipe.model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
@@ -328,9 +328,9 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(
             res,
             {
-                "text": " Conchord returned to its place amidst the tents.",
+                "text": " Conquered returned to its place amidst the tents.",
                 "chunks": [
-                    {"text": " Conchord", "timestamp": (0.54, 1.2)},
+                    {"text": " Conquered", "timestamp": (0.54, 1.2)},
                     {"text": " returned", "timestamp": (1.2, 1.62)},
                     {"text": " to", "timestamp": (1.62, 1.88)},
                     {"text": " its", "timestamp": (1.88, 2.02)},

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -330,7 +330,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             {
                 "text": " Conquered returned to its place amidst the tents.",
                 "chunks": [
-                    {"text": " Conquered", "timestamp": (0.54, 1.2)},
+                    {"text": " Conquered", "timestamp": (0.5, 1.2)},
                     {"text": " returned", "timestamp": (1.2, 1.62)},
                     {"text": " to", "timestamp": (1.62, 1.88)},
                     {"text": " its", "timestamp": (1.88, 2.02)},

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -337,7 +337,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
                     {"text": " place", "timestamp": (2.02, 2.28)},
                     {"text": " amidst", "timestamp": (2.28, 2.78)},
                     {"text": " the", "timestamp": (2.78, 2.96)},
-                    {"text": " tents.", "timestamp": (2.96, 3.48)}],
+                    {"text": " tents.", "timestamp": (2.96, 3.48)},
                 ],
             },
         )

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -317,29 +317,29 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(
             res,
             {
-                "text": " Conquered returned to its place amidst the tents.",
-                "chunks": [{"text": " Conquered returned to its place amidst the tents.", "timestamp": (0.0, 3.36)}],
+                "text": " Conchord returned to its place amidst the tents.",
+                "chunks": [{"timestamp": (0.0, 3.36), "text": " Conchord returned to its place amidst the tents."}],
             },
         )
         pipe.model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
         res = pipe(sample["audio"]["array"], return_timestamps="word")
+
         # fmt: off
-        # Note that the word-level timestamps predicted here are pretty bad.
         self.assertEqual(
             res,
             {
-                "text": " Conquered returned to its place amidst the tents.",
+                "text": " Conchord returned to its place amidst the tents.",
                 "chunks": [
-                    {'text': ' Conquered', 'timestamp': (29.78, 29.9)},
-                    {'text': ' returned', 'timestamp': (29.9, 29.9)},
-                    {'text': ' to', 'timestamp': (29.9, 29.9)},
-                    {'text': ' its', 'timestamp': (29.9, 29.9)},
-                    {'text': ' place', 'timestamp': (29.9, 29.9)},
-                    {'text': ' amidst', 'timestamp': (29.9, 29.9)},
-                    {'text': ' the', 'timestamp': (29.9, 29.9)},
-                    {'text': ' tents.', 'timestamp': (29.9, 29.9)}
-                ]
-            }
+                    {"text": " Conchord", "timestamp": (0.54, 1.2)},
+                    {"text": " returned", "timestamp": (1.2, 1.62)},
+                    {"text": " to", "timestamp": (1.62, 1.88)},
+                    {"text": " its", "timestamp": (1.88, 2.02)},
+                    {"text": " place", "timestamp": (2.02, 2.3)},
+                    {"text": " amidst", "timestamp": (2.3, 2.84)},
+                    {"text": " the", "timestamp": (2.84, 2.98)},
+                    {"text": " tents.", "timestamp": (2.98, 3.5)},
+                ],
+            },
         )
         # fmt: on
 

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -324,7 +324,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         pipe.model.generation_config.alignment_heads = [[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]]
         res = pipe(sample["audio"]["array"], return_timestamps="word")
 
-        print(f'{res=}')
+        self.assertEqual.__self__.maxDiff = None
         # fmt: off
         self.assertEqual(
             res,


### PR DESCRIPTION
# What does this PR do?

In OpenAI's [original implementation for word-level timestamps](https://github.com/openai/whisper/blob/e8622f9afc4eba139bf796c210f5c01081000472/whisper/timing.py#L206), they crop the cross attentions before perform dynamic time warping (to only run the algorithm on valid audio; this prevents getting stuck when backtracking). The current transformers implementation misses this, so this PR fixes that.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Testing code:
```python
from transformers import pipeline
pipe = pipeline("automatic-speech-recognition", "openai/whisper-base")
url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/japanese-audio.wav'
output = pipe(url, return_timestamps="word", chunk_length_s=30, generate_kwargs={'language': 'japanese'})
print(output)
```

Fixed:
```
{
'text': '森長の美味しい牛乳は濃い青いように牛乳ビーンを足らった絶対にのパック牛乳である',
'chunks': [
  {'text': '森', 'timestamp': (0.18, 0.64)},
  {'text': '長', 'timestamp': (0.64, 0.82)},
  {'text': 'の', 'timestamp': (0.82, 1.04)},
  {'text': '美味', 'timestamp': (1.04, 1.2)},
  {'text': 'しい', 'timestamp': (1.2, 1.46)},
  {'text': '牛', 'timestamp': (1.46, 1.68)},
  {'text': '乳', 'timestamp': (1.68, 1.92)},
  {'text': 'は', 'timestamp': (1.92, 2.14)},
  {'text': '濃', 'timestamp': (2.14, 2.32)},
  {'text': 'い', 'timestamp': (2.32, 2.44)},
  {'text': '青', 'timestamp': (2.44, 2.64)},
  {'text': 'い', 'timestamp': (2.64, 2.76)},
  {'text': 'ように', 'timestamp': (2.76, 2.92)},
  {'text': '牛', 'timestamp': (2.92, 3.16)},
  {'text': '乳', 'timestamp': (3.16, 3.36)},
  {'text': 'ビ', 'timestamp': (3.36, 3.58)},
  {'text': 'ーン', 'timestamp': (3.58, 3.66)},
  {'text': 'を', 'timestamp': (3.66, 3.82)},
  {'text': '足', 'timestamp': (3.82, 4.0)},
  {'text': 'ら', 'timestamp': (4.0, 4.12)},
  {'text': 'った', 'timestamp': (4.12, 4.3)},
  {'text': '絶', 'timestamp': (4.3, 4.52)},
  {'text': '対', 'timestamp': (4.52, 4.68)},
  {'text': 'に', 'timestamp': (4.68, 4.78)},
  {'text': 'の', 'timestamp': (4.78, 4.94)},
  {'text': 'パ', 'timestamp': (4.94, 5.1)},
  {'text': 'ック', 'timestamp': (5.1, 5.2)},
  {'text': '牛', 'timestamp': (5.2, 5.44)},
  {'text': '乳', 'timestamp': (5.44, 5.64)},
  {'text': 'で', 'timestamp': (5.64, 5.84)},
  {'text': 'ある', 'timestamp': (5.84, 6.04)}
]
}
```

Previous (broken):
```
{
'text': '森長の美味しい牛乳は濃い青いように牛乳ビーンを足らった絶対にのパック牛乳である',
'chunks': [
  {'text': '森', 'timestamp': (29.98, 29.98)},
  {'text': '長', 'timestamp': (29.98, 29.98)},
  {'text': 'の', 'timestamp': (29.98, 29.98)},
  {'text': '美味', 'timestamp': (29.98, 29.98)},
  {'text': 'しい', 'timestamp': (29.98, 29.98)},
  {'text': '牛', 'timestamp': (29.98, 29.98)},
  {'text': '乳', 'timestamp': (29.98, 29.98)}, 
  'text': 'は', 'timestamp': (29.98, 29.98)},
  {'text': '濃', 'timestamp': (29.98, 29.98)},
  {'text': 'い', 'timestamp': (29.98, 29.98)},
  {'text': '青', 'timestamp': (29.98, 29.98)},
  {'text': 'い', 'timestamp': (29.98, 29.98)},
  {'text': 'ように', 'timestamp': (29.98, 29.98)},
  {'text': '牛', 'timestamp': (29.98, 29.98)},
  {'text': '乳', 'timestamp': (29.98, 29.98)},
  {'text': 'ビ', 'timestamp': (29.98, 29.98)},
  {'text': 'ーン', 'timestamp': (29.98, 29.98)},
  {'text': 'を', 'timestamp': (29.98, 29.98)},
  {'text': '足', 'timestamp': (29.98, 29.98)},
  {'text': 'ら', 'timestamp': (29.98, 29.98)},
  {'text': 'った', 'timestamp': (29.98, 29.98)},
  {'text': '絶', 'timestamp': (29.98, 29.98)},
  {'text': '対', 'timestamp': (29.98, 29.98)},
  {'text': 'に', 'timestamp': (29.98, 29.98)},
  {'text': 'の', 'timestamp': (29.98, 29.98)},
  {'text': 'パ', 'timestamp': (29.98, 29.98)},
  {'text': 'ック', 'timestamp': (29.98, 29.98)},
  {'text': '牛', 'timestamp': (29.98, 29.98)},
  {'text': '乳', 'timestamp': (29.98, 29.98)},
  {'text': 'で', 'timestamp': (29.98, 29.98)},
  {'text': 'ある', 'timestamp': (29.98, 29.98)}
]
}
```

<!-- Remove if not applicable -->

Fixes #25605  (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
@sanchit-gandhi @ArthurZucker 