### PR TITLE
IDEFICS: allow interpolation of vision's pos embeddings

### DIFF
--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -71,8 +71,6 @@ class IdeficsVisionConfig(PretrainedConfig):
             testing).
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
-        interpolate_pos_encoding (`bool`, *optional*, defaults to `False`):
-            Activates interpolation of position embeddings, allowing for images of different sizes.
     """
     model_type = "idefics"
     attribute_map = {

--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -71,7 +71,7 @@ class IdeficsVisionConfig(PretrainedConfig):
             testing).
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
-        interpolate_pos_encoding (`bool`, *optional*, defaults to False):
+        interpolate_pos_encoding (`bool`, *optional*, defaults to `False`):
             Activates interpolation of position embeddings, allowing for images of different sizes.
     """
     model_type = "idefics"

--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -71,6 +71,8 @@ class IdeficsVisionConfig(PretrainedConfig):
             testing).
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        interpolate_pos_encoding (`bool`, *optional*, defaults to False):
+            Activates interpolation of position embeddings, allowing for images of different sizes.
     """
     model_type = "idefics"
     attribute_map = {
@@ -91,6 +93,7 @@ class IdeficsVisionConfig(PretrainedConfig):
         attention_dropout=0.0,
         initializer_range=0.02,
         initializer_factor=1.0,
+        interpolate_pos_encoding=False,
         **kwargs,
     ):
         self.embed_dim = embed_dim
@@ -105,6 +108,7 @@ class IdeficsVisionConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.initializer_factor = initializer_factor
         self.hidden_act = hidden_act
+        self.interpolate_pos_encoding = interpolate_pos_encoding
 
         super().__init__(**kwargs)
 

--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -93,7 +93,6 @@ class IdeficsVisionConfig(PretrainedConfig):
         attention_dropout=0.0,
         initializer_range=0.02,
         initializer_factor=1.0,
-        interpolate_pos_encoding=False,
         **kwargs,
     ):
         self.embed_dim = embed_dim
@@ -108,7 +107,6 @@ class IdeficsVisionConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.initializer_factor = initializer_factor
         self.hidden_act = hidden_act
-        self.interpolate_pos_encoding = interpolate_pos_encoding
 
         super().__init__(**kwargs)
 

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -1157,7 +1157,7 @@ class IdeficsModel(IdeficsPreTrainedModel):
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-        interpolate_pos_encoding: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, IdeficsBaseModelOutputWithPast]:
         device = input_ids.device if input_ids is not None else inputs_embeds.device
@@ -1471,7 +1471,7 @@ class IdeficsForVisionText2Text(IdeficsPreTrainedModel):
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-        interpolate_pos_encoding: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, IdeficsCausalLMOutputWithPast]:
         r"""

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -1157,6 +1157,7 @@ class IdeficsModel(IdeficsPreTrainedModel):
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, IdeficsBaseModelOutputWithPast]:
         device = input_ids.device if input_ids is not None else inputs_embeds.device
@@ -1212,7 +1213,9 @@ class IdeficsModel(IdeficsPreTrainedModel):
             pixel_values = pixel_values.contiguous().view(batch_size * num_images, *pixel_values.shape[2:])
 
             # Get sequence from the vision encoder
-            image_hidden_states = self.vision_model(pixel_values=pixel_values).last_hidden_state
+            image_hidden_states = self.vision_model(
+                pixel_values=pixel_values, interpolate_pos_encoding=interpolate_pos_encoding
+            ).last_hidden_state
 
         elif image_encoder_embeddings is not None:
             batch_size, num_images, image_seq_len, image_hidden_size = image_encoder_embeddings.size()
