### PR TITLE
Add Auto Device Map option for BERT Models

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -745,6 +745,7 @@ class BertPreTrainedModel(PreTrainedModel):
     load_tf_weights = load_tf_weights_in_bert
     base_model_prefix = "bert"
     supports_gradient_checkpointing = True
+    _no_split_modules = ["BertEmbeddings", "BertSelfAttention"]
 
     def _init_weights(self, module):
         """Initialize the weights"""


### PR DESCRIPTION
# What does this PR do?
This PR adds the `'device_map': "auto"` functionality for BERT Models for ease in multi-GPU training.

Fixes #25296 

## Who can review?
@younesbelkada