### PR TITLE
Falcon: remove cache reformatting in the modeling code

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4655,6 +4655,18 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
                 )
             )
         past_key_values = tuple(new_past)
+    # falcon has a KV cache layout of [num_kv_heads, kv_length, head_dim]
+    elif "falcon" in model.__class__.__name__.lower() or (
+        model.config.architectures[0].lower() is not None and "falcon" in model.config.architectures[0].lower()
+    ):
+        for idx in range(len(past_key_values)):
+            new_past.append(
+                (
+                    past_key_values[idx][0][:, :maximum_length, :],
+                    past_key_values[idx][1][:, :maximum_length, :],
+                )
+            )
+        past_key_values = tuple(new_past)
     # gptbigcode is too
     elif "gptbigcode" in model.__class__.__name__.lower() or (
         model.config.architectures is not None and "gptbigcode" in model.config.architectures[0].lower()

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -759,7 +759,7 @@ class GenerationMixin:
         elif "past_buckets_states" in outputs:
             past_key_values = outputs.past_buckets_states
 
-        # Bloom fix: standardizes the cache format when requested
+        # Bloom and Falcon fix: standardizes the cache format when requested
         if standardize_cache_format and hasattr(self, "_convert_to_standard_cache"):
             batch_size = outputs.logits.shape[0]
             past_key_values = self._convert_to_standard_cache(past_key_values, batch_size=batch_size)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4657,7 +4657,7 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
         past_key_values = tuple(new_past)
     # falcon has a KV cache layout of [num_kv_heads, kv_length, head_dim]
     elif "falcon" in model.__class__.__name__.lower() or (
-        model.config.architectures[0].lower() is not None and "falcon" in model.config.architectures[0].lower()
+        model.config.architectures is not None and "falcon" in model.config.architectures[0].lower()
     ):
         for idx in range(len(past_key_values)):
             new_past.append(

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -726,7 +726,7 @@ class FalconPreTrainedModel(PreTrainedModel):
             module.gradient_checkpointing = value
 
     @staticmethod
-    def _convert_cache_to_standard_format(
+    def _convert_to_standard_cache(
         past_key_value: Tuple[Tuple[torch.Tensor, torch.Tensor]], batch_size: int
     ) -> Tuple[Tuple[torch.Tensor, torch.Tensor]]:
         """
@@ -1130,7 +1130,7 @@ class FalconForCausalLM(FalconPreTrainedModel):
 
         Output shares the same memory storage as `past`.
         """
-        standardized_past = self._convert_cache_to_standard_format(past, batch_size=len(beam_idx))
+        standardized_past = self._convert_to_standard_cache(past, batch_size=len(beam_idx))
 
         # Get a copy of `beam_idx` on all the devices where we need those indices.
         device_to_beam_idx = {

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1143,7 +1143,7 @@ class FalconForCausalLM(FalconPreTrainedModel):
             )
             for layer_past in standardized_past
         )
-        return reordered_past
+        return self._convert_to_rw_cache(reordered_past)
 
 
 @add_start_docstrings(

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1031,7 +1031,7 @@ class FalconForCausalLM(FalconPreTrainedModel):
         if past_key_values is not None:
             input_ids = input_ids[:, -1:]
 
-            # the cache may be in the stardard format (e.g. in contrastive search), convert to falcon's format if needed
+            # the cache may be in the standard format (e.g. in contrastive search), convert to falcon's format if needed
             if len(past_key_values[0][0].shape) == 4:
                 past_key_values = self._convert_to_rw_cache(past_key_values)
 

--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -352,7 +352,7 @@ class FalconModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         result = model(input_ids, use_cache=True)
         batch_size = input_ids.shape[0]
         rw_cache = result.past_key_values
-        standard_cache = model._convert_cache_to_standard_format(rw_cache, batch_size)
+        standard_cache = model._convert_to_standard_cache(rw_cache, batch_size)
         rw_cache_back = model._convert_to_rw_cache(standard_cache)
         for layer in range(len(rw_cache)):
             for tensor_idx in range(2):


### PR DESCRIPTION
When Falcon has been ported to transformers, it appears that methods `_convert_to_rw_cache` and `_convert_cache_to_standard_format` were directly called in the model, which is NOT what is traditionally done in Transformers, with the precedent of Bloom: https://github.com/huggingface/transformers/blob/0a55d9f7376f72ad3ff296d4249840021b03bcc4/src/transformers/models/bloom/modeling_bloom.py#L853 & https://github.com/huggingface/transformers/blob/0a55d9f7376f72ad3ff296d4249840021b03bcc4/src/transformers/models/bloom/modeling_bloom.py#L949

@Rocketknight1 I am wondering if it is fine to put back the cache reordering in `prepare_inputs_for_generation` & `_reorder_cache`? Having it in the modeling is a bit bad for people who want to rewrite their own generation, export the model, etc. It is also inconsistent with the information in `FALCON_INPUTS_DOCSTRING`.

I noticed this working on the ONNX export, where it is not really meaningful to have those ops in the model itself. Another solution is to monkey patch transformers, but I believe this should be upstream.

Related: https://github.com/huggingface/transformers/issues/26097