### PR TITLE
Generate: New `Cache` abstraction and Attention Sinks support

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -368,3 +368,20 @@ A [`Constraint`] can be used to force the generation to include specific tokens 
 [[autodoc]] TextStreamer
 
 [[autodoc]] TextIteratorStreamer
+
+## Caches
+
+[[autodoc]] Cache
+    - update
+
+[[autodoc]] DynamicCache
+    - update
+    - get_seq_length
+    - reorder_cache
+    - to_legacy_cache
+    - from_legacy_cache
+
+[[autodoc]] SinkCache
+    - update
+    - get_seq_length
+    - reorder_cache

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1303,7 +1303,7 @@ else:
     _import_structure["activations"] = []
     _import_structure["benchmark.benchmark"] = ["PyTorchBenchmark"]
     _import_structure["benchmark.benchmark_args"] = ["PyTorchBenchmarkArguments"]
-    _import_structure["cache_utils"] = []
+    _import_structure["cache_utils"] = ["Cache", "DynamicCache", "SinkCache"]
     _import_structure["data.datasets"] = [
         "GlueDataset",
         "GlueDataTrainingArguments",
@@ -5946,6 +5946,7 @@ if TYPE_CHECKING:
         # Benchmarks
         from .benchmark.benchmark import PyTorchBenchmark
         from .benchmark.benchmark_args import PyTorchBenchmarkArguments
+        from .cache_utils import Cache, DynamicCache, SinkCache
         from .data.datasets import (
             GlueDataset,
             GlueDataTrainingArguments,

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1303,6 +1303,7 @@ else:
     _import_structure["activations"] = []
     _import_structure["benchmark.benchmark"] = ["PyTorchBenchmark"]
     _import_structure["benchmark.benchmark_args"] = ["PyTorchBenchmarkArguments"]
+    _import_structure["cache_utils"] = []
     _import_structure["data.datasets"] = [
         "GlueDataset",
         "GlueDataTrainingArguments",

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -13,7 +13,14 @@ class Cache(ABC):
         self.value_cache: Dict[int, Tuple[torch.Tensor]] = {}
 
     @abstractmethod
-    def update(self, key_states, value_states, layer_idx: int) -> None:
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cos: Optional[torch.Tensor] = None,
+        sin: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         pass
 
     def get_seq_length(self, layer_idx: int = 0) -> int:
@@ -46,7 +53,14 @@ class Cache(ABC):
 
 
 class DynamicCache(Cache):
-    def update(self, key_states: torch.Tensor, value_states: torch.Tensor, layer_idx: int) -> None:
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cos: Optional[torch.Tensor] = None,
+        sin: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         if layer_idx not in self.key_cache:
             self.key_cache[layer_idx] = key_states
             self.value_cache[layer_idx] = value_states
@@ -57,47 +71,95 @@ class DynamicCache(Cache):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
 
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_single(
+    key_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, position_ids: Optional[torch.IntTensor] = None
+) -> torch.Tensor:
+    if position_ids:
+        cos = cos[position_ids].unsqueeze(1)  # [seq_len, dim] -> [batch_size, 1, seq_len, head_dim]
+        sin = sin[position_ids].unsqueeze(1)
+    rotated_key_states = (key_states * cos) + (rotate_half(key_states) * sin)
+    return rotated_key_states
+
+
 class SinkCache(Cache):
     def __init__(self, window_length: int, num_sink_tokens: int) -> None:
         super().__init__()
-        self.is_prefill = False
         self.window_length = window_length
         self.num_sink_tokens = num_sink_tokens
-        self.index = torch.arange(num_sink_tokens, window_length)
+        self.cos_sin_cache = {}
 
-    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor, layer_idx: int) -> None:
-        # idx is either 0 for key, 1 for values
+    def get_rerotation_cos_sin(
+        self, key_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if key_states.shape[-2] not in self.cos_sin_cache:
+            # Upcast to float32 temporarily for better accuracy
+            cos = cos.to(torch.float32)
+            sin = sin.to(torch.float32)
+
+            # Compute the cos and sin required for back- and forward-rotating to one position earlier in the sequence
+            original_cos = cos[self.num_sink_tokens + key_states.shape[-2] :]
+            shifted_cos = cos[self.num_sink_tokens : -key_states.shape[-2]]
+            original_sin = sin[self.num_sink_tokens + key_states.shape[-2] :]
+            shifted_sin = sin[self.num_sink_tokens : -key_states.shape[-2]]
+            rerotation_cos = original_cos * shifted_cos + original_sin * shifted_sin
+            rerotation_sin = -original_sin * shifted_cos + original_cos * shifted_sin
+
+            self.cos_sin_cache[key_states.shape[-2]] = (
+                rerotation_cos.to(key_states.dtype).unsqueeze(0),
+                rerotation_sin.to(key_states.dtype).unsqueeze(0),
+            )
+        return self.cos_sin_cache[key_states.shape[-2]]
+
+    def get_seq_length(self, layer_idx: int = 0) -> int:
+        # Workaround to make 'key_states.shape[-2] + past_key_value.get_seq_length(self.layer_idx)' <= window_length
+        return min(super().get_seq_length(layer_idx), self.window_length - 1)
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cos: Optional[torch.Tensor] = None,
+        sin: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # [bsz, num_heads, seq_len, head_dim]
         if layer_idx not in self.key_cache:
-            # first in
-            sink_keys = key_states[: self.num_sink_tokens]
-            sink_values = value_states[: self.num_sink_tokens]
+            # Empty cache
+            self.key_cache[layer_idx] = key_states
+            self.value_cache[layer_idx] = value_states
 
-            cached_keys = torch.cat([sink_keys, key_states[:, -self.window_length :]], dim=-1)
-            cached_values = torch.cat([sink_values, value_states[:, -self.window_length :]], dim=-1)
+        elif key_states.shape[-2] + self.get_seq_length(layer_idx) < self.window_length:
+            # Growing cache
+            self.key_cache[layer_idx] = torch.cat([self.key_cache[layer_idx], key_states], dim=-2)
+            self.value_cache[layer_idx] = torch.cat([self.value_cache[layer_idx], value_states], dim=-2)
 
-            self.key_cache[layer_idx] = torch.cat([cached_keys[None, :], cached_values[None, :]], dim=0)
-        elif key_states.shape[1] < self.index.shape[-1] + self.num_sink_tokens:
-            # auto-regressive
-            key_len = key_states.shape[1]
-
-            # roll cache to the left
-            self.key_cache[layer_idx]._index_copy(
-                0, self.index[:key_len], self.key_cache[layer_idx][0][self.num_sink_tokens + key_len :]
-            )
-            self.key_cache[layer_idx]._index_copy(
-                1, self.index[:key_len], self.key_cache[layer_idx][1][self.num_sink_tokens + key_len :]
-            )
-
-            # add new tokens
-            self.key_cache[layer_idx]._index_copy(0, self.index[-key_len:], key_states)
-            self.key_cache[layer_idx]._index_copy(1, self.index[-key_len:], value_states)
         else:
-            self.key_cache[layer_idx]._index_copy(
-                0, self.index, key_states[:, : self.window_length - self.num_sink_tokens]
-            )
-            self.key_cache[layer_idx]._index_copy(
-                1, self.index, value_states[:, : self.window_length - self.num_sink_tokens]
-            )
+            # Shifting cache
+            rotated_keys = self.key_cache[layer_idx][
+                :, :, -self.window_length + self.num_sink_tokens + key_states.shape[-2] :
+            ]
+            rerotation_cos, rerotation_sin = self.get_rerotation_cos_sin(key_states, cos, sin)
+            rerotated_keys = apply_rotary_pos_emb_single(rotated_keys, rerotation_cos, rerotation_sin)
 
-    def update(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
-        pass
+            # Concatenate sink tokens, shifted & rotated tokens, and new tokens
+            self.key_cache[layer_idx] = torch.cat(
+                [self.key_cache[layer_idx][:, :, : self.num_sink_tokens], rerotated_keys, key_states], dim=-2
+            )
+            self.value_cache[layer_idx] = torch.cat(
+                [
+                    self.value_cache[layer_idx][:, :, : self.num_sink_tokens],
+                    self.value_cache[layer_idx][
+                        :, :, -self.window_length + self.num_sink_tokens + value_states.shape[-2] :
+                    ],
+                    value_states,
+                ],
+                dim=-2,
+            )
+        return self.key_cache[layer_idx], self.value_cache[layer_idx]

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -171,7 +171,7 @@ class SinkCache(Cache):
         rotated_key_states = (key_states * cos) + (self._rotate_half(key_states) * sin)
         return rotated_key_states
 
-    def get_rerotation_cos_sin(
+    def _get_rerotation_cos_sin(
         self, key_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if key_states.shape[-2] not in self.cos_sin_cache:
@@ -255,10 +255,10 @@ class SinkCache(Cache):
                 rerotation_cos, rerotation_sin = self._get_rerotation_cos_sin(key_states, cos, sin)
                 if partial_rotation_size is not None:
                     keys_to_keep, keys_pass = (
-                        key_states[..., :partial_rotation_size],
-                        key_states[..., partial_rotation_size:],
+                        keys_to_keep[..., :partial_rotation_size],
+                        keys_to_keep[..., partial_rotation_size:],
                     )
-                keys_to_keep = self.apply_key_rotary_pos_emb(keys_to_keep, rerotation_cos, rerotation_sin)
+                keys_to_keep = self._apply_key_rotary_pos_emb(keys_to_keep, rerotation_cos, rerotation_sin)
                 if partial_rotation_size is not None:
                     keys_to_keep = torch.cat((keys_to_keep, keys_pass), dim=-1)
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -35,20 +35,12 @@ class Cache(ABC):
         )
 
     @classmethod
-    def from_past_key_values(cls, past_key_values: Optional[List[torch.FloatTensor]]) -> "DynamicCache":
+    def from_legacy_cache(cls, past_key_values: Optional[List[torch.FloatTensor]]) -> "DynamicCache":
         if past_key_values is None:
             return cls()
         cache = cls()
         for layer_idx, (key_states, value_states) in enumerate(zip(*past_key_values)):
             cache.update(key_states, value_states, layer_idx)
-        return cache
-
-    @classmethod
-    def from_past_key_value(cls, past_key_value: Optional[torch.FloatTensor]) -> "DynamicCache":
-        if past_key_value is None:
-            return cls()
-        cache = cls()
-        cache.update(past_key_value[0], past_key_value[1], 0)
         return cache
 
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1,0 +1,89 @@
+from abc import ABC, abstractmethod
+from typing import Dict, List, Tuple, TypeVar
+import torch
+
+T = TypeVar("T")
+
+
+class Cache(ABC):
+    def __init__(self) -> None:
+        self.cache: Dict[int, Tuple[torch.Tensor]] = {}
+        self.layer_idx = 0
+
+    @abstractmethod
+    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+        pass
+
+    @abstractmethod
+    def update(self, key_states, value_states) -> None:
+        pass
+
+    def __getitem__(self, index: int):
+        return self.cache[self.layer_idx][index]
+
+    def set_layer_idx(self, layer_idx: int) -> None:
+        self.layer_idx = layer_idx
+
+    def __bool__(self) -> bool:
+        return bool(self.cache) and self.layer_idx in self.cache
+
+class DynamicCache(Cache):
+    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+        pass
+
+    def update(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+        kv_states = torch.cat([key_states[None, :], value_states[None, :]], dim=0)
+        if self.layer_idx not in self.cache:
+            self.cache[self.layer_idx] = kv_states
+        else:
+            self.cache[self.layer_idx] = torch.cat([self.cache[self.layer_idx], kv_states], dim=-2)
+
+    @classmethod
+    def from_past_key_values(cls, past_key_values: List[torch.FloatTensor]) -> "DynamicCache":
+        raise NotImplementedError()
+
+
+class SinkCache(Cache):
+    def __init__(self, window_length: int, num_sink_tokens: int) -> None:
+        super().__init__()
+        self.is_prefill = False
+        self.window_length = window_length
+        self.num_sink_tokens = num_sink_tokens
+        self.index = torch.arange(num_sink_tokens, window_length)
+
+    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+        # idx is either 0 for key, 1 for values
+        if self.layer_idx not in self.cache:
+            # first in
+            sink_keys = key_states[: self.num_sink_tokens]
+            sink_values = value_states[: self.num_sink_tokens]
+
+            cached_keys = torch.cat([sink_keys, key_states[:, -self.window_length :]], dim=-1)
+            cached_values = torch.cat([sink_values, value_states[:, -self.window_length :]], dim=-1)
+
+            self.cache[self.layer_idx] = torch.cat([cached_keys[None, :], cached_values[None, :]], dim=0)
+        elif key_states.shape[1] < self.index.shape[-1] + self.num_sink_tokens:
+            # auto-regressive
+            key_len = key_states.shape[1]
+
+            # roll cache to the left
+            self.cache[self.layer_idx]._index_copy(
+                0, self.index[:key_len], self.cache[self.layer_idx][0][self.num_sink_tokens + key_len :]
+            )
+            self.cache[self.layer_idx]._index_copy(
+                1, self.index[:key_len], self.cache[self.layer_idx][1][self.num_sink_tokens + key_len :]
+            )
+
+            # add new tokens
+            self.cache[self.layer_idx]._index_copy(0, self.index[-key_len:], key_states)
+            self.cache[self.layer_idx]._index_copy(1, self.index[-key_len:], value_states)
+        else:
+            self.cache[self.layer_idx]._index_copy(
+                0, self.index, key_states[:, : self.window_length - self.num_sink_tokens]
+            )
+            self.cache[self.layer_idx]._index_copy(
+                1, self.index, value_states[:, : self.window_length - self.num_sink_tokens]
+            )
+
+    def update(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+        pass

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -9,8 +9,8 @@ class Cache:
         key_states: torch.Tensor,
         value_states: torch.Tensor,
         layer_idx: int,
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
+        cos: Optional[torch.Tensor] = None,    # needed for models having RoPE position embeddings
+        sin: Optional[torch.Tensor] = None,    # needed for models having RoPE position embeddings
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Make sure to implement `update` in a subclass.")
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1,46 +1,60 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple, TypeVar
+from typing import Dict, List, Optional, Tuple, TypeVar
+
 import torch
+
 
 T = TypeVar("T")
 
 
 class Cache(ABC):
     def __init__(self) -> None:
-        self.cache: Dict[int, Tuple[torch.Tensor]] = {}
-        self.layer_idx = 0
+        self.key_cache: Dict[int, Tuple[torch.Tensor]] = {}
+        self.value_cache: Dict[int, Tuple[torch.Tensor]] = {}
 
     @abstractmethod
-    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+    def update(self, key_states, value_states, layer_idx: int) -> None:
         pass
 
-    @abstractmethod
-    def update(self, key_states, value_states) -> None:
-        pass
+    def get_seq_length(self, layer_idx: int = 0) -> int:
+        if layer_idx not in self.key_cache:
+            return 0
+        return self.key_cache[layer_idx].shape[-2]
 
-    def __getitem__(self, index: int):
-        return self.cache[self.layer_idx][index]
-
-    def set_layer_idx(self, layer_idx: int) -> None:
-        self.layer_idx = layer_idx
-
-    def __bool__(self) -> bool:
-        return bool(self.cache) and self.layer_idx in self.cache
-
-class DynamicCache(Cache):
-    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
-        pass
-
-    def update(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
-        kv_states = torch.cat([key_states[None, :], value_states[None, :]], dim=0)
-        if self.layer_idx not in self.cache:
-            self.cache[self.layer_idx] = kv_states
-        else:
-            self.cache[self.layer_idx] = torch.cat([self.cache[self.layer_idx], kv_states], dim=-2)
+    def to_legacy_cache(self) -> Tuple[Tuple[torch.Tensor], Tuple[torch.Tensor]]:
+        return (
+            tuple(self.key_cache[layer_idx] for layer_idx in range(len(self.key_cache))),
+            tuple(self.value_cache[layer_idx] for layer_idx in range(len(self.value_cache))),
+        )
 
     @classmethod
-    def from_past_key_values(cls, past_key_values: List[torch.FloatTensor]) -> "DynamicCache":
-        raise NotImplementedError()
+    def from_past_key_values(cls, past_key_values: Optional[List[torch.FloatTensor]]) -> "DynamicCache":
+        if past_key_values is None:
+            return cls()
+        cache = cls()
+        for layer_idx, (key_states, value_states) in enumerate(zip(*past_key_values)):
+            cache.update(key_states, value_states, layer_idx)
+        return cache
+
+    @classmethod
+    def from_past_key_value(cls, past_key_value: Optional[torch.FloatTensor]) -> "DynamicCache":
+        if past_key_value is None:
+            return cls()
+        cache = cls()
+        cache.update(past_key_value[0], past_key_value[1], 0)
+        return cache
+
+
+class DynamicCache(Cache):
+    def update(self, key_states: torch.Tensor, value_states: torch.Tensor, layer_idx: int) -> None:
+        if layer_idx not in self.key_cache:
+            self.key_cache[layer_idx] = key_states
+            self.value_cache[layer_idx] = value_states
+        else:
+            self.key_cache[layer_idx] = torch.cat([self.key_cache[layer_idx], key_states], dim=-2)
+            self.value_cache[layer_idx] = torch.cat([self.value_cache[layer_idx], value_states], dim=-2)
+
+        return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
 
 class SinkCache(Cache):
@@ -51,9 +65,9 @@ class SinkCache(Cache):
         self.num_sink_tokens = num_sink_tokens
         self.index = torch.arange(num_sink_tokens, window_length)
 
-    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
+    def update_pre_rotation(self, key_states: torch.Tensor, value_states: torch.Tensor, layer_idx: int) -> None:
         # idx is either 0 for key, 1 for values
-        if self.layer_idx not in self.cache:
+        if layer_idx not in self.key_cache:
             # first in
             sink_keys = key_states[: self.num_sink_tokens]
             sink_values = value_states[: self.num_sink_tokens]
@@ -61,27 +75,27 @@ class SinkCache(Cache):
             cached_keys = torch.cat([sink_keys, key_states[:, -self.window_length :]], dim=-1)
             cached_values = torch.cat([sink_values, value_states[:, -self.window_length :]], dim=-1)
 
-            self.cache[self.layer_idx] = torch.cat([cached_keys[None, :], cached_values[None, :]], dim=0)
+            self.key_cache[layer_idx] = torch.cat([cached_keys[None, :], cached_values[None, :]], dim=0)
         elif key_states.shape[1] < self.index.shape[-1] + self.num_sink_tokens:
             # auto-regressive
             key_len = key_states.shape[1]
 
             # roll cache to the left
-            self.cache[self.layer_idx]._index_copy(
-                0, self.index[:key_len], self.cache[self.layer_idx][0][self.num_sink_tokens + key_len :]
+            self.key_cache[layer_idx]._index_copy(
+                0, self.index[:key_len], self.key_cache[layer_idx][0][self.num_sink_tokens + key_len :]
             )
-            self.cache[self.layer_idx]._index_copy(
-                1, self.index[:key_len], self.cache[self.layer_idx][1][self.num_sink_tokens + key_len :]
+            self.key_cache[layer_idx]._index_copy(
+                1, self.index[:key_len], self.key_cache[layer_idx][1][self.num_sink_tokens + key_len :]
             )
 
             # add new tokens
-            self.cache[self.layer_idx]._index_copy(0, self.index[-key_len:], key_states)
-            self.cache[self.layer_idx]._index_copy(1, self.index[-key_len:], value_states)
+            self.key_cache[layer_idx]._index_copy(0, self.index[-key_len:], key_states)
+            self.key_cache[layer_idx]._index_copy(1, self.index[-key_len:], value_states)
         else:
-            self.cache[self.layer_idx]._index_copy(
+            self.key_cache[layer_idx]._index_copy(
                 0, self.index, key_states[:, : self.window_length - self.num_sink_tokens]
             )
-            self.cache[self.layer_idx]._index_copy(
+            self.key_cache[layer_idx]._index_copy(
                 1, self.index, value_states[:, : self.window_length - self.num_sink_tokens]
             )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3984,7 +3984,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._temporary_reorder_cache(
-                    model_kwargs["past_key_values"], beam_idx
+                    model_kwargs["past_key_values"], reordering_indices
                 )
 
             # increase cur_len

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3258,10 +3258,10 @@ class GenerationMixin:
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
+
+            breakpoint()
             if model_kwargs["past_key_values"] is not None:
                 self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
-            if cur_len == 8:
-                breakpoint()
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -24,6 +24,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from ..cache_utils import DynamicCache
 from ..integrations.deepspeed import is_deepspeed_zero3_enabled
 from ..modeling_outputs import CausalLMOutputWithPast, Seq2SeqLMOutput
 from ..models.auto import (
@@ -3226,6 +3227,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if not model_kwargs.get("use_legacy_cache"):
+                    model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3561,6 +3564,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if not model_kwargs.get("use_legacy_cache"):
+                    model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3948,6 +3953,8 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
+                if not model_kwargs.get("use_legacy_cache"):
+                    model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             # increase cur_len
             cur_len = cur_len + 1
@@ -4288,6 +4295,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                if not model_kwargs.get("use_legacy_cache"):
+                    model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3191,6 +3191,7 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
+            breakpoint()
 
             if synced_gpus and this_peer_finished:
                 cur_len = cur_len + 1

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3191,7 +3191,6 @@ class GenerationMixin:
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
             )
-            breakpoint()
 
             if synced_gpus and this_peer_finished:
                 cur_len = cur_len + 1
@@ -3261,6 +3260,8 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
+            if cur_len == 8:
+                breakpoint()
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3227,7 +3227,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache"):
+                if not model_kwargs.get("use_legacy_cache", True):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3564,7 +3564,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache"):
+                if not model_kwargs.get("use_legacy_cache", True):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3953,7 +3953,7 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
-                if not model_kwargs.get("use_legacy_cache"):
+                if not model_kwargs.get("use_legacy_cache", True):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             # increase cur_len
@@ -4295,7 +4295,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache"):
+                if not model_kwargs.get("use_legacy_cache", True):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -24,7 +24,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
-from ..cache_utils import DynamicCache, Cache
+from ..cache_utils import Cache, DynamicCache
 from ..integrations.deepspeed import is_deepspeed_zero3_enabled
 from ..modeling_outputs import CausalLMOutputWithPast, Seq2SeqLMOutput
 from ..models.auto import (
@@ -3227,7 +3227,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(past_key_values, Cache):
+                if not isinstance(model_kwargs["past_key_values"], Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3564,7 +3564,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(past_key_values, Cache):
+                if not isinstance(model_kwargs["past_key_values"], Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3953,7 +3953,7 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
-                if not isinstance(past_key_values, Cache):
+                if not isinstance(model_kwargs["past_key_values"], Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             # increase cur_len
@@ -4295,7 +4295,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(past_key_values, Cache):
+                if not isinstance(model_kwargs["past_key_values"], Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3226,8 +3226,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
+                using_new_cache = isinstance(model_kwargs["past_key_values"], Cache)
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(model_kwargs["past_key_values"], Cache):
+                if using_new_cache:
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3563,8 +3564,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
+                using_new_cache = isinstance(model_kwargs["past_key_values"], Cache)
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(model_kwargs["past_key_values"], Cache):
+                if using_new_cache:
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3950,10 +3952,11 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
+                using_new_cache = isinstance(model_kwargs["past_key_values"], Cache)
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
-                if not isinstance(model_kwargs["past_key_values"], Cache):
+                if using_new_cache:
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             # increase cur_len
@@ -4294,8 +4297,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
+                using_new_cache = isinstance(model_kwargs["past_key_values"], Cache)
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not isinstance(model_kwargs["past_key_values"], Cache):
+                if using_new_cache:
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2969,7 +2969,7 @@ class GenerationMixin:
         """
         model_class = self.__class__.__name__.lower()
         # Exception 1: code path for models using the legacy cache format
-        if isinstance(past_key_values, tuple):
+        if isinstance(past_key_values, (tuple, list)):
             past_key_values = self._reorder_cache(past_key_values, beam_idx)
         # Exception 2: models with different cache formats. These are limited to `DynamicCache` until their
         # cache format is standardized, to avoid adding complexity to the codebase.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -24,7 +24,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
-from ..cache_utils import DynamicCache
+from ..cache_utils import DynamicCache, Cache
 from ..integrations.deepspeed import is_deepspeed_zero3_enabled
 from ..modeling_outputs import CausalLMOutputWithPast, Seq2SeqLMOutput
 from ..models.auto import (
@@ -3227,7 +3227,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache", True):
+                if not isinstance(past_key_values, Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3564,7 +3564,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache", True):
+                if not isinstance(past_key_values, Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:
@@ -3953,7 +3953,7 @@ class GenerationMixin:
                 model_kwargs["past_key_values"] = self._reorder_cache(
                     model_kwargs["past_key_values"], reordering_indices
                 )
-                if not model_kwargs.get("use_legacy_cache", True):
+                if not isinstance(past_key_values, Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             # increase cur_len
@@ -4295,7 +4295,7 @@ class GenerationMixin:
             )
             if model_kwargs["past_key_values"] is not None:
                 model_kwargs["past_key_values"] = self._reorder_cache(model_kwargs["past_key_values"], beam_idx)
-                if not model_kwargs.get("use_legacy_cache", True):
+                if not isinstance(past_key_values, Cache):
                     model_kwargs["past_key_values"] = DynamicCache.from_legacy_cache(model_kwargs["past_key_values"])
 
             if return_dict_in_generate and output_scores:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2962,7 +2962,7 @@ class GenerationMixin:
 
     def _temporary_reorder_cache(self, past_key_values, beam_idx):
         """
-        Temporary function to handle the different types of cache reordering processes.
+        Temporary function to handle the different types of cache reordering processes while we roll out `Cache`.
 
         TODO: standardize cache formats and make all models compatible with `Cache`. It would remove the need
         for this function, with `Cache.reorder_cache` being the sole remaining code path
@@ -3258,10 +3258,10 @@ class GenerationMixin:
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
-
-            breakpoint()
             if model_kwargs["past_key_values"] is not None:
-                self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                model_kwargs["past_key_values"] = self._temporary_reorder_cache(
+                    model_kwargs["past_key_values"], beam_idx
+                )
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3596,7 +3596,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
-                self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                model_kwargs["past_key_values"] = self._temporary_reorder_cache(
+                    model_kwargs["past_key_values"], beam_idx
+                )
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))
@@ -3981,7 +3983,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
-                self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                model_kwargs["past_key_values"] = self._temporary_reorder_cache(
+                    model_kwargs["past_key_values"], beam_idx
+                )
 
             # increase cur_len
             cur_len = cur_len + 1
@@ -4321,7 +4325,9 @@ class GenerationMixin:
                 outputs, model_kwargs, is_encoder_decoder=self.config.is_encoder_decoder
             )
             if model_kwargs["past_key_values"] is not None:
-                self._temporary_reorder_cache(model_kwargs["past_key_values"], beam_idx)
+                model_kwargs["past_key_values"] = self._temporary_reorder_cache(
+                    model_kwargs["past_key_values"], beam_idx
+                )
 
             if return_dict_in_generate and output_scores:
                 beam_indices = tuple((beam_indices[beam_idx[i]] + (beam_idx[i],) for i in range(len(beam_indices))))

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1128,6 +1128,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     # Flash Attention 2 support
     _supports_flash_attn_2 = False
 
+    # Has support for a `Cache` instance as `past_key_values`
+    _supports_cache_class = False
+
     @property
     def dummy_inputs(self) -> Dict[str, torch.Tensor]:
         """

--- a/src/transformers/models/deprecated/open_llama/modeling_open_llama.py
+++ b/src/transformers/models/deprecated/open_llama/modeling_open_llama.py
@@ -860,7 +860,6 @@ class OpenLlamaForCausalLM(OpenLlamaPreTrainedModel):
     """,
     OPEN_LLAMA_START_DOCSTRING,
 )
-# Copied from transformers.models.llama.modeling_llama.LlamaForSequenceClassification with LLAMA->OPEN_LLAMA,Llama->OpenLlama
 class OpenLlamaForSequenceClassification(OpenLlamaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -393,7 +393,7 @@ class LlamaAttention(nn.Module):
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
-        key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx)
+        key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
 
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
@@ -933,7 +933,7 @@ class LlamaModel(LlamaPreTrainedModel):
         all_self_attns = () if output_attentions else None
         next_decoder_cache = None
 
-        for idx, decoder_layer in enumerate(self.layers):
+        for decoder_layer in self.layers:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1066,7 +1066,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
         "Hey, are you conscious? Can you talk to me?\nI'm not conscious, but I can talk to you."
         ```"""
-
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -403,7 +403,8 @@ class LlamaAttention(nn.Module):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
@@ -830,8 +831,8 @@ LLAMA_INPUTS_DOCSTRING = r"""
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as described input above. Otherwise, will return
-            a subclass of `Cache`
+            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
+            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -394,8 +394,8 @@ class LlamaAttention(nn.Module):
         if past_key_value is not None:
             if self.layer_idx is None:
                 raise ValueError(
-                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
-                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -29,12 +29,12 @@ from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
+from ...cache_utils import Cache, DynamicCache
 from ...modeling_attn_mask_utils import (
     AttentionMaskConverter,
     _prepare_4d_attention_mask,
     _prepare_4d_causal_attention_mask,
 )
-from ...cache_utils import Cache, DynamicCache
 from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast, SequenceClassifierOutputWithPast
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import ALL_LAYERNORM_LAYERS, is_torch_greater_or_equal_than_1_13

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -509,7 +509,8 @@ class LlamaFlashAttention2(LlamaAttention):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # TODO: These transpose are quite inefficient but Flash Attention requires the layout [batch_size, sequence_length, num_heads, head_dim]. We would need to refactor the KV cache
         # to be able to avoid many of these transpose/reshape/view.

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -28,14 +28,13 @@ import torch.utils.checkpoint
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
-from transformers.cache_utils import Cache, DynamicCache
-
 from ...activations import ACT2FN
 from ...modeling_attn_mask_utils import (
     AttentionMaskConverter,
     _prepare_4d_attention_mask,
     _prepare_4d_causal_attention_mask,
 )
+from ...cache_utils import Cache, DynamicCache
 from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast, SequenceClassifierOutputWithPast
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import ALL_LAYERNORM_LAYERS, is_torch_greater_or_equal_than_1_13
@@ -288,11 +287,8 @@ class LlamaAttention(nn.Module):
     def __init__(self, config: LlamaConfig, layer_idx: Optional[int] = None):
         super().__init__()
         self.config = config
-<<<<<<< HEAD
         self.attention_dropout = config.attention_dropout
-=======
         self.layer_idx = layer_idx
->>>>>>> 1129513b3 (Address numerous PR suggestions)
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.head_dim = self.hidden_size // self.num_heads

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1129,10 +1129,20 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Discard tokens already processed in the cache
-            input_ids = input_ids[:, past_length:]
+            # Keep only the unprocessed tokens:
+            # 1 - If the length of the attention_mask exceeds the length of input_ids, then we are in a setting where
+            # some of the inputs are exclusivelly passed as part of the cache (e.g. when passing input_embeds as
+            # input)
+            if attention_mask is not None and attention_mask.shape[1] > input_ids.shape[1]:
+                input_ids = input_ids[:, -(attention_mask.shape[1] - past_length) :]
+            # 2 - If the past_length is smaller than input_ids', then input_ids holds all input tokens. We can discard
+            # input_ids based on the past_length.
+            elif past_length < input_ids.shape[1]:
+                input_ids = input_ids[:, past_length:]
+            # 3 - Otherwise (past_length >= input_ids.shape[1]), let's assume input_ids only has unprocessed tokens.
 
-            # If the cache is smaller than the attention mask, let's discard the older values
+            # If the cache has seen more tokens than it can hold, then the cache has a size limit. Let's discard the
+            # older attention values, as their corresponding values are not part of the input.
             if cache_length < past_length and attention_mask is not None:
                 attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -284,10 +284,17 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 class LlamaAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
-    def __init__(self, config: LlamaConfig, layer_idx: int):
+    def __init__(self, config: LlamaConfig, layer_idx: Optional[int] = None):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
         self.attention_dropout = config.attention_dropout
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
@@ -385,6 +392,12 @@ class LlamaAttention(nn.Module):
 
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    "with a layer index."
+                )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -866,7 +866,7 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = None,
+        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -1022,7 +1022,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = None,
+        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1105,7 +1105,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         )
 
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, use_legacy_cache=None, **kwargs
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, use_legacy_cache=True, **kwargs
     ):
         if past_key_values is not None:
             past_length = past_key_values[0][0].shape[2]
@@ -1198,7 +1198,7 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = None,
+        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, SequenceClassifierOutputWithPast]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -756,6 +756,7 @@ class LlamaPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["LlamaDecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
+    _supports_cache_class = True
 
     def _init_weights(self, module):
         std = self.config.initializer_range
@@ -804,13 +805,19 @@ LLAMA_INPUTS_DOCSTRING = r"""
             config.n_positions - 1]`.
 
             [What are position IDs?](../glossary#position-ids)
-        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
-            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and 2 additional tensors of shape
-            `(batch_size, num_heads, decoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`Cache` or `tuple(tuple(torch.FloatTensor))`, *optional*):
+            Pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
+            blocks) that can be used to speed up sequential decoding. This typically consists in the `past_key_values`
+            returned by the model at a previous stage of decoding, when `use_cache=True` or `config.use_cache=True`.
 
-            Contains pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
-            blocks) that can be used (see `past_key_values` input) to speed up sequential decoding.
+            Two formats are allowed:
+            - a [`~cache_utils.Cache`] instance;
+            - Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of
+            shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`). This is also known as the legacy
+            cache format.
+
+            The model will output the same cache format that is fed as input. If no `past_key_values` are passed, the
+            legacy cache format will be returned.
 
             If `past_key_values` are used, the user can optionally input only the last `input_ids` (those that don't
             have their past key value states given to this model) of shape `(batch_size, 1)` instead of all `input_ids`
@@ -830,9 +837,6 @@ LLAMA_INPUTS_DOCSTRING = r"""
             more detail.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
-        use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
-            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 
@@ -881,7 +885,6 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -903,7 +906,8 @@ class LlamaModel(LlamaPreTrainedModel):
 
         past_key_values_length = 0
         if use_cache:
-            if not isinstance(past_key_values, Cache):
+            use_legacy_cache = not isinstance(past_key_values, Cache)
+            if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
             past_key_values_length = past_key_values.get_seq_length()
 
@@ -1036,7 +1040,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1081,7 +1084,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
 
         hidden_states = outputs[0]
@@ -1119,10 +1121,13 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         )
 
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, use_legacy_cache=True, **kwargs
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
         if past_key_values is not None:
-            past_length = past_key_values[0][0].shape[2]
+            if isinstance(past_key_values, Cache):
+                past_length = past_key_values.get_seq_length()
+            else:
+                past_length = past_key_values[0][0].shape[2]
 
             # Some generation methods already pass only the last input ID
             if input_ids.shape[1] > past_length:
@@ -1153,7 +1158,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,
-                "use_legacy_cache": use_legacy_cache,
             }
         )
         return model_inputs
@@ -1212,7 +1216,6 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, SequenceClassifierOutputWithPast]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
@@ -1232,7 +1235,6 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1124,18 +1124,17 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
     ):
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
-                past_length = past_key_values.get_seq_length()
+                cache_length = past_key_values.get_seq_length()
+                past_length = past_key_values.seen_tokens
             else:
-                past_length = past_key_values[0][0].shape[2]
+                cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Some generation methods already pass only the last input ID
-            if input_ids.shape[1] > past_length:
-                remove_prefix_length = past_length
-            else:
-                # Default to old behavior: keep only final ID
-                remove_prefix_length = input_ids.shape[1] - 1
+            # Discard tokens already processed in the cache
+            input_ids = input_ids[:, past_length:]
 
-            input_ids = input_ids[:, remove_prefix_length:]
+            # If the cache is smaller than the attention mask, let's discard the older values
+            if cache_length < past_length and attention_mask is not None:
+                attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 
         position_ids = kwargs.get("position_ids", None)
         if attention_mask is not None and position_ids is None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -360,6 +360,7 @@ class LlamaAttention(nn.Module):
             )
 
         bsz, q_len, _ = hidden_states.size()
+
         if self.config.pretraining_tp > 1:
             key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.config.pretraining_tp
             query_slices = self.q_proj.weight.split(

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -889,7 +889,6 @@ class LlamaModel(LlamaPreTrainedModel):
             if not isinstance(past_key_values, Cache):
                 past_key_values = self.from_legacy_cache(past_key_values)
             past_key_values_length = past_key_values.get_seq_length()
-            seq_length_with_past += past_key_values_length
 
         if position_ids is None:
             device = input_ids.device if input_ids is not None else inputs_embeds.device
@@ -935,7 +934,7 @@ class LlamaModel(LlamaPreTrainedModel):
                     hidden_states,
                     attention_mask,
                     position_ids,
-                    past_key_value,
+                    past_key_values,
                     output_attentions,
                     use_cache,
                 )

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1094,10 +1094,20 @@ class MistralForCausalLM(MistralPreTrainedModel):
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Discard tokens already processed in the cache
-            input_ids = input_ids[:, past_length:]
+            # Keep only the unprocessed tokens:
+            # 1 - If the length of the attention_mask exceeds the length of input_ids, then we are in a setting where
+            # some of the inputs are exclusivelly passed as part of the cache (e.g. when passing input_embeds as
+            # input)
+            if attention_mask is not None and attention_mask.shape[1] > input_ids.shape[1]:
+                input_ids = input_ids[:, -(attention_mask.shape[1] - past_length) :]
+            # 2 - If the past_length is smaller than input_ids', then input_ids holds all input tokens. We can discard
+            # input_ids based on the past_length.
+            elif past_length < input_ids.shape[1]:
+                input_ids = input_ids[:, past_length:]
+            # 3 - Otherwise (past_length >= input_ids.shape[1]), let's assume input_ids only has unprocessed tokens.
 
-            # If the cache is smaller than the attention mask, let's discard the older values
+            # If the cache has seen more tokens than it can hold, then the cache has a size limit. Let's discard the
+            # older attention values, as their corresponding values are not part of the input.
             if cache_length < past_length and attention_mask is not None:
                 attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -264,8 +264,8 @@ class MistralAttention(nn.Module):
         if past_key_value is not None:
             if self.layer_idx is None:
                 raise ValueError(
-                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
-                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -406,7 +406,8 @@ class MistralFlashAttention2(MistralAttention):
                     attention_mask = attention_mask[:, slicing_tokens:]
                     attention_mask = torch.cat([attention_mask, torch.ones_like(attention_mask[:, -1:])], dim=-1)
 
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # repeat k/v heads if n_kv_heads < n_heads
         key_states = repeat_kv(key_states, self.num_key_value_groups)

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1089,18 +1089,17 @@ class MistralForCausalLM(MistralPreTrainedModel):
         # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
-                past_length = past_key_values.get_seq_length()
+                cache_length = past_key_values.get_seq_length()
+                past_length = past_key_values.seen_tokens
             else:
-                past_length = past_key_values[0][0].shape[2]
+                cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Some generation methods already pass only the last input ID
-            if input_ids.shape[1] > past_length:
-                remove_prefix_length = past_length
-            else:
-                # Default to old behavior: keep only final ID
-                remove_prefix_length = input_ids.shape[1] - 1
+            # Discard tokens already processed in the cache
+            input_ids = input_ids[:, past_length:]
 
-            input_ids = input_ids[:, remove_prefix_length:]
+            # If the cache is smaller than the attention mask, let's discard the older values
+            if cache_length < past_length and attention_mask is not None:
+                attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 
         position_ids = kwargs.get("position_ids", None)
         if attention_mask is not None and position_ids is None:

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -273,7 +273,8 @@ class MistralAttention(nn.Module):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # repeat k/v heads if n_kv_heads < n_heads
         key_states = repeat_kv(key_states, self.num_key_value_groups)
@@ -775,8 +776,8 @@ MISTRAL_INPUTS_DOCSTRING = r"""
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as described input above. Otherwise, will return
-            a subclass of `Cache`
+            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
+            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -179,10 +179,17 @@ class PersimmonMLP(nn.Module):
 class PersimmonAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
-    def __init__(self, config: PersimmonConfig, layer_idx: int):
+    def __init__(self, config: PersimmonConfig, layer_idx: Optional[int] = None):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.head_dim = self.hidden_size // self.num_heads
@@ -282,6 +289,12 @@ class PersimmonAttention(nn.Module):
 
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    "with a layer index."
+                )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
 

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -291,8 +291,8 @@ class PersimmonAttention(nn.Module):
         if past_key_value is not None:
             if self.layer_idx is None:
                 raise ValueError(
-                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
-                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -315,7 +315,9 @@ class PersimmonAttention(nn.Module):
         key_states = torch.cat((key_rot, key_pass), dim=-1)
 
         if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            # Specific to RoPE models with partial rotation
+            cache_kwargs = {"sin": sin, "cos": cos, "partial_rotation_size": self.rotary_emb.dim}
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
 
@@ -530,8 +532,8 @@ PERSIMMON_INPUTS_DOCSTRING = r"""
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as described input above. Otherwise, will return
-            a subclass of `Cache`
+            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
+            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -829,18 +829,17 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
     ):
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
-                past_length = past_key_values.get_seq_length()
+                cache_length = past_key_values.get_seq_length()
+                past_length = past_key_values.seen_tokens
             else:
-                past_length = past_key_values[0][0].shape[2]
+                cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Some generation methods already pass only the last input ID
-            if input_ids.shape[1] > past_length:
-                remove_prefix_length = past_length
-            else:
-                # Default to old behavior: keep only final ID
-                remove_prefix_length = input_ids.shape[1] - 1
+            # Discard tokens already processed in the cache
+            input_ids = input_ids[:, past_length:]
 
-            input_ids = input_ids[:, remove_prefix_length:]
+            # If the cache is smaller than the attention mask, let's discard the older values
+            if cache_length < past_length and attention_mask is not None:
+                attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 
         position_ids = kwargs.get("position_ids", None)
         if attention_mask is not None and position_ids is None:

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -457,6 +457,7 @@ class PersimmonPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["PersimmonDecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
+    _supports_cache_class = True
 
     def _init_weights(self, module):
         std = self.config.initializer_range
@@ -505,17 +506,23 @@ PERSIMMON_INPUTS_DOCSTRING = r"""
             config.n_positions - 1]`.
 
             [What are position IDs?](../glossary#position-ids)
-        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
-            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`Cache` or `tuple(tuple(torch.FloatTensor))`, *optional*):
+            Pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
+            blocks) that can be used to speed up sequential decoding. This typically consists in the `past_key_values`
+            returned by the model at a previous stage of decoding, when `use_cache=True` or `config.use_cache=True`.
 
-            Contains pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
-            blocks) that can be used (see `past_key_values` input) to speed up sequential decoding.
+            Two formats are allowed:
+            - a [`~cache_utils.Cache`] instance;
+            - Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of
+            shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`). This is also known as the legacy
+            cache format.
 
-            If `past_key_values` are used, the user can optionally input only the last `decoder_input_ids` (those that
-            don't have their past key value states given to this model) of shape `(batch_size, 1)` instead of all
-            `decoder_input_ids` of shape `(batch_size, sequence_length)`.
+            The model will output the same cache format that is fed as input. If no `past_key_values` are passed, the
+            legacy cache format will be returned.
+
+            If `past_key_values` are used, the user can optionally input only the last `input_ids` (those that don't
+            have their past key value states given to this model) of shape `(batch_size, 1)` instead of all `input_ids`
+            of shape `(batch_size, sequence_length)`.
         inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
             Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
             is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
@@ -531,9 +538,6 @@ PERSIMMON_INPUTS_DOCSTRING = r"""
             more detail.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
-        use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
-            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 
@@ -582,7 +586,6 @@ class PersimmonModel(PersimmonPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -606,7 +609,8 @@ class PersimmonModel(PersimmonPreTrainedModel):
         past_key_values_length = 0
 
         if use_cache:
-            if not isinstance(past_key_values, Cache):
+            use_legacy_cache = not isinstance(past_key_values, Cache)
+            if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
             past_key_values_length = past_key_values.get_seq_length()
             seq_length_with_past = seq_length_with_past + past_key_values_length
@@ -745,7 +749,6 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -790,7 +793,6 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
 
         hidden_states = outputs[0]
@@ -823,10 +825,13 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
 
     # Copied from transformers.models.llama.modeling_llama.LlamaForCausalLM.prepare_inputs_for_generation
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, use_legacy_cache=True, **kwargs
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
         if past_key_values is not None:
-            past_length = past_key_values[0][0].shape[2]
+            if isinstance(past_key_values, Cache):
+                past_length = past_key_values.get_seq_length()
+            else:
+                past_length = past_key_values[0][0].shape[2]
 
             # Some generation methods already pass only the last input ID
             if input_ids.shape[1] > past_length:
@@ -857,7 +862,6 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,
-                "use_legacy_cache": use_legacy_cache,
             }
         )
         return model_inputs
@@ -917,7 +921,6 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, SequenceClassifierOutputWithPast]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
@@ -937,7 +940,6 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -354,7 +354,9 @@ class PhiAttention(nn.Module):
         key_states = torch.cat((key_rot, key_pass), dim=-1)
 
         if past_key_value is not None:
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cos, sin)
+            # Specific to RoPE models with partial rotation
+            cache_kwargs = {"sin": sin, "cos": cos, "partial_rotation_size": self.rotary_emb.dim}
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
 
@@ -782,8 +784,8 @@ PHI_INPUTS_DOCSTRING = r"""
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
         use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as described input above. Otherwise, will return
-            a subclass of `Cache`
+            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
+            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -330,8 +330,8 @@ class PhiAttention(nn.Module):
         if past_key_value is not None:
             if self.layer_idx is None:
                 raise ValueError(
-                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
-                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -218,10 +218,17 @@ class PhiMLP(nn.Module):
 class PhiAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
-    def __init__(self, config: PhiConfig, layer_idx: int):
+    def __init__(self, config: PhiConfig, layer_idx: Optional[int] = None):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
         self.head_dim = self.hidden_size // self.num_heads
@@ -321,6 +328,12 @@ class PhiAttention(nn.Module):
 
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__}"
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class"
+                    "with a layer index."
+                )
             kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
 

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1091,10 +1091,20 @@ class PhiForCausalLM(PhiPreTrainedModel):
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
 
-            # Discard tokens already processed in the cache
-            input_ids = input_ids[:, past_length:]
+            # Keep only the unprocessed tokens:
+            # 1 - If the length of the attention_mask exceeds the length of input_ids, then we are in a setting where
+            # some of the inputs are exclusivelly passed as part of the cache (e.g. when passing input_embeds as
+            # input)
+            if attention_mask is not None and attention_mask.shape[1] > input_ids.shape[1]:
+                input_ids = input_ids[:, -(attention_mask.shape[1] - past_length) :]
+            # 2 - If the past_length is smaller than input_ids', then input_ids holds all input tokens. We can discard
+            # input_ids based on the past_length.
+            elif past_length < input_ids.shape[1]:
+                input_ids = input_ids[:, past_length:]
+            # 3 - Otherwise (past_length >= input_ids.shape[1]), let's assume input_ids only has unprocessed tokens.
 
-            # If the cache is smaller than the attention mask, let's discard the older values
+            # If the cache has seen more tokens than it can hold, then the cache has a size limit. Let's discard the
+            # older attention values, as their corresponding values are not part of the input.
             if cache_length < past_length and attention_mask is not None:
                 attention_mask = attention_mask[:, -(cache_length + input_ids.shape[1]) :]
 

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -709,6 +709,7 @@ class PhiPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
+    _supports_cache_class = True
 
     def _init_weights(self, module):
         std = self.config.initializer_range
@@ -757,17 +758,23 @@ PHI_INPUTS_DOCSTRING = r"""
             config.n_positions - 1]`.
 
             [What are position IDs?](../glossary#position-ids)
-        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
-            Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
-            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and 2 additional tensors of shape
-            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+        past_key_values (`Cache` or `tuple(tuple(torch.FloatTensor))`, *optional*):
+            Pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
+            blocks) that can be used to speed up sequential decoding. This typically consists in the `past_key_values`
+            returned by the model at a previous stage of decoding, when `use_cache=True` or `config.use_cache=True`.
 
-            Contains pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
-            blocks) that can be used (see `past_key_values` input) to speed up sequential decoding.
+            Two formats are allowed:
+            - a [`~cache_utils.Cache`] instance;
+            - Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of
+            shape `(batch_size, num_heads, sequence_length, embed_size_per_head)`). This is also known as the legacy
+            cache format.
 
-            If `past_key_values` are used, the user can optionally input only the last `decoder_input_ids` (those that
-            don't have their past key value states given to this model) of shape `(batch_size, 1)` instead of all
-            `decoder_input_ids` of shape `(batch_size, sequence_length)`.
+            The model will output the same cache format that is fed as input. If no `past_key_values` are passed, the
+            legacy cache format will be returned.
+
+            If `past_key_values` are used, the user can optionally input only the last `input_ids` (those that don't
+            have their past key value states given to this model) of shape `(batch_size, 1)` instead of all `input_ids`
+            of shape `(batch_size, sequence_length)`.
         inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
             Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
             is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
@@ -783,9 +790,6 @@ PHI_INPUTS_DOCSTRING = r"""
             more detail.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
-        use_legacy_cache (`bool`, *optional*):
-            If set to `True` (default), will return `past_key_values` as a tuple, which is what we call the "legacy"
-            cache format. Otherwise, will return a subclass of [`~cache_utils.Cache`]
 """
 
 
@@ -835,7 +839,6 @@ class PhiModel(PhiPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -859,7 +862,8 @@ class PhiModel(PhiPreTrainedModel):
         past_key_values_length = 0
 
         if use_cache:
-            if not isinstance(past_key_values, Cache):
+            use_legacy_cache = not isinstance(past_key_values, Cache)
+            if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
             past_key_values_length = past_key_values.get_seq_length()
             seq_length_with_past = seq_length_with_past + past_key_values_length
@@ -1001,7 +1005,6 @@ class PhiForCausalLM(PhiPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1046,7 +1049,6 @@ class PhiForCausalLM(PhiPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
 
         hidden_states = outputs[0]
@@ -1080,10 +1082,13 @@ class PhiForCausalLM(PhiPreTrainedModel):
 
     # Copied from transformers.models.llama.modeling_llama.LlamaForCausalLM.prepare_inputs_for_generation
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, use_legacy_cache=True, **kwargs
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
         if past_key_values is not None:
-            past_length = past_key_values[0][0].shape[2]
+            if isinstance(past_key_values, Cache):
+                past_length = past_key_values.get_seq_length()
+            else:
+                past_length = past_key_values[0][0].shape[2]
 
             # Some generation methods already pass only the last input ID
             if input_ids.shape[1] > past_length:
@@ -1114,7 +1119,6 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,
-                "use_legacy_cache": use_legacy_cache,
             }
         )
         return model_inputs
@@ -1175,7 +1179,6 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        use_legacy_cache: Optional[bool] = True,
     ) -> Union[Tuple, SequenceClassifierOutputWithPast]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
@@ -1195,7 +1198,6 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            use_legacy_cache=use_legacy_cache,
         )
         hidden_states = model_outputs[0]
         logits = self.score(hidden_states)

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -16,6 +16,27 @@ class PyTorchBenchmarkArguments(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
+class Cache(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class DynamicCache(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class SinkCache(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
 class GlueDataset(metaclass=DummyObject):
     _backends = ["torch"]
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -20,8 +20,10 @@ import unittest
 import warnings
 
 import numpy as np
+from parameterized import parameterized
 
-from transformers import is_torch_available, pipeline
+from transformers import is_torch_available, pipeline, set_seed
+from transformers.cache_utils import DynamicCache
 from transformers.testing_utils import (
     is_flaky,
     require_accelerate,
@@ -1901,6 +1903,68 @@ class GenerationTesterMixin:
                         torch.allclose(
                             outputs.past_key_values[layer_idx][kv_idx],
                             outputs_cached.past_key_values[layer_idx][kv_idx],
+                        )
+                    )
+
+    @parameterized.expand([(1, False), (1, True), (4, False)])
+    def test_new_cache_format(self, num_beams, do_sample):
+        # Tests that generating with the new format is exactly the same as the legacy one (for models that support it).
+        # 👉 tests with and without beam search so that we can test with and without cache reordering.
+        # 👉 tests with and without sampling so we can cover the most common use cases.
+        for model_class in self.all_generative_model_classes:
+            if "use_legacy_cache" not in inspect.signature(model_class.forward).parameters:
+                self.skipTest("This model does not support the new cache format")
+
+            config, input_ids, attention_mask, _ = self._get_input_ids_and_config()
+            config.use_cache = True
+            config.is_decoder = True
+
+            model = model_class(config).to(torch_device).eval()
+            generation_kwargs = {
+                "max_new_tokens": 5,
+                "do_sample": do_sample,
+                "num_beams": num_beams,
+                "num_return_sequences": num_beams,
+                "return_dict_in_generate": True,  # Required to return `past_key_values`
+            }
+
+            # Sets seed before calling `generate` for the case with do_sample=True
+            seed = torch.randint(0, 1000000, (1,)).item()
+            set_seed(seed)
+            legacy_results = model.generate(
+                input_ids, attention_mask=attention_mask, use_legacy_cache=True, **generation_kwargs
+            )
+            set_seed(seed)
+            new_results = model.generate(
+                input_ids, attention_mask=attention_mask, use_legacy_cache=False, **generation_kwargs
+            )
+
+            # The two sets of generated sequences must match, despite the cache format between forward passes being
+            # different
+            self.assertListEqual(legacy_results.sequences.tolist(), new_results.sequences.tolist())
+            self.assertTrue(isinstance(legacy_results.past_key_values, tuple))
+            self.assertTrue(isinstance(new_results.past_key_values, DynamicCache))
+
+            # The contents of the two caches, when converted to the same format (in both directions!), must match
+            legacy_cache = legacy_results.past_key_values
+            new_cache_converted = new_results.past_key_values.to_legacy_cache()
+            for layer_idx in range(len(legacy_cache)):
+                for kv_idx in range(len(legacy_cache[layer_idx])):
+                    self.assertTrue(
+                        torch.allclose(
+                            legacy_cache[layer_idx][kv_idx],
+                            new_cache_converted[layer_idx][kv_idx],
+                        )
+                    )
+
+            new_cache = new_results.past_key_values
+            legacy_cache_converted = DynamicCache.from_legacy_cache(legacy_results.past_key_values)
+            for layer_idx in range(len(new_cache)):
+                for kv_idx in range(len(new_cache[layer_idx])):
+                    self.assertTrue(
+                        torch.allclose(
+                            new_cache[layer_idx][kv_idx],
+                            legacy_cache_converted[layer_idx][kv_idx],
                         )
                     )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -23,7 +23,6 @@ import numpy as np
 from parameterized import parameterized
 
 from transformers import is_torch_available, pipeline, set_seed
-from transformers.cache_utils import DynamicCache
 from transformers.testing_utils import (
     is_flaky,
     require_accelerate,
@@ -55,6 +54,7 @@ if is_torch_available():
         SpeechEncoderDecoderModel,
         top_k_top_p_filtering,
     )
+    from transformers.cache_utils import DynamicCache
     from transformers.generation import (
         BeamSampleDecoderOnlyOutput,
         BeamSampleEncoderDecoderOutput,

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -17,7 +17,7 @@ import unittest
 
 from transformers.testing_utils import require_torch, is_torch_available
 
-if is_torch_available:
+if is_torch_available():
     import torch
 
     from transformers import DynamicCache

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -15,7 +15,8 @@
 
 import unittest
 
-from transformers.testing_utils import require_torch, is_torch_available
+from transformers.testing_utils import is_torch_available, require_torch
+
 
 if is_torch_available():
     import torch
@@ -26,7 +27,7 @@ if is_torch_available():
 @require_torch
 class CacheTest(unittest.TestCase):
     def test_cache_equivalence(self):
-        """ Tests that we can convert back and forth between the legacy cache format and DynamicCache"""
+        """Tests that we can convert back and forth between the legacy cache format and DynamicCache"""
         legacy_cache = ()
         new_cache = DynamicCache()
 
@@ -74,7 +75,7 @@ class CacheTest(unittest.TestCase):
                 )
 
     def test_reorder_cache_retrocompatibility(self):
-        """ Tests that Cache.reorder_cache is retrocompatible with the legacy code path """
+        """Tests that Cache.reorder_cache is retrocompatible with the legacy code path"""
         legacy_reorder_fn = LlamaForCausalLM._reorder_cache  # An example of a legacy `_reorder_cache` function
 
         legacy_cache = ()

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+# Copyright 2023 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers.testing_utils import require_torch, is_torch_available
+
+if is_torch_available:
+    import torch
+
+    from transformers import DynamicCache
+
+
+@require_torch
+class CacheTest(unittest.TestCase):
+    def test_cache_equivalence(self):
+        """ Tests that we can convert back and forth between the legacy cache format and DynamicCache"""
+        legacy_cache = ()
+        new_cache = DynamicCache()
+
+        # Creates a new cache with 10 layers in both formats
+        for layer_idx in range(10):
+            new_key = torch.rand((2, 4, 8, 16))
+            new_value = torch.rand((2, 4, 8, 16))
+            new_cache.update(new_key, new_value, layer_idx)
+            legacy_cache += ((new_key, new_value),)
+
+        # Sanity check 1: they must have the same shapes
+        self.assertTrue(len(legacy_cache), len(new_cache))
+        for layer_idx in range(10):
+            self.assertTrue(len(legacy_cache[layer_idx]), len(legacy_cache[layer_idx]))
+            for key_value_idx in range(2):
+                self.assertTrue(
+                    legacy_cache[layer_idx][key_value_idx].shape == new_cache[layer_idx][key_value_idx].shape
+                )
+
+        # Sanity check 2: we can get the sequence length in multiple ways with DynamicCache, and they return the
+        # expected value
+        self.assertTrue(legacy_cache[0][0].shape[-2] == new_cache[0][0].shape[-2] == new_cache.get_seq_length() == 8)
+
+        # Sanity check 3: they must be equal, and both support indexing
+        for layer_idx in range(10):
+            for key_value_idx in range(2):
+                self.assertTrue(
+                    torch.allclose(new_cache[layer_idx][key_value_idx], legacy_cache[layer_idx][key_value_idx])
+                )
+
+        # Test 1: We can convert from legacy to new with no changes
+        from_legacy = DynamicCache.from_legacy_cache(legacy_cache)
+        for layer_idx in range(10):
+            for key_value_idx in range(2):
+                self.assertTrue(
+                    torch.allclose(from_legacy[layer_idx][key_value_idx], legacy_cache[layer_idx][key_value_idx])
+                )
+
+        # Test 2: We can convert from new to legacy with no changes
+        to_legacy = new_cache.to_legacy_cache()
+        for layer_idx in range(10):
+            for key_value_idx in range(2):
+                self.assertTrue(
+                    torch.allclose(to_legacy[layer_idx][key_value_idx], new_cache[layer_idx][key_value_idx])
+                )

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -182,7 +182,7 @@ class CacheIntegrationTest(unittest.TestCase):
         inputs = tokenizer(["Vaswani et al. (2017) introduced the Transformers"], return_tensors="pt").to(model.device)
 
         # Set up the SinkCache. Using a small window length to contain computational complexity. If this example is run
-        # without a DynamicCache, the last few tokens are gibberish (ends in "of the of the of a of a of")
+        # without a SinkCache, the last few tokens are gibberish (ends in "of the of the of a of a of")
         cache = SinkCache(window_length=508, num_sink_tokens=4)
         gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=3000, past_key_values=cache)
         decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -557,10 +557,6 @@ class ModelTesterMixin:
             return
 
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-            config.use_cache = False
-            config.return_dict = True
-
             if (
                 model_class.__name__
                 in [*get_values(MODEL_MAPPING_NAMES), *get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)]
@@ -569,6 +565,8 @@ class ModelTesterMixin:
                 continue
 
             config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            config.use_cache = False
+            config.return_dict = True
             model = model_class(config)
 
             model.to(torch_device)


### PR DESCRIPTION
Closes #26553

Hello!

# What does this PR do?
I had a few hours on Saturday to work up a draft version of the updated KV caching mechanism as discussed in #26553. Ideally, this should allow Attention Sinks (https://github.com/tomaarsen/attention_sinks) / StreamingLLM (https://arxiv.org/abs/2309.17453) to be easily implemented in a third-party or in transformers directly. 

The implementation doesn't work well yet, as the VRAM usage quickly shoots up after generating even just 8 tokens. This is probably some bug that I haven't had time for yet. There's a few other comments that I have on specific sections of code, so I'll write some comments below.

## Goal for this draft
The intention for this draft is to continue discussion about whether this is moving in the right direction, and to determine the scope (e.g. do we want to include this updated `Cache` for all architectures that use KV caching?). 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@patrickvonplaten 
@gante
@LysandreJik 
@Guangxuan-Xiao

- Tom Aarsen
