### PR TITLE
[`from_pretrained`] Fix failing PEFT tests

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2406,8 +2406,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     _commit_hash=commit_hash,
                 )
             if _adapter_model_path is not None and os.path.isfile(_adapter_model_path):
-                with open(_adapter_model_path, "r", encoding="utf-8"):
+                with open(_adapter_model_path, "r", encoding="utf-8") as f:
                     _adapter_model_path = pretrained_model_name_or_path
+                    pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):


### PR DESCRIPTION
# What does this PR do?

Addresses: https://github.com/huggingface/transformers/pull/25726#issuecomment-1691783489
In fact it is important to overwrite `pretrained_model_name_or_path` with the `base_model_name_or_path` attribute of the adapter config otherwise `from_pretrained` will try to load the config file from the adapter model_id where it should look for  it at `base_model_name_or_path`

now all PEFT tests are green

cc @sgugger @ArthurZucker 