### PR TITLE
Fix Error not captured in PR doctesting

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -234,6 +234,7 @@ class CircleCIJob:
 
         py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
+        check_test_command += f'cat summary_short.txt; echo ""; exit -1; '
 
         # Deeal with failed tests
         check_test_command += f'elif [ -s reports/{self.job_name}/failures_short.txt ]; '
@@ -243,8 +244,8 @@ class CircleCIJob:
 
         py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
-
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '
+
         check_test_command += f'elif [ -s reports/{self.job_name}/stats.txt ]; then echo "All tests pass!"; '
 
         # return code `124` means the previous (pytest run) step is timeout

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -226,12 +226,20 @@ class CircleCIJob:
             test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
-        check_test_command = f'if [ -s reports/{self.job_name}/failures_short.txt ] || [ -s reports/{self.job_name}/errors.txt ]; '
-        check_test_command += 'then echo "Some test failed!"; echo ""; '
+        check_test_command = f'if [ -s reports/{self.job_name}/errors.txt ]; '
+        check_test_command += 'then echo "Some tests errored out!"; echo ""; '
+        check_test_command += f'cat reports/{self.job_name}/errors.txt; '
+        check_test_command += 'echo ""; echo ""; '
+
+        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        check_test_command += f"$(python3 -c '{py_command}'); "
+
+        check_test_command = f'elif [ -s reports/{self.job_name}/failures_short.txt ]; '
+        check_test_command += 'then echo "Some tests failed!"; echo ""; '
         check_test_command += f'cat reports/{self.job_name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '
 
-        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith(("FAILED ", "ERROR "))]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
+        py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("FAILED ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
         check_test_command += f'cat summary_short.txt; echo ""; exit -1; '

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -226,7 +226,7 @@ class CircleCIJob:
             test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
-        check_test_command = f'if [ -s reports/{self.job_name}/failures_short.txt ]; '
+        check_test_command = f'if [ -s reports/{self.job_name}/failures_short.txt ] || [ -s reports/{self.job_name}/errors.txt ]; '
         check_test_command += 'then echo "Some test failed!"; echo ""; '
         check_test_command += f'cat reports/{self.job_name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -226,6 +226,7 @@ class CircleCIJob:
             test_command += " || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
+        # Deal with errors
         check_test_command = f'if [ -s reports/{self.job_name}/errors.txt ]; '
         check_test_command += 'then echo "Some tests errored out!"; echo ""; '
         check_test_command += f'cat reports/{self.job_name}/errors.txt; '
@@ -234,7 +235,8 @@ class CircleCIJob:
         py_command = f'import os; fp = open("reports/{self.job_name}/summary_short.txt"); failed = os.linesep.join([x for x in fp.read().split(os.linesep) if x.startswith("ERROR ")]); fp.close(); fp = open("summary_short.txt", "w"); fp.write(failed); fp.close()'
         check_test_command += f"$(python3 -c '{py_command}'); "
 
-        check_test_command = f'elif [ -s reports/{self.job_name}/failures_short.txt ]; '
+        # Deeal with failed tests
+        check_test_command += f'elif [ -s reports/{self.job_name}/failures_short.txt ]; '
         check_test_command += 'then echo "Some tests failed!"; echo ""; '
         check_test_command += f'cat reports/{self.job_name}/failures_short.txt; '
         check_test_command += 'echo ""; echo ""; '


### PR DESCRIPTION
# What does this PR do?

In https://app.circleci.com/pipelines/github/huggingface/transformers/72920/workflows/33795bcf-6b08-4c2f-b040-aa54bb44b12f/jobs/921247/artifacts, 

we have `errors.txt` but not `failures_short.txt`. But we only checked the file `failures_short.txt`, therefore the error is not detected, and showing all test passed.

This PR fixes this.