### PR TITLE
fix_mbart_tied_weights

### DIFF
--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -1185,8 +1185,9 @@ class MBartModel(MBartPreTrainedModel):
         return self.decoder
 
     def _tie_weights(self):
-        self.encoder.embed_tokens.weight = self.shared.weight
-        self.decoder.embed_tokens.weight = self.shared.weight
+        if self.config.tie_word_embeddings:
+            self._tie_or_clone_weights(self.encoder.embed_tokens, self.get_input_embeddings())
+            self._tie_or_clone_weights(self.decoder.embed_tokens, self.get_input_embeddings())
 
     @add_start_docstrings_to_model_forward(MBART_INPUTS_DOCSTRING)
     @add_code_sample_docstrings(

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -1184,6 +1184,10 @@ class MBartModel(MBartPreTrainedModel):
     def get_decoder(self):
         return self.decoder
 
+    def _tie_weights(self):
+        self.encoder.embed_tokens.weight = self.shared.weight
+        self.decoder.embed_tokens.weight = self.shared.weight
+
     @add_start_docstrings_to_model_forward(MBART_INPUTS_DOCSTRING)
     @add_code_sample_docstrings(
         checkpoint=_CHECKPOINT_FOR_DOC,


### PR DESCRIPTION
# What does this PR do ? 
Fixes #26266. This PR fixes the tied weights for mbart model. Before this PR, only `lm_head` was tied to `model.shared`. Now, we also make sure to tie `model.encoder.embed_tokens` and `model.decoder.embed_tokens` to `model.shared` by defining the `_tie_weights` method which will be called when we do `model.tie_weights()`. I've checked that we get the same weights at the end. This issue only happens when we load with `safetensors` + `device_map` because we don't save the shared tensors and the weights are on the meta device. 