### PR TITLE
Falcon: fix revision propagation

### DIFF
--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1016,10 +1016,9 @@ class AutoConfig:
         kwargs["name_or_path"] = pretrained_model_name_or_path
         trust_remote_code = kwargs.pop("trust_remote_code", None)
         code_revision = kwargs.pop("code_revision", None)
-        revision = kwargs.pop("revision", None)
 
-        revision = sanitize_code_revision(pretrained_model_name_or_path, revision, trust_remote_code)
-        kwargs["revision"] = revision
+        revision = kwargs.pop("revision", None)
+        kwargs["revision"] = sanitize_code_revision(pretrained_model_name_or_path, revision, trust_remote_code)
 
         config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
         has_remote_code = "auto_map" in config_dict and "AutoConfig" in config_dict["auto_map"]

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1019,10 +1019,9 @@ class AutoConfig:
         revision = kwargs.pop("revision", None)
 
         revision = sanitize_code_revision(pretrained_model_name_or_path, revision, trust_remote_code)
+        kwargs["revision"] = revision
 
-        config_dict, unused_kwargs = PretrainedConfig.get_config_dict(
-            pretrained_model_name_or_path, revision=revision, **kwargs
-        )
+        config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
         has_remote_code = "auto_map" in config_dict and "AutoConfig" in config_dict["auto_map"]
         has_local_code = "model_type" in config_dict and config_dict["model_type"] in CONFIG_MAPPING
         trust_remote_code = resolve_trust_remote_code(


### PR DESCRIPTION
Revision should be kept in the kwargs as these are being propagated throughout the method afterwards.