### PR TITLE
[idefics] fix vision's `hidden_act`

### DIFF
--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -57,7 +57,7 @@ class IdeficsVisionConfig(PretrainedConfig):
             Number of attention heads for each attention layer in the Transformer encoder.
         image_num_channels (`int`, *optional*, defaults to `3`):
             Number of image channels.
-        hidden_act (`str` or `function`, *optional*, defaults to `"quick_gelu"`):
+        hidden_act (`str` or `function`, *optional*, defaults to `"gelu"`):
             The non-linear activation function (function or string) in the encoder and pooler. If string, `"gelu"`,
             `"relu"`, `"selu"` and `"gelu_new"` ``"quick_gelu"` are supported.
         layer_norm_eps (`float`, *optional*, defaults to 1e-5):
@@ -86,7 +86,7 @@ class IdeficsVisionConfig(PretrainedConfig):
         num_hidden_layers=32,
         num_attention_heads=16,
         num_channels=3,
-        hidden_act="quick_gelu",
+        hidden_act="gelu",
         layer_norm_eps=1e-5,
         attention_dropout=0.0,
         initializer_range=0.02,


### PR DESCRIPTION
Thanks to @rwightman's discovery this PR is fixing vision config's `hidden_act` to `gelu`.

It looks like we messed things up when splitting the original config into 3 groups during the porting and inherited `clip`'s default config. Whereas the model used during training was using `gelu` as can be seen here. https://huggingface.co/laion/CLIP-ViT-H-14-laion2B-s32B-b79K/blob/main/config.json

Thank you, @rwightman 