### PR TITLE
Add flax installation in daily doctest workflow

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -34,7 +34,7 @@ jobs:
           nvidia-smi
 
       - name: Install transformers in edit mode
-        run: python3 -m pip install -e .
+        run: python3 -m pip install -e .[flax]
 
       - name: GPU visibility
         run: |


### PR DESCRIPTION
# What does this PR do?

#25763 enables the doctesting against a few more files, including some flax related files. As the docker image doesn't have flax/jax installed, the pytest failed to collect the test to run, see [this doctest run](https://github.com/huggingface/transformers/actions/runs/6019814019/job/16330174475):
```bash
src/transformers/generation/flax_utils.py - ModuleNotFoundError: No module named 'flax'
```

Let's install jax/flax in the doctest workflow, and see what this gives us.

Note we don't want to install jax/flax in the docker image, as the same image is used for daily (non-doctest) CI, and we don't want to have them to (potentially) interfere the CI.