### PR TITLE
Remove Falcon from undocumented list

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -936,12 +936,6 @@ UNDOCUMENTED_OBJECTS = [
     "logging",  # External module
     "requires_backends",  # Internal function
     "AltRobertaModel",  # Internal module
-    "FalconConfig",  # TODO Matt Remove this and re-add the docs once TGI is ready
-    "FalconForCausalLM",
-    "FalconForQuestionAnswering",
-    "FalconForSequenceClassification",
-    "FalconForTokenClassification",
-    "FalconModel",
 ]
 
 # This list should be empty. Objects in it should get their own doc page.


### PR DESCRIPTION
Because Falcon was in the library in stealth mode, its classes were added to the undocumented list. That can now be removed!