### PR TITLE
Use Version instead of version.parse to compare versions

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -16,7 +16,7 @@ import math
 from collections import OrderedDict
 
 import torch
-from packaging import version
+from packaging.version import Version
 from torch import Tensor, nn
 
 from .utils import logging
@@ -36,7 +36,7 @@ class PytorchGELUTanh(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if version.parse(torch.__version__) < version.parse("1.12.0"):
+        if Version(torch.__version__) < Version("1.12.0"):
             raise ImportError(
                 f"You are using torch=={torch.__version__}, but torch>=1.12.0 is required to use "
                 "PytorchGELUTanh. Please upgrade torch."
@@ -158,7 +158,7 @@ class MishActivation(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if version.parse(torch.__version__) < version.parse("1.9.0"):
+        if Version(torch.__version__) < Version("1.9.0"):
             self.act = self._mish_python
         else:
             self.act = nn.functional.mish


### PR DESCRIPTION
# What does this PR do?

Use `packaging.version.Version` to compare torch version instead of `packaging.version.parse`.




Fixes #25669


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
