### PR TITLE
[`PEFT`] Protect `adapter_kwargs` check

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2480,7 +2480,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 )
             token = use_auth_token
 
-        if token is not None and "token" not in adapter_kwargs:
+        if token is not None and adapter_kwargs is not None and "token" not in adapter_kwargs:
             adapter_kwargs["token"] = token
 
         if use_safetensors is None and not is_safetensors_available():


### PR DESCRIPTION
# What does this PR do?

Protect `adapter_kwargs` check in case it is excplicitly None

Addresses: https://github.com/huggingface/transformers/pull/26488#issuecomment-1742821190

cc @LysandreJik 

The fix could be also to pop with an empty dict here: https://github.com/huggingface/transformers/blob/main/src/transformers/models/auto/auto_factory.py#L467