### PR TITLE
🎉 Add prompt tuning for bigcode models

### DIFF
--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -409,6 +409,10 @@ class GPTBigCodePreTrainedModel(PreTrainedModel):
         if isinstance(module, GPTBigCodeModel):
             module.gradient_checkpointing = value
 
+    @property
+    def word_embeddings(self):
+        return self.transformer.wte
+
 
 GPT_BIGCODE_START_DOCSTRING = r"""
 


### PR DESCRIPTION
# What does this PR do?

Enables prompt tuning for BigCode models.
Currently, prompt tuning for bigcode models fail due to this error AttributeError (no GPTBigCodeForCausalLM has no attribute named `word_embeddings`).

@ArthurZucker, @younesbelkada, @pacman100 