### PR TITLE
Add use_best_model feature for evaluating trials in hyperparameter searching

### DIFF
--- a/src/transformers/hyperparameter_search.py
+++ b/src/transformers/hyperparameter_search.py
@@ -44,7 +44,7 @@ class HyperParamSearchBackendBase:
     def is_available():
         raise NotImplementedError
 
-    def run(self, trainer, n_trials: int, direction: str, **kwargs):
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
         raise NotImplementedError
 
     def default_hp_space(self, trial):
@@ -68,8 +68,8 @@ class OptunaBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_optuna_available()
 
-    def run(self, trainer, n_trials: int, direction: str, **kwargs):
-        return run_hp_search_optuna(trainer, n_trials, direction, **kwargs)
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+        return run_hp_search_optuna(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):
         return default_hp_space_optuna(trial)
@@ -83,8 +83,8 @@ class RayTuneBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_ray_available()
 
-    def run(self, trainer, n_trials: int, direction: str, **kwargs):
-        return run_hp_search_ray(trainer, n_trials, direction, **kwargs)
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+        return run_hp_search_ray(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):
         return default_hp_space_ray(trial)
@@ -97,8 +97,8 @@ class SigOptBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_sigopt_available()
 
-    def run(self, trainer, n_trials: int, direction: str, **kwargs):
-        return run_hp_search_sigopt(trainer, n_trials, direction, **kwargs)
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+        return run_hp_search_sigopt(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):
         return default_hp_space_sigopt(trial)

--- a/src/transformers/hyperparameter_search.py
+++ b/src/transformers/hyperparameter_search.py
@@ -44,7 +44,7 @@ class HyperParamSearchBackendBase:
     def is_available():
         raise NotImplementedError
 
-    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool = False, **kwargs):
         raise NotImplementedError
 
     def default_hp_space(self, trial):

--- a/src/transformers/hyperparameter_search.py
+++ b/src/transformers/hyperparameter_search.py
@@ -68,7 +68,7 @@ class OptunaBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_optuna_available()
 
-    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool = False, **kwargs):
         return run_hp_search_optuna(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):
@@ -83,7 +83,7 @@ class RayTuneBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_ray_available()
 
-    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool = False, **kwargs):
         return run_hp_search_ray(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):
@@ -97,7 +97,7 @@ class SigOptBackend(HyperParamSearchBackendBase):
     def is_available():
         return is_sigopt_available()
 
-    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool, **kwargs):
+    def run(self, trainer, n_trials: int, direction: str, use_best_model: bool = False, **kwargs):
         return run_hp_search_sigopt(trainer, n_trials, direction, use_best_model, **kwargs)
 
     def default_hp_space(self, trial):

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -228,7 +228,7 @@ def run_hp_search_optuna(trainer, n_trials: int, direction: str, use_best_model:
             # If we want to load the best model, override the object with best
             # metric objective.
             if use_best_model:
-                trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
+                trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict.copy())
             # If there hasn't been any evaluation during the training loop.
             if getattr(trainer, "objective", None) is None:
                 metrics = trainer.evaluate()
@@ -258,7 +258,7 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, use_best_model: bo
         # If we want to load the best model, override the object with best
         # metric objective.
         if use_best_model:
-            local_trainer.objective = local_trainer.compute_objective(local_trainer.state.best_metrics_dict)
+            local_trainer.objective = local_trainer.compute_objective(local_trainer.state.best_metrics_dict.copy())
         # If there hasn't been any evaluation during the training loop.
         if getattr(local_trainer, "objective", None) is None:
             metrics = local_trainer.evaluate()
@@ -392,7 +392,7 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
                 budget=n_trials,
             )
 
-            logger.info(f"created experiment: https://app.sigopt.com/experiment/{experiment.id}")
+            logger.info(f"created experiment: https://app.sigopt.com/experiment/{experiment.id}")j
 
             for run in experiment.loop():
                 with run:
@@ -407,7 +407,7 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
                         trainer.train(resume_from_checkpoint=None, trial=run.run)
                     # Override the objective with best metric objective.
                     if use_best_model:
-                        trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
+                        trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict.copy())
                     # If there hasn't been any evaluation during the training loop.
                     if getattr(trainer, "objective", None) is None:
                         metrics = trainer.evaluate()
