### PR TITLE
feat: change the flow of data preprocess and avoid bug in remove columns

### DIFF
--- a/examples/research_projects/jax-projects/wav2vec2/README.md
+++ b/examples/research_projects/jax-projects/wav2vec2/README.md
@@ -46,6 +46,13 @@ export MODEL_DIR="./wav2vec2-base-robust"
 ln -s ~/transformers/examples/research_projects/jax-projects/wav2vec2/run_wav2vec2_pretrain_flax.py ./
 ```
 
+### Install libraries
+This code requires a minimum version of 2.14.5 for the `datasets` library to run correctly. Therefore, the first step is to upgrade the `datasets` library, and then install any necessary dependencies.
+```bash
+pip install datasets >= 2.14.5
+pip install transformers -U
+```
+
 ### Create the model configuration
 
 Let's first create the model configuration and store it in the model repository. 

--- a/examples/research_projects/jax-projects/wav2vec2/run_wav2vec2_pretrain_flax.py
+++ b/examples/research_projects/jax-projects/wav2vec2/run_wav2vec2_pretrain_flax.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
-from datasets import DatasetDict, load_dataset, Audio
+from datasets import Audio, DatasetDict, load_dataset
 from flax import jax_utils, traverse_util
 from flax.training import train_state
 from flax.training.common_utils import get_metrics, onehot, shard
@@ -332,13 +332,13 @@ def main():
     datasets = datasets.cast_column(data_args.audio_file_column, Audio(sampling_rate=feature_extractor.sampling_rate))
 
     def prepare_dataset(batch):
-        batch["speech"] = batch[data_args.audio_file_column]['array']
+        batch["speech"] = batch[data_args.audio_file_column]["array"]
         return batch
 
     remove_columns_values = datasets["train"].column_names.copy()
-    if 'speech' in set(remove_columns_values):
-        remove_columns_values.remove('speech')
-    
+    if "speech" in set(remove_columns_values):
+        remove_columns_values.remove("speech")
+
     # load audio files into numpy arrays
     vectorized_datasets = datasets.map(
         prepare_dataset, num_proc=data_args.preprocessing_num_workers, remove_columns=remove_columns_values

--- a/examples/research_projects/jax-projects/wav2vec2/run_wav2vec2_pretrain_flax.py
+++ b/examples/research_projects/jax-projects/wav2vec2/run_wav2vec2_pretrain_flax.py
@@ -101,7 +101,7 @@ class DataTrainingArguments:
             )
         },
     )
-    audio_file_column: Optional[str] = field(
+    speech_file_column: Optional[str] = field(
         default="audio",
         metadata={"help": "Column in the dataset that contains audio file. Defaults to 'audio'"},
     )
@@ -329,10 +329,10 @@ def main():
     )
 
     # check that all files have the correct sampling rate
-    datasets = datasets.cast_column(data_args.audio_file_column, Audio(sampling_rate=feature_extractor.sampling_rate))
+    datasets = datasets.cast_column(data_args.speech_file_column, Audio(sampling_rate=feature_extractor.sampling_rate))
 
     def prepare_dataset(batch):
-        batch["speech"] = batch[data_args.audio_file_column]["array"]
+        batch["speech"] = batch[data_args.speech_file_column]["array"]
         return batch
 
     remove_columns_values = datasets["train"].column_names.copy()

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -72,7 +72,7 @@ def _expand_mask(mask: torch.Tensor, dtype: torch.dtype, tgt_len: Optional[int] 
 
 
 # Copied from transformers.models.llama.modeling_llama.LlamaRotaryEmbedding with Llama->Persimmon
-class PersimmonRotaryEmbedding(torch.nn.Module):
+class PersimmonRotaryEmbedding(nn.Module):
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
         super().__init__()
 


### PR DESCRIPTION
# What does this PR do?
I change the data flow of prepare_dataset function, make a case to avoid remove `speech` columns

While examining the 'wav2vec2' workflow, I noticed that the `prepare_dataset` function typically takes the path of audio files and converts them into audio arrays. However, I believe this approach may not be ideal for several reasons:
- Not all data entries contain a `path` column, or the `path` column may not always be correctly populated (e.g., in the case of 'vivos' data). When attempting to use this code with such data, errors can occur.
- This process is somewhat redundant, especially in cases like 'common voice' datasets, where we already have the audio data stored in the `audio` column. In these instances, it would be more efficient to directly pass the audio array to the `speech` column.

To address these issues, I've adjusted the data flow to accept the audio file path as an input column, ensuring that the sampling rate matches the feature extractor's requirements. Additionally, I've created a list of columns to exclude during data processing to prevent inadvertently removing the 'speech' column."

I would like cc @sanchit-gandhi to review my PR.