### PR TITLE
#26566 swin2 sr allow in out channels

### DIFF
--- a/src/transformers/models/swin2sr/configuration_swin2sr.py
+++ b/src/transformers/models/swin2sr/configuration_swin2sr.py
@@ -107,7 +107,8 @@ class Swin2SRConfig(PretrainedConfig):
         self,
         image_size=64,
         patch_size=1,
-        num_channels=3,
+        num_channels_in=3,
+        num_channels_out=3,
         embed_dim=180,
         depths=[6, 6, 6, 6, 6, 6],
         num_heads=[6, 6, 6, 6, 6, 6],
@@ -131,7 +132,8 @@ class Swin2SRConfig(PretrainedConfig):
 
         self.image_size = image_size
         self.patch_size = patch_size
-        self.num_channels = num_channels
+        self.num_channels_in = num_channels_in
+        self.num_channels_out = num_channels_out
         self.embed_dim = embed_dim
         self.depths = depths
         self.num_layers = len(depths)

--- a/src/transformers/models/swin2sr/configuration_swin2sr.py
+++ b/src/transformers/models/swin2sr/configuration_swin2sr.py
@@ -44,8 +44,8 @@ class Swin2SRConfig(PretrainedConfig):
             The size (resolution) of each patch.
         num_channels (`int`, *optional*, defaults to 3):
             The number of input channels.
-        num_channels_out (`int`, *optional*, defaults to 3):
-            The number of output channels.
+        num_channels_out (`int`, *optional*, defaults to `None`):
+            The number of output channels. If not set, it will be set to `num_channels`.
         embed_dim (`int`, *optional*, defaults to 180):
             Dimensionality of patch embedding.
         depths (`list(int)`, *optional*, defaults to `[6, 6, 6, 6, 6, 6]`):
@@ -110,7 +110,7 @@ class Swin2SRConfig(PretrainedConfig):
         image_size=64,
         patch_size=1,
         num_channels=3,
-        num_channels_out=3,
+        num_channels_out=None,
         embed_dim=180,
         depths=[6, 6, 6, 6, 6, 6],
         num_heads=[6, 6, 6, 6, 6, 6],
@@ -135,7 +135,7 @@ class Swin2SRConfig(PretrainedConfig):
         self.image_size = image_size
         self.patch_size = patch_size
         self.num_channels = num_channels
-        self.num_channels_out = num_channels_out
+        self.num_channels_out = num_channels if num_channels_out is None else num_channels_out
         self.embed_dim = embed_dim
         self.depths = depths
         self.num_layers = len(depths)

--- a/src/transformers/models/swin2sr/configuration_swin2sr.py
+++ b/src/transformers/models/swin2sr/configuration_swin2sr.py
@@ -44,7 +44,7 @@ class Swin2SRConfig(PretrainedConfig):
             The size (resolution) of each patch.
         num_channels (`int`, *optional*, defaults to 3):
             The number of input channels.
-        num_channels_out (`int`, *optional*, defaults to `None`):
+        num_channels_out (`int`, *optional*, defaults to `num_channels`):
             The number of output channels. If not set, it will be set to `num_channels`.
         embed_dim (`int`, *optional*, defaults to 180):
             Dimensionality of patch embedding.

--- a/src/transformers/models/swin2sr/configuration_swin2sr.py
+++ b/src/transformers/models/swin2sr/configuration_swin2sr.py
@@ -42,7 +42,7 @@ class Swin2SRConfig(PretrainedConfig):
             The size (resolution) of each image.
         patch_size (`int`, *optional*, defaults to 1):
             The size (resolution) of each patch.
-        num_channels_in (`int`, *optional*, defaults to 3):
+        num_channels (`int`, *optional*, defaults to 3):
             The number of input channels.
         num_channels_out (`int`, *optional*, defaults to 3):
             The number of output channels.
@@ -109,7 +109,7 @@ class Swin2SRConfig(PretrainedConfig):
         self,
         image_size=64,
         patch_size=1,
-        num_channels_in=3,
+        num_channels=3,
         num_channels_out=3,
         embed_dim=180,
         depths=[6, 6, 6, 6, 6, 6],
@@ -134,7 +134,7 @@ class Swin2SRConfig(PretrainedConfig):
 
         self.image_size = image_size
         self.patch_size = patch_size
-        self.num_channels_in = num_channels_in
+        self.num_channels = num_channels
         self.num_channels_out = num_channels_out
         self.embed_dim = embed_dim
         self.depths = depths

