### PR TITLE
fix deepspeed available detection

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -15,6 +15,7 @@
 Integration with Deepspeed
 """
 
+import importlib.metadata as importlib_metadata
 import importlib.util
 import weakref
 from functools import partialmethod
@@ -32,7 +33,16 @@ logger = logging.get_logger(__name__)
 
 
 def is_deepspeed_available():
-    return importlib.util.find_spec("deepspeed") is not None
+    package_exists = importlib.util.find_spec("deepspeed") is not None
+
+    # Check we're not importing a "deepspeed" directory somewhere but the actual library by trying to grab the version
+    # AND checking it has an author field in the metadata that is HuggingFace.
+    if package_exists:
+        try:
+            _ = importlib_metadata.metadata("deepspeed")
+            return True
+        except importlib_metadata.PackageNotFoundError:
+            return False
 
 
 if is_accelerate_available() and is_deepspeed_available():


### PR DESCRIPTION
As per title, make the deepspeed available function more robust as https://github.com/huggingface/accelerate/blob/69e4c3c54da3201eda288b500d138761e7a5221c/src/accelerate/utils/imports.py#L72

Having `tests/deepspeed` & [`get_env`](https://github.com/huggingface/transformers/blob/eb8489971ac1415f67b0abdd1584fde8b659ced9/src/transformers/testing_utils.py#L1344) that adds `tests/` in the path then makes `is_deepspeed_availebl()` returns `True` although it should not, and in turn trainer.py [tries to import](https://github.com/huggingface/transformers/blob/eb8489971ac1415f67b0abdd1584fde8b659ced9/src/transformers/trainer.py#L217) `DeepSpeedSchedulerWrapper` that is [not imported in accelerate](https://github.com/huggingface/accelerate/blob/69e4c3c54da3201eda288b500d138761e7a5221c/src/accelerate/utils/__init__.py#L92) as accelerate rightfully detects that DeepSpeed is not available.

This issue makes the test `tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_apex` fail when APEX is installed but DeepSpeed is not.