@@ -521,7 +521,7 @@ def run_hp_search_wandb(trainer, n_trials: int, direction: str, use_best_model: 
         # Override the objective with best metric objective. Use_best_model assumes
         # we perform evaluation during the training loop.
         if use_best_model:
-            trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
+            trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict.copy())
         # If there hasn't been any evaluation during the training loop.
         if getattr(trainer, "objective", None) is None:
             metrics = trainer.evaluate()

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -200,7 +200,7 @@ def run_hp_search_optuna(trainer, n_trials: int, direction: str, use_best_model:
             # If we want to load the best model, override the object with best
             # metric objective.
             if use_best_model:
-                trainer.objective = trainer.compute_objective(trainer.state.best_metrics.copy())
+                trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict.copy())
             # If there hasn't been any evaluation during the training loop.
             if getattr(trainer, "objective", None) is None:
                 metrics = trainer.evaluate()
@@ -228,7 +228,7 @@ def run_hp_search_optuna(trainer, n_trials: int, direction: str, use_best_model:
             # If we want to load the best model, override the object with best
             # metric objective.
             if use_best_model:
-                trainer.objective = trainer.compute_objective(trainer.state.best_metrics)
+                trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
             # If there hasn't been any evaluation during the training loop.
             if getattr(trainer, "objective", None) is None:
                 metrics = trainer.evaluate()
@@ -258,7 +258,7 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, use_best_model: bo
         # If we want to load the best model, override the object with best
         # metric objective.
         if use_best_model:
-            local_trainer.objective = local_trainer.compute_objective(local_trainer.state.best_metrics)
+            local_trainer.objective = local_trainer.compute_objective(local_trainer.state.best_metrics_dict)
         # If there hasn't been any evaluation during the training loop.
         if getattr(local_trainer, "objective", None) is None:
             metrics = local_trainer.evaluate()
@@ -380,7 +380,6 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
     import sigopt
 
     if trainer.args.process_index == 0:
-        print("In master of sigopt")
         if importlib.metadata.version("sigopt") >= "8.0.0":
             sigopt.set_project("huggingface")
 
@@ -408,7 +407,7 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
                         trainer.train(resume_from_checkpoint=None, trial=run.run)
                     # Override the objective with best metric objective.
                     if use_best_model:
-                        trainer.objective = trainer.compute_objective(trainer.state.best_metrics)
+                        trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
                     # If there hasn't been any evaluation during the training loop.
                     if getattr(trainer, "objective", None) is None:
                         metrics = trainer.evaluate()
@@ -448,7 +447,7 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
                     trainer.train(resume_from_checkpoint=None, trial=suggestion)
 
                 if use_best_model:
-                    trainer.objective = trainer.compute_objective(trainer.state.best_metrics.copy())
+                    trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict.copy())
                 # If there hasn't been any evaluation during the training loop.
                 if getattr(trainer, "objective", None) is None:
                     metrics = trainer.evaluate()
@@ -522,7 +521,7 @@ def run_hp_search_wandb(trainer, n_trials: int, direction: str, use_best_model: 
         # Override the objective with best metric objective. Use_best_model assumes
         # we perform evaluation during the training loop.
         if use_best_model:
-            trainer.objective = trainer.compute_objective(trainer.state.best_metrics)
+            trainer.objective = trainer.compute_objective(trainer.state.best_metrics_dict)
         # If there hasn't been any evaluation during the training loop.
         if getattr(trainer, "objective", None) is None:
             metrics = trainer.evaluate()
@@ -799,7 +798,7 @@ class WandbCallback(TrainerCallback):
                     }
                     if not args.load_best_model_at_end
                     else {
-                        f"eval/{args.metric_for_best_model}": state.best_metric_value,
+                        f"eval/{args.metric_for_best_model}": state.best_metric,
                         "train/total_floss": state.total_flos,
                     }
                 )
@@ -1389,8 +1388,8 @@ class NeptuneCallback(TrainerCallback):
 
             operator = np.greater if args.greater_is_better else np.less
 
-            self._should_upload_checkpoint = state.best_metric_value is None or operator(
-                metric_value, state.best_metric_value
+            self._should_upload_checkpoint = state.best_metric is None or operator(
+                metric_value, state.best_metric
             )
 
     @classmethod

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -370,7 +370,7 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, use_best_model: bo
         num_samples=n_trials,
         **kwargs,
     )
