### PR TITLE
Fix Detr CI

### DIFF
--- a/tests/models/detr/test_modeling_detr.py
+++ b/tests/models/detr/test_modeling_detr.py
@@ -606,7 +606,7 @@ class DetrModelIntegrationTestsTimmBackbone(unittest.TestCase):
             torch_device
         )
         expected_number_of_segments = 5
-        expected_first_segment = {"id": 1, "label_id": 17, "was_fused": False, "score": 0.994097}
+        expected_first_segment = {"id": 1, "label_id": 17, "was_fused": False, "score": 0.994096}
 
         number_of_unique_segments = len(torch.unique(results["segmentation"]))
         self.assertTrue(


### PR DESCRIPTION
# What does this PR do?

#24652 updated an expected value (`0.994097`) used in the test (from a contributor), but our CI still gets the original value `0.994096`. This PR just keeps the original one.
 