### PR TITLE
[`InstructBlip`] FINAL Fix instructblip test

### DIFF
--- a/tests/models/instructblip/test_modeling_instructblip.py
+++ b/tests/models/instructblip/test_modeling_instructblip.py
@@ -538,7 +538,7 @@ class InstructBlipModelIntegrationTest(unittest.TestCase):
             logits = model(**inputs).logits
 
         expected_slice = torch.tensor(
-            [[-3.4727, -11.8203, 8.3828], [-5.1172, -11.3438, 7.7656], [-4.0742, -13.4688, 9.1953]],
+            [[-3.4902, -12.5078, 8.4141], [-5.1211, -12.1328, 7.8281], [-4.0312, -13.5938, 9.1172]],
             device=torch_device,
         )
         self.assertTrue(torch.allclose(logits[0, :3, :3].float(), expected_slice, atol=1e-3))
@@ -548,12 +548,12 @@ class InstructBlipModelIntegrationTest(unittest.TestCase):
         generated_text = processor.batch_decode(outputs, skip_special_tokens=True)[0].strip()
 
         # fmt: off
-        expected_outputs = [2, 450, 22910, 9565, 310, 445, 1967, 338, 393, 263, 767, 338, 13977, 292, 22095, 373, 278, 1250, 310, 263, 13328, 20134, 29963, 1550, 19500, 373, 263, 19587, 4272, 11952, 29889]
+        expected_outputs = [2, 450, 22910, 9565, 310, 445, 1967, 338, 393, 263, 767, 338, 13977, 292, 22095, 373, 278, 1250, 310, 263, 13328, 20134, 29963, 1550, 19500, 1623, 263, 19587, 4272, 11952, 29889]
         # fmt: on
         self.assertEqual(outputs[0].tolist(), expected_outputs)
         self.assertEqual(
             generated_text,
-            "The unusual aspect of this image is that a man is ironing clothes on the back of a yellow SUV while driving on a busy city street.",
+            "The unusual aspect of this image is that a man is ironing clothes on the back of a yellow SUV while driving down a busy city street.",
         )
 
     def test_inference_flant5_xl(self):


### PR DESCRIPTION
# What does this PR do?

Fixes the current failing instructblip slow test

This commit: https://github.com/huggingface/transformers/commit/2230d149f0dc4de05ea7a9a1c5295b6d80e495cd was responsible of the test failure however the commit above sillently fixed an issue.

The PR #25105 introduced the correct way of quantizing composable models (blip2, instructblip) and models on the Hub. Before that commit the lm_head of the language model was converted in 8bit, which in fact is wrong. The lm_head should always stay in fp32 for numerical stability and also for consistency with other causal LM models in the library (we keep all lm_head in fp32). Therefore this PR fixes the expected logits and generations

Tested the fix in the latest docker image `huggingface/transformers-all-latest-gpu` on a 2xNVIDIA T4 and the test pass 

cc @ydshieh @amyeroberts 