--- a/src/transformers/models/swin2sr/configuration_swin2sr.py
+++ b/src/transformers/models/swin2sr/configuration_swin2sr.py
@@ -42,8 +42,10 @@ class Swin2SRConfig(PretrainedConfig):
             The size (resolution) of each image.
         patch_size (`int`, *optional*, defaults to 1):
             The size (resolution) of each patch.
-        num_channels (`int`, *optional*, defaults to 3):
+        num_channels_in (`int`, *optional*, defaults to 3):
             The number of input channels.
+        num_channels_out (`int`, *optional*, defaults to 3):
+            The number of output channels.
         embed_dim (`int`, *optional*, defaults to 180):
             Dimensionality of patch embedding.
         depths (`list(int)`, *optional*, defaults to `[6, 6, 6, 6, 6, 6]`):

--- a/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
+++ b/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
@@ -43,7 +43,6 @@ def get_config(checkpoint_url):
         config.upsampler = "nearest+conv"
     elif "Swin2SR_Jpeg_dynamic" in checkpoint_url:
         config.num_channels = 1
-        config.num_channels_out = 1
         config.upscale = 1
         config.image_size = 126
         config.window_size = 7

--- a/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
+++ b/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
@@ -42,7 +42,8 @@ def get_config(checkpoint_url):
         config.upscale = 4
         config.upsampler = "nearest+conv"
     elif "Swin2SR_Jpeg_dynamic" in checkpoint_url:
-        config.num_channels = 1
+        config.num_channels_in = 1
+        config.num_channels_out = 1
         config.upscale = 1
         config.image_size = 126
         config.window_size = 7
@@ -191,7 +192,7 @@ def convert_swin2sr_checkpoint(checkpoint_url, pytorch_dump_folder_path, push_to
     )
     pixel_values = transforms(image).unsqueeze(0)
 
-    if config.num_channels == 1:
+    if config.num_channels_in == 1:
         pixel_values = pixel_values[:, 0, :, :].unsqueeze(1)
 
     outputs = model(pixel_values)

--- a/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
+++ b/src/transformers/models/swin2sr/convert_swin2sr_original_to_pytorch.py
@@ -42,7 +42,7 @@ def get_config(checkpoint_url):
         config.upscale = 4
         config.upsampler = "nearest+conv"
     elif "Swin2SR_Jpeg_dynamic" in checkpoint_url:
-        config.num_channels_in = 1
+        config.num_channels = 1
         config.num_channels_out = 1
         config.upscale = 1
         config.image_size = 126
@@ -192,7 +192,7 @@ def convert_swin2sr_checkpoint(checkpoint_url, pytorch_dump_folder_path, push_to
     )
     pixel_values = transforms(image).unsqueeze(0)
 
-    if config.num_channels_in == 1:
+    if config.num_channels == 1:
         pixel_values = pixel_values[:, 0, :, :].unsqueeze(1)
 
     outputs = model(pixel_values)

--- a/src/transformers/models/swin2sr/modeling_swin2sr.py
+++ b/src/transformers/models/swin2sr/modeling_swin2sr.py
@@ -81,7 +81,6 @@ class Swin2SREncoderOutput(ModelOutput):
     attentions: Optional[Tuple[torch.FloatTensor]] = None
 
 
-# Copied from transformers.models.swin.modeling_swin.window_partition but adapted
 def window_partition(input_feature, window_size):
     """
     Partitions the given input into windows.
@@ -211,8 +210,6 @@ class Swin2SRPatchUnEmbeddings(nn.Module):
         embeddings = embeddings.transpose(1, 2).view(batch_size, self.embed_dim, x_size[0], x_size[1])  # B Ph*Pw C
         return embeddings
 
-
-# Copied from transformers.models.swinv2.modeling_swinv2.Swinv2PatchMerging with Swinv2->Swin2SR
 class Swin2SRPatchMerging(nn.Module):
     """
     Patch Merging Layer.

--- a/src/transformers/models/swin2sr/modeling_swin2sr.py
+++ b/src/transformers/models/swin2sr/modeling_swin2sr.py
@@ -210,6 +210,7 @@ class Swin2SRPatchUnEmbeddings(nn.Module):
         embeddings = embeddings.transpose(1, 2).view(batch_size, self.embed_dim, x_size[0], x_size[1])  # B Ph*Pw C
         return embeddings
 
