### PR TITLE
Porting the torchaudio kaldi fbank implementation to audio_utils

### DIFF
--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -124,7 +124,7 @@ def mel_filter_bank(
     sampling_rate: int,
     norm: Optional[str] = None,
     mel_scale: str = "htk",
-    use_torchaudio_version: bool = False,
+    triangularize_in_mel_space: bool = False,
 ) -> np.ndarray:
     """
     Creates a frequency bin conversion matrix used to obtain a mel spectrogram. This is called a *mel filter bank*, and
@@ -161,9 +161,10 @@ def mel_filter_bank(
             If `"slaney"`, divide the triangular mel weights by the width of the mel band (area normalization).
         mel_scale (`str`, *optional*, defaults to `"htk"`):
             The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
-        use_torchaudio_version (`bool`, *optional*, defaults to `False`):
-            If set, uses the torchaudio way of computing the mel filters. Results in small numerical differences with
-            the default version.
+        triangularize_in_mel_space (`bool`, *optional*, defaults to `False`):
+            If this option is enabled, the triangular filter is applied in mel space rather than frequency space. This
+            uses the torchaudio method of calculating mel filters and results in small numerical differences from the
+            default version.
 
     Returns:
         `np.ndarray` of shape (`num_frequency_bins`, `num_mel_filters`): Triangular filter bank matrix. This is a
@@ -178,7 +179,7 @@ def mel_filter_bank(
     mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
     filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
 
-    if use_torchaudio_version:
+    if triangularize_in_mel_space:
         fft_bin_width = sampling_rate / (num_frequency_bins * 2)
         mel = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_scale)
         mel_filters = _create_triangular_filter_bank(mel, mel_freqs)

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -162,7 +162,8 @@ def mel_filter_bank(
         mel_scale (`str`, *optional*, defaults to `"htk"`):
             The mel frequency scale to use, `"htk"` or `"slaney"`.
         use_torchaudio_version (`bool`, *optional*, defaults to `False`):
-            If set, uses the torchaudio way of computing the mel filters. Results in small numerical differences with the default version.
+            If set, uses the torchaudio way of computing the mel filters. Results in small numerical differences with
+            the default version.
 
     Returns:
         `np.ndarray` of shape (`num_frequency_bins`, `num_mel_filters`): Triangular filter bank matrix. This is a
@@ -177,7 +178,7 @@ def mel_filter_bank(
     mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
 
     if use_torchaudio_version:
-        fft_bin_width = sampling_rate / (num_frequency_bins*2)
+        fft_bin_width = sampling_rate / (num_frequency_bins * 2)
         mel = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_scale)
         mel_filters = _create_triangular_filter_bank(mel, mel_freqs)
     else:
@@ -378,7 +379,7 @@ def spectrogram(
         db_range (`float`, *optional*):
             Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
             peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
-        remove_dc_offset (`bool`, *optional*): 
+        remove_dc_offset (`bool`, *optional*):
             Subtract mean from waveform on each frame, applied before pre-emphasis.
         dtype (`np.dtype`, *optional*, defaults to `np.float32`):
             Data type of the spectrogram tensor. If `power` is None, this argument is ignored and the dtype will be
@@ -433,7 +434,7 @@ def spectrogram(
 
         if remove_dc_offset:
             buffer[:frame_length] = buffer[:frame_length] - buffer[:frame_length].mean()
-            
+
         if preemphasis is not None:
             buffer[1:frame_length] -= preemphasis * buffer[: frame_length - 1]
             buffer[0] *= 1 - preemphasis

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -382,7 +382,8 @@ def spectrogram(
             Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
             peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
         remove_dc_offset (`bool`, *optional*):
-            Subtract mean from waveform on each frame, applied before pre-emphasis.
+            Subtract mean from waveform on each frame, applied before pre-emphasis. This should be set to `true` in order to get the same results as 
+            `torchaudio.compliance.kaldi.fbank` when computing mel filters.
         dtype (`np.dtype`, *optional*, defaults to `np.float32`):
             Data type of the spectrogram tensor. If `power` is None, this argument is ignored and the dtype will be
             `np.complex64`.

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -76,7 +76,7 @@ def mel_to_hertz(mels: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
         raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
 
     if mel_scale == "htk":
-        return 700.0 * (np.exp(mels / 2595.0, base=10) - 1.0)
+        return 700.0 * (np.power(10, mels / 2595.0) - 1.0)
     elif mel_scale == "kaldi":
         return 700.0 * (np.exp(mels / 1127.0) - 1.0)
 

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -76,7 +76,7 @@ def mel_to_hertz(mels: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
         raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
 
     if mel_scale == "htk":
-        return 700.0 * (np.exp(mels / 2595.0, base =10) - 1.0)
+        return 700.0 * (np.exp(mels / 2595.0, base=10) - 1.0)
     elif mel_scale == "kaldi":
         return 700.0 * (np.exp(mels / 1127.0) - 1.0)
 
@@ -162,8 +162,8 @@ def mel_filter_bank(
         mel_scale (`str`, *optional*, defaults to `"htk"`):
             The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
         triangularize_in_mel_space (`bool`, *optional*, defaults to `False`):
-            If this option is enabled, the triangular filter is applied in mel space rather than frequency space. This should be set to `true` in order to get the same results as 
-            `torchaudio` when computing mel filters.
+            If this option is enabled, the triangular filter is applied in mel space rather than frequency space. This
+            should be set to `true` in order to get the same results as `torchaudio` when computing mel filters.
 
     Returns:
         `np.ndarray` of shape (`num_frequency_bins`, `num_mel_filters`): Triangular filter bank matrix. This is a
@@ -186,8 +186,8 @@ def mel_filter_bank(
     else:
         # frequencies of FFT bins in Hz
         fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
-        
-mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
+
+    mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
 
     if norm is not None and norm == "slaney":
         # Slaney-style mel is scaled to be approx constant energy per channel

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -76,7 +76,7 @@ def mel_to_hertz(mels: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
         raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
 
     if mel_scale == "htk":
-        return 700.0 * (10.0 ** (mels / 2595.0) - 1.0)
+        return 700.0 * (np.exp(mels / 2595.0, base =10) - 1.0)
     elif mel_scale == "kaldi":
         return 700.0 * (np.exp(mels / 1127.0) - 1.0)
 
@@ -162,9 +162,8 @@ def mel_filter_bank(
         mel_scale (`str`, *optional*, defaults to `"htk"`):
             The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
         triangularize_in_mel_space (`bool`, *optional*, defaults to `False`):
-            If this option is enabled, the triangular filter is applied in mel space rather than frequency space. This
-            uses the torchaudio method of calculating mel filters and results in small numerical differences from the
-            default version.
+            If this option is enabled, the triangular filter is applied in mel space rather than frequency space. This should be set to `true` in order to get the same results as 
+            `torchaudio` when computing mel filters.
 
     Returns:
         `np.ndarray` of shape (`num_frequency_bins`, `num_mel_filters`): Triangular filter bank matrix. This is a
@@ -180,13 +179,15 @@ def mel_filter_bank(
     filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
 
     if triangularize_in_mel_space:
+        # frequencies of FFT bins in Hz, but filters triangularized in mel space
         fft_bin_width = sampling_rate / (num_frequency_bins * 2)
-        mel = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_scale)
-        mel_filters = _create_triangular_filter_bank(mel, mel_freqs)
+        fft_freqs = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_scale)
+        filter_freqs = mel_freqs
     else:
         # frequencies of FFT bins in Hz
         fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
-        mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
+        
+mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
 
     if norm is not None and norm == "slaney":
         # Slaney-style mel is scaled to be approx constant energy per channel

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -382,8 +382,8 @@ def spectrogram(
             Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
             peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
         remove_dc_offset (`bool`, *optional*):
-            Subtract mean from waveform on each frame, applied before pre-emphasis. This should be set to `true` in order to get the same results as 
-            `torchaudio.compliance.kaldi.fbank` when computing mel filters.
+            Subtract mean from waveform on each frame, applied before pre-emphasis. This should be set to `true` in
+            order to get the same results as `torchaudio.compliance.kaldi.fbank` when computing mel filters.
         dtype (`np.dtype`, *optional*, defaults to `np.float32`):
             Data type of the spectrogram tensor. If `power` is None, this argument is ignored and the dtype will be
             `np.complex64`.

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -160,7 +160,7 @@ def mel_filter_bank(
         norm (`str`, *optional*):
             If `"slaney"`, divide the triangular mel weights by the width of the mel band (area normalization).
         mel_scale (`str`, *optional*, defaults to `"htk"`):
-            The mel frequency scale to use, `"htk"` or `"slaney"`.
+            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
         use_torchaudio_version (`bool`, *optional*, defaults to `False`):
             If set, uses the torchaudio way of computing the mel filters. Results in small numerical differences with
             the default version.
@@ -176,6 +176,7 @@ def mel_filter_bank(
     mel_min = hertz_to_mel(min_frequency, mel_scale=mel_scale)
     mel_max = hertz_to_mel(max_frequency, mel_scale=mel_scale)
     mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
+    filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
 
     if use_torchaudio_version:
         fft_bin_width = sampling_rate / (num_frequency_bins * 2)
@@ -184,7 +185,6 @@ def mel_filter_bank(
     else:
         # frequencies of FFT bins in Hz
         fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
-        filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
         mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
 
     if norm is not None and norm == "slaney":

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -30,17 +30,19 @@ def hertz_to_mel(freq: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
         freq (`float` or `np.ndarray`):
             The frequency, or multiple frequencies, in hertz (Hz).
         mel_scale (`str`, *optional*, defaults to `"htk"`):
-            The mel frequency scale to use, `"htk"` or `"slaney"`.
+            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
 
     Returns:
         `float` or `np.ndarray`: The frequencies on the mel scale.
     """
 
