### PR TITLE
Avoid class attribute `_keep_in_fp32_modules` being modified

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1142,7 +1142,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         return "pt"
 
     @property
-    def _keep_in_fp32_full_modules(self) -> str:
+    def _keep_in_fp32_full_modules(self) -> list:
         """
         :str: Identifies that this is a PyTorch model.
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1141,6 +1141,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         return "pt"
 
+    @property
+    def _keep_in_fp32_full_modules(self) -> str:
+        """
+        :str: Identifies that this is a PyTorch model.
+        """
+        modules = self._keep_in_fp32_modules
+        modules = modules if modules is not None else []
+        fp32_modules_from_instance = getattr(self, "_keep_in_fp32_modules_in_instance", None)
+        if fp32_modules_from_instance is not None:
+            modules += fp32_modules_from_instance
+
+        modules = modules if len(modules) > 0 else None
+
+        return modules
+
     def __init__(self, config: PretrainedConfig, *inputs, **kwargs):
         super().__init__()
         if not isinstance(config, PretrainedConfig):
@@ -3305,7 +3320,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if use_keep_in_fp32_modules:
             if is_accelerate_available():
                 low_cpu_mem_usage = True
-            keep_in_fp32_modules = model._keep_in_fp32_modules
+            keep_in_fp32_modules = model._keep_in_fp32_full_modules()
         else:
             keep_in_fp32_modules = []
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1152,8 +1152,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if fp32_modules_from_instance is not None:
             modules += fp32_modules_from_instance
 
-        modules = modules if len(modules) > 0 else None
-
         return modules
 
     def __init__(self, config: PretrainedConfig, *inputs, **kwargs):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3320,7 +3320,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if use_keep_in_fp32_modules:
             if is_accelerate_available():
                 low_cpu_mem_usage = True
-            keep_in_fp32_modules = model._keep_in_fp32_full_modules()
+            keep_in_fp32_modules = model._keep_in_fp32_full_modules
         else:
             keep_in_fp32_modules = []
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1148,9 +1148,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         modules = self._keep_in_fp32_modules
         modules = modules if modules is not None else []
-        fp32_modules_from_instance = getattr(self, "_keep_in_fp32_modules_in_instance", None)
-        if fp32_modules_from_instance is not None:
-            modules += fp32_modules_from_instance
+        extra_fp32_modules = getattr(self, "_extra_fp32_modules_in_instance", None)
+        if extra_fp32_modules is not None:
+            modules += extra_fp32_modules
 
         return modules
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1261,7 +1261,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
             self._no_split_modules.extend(language_model._no_split_modules)
 
         if language_model._keep_in_fp32_modules is not None:
-            self._keep_in_fp32_modules.extend(language_model._keep_in_fp32_modules)
+            self._keep_in_fp32_modules_in_instance = language_model._keep_in_fp32_modules
 
         self.language_model = language_model
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1261,7 +1261,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
             self._no_split_modules.extend(language_model._no_split_modules)
 
         if language_model._keep_in_fp32_modules is not None:
-            self._keep_in_fp32_modules_in_instance = language_model._keep_in_fp32_modules
+            self._extra_fp32_modules_in_instance = language_model._keep_in_fp32_modules
 
         self.language_model = language_model
 


### PR DESCRIPTION
# What does this PR do?

Fix #25910

Currently, for `InstructBlip` which can combine/use different architecture as component, we have the following block

https://github.com/huggingface/transformers/blob/abd253103478b21faafb7c9a6e7a1a7d1effe757/src/transformers/models/instructblip/modeling_instructblip.py#L1280-L1281

in order to extent the class attribute `_keep_in_fp32_modules` of `InstructBlipPreTrainedModel`. This modification of class attribute causes some issue:
- loading `Salesforce/instructblip-flan-t5-xl` changes `_keep_in_fp32_modules` from `[]` to `["wo"]`, because the language model is a `T5PreTrainedModel` which has `_keep_in_fp32_modules = ["wo"]`.
  - Then loading `Salesforce/instructblip-vicuna-7b` will keep `qformer.embeddings.word_embeddings.weight` in `fp32`, due to a bug before the fix #26589.
- If we don't load `flan-t5` but just `vicuna`, `qformer.embeddings.word_embeddings.weight` will be in `fp16`.
and the weight values are slightly different -> outputs are different -> CI failure.

**Modifying a class attribute is bad** in general, and we have failing test. This CI tries to incorporate components' in `_keep_in_fp32_modules` without modifying the `_keep_in_fp32_modules` in the parent model class.
