### PR TITLE
include ChannelDimension.NONE + function replicate_channels

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -62,6 +62,7 @@ ImageInput = Union[
 class ChannelDimension(ExplicitEnum):
     FIRST = "channels_first"
     LAST = "channels_last"
+    NONE = "none"
 
 
 def is_pil_image(img):
@@ -155,6 +156,29 @@ def to_numpy_array(img) -> np.ndarray:
     return to_numpy(img)
 
 
+def replicate_channels(img: np.ndarray, num_channels: int = 3) -> np.ndarray:
+    """
+    Transforms an image with format (height, width) to (num_channels, height, width), so that all channels are
+    identical.
+
+    Args:
+        img (`np.ndarray`):
+            Input image.
+        num_channels (`int`, defaults to 3):
+            Expected number of channels in the final image.
+
+    Returns:
+        Image in format `(num_channels, height, width)`.
+    """
+    if not isinstance(img, np.ndarray):
+        raise ValueError(f"Invalid image type: {type(img)}. Expected np.ndarray.")
+
+    # If image has format (height, width), make it (num_channels, height, width)
+    if img.ndim == 2:
+        img = np.stack([img] * num_channels, axis=0)
+    return img
+
+
 def infer_channel_dimension_format(
     image: np.ndarray, num_channels: Optional[Union[int, Tuple[int, ...]]] = None
 ) -> ChannelDimension:
@@ -177,6 +201,8 @@ def infer_channel_dimension_format(
         first_dim, last_dim = 0, 2
     elif image.ndim == 4:
         first_dim, last_dim = 1, 3
+    elif image.ndim == 2:
+        return ChannelDimension.NONE
     else:
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 

--- a/src/transformers/models/vit/image_processing_vit.py
+++ b/src/transformers/models/vit/image_processing_vit.py
@@ -29,6 +29,7 @@ from ...image_utils import (
     infer_channel_dimension_format,
     is_scaled_image,
     make_list_of_images,
+    replicate_channels,
     to_numpy_array,
     valid_images,
 )
@@ -230,6 +231,9 @@ class ViTImageProcessor(BaseImageProcessor):
 
         # All transformations expect numpy arrays.
         images = [to_numpy_array(image) for image in images]
+
+        # All transformations expect 3-channel images
+        images = [replicate_channels(image, 3) for image in images]
 
         if is_scaled_image(images[0]) and do_rescale:
             logger.warning_once(

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -568,10 +568,10 @@ class UtilFunctionTester(unittest.TestCase):
         self.assertEqual(get_image_size(image, channel_dim=ChannelDimension.LAST), (3, 32))
 
     def test_infer_channel_dimension(self):
-        # Test we fail with invalid input
-        with pytest.raises(ValueError):
-            infer_channel_dimension_format(np.random.randint(0, 256, (10, 10)))
+        # Test should not fail with image in format (width, height)
+        self.assertEqual(infer_channel_dimension_format(np.random.randint(0, 256, (10, 10))), ChannelDimension.NONE)
 
+        # Test should fail with 5 dim image
         with pytest.raises(ValueError):
             infer_channel_dimension_format(np.random.randint(0, 256, (10, 10, 10, 10, 10)))
 


### PR DESCRIPTION
# What does this PR do?

Fixes #25694 

The ViT model currently doesn't support grayscale images with a (height, width) format, leading to preprocessing errors.

This PR addresses the issue with a new replicate_channels function. This function converts images in (height, width) format to a 3-channel RGB format (3, height, width), replicating the grayscale channel across all three RGB channels.

While it's possible to integrate format checks and modifications within each processing function (like resize, rescale, normalize, to_channel_dimension_format, etc.), doing so might affect other modules using these functions. To avoid potential complications, I've opted for a direct solution.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 