### PR TITLE
[MusicGen] Add sampling rate to config

### DIFF
--- a/src/transformers/models/musicgen/configuration_musicgen.py
+++ b/src/transformers/models/musicgen/configuration_musicgen.py
@@ -204,6 +204,8 @@ class MusicgenConfig(PretrainedConfig):
         self.decoder = MusicgenDecoderConfig(**decoder_config)
         self.is_encoder_decoder = True
 
+        self.sampling_rate = self.audio_encoder.sampling_rate
+
     @classmethod
     def from_sub_models_config(
         cls,

--- a/src/transformers/models/musicgen/configuration_musicgen.py
+++ b/src/transformers/models/musicgen/configuration_musicgen.py
@@ -204,8 +204,6 @@ class MusicgenConfig(PretrainedConfig):
         self.decoder = MusicgenDecoderConfig(**decoder_config)
         self.is_encoder_decoder = True
 
-        self.sampling_rate = self.audio_encoder.sampling_rate
-
     @classmethod
     def from_sub_models_config(
         cls,
@@ -228,3 +226,8 @@ class MusicgenConfig(PretrainedConfig):
             decoder=decoder_config.to_dict(),
             **kwargs,
         )
+
+    @property
+    # This is a property because you might want to change the codec model on the fly
+    def sampling_rate(self):
+        return self.audio_encoder.sampling_rate

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -39,28 +39,6 @@ class TextToAudioPipelineTests(unittest.TestCase):
     model_mapping = MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING
     # for now only test text_to_waveform and not text_to_spectrogram
 
-    @require_torch
-    def test_tiny_musicgen_pt(self):
-        music_generator = pipeline(
-            task="text-to-audio",
-            model="hf-internal-testing/tiny-random-MusicgenForConditionalGeneration",
-            framework="pt",
-        )
-        sampling_rate = music_generator.model.audio_encoder.config.sampling_rate
-
-        forward_params = {"max_new_tokens": 10}
-        # test single sample
-        outputs = music_generator("this", forward_params=forward_params)
-        self.assertEqual(
-            {"audio": ANY(np.ndarray), "sampling_rate": sampling_rate},
-            outputs,
-        )
-
-        # test batching
-        outputs = music_generator(["this", "this a"], forward_params=forward_params, batch_size=2)
-        audio = [output["audio"] for output in outputs]
-        self.assertEqual([ANY(np.ndarray), ANY(np.ndarray)], audio)
-
     @slow
     @require_torch
     def test_small_musicgen_pt(self):

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -50,10 +50,7 @@ class TextToAudioPipelineTests(unittest.TestCase):
         }
 
         outputs = music_generator("This is a test", forward_params=forward_params)
-        self.assertEqual(
-            {"audio": ANY(np.ndarray), "sampling_rate": 32000},
-            outputs,
-        )
+        self.assertEqual({"audio": ANY(np.ndarray), "sampling_rate": 32000},outputs)
 
         # test two examples side-by-side
         outputs = music_generator(["This is a test", "This is a second test"], forward_params=forward_params)

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -50,7 +50,7 @@ class TextToAudioPipelineTests(unittest.TestCase):
         }
 
         outputs = music_generator("This is a test", forward_params=forward_params)
-        self.assertEqual({"audio": ANY(np.ndarray), "sampling_rate": 32000},outputs)
+        self.assertEqual({"audio": ANY(np.ndarray), "sampling_rate": 32000}, outputs)
 
         # test two examples side-by-side
         outputs = music_generator(["This is a test", "This is a second test"], forward_params=forward_params)


### PR DESCRIPTION
# What does this PR do?

Adds sampling rate attribute to the parent model config. We get the sampling rate from the EnCodec sub-model config. Adding this attribute brings consistency with the other TTA models in the lib, where the output sampling rate is accessible directly through the top-level config (https://github.com/huggingface/audio-transformers-course/pull/140#discussion_r1324226366)
