### PR TITLE
[ASR Pipe Test] Fix CTC timestamps error message

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -402,7 +402,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 raise ValueError("CTC with LM can only predict word level timestamps, set `return_timestamps='word'`")
             if self.type == "ctc" and return_timestamps not in ["char", "word"]:
                 raise ValueError(
-                    "CTC can either predict character (char) level timestamps, or word level timestamps."
+                    "CTC can either predict character level timestamps, or word level timestamps."
                     "Set `return_timestamps='char'` or `return_timestamps='word'` as required."
                 )
             if self.type == "seq2seq_whisper" and return_timestamps == "char":

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1150,7 +1150,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         # CTC models must specify return_timestamps type - cannot set `return_timestamps=True` blindly
         with self.assertRaisesRegex(
             ValueError,
-            "^CTC can either predict character (char) level timestamps, or word level timestamps."
+            "^CTC can either predict character level timestamps, or word level timestamps."
             "Set `return_timestamps='char'` or `return_timestamps='word'` as required.$",
         ):
             _ = speech_recognizer(audio, return_timestamps=True)


### PR DESCRIPTION
# What does this PR do?

The test [`test_chunking_and_timestamps`](https://github.com/huggingface/transformers/blob/70b49f023c9f6579c516671604468a491227b4da/tests/pipelines/test_pipelines_automatic_speech_recognition.py#L1153) failed on the nightly run when checking that the argument `return_timestamps=True` gave the correct error message for CTC models. This is because the string pattern `(char)` in the error message was closing the regex expression. Removing it allows the test to pass as expected.