### PR TITLE
[`CI`]  Fix red CI and ERROR failed should show

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -228,7 +228,7 @@ class CircleCIJob:
 
         check_test_command = f'if [ -s reports/{self.name}/failures_short.txt ]; '
         check_test_command += 'then echo "Some test failed!"; echo ""; '
-        check_test_command += f'cat reports/tests_{self.name}/failures_short.txt; '
+        check_test_command += f'cat reports/{self.name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
         py_command = f'import os; fp = open("reports/{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -226,16 +226,16 @@ class CircleCIJob:
             test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
-        check_test_command = f'if [ -s reports/tests_{self.name}/failures_short.txt ]; '
+        check_test_command = f'if [ -s reports/{self.name}/failures_short.txt ]; '
         check_test_command += 'then echo "Some test failed!"; echo ""; '
         check_test_command += f'cat reports/tests_{self.name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/tests_{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", ("ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", ("ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '
-        check_test_command += f'elif [ -s reports/tests_{self.name}/stats.txt ]; then echo "All tests pass!"; '
+        check_test_command += f'elif [ -s reports/{self.name}/stats.txt ]; then echo "All tests pass!"; '
 
         # return code `124` means the previous (pytest run) step is timeout
         if self.name == "pr_documentation_tests":

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -231,7 +231,7 @@ class CircleCIJob:
         check_test_command += f'cat reports/tests_{self.name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", ("ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -231,7 +231,7 @@ class CircleCIJob:
         check_test_command += f'cat reports/tests_{self.name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/tests_{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/tests_{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", ("ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -226,16 +226,16 @@ class CircleCIJob:
             test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
-        check_test_command = f'if [ -s reports/{self.name}/failures_short.txt ]; '
+        check_test_command = f'if [ -s reports/{self.job_name}/failures_short.txt ]; '
         check_test_command += 'then echo "Some test failed!"; echo ""; '
-        check_test_command += f'cat reports/{self.name}/failures_short.txt; '
+        check_test_command += f'cat reports/{self.job_name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/{self.name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '
-        check_test_command += f'elif [ -s reports/{self.name}/stats.txt ]; then echo "All tests pass!"; '
+        check_test_command += f'elif [ -s reports/{self.job_name}/stats.txt ]; then echo "All tests pass!"; '
 
         # return code `124` means the previous (pytest run) step is timeout
         if self.name == "pr_documentation_tests":

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -300,6 +300,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(output, {"text": "A MAN SAID TO THE UNIVERSE SIR I EXIST"})
 
     @require_torch
+    @slow
     def test_return_timestamps_in_preprocess(self):
         pipe = pipeline(
             task="automatic-speech-recognition",


### PR DESCRIPTION
# What does this PR do?
Fixes the main branch after the merge of #25895 which has a typo when checking the outputs of the ci tests.

Two part fix:
1. Fatal errors were not shown in the outputs so we don't know what was wrong 
```diff
- if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+ if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
```
3. Fix the error:
```diff
- check_test_command = f'if [ -s reports/test_{self.name}/failures_short.txt ]; '
+ check_test_command = f'if [ -s reports/{self.name}/failures_short.txt ]; '
```
should do the trick

3. There is now https://github.com/huggingface/transformers/commit/8d518013efbd10c178dd0dba0f9ba93229e2e78a that broke main, marking the test as slow 😉 