@@ -1468,6 +1471,7 @@ class IdeficsForVisionText2Text(IdeficsPreTrainedModel):
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, IdeficsCausalLMOutputWithPast]:
         r"""
@@ -1516,6 +1520,7 @@ class IdeficsForVisionText2Text(IdeficsPreTrainedModel):
             use_cache=use_cache,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=return_dict,
         )
 

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -236,6 +236,7 @@ def prepare_inputs_for_generation(input_ids, past_key_values=None, **kwargs):
     image_encoder_embeddings = kwargs.get("image_encoder_embeddings", None)
     perceiver_embeddings = kwargs.get("perceiver_embeddings", None)
     image_attention_mask = kwargs.get("image_attention_mask", None)
+    interpolate_pos_encoding = kwargs.get("interpolate_pos_encoding", False)
 
     return {
         "input_ids": input_ids,
@@ -248,6 +249,7 @@ def prepare_inputs_for_generation(input_ids, past_key_values=None, **kwargs):
         "image_encoder_embeddings": image_encoder_embeddings,
         "perceiver_embeddings": perceiver_embeddings,
         "image_attention_mask": image_attention_mask,
+        "interpolate_pos_encoding": interpolate_pos_encoding,
     }
 
 

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -98,7 +98,7 @@ class IdeficsVisionEmbeddings(nn.Module):
         num_patches = embeddings.shape[1] - 1
         num_positions = self.position_embedding.num_embeddings - 1
         if num_patches == num_positions and height == width:
-            return self.position_embedding
+            return self.position_embedding(self.position_ids)
         class_pos_embed = self.position_embedding(torch.tensor([0]))
         patch_pos_embed = self.position_embedding(torch.arange(1, self.position_embedding.num_embeddings))
         embed_dim = embeddings.shape[-1]

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -96,11 +96,13 @@ class IdeficsVisionEmbeddings(nn.Module):
         """
 
         num_patches = embeddings.shape[1] - 1
-        num_positions = self.position_embedding.num_embeddings - 1
+        pos_embed = self.position_embedding(self.position_ids)
+        num_positions = pos_embed.shape[1] - 1
         if num_patches == num_positions and height == width:
-            return self.position_embedding(self.position_ids)
-        class_pos_embed = self.position_embedding(torch.tensor([0]))
-        patch_pos_embed = self.position_embedding(torch.arange(1, self.position_embedding.num_embeddings))
+            return pos_embed
+        class_pos_embed = pos_embed[:, 0]
+        patch_pos_embed = pos_embed[:, 1:]
+
         embed_dim = embeddings.shape[-1]
         num_h_patches = height // self.config.patch_size
         num_w_patches = width // self.config.patch_size

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -15,10 +15,10 @@
 """ PyTorch IdeficsVision model: a copy of CLIPVisionModel using a simpler config object"""
 
 
+import math
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
-import math
 import torch
 import torch.utils.checkpoint
 from torch import nn
@@ -120,7 +120,7 @@ class IdeficsVisionEmbeddings(nn.Module):
         assert int(h0) == patch_pos_embed.shape[-2] and int(w0) == patch_pos_embed.shape[-1]
         patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
         return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1)
