### PR TITLE
reformat: change the eval_dataset * num_device code

### DIFF
--- a/examples/flax/language-modeling/run_bart_dlm_flax.py
+++ b/examples/flax/language-modeling/run_bart_dlm_flax.py
@@ -914,7 +914,7 @@ def main():
 
                     # Model forward
                     metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                        state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                        state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     eval_metrics.append(metrics)
 
@@ -954,7 +954,7 @@ def main():
 
             # Model forward
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 

--- a/examples/flax/language-modeling/run_bart_dlm_flax.py
+++ b/examples/flax/language-modeling/run_bart_dlm_flax.py
@@ -743,8 +743,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
 
     num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
 

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -804,7 +804,7 @@ def main():
                     # Model forward
                     batch = next(eval_loader)
                     metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                        state.params, batch, min_device_batch=per_device_eval_batch_size
+                        state.params, batch, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     eval_metrics.append(metrics)
 
@@ -847,7 +847,7 @@ def main():
             # Model forward
             batch = next(eval_loader)
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, batch, min_device_batch=per_device_eval_batch_size
+                state.params, batch, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 

--- a/examples/flax/language-modeling/run_clm_flax.py
+++ b/examples/flax/language-modeling/run_clm_flax.py
@@ -657,8 +657,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
     steps_per_epoch = len(train_dataset) // train_batch_size
     total_train_steps = steps_per_epoch * num_epochs
 

--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -682,8 +682,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
 
     num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
 

--- a/examples/flax/language-modeling/run_mlm_flax.py
+++ b/examples/flax/language-modeling/run_mlm_flax.py
@@ -855,7 +855,7 @@ def main():
 
                     # Model forward
                     metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                        state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                        state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     eval_metrics.append(metrics)
 
@@ -895,7 +895,7 @@ def main():
 
             # Model forward
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -944,7 +944,7 @@ def main():
 
                     # Model forward
                     metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                        state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                        state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     eval_metrics.append(metrics)
 
@@ -982,7 +982,7 @@ def main():
 
             # Model forward
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, model_inputs.data, min_device_batch=per_device_eval_batch_size
+                state.params, model_inputs.data, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 

--- a/examples/flax/language-modeling/run_t5_mlm_flax.py
+++ b/examples/flax/language-modeling/run_t5_mlm_flax.py
@@ -776,8 +776,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
 
     num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
 

--- a/examples/flax/question-answering/run_qa.py
+++ b/examples/flax/question-answering/run_qa.py
@@ -1013,7 +1013,7 @@ def main():
                     _ = batch.pop("example_id")
                     _ = batch.pop("offset_mapping")
                     predictions = pad_shard_unpad(p_eval_step)(
-                        state, batch, min_device_batch=per_device_eval_batch_size
+                        state, batch, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     start_logits = np.array(predictions[0])
                     end_logits = np.array(predictions[1])
@@ -1061,7 +1061,9 @@ def main():
         ):
             _ = batch.pop("example_id")
             _ = batch.pop("offset_mapping")
-            predictions = pad_shard_unpad(p_eval_step)(state, batch, min_device_batch=per_device_eval_batch_size)
+            predictions = pad_shard_unpad(p_eval_step)(
+                state, batch, min_device_batch=training_args.per_device_eval_batch_size
+                )
             start_logits = np.array(predictions[0])
             end_logits = np.array(predictions[1])
             all_start_logits.append(start_logits)

--- a/examples/flax/question-answering/run_qa.py
+++ b/examples/flax/question-answering/run_qa.py
@@ -889,8 +889,7 @@ def main():
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.local_device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.local_device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.local_device_count()
     # endregion
 
     # region Load model

--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -757,8 +757,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
     steps_per_epoch = len(train_dataset) // train_batch_size
     total_train_steps = steps_per_epoch * num_epochs
 

--- a/examples/flax/summarization/run_summarization_flax.py
+++ b/examples/flax/summarization/run_summarization_flax.py
@@ -935,7 +935,7 @@ def main():
             labels = batch["labels"]
 
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, batch, min_device_batch=per_device_eval_batch_size
+                state.params, batch, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 
@@ -990,7 +990,7 @@ def main():
             labels = batch["labels"]
 
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, batch, min_device_batch=per_device_eval_batch_size
+                state.params, batch, min_device_batch=training_args.per_device_eval_batch_size
             )
             pred_metrics.append(metrics)
 

