### PR TITLE
Update spectrogram and waveform model mapping for TTS/A pipeline

### DIFF
--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -115,8 +115,8 @@ PIPELINE_TAGS_AND_AUTO_MODELS = [
     ("depth-estimation", "MODEL_FOR_DEPTH_ESTIMATION_MAPPING_NAMES", "AutoModelForDepthEstimation"),
     ("video-classification", "MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING_NAMES", "AutoModelForVideoClassification"),
     ("mask-generation", "MODEL_FOR_MASK_GENERATION_MAPPING_NAMES", "AutoModelForMaskGeneration"),
-    ("text-to-audio", "MODEL_FOR_TEXT_TO_SPECTROGRAM_NAMES", "AutoModelForTextToSpectrogram"),
-    ("text-to-audio", "MODEL_FOR_TEXT_TO_WAVEFORM_NAMES", "AutoModelForTextToWaveform"),
+    ("text-to-audio", "MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES", "AutoModelForTextToSpectrogram"),
+    ("text-to-audio", "MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES", "AutoModelForTextToWaveform"),
 ]
 
 


### PR DESCRIPTION
# What does this PR do?

Updates the mapping names for the models used for TTS & TTA pipelines.

Fixes # (issue)
`MODEL_FOR_TEXT_TO_SPECTROGRAM_NAMES` -> `MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES`
`MODEL_FOR_TEXT_TO_SPECTROGRAM_NAMES` -> `MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES`

## Who can review?

@ylacombe @sanchit-gandhi 