### PR TITLE
Avoid all-zeor attnetion mask used in testing

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2960,7 +2960,8 @@ def ids_tensor(shape, vocab_size, rng=None, name=None):
 def random_attention_mask(shape, rng=None, name=None):
     attn_mask = ids_tensor(shape, vocab_size=2, rng=None, name=None)
     # make sure that at least one token is attended to for each batch
-    attn_mask[:, -1] = 1
+    # we choose the 1st token so this property of `at least one being non-zero` still holds after applying causal mask
+    attn_mask[:, 0] = 1
     return attn_mask
 
 


### PR DESCRIPTION
# What does this PR do?

The method `random_attention_mask` used in testing makes sure the last token is non-zero. However, this property will be changed if a causal mask is applied.

This causes some issues in CI, see issue reported 

https://github.com/pytorch/pytorch/issues/110213

In general, a sequence with all zero as attention mask is bad. Let's avoid testing with such case.

(However, we probably need to do some processing in the modeling code - if torch decide this is undefined behavior and won't make change to have previous behavior). 