### PR TITLE
Timm to ViT Model conversion fix #26219

### DIFF
--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -18,7 +18,6 @@
 import argparse
 import json
 import re
-from functools import reduce
 from pathlib import Path
 
 import requests

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -138,7 +138,7 @@ def parse_integer_following_string(in_string: str, search: str):
     match = re.search(to_search, in_string)
 
     if match is not None:
-        return int(reduce(lambda x, y: x or y, match.groups()))
+        return match.group(1)
 
     return match
 


### PR DESCRIPTION
A problem with timm to Vit converter code was identified in #26219 

This is caused by a rather strict index based parsing of the timm model identifier which fails for several cases. This PR does two things:

1. Fixes that issue by using a regex parser for patch and image size. 
2. Fixes ViT configuration differences (ViT Small, missing Vit-Tiny, Vit-giant/gigantic). 



 @amyeroberts, @ArthurZucker
