### PR TITLE
refactor: change default block_size in block size > max position embeddings

### DIFF
--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -574,9 +574,9 @@ def main():
         if block_size > config.max_position_embeddings:
             logger.warning(
                 f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
-                f"Using block_size={config.max_position_embeddings} instead. You can change that default value by passing --block_size xxx."
+                f"Using block_size={min(1024, config.max_position_embeddings)} instead. You can change that default value by passing --block_size xxx."
             )
-            block_size = config.max_position_embeddings
+            block_size = min(1024, config.max_position_embeddings)
     else:
         if data_args.block_size > tokenizer.model_max_length:
             logger.warning(

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -574,9 +574,9 @@ def main():
         if block_size > config.max_position_embeddings:
             logger.warning(
                 f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
-                "Picking 1024 instead. You can change that default value by passing --block_size xxx."
+                f"Using block_size={config.max_position_embeddings} instead. You can change that default value by passing --block_size xxx."
             )
-            block_size = 1024
+            block_size = config.max_position_embeddings
     else:
         if data_args.block_size > tokenizer.model_max_length:
             logger.warning(


### PR DESCRIPTION
Hi,
In the original code, this appears to function correctly when the default block_size is set to 1024. However, I believe that this setting might potentially hinder the training performance. Therefore, I have adjusted the default to be max_position_embeddings when it doesn't match case.
I would like to cc @sanchit-gandhi to review my PR, thank you so much