### PR TITLE
Error with checking args.eval_accumulation_steps to gather tensors

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3193,7 +3193,11 @@ class Trainer:
             self.control = self.callback_handler.on_prediction_step(args, self.state, self.control)
 
             # Gather all tensors and put them back on the CPU if we have done enough accumulation steps.
-            if args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0 and self.accelerator.sync_gradients:
+            if (
+                args.eval_accumulation_steps is not None
+                and (step + 1) % args.eval_accumulation_steps == 0
+                and self.accelerator.sync_gradients
+            ):
                 if losses_host is not None:
                     losses = nested_numpify(losses_host)
                     all_losses = losses if all_losses is None else np.concatenate((all_losses, losses), axis=0)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3193,7 +3193,7 @@ class Trainer:
             self.control = self.callback_handler.on_prediction_step(args, self.state, self.control)
 
             # Gather all tensors and put them back on the CPU if we have done enough accumulation steps.
-            if args.eval_accumulation_steps is not None and self.accelerator.sync_gradients:
+            if args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0 and self.accelerator.sync_gradients:
                 if losses_host is not None:
                     losses = nested_numpify(losses_host)
                     all_losses = losses if all_losses is None else np.concatenate((all_losses, losses), axis=0)


### PR DESCRIPTION
The error is in ```trainer.py```.

While the deprecated (legacy) code has the correct check (line 3772):  
```python
if args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0:
```

The current code does not (line 3196):
```python
if args.eval_accumulation_steps is not None and self.accelerator.sync_gradients:
```

We need to check ```(step + 1) % args.eval_accumulation_steps == 0```, because otherwise, if we set args.eval_accumulation_steps = 10, the code may still gather tensors for each step.

Hence, the line 3196 should be modified to: 
```python
if args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0 and self.accelerator.sync_gradients:
```