-    
+
     # Override ray_scope if use_best_model.
     ray_scope = "all" if use_best_model else trainer.args.ray_scope
 
@@ -1393,9 +1393,7 @@ class NeptuneCallback(TrainerCallback):
 
             operator = np.greater if args.greater_is_better else np.less
 
-            self._should_upload_checkpoint = state.best_metric is None or operator(
-                metric_value, state.best_metric
-            )
+            self._should_upload_checkpoint = state.best_metric is None or operator(metric_value, state.best_metric)
 
     @classmethod
     def get_run(cls, trainer):

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -214,6 +214,7 @@ def run_hp_search_optuna(trainer, n_trials: int, direction: str, use_best_model:
         best_trial = study.best_trial
         return BestRun(str(best_trial.number), best_trial.value, best_trial.params)
     else:
+        print("We have process index not 0")
         for i in range(n_trials):
             trainer.objective = None
             args_main_rank = list(pickle.dumps(trainer.args))
@@ -369,7 +370,11 @@ def run_hp_search_ray(trainer, n_trials: int, direction: str, use_best_model: bo
         num_samples=n_trials,
         **kwargs,
     )
-    best_trial = analysis.get_best_trial(metric="objective", mode=direction[:3], scope=trainer.args.ray_scope)
+    
+    # Override ray_scope if use_best_model.
+    ray_scope = "all" if use_best_model else trainer.args.ray_scope
+
+    best_trial = analysis.get_best_trial(metric="objective", mode=direction[:3], scope=ray_scope)
     best_run = BestRun(best_trial.trial_id, best_trial.last_result["objective"], best_trial.config, analysis)
     if _tb_writer is not None:
         trainer.add_callback(_tb_writer)

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -392,7 +392,7 @@ def run_hp_search_sigopt(trainer, n_trials: int, direction: str, use_best_model:
                 budget=n_trials,
             )
 
-            logger.info(f"created experiment: https://app.sigopt.com/experiment/{experiment.id}")j
+            logger.info(f"created experiment: https://app.sigopt.com/experiment/{experiment.id}")
 
             for run in experiment.loop():
                 with run:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2123,7 +2123,7 @@ class Trainer:
 
     def _load_best_model(self):
         logger.info(
-            f"Loading best model from {self.state.best_model_checkpoint} (score: {self.state.best_metric_value})."
+            f"Loading best model from {self.state.best_model_checkpoint} (score: {self.state.best_metric})."
         )
         best_model_path = os.path.join(self.state.best_model_checkpoint, WEIGHTS_NAME)
         best_safe_model_path = os.path.join(self.state.best_model_checkpoint, SAFE_WEIGHTS_NAME)
@@ -2387,12 +2387,12 @@ class Trainer:
 
             operator = np.greater if self.args.greater_is_better else np.less
             if (
-                self.state.best_metric_value is None
+                self.state.best_metric is None
                 or self.state.best_model_checkpoint is None
-                or operator(metric_value, self.state.best_metric_value)
+                or operator(metric_value, self.state.best_metric)
             ):
-                self.state.best_metrics = metrics.copy()
-                self.state.best_metric_value = metric_value
+                self.state.best_metrics_dict = metrics.copy()
+                self.state.best_metric = metric_value
                 self.state.best_model_checkpoint = output_dir
 
         # Save the Trainer state

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2122,9 +2122,7 @@ class Trainer:
                 self._issue_warnings_after_load(load_result)
 
     def _load_best_model(self):
-        logger.info(
-            f"Loading best model from {self.state.best_model_checkpoint} (score: {self.state.best_metric})."
-        )
+        logger.info(f"Loading best model from {self.state.best_model_checkpoint} (score: {self.state.best_metric}).")
         best_model_path = os.path.join(self.state.best_model_checkpoint, WEIGHTS_NAME)
         best_safe_model_path = os.path.join(self.state.best_model_checkpoint, SAFE_WEIGHTS_NAME)
         best_adapter_model_path = os.path.join(self.state.best_model_checkpoint, ADAPTER_WEIGHTS_NAME)

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -64,7 +64,10 @@ class TrainerState:
             to avoid overflow).
         log_history (`List[Dict[str, float]]`, *optional*):
             The list of logs done since the beginning of training.
