### PR TITLE
Fix DeepSpeed issue with Idefics

### DIFF
--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -428,7 +428,7 @@ class IdeficsDecoupledLinear(nn.Linear):
         output = F.linear(input, self.weight, self.bias)
 
         if self.out_additional_features > 0:
-            additional_features = F.linear(input, self.additional_fc.weight, self.additional_fc.bias)
+            additional_features = self.additional_fc(input)
             output = torch.cat((output, additional_features), -1)
 
         return output


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug when trying to do inference with Idefics with DeepSpeed Zero-3.
The model was loaded correctly, but the shapes were found to be incorrect using DS at a step in `IdeficsDecoupledLinear` during inference.

I checked on different prompts that the output is the same without using DeepSpeed.

## Who can review?

@pacman100
