### PR TITLE
Skip unfixable failing tests on RoCm

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -170,6 +170,7 @@ from .import_utils import (
     is_torch_mps_available,
     is_torch_neuroncore_available,
     is_torch_npu_available,
+    is_torch_rocm_available,
     is_torch_tensorrt_fx_available,
     is_torch_tf32_available,
     is_torch_tpu_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -276,6 +276,18 @@ def is_torch_cuda_available():
         return False
 
 
+def is_torch_rocm_available():
+    if is_torch_available():
+        import torch
+
+        if torch.version.hip:
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
 def is_torch_mps_available():
     if is_torch_available():
         import torch

--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -41,6 +41,7 @@ from transformers.testing_utils import (
 )
 from transformers.trainer_callback import TrainerState
 from transformers.trainer_utils import set_seed
+from transformers.utils import is_torch_rocm_available
 
 
 bindir = os.path.abspath(os.path.dirname(__file__))
@@ -138,6 +139,10 @@ class TestTrainerExt(TestCasePlus):
     @require_apex
     @require_torch_gpu
     def test_run_seq2seq_apex(self):
+        if is_torch_rocm_available():
+            self.skipTest(
+                "Skipped as apex.amp is deprecated and bugged on RoCm systems: https://github.com/ROCmSoftwarePlatform/apex/issues/118"
+            )
         # XXX: apex breaks the trainer if it's run twice e.g. run_seq2seq.main() from the same
         # program and it breaks other tests that run from the same pytest worker, therefore until this is
         # sorted out it must be run only in an external program, that is distributed=True in this

--- a/tests/models/glpn/test_modeling_glpn.py
+++ b/tests/models/glpn/test_modeling_glpn.py
@@ -18,9 +18,12 @@
 import inspect
 import unittest
 
+from packaging import version
+
 from transformers import is_torch_available, is_vision_available
 from transformers.models.auto import get_values
 from transformers.testing_utils import require_torch, require_vision, slow, torch_device
+from transformers.utils import is_torch_rocm_available
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, floats_tensor, ids_tensor
@@ -190,6 +193,10 @@ class GLPNModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             self.assertListEqual(arg_names[:1], expected_arg_names)
 
     def test_attention_outputs(self):
+        if is_torch_rocm_available() and version.parse(torch.__version__) <= version.parse("2.0.99"):
+            self.skipTest(
+                "Skipped as non-contiguous nn.Conv2d in GLPN on RoCm systems is bugged for torch<2.0.1: https://huggingface.slack.com/archives/C05G9EZ9XAN/p1695114097209659"
+            )
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.return_dict = True
 

--- a/tests/models/tvlt/test_modeling_tvlt.py
+++ b/tests/models/tvlt/test_modeling_tvlt.py
@@ -20,6 +20,7 @@ import unittest
 
 import numpy as np
 from huggingface_hub import hf_hub_download
+from packaging import version
 
 from transformers import (
     TvltConfig,
@@ -29,7 +30,7 @@ from transformers import (
     is_vision_available,
 )
 from transformers.testing_utils import require_torch, require_vision, slow, torch_device
-from transformers.utils import cached_property
+from transformers.utils import cached_property, is_torch_rocm_available
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, floats_tensor
@@ -572,6 +573,9 @@ class TvltModelIntegrationTest(unittest.TestCase):
         )
 
     def test_inference_for_base_model(self):
+        if is_torch_rocm_available() and version.parse(torch.__version__) <= version.parse("2.0.99"):
+            self.skipTest("Failing on RoCm devices with torch<2.1 due to a bug in nn.Conv2d")
+
         model = TvltModel.from_pretrained("ZinengTang/tvlt-base").to(torch_device)
 
         image_processor, audio_feature_extractor = self.default_processors


### PR DESCRIPTION
A bug in nn.Conv2d in PyTorch 2.0.1 on RoCm systems make the output of TVLT significantly diverge vs CPU / Nvidia GPUs. The issue is fixed on nightly and on 2.1.0 RC.

Some slow tests may be affected as well, thus marking as draft for now. Adding relevant tensors / code to reproduce the issue just in case.
[conv2d_mi210.zip](https://github.com/huggingface/transformers/files/12652047/conv2d_mi210.zip)
