### PR TITLE
[TTA Pipeline] Fix MusicGen test

### DIFF
--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -208,12 +208,12 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
         # characters are not split at tokenization
 
         # TODO @ArthurZ add them or just update the trie?
-        unique_no_split_tokens = []
+        self.unique_no_split_tokens = []
         for token in self.encoder.keys():
             if len(token) > 1:
-                unique_no_split_tokens.append(AddedToken(token, rstrip=True, lstrip=True, normalized=False))
+                self.unique_no_split_tokens.append(AddedToken(token, rstrip=True, lstrip=True, normalized=False))
 
-        self.add_tokens(unique_no_split_tokens)
+        self.add_tokens(self.unique_no_split_tokens)
 
     def set_target_lang(self, target_lang: str):
         """

--- a/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/tokenization_wav2vec2.py
@@ -208,12 +208,12 @@ class Wav2Vec2CTCTokenizer(PreTrainedTokenizer):
         # characters are not split at tokenization
 
         # TODO @ArthurZ add them or just update the trie?
-        self.unique_no_split_tokens = []
+        unique_no_split_tokens = []
         for token in self.encoder.keys():
             if len(token) > 1:
-                self.unique_no_split_tokens.append(AddedToken(token, rstrip=True, lstrip=True, normalized=False))
+                unique_no_split_tokens.append(AddedToken(token, rstrip=True, lstrip=True, normalized=False))
 
-        self.add_tokens(self.unique_no_split_tokens)
+        self.add_tokens(unique_no_split_tokens)
 
     def set_target_lang(self, target_lang: str):
         """

--- a/src/transformers/pipelines/text_to_audio.py
+++ b/src/transformers/pipelines/text_to_audio.py
@@ -71,13 +71,13 @@ class TextToAudioPipeline(Pipeline):
         if self.sampling_rate is None:
             # get sampling_rate from config and generation config
 
-            config = self.model.config.to_dict()
+            config = self.model.config
             gen_config = self.model.__dict__.get("generation_config", None)
             if gen_config is not None:
                 config.update(gen_config.to_dict())
 
             for sampling_rate_name in ["sample_rate", "sampling_rate"]:
-                sampling_rate = config.get(sampling_rate_name, None)
+                sampling_rate = getattr(config, sampling_rate_name, None)
                 if sampling_rate is not None:
                     self.sampling_rate = sampling_rate
 


### PR DESCRIPTION
# What does this PR do?

The PR #26136 added the `sampling_rate` as a **property** to the MusicGen config, such that it is compatible with the TTA pipeline. However, using a property means it is not registered when we call `config.to_dict()`, since it is not an attribute of the config.

This PR updates the TTA pipeline to avoid converting the config to a dict, thus keeping compatibility with MusicGen.