### PR TITLE
Chat Template kwargs

### DIFF
--- a/src/transformers/models/code_llama/tokenization_code_llama.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama.py
@@ -459,9 +459,9 @@ class CodeLlamaTokenizer(PreTrainedTokenizer):
             "{% if messages[0]['role'] == 'system' %}"
             "{% set loop_messages = messages[1:] %}"  # Extract system message if it's present
             "{% set system_message = messages[0]['content'] %}"
-            "{% elif USE_DEFAULT_PROMPT == true and not '<<SYS>>' in messages[0]['content'] %}"
+            "{% elif use_default_prompt == true and not '<<SYS>>' in messages[0]['content'] %}"
             "{% set loop_messages = messages %}"  # Or use the default system message if the flag is set
-            "{% set system_message = 'DEFAULT_SYSTEM_MESSAGE' %}"
+            "{% set system_message = default_system_message %}"
             "{% else %}"
             "{% set loop_messages = messages %}"
             "{% set system_message = false %}"
@@ -484,11 +484,15 @@ class CodeLlamaTokenizer(PreTrainedTokenizer):
             "{% endif %}"
             "{% endfor %}"
         )
-        template = template.replace("USE_DEFAULT_PROMPT", "true" if self.use_default_system_prompt else "false")
-        default_message = DEFAULT_SYSTEM_PROMPT.replace("\n", "\\n").replace("'", "\\'")
-        template = template.replace("DEFAULT_SYSTEM_MESSAGE", default_message)
-
         return template
+
+    @property
+    # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer.default_chat_template_kwargs
+    def default_chat_template_kwargs(self):
+        return {
+            "use_default_prompt": self.use_default_system_prompt,
+            "default_system_message": DEFAULT_SYSTEM_PROMPT,
+        }
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/src/transformers/models/code_llama/tokenization_code_llama_fast.py
+++ b/src/transformers/models/code_llama/tokenization_code_llama_fast.py
@@ -362,9 +362,9 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
             "{% if messages[0]['role'] == 'system' %}"
             "{% set loop_messages = messages[1:] %}"  # Extract system message if it's present
             "{% set system_message = messages[0]['content'] %}"
-            "{% elif USE_DEFAULT_PROMPT == true and not '<<SYS>>' in messages[0]['content'] %}"
+            "{% elif use_default_prompt == true and not '<<SYS>>' in messages[0]['content'] %}"
             "{% set loop_messages = messages %}"  # Or use the default system message if the flag is set
-            "{% set system_message = 'DEFAULT_SYSTEM_MESSAGE' %}"
+            "{% set system_message = default_system_message %}"
             "{% else %}"
             "{% set loop_messages = messages %}"
             "{% set system_message = false %}"
@@ -387,11 +387,15 @@ class CodeLlamaTokenizerFast(PreTrainedTokenizerFast):
             "{% endif %}"
             "{% endfor %}"
         )
-        template = template.replace("USE_DEFAULT_PROMPT", "true" if self.use_default_system_prompt else "false")
-        default_message = DEFAULT_SYSTEM_PROMPT.replace("\n", "\\n").replace("'", "\\'")
-        template = template.replace("DEFAULT_SYSTEM_MESSAGE", default_message)
-
         return template
+
+    @property
+    # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer.default_chat_template_kwargs
+    def default_chat_template_kwargs(self):
+        return {
+            "use_default_prompt": self.use_default_system_prompt,
+            "default_system_message": DEFAULT_SYSTEM_PROMPT,
+        }
 
     def build_inputs_with_special_tokens(
         self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None

--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -393,9 +393,9 @@ class LlamaTokenizer(PreTrainedTokenizer):
             "{% if messages[0]['role'] == 'system' %}"
             "{% set loop_messages = messages[1:] %}"  # Extract system message if it's present
             "{% set system_message = messages[0]['content'] %}"
-            "{% elif USE_DEFAULT_PROMPT == true and not '<<SYS>>' in messages[0]['content'] %}"
+            "{% elif use_default_prompt == true and not '<<SYS>>' in messages[0]['content'] %}"
             "{% set loop_messages = messages %}"  # Or use the default system message if the flag is set
-            "{% set system_message = 'DEFAULT_SYSTEM_MESSAGE' %}"
+            "{% set system_message = default_system_message %}"
             "{% else %}"
             "{% set loop_messages = messages %}"
             "{% set system_message = false %}"
@@ -418,8 +418,11 @@ class LlamaTokenizer(PreTrainedTokenizer):
             "{% endif %}"
             "{% endfor %}"
         )
-        template = template.replace("USE_DEFAULT_PROMPT", "true" if self.use_default_system_prompt else "false")
-        default_message = DEFAULT_SYSTEM_PROMPT.replace("\n", "\\n").replace("'", "\\'")
-        template = template.replace("DEFAULT_SYSTEM_MESSAGE", default_message)
-
         return template
+
+    @property
+    def default_chat_template_kwargs(self):
+        return {
+            "use_default_prompt": self.use_default_system_prompt,
+            "default_system_message": DEFAULT_SYSTEM_PROMPT,
+        }

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -210,9 +210,9 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
             "{% if messages[0]['role'] == 'system' %}"
             "{% set loop_messages = messages[1:] %}"  # Extract system message if it's present
             "{% set system_message = messages[0]['content'] %}"
-            "{% elif USE_DEFAULT_PROMPT == true and not '<<SYS>>' in messages[0]['content'] %}"
+            "{% elif use_default_prompt == true and not '<<SYS>>' in messages[0]['content'] %}"
             "{% set loop_messages = messages %}"  # Or use the default system message if the flag is set
-            "{% set system_message = 'DEFAULT_SYSTEM_MESSAGE' %}"
+            "{% set system_message = default_system_message %}"
             "{% else %}"
             "{% set loop_messages = messages %}"
             "{% set system_message = false %}"
@@ -235,8 +235,12 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
             "{% endif %}"
             "{% endfor %}"
         )
-        template = template.replace("USE_DEFAULT_PROMPT", "true" if self.use_default_system_prompt else "false")
-        default_message = DEFAULT_SYSTEM_PROMPT.replace("\n", "\\n").replace("'", "\\'")
-        template = template.replace("DEFAULT_SYSTEM_MESSAGE", default_message)
-
         return template
+
+    @property
+    # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer.default_chat_template_kwargs
+    def default_chat_template_kwargs(self):
+        return {
+            "use_default_prompt": self.use_default_system_prompt,
+            "default_system_message": DEFAULT_SYSTEM_PROMPT,
+        }

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2315,6 +2315,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         if self.chat_template is not None:
             tokenizer_config["chat_template"] = self.chat_template
+        if self.chat_template_kwargs is not None:
+            tokenizer_config["chat_template_kwargs"] = self.chat_template_kwargs
 
         if len(self.init_inputs) > 0:
             tokenizer_config["init_inputs"] = copy.deepcopy(self.init_inputs)


### PR DESCRIPTION
This PR adds an extra `chat_template_kwargs` attribute, so that the behaviour of templates can be modified without rewriting the whole thing. I factored out the messy LLaMA default system message stuff in a cleaner way using these, and I'm going to need it for the templates of some other checkpoints on the Hub as well!

This is implemented in a backward-compatible way, so no existing code should break because of it.