### PR TITLE
Change past_key_values shape of gpt_bigcode

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4655,6 +4655,15 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
                 )
             )
         past_key_values = tuple(new_past)
+    else:
+        for idx in range(len(past_key_values)):
+            new_past.append(
+                (
+                    past_key_values[idx][0][:, :, :maximum_length, :],
+                    past_key_values[idx][1][:, :, :maximum_length, :],
+                )
+            )
+        past_key_values = tuple(new_past)
     return past_key_values
 
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4655,25 +4655,6 @@ def _crop_past_key_values(model, past_key_values, maximum_length):
                 )
             )
         past_key_values = tuple(new_past)
-    # gptbigcode is too
-    elif "gptbigcode" in model.__class__.__name__.lower() or (
-        model.config.architectures is not None and "gptbigcode" in model.config.architectures[0].lower()
-    ):
-        if model.config.multi_query:
-            for idx in range(len(past_key_values)):
-                past_key_values[idx] = past_key_values[idx][:, :maximum_length, :]
-        else:
-            for idx in range(len(past_key_values)):
-                past_key_values[idx] = past_key_values[idx][:, :, :maximum_length, :]
-    else:
-        for idx in range(len(past_key_values)):
-            new_past.append(
-                (
-                    past_key_values[idx][0][:, :, :maximum_length, :],
-                    past_key_values[idx][1][:, :, :maximum_length, :],
-                )
-            )
-        past_key_values = tuple(new_past)
     return past_key_values
 
 


### PR DESCRIPTION
Hi @ArthurZucker @younesbelkada 

I found that the shape of `past_key_values` in `gpt_bigcode` is different from others, which will cause inconvenience or unexpected errors in `Optimum` and `Optimum-intel`. Therefore, I added some reshaping operations to make the shape insistent with other models. I have tested it on my device and didn't find any performance decay. Would you please help me review it? Thx!

BTW, could we add a restriction like the shape of `past_key_values` must be (batch_size, num_heads, sequence_length, head_dim)? It could avoid many issues if we have a fixed output and input shape of `past_key_values`