### PR TITLE
Adds `TRANSFORMERS_TEST_BACKEND`

### DIFF
--- a/docs/source/en/testing.md
+++ b/docs/source/en/testing.md
@@ -522,7 +522,7 @@ This variable is useful for testing custom or less common PyTorch backends such 
 
 Certain devices will require an additional import after importing `torch` for the first time. This can be specified using the environment variable `TRANSFORMERS_TEST_BACKEND`:
 ```bash
-TRANSFORMERS_TEST_BACKEND="torch_X" pytest tests/test_logging.py
+TRANSFORMERS_TEST_BACKEND="torch_npu" pytest tests/test_logging.py
 ```
 
 

--- a/docs/source/en/testing.md
+++ b/docs/source/en/testing.md
@@ -511,14 +511,19 @@ from transformers.testing_utils import get_gpu_count
 n_gpu = get_gpu_count()  # works with torch and tf
 ```
 
-### Testing with a specific PyTorch backend
+### Testing with a specific PyTorch backend or device
 
-To run the test suite on a specific torch backend add `TRANSFORMERS_TEST_DEVICE="$device"` where `$device` is the target backend. For example, to test on CPU only:
+To run the test suite on a specific torch device add `TRANSFORMERS_TEST_DEVICE="$device"` where `$device` is the target backend. For example, to test on CPU only:
 ```bash
 TRANSFORMERS_TEST_DEVICE="cpu" pytest tests/test_logging.py
 ```
 
 This variable is useful for testing custom or less common PyTorch backends such as `mps`. It can also be used to achieve the same effect as `CUDA_VISIBLE_DEVICES` by targeting specific GPUs or testing in CPU-only mode.
+
+Certain devices will require an additional import after importing `torch` for the first time. This can be specified using the environment variable `TRANSFORMERS_TEST_BACKEND`:
+```bash
+TRANSFORMERS_TEST_BACKEND="torch_X" pytest tests/test_logging.py
+```
 
 
 ### Distributed training

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -16,6 +16,7 @@ import collections
 import contextlib
 import doctest
 import functools
+import importlib
 import inspect
 import logging
 import multiprocessing
@@ -629,6 +630,16 @@ if is_torch_available():
         torch_device = "npu"
     else:
         torch_device = "cpu"
+
+    if "TRANSFORMERS_TEST_BACKEND" in os.environ:
+        backend = os.environ["TRANSFORMERS_TEST_BACKEND"]
+        try:
+            _ = importlib.import_module(backend)
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                f"Failed to import `TRANSFORMERS_TEST_BACKEND` '{backend}'! This should be the name of an installed module."
+            ) from e
+
 else:
     torch_device = None
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -637,7 +637,8 @@ if is_torch_available():
             _ = importlib.import_module(backend)
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError(
-                f"Failed to import `TRANSFORMERS_TEST_BACKEND` '{backend}'! This should be the name of an installed module."
+                f"Failed to import `TRANSFORMERS_TEST_BACKEND` '{backend}'! This should be the name of an installed module. The original error (look up to see its"
+                f" traceback):\n{e}"
             ) from e
 
 else:


### PR DESCRIPTION
# What does this PR do?

Allows specifying arbitrary additional import following first `import torch`. This is useful for some custom backends, that will require additional imports to trigger backend registration with upstream torch. See https://github.com/pytorch/benchmark/pull/1805 for a similar change in `torchbench`.

If the specified backend does not exist, we throw a helpful error. I have updated the docs to include this new variable.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger would you mind taking a look at this? It relates to my previous PR.