### PR TITLE
[`from_pretrained`]  Simpler code for peft

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2377,9 +2377,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     token=token,
                     commit_hash=commit_hash,
                 )
-            if os.path.isfile(_adapter_model_path):
+            if _adapter_model_path is not None and os.path.isfile(_adapter_model_path):
                 with open(_adapter_model_path, "r", encoding="utf-8") as f:
-                    _adapter_model_path = json.load(f)["base_model_name_or_path"]
+                    _adapter_model_path = pretrained_model_name_or_path
+                    pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2394,21 +2394,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if is_peft_available():
             if _adapter_model_path is None:
                 _adapter_model_path = find_adapter_config_file(
-                pretrained_model_name_or_path,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                local_files_only=local_files_only,
-                token=token,
-                revision=revision,
-                subfolder=subfolder,
-                _commit_hash=commit_hash,
-            )
+                    pretrained_model_name_or_path,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _commit_hash=commit_hash,
+                )
             if _adapter_model_path is not None and os.path.isfile(_adapter_model_path):
-                with open(_adapter_model_path, "r", encoding="utf-8") as f:
+                with open(_adapter_model_path, "r", encoding="utf-8"):
                     _adapter_model_path = pretrained_model_name_or_path
-
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2377,10 +2377,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     token=token,
                     commit_hash=commit_hash,
                 )
-            if os.ispath(_adapter_model_path):
+            if os.path.isfile(_adapter_model_path):
                 with open(_adapter_model_path, "r", encoding="utf-8") as f:
                     _adapter_model_path = json.load(f)["base_model_name_or_path"]
-            adapter_model_id = _adapter_model_path
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):
@@ -3212,9 +3211,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if quantization_method_from_config == QuantizationMethod.GPTQ:
             model = quantizer.post_init_model(model)
 
-        if has_adapter_config:
+        if _adapter_model_path:
             model.load_adapter(
-                adapter_model_id,
+                _adapter_model_path,
                 adapter_name=adapter_name,
                 revision=revision,
                 token=token,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2368,20 +2368,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " ignored."
             )
 
-        if is_peft_available() and _adapter_model_path is None:
-            _adapter_model_path = find_adapter_config_file(
-                pretrained_model_name_or_path,
-                revision=revision,
-                subfolder=subfolder,
-                token=token,
-                commit_hash=commit_hash,
-            )
-
-        if os.ispath(_adapter_model_path):
-            with open(_adapter_model_path, "r", encoding="utf-8") as f:
-                pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
-            adapter_model_id = pretrained_model_name_or_path
-        elif _adapter_model_path is not None:
+        if is_peft_available():
+            if _adapter_model_path is None:
+                _adapter_model_path = find_adapter_config_file(
+                    pretrained_model_name_or_path,
+                    revision=revision,
+                    subfolder=subfolder,
+                    token=token,
+                    commit_hash=commit_hash,
+                )
+            if os.ispath(_adapter_model_path):
+                with open(_adapter_model_path, "r", encoding="utf-8") as f:
+                    _adapter_model_path = json.load(f)["base_model_name_or_path"]
             adapter_model_id = _adapter_model_path
 
         # change device_map into a map if we passed an int, a str or a torch.device

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2369,27 +2369,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
 
         if is_peft_available() and _adapter_model_path is None:
-            maybe_adapter_model_path = find_adapter_config_file(
+            _adapter_model_path = find_adapter_config_file(
                 pretrained_model_name_or_path,
                 revision=revision,
                 subfolder=subfolder,
                 token=token,
                 commit_hash=commit_hash,
             )
-        elif is_peft_available() and _adapter_model_path is not None:
-            maybe_adapter_model_path = _adapter_model_path
-        else:
-            maybe_adapter_model_path = None
 
-        has_adapter_config = maybe_adapter_model_path is not None
-
-        if has_adapter_config:
-            if _adapter_model_path is not None:
-                adapter_model_id = _adapter_model_path
-            else:
-                with open(maybe_adapter_model_path, "r", encoding="utf-8") as f:
-                    adapter_model_id = pretrained_model_name_or_path
-                    pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
+        if os.ispath(_adapter_model_path):
+            with open(_adapter_model_path, "r", encoding="utf-8") as f:
+                pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
+            adapter_model_id = pretrained_model_name_or_path
+        elif _adapter_model_path is not None:
+            adapter_model_id = _adapter_model_path
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3211,7 +3211,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if quantization_method_from_config == QuantizationMethod.GPTQ:
             model = quantizer.post_init_model(model)
 
-        if _adapter_model_path:
+        if _adapter_model_path is not None:
             model.load_adapter(
                 _adapter_model_path,
                 adapter_name=adapter_name,


### PR DESCRIPTION
# What does this PR do?
Simplifies the logic when loading a PEFT model: the `_adapter_model_path` is used instead of `maybe_has_adapter_model_path` and `has_adapter_config`