### PR TITLE
[`Falcon`] Remove SDPA for falcon to support earlier versions of PyTorch (< 2.0)

### DIFF
--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -425,7 +425,7 @@ class FalconAttention(nn.Module):
                 logger.warning_once(
                     "The current implementation of Falcon calls `torch.scaled_dot_product_attention` directly, this will be deprecated in the"
                     " future in favor of the `BetterTransformer` API. Please install the latest optimum library with `pip install -U optimum` and call "
-                    "`model.to_bettertransformer()` to benefit from `torch.scaled_dot_product_attention`."
+                    "`model.to_bettertransformer()` to benefit from `torch.scaled_dot_product_attention` and future performance optimizations."
                 )
 
                 attn_output = F.scaled_dot_product_attention(

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -420,21 +420,11 @@ class FalconAttention(nn.Module):
         value_layer_ = value_layer.reshape(batch_size, num_kv_heads, -1, self.head_dim)
 
         if alibi is None:
-            if output_attentions:
-                # F.scaled_dot_product_attention doesn't return the attention weights, so we have
-                # to do it by hand if we want them
-                attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
-                attention_scores /= math.sqrt(self.head_dim)
+            attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
+            attention_scores /= math.sqrt(self.head_dim)
 
-                attention_scores = F.softmax(
-                    attention_scores + attention_mask_float, dim=-1, dtype=hidden_states.dtype
-                )
-                attn_output = attention_scores @ value_layer_
-            else:
-                attn_output = F.scaled_dot_product_attention(
-                    query_layer_, key_layer_, value_layer_, attention_mask_float, 0.0, is_causal=False
-                )
-                attention_scores = None
+            attention_scores = F.softmax(attention_scores + attention_mask_float, dim=-1, dtype=hidden_states.dtype)
+            attn_output = attention_scores @ value_layer_
 
             attn_output = attn_output.view(batch_size, self.num_heads, query_length, self.head_dim)
             attn_output = attn_output.permute(0, 2, 1, 3)

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -420,15 +420,30 @@ class FalconAttention(nn.Module):
         value_layer_ = value_layer.reshape(batch_size, num_kv_heads, -1, self.head_dim)
 
         if alibi is None:
-            attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
-            attention_scores /= math.sqrt(self.head_dim)
+            if hasattr(F, "scaled_dot_product_attention"):
+                attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
+                attention_scores /= math.sqrt(self.head_dim)
 
-            attention_scores = F.softmax(attention_scores + attention_mask_float, dim=-1, dtype=hidden_states.dtype)
-            attn_output = attention_scores @ value_layer_
+                attention_scores = F.softmax(
+                    attention_scores + attention_mask_float, dim=-1, dtype=hidden_states.dtype
+                )
+                attn_output = attention_scores @ value_layer_
 
-            attn_output = attn_output.view(batch_size, self.num_heads, query_length, self.head_dim)
-            attn_output = attn_output.permute(0, 2, 1, 3)
-            attn_output = attn_output.reshape(batch_size, query_length, self.num_heads * self.head_dim)
+                attn_output = attn_output.view(batch_size, self.num_heads, query_length, self.head_dim)
+                attn_output = attn_output.permute(0, 2, 1, 3)
+                attn_output = attn_output.reshape(batch_size, query_length, self.num_heads * self.head_dim)
+            else:
+                # TODO: deprecate this once we add FA2 support in Falcon
+                logger.warning_once(
+                    "The current implementation of Falcon calls `torch.scaled_dot_product_attention` directly, this will be depracted in the"
+                    " future in favor of `BetterTransformer` API. Please install the latest optimum library `pip install -U optimum` and call "
+                    "`model.to_bettertransformer()` to benefit from `torch.scaled_dot_product_attention`."
+                )
+
+                attn_output = F.scaled_dot_product_attention(
+                    query_layer_, key_layer_, value_layer_, attention_mask_float, 0.0, is_causal=False
+                )
+                attention_scores = None
 
             output_tensor = self.dense(attn_output)
 

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -423,8 +423,8 @@ class FalconAttention(nn.Module):
             if hasattr(F, "scaled_dot_product_attention") and not output_attentions:
                 # TODO: deprecate this once we add FA2 support in Falcon
                 logger.warning_once(
-                    "The current implementation of Falcon calls `torch.scaled_dot_product_attention` directly, this will be depracted in the"
-                    " future in favor of `BetterTransformer` API. Please install the latest optimum library `pip install -U optimum` and call "
+                    "The current implementation of Falcon calls `torch.scaled_dot_product_attention` directly, this will be deprecated in the"
+                    " future in favor of the `BetterTransformer` API. Please install the latest optimum library with `pip install -U optimum` and call "
                     "`model.to_bettertransformer()` to benefit from `torch.scaled_dot_product_attention`."
                 )
 


### PR DESCRIPTION
# What does this PR do?

Removes the call to `torch.scaled_dot_product_attention` in the modeling code of Falcon. That method has been introduced only from PyTorch >= 2.0 thus it is not possible to run falcon on PT 1.13 for instance 

If one wants to use SDPA for using Flash Attention 1, one should use `BetterTransformer` that will route FalconAttention to use SDPA: https://github.com/huggingface/optimum/pull/1343 

```python
model.to_bettertransformer()
```

cc @Rocketknight1 @fxmarty 

All slow tests pass on my end
