### PR TITLE
Skip `push_to_hub` for now

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2165,6 +2165,8 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         except HTTPError:
             pass
 
+    # TODO: fix me (ydshieh)
+    @unittest.skip("skip for now as failing on main")
     def test_push_to_hub(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             trainer = get_regression_trainer(
@@ -2185,6 +2187,8 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             self.assertEqual(model.a.item(), trainer.model.a.item())
             self.assertEqual(model.b.item(), trainer.model.b.item())
 
+    # TODO: fix me (ydshieh)
+    @unittest.skip("skip for now as failing on main")
     def test_push_to_hub_in_organization(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             trainer = get_regression_trainer(output_dir=tmp_dir)


### PR DESCRIPTION
# What does this PR do?

Currently failing on `main`.

Error

```bash
            elif response.status_code == 400:
                message = (
                    f"\n\nBad request for {endpoint_name} endpoint:" if endpoint_name is not None else "\n\nBad request:"
                )
>               raise BadRequestError(message, response=response) from e
E               huggingface_hub.utils._errors.BadRequestError:  (Request ID: Root=1-64f5eaed-3b71af5025f88d14210df38d;e1b1858a-4f29-4bea-b5e2-4f0eb4dac173)
E               
E               Bad request for commit endpoint:
E               "base_model" is not allowed to be empty
```