### PR TITLE
Fix padding for IDEFICS 

### DIFF
--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -280,7 +280,7 @@ class IdeficsProcessor(ProcessorMixin):
             else:
                 return fake_token + image_token + fake_token
 
-        all_texts = []
+        all_prompts = []
         all_images = []
         for sample in prompts:
             # the model was trained on samples starting with <s>
@@ -321,16 +321,17 @@ class IdeficsProcessor(ProcessorMixin):
 
             image_objects = self.image_processor(image_objects, transform=transform)
 
-            text_encoding = self.tokenizer(
-                text=full_text,
-                add_special_tokens=False,
-                padding=padding,
-                truncation=truncation,
-                max_length=max_length,
-            )
-
-            all_texts.append(text_encoding["input_ids"])
+            all_prompts.append(full_text)
             all_images.append(image_objects)
+        
+        text_encoding = self.tokenizer(
+              text=all_prompts,
+              add_special_tokens=False,
+              padding=padding,
+              truncation=truncation,
+              max_length=max_length,
+        )
+        all_texts = text_encoding["input_ids"]
 
         max_seq_len = max(len(x) for x in all_texts)
 
@@ -410,3 +411,4 @@ class IdeficsProcessor(ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         image_processor_input_names = self.image_processor.model_input_names
         return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+

--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -323,13 +323,13 @@ class IdeficsProcessor(ProcessorMixin):
 
             all_prompts.append(full_text)
             all_images.append(image_objects)
-        
+
         text_encoding = self.tokenizer(
-              text=all_prompts,
-              add_special_tokens=False,
-              padding=padding,
-              truncation=truncation,
-              max_length=max_length,
+            text=all_prompts,
+            add_special_tokens=False,
+            padding=padding,
+            truncation=truncation,
+            max_length=max_length,
         )
         all_texts = text_encoding["input_ids"]
 
@@ -411,4 +411,3 @@ class IdeficsProcessor(ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         image_processor_input_names = self.image_processor.model_input_names
         return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
-

--- a/tests/models/idefics/test_processor_idefics.py
+++ b/tests/models/idefics/test_processor_idefics.py
@@ -147,8 +147,10 @@ class IdeficsProcessorTest(TestCasePlus):
 
         processor = IdeficsProcessor(tokenizer=tokenizer, image_processor=image_processor)
 
-        predicted_tokens = ["<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk>",
-        "<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>"]
+        predicted_tokens = [
+            "<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk>",
+            "<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>",
+        ]
 
         prompts = [[prompt] for prompt in self.prepare_prompts()[2]]
         max_length = processor(prompts, padding="max_length", truncation=True, max_length=20)

--- a/tests/models/idefics/test_processor_idefics.py
+++ b/tests/models/idefics/test_processor_idefics.py
@@ -141,6 +141,23 @@ class IdeficsProcessorTest(TestCasePlus):
 
         self.assertListEqual(decoded_tok, decoded_processor)
 
+    def test_tokenizer_padding(self):
+        image_processor = self.get_image_processor()
+        tokenizer = self.get_tokenizer(padding_side="right")
+
+        processor = IdeficsProcessor(tokenizer=tokenizer, image_processor=image_processor)
+
+        predicted_tokens = ["<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk>",
+        "<s>Describe this image.\nAssistant:<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>"]
+
+        prompts = [[prompt] for prompt in self.prepare_prompts()[2]]
+        max_length = processor(prompts, padding="max_length", truncation=True, max_length=20)
+        longest = processor(prompts, padding="longest", truncation=True, max_length=30)
+        decoded_max_length = processor.tokenizer.decode(max_length["input_ids"][-1])
+        decoded_longest = processor.tokenizer.decode(longest["input_ids"][-1])
+        self.assertEqual(decoded_max_length, predicted_tokens[1])
+        self.assertEqual(decoded_longest, predicted_tokens[0])
+
     def test_model_input_names(self):
         image_processor = self.get_image_processor()
         tokenizer = self.get_tokenizer()


### PR DESCRIPTION
# What does this PR do?

Fixes padding issues - 
```python
from transformers import AutoProcessor

processor = AutoProcessor.from_pretrained("HuggingFaceM4/idefics-9b", padding_side="right")

sents = [["hello world"], [" this is a longer sentence to testing padding"]]

# This is the correct behaviour:
a = processor(sents, padding="max_length", truncation=True, max_length=20)
print(processor.tokenizer.decode(a['input_ids'][0]))
# => <s> hello world<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>

# This is the incorrect behaviour:
b = processor(sents, padding="longest", truncation=True, max_length=30)

print(processor.tokenizer.decode(b['input_ids'][0]))
# => <unk><unk><unk><unk><unk><unk><s> hello world
```
With this fix the results would be 
```
# for max_length
<s> hello world<unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk><unk>
# for longest
<s> hello world<unk><unk><unk><unk><unk><unk>
```

Fixes #26354


## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.

## Who can review?
@VictorSanh @ArthurZucker @LysandreJik 

*let me know if there's anything that needs follow-ups*