### PR TITLE
Add `tgs` speed metrics

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1163,7 +1163,7 @@ class Trainer:
         """
         Helper to get number of tokens in a [`~torch.utils.data.DataLoader`] by enumerating dataloader.
         """
-        train_tokens = 0 
+        train_tokens = 0
         try:
             for step, batch in enumerate(train_dl):
                 tokens = batch["input_ids"].numel()
@@ -1608,8 +1608,7 @@ class Trainer:
                 num_train_samples = args.max_steps * total_train_batch_size
                 if args.include_tokens_per_second:
                     num_train_tokens = (
-                        self.num_tokens(train_dataloader, args.max_steps)
-                        * args.gradient_accumulation_steps
+                        self.num_tokens(train_dataloader, args.max_steps) * args.gradient_accumulation_steps
                     )
             else:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
@@ -1625,10 +1624,7 @@ class Trainer:
             num_examples = total_train_batch_size * args.max_steps
             num_train_samples = args.max_steps * total_train_batch_size
             if args.include_tokens_per_second:
-                num_train_tokens = (
-                    self.num_tokens(train_dataloader, args.max_steps)
-                    * args.gradient_accumulation_steps
-                )
+                num_train_tokens = self.num_tokens(train_dataloader, args.max_steps) * args.gradient_accumulation_steps
         else:
             raise ValueError(
                 "args.max_steps must be set to a positive value if dataloader does not have a length, was"

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1164,15 +1164,15 @@ class Trainer:
         Helper to get number of tokens in a [`~torch.utils.data.DataLoader`] by enumerating dataloader.
         """
         try:
-            train_tokes = 0
+            train_tokens = 0
             for step, batch in enumerate(train_dl):
-                tks = batch["input_ids"].size(0) * batch["input_ids"].size(1)
+                tokens = batch["input_ids"].size(0) * batch["input_ids"].size(1)
                 if max_steps:
-                    return tks
-                train_tokes += tks
+                    return tokens
+                train_tokens += tokens
             return train_tokes
-        except:
-            logger.warning(f"Cannot get num_tokens from dataloader")
+        except (KeyError):
+            logger.warning("Cannot get num_tokens from dataloader")
             return 0
 
     def _hp_search_setup(self, trial: Union["optuna.Trial", Dict[str, Any]]):
@@ -1615,7 +1615,7 @@ class Trainer:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
                 num_train_epochs = math.ceil(args.num_train_epochs)
                 num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
-                num_train_tokens = self.num_tokens(train_dataloader) * args.world_size
+                num_train_tokens = self.num_tokens(train_dataloader) * args.world_size * args.num_train_epochs
         elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
             max_steps = args.max_steps
             # Setting a very large number of epochs so we go as many times as necessary over the iterator.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1606,7 +1606,7 @@ class Trainer:
                 # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
                 # the best we can do.
                 num_train_samples = args.max_steps * total_train_batch_size
-                if args.tgs_metrics:
+                if args.include_tokens_per_second:
                     num_train_tokens = (
                         args.max_steps
                         * self.num_tokens(train_dataloader, True)
@@ -1617,7 +1617,7 @@ class Trainer:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
                 num_train_epochs = math.ceil(args.num_train_epochs)
                 num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
-                if args.tgs_metrics:
+                if args.include_tokens_per_second:
                     num_train_tokens = self.num_tokens(train_dataloader) * args.world_size * args.num_train_epochs
         elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
             max_steps = args.max_steps
@@ -1626,7 +1626,7 @@ class Trainer:
             num_update_steps_per_epoch = max_steps
             num_examples = total_train_batch_size * args.max_steps
             num_train_samples = args.max_steps * total_train_batch_size
-            if args.tgs_metrics:
+            if args.include_tokens_per_second:
                 num_train_tokens = (
                     args.max_steps
                     * self.num_tokens(train_dataloader, True)
@@ -2014,7 +2014,7 @@ class Trainer:
             start_time,
             num_samples=num_train_samples,
             num_steps=self.state.max_steps,
-            num_tokens=None if args.tgs_metrics is None else num_train_tokens / args.world_size,
+            num_tokens=None if args.include_tokens_per_second is None else num_train_tokens / args.world_size,
         )
         self.store_flos()
         metrics["total_flos"] = self.state.total_flos

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1159,21 +1159,21 @@ class Trainer:
         except (NameError, AttributeError, TypeError):  # no dataset or length, estimate by length of dataloader
             return len(dataloader) * self.args.per_device_train_batch_size
 
-    def num_tokens(self, train_dl: DataLoader, max_steps: bool = False) -> int:
+    def num_tokens(self, train_dl: DataLoader, max_steps: Optional[int] = None) -> int:
         """
         Helper to get number of tokens in a [`~torch.utils.data.DataLoader`] by enumerating dataloader.
         """
+        train_tokens = 0 
         try:
-            train_tokens = 0
             for step, batch in enumerate(train_dl):
                 tokens = batch["input_ids"].numel()
-                if max_steps:
-                    return tokens
+                if max_steps is not None:
+                    return tokens * max_steps
                 train_tokens += tokens
             return train_tokens
         except KeyError:
             logger.warning("Cannot get num_tokens from dataloader")
-            return 0
+            return train_tokens
 
     def _hp_search_setup(self, trial: Union["optuna.Trial", Dict[str, Any]]):
         """HP search setup code"""

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1165,7 +1165,7 @@ class Trainer:
         """
         train_tokes = 0
         for step, batch in enumerate(train_dl):
-            tks = batch['input_ids'].size(0) * batch['input_ids'].size(1)
+            tks = batch["input_ids"].size(0) * batch["input_ids"].size(1)
             if max_steps:
                 return tks
             train_tokes += tks
@@ -1601,12 +1601,17 @@ class Trainer:
                 # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
                 # the best we can do.
                 num_train_samples = args.max_steps * total_train_batch_size
-                num_train_tokens = args.max_steps * self.num_tokens(train_dataloader, True) * args.gradient_accumulation_steps * args.world_size
+                num_train_tokens = (
+                    args.max_steps
+                    * self.num_tokens(train_dataloader, True)
+                    * args.gradient_accumulation_steps
+                    * args.world_size
+                )
             else:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
                 num_train_epochs = math.ceil(args.num_train_epochs)
                 num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
-                num_train_tokens = self.num_tokens(train_dataloader)
+                num_train_tokens = self.num_tokens(train_dataloader) * args.world_size
         elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
             max_steps = args.max_steps
             # Setting a very large number of epochs so we go as many times as necessary over the iterator.
@@ -1614,7 +1619,12 @@ class Trainer:
             num_update_steps_per_epoch = max_steps
             num_examples = total_train_batch_size * args.max_steps
             num_train_samples = args.max_steps * total_train_batch_size
-            num_train_tokens = args.max_steps * self.num_tokens(train_dataloader, True) * args.gradient_accumulation_steps * args.world_size
+            num_train_tokens = (
+                args.max_steps
+                * self.num_tokens(train_dataloader, True)
+                * args.gradient_accumulation_steps
+                * args.world_size
+            )
         else:
             raise ValueError(
                 "args.max_steps must be set to a positive value if dataloader does not have a length, was"
@@ -1991,7 +2001,13 @@ class Trainer:
         self._total_loss_scalar += tr_loss.item()
         train_loss = self._total_loss_scalar / self.state.global_step
 
-        metrics = speed_metrics("train", start_time, num_samples=num_train_samples, num_steps=self.state.max_steps, num_tokens= num_train_tokens / args.world_size)
+        metrics = speed_metrics(
+            "train",
+            start_time,
+            num_samples=num_train_samples,
+            num_steps=self.state.max_steps,
+            num_tokens=num_train_tokens / args.world_size,
+        )
         self.store_flos()
         metrics["total_flos"] = self.state.total_flos
         metrics["train_loss"] = train_loss

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1171,7 +1171,7 @@ class Trainer:
                     return tokens
                 train_tokens += tokens
             return train_tokens
-        except (KeyError):
+        except KeyError:
             logger.warning("Cannot get num_tokens from dataloader")
             return 0
 
@@ -1592,6 +1592,7 @@ class Trainer:
         total_train_batch_size = self._train_batch_size * args.gradient_accumulation_steps * args.world_size
 
         len_dataloader = None
+        num_train_tokens = 0
         if has_length(train_dataloader):
             len_dataloader = len(train_dataloader)
             num_update_steps_per_epoch = len_dataloader // args.gradient_accumulation_steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1163,13 +1163,17 @@ class Trainer:
         """
         Helper to get number of tokens in a [`~torch.utils.data.DataLoader`] by enumerating dataloader.
         """
-        train_tokes = 0
-        for step, batch in enumerate(train_dl):
-            tks = batch["input_ids"].size(0) * batch["input_ids"].size(1)
-            if max_steps:
-                return tks
-            train_tokes += tks
-        return train_tokes
+        try:
+            train_tokes = 0
+            for step, batch in enumerate(train_dl):
+                tks = batch["input_ids"].size(0) * batch["input_ids"].size(1)
+                if max_steps:
+                    return tks
+                train_tokes += tks
+            return train_tokes
+        except:
+            logger.warning(f"Cannot get num_tokens from dataloader")
+            return 0
 
     def _hp_search_setup(self, trial: Union["optuna.Trial", Dict[str, Any]]):
         """HP search setup code"""

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1608,8 +1608,7 @@ class Trainer:
                 num_train_samples = args.max_steps * total_train_batch_size
                 if args.include_tokens_per_second:
                     num_train_tokens = (
-                        args.max_steps
-                        * self.num_tokens(train_dataloader, True)
+                        self.num_tokens(train_dataloader, args.max_steps)
                         * args.gradient_accumulation_steps
                         * args.world_size
                     )
@@ -1628,8 +1627,7 @@ class Trainer:
             num_train_samples = args.max_steps * total_train_batch_size
             if args.include_tokens_per_second:
                 num_train_tokens = (
-                    args.max_steps
-                    * self.num_tokens(train_dataloader, True)
+                    self.num_tokens(train_dataloader, args.max_steps)
                     * args.gradient_accumulation_steps
                     * args.world_size
                 )
@@ -2014,7 +2012,7 @@ class Trainer:
             start_time,
             num_samples=num_train_samples,
             num_steps=self.state.max_steps,
-            num_tokens=None if args.include_tokens_per_second is None else num_train_tokens / args.world_size,
+            num_tokens=None if not args.include_tokens_per_second else num_train_tokens / args.world_size,
         )
         self.store_flos()
         metrics["total_flos"] = self.state.total_flos

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -360,7 +360,7 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None, num_token
         result[f"{split}_steps_per_second"] = round(steps_per_second, 3)
     if num_tokens is not None:
         tokens_per_second = num_tokens / runtime
-        result[f"{split}_tokens_per_second(tgs)"] = round(tokens_per_second, 3)
+        result[f"{split}_tokens_per_second"] = round(tokens_per_second, 3)
     return result
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -335,7 +335,7 @@ def total_processes_number(local_rank):
     return 1
 
 
-def speed_metrics(split, start_time, num_samples=None, num_steps=None):
+def speed_metrics(split, start_time, num_samples=None, num_steps=None, num_tokens=None):
     """
     Measure and return speed performance metrics.
 
@@ -346,6 +346,7 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None):
     - split: name to prefix metric (like train, eval, test...)
     - start_time: operation start time
     - num_samples: number of samples processed
+    - num_tokens: number of tokens processed
     """
     runtime = time.time() - start_time
     result = {f"{split}_runtime": round(runtime, 4)}
@@ -357,6 +358,9 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None):
     if num_steps is not None:
         steps_per_second = num_steps / runtime
         result[f"{split}_steps_per_second"] = round(steps_per_second, 3)
