### PR TITLE
[Falcon] Fix AutoConfig Tests

### DIFF
--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -590,19 +590,15 @@ class FalconOverrideTest(unittest.TestCase):
 
     def test_config_with_remote_code(self):
         for supported_checkpoint in self.supported_checkpoints:
-            config1 = FalconConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
-            config2 = FalconConfig.from_pretrained(supported_checkpoint)
+            config = FalconConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
 
-            self.assertEqual(config1.model_type, "falcon")
-            self.assertEqual(config1.to_dict(), config2.to_dict())
+            self.assertEqual(config.model_type, "falcon")
 
     def test_auto_config_with_remote_code(self):
         for supported_checkpoint in self.supported_checkpoints:
-            config1 = AutoConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
-            config2 = FalconConfig.from_pretrained(supported_checkpoint)
+            config = AutoConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
 
-            self.assertEqual(config1.model_type, "falcon")
-            self.assertEqual(config1.to_dict(), config2.to_dict())
+            self.assertEqual(config.model_type, "falcon")
 
     def test_config_with_specific_revision(self):
         for supported_checkpoint in self.supported_checkpoints:

--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -592,13 +592,13 @@ class FalconOverrideTest(unittest.TestCase):
         for supported_checkpoint in self.supported_checkpoints:
             config = FalconConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
 
-            self.assertIn(config.model_type, ["RefinedWebModel", "RefinedWeb"])
+            self.assertEqual(config.model_type, "falcon")
 
     def test_auto_config_with_remote_code(self):
         for supported_checkpoint in self.supported_checkpoints:
             config = AutoConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
 
-            self.assertIn(config.model_type, ["RefinedWebModel", "RefinedWeb"])
+            self.assertEqual(config.model_type, "falcon")
 
     def test_config_with_specific_revision(self):
         for supported_checkpoint in self.supported_checkpoints:

--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -590,15 +590,19 @@ class FalconOverrideTest(unittest.TestCase):
 
     def test_config_with_remote_code(self):
         for supported_checkpoint in self.supported_checkpoints:
-            config = FalconConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
+            config1 = FalconConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
+            config2 = FalconConfig.from_pretrained(supported_checkpoint)
 
-            self.assertEqual(config.model_type, "falcon")
+            self.assertEqual(config1.model_type, "falcon")
+            self.assertEqual(config1.to_dict(), config2.to_dict())
 
     def test_auto_config_with_remote_code(self):
         for supported_checkpoint in self.supported_checkpoints:
-            config = AutoConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
+            config1 = AutoConfig.from_pretrained(supported_checkpoint, trust_remote_code=True)
+            config2 = FalconConfig.from_pretrained(supported_checkpoint)
 
-            self.assertEqual(config.model_type, "falcon")
+            self.assertEqual(config1.model_type, "falcon")
+            self.assertEqual(config1.to_dict(), config2.to_dict())
 
     def test_config_with_specific_revision(self):
         for supported_checkpoint in self.supported_checkpoints:


### PR DESCRIPTION
# What does this PR do?

Fixes the auto-config Falcon tests that were failing on `main` after merging #26476. Note that the latest version of the Falcon model on the Hub specifies a model type of `falcon`, following @Rocketknight1's Hub commit [898df13](https://huggingface.co/tiiuae/falcon-7b/commit/898df1396f35e447d5fe44e0a3ccaaaa69f30d36). Thus, we update the config tests in `transformers` to reflect this.

There are still config tests to check that `trust_remote_code` gives the correct configs for older versions (with specific commit ids): https://github.com/huggingface/transformers/blob/0b192de1f353b0e04dad4813e02e2c672de077be/tests/models/falcon/test_modeling_falcon.py#L603