### PR TITLE
fixing + testing center_crop, so it can accept odd sizes

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -462,10 +462,7 @@ def center_crop(
     top = (orig_height - crop_height + 1) // 2
     bottom = top + crop_height
     # In case width is odd
-    diff_width = orig_width - crop_width
-    if diff_width % 2 == 1:
-        diff_width += 1
-    left = diff_width // 2
+    left = (orig_width - crop_width + 1) // 2
     right = left + crop_width
 
     # Check if cropped area is within image boundaries

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -459,10 +459,7 @@ def center_crop(
     crop_height, crop_width = int(crop_height), int(crop_width)
 
     # In case height is odd
-    diff_height = orig_height - crop_height
-    if diff_height % 2 == 1:
-        diff_height += 1
-    top = diff_height // 2
+    top = (orig_height - crop_height + 1) // 2
     bottom = top + crop_height
     # In case width is odd
     diff_width = orig_width - crop_width

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -458,11 +458,17 @@ def center_crop(
     crop_height, crop_width = size
     crop_height, crop_width = int(crop_height), int(crop_width)
 
-    # In case size is odd, (image_shape[0] + size[0]) // 2 won't give the proper result.
-    top = (orig_height - crop_height) // 2
+    # In case height is odd
+    diff_height = orig_height - crop_height
+    if diff_height % 2 == 1:
+        diff_height += 1
+    top = diff_height // 2
     bottom = top + crop_height
-    # In case size is odd, (image_shape[1] + size[1]) // 2 won't give the proper result.
-    left = (orig_width - crop_width) // 2
+    # In case width is odd
+    diff_width = orig_width - crop_width
+    if diff_width % 2 == 1:
+        diff_width += 1
+    left = diff_width // 2
     right = left + crop_width
 
     # Check if cropped area is within image boundaries


### PR DESCRIPTION
# What does this PR do?

Fixes #22505 

Our `center_crop` function does not give proper results if `orig_height - crop_height` is odd or if `orig_width - crop_width` is odd. 

It seems that our code [here](https://github.com/huggingface/transformers/blob/main/src/transformers/image_transforms.py#L461C66-L461C88) and [here](https://github.com/huggingface/transformers/blob/main/src/transformers/image_transforms.py#L464) alerts about this problem.

This problem explains why:
* Our `test_center_crop` fails [here](https://github.com/huggingface/transformers/blob/e469be340673d1f6931eb22562efd2be7f5a5b8d/tests/test_image_transforms.py#L329) if we try image sizes with odd height or width. e.g. changing this line [here](https://github.com/huggingface/transformers/blob/e469be340673d1f6931eb22562efd2be7f5a5b8d/tests/test_image_transforms.py#L317) to `image = np.random.randint(0, 256, (3, 223, 223))` will make the test fail.
* Our results are different than OpenAI image features, as reported in issue #22505 

This PR fixes this problem and includes pytests comparing the output of our `center_crop` function to `torchvision.transforms.CenterCrop` with different image sizes and expected output sizes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@ArthurZucker and @amyeroberts
