### PR TITLE
[VITS] Fix nightly tests

### DIFF
--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -21,7 +21,6 @@ import unittest
 from typing import Dict, List, Tuple
 
 import numpy as np
-from torch import nn
 
 from transformers import PretrainedConfig, VitsConfig
 from transformers.testing_utils import (
@@ -180,7 +179,7 @@ class VitsModelTest(ModelTesterMixin, unittest.TestCase):
         self.model_tester.create_and_check_model_forward(*config_and_inputs)
 
     @require_torch_multi_gpu
-    # override to make test deterministic across GPUs
+    # override to force all elements of the batch to have the same sequence length across GPUs
     def test_multi_gpu_data_parallel_forward(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.use_stochastic_duration_prediction = False
@@ -198,7 +197,7 @@ class VitsModelTest(ModelTesterMixin, unittest.TestCase):
             model.eval()
 
             # Wrap model in nn.DataParallel
-            model = nn.DataParallel(model)
+            model = torch.nn.DataParallel(model)
             set_seed(555)
             with torch.no_grad():
                 _ = model(**self._prepare_for_class(inputs_dict, model_class)).waveform

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -28,8 +28,9 @@ from transformers.testing_utils import (
     is_flaky,
     is_torch_available,
     require_torch,
+    require_torch_multi_gpu,
     slow,
-    torch_device, require_torch_multi_gpu,
+    torch_device,
 )
 from transformers.trainer_utils import set_seed
 

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -68,7 +68,7 @@ class VitsModelTester:
         self,
         parent,
         batch_size=2,
-        seq_length=7,
+        seq_length=8,
         is_training=False,
         hidden_size=16,
         num_hidden_layers=2,
@@ -148,7 +148,7 @@ class VitsModelTester:
         attention_mask = inputs_dict["attention_mask"]
 
         result = model(input_ids, attention_mask=attention_mask)
-        self.parent.assertEqual((self.batch_size, 624), result.waveform.shape)
+        self.parent.assertEqual((self.batch_size, 272), result.waveform.shape)
 
 
 @require_torch

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -150,7 +150,7 @@ class VitsModelTester:
         attention_mask = inputs_dict["attention_mask"]
 
         result = model(input_ids, attention_mask=attention_mask)
-        self.parent.assertEqual((self.batch_size, 272), result.waveform.shape)
+        self.parent.assertEqual((self.batch_size, 624), result.waveform.shape)
 
 
 @require_torch

--- a/tests/models/vits/test_tokenization_vits.py
+++ b/tests/models/vits/test_tokenization_vits.py
@@ -174,8 +174,7 @@ class VitsTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         for tokenizer_class in tokenizer_classes:
             tokenizer = tokenizer_class.from_pretrained(
                 "facebook/mms-tts-eng",
-                revision="28cedf176aa99de5023a4344fd8a2cc477126fb8",  # to pin the tokenizer version
-                pad_token="<pad>",
+                revision="089bbb15da46b2ab2b282145941399aae353d917",  # to pin the tokenizer version
             )
 
             encoding = tokenizer(sequences, padding=True, normalize=True)

--- a/tests/models/vits/test_tokenization_vits.py
+++ b/tests/models/vits/test_tokenization_vits.py
@@ -174,7 +174,8 @@ class VitsTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         for tokenizer_class in tokenizer_classes:
             tokenizer = tokenizer_class.from_pretrained(
                 "facebook/mms-tts-eng",
-                revision="d188a254c84ae6cfd24deb7a8f5c0c1d349d7d9f",  # to pin the tokenizer version
+                revision="28cedf176aa99de5023a4344fd8a2cc477126fb8",  # to pin the tokenizer version
+                pad_token="<pad>",
             )
 
             encoding = tokenizer(sequences, padding=True, normalize=True)


### PR DESCRIPTION
# What does this PR do?

Fixes the tokenizer integration test and multi-GPU test that failed on the nightly run: https://github.com/huggingface/transformers/actions/runs/6068405445/job/16461410319

The tokenizer fix is trivial (needed to update the commit ID)!

The multi-GPU test was failing because the output sequence length for VITS is a function of the model **inputs**, rather than being a function of the input **sequence lengths** only.

Let's say we have 2 GPUs over which we want to run DP:
* GPU 1 outputs a sequence length of `N`, which is computed based on the input in the first element of the batch `x`
* GPU 2 outputs a sequence length of `M`, which is computed based on the input in the second element of the batch `y`

=> there is nothing to enforce that `N = M`, since the VITS output sequence length is a function of the inputs. Thus, we cannot concatenate the inputs after running the forward pass, since they have different dims. 

```python
# pseudo code for data parallelism
input_1, input_2 = torch.split(input, 2, dim=0)

output_1 = model(input_1) 
output_2 = model(input_2)

output = torch.concatenate([output_1, output_2], dim=0)  # breaks because input_1 and input_2 have different sequence lengths
```

The fix for the test is to pass the same inputs to both GPUs, and disable the stochastic duration predictor. This way, we get consistent outputs across our GPUs.