### PR TITLE
Support loading pre-trained LayoutLM models with device_map argument

### DIFF
--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -508,6 +508,7 @@ class LayoutLMv2PreTrainedModel(PreTrainedModel):
     config_class = LayoutLMv2Config
     pretrained_model_archive_map = LAYOUTLMV2_PRETRAINED_MODEL_ARCHIVE_LIST
     base_model_prefix = "layoutlmv2"
+    _no_split_modules = []
 
     def _init_weights(self, module):
         """Initialize the weights"""

--- a/src/transformers/models/layoutlmv3/modeling_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/modeling_layoutlmv3.py
@@ -357,6 +357,7 @@ class LayoutLMv3PreTrainedModel(PreTrainedModel):
 
     config_class = LayoutLMv3Config
     base_model_prefix = "layoutlmv3"
+    _no_split_modules = []
 
     def _init_weights(self, module):
         """Initialize the weights"""


### PR DESCRIPTION
# What does this PR do?

Loading pre-trained LayoutLMv2 & LayoutLMv3 models with, say `LayoutLMv3Model.from_pretrained(..., device_map="auto")`, currently fails with error message: `ValueError: LayoutLMv3ForTokenClassification does not support `device_map='auto'`. To implement support, the modelclass needs to implement the '_no_split_modules' attribute.`

This PR just implements the `_no_split_modules` attribute to the LayoutLMv2 & LayoutLMv3 model classes as suggested by the error message.


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@NielsRogge, @ArthurZucker 
