### PR TITLE
Show failed tests on CircleCI layout in a better way

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -234,15 +234,14 @@ class CircleCIJob:
         py_command = f'import os; fp = open("reports/tests_{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
-        check_test_command += f'cat summary_short.txt; exit -1; '
+        check_test_command += f'cat summary_short.txt; echo ""; exit -1; '
         check_test_command += f'elif [ -s reports/tests_{self.name}/stats.txt ]; then echo "All tests pass!"; '
 
         # return code `124` means the previous (pytest run) step is timeout
         if self.name == "pr_documentation_tests":
             check_test_command += 'elif [ -f 124.txt ]; then echo "doctest timeout!"; '
 
-        check_test_command += 'else echo "other fatal error"; exit -1; fi;'
-        check_test_command += 'echo ""; '
+        check_test_command += 'else echo "other fatal error"; echo ""; exit -1; fi;'
 
         steps.append({"run": {"name": "Check test results", "command": check_test_command}})
 
@@ -604,7 +603,7 @@ def create_circleci_config(folder=None):
                 job.tests_to_run = [f"examples/{framework}"]
             else:
                 job.tests_to_run = [f for f in example_tests.split(" ") if f.startswith(f"examples/{framework}")]
-            
+
             if len(job.tests_to_run) > 0:
                 jobs.append(job)
 

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -223,18 +223,28 @@ class CircleCIJob:
             # failure.
             test_command = f"({test_command}) || true"
         else:
-            test_command += " | tee tests_output.txt"
+            test_command += " | tee tests_output.txt || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
+
+        check_test_command = f'if [ -s reports/tests_{self.name}/failures_short.txt ]; '
+        check_test_command += 'then echo "Some test failed!"; echo ""; '
+        check_test_command += f'cat reports/tests_{self.name}/failures_short.txt; '
+        check_test_command += 'echo ""; echo ""; '
+
+        py_command = f'import os; fp = open("reports/tests_{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        check_test_command += f"$(python3 -c '{py_command}'); "
+
+        check_test_command += f'cat summary_short.txt; exit -1; '
+        check_test_command += f'elif [ -s reports/tests_{self.name}/stats.txt ]; then echo "All tests pass!"; '
 
         # return code `124` means the previous (pytest run) step is timeout
         if self.name == "pr_documentation_tests":
-            checkout_doctest_command = 'if [ -s reports/tests_pr_documentation_tests/failures_short.txt ]; '
-            checkout_doctest_command += 'then echo "some test failed"; '
-            checkout_doctest_command += 'cat reports/tests_pr_documentation_tests/failures_short.txt; '
-            checkout_doctest_command += 'cat reports/tests_pr_documentation_tests/summary_short.txt; exit -1; '
-            checkout_doctest_command += 'elif [ -s reports/tests_pr_documentation_tests/stats.txt ]; then echo "All tests pass!"; '
-            checkout_doctest_command += 'elif [ -f 124.txt ]; then echo "doctest timeout!"; else echo "other fatal error)"; exit -1; fi;'
-            steps.append({"run": {"name": "Check doctest results", "command": checkout_doctest_command}})
+            check_test_command += 'elif [ -f 124.txt ]; then echo "doctest timeout!"; '
+
+        check_test_command += 'else echo "other fatal error"; exit -1; fi;'
+        check_test_command += 'echo ""; '
+
+        steps.append({"run": {"name": "Check test results", "command": check_test_command}})
 
         steps.append({"store_artifacts": {"path": "~/transformers/tests_output.txt"}})
         steps.append({"store_artifacts": {"path": "~/transformers/reports"}})

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -223,7 +223,7 @@ class CircleCIJob:
             # failure.
             test_command = f"({test_command}) || true"
         else:
-            test_command += " | tee tests_output.txt || true"
+            test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
         check_test_command = f'if [ -s reports/tests_{self.name}/failures_short.txt ]; '


### PR DESCRIPTION
# What does this PR do?

I am not sure if this will helps the navigation (much), but at least for the team members to try.

A new step is added to show the (only faiiled) test results, and it looks like
<img width="650" alt="Screenshot 2023-08-31 184247" src="https://github.com/huggingface/transformers/assets/2521628/5f77833d-d859-43ce-8636-7db428641fe4">


The `Run tests` step won't fail now (otherwise we can't have the new `Check test results` step), but the new step will (if there is indeed a failed test).

For a job run page, see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/71854/workflows/8151a27f-4617-4781-9d0d-80bcb4847edf/jobs/905042)

WDYT?