### PR TITLE
[AutoTokenizer] Add data2vec to mapping

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -131,6 +131,7 @@ else:
             ),
             ("cpmant", ("CpmAntTokenizer", None)),
             ("ctrl", ("CTRLTokenizer", None)),
+            ("data2vec-audio", ("Wav2Vec2CTCTokenizer", None)),
             ("data2vec-text", ("RobertaTokenizer", "RobertaTokenizerFast" if is_tokenizers_available() else None)),
             ("deberta", ("DebertaTokenizer", "DebertaTokenizerFast" if is_tokenizers_available() else None)),
             (


### PR DESCRIPTION
# What does this PR do?

Currently, loading the `pipeline` class with data2vec returns an empty tokenizer:

```python
from transformers import pipeline

pipe = pipeline("automatic-speech-recognition", model="facebook/data2vec-audio-base-960h")
print(pipe.tokenizer is None)
```

**Print Output:**
```
True
```

This is because data2vec is missing from the auto-tokenizer mapping list.

cc @Vaibhavs10 