### PR TITLE
Falcon: batched generation

### DIFF
--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -67,6 +67,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
+# TODO (joao): Is this the same implementation as in Llama? If so, let's make them the same and add the copy facilities
 class FalconRotaryEmbedding(nn.Module):
     """Implementation of RotaryEmbedding from GPT-NeoX.
     This implementation is designed to operate on queries and keys that are compatible with `[batch_size,


### PR DESCRIPTION
# What does this PR do?

This PR does three things:
1. Fixes the minimum float number added to the attention mask, in the positions the attention mask is `0`. In some numerical precisions, the numerical attention mask was getting `-inf`, which wrecked downstream computations.
2. Adds the `position_ids` input to Falcon, which is needed for proper batched generation. When it is not passed, the forward pass builds the position ids from the sequence length, which does not account for the left-padding in batched generation -- the model could still generate, but the results should be slightly better after the fix.
3. Add tests for batched generation with left padding