-        best_metric (`float`, *optional*):
+        best_metrics (`Dict[str, float]`, *optional*):
+            When tracking the best model, the full metrics dictionary for the checkpoint with the best metric value
+            encounted so far.
+        best_metric_value (`float`, *optional*):
             When tracking the best model, the value of the best metric encountered so far.
         best_model_checkpoint (`str`, *optional*):
             When tracking the best model, the value of the name of the checkpoint for the best model encountered so
@@ -89,7 +92,8 @@ class TrainerState:
     num_train_epochs: int = 0
     total_flos: float = 0
     log_history: List[Dict[str, float]] = None
-    best_metric: Optional[float] = None
+    best_metrics: Dict[str, float] = None
+    best_metric_value: Optional[float] = None
     best_model_checkpoint: Optional[str] = None
     is_local_process_zero: bool = True
     is_world_process_zero: bool = True
@@ -556,11 +560,11 @@ class EarlyStoppingCallback(TrainerCallback):
         self.early_stopping_patience_counter = 0
 
     def check_metric_value(self, args, state, control, metric_value):
-        # best_metric is set by code for load_best_model
+        # best_metric_value is set by code for load_best_model
         operator = np.greater if args.greater_is_better else np.less
-        if state.best_metric is None or (
-            operator(metric_value, state.best_metric)
-            and abs(metric_value - state.best_metric) > self.early_stopping_threshold
+        if state.best_metric_value is None or (
+            operator(metric_value, state.best_metric_value)
+            and abs(metric_value - state.best_metric_value) > self.early_stopping_threshold
         ):
             self.early_stopping_patience_counter = 0
         else:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -64,10 +64,10 @@ class TrainerState:
             to avoid overflow).
         log_history (`List[Dict[str, float]]`, *optional*):
             The list of logs done since the beginning of training.
-        best_metrics (`Dict[str, float]`, *optional*):
+        best_metrics_dict (`Dict[str, float]`, *optional*):
             When tracking the best model, the full metrics dictionary for the checkpoint with the best metric value
             encounted so far.
-        best_metric_value (`float`, *optional*):
+        best_metric (`float`, *optional*):
             When tracking the best model, the value of the best metric encountered so far.
         best_model_checkpoint (`str`, *optional*):
             When tracking the best model, the value of the name of the checkpoint for the best model encountered so
@@ -92,8 +92,8 @@ class TrainerState:
     num_train_epochs: int = 0
     total_flos: float = 0
     log_history: List[Dict[str, float]] = None
-    best_metrics: Dict[str, float] = None
-    best_metric_value: Optional[float] = None
+    best_metrics_dict: Dict[str, float] = None
+    best_metric: Optional[float] = None
     best_model_checkpoint: Optional[str] = None
     is_local_process_zero: bool = True
     is_world_process_zero: bool = True
@@ -560,11 +560,11 @@ class EarlyStoppingCallback(TrainerCallback):
         self.early_stopping_patience_counter = 0
 
     def check_metric_value(self, args, state, control, metric_value):
-        # best_metric_value is set by code for load_best_model
+        # best_metric is set by code for load_best_model
         operator = np.greater if args.greater_is_better else np.less
-        if state.best_metric_value is None or (
-            operator(metric_value, state.best_metric_value)
-            and abs(metric_value - state.best_metric_value) > self.early_stopping_threshold
+        if state.best_metric is None or (
+            operator(metric_value, state.best_metric)
+            and abs(metric_value - state.best_metric) > self.early_stopping_threshold
         ):
             self.early_stopping_patience_counter = 0
         else:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Enables use of best epoch when evaluating trials in hyperparameter searching. Addresses feature request https://github.com/huggingface/transformers/issues/25247

I considered two approaches to adding this:
1. Add as a another flag in TrainingArguments.
2. (this one) Add by piping it through the `hyperparameter_search` method.

I ended up choosing (2) because hyperparameter searching seems like something "applied onto" training, rather than something intrinsic to training itself.

Once a reviewer confirms approach (2) looks good, I can write unit tests. Previously tested by setting `use_best_model=True` and inspecting values manually. Would also appreciate if anyone had thoughts on what the tests should look like.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerz and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
