### PR TITLE
Fix Mega chunking error when using decoder-only model

### DIFF
--- a/src/transformers/models/mega/modeling_mega.py
+++ b/src/transformers/models/mega/modeling_mega.py
@@ -1542,6 +1542,9 @@ class MegaModel(MegaPreTrainedModel):
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
+        if self.config.use_chunking:
+            input_shape = torch.tensor([input_shape[0], self.config.chunk_size])
+
         batch_size, sequence_length = input_shape
 
         if self.config.use_chunking and (sequence_length > self.config.chunk_size):

--- a/tests/models/mega/test_modeling_mega.py
+++ b/tests/models/mega/test_modeling_mega.py
@@ -332,9 +332,11 @@ class MegaModelTester:
 
         model = MegaForCausalLM(config).to(torch_device).eval()
 
-        result = model(
-            input_ids.repeat(1, 8),
-        )
+        input_ids = input_ids.repeat(1, 8)
+        # multiply the sequence length by 8 since we repeat the same ids 8 times in input_ids
+        input_mask = random_attention_mask([self.batch_size, self.seq_length * 8])
+
+        result = model(input_ids, attention_mask=input_mask)
 
         # test if the sequence length of attentions is same provided chunk_size
         self.parent.assertEqual(result["attentions"][0].shape[-1], config.chunk_size)


### PR DESCRIPTION
# What does this PR do?

This PR aims to fix the error caused by `MegaModel` when the `is_decoder` setting is used in conjunction with `use_chunking` and `chunk_size` settings.

The error is described in detail [here](https://github.com/huggingface/transformers/issues/23331#issuecomment-1693729295).

Fixes #23331

## Who can review?
@ArthurZucker 