### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -231,7 +231,7 @@ class CircleCIJob:
         check_test_command += f'cat reports/{self.job_name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ", "ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith(("FAILED ", "ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '


### PR DESCRIPTION
# What does this PR do?

@ArthurZucker fixed (in #25995) my PR #25895, but there change had a minor issue.

The `startswith` method of python's `str` requires `startswith arg must be str or a tuple of str`.

Not a big deal, but currently we just lose showing the summary part (only the `failure_short.txt` being showed).

For example, see https://app.circleci.com/pipelines/github/huggingface/transformers/72336/workflows/87f9e28c-9b95-46a9-b306-36a9a371da2e/jobs/912355

