### PR TITLE
Generate: legacy mode is only triggered when `generation_config` is untouched

### DIFF
--- a/docs/source/en/generation_strategies.md
+++ b/docs/source/en/generation_strategies.md
@@ -55,12 +55,10 @@ When you load a model explicitly, you can inspect the generation configuration t
 >>> from transformers import AutoModelForCausalLM
 
 >>> model = AutoModelForCausalLM.from_pretrained("distilgpt2")
->>> model.generation_config  # doctest: +IGNORE_RESULT
+>>> model.generation_config
 GenerationConfig {
-    "_from_model_config": true,
     "bos_token_id": 50256,
     "eos_token_id": 50256,
-    "transformers_version": "4.26.0.dev0"
 }
 ```
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -729,7 +729,11 @@ class GenerationConfig(PushToHubMixin):
         else:
             logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
 
-        return cls.from_dict(config_dict, **kwargs)
+        generation_config = cls.from_dict(config_dict, **kwargs)
+        # If the generation_config contains the `_from_config` attribute, we ignore it. This attribute's purpose is to
+        # flag that the GenerationConfig instance was created from a model config file, which is not the case here.
+        generation_config._from_model_config = False
+        return generation_config
 
     @classmethod
     def _dict_from_json_file(cls, json_file: Union[str, os.PathLike]):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -737,7 +737,9 @@ class GenerationConfig(PushToHubMixin):
         else:
             logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
 
-        return cls.from_dict(config_dict, **kwargs)
+        config = cls.from_dict(config_dict, **kwargs)
+        config._original_object_hash = hash(config)
+        return config
 
     @classmethod
     def _dict_from_json_file(cls, json_file: Union[str, os.PathLike]):
@@ -775,7 +777,6 @@ class GenerationConfig(PushToHubMixin):
 
         # Keep the original hash to detect whether the generation config has been mutated. This property is used to
         # disable legacy behavior (if the generation config is mutated, the legacy behavior is disabled).
-        config._original_object_hash = hash(config)
 
         logger.info(f"Generate config {config}")
         if return_unused_kwargs:
@@ -898,6 +899,7 @@ class GenerationConfig(PushToHubMixin):
                     if attr in decoder_config and getattr(config, attr) == getattr(default_generation_config, attr):
                         setattr(config, attr, decoder_config[attr])
 
+        config._original_object_hash = hash(config)
         return config
 
     def update(self, **kwargs):

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -322,8 +322,8 @@ class FlaxGenerationMixin:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
                         " deprecated strategy to control generation and will be removed soon, in a future version."
-                        " Please use a generation configuration file (see"
-                        " https://huggingface.co/docs/transformers/main_classes/text_generation )"
+                        " Please use and modify the model generation configuration (see"
+                        " https://huggingface.co/docs/transformers/generation_strategies#default-text-generation-configuration )"
                     )
                     self.generation_config = new_generation_config
             generation_config = self.generation_config

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -310,9 +310,13 @@ class FlaxGenerationMixin:
 
         # priority: `generation_config` argument > `model.generation_config` (the default generation config)
         if generation_config is None:
-            # legacy: users may modify the model configuration to control generation -- update the generation config
-            # model attribute accordingly, if it was created from the model config
-            if self.generation_config._from_model_config:
+            # legacy: users may modify the model configuration to control generation. To trigger this legacy behavior,
+            # two conditions must be met
+            # 1) the generation config must have been created from the model config (`_from_model_config` field);
+            # 2) the generation config must have seen no modification since its creation (the hash is the same).
+            if self.generation_config._from_model_config and self.generation_config._original_object_hash == hash(
+                self.generation_config
+            ):
                 new_generation_config = GenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:
                     warnings.warn(

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -728,8 +728,8 @@ class TFGenerationMixin:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
                         " deprecated strategy to control generation and will be removed soon, in a future version."
-                        " Please use a generation configuration file (see"
-                        " https://huggingface.co/docs/transformers/main_classes/text_generation )"
+                        " Please use and modify the model generation configuration (see"
+                        " https://huggingface.co/docs/transformers/generation_strategies#default-text-generation-configuration )"
                     )
                     self.generation_config = new_generation_config
             generation_config = self.generation_config

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -716,9 +716,13 @@ class TFGenerationMixin:
 
         # priority: `generation_config` argument > `model.generation_config` (the default generation config)
         if generation_config is None:
-            # legacy: users may modify the model configuration to control generation -- update the generation config
-            # model attribute accordingly, if it was created from the model config
-            if self.generation_config._from_model_config:
+            # legacy: users may modify the model configuration to control generation. To trigger this legacy behavior,
+            # two conditions must be met
+            # 1) the generation config must have been created from the model config (`_from_model_config` field);
+            # 2) the generation config must have seen no modification since its creation (the hash is the same).
+            if self.generation_config._from_model_config and self.generation_config._original_object_hash == hash(
+                self.generation_config
+            ):
                 new_generation_config = GenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:
                     warnings.warn(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1409,16 +1409,20 @@ class GenerationMixin:
 
         # priority: `generation_config` argument > `model.generation_config` (the default generation config)
         if generation_config is None:
-            # legacy: users may modify the model configuration to control generation -- update the generation config
-            # model attribute accordingly, if it was created from the model config
-            if self.generation_config._from_model_config:
+            # legacy: users may modify the model configuration to control generation. To trigger this legacy behavior,
+            # two conditions must be met
+            # 1) the generation config must have been created from the model config (`_from_model_config` field);
+            # 2) the generation config must have seen no modification since its creation (the hash is the same).
+            if self.generation_config._from_model_config and self.generation_config._original_object_hash == hash(
+                self.generation_config
+            ):
                 new_generation_config = GenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:
                     warnings.warn(
                         "You have modified the pretrained model configuration to control generation. This is a"
                         " deprecated strategy to control generation and will be removed soon, in a future version."
-                        " Please use a generation configuration file (see"
-                        " https://huggingface.co/docs/transformers/main_classes/text_generation )"
+                        " Please use and modify the model generation configuration (see"
+                        " https://huggingface.co/docs/transformers/generation_strategies#default-text-generation-configuration )"
                     )
                     self.generation_config = new_generation_config
             generation_config = self.generation_config

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2880,7 +2880,7 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
 
         # Generation config max_length != 20 -> no warning
         with warnings.catch_warnings(record=True) as warning_list:
+            # generation_config is modified -> legacy mode is disabled = generation_config takes precedence
             model.generation_config.max_length = 10
-            model.generation_config._from_model_config = False  # otherwise model.config.max_length=20 takes precedence
             model.generate(input_ids)
             self.assertEqual(len(warning_list), 0)


### PR DESCRIPTION
This is a long description, but bear with me -- it is important to understand the whole context here!

# Background

Long ago, in ancient times (2022), `model.config` held all model-related configurations, including generative configuration. This means it would be possible to modify the model config to parameterize `.generate()`, e.g.:

```py
# (Load model, prepare input)
model.generate(**model_inputs)   # generates up to 20 tokens, the default
model.config.max_length = 100
model.generate(**model_inputs)   # now generates up to 100 tokens
```

By the end of last year, since a given model could have its generation parameterized differently for separate purposes, we carved out the generation parameterization into `generate_config`. To facilitate the transition process, in the absence of a manually set `generate_config`, its parameters are pulled from `model.config` and `_from_model_config` is set to `True` to flag it.

*Keeping retrocompatibility is paramount*, so when `_from_model_config` is `True`, we revert to the legacy mode and `model.config` takes precedence.

# The problem

Currenty, here's what happens:
✅ The user never touches `model.generation_config` and does all parameterization through `.generate()` and/or through `model.config` (i.e. legacy mode)
✅ The user sets a new generation config in the model (`model.generation_config = generation_config`) and/or passes a new `generation_config` to `.generate()`, where the former takes precedence.
❌  Hybrid situations: the user modifies a `model.generation_config` while `_from_model_config` is set to `True`. This fails because `model.config` takes precedence, and thus changes are ignored (*with a warning!*). #25917 is an example of this issue, but there were others in the past.

# The solution (this PR)

My proposed solution is based on the following assumption: if the user touches `generation_config`, then they are aware of the best practices to configure `.generate()`. Therefore, when it happens, NEVER enter the legacy mode, and `model.generation_config` is always in charge.

In practice, this is done through hashing: at `generation_config` creation time, we store its hash. If the hash changes, then the user has touched the object, rejecting the legacy mode.