-    if mel_scale not in ["slaney", "htk"]:
-        raise ValueError('mel_scale should be one of "htk" or "slaney".')
+    if mel_scale not in ["slaney", "htk", "kaldi"]:
+        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
 
     if mel_scale == "htk":
         return 2595.0 * np.log10(1.0 + (freq / 700.0))
+    elif mel_scale == "kaldi":
+        return 1127.0 * np.log(1.0 + (freq / 700.0))
 
     min_log_hertz = 1000.0
     min_log_mel = 15.0
@@ -64,17 +66,19 @@ def mel_to_hertz(mels: Union[float, np.ndarray], mel_scale: str = "htk") -> Unio
         mels (`float` or `np.ndarray`):
             The frequency, or multiple frequencies, in mels.
         mel_scale (`str`, *optional*, `"htk"`):
-            The mel frequency scale to use, `"htk"` or `"slaney"`.
+            The mel frequency scale to use, `"htk"`, `"kaldi"` or `"slaney"`.
 
     Returns:
         `float` or `np.ndarray`: The frequencies in hertz.
     """
 
-    if mel_scale not in ["slaney", "htk"]:
-        raise ValueError('mel_scale should be one of "htk" or "slaney".')
+    if mel_scale not in ["slaney", "htk", "kaldi"]:
+        raise ValueError('mel_scale should be one of "htk", "slaney" or "kaldi".')
 
     if mel_scale == "htk":
         return 700.0 * (10.0 ** (mels / 2595.0) - 1.0)
+    elif mel_scale == "kaldi":
+        return 700.0 * (np.exp(mels / 1127.0) - 1.0)
 
     min_log_hertz = 1000.0
     min_log_mel = 15.0
@@ -120,6 +124,7 @@ def mel_filter_bank(
     sampling_rate: int,
     norm: Optional[str] = None,
     mel_scale: str = "htk",
+    use_torchaudio_version: bool = False,
 ) -> np.ndarray:
     """
     Creates a frequency bin conversion matrix used to obtain a mel spectrogram. This is called a *mel filter bank*, and
