### PR TITLE
Fix encoder->decoder typo bug in convert_t5x_checkpoint_to_pytorch.py

### DIFF
--- a/src/transformers/models/t5/convert_t5x_checkpoint_to_pytorch.py
+++ b/src/transformers/models/t5/convert_t5x_checkpoint_to_pytorch.py
@@ -139,7 +139,7 @@ def convert_t5x_to_pytorch(variables: dict, *, num_layers: int, is_encoder_only:
                 new[f"decoder.block.{i}.layer.2.DenseReluDense.wi_0.weight"] = wi[0].T
                 new[f"decoder.block.{i}.layer.2.DenseReluDense.wi_1.weight"] = wi[1].T
             else:
-                new[f"encoder.block.{i}.layer.2.DenseReluDense.wi.weight"] = wi.T
+                new[f"decoder.block.{i}.layer.2.DenseReluDense.wi.weight"] = wi.T
             new[f"decoder.block.{i}.layer.2.DenseReluDense.wo.weight"] = wo.T
 
         new["decoder.final_layer_norm.weight"] = old["decoder/decoder_norm/scale"]


### PR DESCRIPTION
# What does this PR do?
The convert_t5x_checkpoint_to_pytorch is used to convert t5x models into pytorch models.
However, it contains a typo at [line 142](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/convert_t5x_checkpoint_to_pytorch.py#L142): The wi weights in **decoder** is converted to weights in **encoder**, and it makes the following errors when we run the script **for t5 v1.0 models** (where Split MLP layers is false and uses T5DenseActDense(wi) instead of T5DenseGatedActDense(wi_0, wi_1) is run:

```
 File "/opt/conda/envs/myenv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1497, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for T5ForConditionalGeneration:
        Missing key(s) in state_dict: "decoder.block.0.layer.2.DenseReluDense.wi.weight", "decoder.block.1.layer.2.DenseReluDense.wi.weight", "decoder.block.2.layer.2.DenseReluDense.wi.weight", "decoder.block.3.layer.2.DenseReluDense.wi.weight", "decoder.block.4.layer.2.DenseReluDense.wi.weight", "decoder.block.5.layer.2.DenseReluDense.wi.weight", "decoder.block.6.layer.2.DenseReluDense.wi.weight", "decoder.block.7.layer.2.DenseReluDense.wi.weight", "decoder.block.8.layer.2.DenseReluDense.wi.weight", "decoder.block.9.layer.2.DenseReluDense.wi.weight", "decoder.block.10.layer.2.DenseReluDense.wi.weight", "decoder.block.11.layer.2.DenseReluDense.wi.weight".
        Unexpected key(s) in state_dict: "encoder.block.0.layer.2.DenseReluDense.wi.weight", "encoder.block.1.layer.2.DenseReluDense.wi.weight", "encoder.block.2.layer.2.DenseReluDense.wi.weight", "encoder.block.3.layer.2.DenseReluDense.wi.weight", "encoder.block.4.layer.2.DenseReluDense.wi.weight", "encoder.block.5.layer.2.DenseReluDense.wi.weight", "encoder.block.6.layer.2.DenseReluDense.wi.weight", "encoder.block.7.layer.2.DenseReluDense.wi.weight", "encoder.block.8.layer.2.DenseReluDense.wi.weight", "encoder.block.9.layer.2.DenseReluDense.wi.weight", "encoder.block.10.layer.2.DenseReluDense.wi.weight", "encoder.block.11.layer.2.DenseReluDense.wi.weight".
```

The following is the changed part:
```
            if split_mlp_wi:

                new[f"decoder.block.{i}.layer.2.DenseReluDense.wi_0.weight"] = wi[0].T

                new[f"decoder.block.{i}.layer.2.DenseReluDense.wi_1.weight"] = wi[1].T

            else:

                new[f"encoder.block.{i}.layer.2.DenseReluDense.wi.weight"] = wi.T
```

When changing the following line from 
```
new[f"encoder.block.{i}.layer.2.DenseReluDense.wi.weight"] = wi.T
```
to 
```
new[f"decoder.block.{i}.layer.2.DenseReluDense.wi.weight"] = wi.T
``` 
the code works fine.


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Related pull request seems to be [this one](https://github.com/huggingface/transformers/pull/20801), 
so tagging the original author @basting and the one mentioned in that PR:
@patrickvonplaten
@sanchit-gandhi
@ArthurZucker
@younesbelkada

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.



Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
