### PR TITLE
feat: add enable_gradient_checkpoint for roberta

### DIFF
--- a/src/transformers/models/roberta/modeling_flax_roberta.py
+++ b/src/transformers/models/roberta/modeling_flax_roberta.py
@@ -1008,6 +1008,9 @@ class FlaxRobertaForMaskedLMModule(nn.Module):
         )
         self.lm_head = FlaxRobertaLMHead(config=self.config, dtype=self.dtype)
 
+    def enable_gradient_checkpointing(self):
+        self.roberta.gradient_checkpointing = True
+
     def __call__(
         self,
         input_ids,


### PR DESCRIPTION
# What does this PR do?

While reviewing the "run_mlm_flax.py" file, I encountered an issue when attempting to execute the "model.enable_gradient_checkpointing()" function. Upon further investigation, I observed that there was no "enable_gradient_checkpointing" available. As a solution, I configured FlaxRobertaForMasked to include the "enable_gradient_checkpoint" feature.

I would like to cc @sanchit-gandhi to review my code