### PR TITLE
[`FA2`] Cast to correct dtype

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1320,7 +1320,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 "initialise the model on a GPU by passing a device_map that contains only GPU devices as keys."
             )
         config._flash_attn_2_enabled = True
-        config._flash_attn_2_attention_dtype = torch_dtype
+
+        if torch_dtype is not None:
+            config._flash_attn_2_attention_dtype = torch_dtype
+        else:
+            config._flash_attn_2_attention_dtype = torch.float16
         return config
 
     def enable_input_require_grads(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2196,7 +2196,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 elif target_dtype is not None:
                     self.config._flash_attn_2_attention_dtype = target_dtype
 
-
             return super().to(*args, **kwargs)
 
     def half(self, *args):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2178,6 +2178,25 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         else:
+            if getattr(self.config, "_flash_attn_2_enabled", False):
+                target_dtype = None
+
+                if "dtype" not in kwargs:
+                    for arg in args:
+                        if isinstance(arg, torch.dtype):
+                            target_dtype = arg
+                            break
+                else:
+                    target_dtype = kwargs["dtype"]
+
+                if target_dtype is not None and target_dtype == torch.float32:
+                    raise ValueError(
+                        "You cannot cast a model that has been loaded with Flash Attention 2 in `float32`"
+                    )
+                elif target_dtype is not None:
+                    self.config._flash_attn_2_attention_dtype = target_dtype
+
+
             return super().to(*args, **kwargs)
 
     def half(self, *args):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1289,7 +1289,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if torch_dtype is None:
             logger.warning(
-                "You are attempting to use Flash Attention 2.0 without specifying a torch dtype. This might lead to unexpected behaviour"
+                "You are attempting to use Flash Attention 2.0 without specifying a torch dtype. This might lead to unexpected behaviour. Make sure to "
+                "pass `torch_dtype=torch.float16` or `torch_dtype=torch.bfloat16` when initialising the model."
             )
         elif torch_dtype is not None and torch_dtype not in [torch.float16, torch.bfloat16]:
             raise ValueError(
@@ -1319,6 +1320,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 "initialise the model on a GPU by passing a device_map that contains only GPU devices as keys."
             )
         config._flash_attn_2_enabled = True
+        config._flash_attn_2_attention_dtype = torch_dtype
         return config
 
     def enable_input_require_grads(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2175,6 +2175,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         else:
+            # TODO: @younesbelkada find a better way to do this directly in `xxxFlashAttention` modules
+            # currently it is not possible to retrieve the original dtype for quantized models.
             if getattr(self.config, "_flash_attn_2_enabled", False):
                 target_dtype = None
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1321,10 +1321,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
         config._flash_attn_2_enabled = True
 
-        if torch_dtype is not None:
-            config._flash_attn_2_attention_dtype = torch_dtype
-        else:
-            config._flash_attn_2_attention_dtype = torch.float16
+        config._flash_attn_2_attention_dtype = torch_dtype if torch_dtype is not None else torch.float16
         return config
 
     def enable_input_require_grads(self):

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -613,10 +613,7 @@ class FalconFlashAttention2(FalconAttention):
         # cast them back in float16 just to be sure everything works as expected.
         input_dtype = query_layer.dtype
         if input_dtype == torch.float32:
-            if getattr(self.config, "_flash_attn_2_attention_dtype", None) is not None:
-                attention_dtype = self.config._flash_attn_2_attention_dtype
-            else:
-                attention_dtype = torch.float16
+            attention_dtype = self.config._flash_attn_2_attention_dtype
 
             logger.warning_once(
                 f"The input hidden states seems to be silently casted in float32, this might be related to"

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -476,10 +476,7 @@ class LlamaFlashAttention2(LlamaAttention):
         # in fp32. (LlamaRMSNorm handles it correctly)
         input_dtype = query_states.dtype
         if input_dtype == torch.float32:
-            if getattr(self.config, "_flash_attn_2_attention_dtype", None) is not None:
-                attention_dtype = self.config._flash_attn_2_attention_dtype
-            else:
-                attention_dtype = torch.float16
+            attention_dtype = self.config._flash_attn_2_attention_dtype
 
             logger.warning_once(
                 f"The input hidden states seems to be silently casted in float32, this might be related to"

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -476,15 +476,20 @@ class LlamaFlashAttention2(LlamaAttention):
         # in fp32. (LlamaRMSNorm handles it correctly)
         input_dtype = query_states.dtype
         if input_dtype == torch.float32:
+            if getattr(self.config, "_flash_attn_2_attention_dtype", None) is not None:
+                attention_dtype = self.config._flash_attn_2_attention_dtype
+            else:
+                attention_dtype = torch.float16
+
             logger.warning_once(
-                "The input hidden states seems to be silently casted in float32, this might be related to"
-                " the fact you have upcasted embedding or layer norm layers in float32. We will cast back the input in"
-                " float16."
+                f"The input hidden states seems to be silently casted in float32, this might be related to"
+                f" the fact you have upcasted embedding or layer norm layers in float32. We will cast back the input in"
+                f" {attention_dtype}. Make sure to pass the desired dtype when calling `from_pretrained` with `torch_dtype=your_dtype`"
             )
 
-            query_states = query_states.to(torch.float16)
-            key_states = key_states.to(torch.float16)
-            value_states = value_states.to(torch.float16)
+            query_states = query_states.to(attention_dtype)
+            key_states = key_states.to(attention_dtype)
+            value_states = value_states.to(attention_dtype)
 
         attn_output = self._flash_attention_forward(
             query_states, key_states, value_states, padding_mask, q_len, dropout=dropout_rate

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -411,10 +411,7 @@ class MistralFlashAttention2(MistralAttention):
         # cast them back in float16 just to be sure everything works as expected.
         input_dtype = query_states.dtype
         if input_dtype == torch.float32:
-            if getattr(self.config, "_flash_attn_2_attention_dtype", None) is not None:
-                attention_dtype = self.config._flash_attn_2_attention_dtype
-            else:
-                attention_dtype = torch.float16
+            attention_dtype = self.config._flash_attn_2_attention_dtype
 
             logger.warning_once(
                 f"The input hidden states seems to be silently casted in float32, this might be related to"


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/26451

Currently performing bf16 fine-tuning with FA-2 leads to hidden states silently being casted in float16
As it is challenging to retrieve the original dtype of the model in case the model is quantized, I propose to store that dtype in a private attribute to be able to retrieve it conveniently without having to perform any sort of hack that gets the correct dtype if the model is quantized


