### PR TITLE
[`PEFT`] Fix PEFT multi adapters support

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..utils import (
     check_peft_version,
@@ -326,12 +326,18 @@ class PeftAdapterMixin:
                 else:
                     module.disable_adapters = False
 
-    def active_adapter(self) -> str:
+    def active_adapter(self, return_multi_adapters: bool = False) -> Union[str, List[str]]:
         """
         If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
         official documentation: https://huggingface.co/docs/peft
 
-        Gets the current active adapter of the model.
+        Gets the current active adapter of the model. In case of multi-adapter inference (combining multiple adapters
+        for inference) returns the list of active adapters so that users can deal with them accordingly.
+
+        Args:
+            return_multi_adapters (`bool`, *optional*, defaults to `False`):
+                Whether to return a list of active adapters or not. If `False`, only the first adapter is returned. If
+                `True`, returns the list of active adapters.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 
@@ -346,9 +352,14 @@ class PeftAdapterMixin:
         for _, module in self.named_modules():
             if isinstance(module, BaseTunerLayer):
                 active_adapter = module.active_adapter
-                if isinstance(active_adapter, list):
+                if isinstance(active_adapter, list) and not return_multi_adapters:
                     # In case the adapter name is a list (multiple adapters), we only consider the first one
                     active_adapter = active_adapter[0]
+
+                    logger.warning(
+                        "Multiple adapters detected, we will only consider the first adapter. If you want to get all active adapters, "
+                        "call `active_adapter(return_multi_adapters=True)` instead."
+                    )
                 return active_adapter
 
     def get_adapter_state_dict(self, adapter_name: Optional[str] = None) -> dict:
@@ -372,15 +383,6 @@ class PeftAdapterMixin:
 
         if adapter_name is None:
             adapter_name = self.active_adapter()
-
-        if isinstance(adapter_name, list):
-            # In case the adapter name is a list (multiple adapters), we only consider the first one
-            adapter_name = adapter_name[0]
-
-            logger.warning(
-                "Multiple adapters detected, we will only consider the first adapter, to get all adapters state dict manually loop "
-                "over the list of adapters and call `get_adapter_state_dict` for each adapter."
-            )
 
         adapter_state_dict = get_peft_model_state_dict(self, adapter_name=adapter_name)
         return adapter_state_dict

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -260,11 +260,12 @@ class PeftAdapterMixin:
         if not self._hf_peft_config_loaded:
             raise ValueError("No adapter loaded. Please load an adapter first.")
         elif isinstance(adapter_name, list):
-            for adapter in adapter_name:
-                if adapter not in self.peft_config:
-                    raise ValueError(
-                        f"Adapter with name {adapter} not found. Please pass the correct adapter name among {list(self.peft_config.keys())}"
-                    )
+            missing = set(adapter_name) - set(self.peft_config)
+            if len(missing) > 0:
+                raise ValueError(
+                    f"Following adapter(s) could not be found: {', '.join(missing)}. Make sure you are passing the correct adapter name(s)."
+                    f" current loaded adapters are: {list(self.peft_config.keys())}"
+                )
         elif adapter_name not in self.peft_config:
             raise ValueError(
                 f"Adapter with name {adapter_name} not found. Please pass the correct adapter name among {list(self.peft_config.keys())}"

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -341,7 +341,7 @@ class PeftAdapterMixin:
         Gets the current active adapters of the model. In case of multi-adapter inference (combining multiple adapters
         for inference) returns the list of all active adapters so that users can deal with them accordingly.
 
-        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return 
+        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return
         a single string.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -343,7 +343,7 @@ class PeftAdapterMixin:
         Args:
             return_multi_adapters (`bool`, *optional*, defaults to `True`):
                 Whether to return a list of active adapters or not. If `False`, only the first adapter is returned. If
-                `True`, returns the list of active adapters.
+                `True`, returns the list of all active adapters, if there is more than one.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -366,16 +366,11 @@ class PeftAdapterMixin:
         return active_adapters
 
     def active_adapter(self) -> str:
-        active_adapters = self.active_adapters()
+        logger.warning(
+            "The `active_adapter` method is deprecated and will be removed in a future version. ", FutureWarning
+        )
 
-        if isinstance(active_adapters, list):
-            logger.warning(
-                "`active_adapter` will return the first adapter in case of multi-adapter inference. Make sure to know what you are doing.",
-                " you should use `model.active_adapters() instead to get the list of active adapters",
-            )
-            active_adapters = active_adapters[0]
-
-        return active_adapters
+        return self.active_adapters()[0]
 
     def get_adapter_state_dict(self, adapter_name: Optional[str] = None) -> dict:
         """

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -366,14 +366,6 @@ class PeftAdapterMixin:
         return active_adapters
 
     def active_adapter(self) -> str:
-        """
-        Gets the current active adapter of the model. In case of multi-adapter inference (combining multiple adapters
-        for inference) returns the first active adapter - kept for backward compatibility.
-
-        For higher versions of PEFT, users should use `model.active_adapters()` instead to get the list of active
-        adapters.
-        """
-
         active_adapters = self.active_adapters()
 
         if isinstance(active_adapters, list):

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -341,6 +341,8 @@ class PeftAdapterMixin:
         Gets the current active adapters of the model. In case of multi-adapter inference (combining multiple adapters
         for inference) returns the list of all active adapters so that users can deal with them accordingly.
 
+        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return 
+        a single string.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 
@@ -354,10 +356,14 @@ class PeftAdapterMixin:
 
         for _, module in self.named_modules():
             if isinstance(module, BaseTunerLayer):
-                active_adapter = module.active_adapter
+                active_adapters = module.active_adapter
                 break
 
-        return active_adapter
+        # For previous PEFT versions
+        if isinstance(active_adapters, str):
+            active_adapters = [active_adapters]
+
+        return active_adapters
 
     def active_adapter(self) -> str:
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2006,15 +2006,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_state_dict[f"base_model.model.{key}"] = value
                     state_dict = peft_state_dict
 
-                active_adapter = self.active_adapter()
+                active_adapter = self.active_adapters()
 
-                if isinstance(active_adapter, list):
-                    if len(active_adapter) > 1:
-                        logger.warning(
-                            "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
-                            " adapter name and save them one by one manually. "
-                        )
-                    active_adapter = active_adapter[0]
+                if len(active_adapter) > 1:
+                    logger.warning(
+                        "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
+                        " adapter name and save them one by one manually. "
+                    )
+                active_adapter = active_adapter[0]
 
                 current_peft_config = self.peft_config[active_adapter]
                 current_peft_config.save_pretrained(save_directory)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2009,9 +2009,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 active_adapter = self.active_adapters()
 
                 if len(active_adapter) > 1:
-                    logger.warning(
-                        "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
-                        " adapter name and save them one by one manually. "
+                    raise ValueError(
+                        "Multiple active adapters detected, saving multiple active adapters is not supported yet. You can save adapters separately one by one "
+                        "by iteratively calling `model.set_adapter(adapter_name)` then `model.save_pretrained(...)`"
                     )
                 active_adapter = active_adapter[0]
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2006,7 +2006,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_state_dict[f"base_model.model.{key}"] = value
                     state_dict = peft_state_dict
 
-                current_peft_config = self.peft_config[self.active_adapter()]
+                active_adapter = self.active_adapter()
+
+                if isinstance(active_adapter, list):
+                    if len(active_adapter) > 1:
+                        logger.warning(
+                            "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
+                            " adapter name and save them one by one manually. "
+                        )
+                    active_adapter = active_adapter[0]
+
+                current_peft_config = self.peft_config[active_adapter]
                 current_peft_config.save_pretrained(save_directory)
 
         # Save the model

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -291,6 +291,10 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                     torch.allclose(logits_adapter_2.logits, logits_adapter_mixed.logits, atol=1e-6, rtol=1e-6)
                 )
 
+                # multi active adapter saving not supported
+                with self.assertRaises(ValueError), tempfile.TemporaryDirectory() as tmpdirname:
+                    model.save_pretrained(tmpdirname)
+
     @require_torch_gpu
     def test_peft_from_pretrained_kwargs(self):
         """

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -280,6 +280,7 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
 
                 model.set_adapter(["adapter-2", "default"])
                 self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
 
                 logits_adapter_mixed = model(dummy_input)
                 self.assertFalse(

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -265,12 +265,12 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 _ = model.generate(input_ids=dummy_input)
 
                 model.set_adapter("default")
-                self.assertTrue(model.active_adapter() == ["default"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "default")
+                self.assertTrue(model.active_adapters() == ["default"])
+                self.assertTrue(model.active_adapter() == "default")
 
                 model.set_adapter("adapter-2")
-                self.assertTrue(model.active_adapter() == ["adapter-2"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
+                self.assertTrue(model.active_adapters() == ["adapter-2"])
+                self.assertTrue(model.active_adapter() == "adapter-2")
 
                 # Logits comparison
                 self.assertFalse(
@@ -279,8 +279,8 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 self.assertFalse(torch.allclose(logits_original_model, logits_adapter_2.logits, atol=1e-6, rtol=1e-6))
 
                 model.set_adapter(["adapter-2", "default"])
-                self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
+                self.assertTrue(model.active_adapters() == ["adapter-2", "default"])
+                self.assertTrue(model.active_adapter() == "adapter-2")
 
                 logits_adapter_mixed = model(dummy_input)
                 self.assertFalse(

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -265,16 +265,30 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 _ = model.generate(input_ids=dummy_input)
 
                 model.set_adapter("default")
-                self.assertTrue(model.active_adapter() == "default")
+                self.assertTrue(model.active_adapter() == ["default"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "default")
 
                 model.set_adapter("adapter-2")
-                self.assertTrue(model.active_adapter() == "adapter-2")
+                self.assertTrue(model.active_adapter() == ["adapter-2"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
 
                 # Logits comparison
                 self.assertFalse(
                     torch.allclose(logits_adapter_1.logits, logits_adapter_2.logits, atol=1e-6, rtol=1e-6)
                 )
                 self.assertFalse(torch.allclose(logits_original_model, logits_adapter_2.logits, atol=1e-6, rtol=1e-6))
+
+                model.set_adapter(["adapter-2", "default"])
+                self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
+
+                logits_adapter_mixed = model(dummy_input)
+                self.assertFalse(
+                    torch.allclose(logits_adapter_1.logits, logits_adapter_mixed.logits, atol=1e-6, rtol=1e-6)
+                )
+
+                self.assertFalse(
+                    torch.allclose(logits_adapter_2.logits, logits_adapter_mixed.logits, atol=1e-6, rtol=1e-6)
+                )
 
     @require_torch_gpu
     def test_peft_from_pretrained_kwargs(self):


### PR DESCRIPTION
# What does this PR do?

With https://github.com/huggingface/peft/pull/905 being merged, it added the support for multi-adapter inference (combining multiple adapters at inference). 

The PR has introduced some changes that are not compatible anymore with peft integration of transformers, for example `active_adapter` is now a property method and returns a list. This PR adds the corresponding fixes to make everything compatible with the newest features of PEFT, while preserving backward compatiblity

cc @BenjaminBossan @pacman100 