### PR TITLE
Keypoints 0.0 are confusing ../transformers/models/detr/image_processing_detr.py which are fixed

### DIFF
--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -338,7 +338,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints 
+        new_target["keypoints"] = keypoints
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -332,10 +332,10 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
-        # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
-        # converting the filtered keypoints list to a numpy array and reshape it
+        # Converting the filtered keypoints list to a numpy array
         keypoints = np.asarray(keypoints, dtype=np.float32)
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = keypoints[keep]
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
         new_target["keypoints"] = keypoints

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -338,7 +338,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
+        new_target["keypoints"] = keypoints 
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -332,10 +332,13 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints[keep]
+        new_target["keypoints"] = keypoints # We no longer apply keep mask here    
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -333,12 +333,12 @@ def prepare_coco_detection_annotation(
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
         # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
         # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints # We no longer apply keep mask here    
+        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -337,7 +337,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
+        new_target["keypoints"] = keypoints  
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -337,7 +337,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  
+        new_target["keypoints"] = keypoints
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -331,10 +331,10 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
-        # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
-        # converting the filtered keypoints list to a numpy array and reshape it
+        # Converting the filtered keypoints list to a numpy array
         keypoints = np.asarray(keypoints, dtype=np.float32)
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = keypoints[keep]
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
         new_target["keypoints"] = keypoints

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -332,12 +332,12 @@ def prepare_coco_detection_annotation(
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
         # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
         # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
+        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -331,10 +331,13 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints[keep]
+        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -323,10 +323,10 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
-        # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
-        # converting the filtered keypoints list to a numpy array and reshape it
+        # Converting the filtered keypoints list to a numpy array
         keypoints = np.asarray(keypoints, dtype=np.float32)
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = keypoints[keep]
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
         new_target["keypoints"] = keypoints

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -329,7 +329,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  
+        new_target["keypoints"] = keypoints
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -329,7 +329,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
+        new_target["keypoints"] = keypoints  
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -323,10 +323,13 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints[keep]
+        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -324,12 +324,12 @@ def prepare_coco_detection_annotation(
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
         # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
         # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
+        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -332,7 +332,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  
+        new_target["keypoints"] = keypoints
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -326,10 +326,10 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
-        # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
-        # converting the filtered keypoints list to a numpy array and reshape it
+        # Converting the filtered keypoints list to a numpy array
         keypoints = np.asarray(keypoints, dtype=np.float32)
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = keypoints[keep]
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
         new_target["keypoints"] = keypoints

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -332,7 +332,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
+        new_target["keypoints"] = keypoints  
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -326,10 +326,13 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
+        # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints[keep]
+        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -261,7 +261,7 @@ def freeze_model(model, module_exceptions=[]):
     }
     module_exceptions_mapped = [mapping[m] for m in module_exceptions]
     for module in model.modules():
-        if module_exceptions and any(isinstance(module, t) for t in module_exceptions_mapped):
+        if module_exceptions and any([isinstance(module, t) for t in module_exceptions_mapped]):
             module.requires_grad_(True)  # Explicitely setting it to true to avoid any mistakes
         else:
             module.requires_grad_(False)

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -261,7 +261,7 @@ def freeze_model(model, module_exceptions=[]):
     }
     module_exceptions_mapped = [mapping[m] for m in module_exceptions]
     for module in model.modules():
-        if module_exceptions and any([isinstance(module, t) for t in module_exceptions_mapped]):
+        if module_exceptions and any(isinstance(module, t) for t in module_exceptions_mapped):
             module.requires_grad_(True)  # Explicitely setting it to true to avoid any mistakes
         else:
             module.requires_grad_(False)

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -335,7 +335,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
+        new_target["keypoints"] = keypoints  
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -329,10 +329,10 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
-        # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
-        # converting the filtered keypoints list to a numpy array and reshape it
+        # Converting the filtered keypoints list to a numpy array
         keypoints = np.asarray(keypoints, dtype=np.float32)
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = keypoints[keep]
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
         new_target["keypoints"] = keypoints

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -335,7 +335,7 @@ def prepare_coco_detection_annotation(
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints  
+        new_target["keypoints"] = keypoints
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -329,10 +329,13 @@ def prepare_coco_detection_annotation(
 
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
+        # Apply the keep mask here to filter the relevant annotations
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints[keep]
+        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -330,12 +330,12 @@ def prepare_coco_detection_annotation(
     if annotations and "keypoints" in annotations[0]:
         keypoints = [obj["keypoints"] for obj in annotations]
         # Apply the keep mask here to filter the relevant annotations
-        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]   
+        keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
         # converting the filtered keypoints list to a numpy array and reshape it
         keypoints = np.asarray(keypoints, dtype=np.float32)
         num_keypoints = keypoints.shape[0]
         keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
-        new_target["keypoints"] = keypoints # We no longer apply keep mask here   
+        new_target["keypoints"] = keypoints  # We no longer apply keep mask here
 
     if return_segmentation_masks:
         segmentation_masks = [obj["segmentation"] for obj in annotations]


### PR DESCRIPTION
# What does this PR do?

This PR will fix the keypoint 0.0 at this transformers/models/detr/image_processing_detr.py as suggested by @duckheada

To fix this, I had to edit this file in transformers library:
.conda/lib/python3.9/site-packages/transformers/models/detr/image_processing_detr.py

I changed this as suggested by: @duckheada
  
```python
    if annotations and "keypoints" in annotations[0]:
       keypoints = [obj["keypoints"] for obj in annotations]
       print("keypoints", keypoints) #TODO: remove
       keypoints = np.asarray(keypoints, dtype=np.float32)
       num_keypoints = keypoints.shape[0]
       keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
       new_target["keypoints"] = keypoints[keep]
```
To this:
```python
    if annotations and "keypoints" in annotations[0]:
     keypoints = [obj["keypoints"] for obj in annotations]
     # Apply the keep mask here to filter the relevant annotations
     keypoints = [keypoints[i] for i in range(len(keypoints)) if keep[i]]
     # converting the filtered keypoints list to a numpy array and reshape it
     keypoints = np.asarray(keypoints, dtype=np.float32)
     num_keypoints = keypoints.shape[0]
     keypoints = keypoints.reshape((-1, 3)) if num_keypoints else keypoints
     new_target["keypoints"] = keypoints # We no longer apply keep mask here
```
Why?
To ensure that the filtering applied to the key points respects its original structure (number of keypoints per annotation). When you reshape keypoints with key points. reshape((-1, 3)), it loses the information about which keypoints belong to which annotation.

Here is what needed to be done (at least in my little hack-ish workaround):

Before reshaping the key points array, I had to apply the keep mask to retain only the annotations I was interested in. Only after this could I reshape the keypoints array to apply further operations.
Then, I applied the keep mask on the keypoints list before converting it into a numpy array and reshaping it. This ensured that I only keep the keypoints corresponding to the bounding boxes that satisfy the condition in the keep mask.

Fixes #26126 

## Who can review?

@ArthurZucker, @younesbelkada, and @amyeroberts 
Please let me know if I need to do anything else for this issue.
