### PR TITLE
fix encoder hook

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -33,7 +33,7 @@ from ..models.auto import (
     MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
     MODEL_FOR_VISION_2_SEQ_MAPPING,
 )
-from ..utils import ExplicitEnum, ModelOutput, logging, is_accelerate_available
+from ..utils import ExplicitEnum, ModelOutput, is_accelerate_available, logging
 from .beam_constraints import DisjunctiveConstraint, PhrasalConstraint
 from .beam_search import BeamScorer, BeamSearchScorer, ConstrainedBeamSearchScorer
 from .configuration_utils import GenerationConfig
@@ -81,7 +81,8 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 if is_accelerate_available():
-    from accelerate.hooks import add_hook_to_module, AlignDevicesHook
+    from accelerate.hooks import AlignDevicesHook, add_hook_to_module
+
 
 @dataclass
 class GreedySearchDecoderOnlyOutput(ModelOutput):
@@ -633,7 +634,7 @@ class GenerationMixin:
         encoder = self.get_encoder()
         # Compatibility with Accelerate big model inference: we need the encoder to outputs stuff on the same device
         # as the inputs.
-        if hasattr(self,"hf_device_map"):
+        if hasattr(self, "hf_device_map"):
             if hasattr(encoder, "_hf_hook"):
                 encoder._hf_hook.io_same_device = True
             else:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -33,7 +33,7 @@ from ..models.auto import (
     MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
     MODEL_FOR_VISION_2_SEQ_MAPPING,
 )
-from ..utils import ExplicitEnum, ModelOutput, logging
+from ..utils import ExplicitEnum, ModelOutput, logging, is_accelerate_available
 from .beam_constraints import DisjunctiveConstraint, PhrasalConstraint
 from .beam_search import BeamScorer, BeamSearchScorer, ConstrainedBeamSearchScorer
 from .configuration_utils import GenerationConfig
@@ -80,6 +80,8 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
+if is_accelerate_available():
+    from accelerate.hooks import add_hook_to_module, AlignDevicesHook
 
 @dataclass
 class GreedySearchDecoderOnlyOutput(ModelOutput):
@@ -631,8 +633,11 @@ class GenerationMixin:
         encoder = self.get_encoder()
         # Compatibility with Accelerate big model inference: we need the encoder to outputs stuff on the same device
         # as the inputs.
-        if hasattr(encoder, "_hf_hook"):
-            encoder._hf_hook.io_same_device = True
+        if hasattr(self,"hf_device_map"):
+            if hasattr(encoder, "_hf_hook"):
+                encoder._hf_hook.io_same_device = True
+            else:
+                add_hook_to_module(encoder, AlignDevicesHook(io_same_device=True))
 
         # 2. Prepare encoder args and encoder kwargs from model kwargs.
         irrelevant_prefix = ["decoder_", "cross_attn", "use_cache"]


### PR DESCRIPTION
# What does this PR do ? 
Fixes #23385. This PR makes sure that we indeed have a hook with `io_same_device=True` on the encoder which was not the case previously. If we don't have that, the generation will fail as the output of the encoder won't be on the same device as `unfinished_sequences = torch.ones(input_ids.shape[0], dtype=torch.long, device=input_ids.device)` and this will lead to an error here: `next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)`.