### PR TITLE
Fix `test_load_img_url_timeout`

### DIFF
--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -21,7 +21,7 @@ import datasets
 import numpy as np
 import pytest
 from huggingface_hub.file_download import http_get
-from requests import ReadTimeout, ConnectTimeout
+from requests import ConnectTimeout, ReadTimeout
 
 from tests.pipelines.test_pipelines_document_question_answering import INVOICE_URL
 from transformers import is_torch_available, is_vision_available

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -21,7 +21,7 @@ import datasets
 import numpy as np
 import pytest
 from huggingface_hub.file_download import http_get
-from requests import ConnectTimeout
+from requests import ReadTimeout, ConnectTimeout
 
 from tests.pipelines.test_pipelines_document_question_answering import INVOICE_URL
 from transformers import is_torch_available, is_vision_available
@@ -491,7 +491,7 @@ class LoadImageTester(unittest.TestCase):
 
     @is_flaky()
     def test_load_img_url_timeout(self):
-        with self.assertRaises(ConnectTimeout):
+        with self.assertRaises((ReadTimeout, ConnectTimeout)):
             load_image(INVOICE_URL, timeout=0.001)
 
     def test_load_img_local(self):

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -21,7 +21,7 @@ import datasets
 import numpy as np
 import pytest
 from huggingface_hub.file_download import http_get
-from requests import ReadTimeout
+from requests import ConnectTimeout
 
 from tests.pipelines.test_pipelines_document_question_answering import INVOICE_URL
 from transformers import is_torch_available, is_vision_available
@@ -491,7 +491,7 @@ class LoadImageTester(unittest.TestCase):
 
     @is_flaky()
     def test_load_img_url_timeout(self):
-        with self.assertRaises(ReadTimeout):
+        with self.assertRaises(ConnectTimeout):
             load_image(INVOICE_URL, timeout=0.001)
 
     def test_load_img_local(self):


### PR DESCRIPTION
# What does this PR do?

#25184 added timeout parameter to some function and also a test. But the expected exception in the test is `ConnectTimeout` (on daily CI) instead of `ReadTimeout`, but it is `ReadTimeout` on `CircleCI`.

I haven't looked why there are such difference. But this PR updates the expected value to `(ReadTimeout, ConnectTimeout)` so the test added in #25184 won't fail.

(let me know if you think we should dive into this)