-        
+
     def forward(self, pixel_values: torch.FloatTensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, num_channels, height, width = pixel_values.shape
         if not interpolate_pos_encoding:
@@ -132,7 +132,7 @@ class IdeficsVisionEmbeddings(nn.Module):
 
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  # shape = [*, width, grid, grid]
-        
+
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 
         class_embeds = self.class_embedding.expand(batch_size, 1, -1)
@@ -140,7 +140,7 @@ class IdeficsVisionEmbeddings(nn.Module):
 
         # add positional encoding to each token
         if interpolate_pos_encoding:
-            embeddings =  embeddings + self.interpolate_pos_encoding(embeddings, height, width)
+            embeddings = embeddings + self.interpolate_pos_encoding(embeddings, height, width)
         else:
             embeddings = embeddings + self.position_embedding(self.position_ids)
 
@@ -428,7 +428,7 @@ class IdeficsVisionTransformer(nn.Module):
     def __init__(self, config: IdeficsVisionConfig):
         super().__init__()
         self.config = config
-        self.interpolate_pos_encoding = config.interpolate_pos_encoding 
+        self.interpolate_pos_encoding = config.interpolate_pos_encoding
         embed_dim = config.hidden_size
 
         self.embeddings = IdeficsVisionEmbeddings(config)

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -61,6 +61,7 @@ class IdeficsVisionModelOutput(ModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
+# Adapted from transformers.models.clip.modeling_clip.CLIPVisionEmbeddings
 class IdeficsVisionEmbeddings(nn.Module):
     def __init__(self, config: IdeficsVisionConfig):
         super().__init__()
@@ -430,7 +431,6 @@ class IdeficsVisionTransformer(nn.Module):
     def __init__(self, config: IdeficsVisionConfig):
         super().__init__()
         self.config = config
-        self.interpolate_pos_encoding = config.interpolate_pos_encoding
         embed_dim = config.hidden_size
 
         self.embeddings = IdeficsVisionEmbeddings(config)
@@ -438,12 +438,13 @@ class IdeficsVisionTransformer(nn.Module):
         self.encoder = IdeficsVisionEncoder(config)
         self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
 
-    # copied from transformers.models.clip.modeling_clip.CLIPVisionTransformer.forward
+    # Adapted from transformers.models.clip.modeling_clip.CLIPVisionTransformer.forward
     def forward(
         self,
         pixel_values: Optional[torch.FloatTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
         r"""
@@ -459,7 +460,7 @@ class IdeficsVisionTransformer(nn.Module):
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=self.interpolate_pos_encoding)
+        hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
         hidden_states = self.pre_layrnorm(hidden_states)
 
         encoder_outputs = self.encoder(

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -115,10 +115,7 @@ class IdeficsVisionEmbeddings(nn.Module):
             mode="bicubic",
             align_corners=False,
         )
-        if (
-            int(num_h_patches) != patch_pos_embed.shape[-2] 
-            or int(num_w_patches) == patch_pos_embed.shape[-1]
-        ):
+        if int(num_h_patches) != patch_pos_embed.shape[-2] or int(num_w_patches) != patch_pos_embed.shape[-1]:
             raise ValueError(
                 f"Number of patches for images ({int(num_h_patches), int(num_w_patches)}) don't match the "
                 f"shape of position embedding ({patch_pos_embed.shape[-2], patch_pos_embed.shape[-1]})"

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -25,10 +25,7 @@ from torch import nn
 
 from ...activations import ACT2FN
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
-from ...utils import (
-    ModelOutput,
-    logging,
-)
+from ...utils import ModelOutput, logging
 from .configuration_idefics import IdeficsVisionConfig
 
 

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -141,7 +141,7 @@ class IdeficsVisionEmbeddings(nn.Module):
             if height != self.image_size or width != self.image_size:
                 raise ValueError(
                     f"Input image size ({height}*{width}) doesn't match model"
-                    f" ({self.image_size}*{self.image_size})."
+                    f" ({self.image_size}*{self.image_size}). You should try to set `interpolate_pos_encoding=True`"
                 )
 
         target_dtype = self.patch_embedding.weight.dtype

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -84,6 +84,7 @@ class IdeficsVisionEmbeddings(nn.Module):
         self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
         self.register_buffer("position_ids", torch.arange(self.num_positions).expand((1, -1)), persistent=False)
 
+    # Heavily inspired from https://github.com/huggingface/transformers/blob/v4.33.0/src/transformers/models/vit/modeling_vit.py#L82
     def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
         """
         This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -61,7 +61,6 @@ class IdeficsVisionModelOutput(ModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
-# Copied from transformers.models.clip.modeling_clip.CLIPVisionEmbeddings with CLIP->Idefics
 class IdeficsVisionEmbeddings(nn.Module):
     def __init__(self, config: IdeficsVisionConfig):
         super().__init__()

--- a/src/transformers/models/idefics/vision.py
+++ b/src/transformers/models/idefics/vision.py
@@ -115,8 +115,8 @@ class IdeficsVisionEmbeddings(nn.Module):
         fp32_upcasting = patch_pos_embed.dtype == torch.bfloat16
         if fp32_upcasting:
             logger.warning_once(
-                "Upcasting patch_pos_embed to fp32 for interpolation since upsample_bicubic2d_out_frame in nn.functional.interpolate"
-                "is not implemented for 'BFloat16'. This will result in a slight overhead"
+                "Upcasting patch_pos_embed to fp32 for interpolation since `upsample_bicubic2d_out_frame` in nn.functional.interpolate"
+                "is not implemented for 'torch.bfloat16' dtype. This will result in a slight overhead"
             )
             patch_pos_embed = patch_pos_embed.to(torch.float)
         patch_pos_embed = nn.functional.interpolate(

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -282,7 +282,7 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         self.model_tester.create_and_check_model(*config_and_inputs)
 
     def test_model_with_image_pos_embeddings_interpolation(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=False)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=True)
         self.model_tester.create_and_check_model(*config_and_inputs)
 
     def test_training(self):

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -305,7 +305,7 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         )
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    def test_model_with_image_pos_embeddings_interpolation(self):
+    def test_model_with_image_pos_embeddings_interpolation_single_image(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs(
             num_images=1, interpolate_pos_encoding=True, image_expansion=2
         )
@@ -315,9 +315,25 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         )
         self.model_tester.create_and_check_model(*config_and_inputs)
 
-    def test_generate_with_image_pos_embeddings_interpolation(self):
+    def test_model_with_image_pos_embeddings_interpolation_multiple_images(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=2, interpolate_pos_encoding=True, image_expansion=2
+        )
+        self.model_tester.create_and_check_model(*config_and_inputs)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=2, interpolate_pos_encoding=True, image_expansion=0
+        )
+        self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_generate_with_image_pos_embeddings_interpolation_single_image(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs(
             num_images=1, interpolate_pos_encoding=True, image_expansion=2
+        )
+        self.model_tester.create_and_check_model_gen(*config_and_inputs)
+
+    def test_generate_with_image_pos_embeddings_interpolation_multiple_images(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=2, interpolate_pos_encoding=True, image_expansion=2
         )
         self.model_tester.create_and_check_model_gen(*config_and_inputs)
 

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -146,17 +146,16 @@ class IdeficsModelTester:
         # this is equal to the seq length of the text tokens + number of image patches + 1 for the CLS token
         self.expected_seq_len = self.seq_length + (self.image_size // self.patch_size) ** 2 + 1
 
-    def prepare_config_and_inputs(self, num_images=1, interpolate_pos_encoding=False):
+    def prepare_config_and_inputs(self, num_images=1, interpolate_pos_encoding=False, image_expansion=0):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
-        expand_image_size = 2 if interpolate_pos_encoding else 0
         pixel_values = floats_tensor(
             [
                 self.batch_size,
                 num_images,
                 self.num_channels,
-                self.image_size + expand_image_size,
-                self.image_size + expand_image_size,
+                self.image_size + image_expansion,
+                self.image_size + image_expansion,
             ]
         )
         input_mask = None
@@ -295,19 +294,31 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         self.config_tester.run_common_tests()
 
     def test_model_single_image(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=False)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=1, interpolate_pos_encoding=False, image_expansion=0
+        )
         self.model_tester.create_and_check_model(*config_and_inputs)
 
     def test_model_multiple_images(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=2, interpolate_pos_encoding=False)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=2, interpolate_pos_encoding=False, image_expansion=0
+        )
         self.model_tester.create_and_check_model(*config_and_inputs)
 
     def test_model_with_image_pos_embeddings_interpolation(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=True)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=1, interpolate_pos_encoding=True, image_expansion=2
+        )
+        self.model_tester.create_and_check_model(*config_and_inputs)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=1, interpolate_pos_encoding=True, image_expansion=0
+        )
         self.model_tester.create_and_check_model(*config_and_inputs)
 
     def test_generate_with_image_pos_embeddings_interpolation(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=True)
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(
+            num_images=1, interpolate_pos_encoding=True, image_expansion=2
+        )
         self.model_tester.create_and_check_model_gen(*config_and_inputs)
 
     def test_training(self):

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -213,6 +213,27 @@ class IdeficsModelTester:
             result.last_hidden_state.shape, (self.batch_size, input_ids.shape[1], self.hidden_size)
         )
 
