### PR TITLE
Fix no_grad when using AdaFactor out of transformers.

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -646,7 +646,8 @@ class Adafactor(Optimizer):
         """
         loss = None
         if closure is not None:
-            loss = closure()
+            with torch.enable_grad():
+                loss = closure()
 
         for group in self.param_groups:
             for p in group["params"]:


### PR DESCRIPTION
When using `transformers.optimization.AdaFactor` with my own code not using `Trainer`, autograd will say there is no grad to backprop. 

I believe it might work well with `Trainer`, but this simple and small fix makes it more useful.