### PR TITLE
Warnings controlled by logger level

### DIFF
--- a/docs/source/en/main_classes/logging.md
+++ b/docs/source/en/main_classes/logging.md
@@ -71,6 +71,19 @@ verbose to the most verbose), those levels (with their corresponding int values 
 
 By default, `tqdm` progress bars will be displayed during model download. [`logging.disable_progress_bar`] and [`logging.enable_progress_bar`] can be used to suppress or unsuppress this behavior.
 
+## `logging` vs `warnings`
+
+Python has two logging systems that are often used in conjunction: `logging`, which is explained above, and `warnings`,
+which allows further classification of warnings in specific buckets, e.g., `FutureWarning` for a feature or path
+that has already been deprecated and `DeprecationWarning` to indicate an upcoming deprecation.
+
+We use both in the `transformers` library. We leverage and adapt `logging`'s `captureWarning` method to allow
+management of these warning messages by the verbosity setters above.
+
+See reference of the `captureWarnings` method below.
+
+[[autodoc]] logging.captureWarnings
+
 ## Base setters
 
 [[autodoc]] logging.set_verbosity_error

--- a/docs/source/en/main_classes/logging.md
+++ b/docs/source/en/main_classes/logging.md
@@ -80,6 +80,10 @@ that has already been deprecated and `DeprecationWarning` to indicate an upcomin
 We use both in the `transformers` library. We leverage and adapt `logging`'s `captureWarning` method to allow
 management of these warning messages by the verbosity setters above.
 
+What does that mean for developers of the library? We should respect the following heuristic:
+- `warnings` should be favored for developers of the library and libraries dependent on `transformers`
+- `logging` should be used for end-users of the library using it in every-day projects
+
 See reference of the `captureWarnings` method below.
 
 [[autodoc]] logging.captureWarnings

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -30,6 +30,9 @@ from logging import (
     WARN,  # NOQA
     WARNING,  # NOQA
 )
+from logging import (
+    captureWarnings as _captureWarnings,
+)
 from typing import Optional
 
 import huggingface_hub.utils as hf_hub_utils
@@ -119,6 +122,29 @@ def _reset_library_root_logger() -> None:
 
 def get_log_levels_dict():
     return log_levels
+
+
+def captureWarnings(capture):
+    """
+    Calls the `captureWarnings` method from the logging library to enable management of the warnings emitted by the
+    `warnings` library.
+
+    Read more about this method here:
+    https://docs.python.org/3/library/logging.html#integration-with-the-warnings-module
+
+    All warnings will be logged through the `py.warnings` logger.
+
+    Careful: this method also adds a handler to this logger if it does not already have one, and updates the logging
+    level of that logger to the library's root logger.
+    """
+    logger = get_logger("py.warnings")
+
+    if not logger.handlers:
+        logger.addHandler(_default_handler)
+
+    logger.setLevel(_get_library_root_logger().level)
+
+    _captureWarnings(capture)
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:


### PR DESCRIPTION
This explicitely shows how to control `warnings` using the `logging` level setters in `transformers.

Fix https://github.com/huggingface/transformers/issues/26381