### PR TITLE
Call torch.use_deterministic_algorithms(True) for tests that require determinism

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -885,6 +885,15 @@ def require_cython(test_case):
     return unittest.skipUnless(is_cython_available(), "test requires cython")(test_case)
 
 
+@contextlib.contextmanager
+def require_torch_determinism(*args, **kwargs):
+    torch.use_deterministic_algorithms(True, warn_only=True)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(False)
+
+
 def get_gpu_count():
     """
     Return the number of available gpus (regardless of whether torch, tf or jax is used)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -887,6 +887,11 @@ def require_cython(test_case):
 
 @contextlib.contextmanager
 def require_torch_determinism(*args, **kwargs):
+    if not is_torch_available():
+        raise ValueError("PyTorch is required to use the decorator require_torch_determinism.")
+    else:
+        import torch
+
     torch.use_deterministic_algorithms(True, warn_only=True)
     try:
         yield

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -224,7 +224,7 @@ class ModelTesterMixin:
 
     def test_save_load(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True)
+        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def check_save_load(out1, out2):
             # make sure we don't have nans
@@ -262,6 +262,8 @@ class ModelTesterMixin:
                     check_save_load(tensor1, tensor2)
             else:
                 check_save_load(first, second)
+
+        torch.use_deterministic_algorithms(False)
 
     def test_from_pretrained_no_checkpoint(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
@@ -457,7 +459,7 @@ class ModelTesterMixin:
 
     def test_determinism(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True)
+        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def check_determinism(first, second):
             out_1 = first.cpu().numpy()
@@ -480,6 +482,8 @@ class ModelTesterMixin:
                     check_determinism(tensor1, tensor2)
             else:
                 check_determinism(first, second)
+
+        torch.use_deterministic_algorithms(False)
 
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
@@ -1729,7 +1733,7 @@ class ModelTesterMixin:
 
     def test_model_outputs_equivalence(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True)
+        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def set_nan_tensor_to_zero(t):
             t[t != t] = 0
@@ -1801,6 +1805,8 @@ class ModelTesterMixin:
                 check_equivalence(
                     model, tuple_inputs, dict_inputs, {"output_hidden_states": True, "output_attentions": True}
                 )
+
+        torch.use_deterministic_algorithms(False)
 
     # Don't copy this method to model specific test file!
     # TODO: remove this method once the issues are all fixed!

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -224,6 +224,7 @@ class ModelTesterMixin:
 
     def test_save_load(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        torch.use_deterministic_algorithms(True)
 
         def check_save_load(out1, out2):
             # make sure we don't have nans
@@ -456,6 +457,7 @@ class ModelTesterMixin:
 
     def test_determinism(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        torch.use_deterministic_algorithms(True)
 
         def check_determinism(first, second):
             out_1 = first.cpu().numpy()
@@ -1727,6 +1729,7 @@ class ModelTesterMixin:
 
     def test_model_outputs_equivalence(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        torch.use_deterministic_algorithms(True)
 
         def set_nan_tensor_to_zero(t):
             t[t != t] = 0

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -66,6 +66,7 @@ from transformers.testing_utils import (
     require_accelerate,
     require_safetensors,
     require_torch,
+    require_torch_determinism,
     require_torch_gpu,
     require_torch_multi_gpu,
     slow,
@@ -222,9 +223,9 @@ class ModelTesterMixin:
 
         return inputs_dict
 
+    @require_torch_determinism
     def test_save_load(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def check_save_load(out1, out2):
             # make sure we don't have nans
@@ -262,8 +263,6 @@ class ModelTesterMixin:
                     check_save_load(tensor1, tensor2)
             else:
                 check_save_load(first, second)
-
-        torch.use_deterministic_algorithms(False)
 
     def test_from_pretrained_no_checkpoint(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
@@ -457,9 +456,9 @@ class ModelTesterMixin:
                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                     )
 
+    @require_torch_determinism()
     def test_determinism(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def check_determinism(first, second):
             out_1 = first.cpu().numpy()
@@ -482,8 +481,6 @@ class ModelTesterMixin:
                     check_determinism(tensor1, tensor2)
             else:
                 check_determinism(first, second)
-
-        torch.use_deterministic_algorithms(False)
 
     def test_forward_signature(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
@@ -1731,9 +1728,9 @@ class ModelTesterMixin:
                     " `persistent=False`",
                 )
 
+    @require_torch_determinism
     def test_model_outputs_equivalence(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        torch.use_deterministic_algorithms(True, warn_only=True)
 
         def set_nan_tensor_to_zero(t):
             t[t != t] = 0
@@ -1805,8 +1802,6 @@ class ModelTesterMixin:
                 check_equivalence(
                     model, tuple_inputs, dict_inputs, {"output_hidden_states": True, "output_attentions": True}
                 )
-
-        torch.use_deterministic_algorithms(False)
 
     # Don't copy this method to model specific test file!
     # TODO: remove this method once the issues are all fixed!


### PR DESCRIPTION
Although it appears that on Nvidia GPUs all model tests requiring determinism pass without this option, this is not the case on AMD MI210, and it is not safe to assume in general. For example `CUDA_VISIBLE_DEVICES=1 pytest tests/models/cpmant/test_modeling_cpmant.py -s -k "test_determinism"` do not pass on main but do pass with this PR. Looking at the intermediate logits, it appears that a nn.Linear call is responsible of the deviation.