### PR TITLE
only main process should call _save on deepspeed zero3

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2850,7 +2850,8 @@ class Trainer:
                     " stage3_gather_16bit_weights_on_model_save=false. Saving the full checkpoint instead, use"
                     " zero_to_fp32.py to recover weights"
                 )
-                self._save(output_dir, state_dict={})
+                if self.args.should_save:
+                    self._save(output_dir, state_dict={})
                 # remove the dummy state_dict
                 remove_dummy_checkpoint(self.args.should_save, output_dir, [WEIGHTS_NAME, SAFE_WEIGHTS_NAME])
                 self.model_wrapped.save_checkpoint(output_dir)


### PR DESCRIPTION
# Background

`trainer._save` call on all process after https://github.com/huggingface/transformers/pull/25817. will raise `FileExistsError` when model save.

# What does this PR do?

this pr fix it, `trainer._save` will call on main process only.