### PR TITLE
[RFC, Logging] Change warning to info

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1614,7 +1614,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 new_num_tokens = old_embeddings.weight.shape[0]
             new_num_tokens = ((new_num_tokens + pad_to_multiple_of - 1) // pad_to_multiple_of) * pad_to_multiple_of
         else:
-            logger.warning(
+            logger.info(
                 "You are resizing the embedding layer without providing a `pad_to_multiple_of` parameter. This means that the new embedding"
                 f" dimension will be {new_num_tokens}. This might induce some performance reduction as *Tensor Cores* will not be available."
                 " For more details about this, or help on choosing the correct value for resizing, refer to this guide:"


### PR DESCRIPTION
# What does this PR do?

Change warning to info when adding a new text embedding. The reason is that this warning is trigger every time someone runs:

which confuses users: https://github.com/huggingface/diffusers/issues/5212 .

I don't think we should use `pad_to_multiple` here as it would mean that we add 8 new tokens every time we call `load_textual_inversion`
