### PR TITLE
Smarter check for `is_tensor`

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -74,7 +74,7 @@ def strtobool(val):
 def infer_framework_from_repr(x):
     """
     Tries to guess the framework of an object `x` from its repr (brittle but will help in `is_tensor` to try the
-    frameworks in a smart order).
+    frameworks in a smart order, without the need to import the frameworks).
     """
     representation = repr(x)
     if representation.startswith("tensor"):
@@ -109,7 +109,7 @@ def _get_frameworks_and_tests(x):
 
 def is_tensor(x):
     """
-    Tests if `x` is a `torch.Tensor`, `tf.Tensor`, `jaxlib.xla_extension.DeviceArray` or `np.ndarray`.
+    Tests if `x` is a `torch.Tensor`, `tf.Tensor`, `jaxlib.xla_extension.DeviceArray` or `np.ndarray` in the order defined by `infer_framework_from_repr` 
     """
     # This gives us a smart order to test the frameworks with the corresponding tests.
     framework_tests = _get_frameworks_and_tests(x)

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -92,10 +92,10 @@ def is_tensor(x):
     Tests if `x` is a `torch.Tensor`, `tf.Tensor`, `jaxlib.xla_extension.DeviceArray` or `np.ndarray`.
     """
     framework_tests = {
-        "pt": _is_torch,
-        "tf": _is_tensorflow,
-        "jax": _is_jax,
-        "np": _is_numpy,
+        "pt": is_torch_tensor,
+        "tf": is_tf_tensor,
+        "jax": is_jax_tensor,
+        "np": is_numpy_array,
     }
     preferred_framework = infer_framework_from_repr(x)
     # We will test this one first, then numpy, then the others.


### PR DESCRIPTION
# What does this PR do?

This PR makes the check in `is_tensor` a bit smarter by trying first the framework we guess from the repr of the object passed, then Numpy, then the others. It shouldn't break anything as we just swith the order of the tests, but still test the same things.

Just need to make sure all imports are properly protected but you get the gist of it. The same can then be applied to `to_py_obj` or `to_numpy`.

Fixes #25747 