### PR TITLE
MaskFormer,Mask2former - reduce memory load

### DIFF
--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -1711,13 +1711,15 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
             class_queries_logits = classes[-1]
             # get the masks
             mask_embeddings = self.mask_embedder(stacked_transformer_decoder_outputs)
-            # sum up over the channels for each embedding
-            # (num_embeddings, batch_size, num_queries, num_channels, 1, 1)
-            mask_embeddings = mask_embeddings.unsqueeze(-1).unsqueeze(-1)
-            # (1, batch_size, 1, num_channels, height, width)
-            pixel_embeddings = pixel_embeddings.unsqueeze(0).unsqueeze(2)
-            # (num_embeddings, batch_size, num_queries, height, width)
-            binaries_masks = (mask_embeddings * pixel_embeddings).sum(dim=3)
+
+            # Equivalent to einsum('lbqc, bchw -> lbqhw') but jit friendly
+            num_embeddings, batch_size, num_queries, num_channels = mask_embeddings.shape
+            _, _, height, width = pixel_embeddings.shape
+            binaries_masks = torch.zeros(
+                (num_embeddings, batch_size, num_queries, height, width), device=mask_embeddings.device
+            )
+            for c in range(num_channels):
+                binaries_masks += mask_embeddings[..., c][..., None, None] * pixel_embeddings[None, :, None, c]
 
             masks_queries_logits = binaries_masks[-1]
             # go til [:-1] because the last one is always used
@@ -1733,12 +1735,13 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
             # get the masks
             mask_embeddings = self.mask_embedder(transformer_decoder_hidden_states)
             # sum up over the channels
-            # (batch_size, num_queries, num_channels, 1, 1)
-            mask_embeddings = mask_embeddings.unsqueeze(-1).unsqueeze(-1)
-            # (batch_size, 1, num_channels, height, width)
-            pixel_embeddings = pixel_embeddings.unsqueeze(1)
-            # (batch_size, num_queries, height, width)
-            masks_queries_logits = (mask_embeddings * pixel_embeddings).sum(dim=2)
+
+            # Equivalent to einsum('bqc, bchw -> bqhw') but jit friendly
+            batch_size, num_queries, num_channels = mask_embeddings.shape
+            _, _, height, width = pixel_embeddings.shape
+            masks_queries_logits = torch.zeros((batch_size, num_queries, height, width), device=mask_embeddings.device)
+            for c in range(num_channels):
+                masks_queries_logits += mask_embeddings[..., c][..., None, None] * pixel_embeddings[:, None, c]
 
         return class_queries_logits, masks_queries_logits, auxiliary_logits
 


### PR DESCRIPTION
# What does this PR do?

#25297 resolved an error that occurred when trying to trace MaskFormer-like models. The solution was to remove einsum operations. However, the replacements were very memory intensive: a large matrix was created and then summed over. 

This PR replaces this logic by creating the result array and the iterates over the summed dimension. 

Fixes #25709

It was confirmed that this resolved the memory issue, by installing from this branch and rerunning the example notebook successfully: https://colab.research.google.com/drive/1xq54l9a2AQLIHT5jw63btifbOrvSqzts?usp=sharing


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?