### PR TITLE
Fix `JumanppTokenizer` to deal with half-width spaces properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ _deps = [
     "ray[tune]",
     "regex!=2019.12.17",
     "requests",
-    "rhoknp>=1.1.0,<1.3.1",
+    "rhoknp>=1.5.0",
     "rjieba",
     "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff>=0.0.241,<=0.0.259",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -58,7 +58,7 @@ deps = {
     "ray[tune]": "ray[tune]",
     "regex": "regex!=2019.12.17",
     "requests": "requests",
-    "rhoknp": "rhoknp>=1.1.0,<1.3.1",
+    "rhoknp": "rhoknp>=1.5.0",
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff>=0.0.241,<=0.0.259",

--- a/tests/models/bert_japanese/test_tokenization_bert_japanese.py
+++ b/tests/models/bert_japanese/test_tokenization_bert_japanese.py
@@ -282,7 +282,7 @@ class BertJapaneseTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             tokenizer.tokenize(" \tｱｯﾌﾟﾙストアでiPhone８ が  \n 発売された　。  "),
             # fmt: off
-            ["アップル", "ストア", "で", "iPhone", "8", "\u3000", "が", "\u3000", "\u3000", "\u3000", "発売", "さ", "れた", "\u3000", "。"],
+            ["アップル", "ストア", "で", "iPhone", "8", " ", "が", " ", " ", " ", "発売", "さ", "れた", " ", "。"],
             # fmt: on
         )
 
@@ -293,7 +293,7 @@ class BertJapaneseTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             tokenizer.tokenize(" \tｱｯﾌﾟﾙストアでiPhone８ が  \n 発売された　。  "),
             # fmt: off
-            ["アップル", "ストア", "で", "iphone", "8", "\u3000", "が", "\u3000", "\u3000", "\u3000", "発売", "さ", "れた", "\u3000", "。"],
+            ["アップル", "ストア", "で", "iphone", "8", " ", "が", " ", " ", " ", "発売", "さ", "れた", " ", "。"],
             # fmt: on
         )
 
@@ -304,7 +304,7 @@ class BertJapaneseTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertListEqual(
             tokenizer.tokenize(" \tｱｯﾌﾟﾙストアでiPhone８ が  \n 発売された　。  "),
             # fmt: off
-            ["ｱ", "ｯ", "ﾌ", "ﾟ", "ﾙ", "ストア", "で", "iPhone", "８", "\u3000", "が", "\u3000", "\u3000", "\u3000", "発売", "さ", "れた", "\u3000", "。"],
+            ["ｱ", "ｯ", "ﾌ", "ﾟ", "ﾙ", "ストア", "で", "iPhone", "８", " ", "が", " ", " ", " ", "発売", "さ", "れた", "　", "。"],
             # fmt: on
         )
 


### PR DESCRIPTION
# What does this PR do?

This PR addresses the issue with the `JumanppTokenizer` that incorrectly handled half-width spaces by replacing them with full-width spaces. This problem originated from a bug in the dependent library, `rhoknp`. This PR resolves this bug by updating `rhoknp` to the latest version.

Before this PR:

```python
>>> tokenizer = JumanppTokenizer()
>>> tokenizer.tokenize("foo\u2009bar")  # \u2009: half-width space
>>> ["foo", "\u3000", "bar"]  # \u3000: full-width space (bug)
```

With this PR:

```python
# With this PR
>>> tokenizer = JumanppTokenizer()
>>> tokenizer.tokenize("foo\u2009bar")  # \u2009: half-width space
>>> ["foo", "\u2009", "bar"]
```

This PR also includes updates to the test cases for `JumanppTokenizer` to ensure its proper functionality.

It's important to note that this PR changes the behavior of `JumanppTokenizer`. Even though the change corrects a bug, some existing models might be built upon the earlier behavior and could be impacted.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker 