### PR TITLE
Fix tokenizer truncation 

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3337,7 +3337,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
         # Truncation: Handle max sequence length
         overflowing_tokens = []
-        if truncation_strategy != TruncationStrategy.DO_NOT_TRUNCATE and max_length and total_len > max_length:
+        if truncation_strategy != TruncationStrategy.DO_NOT_TRUNCATE and total_len > max_length:
             ids, pair_ids, overflowing_tokens = self.truncate_sequences(
                 ids,
                 pair_ids=pair_ids,
@@ -3444,7 +3444,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         if truncation_strategy == TruncationStrategy.ONLY_FIRST or (
             truncation_strategy == TruncationStrategy.LONGEST_FIRST and pair_ids is None
         ):
-            if len(ids) > num_tokens_to_remove:
+            if len(ids) >= num_tokens_to_remove:
                 window_len = min(len(ids), stride + num_tokens_to_remove)
                 if self.truncation_side == "left":
                     overflowing_tokens = ids[:window_len]
@@ -3489,7 +3489,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     else:
                         raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
         elif truncation_strategy == TruncationStrategy.ONLY_SECOND and pair_ids is not None:
-            if len(pair_ids) > num_tokens_to_remove:
+            if len(pair_ids) >= num_tokens_to_remove:
                 window_len = min(len(pair_ids), stride + num_tokens_to_remove)
                 if self.truncation_side == "right":
                     overflowing_tokens = pair_ids[-window_len:]


### PR DESCRIPTION
# This PR fixes a tokenizer truncation bug.

Setting max_length=0 or 1 leads to the following problem that should be fixed: 

```python
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf", use_fast=False)
text = "hello world hello world"
tokens = tokenizer(text, max_length=1, truncation=True, add_special_tokens=True)
print("tokens: ", tokens)


>>> [ERROR|/root/data/code/transformers/src/transformers/tokenization_utils_base.py:3468] 2023-09-17 13:08:29,020 >> >>> We need to remove 4 to truncate the input but the first sequence has a length 4. 
>>> tokens:  {'input_ids': [1, 22172, 3186, 22172, 3186], 'attention_mask': [1, 1, 1, 1, 1]}
```

This PR also make the length of tokens in consistent with fast-tokenizer. 

Also added unit-test for this fix. 


