### PR TITLE
removing unnecesssary extra parameter

### DIFF
--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -1314,9 +1314,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
             ]
             if annotations is not None:
                 annotations = [
-                    self.normalize_annotation(
-                        annotation, get_image_size(image, input_data_format), input_data_format=input_data_format
-                    )
+                    self.normalize_annotation(annotation, get_image_size(image, input_data_format))
                     for annotation, image in zip(annotations, images)
                 ]
 

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -1312,9 +1312,7 @@ class DeformableDetrImageProcessor(BaseImageProcessor):
             ]
             if annotations is not None:
                 annotations = [
-                    self.normalize_annotation(
-                        annotation, get_image_size(image, input_data_format), input_data_format=input_data_format
-                    )
+                    self.normalize_annotation(annotation, get_image_size(image, input_data_format))
                     for annotation, image in zip(annotations, images)
                 ]
 

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -1284,9 +1284,7 @@ class DetrImageProcessor(BaseImageProcessor):
             ]
             if annotations is not None:
                 annotations = [
-                    self.normalize_annotation(
-                        annotation, get_image_size(image, input_data_format), input_data_format=input_data_format
-                    )
+                    self.normalize_annotation(annotation, get_image_size(image, input_data_format))
                     for annotation, image in zip(annotations, images)
                 ]
 


### PR DESCRIPTION
# What does this PR do?

Fix errors raised when function `self.normalize_annotation` is called in 3 models. 

There are 3 models (`conditional detr`, `deformable detr` and `detr`), whose `self.normalize_annotation` functions do not receive the `input_data_format` parameter. 

`input_data_format` parameter was introduced in [PR #25464](https://github.com/huggingface/transformers/pull/25464) to allow images with unusual number of channels to be used. However, functions like `self.normalize_annotation` deal with annotations only, and don't need this parameter. In fact, this parameter raises an error, as it is not defined in the signature of the functions `self.normalize_annotation`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 
