### PR TITLE
Reduce CI output

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -32,7 +32,8 @@ COMMON_ENV_VARIABLES = {
     "RUN_PT_TF_CROSS_TESTS": False,
     "RUN_PT_FLAX_CROSS_TESTS": False,
 }
-COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile", "s": None}
+# Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
+COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile"}
 DEFAULT_DOCKER_IMAGE = [{"image": "cimg/python:3.8.12"}]
 
 


### PR DESCRIPTION
# What does this PR do?

The use of `-s` will show a lot of outputs: the `torch_job` has more than 1.6M lines in the outputs, which makes the loading very long and hard to see the final failed test names at the end.

Let's not use this flag. If this affects other core maintainer's workflow, let's see what to do alternatively.