### PR TITLE
Text2text pipeline: don't parameterize from the config

### DIFF
--- a/src/transformers/pipelines/text2text_generation.py
+++ b/src/transformers/pipelines/text2text_generation.py
@@ -181,9 +181,11 @@ class Text2TextGenerationPipeline(Pipeline):
         elif self.framework == "tf":
             in_b, input_length = tf.shape(model_inputs["input_ids"]).numpy()
 
-        generate_kwargs["min_length"] = generate_kwargs.get("min_length", self.model.config.min_length)
-        generate_kwargs["max_length"] = generate_kwargs.get("max_length", self.model.config.max_length)
-        self.check_inputs(input_length, generate_kwargs["min_length"], generate_kwargs["max_length"])
+        self.check_inputs(
+            input_length,
+            generate_kwargs.get("min_length", self.model.config.min_length),
+            generate_kwargs.get("max_length", self.model.config.max_length),
+        )
         output_ids = self.model.generate(**model_inputs, **generate_kwargs)
         out_b = output_ids.shape[0]
         if self.framework == "pt":


### PR DESCRIPTION
# What does this PR do?

Fixes the warning raised in [this comment](https://github.com/huggingface/transformers/pull/23139#issuecomment-1674143603).

Similar to other recent PRs, it removes a few lines that attempt to parameterize `.generate()` using values from the model config, when they are absent. The `GenerationConfig` class already handles these default values, so it's redundant. Moreover, when an unused kwarg is explicitly passed to `.generate()`, warnings are triggered (which was the issue in the comment).