### PR TITLE
Add missing Maskformer dataclass decorator, add dataclass check in ModelOutput for subclasses

### DIFF
--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -118,6 +118,7 @@ class MaskFormerPixelLevelModuleOutput(ModelOutput):
     decoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
 
 
+@dataclass
 class MaskFormerPixelDecoderOutput(ModelOutput):
     """
     MaskFormer's pixel decoder module output, practically a Feature Pyramid Network. It returns the last hidden state

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -20,7 +20,7 @@ import tempfile
 from collections import OrderedDict, UserDict
 from collections.abc import MutableMapping
 from contextlib import ExitStack, contextmanager
-from dataclasses import fields
+from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any, ContextManager, List, Tuple
 
@@ -263,7 +263,28 @@ class ModelOutput(OrderedDict):
                 lambda values, context: cls(**torch.utils._pytree._dict_unflatten(values, context)),
             )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Subclasses of ModelOutput must use the @dataclass decorator
+        # This check is done in __init__ because the @dataclass decorator operates after __init_subclass__
+        # issubclass() would return True for issubclass(ModelOutput, ModelOutput) when False is needed
+        # Just need to check that the current class is not ModelOutput
+        is_modeloutput_subclass = self.__class__ != ModelOutput
+
+        if is_modeloutput_subclass and not is_dataclass(self):
+            raise TypeError(
+                (
+                    f"{self.__module__}.{self.__class__.__name__} is not a dataclasss."
+                    " This is a subclass of ModelOutput and so must use the @dataclass decorator."
+                )
+            )
+
     def __post_init__(self):
+        """Check the ModelOutput dataclass.
+
+        Only occurs if @dataclass decorator has been used.
+        """
         class_fields = fields(self)
 
         # Safety and consistency checks

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -274,10 +274,8 @@ class ModelOutput(OrderedDict):
 
         if is_modeloutput_subclass and not is_dataclass(self):
             raise TypeError(
-                (
-                    f"{self.__module__}.{self.__class__.__name__} is not a dataclasss."
-                    " This is a subclass of ModelOutput and so must use the @dataclass decorator."
-                )
+                f"{self.__module__}.{self.__class__.__name__} is not a dataclasss."
+                " This is a subclass of ModelOutput and so must use the @dataclass decorator."
             )
 
     def __post_init__(self):

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -17,6 +17,8 @@ import unittest
 from dataclasses import dataclass
 from typing import Optional
 
+import pytest
+
 from transformers.testing_utils import require_torch
 from transformers.utils import ModelOutput
 
@@ -143,3 +145,23 @@ class ModelOutputTester(unittest.TestCase):
 
         unflattened_x = torch.utils._pytree.tree_unflatten(actual_flat_outs, actual_tree_spec)
         self.assertEqual(x, unflattened_x)
+
+
+class ModelOutputTestNoDataclass(ModelOutput):
+    """Invalid test subclass of ModelOutput where @dataclass decorator is not used"""
+
+    a: float
+    b: Optional[float] = None
+    c: Optional[float] = None
+
+
+class ModelOutputSubclassTester(unittest.TestCase):
+    def test_direct_model_output(self):
+        # Check that direct usage of ModelOutput instantiates without errors
+        ModelOutput({"a": 1.1})
+
+    def test_subclass_no_dataclass(self):
+        # Check that a subclass of ModelOutput without @dataclass is invalid
+        # A valid subclass is inherently tested other unit tests above.
+        with pytest.raises(TypeError):
+            ModelOutputTestNoDataclass(a=1.1, b=2.2, c=3.3)

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -17,8 +17,6 @@ import unittest
 from dataclasses import dataclass
 from typing import Optional
 
-import pytest
-
 from transformers.testing_utils import require_torch
 from transformers.utils import ModelOutput
 
@@ -163,5 +161,5 @@ class ModelOutputSubclassTester(unittest.TestCase):
     def test_subclass_no_dataclass(self):
         # Check that a subclass of ModelOutput without @dataclass is invalid
         # A valid subclass is inherently tested other unit tests above.
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             ModelOutputTestNoDataclass(a=1.1, b=2.2, c=3.3)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # https://github.com/huggingface/transformers/issues/25504


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @sgugger

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam

Documentation: @sgugger, @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: @sgugger
- TensorFlow: @Rocketknight1

 -->
@amyeroberts 

Some additional notes:
* I tried finding a way to find all subclasses of `ModelOutput` that could be tested in one unittest to check to see if they were a `dataclass`, but this may not be possible without finding all files that use `ModelOutput` and importing each subclass. I instead opted for a check inside `ModelOutput` that happens if a subclass is instantiated.
* One problem I ran into was that `Pipeline` uses `ModelOutput` directly: https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/base.py#L933. This is not a true `dataclass`, so `dataclasses` utilities such as `is_dataclass` cannot be reliably used. The checks done in `ModelOutput.__post_init__` would not be executed because `__post_init__` is a `dataclass`-specific dunder. This makes me think there should be a separate `PipelineOutput` class that can be created from a `ModelOutput` to create a true `dataclass`, or a class method in `ModelOutput` that creates a true `dataclass` given arguments similar as ones for `OrderedDict`. However, I don't know what the potential impacts could be since I don't know all the inner workings of `transformers.`