### PR TITLE
correct resume training steps number in progress bar

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -598,8 +598,8 @@ def main():
             # need to multiply `gradient_accumulation_steps` to reflect real steps
             resume_step = int(training_difference.replace("step_", "")) * args.gradient_accumulation_steps
             starting_epoch = resume_step // len(train_dataloader)
-            resume_step -= starting_epoch * len(train_dataloader)
             completed_steps = resume_step // args.gradient_accumulation_steps
+            resume_step -= starting_epoch * len(train_dataloader)
 
     # update the progress_bar if load from checkpoint
     progress_bar.update(completed_steps)


### PR DESCRIPTION
Hi,
In this code of resume training with step, I see that completed_steps will always start at epoch 0, and it does not seem to be corrected (progress_bar needs to be at the step in the file save). So I changed the location of this code to make the progress_bar update with the latest step.

I would like to cc @sgugger to review it.