### PR TITLE
Ignore all exceptions from signal in dynamic code

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -603,7 +603,7 @@ def resolve_trust_remote_code(trust_remote_code, model_name, has_local_code, has
                     elif answer.lower() in ["no", "n", "0", ""]:
                         trust_remote_code = False
                 signal.alarm(0)
-            except AttributeError:
+            except Exception:
                 # OS which does not support signal.SIGALRM
                 raise ValueError(
                     "Loading this model requires you to execute execute some code in that repo on your local machine. "


### PR DESCRIPTION
# What does this PR do?

#25613 shows we can have different exception types coming from `signal` when asking the user if they want to trust remote code or not. This PR ignores them all.
As a reminder this is only a convenience function trying to help the user that did not set `trust_remote_code=True`, so the errors all become "Please set `trust_remote_code`"