### PR TITLE
[`VITS`]  tokenizer integration test: fix revision did not exist

### DIFF
--- a/tests/models/vits/test_tokenization_vits.py
+++ b/tests/models/vits/test_tokenization_vits.py
@@ -174,7 +174,7 @@ class VitsTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         for tokenizer_class in tokenizer_classes:
             tokenizer = tokenizer_class.from_pretrained(
                 "facebook/mms-tts-eng",
-                revision="dbb8b304793064d664490cc14438247f7da9e551",  # to pin the tokenizer version
+                revision="089bbb15da46b2ab2b282145941399aae353d917",  # to pin the tokenizer version
             )
 
             encoding = tokenizer(sequences, padding=True, normalize=True)

--- a/tests/models/vits/test_tokenization_vits.py
+++ b/tests/models/vits/test_tokenization_vits.py
@@ -174,7 +174,7 @@ class VitsTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         for tokenizer_class in tokenizer_classes:
             tokenizer = tokenizer_class.from_pretrained(
                 "facebook/mms-tts-eng",
-                revision="d188a254c84ae6cfd24deb7a8f5c0c1d349d7d9f",  # to pin the tokenizer version
+                revision="dbb8b304793064d664490cc14438247f7da9e551",  # to pin the tokenizer version
             )
 
             encoding = tokenizer(sequences, padding=True, normalize=True)


### PR DESCRIPTION
# What does this PR do?
Fixes the revisiono f the integration test for the VITs tokenizer.
`RUN_SLOW=1 pytest tests/models/vits/test_tokenization_vits.py `  on main outputs:
```python 
E           OSError: Can't load tokenizer for 'facebook/mms-tts-eng'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'facebook/mms-tts-eng' is the correct path to a directory containing all relevant files for a VitsTokenizer tokenizer.

src/transformers/tokenization_utils_base.py:1893: OSError
```
because the revision does not exist