### PR TITLE
Modify efficient GPU training doc with now-available adamw_bnb_8bit optimizer

### DIFF
--- a/docs/source/en/perf_train_gpu_one.md
+++ b/docs/source/en/perf_train_gpu_one.md
@@ -237,10 +237,11 @@ For example if you have [NVIDIA/apex](https://github.com/NVIDIA/apex) installed,
 fastest training experience among all supported AdamW optimizers.
 
 [`Trainer`] integrates a variety of optimizers that can be used out of box: `adamw_hf`, `adamw_torch`, `adamw_torch_fused`, 
-`adamw_apex_fused`, `adamw_anyprecision` or `adafactor`. More optimizers can be plugged in via a third-party implementation.
+`adamw_apex_fused`, `adamw_anyprecision`, `adafactor`, or `adamw_bnb_8bit`. More optimizers can be plugged in via a third-party implementation.
 
-Let's take a closer look at two alternatives to AdamW optimizer - Adafactor (available in Trainer), and 8bit BNB quantized 
-optimizer (third-party implementation).
+Let's take a closer look at two alternatives to AdamW optimizer:
+1. `Adafactor`, available in Trainer
+2. `8bit BNB quantized optimizer` which is [now](https://github.com/huggingface/transformers/issues/14819) available in Trainer, but for which a third-party integration is provided below for demonstration.
 
 For comparison, for a 3B-parameter model, like “t5-3b”: 
 * A standard AdamW optimizer will need 24GB of GPU memory because it uses 8 bytes for each parameter (8*3 => 24GB)
@@ -269,7 +270,13 @@ Instead of aggregating optimizer states like Adafactor, 8-bit Adam keeps the ful
 means that it stores the state with lower precision and dequantizes it only for the optimization. This is similar to the 
 idea behind mixed precision training.
 
-To use the 8-bit optimizer, you need to install it separately and then pass it as a custom optimizer to the [`Trainer`]. 
+To use the 8-bit optimizer, similar to Adafactor, you simply need to set `optim="adamw_bnb_8bit"` in [`TrainingArguments`]:
+
+```py
+training_args = TrainingArguments(per_device_train_batch_size=4, optim="adamw_bnb_8bit", **default_args)
+```
+
+However, for demonstration purposes, we can also use a third-party implementation of the 8-bit optimizer, to see how that can be integrated. In that case, we need to install it separately and then pass it as a custom optimizer to the [`Trainer`]. 
 
 First, follow the installation guide in the GitHub [repo](https://github.com/TimDettmers/bitsandbytes) to install the `bitsandbytes` library 
 that implements the 8-bit Adam optimizer.
@@ -310,13 +317,6 @@ adam_bnb_optim = bnb.optim.Adam8bit(
     lr=training_args.learning_rate,
 )
 ```
-
-<Tip>
-
-To use the 8-bit optimizer with an existing pretrained model, you need to make a change to the embedding layer.
-Read [this issue](https://github.com/huggingface/transformers/issues/14819) for more information.
-
-</Tip>
 
 Finally, pass the custom optimizer as an argument to the `Trainer`:
 

--- a/docs/source/en/perf_train_gpu_one.md
+++ b/docs/source/en/perf_train_gpu_one.md
@@ -240,8 +240,8 @@ fastest training experience among all supported AdamW optimizers.
 `adamw_apex_fused`, `adamw_anyprecision`, `adafactor`, or `adamw_bnb_8bit`. More optimizers can be plugged in via a third-party implementation.
 
 Let's take a closer look at two alternatives to AdamW optimizer:
-1. `Adafactor`, available in Trainer
-2. `8bit BNB quantized optimizer` which is [now](https://github.com/huggingface/transformers/issues/14819) available in Trainer, but for which a third-party integration is provided below for demonstration.
+1. `adafactor` which is available in [`Trainer`]
+2. `adamw_bnb_8bit` is also available in Trainer, but a third-party integration is provided below for demonstration.
 
 For comparison, for a 3B-parameter model, like “t5-3b”: 
 * A standard AdamW optimizer will need 24GB of GPU memory because it uses 8 bytes for each parameter (8*3 => 24GB)
@@ -270,13 +270,13 @@ Instead of aggregating optimizer states like Adafactor, 8-bit Adam keeps the ful
 means that it stores the state with lower precision and dequantizes it only for the optimization. This is similar to the 
 idea behind mixed precision training.
 
-To use the 8-bit optimizer, similar to Adafactor, you simply need to set `optim="adamw_bnb_8bit"` in [`TrainingArguments`]:
+To use `adamw_bnb_8bit`, you simply need to set `optim="adamw_bnb_8bit"` in [`TrainingArguments`]:
 
 ```py
 training_args = TrainingArguments(per_device_train_batch_size=4, optim="adamw_bnb_8bit", **default_args)
 ```
 
-However, for demonstration purposes, we can also use a third-party implementation of the 8-bit optimizer, to see how that can be integrated. In that case, we need to install it separately and then pass it as a custom optimizer to the [`Trainer`]. 
+However, we can also use a third-party implementation of the 8-bit optimizer for demonstration purposes to see how that can be integrated.
 
 First, follow the installation guide in the GitHub [repo](https://github.com/TimDettmers/bitsandbytes) to install the `bitsandbytes` library 
 that implements the 8-bit Adam optimizer.


### PR DESCRIPTION
# What does this PR do?
The documentation for efficient single-GPU training previously mentioned that the `adamw_bnb_8bit` optimizer could only be integrated using a third-party implementation. However, this is now available in Trainer directly as a result of this [issue](https://github.com/huggingface/transformers/issues/14819
) and corresponding [PR](https://github.com/huggingface/transformers/pull/15622).

I think it's valuable to keep the 8-bit Adam entry in the documentation as it's a significant improvement over Adafactor. And I also think it's valuable to keep the sample integration with a third-party implementation of an optimizer for reference purposes. I have adjusted the documentation accordingly.

I was able to validate myself that both approaches, using Trainer directly with the `optim` flag and doing the third-party integration still appear to work when fine-tuning small LLMs on a single GPU.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@stevhliu and @MKhalusova
