### PR TITLE
Pass the proper token to PEFT integration in auto classes

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -475,10 +475,7 @@ class _BaseAutoModelClass:
             subfolder = kwargs.get("subfolder", None)
 
             maybe_adapter_path = find_adapter_config_file(
-                pretrained_model_name_or_path,
-                revision=revision,
-                token=use_auth_token,
-                subfolder=subfolder,
+                pretrained_model_name_or_path, revision=revision, token=token, subfolder=subfolder
             )
 
             if maybe_adapter_path is not None:


### PR DESCRIPTION
# What does this PR do?

This fixes the token passed along to the PEFT integration in the auto classes, which result in errors for every users with private models.