### PR TITLE
add pipeline support for Ascend NPU

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -75,6 +75,7 @@ from .utils import (
     is_peft_available,
     is_remote_url,
     is_safetensors_available,
+    is_torch_npu_available,
     is_torch_tpu_available,
     logging,
     replace_return_docstrings,
@@ -88,6 +89,9 @@ from .utils.versions import require_version_core
 
 XLA_USE_BF16 = os.environ.get("XLA_USE_BF16", "0").upper()
 XLA_DOWNCAST_BF16 = os.environ.get("XLA_DOWNCAST_BF16", "0").upper()
+
+if is_torch_npu_available():
+    import torch_npu  # noqa: F401
 
 if is_accelerate_available():
     from accelerate import dispatch_model, infer_auto_device_map, init_empty_weights

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -41,6 +41,7 @@ from ..utils import (
     is_pyctcdecode_available,
     is_tf_available,
     is_torch_available,
+    is_torch_npu_available,
     logging,
 )
 from .audio_classification import AudioClassificationPipeline
@@ -629,8 +630,8 @@ def pipeline(
             The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
             when running `huggingface-cli login` (stored in `~/.huggingface`).
         device (`int` or `str` or `torch.device`):
-            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"npu:1"`, `"mps"`, or a GPU/NPU ordinal rank like `1`) on which this
-            pipeline will be allocated.
+            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"npu:1"`, `"mps"`, or a GPU/NPU ordinal rank like `1`) on
+            which this pipeline will be allocated.
         device_map (`str` or `Dict[str, Union[int, str, torch.device]`, *optional*):
             Sent directly as `model_kwargs` (just a simpler shortcut). When `accelerate` library is present, set
             `device_map="auto"` to compute the most optimized `device_map` automatically (see

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -107,6 +107,9 @@ if is_tf_available():
 if is_torch_available():
     import torch
 
+    if is_torch_npu_available():
+        import torch_npu  # noqa: F401
+
     from ..models.auto.modeling_auto import (
         AutoModel,
         AutoModelForAudioClassification,
@@ -626,7 +629,7 @@ def pipeline(
             The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
             when running `huggingface-cli login` (stored in `~/.huggingface`).
         device (`int` or `str` or `torch.device`):
-            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"mps"`, or a GPU ordinal rank like `1`) on which this
+            Defines the device (*e.g.*, `"cpu"`, `"cuda:1"`, `"npu:1"`, `"mps"`, or a GPU/NPU ordinal rank like `1`) on which this
             pipeline will be allocated.
         device_map (`str` or `Dict[str, Union[int, str, torch.device]`, *optional*):
             Sent directly as `model_kwargs` (just a simpler shortcut). When `accelerate` library is present, set

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -34,7 +34,15 @@ from ..image_processing_utils import BaseImageProcessor
 from ..modelcard import ModelCard
 from ..models.auto.configuration_auto import AutoConfig
 from ..tokenization_utils import PreTrainedTokenizer
-from ..utils import ModelOutput, add_end_docstrings, infer_framework, is_tf_available, is_torch_available, is_torch_npu_available, logging
+from ..utils import (
+    ModelOutput,
+    add_end_docstrings,
+    infer_framework,
+    is_tf_available,
+    is_torch_available,
+    is_torch_npu_available,
+    logging,
+)
 
 
 GenericTensor = Union[List["GenericTensor"], "torch.Tensor", "tf.Tensor"]
@@ -722,8 +730,8 @@ PIPELINE_INIT_ARGS = r"""
         args_parser ([`~pipelines.ArgumentHandler`], *optional*):
             Reference to the object in charge of parsing supplied pipeline parameters.
         device (`int`, *optional*, defaults to -1):
-            Device ordinal for CPU/GPU/NPU supports. Setting this to -1 will leverage CPU, a positive will run the model on
-            the associated CUDA/NPU device id. You can pass native `torch.device` or a `str` too.
+            Device ordinal for CPU/GPU/NPU supports. Setting this to -1 will leverage CPU, a positive will run the
+            model on the associated CUDA/NPU device id. You can pass native `torch.device` or a `str` too.
         binary_output (`bool`, *optional*, defaults to `False`):
             Flag indicating if the output the pipeline should happen in a binary format (i.e., pickle) or as raw text.
 """


### PR DESCRIPTION
# What does this PR do?
Currently, Transformers's Trainer library has supported Ascend NPU([see](https://github.com/huggingface/transformers/pull/24879)).

This PR makes the pipeline library available on Ascend NPU. For example, we can run a text-classification pipeline on Ascend NPU with the following command(reference the example of `TextClassificationPipeline`):

```python
>>> from transformers import pipeline

>>> classifier = pipeline(model="distilbert-base-uncased-finetuned-sst-2-english", device="npu:1")

>>> classifier("Director tried too much.")
[{'label': 'NEGATIVE', 'score': 0.9963733553886414}]
```

## Who can review?
Anyone in the community is free to review the PR once the tests have passed.

