### PR TITLE
Generate: nudge towards `do_sample=False` when `temperature=0.0`

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -271,7 +271,7 @@ class TemperatureLogitsWarper(LogitsWarper):
                 "scores will be invalid."
             )
             if isinstance(temperature, float) and temperature == 0.0:
-                except_msg += "If you're looking for greedy decoding strategies, set `do_sample=False`."
+                except_msg += " If you're looking for greedy decoding strategies, set `do_sample=False`."
             raise ValueError(except_msg)
 
         self.temperature = temperature

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -266,7 +266,10 @@ class TemperatureLogitsWarper(LogitsWarper):
 
     def __init__(self, temperature: float):
         if not isinstance(temperature, float) or not (temperature > 0):
-            raise ValueError(f"`temperature` has to be a strictly positive float, but is {temperature}")
+            except_msg = f"`temperature` (={temperature}) has to be a strictly positive float, otherwise your next token scores will be invalid."
+            if isinstance(temperature, float) and temperature == 0.0:
+                except_msg += "If you're looking for greedy decoding strategies, set `do_sample=False`."
+            raise ValueError(except_msg)
 
         self.temperature = temperature
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -266,7 +266,10 @@ class TemperatureLogitsWarper(LogitsWarper):
 
     def __init__(self, temperature: float):
         if not isinstance(temperature, float) or not (temperature > 0):
-            except_msg = f"`temperature` (={temperature}) has to be a strictly positive float, otherwise your next token scores will be invalid."
+            except_msg = (
+                f"`temperature` (={temperature}) has to be a strictly positive float, otherwise your next token "
+                "scores will be invalid."
+            )
             if isinstance(temperature, float) and temperature == 0.0:
                 except_msg += "If you're looking for greedy decoding strategies, set `do_sample=False`."
             raise ValueError(except_msg)


### PR DESCRIPTION
# What does this PR do?

Related issue: https://github.com/facebookresearch/llama/issues/687

Improves the error message when `temperature=0.0`, which asymptotically corresponds to greedy decoding... except that it results in numerical problems :D 

___________________________
test run:
```py
from transformers import AutoModelForCausalLM, AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
model = AutoModelForCausalLM.from_pretrained("distilgpt2")

inputs = tokenizer(["The quick brown"], return_tensors="pt")
gen_out = model.generate(**inputs, do_sample=True, temperature=0.0)
```

yields
```
ValueError: `temperature` (=0.0) has to be a strictly positive float, otherwise your next token scores will be invalid. If you're looking for greedy decoding strategies, set `do_sample=False`.
```