### PR TITLE
remove the obsolete code related to fairscale FSDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1835,12 +1835,6 @@ class Trainer:
 
                         if is_sagemaker_mp_enabled() and args.fp16:
                             self.optimizer.clip_master_grads(args.max_grad_norm)
-                        elif hasattr(self.optimizer, "clip_grad_norm"):
-                            # Some optimizers (like the sharded optimizer) have a specific way to do gradient clipping
-                            self.optimizer.clip_grad_norm(args.max_grad_norm)
-                        elif hasattr(model, "clip_grad_norm_"):
-                            # Some models (like FullyShardedDDP) have a specific way to do gradient clipping
-                            model.clip_grad_norm_(args.max_grad_norm)
                         elif self.use_apex:
                             # Revert to normal clipping otherwise, handling Apex or full precision
                             nn.utils.clip_grad_norm_(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1376,10 +1376,7 @@ class TrainingArguments:
 
         if self.bf16:
             if self.half_precision_backend == "apex":
-                raise ValueError(
-                    " `--half_precision_backend apex`: GPU bf16 is not supported by apex. Use"
-                    " `--half_precision_backend auto` instead"
-                )
+                raise ValueError(" `--half_precision_backend apex`: GPU bf16 is not supported by apex.")
 
         if self.lr_scheduler_type == SchedulerType.REDUCE_ON_PLATEAU:
             if self.evaluation_strategy == IntervalStrategy.NO:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1378,7 +1378,7 @@ class TrainingArguments:
             if self.half_precision_backend == "apex":
                 raise ValueError(
                     " `--half_precision_backend apex`: GPU bf16 is not supported by apex. Use"
-                    " `--half_precision_backend cuda_amp` instead"
+                    " `--half_precision_backend auto` instead"
                 )
 
         if self.lr_scheduler_type == SchedulerType.REDUCE_ON_PLATEAU:


### PR DESCRIPTION
# What does this PR do?

As the title says, this PR introduces two modifications:
1. remove the gradient clipping code related to fairscale FSDP, as fairscale FSDP has been removed. See: https://github.com/huggingface/transformers/pull/25702 
2. updated the error message when mixing `--bf16` and `--half_precision_backend apex` as the `cuda_amp` option is no longer available. I'm not sure how to write it more appropriately, so I just use `auto` instead.

