### PR TITLE
fix RoPE t range issue for fp16

### DIFF
--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -108,7 +108,7 @@ class FalconRotaryEmbedding(nn.Module):
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
         self.seq_len_cached = seq_len
-        t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+        t = torch.arange(seq_len, device=device).to(dtype)
         freqs = torch.einsum("i,j->ij", t, self.inv_freq)
         emb = torch.cat((freqs, freqs), dim=-1).to(device)
 
@@ -171,7 +171,7 @@ class FalconLinearScalingRotaryEmbedding(FalconRotaryEmbedding):
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
         self.seq_len_cached = seq_len
-        t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+        t = torch.arange(seq_len, device=device).to(dtype)
         # This line is the only difference from FalconRotaryEmbedding._set_cos_sin_cache
         t = t / self.scaling_factor
 
@@ -208,7 +208,7 @@ class FalconDynamicNTKScalingRotaryEmbedding(FalconRotaryEmbedding):
             inv_freq = 1.0 / (base ** (torch.arange(0, self.head_dim, 2).float().to(device) / self.head_dim))
             self.register_buffer("inv_freq", inv_freq, persistent=False)
 
-        t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+        t = torch.arange(seq_len, device=device).to(dtype)
         freqs = torch.einsum("i,j->ij", t, self.inv_freq)
         emb = torch.cat((freqs, freqs), dim=-1).to(device)
 


### PR DESCRIPTION
#### Issue
Sometimes training with `fp16`, the `dtype` of `self.inv_freq` will be changed from `fp32` to `fp16`. This scenario will cause the position `t` to use dtype of `fp16`, like
```
t = torch.arange(seq_len, device=device, dtype=torch.float16)
```

After converting to onnx graph, however, Range Ops  in `onnx` do not support `fp16` as [here](https://github.com/onnx/onnx/blob/e11dacfa9930eafd3b34391ef5422d09ba9896dc/onnx/defs/generator/defs.cc#L488-L557)

#### Update

Use the below to avoid this scenario

```
t = torch.arange(seq_len, device=device).to(dtype)
```

