### PR TITLE
[`core`] Import tensorflow inside relevant methods in `trainer_utils`

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -46,9 +46,6 @@ from .utils import (
 if is_torch_available():
     import torch
 
-if is_tf_available():
-    import tensorflow as tf
-
 
 def seed_worker(_):
     """
@@ -80,6 +77,8 @@ def enable_full_determinism(seed: int, warn_only: bool = False):
         torch.backends.cudnn.benchmark = False
 
     if is_tf_available():
+        import tensorflow as tf
+
         tf.config.experimental.enable_op_determinism()
 
 
@@ -101,6 +100,8 @@ def set_seed(seed: int):
     if is_torch_xpu_available():
         torch.xpu.manual_seed_all(seed)
     if is_tf_available():
+        import tensorflow as tf
+
         tf.random.set_seed(seed)
 
 


### PR DESCRIPTION
# What does this PR do?

Imports tensorflow inside relevant methods in `trainer_utils`. 
When Deepspeed and accelerate are available in your env, it will try to import transformers all the way down to https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_utils.py#L49 

Leading to considerable slowdowns in import time

![Screenshot 2023-09-12 at 10 48 50](https://github.com/huggingface/transformers/assets/49240599/b03a4f28-dafb-4b06-89d2-2f9516f49b58)

This PR imports tensorflow inside the relevant methods so that it will never get globally imported by transformers anymore.
If this patch gets applied, there is no speedup, however this can be fixed by lazy loading TF in accelerate itself:
 
![Screenshot 2023-09-12 at 10 49 26](https://github.com/huggingface/transformers/assets/49240599/c61e1eda-ea96-4940-970f-49ccea6ee50b)

cc @amyeroberts @patrickvonplaten @pacman100 @muellerzr @SunMarc 
