### PR TITLE
feat: add trainer label to wandb run upon initialization

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -753,6 +753,7 @@ class WandbCallback(TrainerCallback):
             _watch_model = os.getenv("WANDB_WATCH", "false")
             if not is_torch_tpu_available() and _watch_model in ("all", "parameters", "gradients"):
                 self._wandb.watch(model, log=_watch_model, log_freq=max(100, state.logging_steps))
+            self._wandb.run._label(code="transformers_trainer")
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):
         if self._wandb is None:


### PR DESCRIPTION
# What does this PR do?
This PR adds a telemetry label to the wandb run making it possible to identify W&B usage from the trainer class.
 
ref: https://github.com/huggingface/transformers/pull/25590

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?

## Who can review?
@LysandreJik 


