### PR TITLE
Fix gated repo tests

### DIFF
--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -128,14 +128,12 @@ class GetFromCacheTests(unittest.TestCase):
 
             self.assertIsNone(get_file_from_repo(tmp_dir, "b.txt"))
 
-    @unittest.skip("Test is broken, fix me Wauplain!")
     def test_get_file_gated_repo(self):
         """Test download file from a gated repo fails with correct message when not authenticated."""
         with self.assertRaisesRegex(EnvironmentError, "You are trying to access a gated repo."):
-            cached_file(GATED_REPO, README_FILE, use_auth_token=False)
+            cached_file(GATED_REPO, "gated_file.txt", use_auth_token=False)
 
-    @unittest.skip("Test is broken, fix me Wauplain!")
     def test_has_file_gated_repo(self):
         """Test check file existence from a gated repo fails with correct message when not authenticated."""
         with self.assertRaisesRegex(EnvironmentError, "is a gated repository"):
-            has_file(GATED_REPO, README_FILE, use_auth_token=False)
+            has_file(GATED_REPO, "gated_file.txt", use_auth_token=False)

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -131,9 +131,11 @@ class GetFromCacheTests(unittest.TestCase):
     def test_get_file_gated_repo(self):
         """Test download file from a gated repo fails with correct message when not authenticated."""
         with self.assertRaisesRegex(EnvironmentError, "You are trying to access a gated repo."):
+            # All files except README.md are protected on a gated repo.
             cached_file(GATED_REPO, "gated_file.txt", use_auth_token=False)
 
     def test_has_file_gated_repo(self):
         """Test check file existence from a gated repo fails with correct message when not authenticated."""
         with self.assertRaisesRegex(EnvironmentError, "is a gated repository"):
+            # All files except README.md are protected on a gated repo.
             has_file(GATED_REPO, "gated_file.txt", use_auth_token=False)


### PR DESCRIPTION
Related to this [slack thread](https://huggingface.slack.com/archives/C01NE71C4F7/p1692855942544019) (private).

Since end of August (https://github.com/huggingface/transformers/commit/68fa9a5937ae7aa707f5ff2639aa36a37a0a9928), gated repo tests were skipped because failing to pass. This was due to a server-side change that now makes the README files readable even on gated repo (since users have to be able to read a model card before requesting access). This PR fixes the tests -and unskip them- by trying to download [gated_file.txt](https://huggingface.co/hf-internal-testing/dummy-gated-model/blob/main/gated_file.txt) instead.

cc @ydshieh 