@@ -156,6 +161,8 @@ def mel_filter_bank(
             If `"slaney"`, divide the triangular mel weights by the width of the mel band (area normalization).
         mel_scale (`str`, *optional*, defaults to `"htk"`):
             The mel frequency scale to use, `"htk"` or `"slaney"`.
+        use_torchaudio_version (`bool`, *optional*, defaults to `False`):
+            If set, uses the torchaudio way of computing the mel filters. Results in small numerical differences with the default version.
 
     Returns:
         `np.ndarray` of shape (`num_frequency_bins`, `num_mel_filters`): Triangular filter bank matrix. This is a
@@ -164,16 +171,20 @@ def mel_filter_bank(
     if norm is not None and norm != "slaney":
         raise ValueError('norm must be one of None or "slaney"')
 
-    # frequencies of FFT bins in Hz
-    fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
-
     # center points of the triangular mel filters
     mel_min = hertz_to_mel(min_frequency, mel_scale=mel_scale)
     mel_max = hertz_to_mel(max_frequency, mel_scale=mel_scale)
     mel_freqs = np.linspace(mel_min, mel_max, num_mel_filters + 2)
-    filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
 
-    mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
+    if use_torchaudio_version:
+        fft_bin_width = sampling_rate / (num_frequency_bins*2)
+        mel = hertz_to_mel(fft_bin_width * np.arange(num_frequency_bins), mel_scale=mel_scale)
+        mel_filters = _create_triangular_filter_bank(mel, mel_freqs)
+    else:
+        # frequencies of FFT bins in Hz
+        fft_freqs = np.linspace(0, sampling_rate // 2, num_frequency_bins)
+        filter_freqs = mel_to_hertz(mel_freqs, mel_scale=mel_scale)
+        mel_filters = _create_triangular_filter_bank(fft_freqs, filter_freqs)
 
     if norm is not None and norm == "slaney":
         # Slaney-style mel is scaled to be approx constant energy per channel
@@ -218,6 +229,7 @@ def window_function(
         - `"boxcar"`: a rectangular window
         - `"hamming"`: the Hamming window
         - `"hann"`: the Hann window
+        - `"povey"`: the Povey window
 
     Args:
         window_length (`int`):
@@ -243,6 +255,8 @@ def window_function(
         window = np.hamming(length)
     elif name in ["hann", "hann_window"]:
         window = np.hanning(length)
+    elif name in ["povey"]:
+        window = np.power(np.hanning(length), 0.85)
     else:
         raise ValueError(f"Unknown window function '{name}'")
 
@@ -281,6 +295,7 @@ def spectrogram(
     reference: float = 1.0,
     min_value: float = 1e-10,
     db_range: Optional[float] = None,
+    remove_dc_offset: Optional[bool] = None,
     dtype: np.dtype = np.float32,
 ) -> np.ndarray:
     """
@@ -363,6 +378,8 @@ def spectrogram(
         db_range (`float`, *optional*):
             Sets the maximum dynamic range in decibels. For example, if `db_range = 80`, the difference between the
             peak value and the smallest value will never be more than 80 dB. Must be greater than zero.
+        remove_dc_offset (`bool`, *optional*): 
+            Subtract mean from waveform on each frame, applied before pre-emphasis.
         dtype (`np.dtype`, *optional*, defaults to `np.float32`):
             Data type of the spectrogram tensor. If `power` is None, this argument is ignored and the dtype will be
             `np.complex64`.
@@ -414,6 +431,9 @@ def spectrogram(
     for frame_idx in range(num_frames):
         buffer[:frame_length] = waveform[timestep : timestep + frame_length]
 
+        if remove_dc_offset:
+            buffer[:frame_length] = buffer[:frame_length] - buffer[:frame_length].mean()
+            
         if preemphasis is not None:
             buffer[1:frame_length] -= preemphasis * buffer[: frame_length - 1]
             buffer[0] *= 1 - preemphasis

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -344,7 +344,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
 
         spec = spectrogram(
             waveform,
-            window_function(400, "povey"),
+            window_function(400, "povey", periodic=False),
             frame_length=400,
             hop_length=160,
             fft_length=512,
@@ -379,12 +379,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
        -15.94238515, -15.94238515, -15.94238515,  -5.91641988]
         )
         # fmt: on
-        self.assertTrue(np.allclose(spec[:64, 400], expected, atol=5e-2))
-        
-        #from torchaudio.compliance.kaldi import fbank
-        #import torch
-        #expected = fbank(torch.tensor(waveform).unsqueeze(0), num_mel_bins=400, sample_frequency=16000)
-
+        self.assertTrue(np.allclose(spec[:64, 400], expected, atol=1e-5))
 
     def test_spectrogram_center_padding(self):
         waveform = self._load_datasamples(1)[0]

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -105,7 +105,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             sampling_rate=16000,
             norm="slaney",
             mel_scale="slaney",
-            use_torchaudio_version=True,
+            triangularize_in_mel_space=True,
         )
         self.assertEqual(mel_filters.shape, (513, 13))
 
@@ -182,7 +182,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             sampling_rate=4000,
             norm=None,
             mel_scale="kaldi",
-            use_torchaudio_version=True,
+            triangularize_in_mel_space=True,
         )
         # fmt: off
         expected = np.array(
@@ -332,7 +332,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             sampling_rate=16000,
             norm=None,
             mel_scale="kaldi",
-            use_torchaudio_version=True,
+            triangularize_in_mel_space=True,
         )
 
         mel_filters = np.pad(mel_filters, ((0, 1), (0, 0)))

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -44,7 +44,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         inputs = np.array([60, 100, 200, 1000, 1001, 2000])
         expected = np.array([0.9, 1.5, 3.0, 15.0, 15.01453781, 25.08188016])
         self.assertTrue(np.allclose(hertz_to_mel(inputs, "slaney"), expected))
-        
+
         inputs = np.array([60, 100, 200, 1000, 1001, 2000])
         expected = np.array([92.6824, 150.4899, 283.2313, 999.9907, 1000.6534, 1521.3674])
         self.assertTrue(np.allclose(hertz_to_mel(inputs, "kaldi"), expected))
@@ -66,12 +66,10 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         inputs = np.array([0.9, 1.5, 3.0, 15.0, 15.01453781, 25.08188016])
         expected = np.array([60, 100, 200, 1000, 1001, 2000])
         self.assertTrue(np.allclose(mel_to_hertz(inputs, "slaney"), expected))
-        
-        
+
         expected = np.array([60, 100, 200, 1000, 1001, 2000])
         inputs = np.array([92.6824, 150.4899, 283.2313, 999.9907, 1000.6534, 1521.3674])
         self.assertTrue(np.allclose(mel_to_hertz(inputs, "kaldi"), expected))
-
 
         with pytest.raises(ValueError):
             mel_to_hertz(100, mel_scale=None)
@@ -98,7 +96,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             mel_scale="slaney",
         )
         self.assertEqual(mel_filters.shape, (513, 13))
-        
+
         mel_filters = mel_filter_bank(
             num_frequency_bins=513,
             num_mel_filters=13,
@@ -110,7 +108,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             use_torchaudio_version=True,
         )
         self.assertEqual(mel_filters.shape, (513, 13))
-        
+
     def test_mel_filter_bank_htk(self):
         mel_filters = mel_filter_bank(
             num_frequency_bins=16,
@@ -174,8 +172,7 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         ])
         # fmt: on
         self.assertTrue(np.allclose(mel_filters, expected))
-        
-        
+
     def test_mel_filter_bank_kaldi(self):
         mel_filters = mel_filter_bank(
             num_frequency_bins=16,
@@ -326,8 +323,6 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         )
         self.assertEqual(spec.shape, (257, 732))
         self.assertTrue(np.allclose(spec[:64, 400], expected))
-        
-        
 
         mel_filters = mel_filter_bank(
             num_frequency_bins=256,
@@ -339,8 +334,8 @@ class AudioUtilsFunctionTester(unittest.TestCase):
             mel_scale="kaldi",
             use_torchaudio_version=True,
         )
-        
-        mel_filters = np.pad(mel_filters, ((0,1), (0,0)))
+
+        mel_filters = np.pad(mel_filters, ((0, 1), (0, 0)))
 
         spec = spectrogram(
             waveform,

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -67,8 +67,8 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         expected = np.array([60, 100, 200, 1000, 1001, 2000])
         self.assertTrue(np.allclose(mel_to_hertz(inputs, "slaney"), expected))
 
-        expected = np.array([60, 100, 200, 1000, 1001, 2000])
         inputs = np.array([92.6824, 150.4899, 283.2313, 999.9907, 1000.6534, 1521.3674])
+        expected = np.array([60, 100, 200, 1000, 1001, 2000])
         self.assertTrue(np.allclose(mel_to_hertz(inputs, "kaldi"), expected))
 
         with pytest.raises(ValueError):

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -44,6 +44,10 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         inputs = np.array([60, 100, 200, 1000, 1001, 2000])
         expected = np.array([0.9, 1.5, 3.0, 15.0, 15.01453781, 25.08188016])
         self.assertTrue(np.allclose(hertz_to_mel(inputs, "slaney"), expected))
+        
+        inputs = np.array([60, 100, 200, 1000, 1001, 2000])
+        expected = np.array([92.6824, 150.4899, 283.2313, 999.9907, 1000.6534, 1521.3674])
+        self.assertTrue(np.allclose(hertz_to_mel(inputs, "kaldi"), expected))
 
         with pytest.raises(ValueError):
             hertz_to_mel(100, mel_scale=None)

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -66,6 +66,12 @@ class AudioUtilsFunctionTester(unittest.TestCase):
         inputs = np.array([0.9, 1.5, 3.0, 15.0, 15.01453781, 25.08188016])
         expected = np.array([60, 100, 200, 1000, 1001, 2000])
         self.assertTrue(np.allclose(mel_to_hertz(inputs, "slaney"), expected))
+        
+        
+        expected = np.array([60, 100, 200, 1000, 1001, 2000])
+        inputs = np.array([92.6824, 150.4899, 283.2313, 999.9907, 1000.6534, 1521.3674])
+        self.assertTrue(np.allclose(mel_to_hertz(inputs, "kaldi"), expected))
+
 
         with pytest.raises(ValueError):
             mel_to_hertz(100, mel_scale=None)


### PR DESCRIPTION
# What does this PR do?

> [Kaldi](https://kaldi-asr.org/doc/) is a toolkit for speech recognition, intended for use by speech recognition researchers and professionals. 

Its [torchaudio `fbank` implementation](https://pytorch.org/audio/stable/compliance.kaldi.html) is sometimes used in the library, notably in the [Audio Spectrogram Transformer](https://github.com/huggingface/transformers/blob/d70fab8b2062526e9c2c60196421a8bc96c7df03/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py#L97) and [SpeechToText](https://github.com/huggingface/transformers/blob/d70fab8b2062526e9c2c60196421a8bc96c7df03/src/transformers/models/speech_to_text/feature_extraction_speech_to_text.py#L90) models.

It will also be used in the future [SeamlessM4T model](https://github.com/huggingface/transformers/pull/25693#pullrequestreview-1624417597).

This PR aims to port [the implementation](https://pytorch.org/audio/stable/_modules/torchaudio/compliance/kaldi.html#fbank) to `numpy`, directly in `audio_utils.py`.

Why is this important? It will reduce `transformers` dependence on `torchaudio` for some models.

Atm, I enriched some of `audio_utils` methods and added tests to make sure it has the same results as `torchaudio`.



## Before submitting
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

cc @ArthurZucker and @sanchit-gandhi , what do you think of this feature ?