### PR TITLE
Avoid CI OOM

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -311,7 +311,7 @@ torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager git+https://github.com/huggingface/accelerate",
     ],
     parallelism=1,
-    pytest_num_workers=8,
+    pytest_num_workers=6,
 )
 
 
@@ -347,6 +347,7 @@ pipelines_torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm,video]",
     ],
     marker="is_pipeline_test",
+    pytest_num_workers=6,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

The torch and torch pipeline job again (almost) reach the limit of CircleCI runner's RAM (16 G).

torch pipeline job crashed [nightly run here](https://app.circleci.com/pipelines/github/huggingface/transformers/74561/workflows/5c4e2b07-0688-4d86-bac6-85250ebbd741/jobs/944985)

A screenshot (of [another run](https://app.circleci.com/pipelines/github/huggingface/transformers/74427/workflows/d5130b1e-0bec-4b41-867c-7dd61722434e/jobs/942978/resources))

<img width="1061" alt="Screenshot 2023-10-06 175412" src="https://github.com/huggingface/transformers/assets/2521628/2f9dc0b6-3a0d-46a6-88c6-bd1e787f06b6">

Let's use 6 workers for now: I will try to find time to investigate what happens recently.