### PR TITLE
[docs] last hidden state vs hidden_states[-1]

### DIFF
--- a/docs/source/en/main_classes/output.md
+++ b/docs/source/en/main_classes/output.md
@@ -43,7 +43,7 @@ an optional `attentions` attribute. Here we have the `loss` since we passed alon
 <Tip>
 
 When passing `output_hidden_states=True` you may expect the `outputs.hidden_states[-1]` to match `outputs.last_hidden_states` exactly.
-However, this is not always the case. Some models apply normalization to the last hidden state when it's returned.
+However, this is not always the case. Some models apply normalization or subsequent process to the last hidden state when it's returned.
 </Tip>
 
 

--- a/docs/source/en/main_classes/output.md
+++ b/docs/source/en/main_classes/output.md
@@ -40,6 +40,13 @@ an optional `attentions` attribute. Here we have the `loss` since we passed alon
 `hidden_states` and `attentions` because we didn't pass `output_hidden_states=True` or
 `output_attentions=True`.
 
+<Tip>
+
+When passing `output_hidden_states=True` you may expect the `outputs.hidden_states[-1]` to match `outputs.last_hidden_states` exactly.
+However, this is not always the case. Some models apply normalization to the last hidden state when it's returned.
+</Tip>
+
+
 You can access each attribute as you would usually do, and if that attribute has not been returned by the model, you
 will get `None`. Here for instance `outputs.loss` is the loss computed by the model, and `outputs.attentions` is
 `None`.


### PR DESCRIPTION
Intuitively one may think that `output.hidden_states[-1]` (returned when `output_hidden_states` is set to `True`) should match the `output.last_hidden_states` exactly. However, this is not always the case. Models like CLIP, ClipSeg, GroupVit, OWLViT, and X-CLIP apply `layernorm` before returning the `last_hidden_states`. Some other models apply `post_layernorm` or `norm`.

This PR adds a small note in the docs to address possible confusion.