### PR TITLE
Fix failing test

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -459,7 +459,7 @@ class TrainingSummary:
         metadata = {}
         metadata = _insert_values_as_list(metadata, "language", self.language)
         metadata = _insert_value(metadata, "license", self.license)
-        if self.finetuned_from is not None:
+        if self.finetuned_from is not None and isinstance(self.finetuned_from, str) and len(self.finetuned_from) > 0:
             metadata = _insert_value(metadata, "base_model", self.finetuned_from)
         metadata = _insert_values_as_list(metadata, "tags", self.tags)
         metadata = _insert_values_as_list(metadata, "datasets", self.dataset_tags)


### PR DESCRIPTION
The `self.finetuned_from` field can be `None` as it can be an empty string; in both cases, the `Trainer` should not save that value to the metadata.

Fixes failing tests such as:
```
=========================== short test summary info ============================
FAILED tests/trainer/test_trainer.py::TrainerIntegrationWithHubTester::test_push_to_hub - huggingface_hub.utils._errors.BadRequestError:  (Request ID: Root=1-64f602bf-2d4e7f4f785e0578301e9f88;1471536e-9bca-4afd-830e-6c8f0471c6f1)

Bad request for commit endpoint:
"base_model" is not allowed to be empty
FAILED tests/trainer/test_trainer.py::TrainerIntegrationWithHubTester::test_push_to_hub_in_organization - huggingface_hub.utils._errors.BadRequestError:  (Request ID: Root=1-64f602c0-09d498af536f9985424a47b5;1e5b77dd-a8a7-4b87-891a-a70336f5bc30)

Bad request for commit endpoint:
"base_model" is not allowed to be empty
============ 2 failed, 22 passed, 5 skipped, 36 warnings in 44.14s =============
```