### PR TITLE
[`GPTNeo`]  Add input_embeds functionality to gpt_neo Causal LM 

### DIFF
--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -706,7 +706,6 @@ class GPTNeoForCausalLM(GPTNeoPreTrainedModel):
 
         model_inputs.update(
             {
-                "input_ids": input_ids,
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "position_ids": position_ids,


### PR DESCRIPTION
# What does this PR do?
Follow PR of #25659, were model inputs are updated with the input ids, meaning both input ids and input embeds are passed. 