### PR TITLE
[`core`/  `auto` ] Fix bnb test with code revision + bug with code revision

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -444,7 +444,6 @@ class _BaseAutoModelClass:
             return model_class._from_config(config, **kwargs)
         elif type(config) in cls._model_mapping.keys():
             model_class = _get_model_class(config, cls._model_mapping)
-
             return model_class._from_config(config, **kwargs)
 
         raise ValueError(

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -439,7 +439,6 @@ class _BaseAutoModelClass:
                 model_class.register_for_auto_class(cls.__name__)
             else:
                 cls.register(config.__class__, model_class, exist_ok=True)
-
             _ = kwargs.pop("code_revision", None)
             return model_class._from_config(config, **kwargs)
         elif type(config) in cls._model_mapping.keys():

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -441,9 +441,6 @@ class _BaseAutoModelClass:
                 cls.register(config.__class__, model_class, exist_ok=True)
 
             _ = kwargs.pop("code_revision", None)
-            # Also pop the revision
-            _ = kwargs.pop("revision", None)
-
             return model_class._from_config(config, **kwargs)
         elif type(config) in cls._model_mapping.keys():
             model_class = _get_model_class(config, cls._model_mapping)

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -439,10 +439,15 @@ class _BaseAutoModelClass:
                 model_class.register_for_auto_class(cls.__name__)
             else:
                 cls.register(config.__class__, model_class, exist_ok=True)
+
             _ = kwargs.pop("code_revision", None)
+            # Also pop the revision
+            _ = kwargs.pop("revision", None)
+
             return model_class._from_config(config, **kwargs)
         elif type(config) in cls._model_mapping.keys():
             model_class = _get_model_class(config, cls._model_mapping)
+
             return model_class._from_config(config, **kwargs)
 
         raise ValueError(

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -139,7 +139,7 @@ class MixedInt8Test(BaseMixedInt8Test):
         )
         with init_empty_weights():
             model = AutoModelForCausalLM.from_config(
-                config, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+                config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
             )
         self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
         # without trust_remote_code

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -138,7 +138,9 @@ class MixedInt8Test(BaseMixedInt8Test):
             model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
         )
         with init_empty_weights():
-            model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+            model = AutoModelForCausalLM.from_config(
+                config, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+            )
         self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
         # without trust_remote_code
         config = AutoConfig.from_pretrained(model_id, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")


### PR DESCRIPTION
# What does this PR do?

Fixes a bug that was catched by the bnb test that is currently failing on the main branch

Link to failing job: https://github.com/huggingface/transformers/actions/runs/6307307607/job/17123869223 

(the bug is very niche)

When loading a trust remote code model from a config loaded with a specific revision, one needs to pass that revision to the model class when calling `from_config`

The snippet below:

<details><summary>Click to check the repro snippet</summary>

```python
from accelerate import init_empty_weights

from transformers import AutoModelForCausalLM

model_id = "mosaicml/mpt-7b"
config = AutoConfig.from_pretrained(
    model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
)
with init_empty_weights():
    model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
```

</details>

Returns:

```bash
E           ValueError: The model class you are passing has a `config_class` attribute that is not consistent with the config class you passed (model has <class 'transformers_modules.mosaicml.mpt-7b.0b57768f52b7775563f7cc78c4724e407b39593b.configuration_mpt.MPTConfig'> and you passed <class 'transformers_modules.mosaicml.mpt-7b.72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7.configuration_mpt.MPTConfig'>. Fix one of those so they match!
```

Because for the case of `mosaicml/mpt-7b`, `AutoModelForCausalLM.from_config` will load the model class from the latest commit, which is `0b57768` in the case of that repository. 

Passing a specific revision to `from_config`: 

<details><summary>Click to check the repro snippet</summary>

```python
from accelerate import init_empty_weights

from transformers import AutoModelForCausalLM

model_id = "mosaicml/mpt-7b"
config = AutoConfig.from_pretrained(
    model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
)
with init_empty_weights():
    model = AutoModelForCausalLM.from_config(config, trust_remote_code=True, , revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")
```

</details>

Gives:

```bash
    def _from_config(cls, config, **kwargs):
        """
        All context managers that the model should be initialized under go here.
    
        Args:
            torch_dtype (`torch.dtype`, *optional*):
                Override the default `torch.dtype` and load the model under this dtype.
        """
        torch_dtype = kwargs.pop("torch_dtype", None)
    
        # override default dtype if needed
        dtype_orig = None
        if torch_dtype is not None:
            dtype_orig = cls._set_default_torch_dtype(torch_dtype)
    
        if is_deepspeed_zero3_enabled():
            import deepspeed
    
            logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
            # this immediately partitions the model across all gpus, to avoid the overhead in time
            # and memory copying it on CPU or each GPU first
            with deepspeed.zero.Init(config_dict_or_path=deepspeed_config()):
                model = cls(config, **kwargs)
        else:
>           model = cls(config, **kwargs)
E           TypeError: __init__() got an unexpected keyword argument 'revision'
```

Looking deeper into the code, it seems the argument `code_revision` is popped, I am unsure whether we should use that argument or `revision`. I propose to have an api that is consistent with `revision` behaviour of `from_pretrained` but I am also happy to revert that and simply pass `code_revision` to the test

cc @ArthurZucker @LysandreJik 