### PR TITLE
Make fsdp ram efficient loading optional

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -125,6 +125,7 @@ def is_fsdp_enabled():
         torch.distributed.is_available()
         and torch.distributed.is_initialized()
         and strtobool(os.environ.get("ACCELERATE_USE_FSDP", "False")) == 1
+        and strtobool(os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING", "False")) == 1
     )
 
 


### PR DESCRIPTION
# What does this PR do?
1. Make fsdp ram efficient loading optional. Certain models are having issues when handling meta devices during pre-trained model loading. Fixes https://github.com/huggingface/accelerate/issues/1948 and https://github.com/huggingface/accelerate/issues/2031 by making the ram efficient loading optional.
2. This PR should be merged after PR https://github.com/huggingface/accelerate/pull/2037 is merged.