### PR TITLE
[FIX] resize_token_embeddings

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1503,7 +1503,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
             if new_num_tokens is None:
                 new_num_tokens = old_embeddings.weight.shape[0]
-            new_num_tokens = ((new_num_tokens // pad_to_multiple_of) + 1) * pad_to_multiple_of
+            new_num_tokens = ((new_num_tokens + pad_to_multiple_of - 1) // pad_to_multiple_of) * pad_to_multiple_of
         else:
             logger.warning(
                 "You are resizing the embedding layer without providing a `pad_to_multiple_of` parameter. This means that the new embedding"

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1426,6 +1426,11 @@ class ModelTesterMixin:
 
             model_embed = model.resize_token_embeddings(model_vocab_size + 13, pad_to_multiple_of=64)
             self.assertTrue(model_embed.weight.shape[0] // 64, 0)
+            
+            # Check that resizing a model to a multiple of pad_to_multiple leads to a model of exactly that size
+            target_dimension = int(np.ceil(model_embed.weight.shape[0]/64)*64) + 64
+            model_embed = model.resize_token_embeddings(target_dimension, pad_to_multiple_of=64)
+            self.assertTrue(model_embed.weight.shape[0], target_dimension)
 
             with self.assertRaisesRegex(
                 ValueError,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1428,7 +1428,7 @@ class ModelTesterMixin:
             self.assertTrue(model_embed.weight.shape[0] // 64, 0)
             
             # Check that resizing a model to a multiple of pad_to_multiple leads to a model of exactly that size
-            target_dimension = int(np.ceil(model_embed.weight.shape[0]/64)*64) + 64
+            target_dimension = 128
             model_embed = model.resize_token_embeddings(target_dimension, pad_to_multiple_of=64)
             self.assertTrue(model_embed.weight.shape[0], target_dimension)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1426,7 +1426,7 @@ class ModelTesterMixin:
 
             model_embed = model.resize_token_embeddings(model_vocab_size + 13, pad_to_multiple_of=64)
             self.assertTrue(model_embed.weight.shape[0] // 64, 0)
-            
+
             # Check that resizing a model to a multiple of pad_to_multiple leads to a model of exactly that size
             target_dimension = 128
             model_embed = model.resize_token_embeddings(target_dimension, pad_to_multiple_of=64)


### PR DESCRIPTION
# What does this PR do?

When `resize_token_embeddings(new_num_tokens, pad_to_multiple)` is called with `new_num_tokens` a multiple of `pad_to_multiple`, the model should be resized to `new_num_tokens`. Due to a math error, it is instead resized to `new_num_tokens+pad_to_multiple`. This PR fixes that bug.

@ArthurZucker https://github.com/huggingface/transformers/pull/25088
