### PR TITLE
[bug fix]tokenizer init via tokenization_utils_base.py in some case make "Do you accept" emerge even if trust_remote_code=True is setted 

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1932,7 +1932,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     cache_dir=cache_dir,
                     local_files_only=local_files_only,
                     _commit_hash=_commit_hash,
-                    trust_remote_code=kwargs.get('trust_remote_code',False)
+                    **(copy.deepcopy(kwargs)),
                 )
                 config_tokenizer_class = config.tokenizer_class
             except (OSError, ValueError, KeyError):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1932,6 +1932,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     cache_dir=cache_dir,
                     local_files_only=local_files_only,
                     _commit_hash=_commit_hash,
+                    trust_remote_code=kwargs.get('trust_remote_code',False)
                 )
                 config_tokenizer_class = config.tokenizer_class
             except (OSError, ValueError, KeyError):

--- a/tests/tokenization/test_tokenization_utils_base.py
+++ b/tests/tokenization/test_tokenization_utils_base.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+# Copyright 2018 HuggingFace Inc..
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+isort:skip_file
+"""
+import os
+import pickle
+import tempfile
+import unittest
+from unittest.mock import patch
+import transformers
+from transformers import AutoTokenizer, AutoConfig
+from transformers.testing_utils import slow
+from transformers.utils import cached_file
+
+# mock cached_file function to remove "tokenizer_config_file" keys, ensure the entire call pipeline contains AutoConfig.from_pretrained
+def mock_cached_file(*args, **kwargs):
+    resolved_vocab_files = cached_file(*args, **kwargs)
+    _ = resolved_vocab_files.pop("tokenizer_config_file", None)
+    return resolved_vocab_files
+
+#mock AutoConfig.from_pretrained to check the parameters is passed
+original_from_pretrained = transformers.AutoConfig.from_pretrained
+def mock_autoconfig_from_pretrained(*args, **kwargs):
+    config = original_from_pretrained(*args, **kwargs)
+    assert (kwargs['special_arg1'] == "value1")
+    assert (kwargs['special_arg2'] == "value2")
+    return config
+
+class TokenizationUtilsBaseTest(unittest.TestCase):
+
+    @slow
+    @patch('transformers.utils.hub.cached_file', side_effect=mock_cached_file)
+    @patch('transformers.AutoConfig.from_pretrained', side_effect=mock_autoconfig_from_pretrained)
+    def test_from_pretrained_with_kwargs(self, mock_cached_file, mock_autoconfig):
+        # additional kwargs
+        additional_kwargs = {
+            "special_arg1": "value1",
+            "special_arg2": "value2"
+        }
+        tokenizer = AutoTokenizer.from_pretrained(
+            "bert-base-uncased",
+            **additional_kwargs
+        )
+        self.assertIsNotNone(tokenizer)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

This PR fix a bug for tokenizer from_pretrained method causing manual input issue in tokenizer initialization
if not fixed ,in some rare contidition tokenizer init via tokenization_utils_base would need typed "yes",which caused from inner call AutoConfig.from_pretrained() , but not transfer the trust_remote_code parameter when init tokenizer

Fixes # (issue)

the original behavior of tokenization_utils_base AutoConfig.from_pretrained() works in most cases.But in some rare scene, when the tokenizer initializes, it internally calls AutoConfig.pretrained. During this call, the trust_remote_code parameter was omitted, leading to a situation where the user is always required to manually enter yes, regardless of original parameters or settings.

I encountered this bug when i init tokenizer from local disk file, a model named Baichuan-13B-Chat but tokenizer type equals to LlamaTokenizer (same as sentencepiece),and the from_pretrained-used parameter directory 
has config.json,tokenizer.model (but no other tokenizer related file), this bug triggered

![image](https://github.com/huggingface/transformers/assets/11573254/55568839-f4f2-4118-9e66-ec5a4f8bf4ac)
_this picture is minimal reproduce file structure_

While this might seem benign, it becomes problematic in scenarios like some distribute environment, (eg.  Aliyun PAI platform,Tencent cloud platform Ti-One) where manual input isn't feasible. As a result, the interface flushes in the incorrect input and eventually raises an EOFError

![image](https://github.com/huggingface/transformers/assets/11573254/f08a744d-f62c-431d-bb36-040bc146ff37)
_this log message ascend from bottom to up_

To Reproduce:
1. mkdir test_tokenizer && cd test_tokenizer
2. wget https://huggingface.co/baichuan-inc/Baichuan-13B-Chat/resolve/main/tokenizer.model
 wget https://huggingface.co/baichuan-inc/Baichuan-13B-Chat/resolve/main/config.json
4. cd ..

> from transformers import LlamaTokenizer
> tokenizer=LlamaTokenizer.from_pretrained('test_tokenizer/',trust_remote_code=True)

Then run this code would triggered the bug, this may caused by abnormal used of tokenizer,
but i think add the trust_remote_code parameter in tokenization_utils_base  would be safer


![image](https://github.com/huggingface/transformers/assets/11573254/b2db3d14-4866-4380-81fd-06a08bcf9f05)


## Before submitting
- This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- Did you write any new necessary tests?


## Who can review?
@ArthurZucker 