### PR TITLE
[`WIP`] Multi-adapter saving support for PEFT

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..utils import (
     check_peft_version,
@@ -326,12 +326,18 @@ class PeftAdapterMixin:
                 else:
                     module.disable_adapters = False
 
-    def active_adapter(self) -> str:
+    def active_adapter(self, return_multi_adapters: bool = False) -> Union[str, List[str]]:
         """
         If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
         official documentation: https://huggingface.co/docs/peft
 
-        Gets the current active adapter of the model.
+        Gets the current active adapter of the model. In case of multi-adapter inference (combining multiple adapters
+        for inference) returns the list of active adapters so that users can deal with them accordingly.
+
+        Args:
+            return_multi_adapters (`bool`, *optional*, defaults to `False`):
+                Whether to return a list of active adapters or not. If `False`, only the first adapter is returned. If
+                `True`, returns the list of active adapters.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 
@@ -346,9 +352,14 @@ class PeftAdapterMixin:
         for _, module in self.named_modules():
             if isinstance(module, BaseTunerLayer):
                 active_adapter = module.active_adapter
-                if isinstance(active_adapter, list):
+                if isinstance(active_adapter, list) and not return_multi_adapters:
                     # In case the adapter name is a list (multiple adapters), we only consider the first one
                     active_adapter = active_adapter[0]
+
+                    logger.warning(
+                        "Multiple adapters detected, we will only consider the first adapter. If you want to get all active adapters, "
+                        "call `active_adapter(return_multi_adapters=True)` instead."
+                    )
                 return active_adapter
 
     def get_adapter_state_dict(self, adapter_name: Optional[str] = None) -> dict:
@@ -372,15 +383,6 @@ class PeftAdapterMixin:
 
         if adapter_name is None:
             adapter_name = self.active_adapter()
-
-        if isinstance(adapter_name, list):
-            # In case the adapter name is a list (multiple adapters), we only consider the first one
-            adapter_name = adapter_name[0]
-
-            logger.warning(
-                "Multiple adapters detected, we will only consider the first adapter, to get all adapters state dict manually loop "
-                "over the list of adapters and call `get_adapter_state_dict` for each adapter."
-            )
 
         adapter_state_dict = get_peft_model_state_dict(self, adapter_name=adapter_name)
         return adapter_state_dict

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -260,11 +260,12 @@ class PeftAdapterMixin:
         if not self._hf_peft_config_loaded:
             raise ValueError("No adapter loaded. Please load an adapter first.")
         elif isinstance(adapter_name, list):
-            for adapter in adapter_name:
-                if adapter not in self.peft_config:
-                    raise ValueError(
-                        f"Adapter with name {adapter} not found. Please pass the correct adapter name among {list(self.peft_config.keys())}"
-                    )
+            missing = set(adapter_name) - set(self.peft_config)
+            if len(missing) > 0:
+                raise ValueError(
+                    f"Following adapter(s) could not be found: {', '.join(missing)}. Make sure you are passing the correct adapter name(s)."
+                    f" current loaded adapters are: {list(self.peft_config.keys())}"
+                )
         elif adapter_name not in self.peft_config:
             raise ValueError(
                 f"Adapter with name {adapter_name} not found. Please pass the correct adapter name among {list(self.peft_config.keys())}"

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -341,7 +341,7 @@ class PeftAdapterMixin:
         Gets the current active adapters of the model. In case of multi-adapter inference (combining multiple adapters
         for inference) returns the list of all active adapters so that users can deal with them accordingly.
 
-        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return 
+        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return
         a single string.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -343,7 +343,7 @@ class PeftAdapterMixin:
         Args:
             return_multi_adapters (`bool`, *optional*, defaults to `True`):
                 Whether to return a list of active adapters or not. If `False`, only the first adapter is returned. If
-                `True`, returns the list of active adapters.
+                `True`, returns the list of all active adapters, if there is more than one.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -341,6 +341,8 @@ class PeftAdapterMixin:
         Gets the current active adapters of the model. In case of multi-adapter inference (combining multiple adapters
         for inference) returns the list of all active adapters so that users can deal with them accordingly.
 
+        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return 
+        a single string.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 
@@ -354,10 +356,14 @@ class PeftAdapterMixin:
 
         for _, module in self.named_modules():
             if isinstance(module, BaseTunerLayer):
-                active_adapter = module.active_adapter
+                active_adapters = module.active_adapter
                 break
 
-        return active_adapter
+        # For previous PEFT versions
+        if isinstance(active_adapters, str):
+            active_adapters = [active_adapters]
+
+        return active_adapters
 
     def active_adapter(self) -> str:
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2006,15 +2006,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_state_dict[f"base_model.model.{key}"] = value
                     state_dict = peft_state_dict
 
-                active_adapter = self.active_adapter()
+                active_adapter = self.active_adapters()
 
-                if isinstance(active_adapter, list):
-                    if len(active_adapter) > 1:
-                        logger.warning(
-                            "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
-                            " adapter name and save them one by one manually. "
-                        )
-                    active_adapter = active_adapter[0]
+                if len(active_adapter) > 1:
+                    logger.warning(
+                        "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
+                        " adapter name and save them one by one manually. "
+                    )
+                active_adapter = active_adapter[0]
 
                 current_peft_config = self.peft_config[active_adapter]
                 current_peft_config.save_pretrained(save_directory)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1983,7 +1983,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             custom_object_save(self, save_directory, config=self.config)
 
         _hf_peft_config_loaded = getattr(model_to_save, "_hf_peft_config_loaded", False)
-        peft_multi_adapter_state_dict = None
+        peft_multi_adapter_state_dict = {}
 
         # Save the config
         if is_main_process:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2006,7 +2006,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         peft_state_dict[f"base_model.model.{key}"] = value
                     state_dict = peft_state_dict
 
-                current_peft_config = self.peft_config[self.active_adapter()]
+                active_adapter = self.active_adapter()
+
+                if isinstance(active_adapter, list):
+                    if len(active_adapter) > 1:
+                        logger.warning(
+                            "Multiple active adapters detected, will only consider the first active adapter. In order to save them all, please iteratively call `set_adapter()` on each"
+                            " adapter name and save them one by one manually. "
+                        )
+                    active_adapter = active_adapter[0]
+
+                current_peft_config = self.peft_config[active_adapter]
                 current_peft_config.save_pretrained(save_directory)
 
         # Save the model

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1996,9 +1996,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 logger.info(
                     "Detected adapters on the model, saving the model in the PEFT format, only adapter weights will be saved."
                 )
-                
+
                 total_adapters = list(self.peft_config.keys())
-                
+
                 for adapter_name in total_adapters:
                     adapter_state_dict = model_to_save.get_adapter_state_dict(adapter_name=adapter_name)
 
@@ -2026,7 +2026,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     current_adapter = list(peft_multi_adapter_state_dict.keys())[0]
                     state_dict = peft_multi_adapter_state_dict[current_adapter].copy()
                     peft_multi_adapter_state_dict = None
-
 
         _peft_save_multi_adapter = _hf_peft_config_loaded and peft_multi_adapter_state_dict is not None
 
@@ -2067,11 +2066,22 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             weights_name = ADAPTER_SAFE_WEIGHTS_NAME if safe_serialization else ADAPTER_WEIGHTS_NAME
 
         if not _peft_save_multi_adapter:
-            self._shard_and_save_checkpoints(save_directory, state_dict, weights_name, max_shard_size, safe_serialization, is_main_process, variant, save_function)
+            self._shard_and_save_checkpoints(
+                save_directory,
+                state_dict,
+                weights_name,
+                max_shard_size,
+                safe_serialization,
+                is_main_process,
+                variant,
+                save_function,
+            )
         else:
             for adapter_name in peft_multi_adapter_state_dict:
                 # The default adapter always needs to be saved on the root directory
-                adapter_save_path = save_directory if adapter_name == "default" else os.path.join(save_directory, adapter_name)
+                adapter_save_path = (
+                    save_directory if adapter_name == "default" else os.path.join(save_directory, adapter_name)
+                )
 
                 self._shard_and_save_checkpoints(
                     adapter_save_path,
@@ -2082,7 +2092,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     is_main_process,
                     variant,
                     save_function,
-                ) 
+                )
 
         if push_to_hub:
             self._upload_modified_files(
@@ -2094,15 +2104,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
 
     def _shard_and_save_checkpoints(
-        self, 
-        save_directory, 
-        state_dict, 
-        weights_name, 
-        max_shard_size, 
-        safe_serialization, 
-        is_main_process, 
-        variant, 
-        save_function: Callable = torch.save
+        self,
+        save_directory,
+        state_dict,
+        weights_name,
+        max_shard_size,
+        safe_serialization,
+        is_main_process,
+        variant,
+        save_function: Callable = torch.save,
     ):
         shards, index = shard_checkpoint(state_dict, max_shard_size=max_shard_size, weights_name=weights_name)
 
@@ -2189,7 +2199,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             logger.warning_once(
                 f"Removed shared tensor {warn_names} while saving. This should be OK, but check by verifying that you don't receive any warning while reloading",
             )
-        
+
         return state_dict
 
     def get_memory_footprint(self, return_buffers=True):

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -280,6 +280,7 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
 
                 model.set_adapter(["adapter-2", "default"])
                 self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
 
                 logits_adapter_mixed = model(dummy_input)
                 self.assertFalse(

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -265,12 +265,12 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 _ = model.generate(input_ids=dummy_input)
 
                 model.set_adapter("default")
-                self.assertTrue(model.active_adapter() == ["default"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "default")
+                self.assertTrue(model.active_adapters() == ["default"])
+                self.assertTrue(model.active_adapter() == "default")
 
                 model.set_adapter("adapter-2")
-                self.assertTrue(model.active_adapter() == ["adapter-2"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
+                self.assertTrue(model.active_adapters() == ["adapter-2"])
+                self.assertTrue(model.active_adapter() == "adapter-2")
 
                 # Logits comparison
                 self.assertFalse(
@@ -279,8 +279,8 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 self.assertFalse(torch.allclose(logits_original_model, logits_adapter_2.logits, atol=1e-6, rtol=1e-6))
 
                 model.set_adapter(["adapter-2", "default"])
-                self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
-                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
+                self.assertTrue(model.active_adapters() == ["adapter-2", "default"])
+                self.assertTrue(model.active_adapter() == "adapter-2")
 
                 logits_adapter_mixed = model(dummy_input)
                 self.assertFalse(

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -265,16 +265,30 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
                 _ = model.generate(input_ids=dummy_input)
 
                 model.set_adapter("default")
-                self.assertTrue(model.active_adapter() == "default")
+                self.assertTrue(model.active_adapter() == ["default"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "default")
 
                 model.set_adapter("adapter-2")
-                self.assertTrue(model.active_adapter() == "adapter-2")
+                self.assertTrue(model.active_adapter() == ["adapter-2"])
+                self.assertTrue(model.active_adapter(return_multi_adapters=False) == "adapter-2")
 
                 # Logits comparison
                 self.assertFalse(
                     torch.allclose(logits_adapter_1.logits, logits_adapter_2.logits, atol=1e-6, rtol=1e-6)
                 )
                 self.assertFalse(torch.allclose(logits_original_model, logits_adapter_2.logits, atol=1e-6, rtol=1e-6))
+
+                model.set_adapter(["adapter-2", "default"])
+                self.assertTrue(model.active_adapter() == ["adapter-2", "default"])
+
+                logits_adapter_mixed = model(dummy_input)
+                self.assertFalse(
+                    torch.allclose(logits_adapter_1.logits, logits_adapter_mixed.logits, atol=1e-6, rtol=1e-6)
+                )
+
+                self.assertFalse(
+                    torch.allclose(logits_adapter_2.logits, logits_adapter_mixed.logits, atol=1e-6, rtol=1e-6)
+                )
 
     @require_torch_gpu
     def test_peft_from_pretrained_kwargs(self):


### PR DESCRIPTION
# What does this PR do?

To be potentially merged after https://github.com/huggingface/transformers/pull/26407 
This PR adds the multi-adapter support for `save_pretrained` to be consistent with PEFT API that saves all adapters when calling `save_pretrained`. Note the default adapter is always saved in the root directory of `save_directory`.

cc @LysandreJik @BenjaminBossan @pacman100 
