### PR TITLE
[docs] Fix model reference in zero shot image classification example

### DIFF
--- a/docs/source/en/tasks/zero_shot_image_classification.md
+++ b/docs/source/en/tasks/zero_shot_image_classification.md
@@ -75,7 +75,7 @@ include a local path to an image or an image url.
 The candidate labels can be simple words like in this example, or more descriptive.
 
 ```py
->>> predictions = classifier(image, candidate_labels=["fox", "bear", "seagull", "owl"])
+>>> predictions = detector(image, candidate_labels=["fox", "bear", "seagull", "owl"])
 >>> predictions
 [{'score': 0.9996670484542847, 'label': 'owl'},
  {'score': 0.000199399160919711, 'label': 'seagull'},


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo in the docs, more specifically the model reference, since it it defined as `detector` and later referenced as predictor which is not defined. Settled on `detector`, since on example in other locale (`docs/source/ko/tasks/zero_shot_object_detection.md`) is `detector`.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)