### PR TITLE
APEX: use MixedFusedRMSNorm instead of FusedRMSNorm for numerical consistency

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -247,11 +247,11 @@ class LongT5LayerNorm(nn.Module):
 
 
 try:
-    from apex.normalization import FusedRMSNorm
+    from apex.normalization import MixedFusedRMSNorm
 
-    LongT5LayerNorm = FusedRMSNorm  # noqa
+    LongT5LayerNorm = MixedFusedRMSNorm  # noqa
 
-    logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of LongT5LayerNorm")
+    logger.info("Discovered apex.normalization.MixedFusedRMSNorm - will use it instead of LongT5LayerNorm")
 except ImportError:
     # using the normal LongT5LayerNorm
     pass

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -99,11 +99,11 @@ class Pix2StructLayerNorm(nn.Module):
 
 
 try:
-    from apex.normalization import FusedRMSNorm
+    from apex.normalization import MixedFusedRMSNorm
 
-    Pix2StructLayerNorm = FusedRMSNorm  # noqa
+    Pix2StructLayerNorm = MixedFusedRMSNorm  # noqa
 
-    logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of Pix2StructLayerNorm")
+    logger.info("Discovered apex.normalization.MixedFusedRMSNorm - will use it instead of Pix2StructLayerNorm")
 except ImportError:
     # using the normal Pix2StructLayerNorm
     pass

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -49,11 +49,11 @@ logger = logging.get_logger(__name__)
 _load_pop2piano_layer_norm = True
 
 try:
-    from apex.normalization import FusedRMSNorm
+    from apex.normalization import MixedFusedRMSNorm
 
     _load_pop2piano_layer_norm = False
 
-    logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of Pop2PianoLayerNorm")
+    logger.info("Discovered apex.normalization.MixedFusedRMSNorm - will use it instead of Pop2PianoLayerNorm")
 except ImportError:
     # using the normal Pop2PianoLayerNorm
     pass
@@ -172,7 +172,7 @@ class Pop2PianoLayerNorm(nn.Module):
 
 
 if not _load_pop2piano_layer_norm:
-    Pop2PianoLayerNorm = FusedRMSNorm  # noqa
+    Pop2PianoLayerNorm = MixedFusedRMSNorm  # noqa
 
 ALL_LAYERNORM_LAYERS.append(Pop2PianoLayerNorm)
 

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -262,11 +262,11 @@ class T5LayerNorm(nn.Module):
 
 
 try:
-    from apex.normalization import FusedRMSNorm
+    from apex.normalization import MixedFusedRMSNorm
 
-    T5LayerNorm = FusedRMSNorm  # noqa
+    T5LayerNorm = MixedFusedRMSNorm  # noqa
 
-    logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of T5LayerNorm")
+    logger.info("Discovered apex.normalization.MixedFusedRMSNorm - will use it instead of T5LayerNorm")
 except ImportError:
     # using the normal T5LayerNorm
     pass


### PR DESCRIPTION
As per title.

APEX `FusedRMSNorm` initialize the returned tensor to the `input` dtype, which raises an error in case the model is set on fp16, where we may have `fp32` input to the layer norm layer:
```
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/apex-0.1-py3.8-linux-x86_64.egg/apex/normalization/fused_layer_norm.py", line 189, in fused_rms_norm_affine
    return FusedRMSNormAffineFunction.apply(*args)
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/autograd/function.py", line 506, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/apex-0.1-py3.8-linux-x86_64.egg/apex/normalization/fused_layer_norm.py", line 69, in forward
    output, invvar = fused_layer_norm_cuda.rms_forward_affine(
```

Comparing to [T5LayerNorm](https://github.com/huggingface/transformers/blob/820c46a707ddd033975bc3b0549eea200e64c7da/src/transformers/models/t5/modeling_t5.py#L247-L261) where the output is on the weight dtype. That is exactly what `MixedFusedRMSNorm` is for, see https://github.com/NVIDIA/apex/blob/52e18c894223800cb611682dce27d88050edf1de/apex/normalization/fused_layer_norm.py#L420 and https://github.com/NVIDIA/apex/blob/52e18c894223800cb611682dce27d88050edf1de/csrc/layer_norm_cuda.cpp#L205

For example, the test `pytest tests/test_pipeline_mixin.py::VisualQuestionAnsweringPipelineTests::test_small_model_pt_blip2 -s -vvvvv` fails when `apex` is available (and accelerate is installed). This error was never detected because the docker images used for testing do not have APEX installed (e.g. `nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04`)

This is an issue for the AMD CI as the image used `rocm/pytorch:rocm5.6_ubuntu20.04_py3.8_pytorch_2.0.1` has RoCm APEX installed by default.

---
Slightly out of topic: something I don't get is why [neither t5x](https://github.com/google-research/t5x/blob/ea66ec835a5b413ca9d211de96aa899900a84c13/t5x/examples/t5/layers.py#L445) nor transformers seem to recast to fp16 after the FFN. Due to the `keep_in_fp32` attribute, [this weight](https://github.com/huggingface/transformers/blob/820c46a707ddd033975bc3b0549eea200e64c7da/src/transformers/models/t5/modeling_t5.py#L284C14-L284C14) is always in fp32 and then fp32 is propagated in the model. t5x seem to do the same.

Related: https://github.com/huggingface/transformers/pull/26225