### PR TITLE
Make `ModelOutput` serializable

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -422,7 +422,7 @@ class ModelOutput(OrderedDict):
         callable, _args, *remaining = super().__reduce__()
         args = tuple(getattr(self, field.name) for field in fields(self))
         return callable, args, *remaining
-    
+
     def to_tuple(self) -> Tuple[Any]:
         """
         Convert self to a tuple containing all the attributes/keys that are not `None`.

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -416,6 +416,13 @@ class ModelOutput(OrderedDict):
         # Don't call self.__setattr__ to avoid recursion errors
         super().__setattr__(key, value)
 
+    def __reduce__(self):
+        if not is_dataclass(self):
+            return super().__reduce__()
+        callable, _args, *remaining = super().__reduce__()
+        args = tuple(getattr(self, field.name) for field in fields(self))
+        return callable, args, *remaining
+    
     def to_tuple(self) -> Tuple[Any]:
         """
         Convert self to a tuple containing all the attributes/keys that are not `None`.


### PR DESCRIPTION
Currently, `@dataclass` `ModelOutput` instances can't be pickled, which can be inconvenient in some situations
This PR fixes this by adding a custom `__reduce__` method to the `ModelOutput` class

Original PR from diffusers : https://github.com/huggingface/diffusers/pull/5234

**EDIT**: Actual use case for me is passing a ModelOutput instance in a multiprocessing queue
(this is needed if a model `__call__` is wrapped inside the ZeroGPU decorator : `model = spaces.GPU(model)`)