### PR TITLE
Updated convert_llama_weights_to_hf.py to support llama2 chat models and default llama director name 

### DIFF
--- a/src/transformers/models/llama/convert_llama_weights_to_hf.py
+++ b/src/transformers/models/llama/convert_llama_weights_to_hf.py
@@ -56,13 +56,16 @@ come in several checkpoints they each contain a part of each weight of the model
 NUM_SHARDS = {
     "7B": 1,
     "7Bf": 1,
+    "7B-chat": 1, 
     "13B": 2,
     "13Bf": 2,
+    "13B-chat": 2,
     "34B": 4,
     "30B": 4,
     "65B": 8,
     "70B": 8,
     "70Bf": 8,
+    "70B-chat": 8,
 }
 
 
@@ -83,7 +86,10 @@ def write_json(text, path):
 def write_model(model_path, input_base_path, model_size, tokenizer_path=None, safe_serialization=True):
     # for backward compatibility, before you needed the repo to be called `my_repo/model_size`
     if not os.path.isfile(os.path.join(input_base_path, "params.json")):
-        input_base_path = os.path.join(input_base_path, model_size)
+        model_path = model_size
+        if model_size == ('7B' or '13B' or '70B' or '7B-chat' or '13B-chat' or '70B-chat'):
+            model_path = 'llama-2-' + model_size.lower()
+        input_base_path = os.path.join(input_base_path, model_path)
 
     os.makedirs(model_path, exist_ok=True)
     tmp_model_path = os.path.join(model_path, "tmp")
@@ -292,7 +298,7 @@ def main():
     )
     parser.add_argument(
         "--model_size",
-        choices=["7B", "7Bf", "13B", "13Bf", "30B", "34B", "65B", "70B", "70Bf", "tokenizer_only"],
+        choices=["7B", "7Bf", "7B-chat", "13B", "13Bf", "13B-chat", "30B", "34B", "65B", "70B", "70Bf", "70B-chat","tokenizer_only"],
         help="'f' models correspond to the finetuned versions, and are specific to the Llama2 official release. For more details on Llama2, checkout the original repo: https://huggingface.co/meta-llama",
     )
     parser.add_argument(

--- a/src/transformers/models/llama/convert_llama_weights_to_hf.py
+++ b/src/transformers/models/llama/convert_llama_weights_to_hf.py
@@ -68,6 +68,7 @@ NUM_SHARDS = {
     "70B-chat": 8,
 }
 
+LLAMA_2_BASE_FOLDER_NAME = 'llama-2-'
 
 def compute_intermediate_size(n, ffn_dim_multiplier=1, multiple_of=256):
     return multiple_of * ((int(ffn_dim_multiplier * int(8 * n / 3)) + multiple_of - 1) // multiple_of)
@@ -88,7 +89,7 @@ def write_model(model_path, input_base_path, model_size, tokenizer_path=None, sa
     if not os.path.isfile(os.path.join(input_base_path, "params.json")):
         model_path = model_size
         if model_size == ('7B' or '13B' or '70B' or '7B-chat' or '13B-chat' or '70B-chat'):
-            model_path = 'llama-2-' + model_size.lower()
+            model_path = LLAMA_2_BASE_FOLDER_NAME + model_size.lower()
         input_base_path = os.path.join(input_base_path, model_path)
 
     os.makedirs(model_path, exist_ok=True)


### PR DESCRIPTION
# What does this PR do?

When running the ./downloads.sh the options available to download are ("7B,13B,70B,7B-chat,13B-chat,70B-chat"). The download.sh script creates the folder in the following format based on the model chosen ('llama-2' + model_size.lower())

Hugging face script does not support the above directory naming convention. Resulting in having to rename the folders required by hugging face options ("7B", "7Bf", "13B", "13Bf", "30B", "34B", "65B", "70B", "70Bf", "tokenizer_only"). 

Also, the existing options does not support 7B-chat, 13B-chat and 70B-chat. 

This scripts adds support to the following

1. llama-chat models
2. New directory naming format

## Before submitting
- [] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@chauhang @HamidShojanazeri