### PR TITLE
[docs] removed MaskFormerSwin and TimmBackbone from the table on index.md

### DIFF
--- a/docs/source/en/index.md
+++ b/docs/source/en/index.md
@@ -393,7 +393,6 @@ Flax), PyTorch, and/or TensorFlow.
 |           MarkupLM            |       ✅        |         ❌         |      ❌      |
 |          Mask2Former          |       ✅        |         ❌         |      ❌      |
 |          MaskFormer           |       ✅        |         ❌         |      ❌      |
-|        MaskFormerSwin         |       ❌        |         ❌         |      ❌      |
 |             mBART             |       ✅        |         ✅         |      ✅      |
 |             MEGA              |       ✅        |         ❌         |      ❌      |
 |         Megatron-BERT         |       ✅        |         ❌         |      ❌      |
@@ -462,7 +461,6 @@ Flax), PyTorch, and/or TensorFlow.
 |             TAPAS             |       ✅        |         ✅         |      ❌      |
 |    Time Series Transformer    |       ✅        |         ❌         |      ❌      |
 |          TimeSformer          |       ✅        |         ❌         |      ❌      |
-|         TimmBackbone          |       ❌        |         ❌         |      ❌      |
 |    Trajectory Transformer     |       ✅        |         ❌         |      ❌      |
 |        Transformer-XL         |       ✅        |         ✅         |      ❌      |
 |             TrOCR             |       ✅        |         ❌         |      ❌      |

--- a/utils/check_table.py
+++ b/utils/check_table.py
@@ -173,7 +173,12 @@ def get_model_table_from_auto_modules() -> str:
 
     # Let's build that table!
     model_names = list(model_name_to_config.keys())
+
+    # MaskFormerSwin and TimmBackbone are backbones and so not meant to be loaded and used on their own. Instead, they define architectures which can be loaded using the AutoBackbone API.
+    names_to_exclude = ["MaskFormerSwin", "TimmBackbone"]
+    model_names = [name for name in model_names if name not in names_to_exclude]
     model_names.sort(key=str.lower)
+
     columns = ["Model", "PyTorch support", "TensorFlow support", "Flax Support"]
     # We'll need widths to properly display everything in the center (+2 is to leave one extra space on each side).
     widths = [len(c) + 2 for c in columns]


### PR DESCRIPTION
# What does this PR do?

The PR addresses  #25967:

`MaskFormerSwin` and `TimmBackbone` should not be listed in the framework support table on the index.md page because these models are backbones and so not meant to be loaded and used on their own. Instead, they define architectures which can be loaded using the AutoBackbone API. See the [comment](https://github.com/huggingface/transformers/issues/25967#issuecomment-1717818649) in the issue. 

This PR updates the table, and the script that builds the table so that these models are excluded when building the table. 
