### PR TITLE
update hf hub dependency to be compatible with the new tokenizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ _deps = [
     "fugashi>=1.0",
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.15.1,<1.0",
+    "huggingface-hub>=0.16.4,<1.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -25,7 +25,7 @@ deps = {
     "fugashi": "fugashi>=1.0",
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
-    "huggingface-hub": "huggingface-hub>=0.15.1,<1.0",
+    "huggingface-hub": "huggingface-hub>=0.16.4,<1.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",


### PR DESCRIPTION
# What does this PR do?
Fixes  #26276, `tokenizers==0.14` requires `"huggingface-hub>=0.16.4,<1.0"`, so updated the dependency in setup.py