--- a/examples/flax/text-classification/run_flax_glue.py
+++ b/examples/flax/text-classification/run_flax_glue.py
@@ -552,8 +552,7 @@ def main():
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.local_device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.local_device_count()
 
     learning_rate_fn = create_learning_rate_fn(
         len(train_dataset),

--- a/examples/flax/text-classification/run_flax_glue.py
+++ b/examples/flax/text-classification/run_flax_glue.py
@@ -655,7 +655,7 @@ def main():
                 ):
                     labels = batch.pop("labels")
                     predictions = pad_shard_unpad(p_eval_step)(
-                        state, batch, min_device_batch=per_device_eval_batch_size
+                        state, batch, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     metric.add_batch(predictions=np.array(predictions), references=labels)
 

--- a/examples/flax/text-classification/run_flax_glue.py
+++ b/examples/flax/text-classification/run_flax_glue.py
@@ -552,7 +552,7 @@ def main():
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.local_device_count()
-    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.local_device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
 
     learning_rate_fn = create_learning_rate_fn(
         len(train_dataset),

--- a/examples/flax/token-classification/run_flax_ner.py
+++ b/examples/flax/token-classification/run_flax_ner.py
@@ -632,8 +632,7 @@ def main():
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
     train_batch_size = training_args.per_device_train_batch_size * jax.local_device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = training_args.per_device_eval_batch_size * jax.local_device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.local_device_count()
 
     learning_rate_fn = create_learning_rate_fn(
         len(train_dataset),

--- a/examples/flax/token-classification/run_flax_ner.py
+++ b/examples/flax/token-classification/run_flax_ner.py
@@ -764,7 +764,7 @@ def main():
                 ):
                     labels = batch.pop("labels")
                     predictions = pad_shard_unpad(p_eval_step)(
-                        state, batch, min_device_batch=per_device_eval_batch_size
+                        state, batch, min_device_batch=training_args.per_device_eval_batch_size
                     )
                     predictions = np.array(predictions)
                     labels[np.array(chain(*batch["attention_mask"])) == 0] = -100
@@ -803,7 +803,7 @@ def main():
         eval_loader = eval_data_collator(eval_dataset, eval_batch_size)
         for batch in tqdm(eval_loader, total=len(eval_dataset) // eval_batch_size, desc="Evaluating ...", position=2):
             labels = batch.pop("labels")
-            predictions = pad_shard_unpad(p_eval_step)(state, batch, min_device_batch=per_device_eval_batch_size)
+            predictions = pad_shard_unpad(p_eval_step)(state, batch, min_device_batch=training_args.per_device_eval_batch_size)
             predictions = np.array(predictions)
             labels[np.array(chain(*batch["attention_mask"])) == 0] = -100
             preds, refs = get_labels(predictions, labels)

--- a/examples/flax/vision/run_image_classification.py
+++ b/examples/flax/vision/run_image_classification.py
@@ -562,7 +562,7 @@ def main():
         for batch in eval_loader:
             # Model forward
             metrics = pad_shard_unpad(p_eval_step, static_return=True)(
-                state.params, batch, min_device_batch=per_device_eval_batch_size
+                state.params, batch, min_device_batch=training_args.per_device_eval_batch_size
             )
             eval_metrics.append(metrics)
 

--- a/examples/flax/vision/run_image_classification.py
+++ b/examples/flax/vision/run_image_classification.py
@@ -397,8 +397,7 @@ def main():
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-    per_device_eval_batch_size = int(training_args.per_device_eval_batch_size)
-    eval_batch_size = per_device_eval_batch_size * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
     steps_per_epoch = len(train_dataset) // train_batch_size
     total_train_steps = steps_per_epoch * num_epochs
 


### PR DESCRIPTION
Hi,
In this code, it appears that there might be some confusion regarding the assign of per_device_eval_batch_size to another variable and then multiplying it by jax.device_count(). However, there is a discrepancy between the code styles used for training and evaluation, which makes it less clear. To improve clarity and align with the coding style used for train_batch_size, I have simplified eval_batch_size to a single line for a cleaner and more consistent coding style.
I would like cc @sanchit-gandhi to review my PR.