### PR TITLE
[AutoBackbone] Add test

### DIFF
--- a/src/transformers/models/dinov2/configuration_dinov2.py
+++ b/src/transformers/models/dinov2/configuration_dinov2.py
@@ -32,7 +32,7 @@ DINOV2_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 }
 
 
-class Dinov2Config(PretrainedConfig, BackboneConfigMixin):
+class Dinov2Config(BackboneConfigMixin, PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`Dinov2Model`]. It is used to instantiate an
     Dinov2 model according to the specified arguments, defining the model architecture. Instantiating a configuration

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -106,8 +106,9 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
     has_attentions = False
 
     def setUp(self):
+        self.config_class = PretrainedConfig
         self.model_tester = TimmBackboneModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PretrainedConfig, has_text_modality=False)
+        self.config_tester = ConfigTester(self, config_class=self.config_class, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.create_and_test_config_to_json_string()

--- a/tests/test_backbone_common.py
+++ b/tests/test_backbone_common.py
@@ -15,6 +15,7 @@
 
 import copy
 import inspect
+import tempfile
 
 from transformers.testing_utils import require_torch, torch_device
 from transformers.utils.backbone_utils import BackboneType
@@ -71,6 +72,16 @@ class BackboneTesterMixin:
             arg_names = [*signature.parameters.keys()]
             expected_arg_names = ["pixel_values"]
             self.assertListEqual(arg_names[:1], expected_arg_names)
+
+    def test_config_save_pretrained(self):
+        config_class = self.config_class
+        config_first = config_class(out_indices=[0, 1, 2, 3])
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_first.save_pretrained(tmpdirname)
+            config_second = self.config_class.from_pretrained(tmpdirname)
+
+        self.assertEqual(config_second.to_dict(), config_first.to_dict())
 
     def test_channels(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

This PR adds a test which verifies that out_indices and out_features get saved properly.

The test fails if a Backbone class first inherits from `PretrainedConfig`, then from `BackboneConfigMixin`.