### PR TITLE
Fix wrong vocab_size updating when calling `resize_token_embeddings` on an uninitialized model

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1452,8 +1452,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return model_embeds
 
         # Update base model and current model config
-        self.config.vocab_size = model_embeds.weight.shape[0]
-        self.vocab_size = model_embeds.weight.shape[0]
+        self.config.vocab_size = model_embeds.weight.shape[0] or new_num_tokens
+        self.vocab_size = self.config.vocab_size
 
         # Tie weights again if needed
         self.tie_weights()


### PR DESCRIPTION
# What does this PR do?

`resize_token_embeddings` intends to update model vocab_size to the size of the first dimension of the newly-built embedding's weight.

However, if this method is call on an uninitialized model (e.g.: in `no_init_weight` context) and the parameter `new_num_tokens` equals to the old vocab_size, the internal function `_resize_token_embeddings` will return the old embedding directly whose weight is not initialized.

In this scenario, the model's vocab_size will be set to 0 which is unexpected.


## Who can review?

@ArthurZucker and @younesbelkada

