### PR TITLE
For xla tensors, use an alternative way to get a unique id

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -285,4 +285,14 @@ def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with
     non-overlapping lifetimes may have the same id.
     """
+    if tensor.device.type == 'xla':
+        # NOTE: xla tensors dont have storage
+        # use some other unique id to distinguish.
+        # this is a XLA tensor, it must be created using torch_xla's
+        # device. So the following import is safe:
+        import torch_xla
+        unique_id = torch_xla._XLAC._xla_get_tensor_id(tensor)
+    else:
+        unique_id = storage_ptr(tensor)
+
     return tensor.device, storage_ptr(tensor), storage_size(tensor)

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -19,7 +19,7 @@ from packaging import version
 from safetensors.torch import storage_ptr, storage_size
 from torch import nn
 
-from .utils import logging
+from .utils import is_torch_tpu_available, logging
 
 
 ALL_LAYERNORM_LAYERS = [nn.LayerNorm]
@@ -285,14 +285,15 @@ def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with
     non-overlapping lifetimes may have the same id.
     """
-    if tensor.device.type == 'xla':
+    if tensor.device.type == "xla" and is_torch_tpu_available():
         # NOTE: xla tensors dont have storage
         # use some other unique id to distinguish.
         # this is a XLA tensor, it must be created using torch_xla's
         # device. So the following import is safe:
         import torch_xla
+
         unique_id = torch_xla._XLAC._xla_get_tensor_id(tensor)
     else:
         unique_id = storage_ptr(tensor)
 
-    return tensor.device, storage_ptr(tensor), storage_size(tensor)
+    return tensor.device, unique_id, storage_size(tensor)


### PR DESCRIPTION

# What does this PR do?

XLA tensors don't have storage and attempting to get it's storage will get

RuntimeError: Attempted to access the data pointer on an
invalid python storage.

Repro:
```
from transformers import pytorch_utils
import torch_xla.core.xla_model as xm
device = xm.xla_device()
a = torch.ones((10,10)).to(device)
pytorch_utils.id_tensor_storage(a)  # raises RuntimeError
```
With this patch it would print out
(device(type='xla', index=0), 1, 400).