### PR TITLE
Generate: models with custom `generate()` return `True` in `can_generate()`

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -475,8 +475,9 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
         Returns whether this model can generate sequences with `.generate()`. Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
-        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation
-        if "GenerationMixin" in str(cls.prepare_inputs_for_generation):
+        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation.
+        # Alternativelly, the model can also have a custom `generate` function.
+        if "GenerationMixin" in str(cls.prepare_inputs_for_generation) and "GenerationMixin" in str(cls.generate):
             return False
         return True
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1307,8 +1307,9 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
-        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation
-        if "GenerationMixin" in str(cls.prepare_inputs_for_generation):
+        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation.
+        # Alternativelly, the model can also have a custom `generate` function.
+        if "GenerationMixin" in str(cls.prepare_inputs_for_generation) and "GenerationMixin" in str(cls.generate):
             return False
         return True
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1216,8 +1216,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
-        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation
-        if "GenerationMixin" in str(cls.prepare_inputs_for_generation):
+        # Detects whether `prepare_inputs_for_generation` has been overwritten, which is a requirement for generation.
+        # Alternativelly, the model can also have a custom `generate` function.
+        if "GenerationMixin" in str(cls.prepare_inputs_for_generation) and "GenerationMixin" in str(cls.generate):
             return False
         return True
 

--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1231,13 +1231,6 @@ class BarkFineModel(BarkPreTrainedModel):
             attentions=all_self_attentions,
         )
 
-    def can_generate(self) -> bool:
-        """
-        Returns True. Despite being an autoencoder, BarkFineModel shares some characteristics with generative models
-        due to the way audio are generated.
-        """
-        return True
-
     def generate(
         self,
         coarse_output: torch.Tensor,
@@ -1594,10 +1587,3 @@ class BarkModel(BarkPreTrainedModel):
             self.codec_model_hook.offload()
 
         return audio
-
-    def can_generate(self) -> bool:
-        """
-        Returns True. Despite not having a `self.generate` method, this model can `generate` and thus needs a
-        BarkGenerationConfig.
-        """
-        return True

--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -2779,13 +2779,6 @@ class SpeechT5ForTextToSpeech(SpeechT5PreTrainedModel):
             encoder_attentions=outputs.encoder_attentions,
         )
 
-    def can_generate(self) -> bool:
-        """
-        Returns True. This model can `generate` and must therefore have this property set to True in order to be used
-        in the TTS pipeline.
-        """
-        return True
-
     @torch.no_grad()
     def generate(
         self,


### PR DESCRIPTION
# What does this PR do?

See discussion in #25532 

This PR updates `GenerationMixin.can_generate()` to also return `True` when a model has a custom `generate()` -- which means that the model is allowed to call `generate()`. While at it, removes a few overloads, as they are redundant with the change in the PR ✂️ 

Additional context: ALL models have a `generate()` function defined, as the mixin is added to all models. This function is a helper to detect when the model class is compatible with `generate()` or not.

______________________________________________
Double-checking with code:
```py
from transformers import Blip2ForConditionalGeneration, BertForQuestionAnswering, BarkFineModel, BarkModel, SpeechT5ForTextToSpeech

print(Blip2ForConditionalGeneration.can_generate())
print(BarkFineModel.can_generate())
print(BarkModel.can_generate())
print(SpeechT5ForTextToSpeech.can_generate())
print(BertForQuestionAnswering.can_generate())  # sanity check: this one can't generate
```
After this PR, this prints `True` in all cases except the last one, as expected. 