### PR TITLE
Don't install `pytorch-quantization` in Doc Builder docker file

### DIFF
--- a/docker/transformers-doc-builder/Dockerfile
+++ b/docker/transformers-doc-builder/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y update && apt-get install -y libsndfile1-dev && apt install -y te
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed]
 
 RUN python3 -m pip install --no-cache-dir torchvision git+https://github.com/facebookresearch/detectron2.git pytesseract
-RUN python3 -m pip install --no-cache-dir pytorch-quantization --extra-index-url https://pypi.ngc.nvidia.com
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 
 # Test if the image could successfully build the doc. before publishing the image


### PR DESCRIPTION
# What does this PR do?

Doc builder docker image build starts to fail with

```
The package you are trying to install is only a placeholder project on PyPI.org repository.
This package is hosted on NVIDIA Python Package Index.
  
This package can be installed as:

$ pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com/ pytorch-quantization
```

I tried to install it with the suggested command, but the doc build step will fail with some cuda libary issue.
(when building `transformers/docs/source/en/model_doc/qdqbert.md`)

**I removed the line that installs `pytorch-quantization` and doc build can pass (and docker image built).**