### PR TITLE
[`core`] Fix keep in fp32 silent bug

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1135,7 +1135,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         return "pt"
 
     @property
-    def _keep_in_fp32_full_modules(self) -> str:
+    def _keep_in_fp32_full_modules(self) -> list:
         """
         :str: Identifies that this is a PyTorch model.
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1134,6 +1134,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         return "pt"
 
+    @property
+    def _keep_in_fp32_full_modules(self) -> str:
+        """
+        :str: Identifies that this is a PyTorch model.
+        """
+        modules = self._keep_in_fp32_modules
+        modules = modules if modules is not None else []
+        fp32_modules_from_instance = getattr(self, "_keep_in_fp32_modules_in_instance", None)
+        if fp32_modules_from_instance is not None:
+            modules += fp32_modules_from_instance
+
+        modules = modules if len(modules) > 0 else None
+
+        return modules
+
     def __init__(self, config: PretrainedConfig, *inputs, **kwargs):
         super().__init__()
         if not isinstance(config, PretrainedConfig):
@@ -3070,7 +3085,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if use_keep_in_fp32_modules:
             if is_accelerate_available():
                 low_cpu_mem_usage = True
-            keep_in_fp32_modules = model._keep_in_fp32_modules
+            keep_in_fp32_modules = model._keep_in_fp32_full_modules()
         else:
             keep_in_fp32_modules = []
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1145,8 +1145,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if fp32_modules_from_instance is not None:
             modules += fp32_modules_from_instance
 
-        modules = modules if len(modules) > 0 else None
-
         return modules
 
     def __init__(self, config: PretrainedConfig, *inputs, **kwargs):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3528,7 +3528,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if (
                     keep_in_fp32_modules is not None
                     and dtype == torch.float16
-                    and any(module_to_keep_in_fp32 in key for module_to_keep_in_fp32 in keep_in_fp32_modules)
+                    and any(module_to_keep_in_fp32 in key.split(".") for module_to_keep_in_fp32 in keep_in_fp32_modules)
                 ):
                     target_dtype = torch.float32
 
@@ -3555,7 +3555,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Set some modules to fp32 if any
         if keep_in_fp32_modules is not None:
             for name, param in model.named_parameters():
-                if any(module_to_keep_in_fp32 in name for module_to_keep_in_fp32 in keep_in_fp32_modules):
+                if any(module_to_keep_in_fp32 in name.split(".") for module_to_keep_in_fp32 in keep_in_fp32_modules):
                     # param = param.to(torch.float32) does not work here as only in the local scope.
                     param.data = param.data.to(torch.float32)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3085,7 +3085,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if use_keep_in_fp32_modules:
             if is_accelerate_available():
                 low_cpu_mem_usage = True
-            keep_in_fp32_modules = model._keep_in_fp32_full_modules()
+            keep_in_fp32_modules = model._keep_in_fp32_full_modules
         else:
             keep_in_fp32_modules = []
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1278,7 +1278,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
             self._no_split_modules.extend(language_model._no_split_modules)
 
         if language_model._keep_in_fp32_modules is not None:
-            self._keep_in_fp32_modules.extend(language_model._keep_in_fp32_modules)
+            self._keep_in_fp32_modules_in_instance = language_model._keep_in_fp32_modules
 
         self.language_model = language_model
 


### PR DESCRIPTION
# What does this PR do?

Before this PR we were performing a simple check `if module_name in key` but that lead to some modules silently converted in fp32. 

For example instructblip models got their `word_embedding` layers converted in fp32 because `_keep_in_fp32_modules` includes `"wo"` which is contained in the string `word_embedding`. The fix is to check if `module_name in key.split(".")`

cc @ydshieh 

Related bnb and T5 test all pass

Need to investigate if instructblip tests pass