### PR TITLE
[CLAP] Fix logit scales dtype for fp16

### DIFF
--- a/src/transformers/models/clap/modeling_clap.py
+++ b/src/transformers/models/clap/modeling_clap.py
@@ -1955,8 +1955,8 @@ class ClapModel(ClapPreTrainedModel):
         text_config = config.text_config
         audio_config = config.audio_config
 
-        self.logit_scale_a = nn.Parameter(torch.log(torch.tensor(config.logit_scale_init_value)))
-        self.logit_scale_t = nn.Parameter(torch.log(torch.tensor(config.logit_scale_init_value)))
+        self.logit_scale_a = nn.Parameter(torch.tensor(math.log(config.logit_scale_init_value)))
+        self.logit_scale_t = nn.Parameter(torch.tensor(math.log(config.logit_scale_init_value)))
 
         self.projection_dim = config.projection_dim
 


### PR DESCRIPTION
# What does this PR do?

On some hardware, taking `torch.log` of a tensor in float16 on the CPU fails:
```python
in __init__(self, config)
   1956         audio_config = config.audio_config
   1957 
-> 1958         self.logit_scale_a = nn.Parameter(torch.log(torch.tensor(config.logit_scale_init_value)))
   1959         self.logit_scale_t = nn.Parameter(torch.log(torch.tensor(config.logit_scale_init_value)))
   1960 

RuntimeError: "log_vml_cpu" not implemented for 'Half'
```
Note that this only failed for me on a Colab T4, but not on a Titan RTX (used to test #25682).

Let's take `math.log` **then** convert it to a tensor - this will respect the dtype of the model but not take `torch.log` of a float16 CPU param.