### PR TITLE
Fix num. of minimal calls to the Hub with peft for pipeline 

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -33,7 +33,10 @@ from ..models.auto.modeling_auto import AutoModelForDepthEstimation, AutoModelFo
 from ..models.auto.tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
 from ..tokenization_utils import PreTrainedTokenizer
 from ..utils import (
+    CONFIG_NAME,
     HUGGINGFACE_CO_RESOLVE_ENDPOINT,
+    cached_file,
+    extract_commit_hash,
     find_adapter_config_file,
     is_kenlm_available,
     is_offline_mode,
@@ -698,11 +701,14 @@ def pipeline(
             raise ValueError("`token` and `use_auth_token` are both specified. Please set only the argument `token`.")
         token = use_auth_token
 
+    code_revision = kwargs.pop("code_revision", None)
+    commit_hash = kwargs.pop("_commit_hash", None)
+
     hub_kwargs = {
         "revision": revision,
         "token": token,
         "trust_remote_code": trust_remote_code,
-        "_commit_hash": None,
+        "_commit_hash": commit_hash,
     }
 
     if task is None and model is None:
@@ -727,28 +733,42 @@ def pipeline(
     if isinstance(model, Path):
         model = str(model)
 
+    if hub_kwargs["_commit_hash"] is None:
+        pretrained_model_name_or_path = None
+        if isinstance(config, str):
+            pretrained_model_name_or_path = config
+        elif config is None and isinstance(model, str):
+            pretrained_model_name_or_path = model
+
+        if not isinstance(config, PretrainedConfig) and pretrained_model_name_or_path is not None:
+            # We make a call to the config file first (which may be absent) to get the commit hash as soon as possible
+            resolved_config_file = cached_file(
+                pretrained_model_name_or_path,
+                CONFIG_NAME,
+                _raise_exceptions_for_missing_entries=False,
+                _raise_exceptions_for_connection_errors=False,
+                **hub_kwargs,
+            )
+            hub_kwargs["_commit_hash"] = extract_commit_hash(resolved_config_file, commit_hash)
+        else:
+            hub_kwargs["_commit_hash"] = getattr(config, "_commit_hash", None)
+
     # Config is the primordial information item.
     # Instantiate config if needed
     if isinstance(config, str):
-        config = AutoConfig.from_pretrained(config, _from_pipeline=task, **hub_kwargs, **model_kwargs)
+        config = AutoConfig.from_pretrained(config, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs)
         hub_kwargs["_commit_hash"] = config._commit_hash
     elif config is None and isinstance(model, str):
         # Check for an adapter file in the model path if PEFT is available
         if is_peft_available():
-            subfolder = hub_kwargs.get("subfolder", None)
-            maybe_adapter_path = find_adapter_config_file(
-                model,
-                revision=revision,
-                token=use_auth_token,
-                subfolder=subfolder,
-            )
+            maybe_adapter_path = find_adapter_config_file(model, **hub_kwargs)
 
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:
                     adapter_config = json.load(f)
                     model = adapter_config["base_model_name_or_path"]
 
-        config = AutoConfig.from_pretrained(model, _from_pipeline=task, **hub_kwargs, **model_kwargs)
+        config = AutoConfig.from_pretrained(model, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs)
         hub_kwargs["_commit_hash"] = config._commit_hash
 
     custom_tasks = {}
@@ -769,7 +789,7 @@ def pipeline(
                 "Inferring the task automatically requires to check the hub with a model_id defined as a `str`."
                 f"{model} is not a valid model_id."
             )
-        task = get_task(model, use_auth_token)
+        task = get_task(model, token)
 
     # Retrieve the task
     if task in custom_tasks:
@@ -784,7 +804,7 @@ def pipeline(
                 )
             class_ref = targeted_task["impl"]
             pipeline_class = get_class_from_dynamic_module(
-                class_ref, model, revision=revision, use_auth_token=use_auth_token
+                class_ref, model, revision=revision, code_revision=code_revision, **hub_kwargs,
             )
     else:
         normalized_task, targeted_task, task_options = check_task(task)

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -765,7 +765,7 @@ def pipeline(
         if is_peft_available():
             # `find_adapter_config_file` doesn't accept `trust_remote_code`
             _hub_kwargs = {k: v for k, v in hub_kwargs.items() if k != "trust_remote_code"}
-            maybe_adapter_path = find_adapter_config_file(model, **hub_kwargs)
+            maybe_adapter_path = find_adapter_config_file(model, **_hub_kwargs)
 
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -763,6 +763,8 @@ def pipeline(
     elif config is None and isinstance(model, str):
         # Check for an adapter file in the model path if PEFT is available
         if is_peft_available():
+            # `find_adapter_config_file` doesn't accept `trust_remote_code`
+            _hub_kwargs = {k: v for k, v in hub_kwargs.items() if k != "trust_remote_code"}
             maybe_adapter_path = find_adapter_config_file(model, **hub_kwargs)
 
             if maybe_adapter_path is not None:

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -733,7 +733,7 @@ def pipeline(
     if isinstance(model, Path):
         model = str(model)
 
-    if hub_kwargs["_commit_hash"] is None:
+    if commit_hash is None:
         pretrained_model_name_or_path = None
         if isinstance(config, str):
             pretrained_model_name_or_path = config
@@ -765,7 +765,12 @@ def pipeline(
         if is_peft_available():
             # `find_adapter_config_file` doesn't accept `trust_remote_code`
             _hub_kwargs = {k: v for k, v in hub_kwargs.items() if k != "trust_remote_code"}
-            maybe_adapter_path = find_adapter_config_file(model, **_hub_kwargs)
+            maybe_adapter_path = find_adapter_config_file(
+                model,
+                token=hub_kwargs["token"],
+                revision=hub_kwargs["revision"],
+                _commit_hash=hub_kwargs["_commit_hash"],
+            )
 
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -812,7 +812,6 @@ def pipeline(
             pipeline_class = get_class_from_dynamic_module(
                 class_ref,
                 model,
-                revision=revision,
                 code_revision=code_revision,
                 **hub_kwargs,
             )

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -756,7 +756,9 @@ def pipeline(
     # Config is the primordial information item.
     # Instantiate config if needed
     if isinstance(config, str):
-        config = AutoConfig.from_pretrained(config, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs)
+        config = AutoConfig.from_pretrained(
+            config, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs
+        )
         hub_kwargs["_commit_hash"] = config._commit_hash
     elif config is None and isinstance(model, str):
         # Check for an adapter file in the model path if PEFT is available
@@ -768,7 +770,9 @@ def pipeline(
                     adapter_config = json.load(f)
                     model = adapter_config["base_model_name_or_path"]
 
-        config = AutoConfig.from_pretrained(model, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs)
+        config = AutoConfig.from_pretrained(
+            model, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs
+        )
         hub_kwargs["_commit_hash"] = config._commit_hash
 
     custom_tasks = {}
@@ -804,7 +808,11 @@ def pipeline(
                 )
             class_ref = targeted_task["impl"]
             pipeline_class = get_class_from_dynamic_module(
-                class_ref, model, revision=revision, code_revision=code_revision, **hub_kwargs,
+                class_ref,
+                model,
+                revision=revision,
+                code_revision=code_revision,
+                **hub_kwargs,
             )
     else:
         normalized_task, targeted_task, task_options = check_task(task)


### PR DESCRIPTION
# What does this PR do?

This is a continuation of #25715 where @sgugger fix `test_cached_model_has_minimum_calls_to_head` but not `test_cached_pipeline_has_minimum_calls_to_head` (as I didn't mention this to him).

This PR mostly copies the logic from #25715.

The current failing test and the error are

```bash
tests/pipelines/test_pipelines_common.py::CustomPipelineTest::test_cached_pipeline_has_minimum_calls_to_head
(line 905)  AssertionError: 2 != 1
```

