### PR TITLE
Add torchaudio with rocm 5.6 to AMD Dockerfile

### DIFF
--- a/docker/transformers-pytorch-gpu/Dockerfile.amd
+++ b/docker/transformers-pytorch-gpu/Dockerfile.amd
@@ -3,26 +3,28 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update
-RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg
-RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN apt update && \
+    apt install -y --no-install-recommends git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-pip ffmpeg && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools ninja git+https://github.com/facebookresearch/detectron2.git pytesseract "itsdangerous<2.1.0"
+
+# If set to nothing, will install the latest version
+ARG PYTORCH='2.0.1'
+ARG TORCH_VISION='0.15.2'
+ARG TORCH_AUDIO='2.0.2'
+ARG ROCM='5.6'
+
+RUN git clone --depth 1 --branch v$TORCH_AUDIO https://github.com/pytorch/audio.git
+RUN cd audio && USE_ROCM=1 USE_CUDA=0 python setup.py install
 
 ARG REF=main
 WORKDIR /
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing,video]
 
-# If set to nothing, will install the latest version
-ARG PYTORCH='2.0.1'
-ARG TORCH_VISION=''
-ARG TORCH_AUDIO=''
-ARG ROCM='rocm5.6'
-
-# TODO: INSTALL TORCHAUDIO with ROCM5.6
 RUN python3 -m pip uninstall -y tensorflow flax
-
-RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract
-RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.


### PR DESCRIPTION
As per title

e.g. `CUDA_VISIBLE_DEVICES=0 pytest tests/models/wav2vec2/test_modeling_wav2vec2.py -s -vvvvv` now do pass.