### PR TITLE
[`CodeLlamaTokenizerFast`] Fix fix `set_infilling_processor` to properly reset

### DIFF
--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -257,14 +257,14 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
 
     def set_infilling_processor(self, reset, suffix_first=False, add_special_tokens=True):
         """
-        Updates the normalizer to make sure the prompt format for `infilling` is respected. The infilling format is the following: if suffix_first
+        Updates the normalizer to make sure the prompt format for `infilling` is respected. The infilling format is the
+        following: if suffix_first
             " <PRE> <SUF>{suf} <MID> {pre}"
         else:
             " <PRE> {pre} <SUF>{suf} <MID>"
 
-        If `reset` is set to `True`, the `normalizer` and `post_processor` are reset to
-        their "normal" behaviour, which is to add a prefix space for the normalizer,
-        and add a `bos_token` to the input text for the `post_processor`.
+        If `reset` is set to `True`, the `normalizer` and `post_processor` are reset to their "normal" behaviour, which
+        is to add a prefix space for the normalizer, and add a `bos_token` to the input text for the `post_processor`.
         """
         if reset:
             self._tokenizer.normalizer = normalizers.Sequence(

--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -256,6 +256,15 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
         self.update_post_processor()
 
     def set_infilling_processor(self, reset, suffix_first=False, add_special_tokens=True):
+        """
+        Updates the normalizer to make sure the prompt format for `infilling` is respected.
+        If `reset` is set to `True`, the normalizer is reset to the normal behaviour.
+        The infilling format is the following:
+        if suffix_first
+            " <PRE> <SUF>{suf} <MID> {pre}"
+        else:
+            " <PRE> {pre} <SUF>{suf} <MID>"
+        """
         if reset:
             self._tokenizer.normalizer = normalizers.Sequence(
                 [

--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -257,11 +257,14 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
 
     def set_infilling_processor(self, reset, suffix_first=False, add_special_tokens=True):
         """
-        Updates the normalizer to make sure the prompt format for `infilling` is respected. If `reset` is set to
-        `True`, the normalizer is reset to the normal behaviour. The infilling format is the following: if suffix_first
+        Updates the normalizer to make sure the prompt format for `infilling` is respected. The infilling format is the following: if suffix_first
             " <PRE> <SUF>{suf} <MID> {pre}"
         else:
             " <PRE> {pre} <SUF>{suf} <MID>"
+
+        If `reset` is set to `True`, the `normalizer` and `post_processor` are reset to
+        their "normal" behaviour, which is to add a prefix space for the normalizer,
+        and add a `bos_token` to the input text for the `post_processor`.
         """
         if reset:
             self._tokenizer.normalizer = normalizers.Sequence(

--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -264,6 +264,7 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
                 ]
             )
             self.update_post_processor()
+            return
 
         self._tokenizer.normalizer = normalizers.Replace(pattern=" ", content="▁")
         pair = [self.bos_token] if self.add_bos_token and add_special_tokens else []

--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -257,10 +257,8 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
 
     def set_infilling_processor(self, reset, suffix_first=False, add_special_tokens=True):
         """
-        Updates the normalizer to make sure the prompt format for `infilling` is respected.
-        If `reset` is set to `True`, the normalizer is reset to the normal behaviour.
-        The infilling format is the following:
-        if suffix_first
+        Updates the normalizer to make sure the prompt format for `infilling` is respected. If `reset` is set to
+        `True`, the normalizer is reset to the normal behaviour. The infilling format is the following: if suffix_first
             " <PRE> <SUF>{suf} <MID> {pre}"
         else:
             " <PRE> {pre} <SUF>{suf} <MID>"


### PR DESCRIPTION
# What does this PR do?
Fixes #26038 were the `set_infilling_processor` was not properly reseting the template processing for `CodeLlama`