### PR TITLE
fix ram efficient fsdp init

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -113,11 +113,11 @@ _init_weights = True
 
 
 def is_fsdp_enabled():
-    return strtobool(os.environ.get("ACCELERATE_USE_FSDP", "False")) == 1
+    return torch.distributed.is_initialized() and strtobool(os.environ.get("ACCELERATE_USE_FSDP", "False")) == 1
 
 
 def is_fsdp_enabled_and_dist_rank_0():
-    return is_fsdp_enabled() and torch.distributed.is_initialized() and torch.distributed.get_rank() == 0
+    return is_fsdp_enabled() and torch.distributed.get_rank() == 0
 
 
 if is_sagemaker_mp_enabled():


### PR DESCRIPTION
# What does this PR do?
1. Currently, when using Trainer if the model is loaded before creating `TrainingArguments` object, torch distributed process group won't be initialized and as such when FSDP is enabled via accelerate config, it will end up initializing the model with random weights on all ranks as the `is_fsdp_enabled_and_dist_rank_0` function will always return `False`. This results in NaN losses. Quite a journey to uncover this bug. This PR fixes it.