+
 class Swin2SRPatchMerging(nn.Module):
     """
     Patch Merging Layer.

--- a/src/transformers/models/swin2sr/modeling_swin2sr.py
+++ b/src/transformers/models/swin2sr/modeling_swin2sr.py
@@ -259,7 +259,9 @@ class Swin2SRPatchMerging(nn.Module):
         input_feature_3 = input_feature[:, 1::2, 1::2, :]
         # [batch_size, height/2 * width/2, 4*num_channels]
         input_feature = torch.cat([input_feature_0, input_feature_1, input_feature_2, input_feature_3], -1)
-        input_feature = input_feature.view(batch_size, -1, 4 * num_channels_in)  # [batch_size, height/2 * width/2, 4*C]
+        input_feature = input_feature.view(
+            batch_size, -1, 4 * num_channels_in
+        )  # [batch_size, height/2 * width/2, 4*C]
 
         input_feature = self.reduction(input_feature)
         input_feature = self.norm(input_feature)

--- a/src/transformers/models/swin2sr/modeling_swin2sr.py
+++ b/src/transformers/models/swin2sr/modeling_swin2sr.py
@@ -849,7 +849,7 @@ class Swin2SRModel(Swin2SRPreTrainedModel):
         super().__init__(config)
         self.config = config
 
-        if config.num_channels == 3:
+        if config.num_channels == 3 and config.num_channels_out == 3:
             rgb_mean = (0.4488, 0.4371, 0.4040)
             self.mean = torch.Tensor(rgb_mean).view(1, 3, 1, 1)
         else:

--- a/tests/models/swin2sr/test_modeling_swin2sr.py
+++ b/tests/models/swin2sr/test_modeling_swin2sr.py
@@ -46,6 +46,7 @@ class Swin2SRModelTester:
         image_size=32,
         patch_size=1,
         num_channels=3,
+        num_channels_out=1,
         embed_dim=16,
         depths=[1, 2, 1],
         num_heads=[2, 2, 4],
@@ -70,6 +71,7 @@ class Swin2SRModelTester:
         self.image_size = image_size
         self.patch_size = patch_size
         self.num_channels = num_channels
+        self.num_channels_out = num_channels_out
         self.embed_dim = embed_dim
         self.depths = depths
         self.num_heads = num_heads
@@ -110,6 +112,7 @@ class Swin2SRModelTester:
             image_size=self.image_size,
             patch_size=self.patch_size,
             num_channels=self.num_channels,
+            num_channels_out=self.num_channels_out,
             embed_dim=self.embed_dim,
             depths=self.depths,
             num_heads=self.num_heads,
@@ -145,7 +148,7 @@ class Swin2SRModelTester:
 
         expected_image_size = self.image_size * self.upscale
         self.parent.assertEqual(
-            result.reconstruction.shape, (self.batch_size, self.num_channels, expected_image_size, expected_image_size)
+            result.reconstruction.shape, (self.batch_size, self.num_channels_out, expected_image_size, expected_image_size)
         )
 
     def prepare_config_and_inputs_for_common(self):

--- a/tests/models/swin2sr/test_modeling_swin2sr.py
+++ b/tests/models/swin2sr/test_modeling_swin2sr.py
@@ -148,7 +148,8 @@ class Swin2SRModelTester:
 
         expected_image_size = self.image_size * self.upscale
         self.parent.assertEqual(
-            result.reconstruction.shape, (self.batch_size, self.num_channels_out, expected_image_size, expected_image_size)
+            result.reconstruction.shape,
+            (self.batch_size, self.num_channels_out, expected_image_size, expected_image_size),
         )
 
     def prepare_config_and_inputs_for_common(self):


### PR DESCRIPTION
# What does this PR do?

This PR adds the feature of accepting arbitary number of input and output channels when using the Swin2SR model. This allows to perform super resolution from greyscale (1 channel) to color (rgb), or from low resolution multi band satellite to high resolution rgb satellite.

All examples and pretrained models are running as expected based on my tests. No new dependencies have been added.

Just use it like

```python
from transformers import Swin2SRForImageSuperResolution, Swin2SRConfig
import torch

Swin2SRConfig = (
     num_channels_in=1,
     num_channels_out=3
)
model = Swin2SRForImageSuperResolution(Swin2SRConfig)

with torch.no_grad():
    # or use the image preprocessor per default
    out = model({"pixel_values":torch.randn((1,1,264,264))})

```

Fixes #26566.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Yes [here](https://github.com/huggingface/transformers/issues/26566)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? No, test where there already.


## Tagging the reviewers

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts

