### PR TITLE
docs: change dataset name

### DIFF
--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -42,7 +42,7 @@ The example script uses the 🤗 Datasets library. You can easily customize them
 To setup all relevant files for training, let's create a directory.
 
 ```bash
-mkdir ./norwegian-roberta-base
+mkdir ./vietnam-roberta-base
 ```
 
 ### Train tokenizer
@@ -76,7 +76,7 @@ tokenizer.train_from_iterator(batch_iterator(), vocab_size=50265, min_frequency=
 ])
 
 # Save files to disk
-tokenizer.save("./norwegian-roberta-base/tokenizer.json")
+tokenizer.save("./vietnam-roberta-base/tokenizer.json")
 ```
 
 ### Create configuration
@@ -89,7 +89,7 @@ in the local model folder:
 from transformers import RobertaConfig
 
 config = RobertaConfig.from_pretrained("roberta-base", vocab_size=50265)
-config.save_pretrained("./norwegian-roberta-base")
+config.save_pretrained("./vietnam-roberta-base")
 ```
 
 Great, we have set up our model repository. During training, we will automatically
@@ -101,10 +101,10 @@ Next we can run the example script to pretrain the model:
 
 ```bash
 python run_mlm_flax.py \
-    --output_dir="./norwegian-roberta-base" \
+    --output_dir="./vietnam-roberta-base" \
     --model_type="roberta" \
-    --config_name="./norwegian-roberta-base" \
-    --tokenizer_name="./norwegian-roberta-base" \
+    --config_name="./vietnam-roberta-base" \
+    --tokenizer_name="./vietnam-roberta-base" \
     --dataset_name="oscar" \
     --dataset_config_name="unshuffled_deduplicated_vi" \
     --max_seq_length="128" \
@@ -455,7 +455,7 @@ are 8 TPU cores on 4 chips (each chips has 2 cores), while "8 GPU" are 8 GPU chi
 
 For comparison one can run the same pre-training with PyTorch/XLA on TPU. To set up PyTorch/XLA on Cloud TPU VMs, please 
 refer to [this](https://cloud.google.com/tpu/docs/pytorch-xla-ug-tpu-vm) guide.
-Having created the tokenzier and configuration in `norwegian-roberta-base`, we create the following symbolic links:
+Having created the tokenzier and configuration in `vietnam-roberta-base`, we create the following symbolic links:
 
 ```bash
 ln -s ~/transformers/examples/pytorch/language-modeling/run_mlm.py ./
@@ -470,7 +470,7 @@ unset LD_PRELOAD
 
 export NUM_TPUS=8
 export TOKENIZERS_PARALLELISM=0
-export MODEL_DIR="./norwegian-roberta-base"
+export MODEL_DIR="./vietnam-roberta-base"
 mkdir -p ${MODEL_DIR}
 ```
 
@@ -505,7 +505,7 @@ python3 xla_spawn.py --num_cores ${NUM_TPUS} run_mlm.py --output_dir="./runs" \
 
 For comparison you can run the same pre-training with PyTorch on GPU. Note that we have to make use of `gradient_accumulation` 
 because the maximum batch size that fits on a single V100 GPU is 32 instead of 128.
-Having created the tokenzier and configuration in `norwegian-roberta-base`, we create the following symbolic links:
+Having created the tokenzier and configuration in `vietnam-roberta-base`, we create the following symbolic links:
 
 ```bash
 ln -s ~/transformers/examples/pytorch/language-modeling/run_mlm.py ./
@@ -516,7 +516,7 @@ ln -s ~/transformers/examples/pytorch/language-modeling/run_mlm.py ./
 ```bash
 export NUM_GPUS=8
 export TOKENIZERS_PARALLELISM=0
-export MODEL_DIR="./norwegian-roberta-base"
+export MODEL_DIR="./vietnam-roberta-base"
 mkdir -p ${MODEL_DIR}
 ```
 

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -51,7 +51,7 @@ from datasets import load_dataset
 from tokenizers import trainers, Tokenizer, normalizers, ByteLevelBPETokenizer
 
 # load dataset
-dataset = load_dataset("oscar", "unshuffled_deduplicated_no", split="train")
+dataset = load_dataset("oscar", "unshuffled_deduplicated_vi", split="train")
 
 # Instantiate tokenizer
 tokenizer = ByteLevelBPETokenizer()
@@ -100,7 +100,7 @@ python run_mlm_flax.py \
     --config_name="./norwegian-roberta-base" \
     --tokenizer_name="./norwegian-roberta-base" \
     --dataset_name="oscar" \
-    --dataset_config_name="unshuffled_deduplicated_no" \
+    --dataset_config_name="unshuffled_deduplicated_vi" \
     --max_seq_length="128" \
     --weight_decay="0.01" \
     --per_device_train_batch_size="128" \
@@ -154,7 +154,7 @@ from datasets import load_dataset
 from tokenizers import trainers, Tokenizer, normalizers, ByteLevelBPETokenizer
 
 # load dataset
-dataset = load_dataset("oscar", "unshuffled_deduplicated_no", split="train")
+dataset = load_dataset("oscar", "unshuffled_deduplicated_vi", split="train")
 
 # Instantiate tokenizer
 tokenizer = ByteLevelBPETokenizer()
@@ -203,7 +203,7 @@ python run_clm_flax.py \
     --config_name="./norwegian-gpt2" \
     --tokenizer_name="./norwegian-gpt2" \
     --dataset_name="oscar" \
-    --dataset_config_name="unshuffled_deduplicated_no" \
+    --dataset_config_name="unshuffled_deduplicated_vi" \
     --do_train --do_eval \
     --block_size="512" \
     --per_device_train_batch_size="64" \
@@ -266,7 +266,7 @@ vocab_size = 32_000
 input_sentence_size = None
 
 # Initialize a dataset
-dataset = datasets.load_dataset("oscar", name="unshuffled_deduplicated_no", split="train")
+dataset = datasets.load_dataset("oscar", name="unshuffled_deduplicated_vi", split="train")
 
 tokenizer = SentencePieceUnigramTokenizer(unk_token="<unk>", eos_token="</s>", pad_token="<pad>")
 
@@ -318,7 +318,7 @@ python run_t5_mlm_flax.py \
 	--config_name="./norwegian-t5-base" \
 	--tokenizer_name="./norwegian-t5-base" \
 	--dataset_name="oscar" \
-	--dataset_config_name="unshuffled_deduplicated_no" \
+	--dataset_config_name="unshuffled_deduplicated_vi" \
 	--max_seq_length="512" \
 	--per_device_train_batch_size="32" \
 	--per_device_eval_batch_size="32" \
@@ -365,7 +365,7 @@ from datasets import load_dataset
 from tokenizers import trainers, Tokenizer, normalizers, ByteLevelBPETokenizer
 
 # load dataset
-dataset = load_dataset("oscar", "unshuffled_deduplicated_no", split="train")
+dataset = load_dataset("oscar", "unshuffled_deduplicated_vi", split="train")
 
 # Instantiate tokenizer
 tokenizer = ByteLevelBPETokenizer()
@@ -412,7 +412,7 @@ python run_bart_dlm_flax.py \
     --config_name="./norwegian-bart-base" \
     --tokenizer_name="./norwegian-bart-base" \
     --dataset_name="oscar" \
-    --dataset_config_name="unshuffled_deduplicated_no" \
+    --dataset_config_name="unshuffled_deduplicated_vi" \
     --max_seq_length="1024" \
     --per_device_train_batch_size="32" \
     --per_device_eval_batch_size="32" \
@@ -476,7 +476,7 @@ python3 xla_spawn.py --num_cores ${NUM_TPUS} run_mlm.py --output_dir="./runs" \
     --config_name="${MODEL_DIR}" \
     --tokenizer_name="${MODEL_DIR}" \
     --dataset_name="oscar" \
-    --dataset_config_name="unshuffled_deduplicated_no" \
+    --dataset_config_name="unshuffled_deduplicated_vi" \
     --max_seq_length="128" \
     --weight_decay="0.01" \
     --per_device_train_batch_size="128" \
@@ -523,7 +523,7 @@ python3 -m torch.distributed.launch --nproc_per_node ${NUM_GPUS} run_mlm.py \
     --config_name="${MODEL_DIR}" \
     --tokenizer_name="${MODEL_DIR}" \
     --dataset_name="oscar" \
-    --dataset_config_name="unshuffled_deduplicated_no" \
+    --dataset_config_name="unshuffled_deduplicated_vi" \
     --max_seq_length="128" \
     --weight_decay="0.01" \
     --per_device_train_batch_size="32" \

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -23,6 +23,12 @@ JAX/Flax allows you to trace pure functions and compile them into efficient, fus
 Models written in JAX/Flax are **immutable** and updated in a purely functional
 way which enables simple and efficient model parallelism.
 
+## Table of contents
+- [Masked language modeling](#masked-language-modeling)
+- [Causal language modeling](#causal-language-modeling)
+- [BART: Denoising language modeling](#bart-denoising-language-modeling)
+- [Runtime evaluation](runtime-evaluation)
+
 ## Masked language modeling
 
 In the following, we demonstrate how to train a bi-directional transformer model 


### PR DESCRIPTION
# What does this PR do?

In the sample code for running a language model in the Flax framework, I believe that "unshuffled_deduplicated_no" is not a suitable example due to its size, which consists of 3.18M samples. Loading such a large dataset can be time-consuming, especially for beginners. Therefore, I suggest changing the dataset to something smaller, like 1M samples, for testing purposes. As a result, I have modified the data source to "unshuffled_deduplicated_vi"
