### PR TITLE
Fix doctest CI

### DIFF
--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -790,11 +790,11 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         ```python
         >>> from transformers import AutoTokenizer, PersimmonForCausalLM
 
-        >>> model = PersimmonForCausalLM.from_pretrained("ArthurZ/persimmon-8b-base").cuda()
+        >>> model = PersimmonForCausalLM.from_pretrained("ArthurZ/persimmon-8b-base")
         >>> tokenizer = AutoTokenizer.from_pretrained("ArthurZ/persimmon-8b-base")
 
         >>> prompt = "human: Hey, what should I eat for dinner?"
-        >>> inputs = tokenizer(prompt, return_tensors="pt").cuda()
+        >>> inputs = tokenizer(prompt, return_tensors="pt")
 
         >>> # Generate
         >>> generate_ids = model.generate(inputs.input_ids, max_length=30)

--- a/utils/not_doctested.txt
+++ b/utils/not_doctested.txt
@@ -710,6 +710,7 @@ src/transformers/models/pegasus_x/modeling_pegasus_x.py
 src/transformers/models/perceiver/configuration_perceiver.py
 src/transformers/models/perceiver/convert_perceiver_haiku_to_pytorch.py
 src/transformers/models/persimmon/convert_persimmon_weights_to_hf.py
+src/transformers/models/persimmon/modeling_persimmon.py
 src/transformers/models/pix2struct/configuration_pix2struct.py
 src/transformers/models/pix2struct/convert_pix2struct_original_pytorch_to_hf.py
 src/transformers/models/pix2struct/image_processing_pix2struct.py


### PR DESCRIPTION
# What does this PR do?

The daily doctest CI is killed due to memory issue (from `PersimmonForCausalLM.forward`'s docstring). It's not only about GPU, even running with the 60G CPU memory, the job is still killed.

If I  run that test only - it could pass (with running on CPU), but the process is killed when the whole suite is run. 
(There might be some memory (leak) issue to check as a whole).

This PR put `src/transformers/models/persimmon/modeling_persimmon.py` to `not_doctested.txt`.

We probably better to further separate what are not doctested yet and what are ignored intentionally, so we won't forget to try to put them back to doctests.