+    if num_tokens is not None:
+        tokens_per_second = num_tokens / runtime
+        result[f"{split}_steps_per_second(tgs)"] = round(tokens_per_second, 3)
     return result
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -360,7 +360,7 @@ def speed_metrics(split, start_time, num_samples=None, num_steps=None, num_token
         result[f"{split}_steps_per_second"] = round(steps_per_second, 3)
     if num_tokens is not None:
         tokens_per_second = num_tokens / runtime
-        result[f"{split}_steps_per_second(tgs)"] = round(tokens_per_second, 3)
+        result[f"{split}_tokens_per_second(tgs)"] = round(tokens_per_second, 3)
     return result
 
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1240,7 +1240,7 @@ class TrainingArguments:
 
     tgs_metrics: Optional[bool] = field(
         default=False,
-        metadata={"help": ("If set to `True`, the speed metrics will include `tgs`(tokens per second per device).")},
+        metadata={"help": "If set to `True`, the speed metrics will include `tgs`(tokens per second per device)."},
     )
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1240,7 +1240,7 @@ class TrainingArguments:
 
     include_tokens_per_second: Optional[bool] = field(
         default=False,
-        metadata={"help": "If set to `True`, the speed metrics will include `tgs`(tokens per second per device)."},
+        metadata={"help": "If set to `True`, the speed metrics will include `tgs` (tokens per second per device)."},
     )
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -633,14 +633,9 @@ class TrainingArguments:
             Refer to the PyTorch doc for possible values and note that they may change across PyTorch versions.
 
             This flag is experimental and subject to change in future releases.
-        tgs_metrics (`bool`, *optional*, defaults to `False`):
-            Whether or not to compute the `tgs` for training speed metrics.
-
-            If set to `True`, the speed metrics will include `tgs`(tokens per second per device).
-
-            It will iterate over the dataloader ahead of training.
-
-            This will slow down the whole process, especally for large datasets.
+        include_tokens_per_second (`bool`, *optional*):
+            Whether or not to compute the number of tokens per second per device for training speed metrics.
+            This will iterate over the entire training dataloader once beforehand, and will slow down the entire process.
     """
 
     framework = "pt"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -636,9 +636,9 @@ class TrainingArguments:
         tgs_metrics (`bool`, *optional*, defaults to `False`):
             Whether or not to compute the `tgs` for training speed metrics.
 
-            "If set to `True`, the speed metrics will include `tgs`(tokens per second per device)."
-            " It will iterate over the dataloader ahead of training, which might slow down the whole process,"
-            " especally for large datasets."
+            If set to `True`, the speed metrics will include `tgs`(tokens per second per device).
+
+            It will iterate over the dataloader ahead of training, which might slow down the whole process, especally for large datasets.
     """
 
     framework = "pt"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -637,8 +637,10 @@ class TrainingArguments:
             Whether or not to compute the `tgs` for training speed metrics.
 
             If set to `True`, the speed metrics will include `tgs`(tokens per second per device).
-
-            It will iterate over the dataloader ahead of training, which might slow down the whole process, especally for large datasets.
+            
+            It will iterate over the dataloader ahead of training.
+            
+            This will slow down the whole process, especally for large datasets.
     """
 
     framework = "pt"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -637,9 +637,9 @@ class TrainingArguments:
             Whether or not to compute the `tgs` for training speed metrics.
 
             If set to `True`, the speed metrics will include `tgs`(tokens per second per device).
-            
+
             It will iterate over the dataloader ahead of training.
-            
+
             This will slow down the whole process, especally for large datasets.
     """
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -633,6 +633,12 @@ class TrainingArguments:
             Refer to the PyTorch doc for possible values and note that they may change across PyTorch versions.
 
             This flag is experimental and subject to change in future releases.
+        tgs_metrics (`bool`, *optional*, defaults to `False`):
+            Whether or not to compute the `tgs` for training speed metrics.
+
+            "If set to `True`, the speed metrics will include `tgs`(tokens per second per device)."
+            " It will iterate over the dataloader ahead of training, which might slow down the whole process,"
+            " especally for large datasets."
     """
 
     framework = "pt"
@@ -1230,6 +1236,11 @@ class TrainingArguments:
             "and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose"
             "underlying dataset is an `IterableDataset`, `False` otherwise."
         },
+    )
+
+    tgs_metrics: Optional[bool] = field(
+        default=False,
+        metadata={"help": ("If set to `True`, the speed metrics will include `tgs`(tokens per second per device).")},
     )
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -635,7 +635,10 @@ class TrainingArguments:
             This flag is experimental and subject to change in future releases.
         include_tokens_per_second (`bool`, *optional*):
             Whether or not to compute the number of tokens per second per device for training speed metrics.
-            This will iterate over the entire training dataloader once beforehand, and will slow down the entire process.
+
+            This will iterate over the entire training dataloader once beforehand,
+
+            and will slow down the entire process.
     """
 
     framework = "pt"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1235,7 +1235,7 @@ class TrainingArguments:
         },
     )
 
-    tgs_metrics: Optional[bool] = field(
+    include_tokens_per_second: Optional[bool] = field(
         default=False,
         metadata={"help": "If set to `True`, the speed metrics will include `tgs`(tokens per second per device)."},
     )


### PR DESCRIPTION
add tgs metrics for `trainer`. the motivation is that: current `speed_metrics` only consider `train_samples_per_second`. but the length of each example is  not the same(especailly `cutting_off ` increase). this pr introduce `tgs` metrics, which take `tokens` into considerations.