### PR TITLE
Fixing tokenizer when `transformers` is installed without `tokenizers`

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -101,6 +101,9 @@ else:
         def __getstate__(self):
             return self.__dict__
 
+        def __str__(self):
+            return self.content
+
     @dataclass
     class EncodingFast:
         """This is dummy class because without the `tokenizers` library we don't have these objects anyway"""

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -78,7 +78,7 @@ if is_tokenizers_available():
     from tokenizers import Encoding as EncodingFast
 else:
 
-    @dataclass(frozen=False, eq=True)
+    @dataclass(repr=True, frozen=False, eq=True)
     class AddedToken:
         """
         AddedToken represents a token to be added to a Tokenizer An AddedToken can have special options defining the
@@ -102,6 +102,9 @@ else:
             return self.__dict__
 
         def __str__(self):
+            return self.content
+
+        def __repr__(self):
             return self.content
 
     @dataclass

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -78,7 +78,7 @@ if is_tokenizers_available():
     from tokenizers import Encoding as EncodingFast
 else:
 
-    @dataclass(repr=True, frozen=False, eq=True)
+    @dataclass(frozen=False, eq=True)
     class AddedToken:
         """
         AddedToken represents a token to be added to a Tokenizer An AddedToken can have special options defining the
@@ -102,9 +102,6 @@ else:
             return self.__dict__
 
         def __str__(self):
-            return self.content
-
-        def __repr__(self):
             return self.content
 
     @dataclass


### PR DESCRIPTION
# What does this PR do?

This PR fixes the tokenization of the `<s>` and `</s>` tokens, when `transformers` is installed but `tokenizers` is not installed, fixing the string representation of the `AddedToken` class.

Using `transformers` _without_ `tokenizers` installed results in the following problem:
```
import transformers
tokenizer = transformers.AutoTokenizer.from_pretrained('facebook/bart-large-mnli')

print(tokenizer.convert_tokens_to_ids(['<s>', 'a', '</s>']))
print(tokenizer.encode('a'))
```
Prints:
```
>>> [0, 102, 2]
>>> [50265, 102, 50266]
```

In other words, the tokenizer knows that the correct IDs for `<s>` and `</s>` are `0` and `2`, but when encoding an arbitrary string, it adds the new IDs `50265` and `50266` (which are not known to the model!).

Using this solution, the tokenizer does *not* add additional token IDs 50265 and up, because it recognizes them as existing already in IDs 0-3.
Then, encoding a string using a tokenizer results in adding `0` and `2` as the `<s>` and `</s>` tokens.
The two lines of:

```
print(tokenizer.convert_tokens_to_ids(['<s>', 'a', '</s>']))
print(tokenizer.encode('a'))
```
result in the same output of `[0, 102, 2]`, as expected.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @ydshieh @hvaara @amyeroberts 