### PR TITLE
Save image_processor while saving pipeline (ImageSegmentationPipeline)

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -872,6 +872,9 @@ class Pipeline(_ScikitCompat):
         if self.feature_extractor is not None:
             self.feature_extractor.save_pretrained(save_directory)
 
+        if self.image_processor is not None:
+            self.image_processor.save_pretrained(save_directory)
+
         if self.modelcard is not None:
             self.modelcard.save_pretrained(save_directory)
 

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -33,7 +33,7 @@ from transformers import (
     ImageSegmentationPipeline,
     MaskFormerForInstanceSegmentation,
     is_vision_available,
-    pipeline, Pipeline,
+    pipeline,
 )
 from transformers.testing_utils import (
     is_pipeline_test,
@@ -722,10 +722,10 @@ class ImageSegmentationPipelineTests(unittest.TestCase):
         model = AutoModelForImageSegmentation.from_pretrained(model_id)
         image_processor = AutoImageProcessor.from_pretrained(model_id)
         image_segmenter = pipeline(
-            task='image-segmentation',
+            task="image-segmentation",
             model=model,
             image_processor=image_processor,
         )
         with tempfile.TemporaryDirectory() as tmpdirname:
             image_segmenter.save_pretrained(tmpdirname)
-            loaded_image_segmenter = pipeline(task = 'image-segmentation',model=tmpdirname)
+            pipeline(task="image-segmentation", model=tmpdirname)

--- a/tests/pipelines/test_pipelines_image_segmentation.py
+++ b/tests/pipelines/test_pipelines_image_segmentation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import hashlib
+import tempfile
 import unittest
 from typing import Dict
 
@@ -32,7 +33,7 @@ from transformers import (
     ImageSegmentationPipeline,
     MaskFormerForInstanceSegmentation,
     is_vision_available,
-    pipeline,
+    pipeline, Pipeline,
 )
 from transformers.testing_utils import (
     is_pipeline_test,
@@ -714,3 +715,17 @@ class ImageSegmentationPipelineTests(unittest.TestCase):
                 },
             ],
         )
+
+    def test_save_load(self):
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3-panoptic"
+
+        model = AutoModelForImageSegmentation.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        image_segmenter = pipeline(
+            task='image-segmentation',
+            model=model,
+            image_processor=image_processor,
+        )
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            image_segmenter.save_pretrained(tmpdirname)
+            loaded_image_segmenter = pipeline(task = 'image-segmentation',model=tmpdirname)


### PR DESCRIPTION
# What does this PR do?

Fixes #25804 

When saving the pipeline, we had missed saving image_processor which was causing error when loading pipeline from disk. This PR fixes this bug.

@ArthurZucker 