### PR TITLE
Fix `cos_sin` device issue in Falcon model

### DIFF
--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -129,9 +129,15 @@ class FalconRotaryEmbedding(nn.Module):
         total_length = seq_len + past_key_values_length
         if total_length > self.seq_len_cached:
             self._set_cos_sin_cache(total_length, device, dtype)
+
+        # the cached tensors need to update their devices (for example, after we change the model's device)
+        if device != self.cos_cached:
+            self.cos_cached = self.cos_cached.to(device)
+            self.sin_cached = self.sin_cached.to(device)
+
         # Gather cos, sin at the designated position ids
-        cos = self.cos_cached.squeeze(0)[position_ids].to(device)  # [bs, seq_len, dim]
-        sin = self.sin_cached.squeeze(0)[position_ids].to(device)  # [bs, seq_len, dim]
+        cos = self.cos_cached.squeeze(0)[position_ids]  # [bs, seq_len, dim]
+        sin = self.sin_cached.squeeze(0)[position_ids]  # [bs, seq_len, dim]
         return cos, sin
 
     def forward(self, query, key, past_key_values_length, position_ids):

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -131,9 +131,8 @@ class FalconRotaryEmbedding(nn.Module):
             self._set_cos_sin_cache(total_length, device, dtype)
 
         # the cached tensors need to update their devices (for example, after we change the model's device)
-        if device != self.cos_cached:
-            self.cos_cached = self.cos_cached.to(device)
-            self.sin_cached = self.sin_cached.to(device)
+        self.cos_cached = self.cos_cached.to(device)
+        self.sin_cached = self.sin_cached.to(device)
 
         # Gather cos, sin at the designated position ids
         cos = self.cos_cached.squeeze(0)[position_ids]  # [bs, seq_len, dim]

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -130,8 +130,8 @@ class FalconRotaryEmbedding(nn.Module):
         if total_length > self.seq_len_cached:
             self._set_cos_sin_cache(total_length, device, dtype)
         # Gather cos, sin at the designated position ids
-        cos = self.cos_cached.squeeze(0)[position_ids]  # [bs, seq_len, dim]
-        sin = self.sin_cached.squeeze(0)[position_ids]  # [bs, seq_len, dim]
+        cos = self.cos_cached.squeeze(0)[position_ids].to(device)  # [bs, seq_len, dim]
+        sin = self.sin_cached.squeeze(0)[position_ids].to(device)  # [bs, seq_len, dim]
         return cos, sin
 
     def forward(self, query, key, past_key_values_length, position_ids):


### PR DESCRIPTION
# What does this PR do?

We should update the device accordingly. See the comments along the changes.

So far, running the model on GPU, then change model to CPU and running CPU inputs, the cached tensors (like `cos_cached`) will be on GPU and fail to run with CPU tensors.