### PR TITLE
[`FA` / `tests`] Add use_cache tests for FA models

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2909,6 +2909,36 @@ class ModelTesterMixin:
                 self.assertTrue(torch.equal(out, out_fa))
 
 
+    @require_flash_attn
+    @require_torch_gpu
+    @mark.flash_attn_test
+    @slow
+    def test_flash_attn_2_generate_use_cache(self):
+        import torch
+
+        for model_class in self.all_generative_model_classes:
+            if not model_class._supports_flash_attn_2:
+                return
+
+            config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+            model = model_class(config)
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                model.save_pretrained(tmpdirname)
+
+                dummy_input = torch.LongTensor([[0, 2, 3, 4], [0, 2, 3, 4]]).to(torch_device)
+                dummy_attention_mask = torch.LongTensor([[1, 1, 1, 1], [1, 1, 1, 0]]).to(torch_device)
+
+                model = model_class.from_pretrained(
+                    tmpdirname, torch_dtype=torch.float16, use_flash_attention_2=True, low_cpu_mem_usage=True
+                ).to(torch_device)
+
+                # Just test that a large cache works as expected
+                _ = model.generate(
+                    dummy_input, attention_mask=dummy_attention_mask, max_new_tokens=30, do_sample=False
+                )
+
+
 global_rng = random.Random()
 
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2908,7 +2908,6 @@ class ModelTesterMixin:
 
                 self.assertTrue(torch.equal(out, out_fa))
 
-
     @require_flash_attn
     @require_torch_gpu
     @mark.flash_attn_test


### PR DESCRIPTION
# What does this PR do?

While testing out https://github.com/huggingface/transformers/pull/26414 I realised the current tests silently pass as we only check for the immediate next predicted token  
For small models FA2 is quite flaky so I have decided to not increase `max_new_tokens` in `test_flash_attn_2_generate_padding_right` and `test_flash_attn_2_generate_left_padding` and rather have a separate test that will run `generate` with `use_cache` with a relatively large `max_new_tokens` to catch issues with caching when porting models to FA

cc @LysandreJik 
