### PR TITLE
fix CLIPImageProcessor returns NaNs/Infs when input is a float tensor…

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -340,7 +340,7 @@ def resize(
         )
         # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
         # rescale it back to the original range.
-        resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
+        resized_image = rescale(resized_image, 1 / 255) if do_rescale else rescale(resized_image, 1)
     return resized_image
 
 


### PR DESCRIPTION
… or np.array filled with 0s or 1s, and do_rescale=False

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes a bug that causes image processors like CLIPImageProcessor return NaN/Inf values when an input image is a float tensor/np.array filled with 0s or 1s, and `do_rescale=False`

Reproduction code:
```
from transformers import CLIPImageProcessor
import numpy as np
processor = CLIPImageProcessor.from_pretrained("openai/clip-vit-large-patch14")
image = np.random.randint(0,2,(3,3,3)).astype(np.float32)
print(processor(image, do_rescale=False))
```

With such an input, `image_transform.resize` will return a uint8 image. Due to `do_rescale=False`, the input image for `image_transform.normalize` is also uint8, which makes `std=[0,0,0]` at https://github.com/huggingface/transformers/blob/1b8decb04c246ec8e1c4ba7f2749043d0876d24e/src/transformers/image_transforms.py#L391  
This leads to division-by-zero when the image is normalized
This PR fixes this bug simply by making `image_transform.resize` return a float image for this case

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Could you please review this PR @amyeroberts?