+    def create_and_check_model_gen(
+        self,
+        config,
+        input_ids,
+        input_mask,
+        pixel_values,
+        image_attention_mask,
+        interpolate_pos_encoding,
+    ):
+        model = IdeficsForVisionText2Text(config)
+        model.to(torch_device)
+        model.eval()
+        model.generate(
+            input_ids,
+            attention_mask=input_mask,
+            pixel_values=pixel_values,
+            image_attention_mask=image_attention_mask,
+            interpolate_pos_encoding=interpolate_pos_encoding,
+            max_length=self.seq_length + 2,
+        )
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -284,6 +305,10 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     def test_model_with_image_pos_embeddings_interpolation(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=True)
         self.model_tester.create_and_check_model(*config_and_inputs)
+
+    def test_generate_with_image_pos_embeddings_interpolation(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs(num_images=1, interpolate_pos_encoding=True)
+        self.model_tester.create_and_check_model_gen(*config_and_inputs)
 
     def test_training(self):
         if not self.model_tester.is_training:

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -303,8 +303,6 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
             model.train()
             inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
             for k, v in inputs.items():
-                if isinstance(v, torch.Tensor):
-                    print(k, v.shape)
             loss = model(**inputs).loss
             loss.backward()
 

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -149,7 +149,7 @@ class IdeficsModelTester:
     def prepare_config_and_inputs(self, num_images=1, interpolate_pos_encoding=False):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 
-        expand_image_size = 0 if not interpolate_pos_encoding else 2
+        expand_image_size = 2 if interpolate_pos_encoding else 0
         pixel_values = floats_tensor(
             [
                 self.batch_size,

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -302,7 +302,6 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
             model.to(torch_device)
             model.train()
             inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-            for k, v in inputs.items():
             loss = model(**inputs).loss
             loss.backward()
 


### PR DESCRIPTION
# What does this PR do?

Allows vision position embeddings to be interpolated. Thus allowing bigger images to be passed to the model.
Fixes issue #26154

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?
@ArthurZucker @amyeroberts
