### PR TITLE
Fix PEFT integration failures on nightly CI

### DIFF
--- a/src/transformers/utils/peft_utils.py
+++ b/src/transformers/utils/peft_utils.py
@@ -59,7 +59,9 @@ def find_adapter_config_file(
             are on HuggingFace Hub. You might need to call `huggingface-cli login` and paste your tokens to cache it.
     """
     adapter_cached_filename = None
-    if os.path.isdir(model_id):
+    if model_id is None:
+        return None
+    elif os.path.isdir(model_id):
         list_remote_files = os.listdir(model_id)
         if ADAPTER_CONFIG_NAME in list_remote_files:
             adapter_cached_filename = os.path.join(model_id, ADAPTER_CONFIG_NAME)


### PR DESCRIPTION
# What does this PR do?

Fixes all failing CIs when PEFT is installed that has the error:

```bash
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

The failing tests are `test_from_pretrained_no_checkpoint` tests that calls `xxx.from_pretrained()` with model_id explicitly being to None. When PEFT is installed (which is the case in the daily CI runners since #25077 ) `from_pretrained` will look for adapter files in the model repo, and a check that ignores `model_id` if it is set to None was forgotten. 

cc @ydshieh @sgugger 
