### PR TITLE
🤦update warning to If you want to use the new behaviour, set `legacy=…

### DIFF
--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -141,7 +141,7 @@ class LlamaTokenizer(PreTrainedTokenizer):
             logger.warning_once(
                 f"You are using the default legacy behaviour of the {self.__class__}. If you see this, DO NOT PANIC! This is"
                 " expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you."
-                " If you want to use the new behaviour, set `legacy=True`. This should only be set if you understand what it"
+                " If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it"
                 " means, and thouroughly read the reason why this was added as explained in"
                 " https://github.com/huggingface/transformers/pull/24565"
             )

--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -168,7 +168,7 @@ class T5Tokenizer(PreTrainedTokenizer):
             logger.warning_once(
                 f"You are using the default legacy behaviour of the {self.__class__}. If you see this, DO NOT PANIC! This is"
                 " expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you."
-                " If you want to use the new behaviour, set `legacy=True`. This should only be set if you understand what it"
+                " If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it"
                 " means, and thouroughly read the reason why this was added as explained in"
                 " https://github.com/huggingface/transformers/pull/24565"
             )


### PR DESCRIPTION
# What does this PR do?
Fixes #25828, the documentation was suggesting to use legacy=True instead of legacy=False to use the new behavior 