### PR TITLE
[`PEFT`] Pass token when calling `find_adapter_config`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2480,6 +2480,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
             token = use_auth_token
 
+        if token is not None and "token" not in adapter_kwargs:
+            adapter_kwargs["token"] = token
+
         if use_safetensors is None and not is_safetensors_available():
             use_safetensors = False
 
@@ -2526,7 +2529,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     resume_download=resume_download,
                     proxies=proxies,
                     local_files_only=local_files_only,
-                    token=token,
                     _commit_hash=commit_hash,
                     **adapter_kwargs,
                 )

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -506,10 +506,15 @@ class _BaseAutoModelClass:
         if is_peft_available():
             if adapter_kwargs is None:
                 adapter_kwargs = {}
+                if token is not None:
+                    adapter_kwargs["token"] = token
 
             maybe_adapter_path = find_adapter_config_file(
                 pretrained_model_name_or_path, _commit_hash=commit_hash, **adapter_kwargs
             )
+
+            if token is not None:
+                adapter_kwargs.pop("token")
 
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -514,7 +514,7 @@ class _BaseAutoModelClass:
             )
 
             if token is not None:
-                adapter_kwargs.pop("token")
+                adapter_kwargs.pop("token", None)
 
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -513,9 +513,6 @@ class _BaseAutoModelClass:
                 pretrained_model_name_or_path, _commit_hash=commit_hash, **adapter_kwargs
             )
 
-            if token is not None:
-                adapter_kwargs.pop("token", None)
-
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:
                     adapter_config = json.load(f)


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue that was reported on Spaces. I was not able to reproduce the issue locally though. 
When loading a model with `token=True` (i.e. on a gated or private repository), `find_adapter_config` will try to look for an adapter file inside a private repository without the token, leading to an authentication error. 

The fix is to pass the token to `adapter_kwargs` and remove the duplication here: https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L2529 

cc @LysandreJik 