### PR TITLE
Add links to the Hub

### DIFF
--- a/docs/source/en/model_doc/align.md
+++ b/docs/source/en/model_doc/align.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ALIGN
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=align">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-align-blueviolet">
+</div>
+
 ## Overview
 
 The ALIGN model was proposed in [Scaling Up Visual and Vision-Language Representation Learning With Noisy Text Supervision](https://arxiv.org/abs/2102.05918) by Chao Jia, Yinfei Yang, Ye Xia, Yi-Ting Chen, Zarana Parekh, Hieu Pham, Quoc V. Le, Yunhsuan Sung, Zhen Li, Tom Duerig. ALIGN is a multi-modal vision and language model. It can be used for image-text similarity and for zero-shot image classification. ALIGN features a dual-encoder architecture with [EfficientNet](efficientnet) as its vision encoder and [BERT](bert) as its text encoder, and learns to align visual and text representations with contrastive learning. Unlike previous work, ALIGN leverages a massive noisy dataset and shows that the scale of the corpus can be used to achieve SOTA representations with a simple recipe.

--- a/docs/source/en/model_doc/altclip.md
+++ b/docs/source/en/model_doc/altclip.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # AltCLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=altclip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-altclip-blueviolet">
+</div>
+
 ## Overview
 
 The AltCLIP model was proposed in [AltCLIP: Altering the Language Encoder in CLIP for Extended Language Capabilities](https://arxiv.org/abs/2211.06679v2) by Zhongzhi Chen, Guang Liu, Bo-Wen Zhang, Fulong Ye, Qinghong Yang, Ledell Wu. AltCLIP

--- a/docs/source/en/model_doc/audio-spectrogram-transformer.md
+++ b/docs/source/en/model_doc/audio-spectrogram-transformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Audio Spectrogram Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=audio-spectrogram-transformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-audio-spectrogram-transformer-blueviolet">
+</div>
+
 ## Overview
 
 The Audio Spectrogram Transformer model was proposed in [AST: Audio Spectrogram Transformer](https://arxiv.org/abs/2104.01778) by Yuan Gong, Yu-An Chung, James Glass.

--- a/docs/source/en/model_doc/auto.md
+++ b/docs/source/en/model_doc/auto.md
@@ -32,6 +32,11 @@ will create a model that is an instance of [`BertModel`].
 
 There is one class of `AutoModel` for each task, and for each backend (PyTorch, TensorFlow, or Flax).
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=auto">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-auto-blueviolet">
+</div>
+
 ## Extending the Auto Classes
 
 Each of the auto classes has a method to be extended with your custom classes. For instance, if you have defined a

--- a/docs/source/en/model_doc/autoformer.md
+++ b/docs/source/en/model_doc/autoformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Autoformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=autoformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-autoformer-blueviolet">
+</div>
+
 ## Overview
 
 The Autoformer model was proposed in [Autoformer: Decomposition Transformers with Auto-Correlation for Long-Term Series Forecasting](https://arxiv.org/abs/2106.13008) by Haixu Wu, Jiehui Xu, Jianmin Wang, Mingsheng Long.

--- a/docs/source/en/model_doc/bark.md
+++ b/docs/source/en/model_doc/bark.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # Bark
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bark">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bark-blueviolet">
+</div>
+
 ## Overview
 
 Bark is a transformer-based text-to-speech model proposed by Suno AI in [suno-ai/bark](https://github.com/suno-ai/bark).

--- a/docs/source/en/model_doc/barthez.md
+++ b/docs/source/en/model_doc/barthez.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BARThez
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=barthez">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-barthez-blueviolet">
+</div>
+
 ## Overview
 
 The BARThez model was proposed in [BARThez: a Skilled Pretrained French Sequence-to-Sequence Model](https://arxiv.org/abs/2010.12321) by Moussa Kamal Eddine, Antoine J.-P. Tixier, Michalis Vazirgiannis on 23 Oct,

--- a/docs/source/en/model_doc/bartpho.md
+++ b/docs/source/en/model_doc/bartpho.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BARTpho
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bartpho">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bartpho-blueviolet">
+</div>
+
 ## Overview
 
 The BARTpho model was proposed in [BARTpho: Pre-trained Sequence-to-Sequence Models for Vietnamese](https://arxiv.org/abs/2109.09701) by Nguyen Luong Tran, Duong Minh Le and Dat Quoc Nguyen.

--- a/docs/source/en/model_doc/beit.md
+++ b/docs/source/en/model_doc/beit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BEiT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=beit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-beit-blueviolet">
+</div>
+
 ## Overview
 
 The BEiT model was proposed in [BEiT: BERT Pre-Training of Image Transformers](https://arxiv.org/abs/2106.08254) by

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BertGeneration
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bert-generation">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bert-generation-blueviolet">
+</div>
+
 ## Overview
 
 The BertGeneration model is a BERT model that can be leveraged for sequence-to-sequence tasks using

--- a/docs/source/en/model_doc/bert-japanese.md
+++ b/docs/source/en/model_doc/bert-japanese.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BertJapanese
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bert-japanese">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bert-japanese-blueviolet">
+</div>
+
 ## Overview
 
 The BERT models trained on Japanese text.

--- a/docs/source/en/model_doc/bertweet.md
+++ b/docs/source/en/model_doc/bertweet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BERTweet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bertweet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bertweet-blueviolet">
+</div>
+
 ## Overview
 
 The BERTweet model was proposed in [BERTweet: A pre-trained language model for English Tweets](https://www.aclweb.org/anthology/2020.emnlp-demos.2.pdf) by Dat Quoc Nguyen, Thanh Vu, Anh Tuan Nguyen.

--- a/docs/source/en/model_doc/big_bird.md
+++ b/docs/source/en/model_doc/big_bird.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BigBird
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=big_bird">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-big_bird-blueviolet">
+</div>
+
 ## Overview
 
 The BigBird model was proposed in [Big Bird: Transformers for Longer Sequences](https://arxiv.org/abs/2007.14062) by

--- a/docs/source/en/model_doc/bigbird_pegasus.md
+++ b/docs/source/en/model_doc/bigbird_pegasus.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BigBirdPegasus
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bigbird_pegasus">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bigbird_pegasus-blueviolet">
+</div>
+
 ## Overview
 
 The BigBird model was proposed in [Big Bird: Transformers for Longer Sequences](https://arxiv.org/abs/2007.14062) by

--- a/docs/source/en/model_doc/biogpt.md
+++ b/docs/source/en/model_doc/biogpt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BioGPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=biogpt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-biogpt-blueviolet">
+</div>
+
 ## Overview
 
 The BioGPT model was proposed in [BioGPT: generative pre-trained transformer for biomedical text generation and mining

--- a/docs/source/en/model_doc/bit.md
+++ b/docs/source/en/model_doc/bit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Big Transfer (BiT)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bit-blueviolet">
+</div>
+
 ## Overview
 
 The BiT model was proposed in [Big Transfer (BiT): General Visual Representation Learning](https://arxiv.org/abs/1912.11370) by Alexander Kolesnikov, Lucas Beyer, Xiaohua Zhai, Joan Puigcerver, Jessica Yung, Sylvain Gelly, Neil Houlsby.

--- a/docs/source/en/model_doc/blenderbot-small.md
+++ b/docs/source/en/model_doc/blenderbot-small.md
@@ -22,6 +22,11 @@ Note that [`BlenderbotSmallModel`] and
 instead be used with [`BlenderbotModel`] and
 [`BlenderbotForConditionalGeneration`]
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=blenderbot-small">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-blenderbot-small-blueviolet">
+</div>
+
 ## Overview
 
 The Blender chatbot model was proposed in [Recipes for building an open-domain chatbot](https://arxiv.org/pdf/2004.13637.pdf) Stephen Roller, Emily Dinan, Naman Goyal, Da Ju, Mary Williamson, Yinhan Liu,

--- a/docs/source/en/model_doc/blenderbot.md
+++ b/docs/source/en/model_doc/blenderbot.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Blenderbot
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=blenderbot">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-blenderbot-blueviolet">
+</div>
+
 ## Overview
 
 The Blender chatbot model was proposed in [Recipes for building an open-domain chatbot](https://arxiv.org/pdf/2004.13637.pdf) Stephen Roller, Emily Dinan, Naman Goyal, Da Ju, Mary Williamson, Yinhan Liu,

--- a/docs/source/en/model_doc/blip-2.md
+++ b/docs/source/en/model_doc/blip-2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BLIP-2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=blip-2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-blip-2-blueviolet">
+</div>
+
 ## Overview
 
 The BLIP-2 model was proposed in [BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models](https://arxiv.org/abs/2301.12597) by

--- a/docs/source/en/model_doc/blip.md
+++ b/docs/source/en/model_doc/blip.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=blip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-blip-blueviolet">
+</div>
+
 ## Overview
 
 The BLIP model was proposed in [BLIP: Bootstrapping Language-Image Pre-training for Unified Vision-Language Understanding and Generation](https://arxiv.org/abs/2201.12086) by Junnan Li, Dongxu Li, Caiming Xiong, Steven Hoi.

--- a/docs/source/en/model_doc/bloom.md
+++ b/docs/source/en/model_doc/bloom.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BLOOM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bloom">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bloom-blueviolet">
+</div>
+
 ## Overview
 
 The BLOOM model has been proposed with its various versions through the [BigScience Workshop](https://bigscience.huggingface.co/). BigScience is inspired by other open science initiatives where researchers have pooled their time and resources to collectively achieve a higher impact.

--- a/docs/source/en/model_doc/bort.md
+++ b/docs/source/en/model_doc/bort.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bort">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bort-blueviolet">
+</div>
+
 ## Overview
 
 The BORT model was proposed in [Optimal Subarchitecture Extraction for BERT](https://arxiv.org/abs/2010.10499) by

--- a/docs/source/en/model_doc/bridgetower.md
+++ b/docs/source/en/model_doc/bridgetower.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # BridgeTower
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bridgetower">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bridgetower-blueviolet">
+</div>
+
 ## Overview
 
 The BridgeTower model was proposed in [BridgeTower: Building Bridges Between Encoders in Vision-Language Representative Learning](https://arxiv.org/abs/2206.08657) by Xiao Xu, Chenfei Wu, Shachar Rosenman, Vasudev Lal, Wanxiang Che, Nan Duan. The goal of this model is to build a

--- a/docs/source/en/model_doc/bros.md
+++ b/docs/source/en/model_doc/bros.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # BROS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=bros">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-bros-blueviolet">
+</div>
+
 ## Overview
 
 The BROS model was proposed in [BROS: A Pre-trained Language Model Focusing on Text and Layout for Better Key Information Extraction from Documents](https://arxiv.org/abs/2108.04539) by Teakgyu Hong, Donghyun Kim, Mingi Ji, Wonseok Hwang, Daehyun Nam, Sungrae Park.

--- a/docs/source/en/model_doc/byt5.md
+++ b/docs/source/en/model_doc/byt5.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ByT5
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=byt5">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-byt5-blueviolet">
+</div>
+
 ## Overview
 
 The ByT5 model was presented in [ByT5: Towards a token-free future with pre-trained byte-to-byte models](https://arxiv.org/abs/2105.13626) by Linting Xue, Aditya Barua, Noah Constant, Rami Al-Rfou, Sharan Narang, Mihir

--- a/docs/source/en/model_doc/camembert.md
+++ b/docs/source/en/model_doc/camembert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CamemBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=camembert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-camembert-blueviolet">
+</div>
+
 ## Overview
 
 The CamemBERT model was proposed in [CamemBERT: a Tasty French Language Model](https://arxiv.org/abs/1911.03894) by

--- a/docs/source/en/model_doc/canine.md
+++ b/docs/source/en/model_doc/canine.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CANINE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=canine">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-canine-blueviolet">
+</div>
+
 ## Overview
 
 The CANINE model was proposed in [CANINE: Pre-training an Efficient Tokenization-Free Encoder for Language

--- a/docs/source/en/model_doc/chinese_clip.md
+++ b/docs/source/en/model_doc/chinese_clip.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Chinese-CLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=chinese_clip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-chinese_clip-blueviolet">
+</div>
+
 ## Overview
 
 The Chinese-CLIP model was proposed in [Chinese CLIP: Contrastive Vision-Language Pretraining in Chinese](https://arxiv.org/abs/2211.01335) by An Yang, Junshu Pan, Junyang Lin, Rui Men, Yichang Zhang, Jingren Zhou, Chang Zhou.

--- a/docs/source/en/model_doc/clap.md
+++ b/docs/source/en/model_doc/clap.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CLAP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=clap">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-clap-blueviolet">
+</div>
+
 ## Overview
 
 The CLAP model was proposed in [Large Scale Contrastive Language-Audio pretraining with

--- a/docs/source/en/model_doc/clip.md
+++ b/docs/source/en/model_doc/clip.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=clip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-clip-blueviolet">
+</div>
+
 ## Overview
 
 The CLIP model was proposed in [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020) by Alec Radford, Jong Wook Kim, Chris Hallacy, Aditya Ramesh, Gabriel Goh,

--- a/docs/source/en/model_doc/clipseg.md
+++ b/docs/source/en/model_doc/clipseg.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CLIPSeg
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=clipseg">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-clipseg-blueviolet">
+</div>
+
 ## Overview
 
 The CLIPSeg model was proposed in [Image Segmentation Using Text and Image Prompts](https://arxiv.org/abs/2112.10003) by Timo Lüddecke

--- a/docs/source/en/model_doc/clvp.md
+++ b/docs/source/en/model_doc/clvp.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CLVP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=clvp">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-clvp-blueviolet">
+</div>
+
 ## Overview
 
 The CLVP (Contrastive Language-Voice Pretrained Transformer) model was proposed in [Better speech synthesis through scaling](https://arxiv.org/abs/2305.07243) by James Betker.

--- a/docs/source/en/model_doc/code_llama.md
+++ b/docs/source/en/model_doc/code_llama.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CodeLlama
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=code_llama">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-code_llama-blueviolet">
+</div>
+
 ## Overview
 
 The Code Llama model was proposed in [Code Llama: Open Foundation Models for Code](https://ai.meta.com/research/publications/code-llama-open-foundation-models-for-code/) by Baptiste Rozière, Jonas Gehring, Fabian Gloeckle, Sten Sootla, Itai Gat, Xiaoqing Ellen Tan, Yossi Adi, Jingyu Liu, Tal Remez, Jérémy Rapin, Artyom Kozhevnikov, Ivan Evtimov, Joanna Bitton, Manish Bhatt, Cristian Canton Ferrer, Aaron Grattafiori, Wenhan Xiong, Alexandre Défossez, Jade Copet, Faisal Azhar, Hugo Touvron, Louis Martin, Nicolas Usunier, Thomas Scialom, Gabriel Synnaeve.

--- a/docs/source/en/model_doc/codegen.md
+++ b/docs/source/en/model_doc/codegen.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CodeGen
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=codegen">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-codegen-blueviolet">
+</div>
+
 ## Overview
 
 The CodeGen model was proposed in [A Conversational Paradigm for Program Synthesis](https://arxiv.org/abs/2203.13474) by Erik Nijkamp, Bo Pang, Hiroaki Hayashi, Lifu Tu, Huan Wang, Yingbo Zhou, Silvio Savarese, and Caiming Xiong.

--- a/docs/source/en/model_doc/conditional_detr.md
+++ b/docs/source/en/model_doc/conditional_detr.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Conditional DETR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=conditional_detr">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-conditional_detr-blueviolet">
+</div>
+
 ## Overview
 
 The Conditional DETR model was proposed in [Conditional DETR for Fast Training Convergence](https://arxiv.org/abs/2108.06152) by Depu Meng, Xiaokang Chen, Zejia Fan, Gang Zeng, Houqiang Li, Yuhui Yuan, Lei Sun, Jingdong Wang. Conditional DETR presents a conditional cross-attention mechanism for fast DETR training. Conditional DETR converges 6.7× to 10× faster than DETR.

--- a/docs/source/en/model_doc/convnext.md
+++ b/docs/source/en/model_doc/convnext.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ConvNeXT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=convnext">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-convnext-blueviolet">
+</div>
+
 ## Overview
 
 The ConvNeXT model was proposed in [A ConvNet for the 2020s](https://arxiv.org/abs/2201.03545) by Zhuang Liu, Hanzi Mao, Chao-Yuan Wu, Christoph Feichtenhofer, Trevor Darrell, Saining Xie.

--- a/docs/source/en/model_doc/convnextv2.md
+++ b/docs/source/en/model_doc/convnextv2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ConvNeXt V2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=convnextv2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-convnextv2-blueviolet">
+</div>
+
 ## Overview
 
 The ConvNeXt V2 model was proposed in [ConvNeXt V2: Co-designing and Scaling ConvNets with Masked Autoencoders](https://arxiv.org/abs/2301.00808) by Sanghyun Woo, Shoubhik Debnath, Ronghang Hu, Xinlei Chen, Zhuang Liu, In So Kweon, Saining Xie.

--- a/docs/source/en/model_doc/cpm.md
+++ b/docs/source/en/model_doc/cpm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CPM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=cpm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-cpm-blueviolet">
+</div>
+
 ## Overview
 
 The CPM model was proposed in [CPM: A Large-scale Generative Chinese Pre-trained Language Model](https://arxiv.org/abs/2012.00413) by Zhengyan Zhang, Xu Han, Hao Zhou, Pei Ke, Yuxian Gu, Deming Ye, Yujia Qin,

--- a/docs/source/en/model_doc/cpmant.md
+++ b/docs/source/en/model_doc/cpmant.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # CPMAnt
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=cpmant">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-cpmant-blueviolet">
+</div>
+
 ## Overview
 
 CPM-Ant is an open-source Chinese pre-trained language model (PLM) with 10B parameters. It is also the first milestone of the live training process of CPM-Live. The training process is cost-effective and environment-friendly. CPM-Ant also achieves promising results with delta tuning on the CUGE benchmark. Besides the full model, we also provide various compressed versions to meet the requirements of different hardware configurations. [See more](https://github.com/OpenBMB/CPM-Live/tree/cpm-ant/cpm-live)

--- a/docs/source/en/model_doc/cvt.md
+++ b/docs/source/en/model_doc/cvt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Convolutional Vision Transformer (CvT)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=cvt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-cvt-blueviolet">
+</div>
+
 ## Overview
 
 The CvT model was proposed in [CvT: Introducing Convolutions to Vision Transformers](https://arxiv.org/abs/2103.15808) by Haiping Wu, Bin Xiao, Noel Codella, Mengchen Liu, Xiyang Dai, Lu Yuan and Lei Zhang. The Convolutional vision Transformer (CvT) improves the [Vision Transformer (ViT)](vit) in performance and efficiency by introducing convolutions into ViT to yield the best of both designs.

--- a/docs/source/en/model_doc/data2vec.md
+++ b/docs/source/en/model_doc/data2vec.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Data2Vec
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=data2vec">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-data2vec-blueviolet">
+</div>
+
 ## Overview
 
 The Data2Vec model was proposed in [data2vec: A General Framework for Self-supervised Learning in Speech, Vision and Language](https://arxiv.org/pdf/2202.03555) by Alexei Baevski, Wei-Ning Hsu, Qiantong Xu, Arun Babu, Jiatao Gu and Michael Auli.

--- a/docs/source/en/model_doc/deberta-v2.md
+++ b/docs/source/en/model_doc/deberta-v2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DeBERTa-v2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deberta-v2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deberta-v2-blueviolet">
+</div>
+
 ## Overview
 
 The DeBERTa model was proposed in [DeBERTa: Decoding-enhanced BERT with Disentangled Attention](https://arxiv.org/abs/2006.03654) by Pengcheng He, Xiaodong Liu, Jianfeng Gao, Weizhu Chen It is based on Google's

--- a/docs/source/en/model_doc/deberta.md
+++ b/docs/source/en/model_doc/deberta.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DeBERTa
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deberta">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deberta-blueviolet">
+</div>
+
 ## Overview
 
 The DeBERTa model was proposed in [DeBERTa: Decoding-enhanced BERT with Disentangled Attention](https://arxiv.org/abs/2006.03654) by Pengcheng He, Xiaodong Liu, Jianfeng Gao, Weizhu Chen It is based on Google's

--- a/docs/source/en/model_doc/decision_transformer.md
+++ b/docs/source/en/model_doc/decision_transformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Decision Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=decision_transformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-decision_transformer-blueviolet">
+</div>
+
 ## Overview
 
 The Decision Transformer model was proposed in [Decision Transformer: Reinforcement Learning via Sequence Modeling](https://arxiv.org/abs/2106.01345)  

--- a/docs/source/en/model_doc/deformable_detr.md
+++ b/docs/source/en/model_doc/deformable_detr.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Deformable DETR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deformable_detr">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deformable_detr-blueviolet">
+</div>
+
 ## Overview
 
 The Deformable DETR model was proposed in [Deformable DETR: Deformable Transformers for End-to-End Object Detection](https://arxiv.org/abs/2010.04159) by Xizhou Zhu, Weijie Su, Lewei Lu, Bin Li, Xiaogang Wang, Jifeng Dai.

--- a/docs/source/en/model_doc/deit.md
+++ b/docs/source/en/model_doc/deit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DeiT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deit-blueviolet">
+</div>
+
 ## Overview
 
 The DeiT model was proposed in [Training data-efficient image transformers & distillation through attention](https://arxiv.org/abs/2012.12877) by Hugo Touvron, Matthieu Cord, Matthijs Douze, Francisco Massa, Alexandre

--- a/docs/source/en/model_doc/deplot.md
+++ b/docs/source/en/model_doc/deplot.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DePlot
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deplot">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deplot-blueviolet">
+</div>
+
 ## Overview 
 
 DePlot was proposed in the paper [DePlot: One-shot visual language reasoning by plot-to-table translation](https://arxiv.org/abs/2212.10505) from Fangyu Liu, Julian Martin Eisenschlos, Francesco Piccinno, Syrine Krichene, Chenxi Pang, Kenton Lee, Mandar Joshi, Wenhu Chen, Nigel Collier, Yasemin Altun.

--- a/docs/source/en/model_doc/deta.md
+++ b/docs/source/en/model_doc/deta.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DETA
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=deta">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-deta-blueviolet">
+</div>
+
 ## Overview
 
 The DETA model was proposed in [NMS Strikes Back](https://arxiv.org/abs/2212.06137) by Jeffrey Ouyang-Zhang, Jang Hyun Cho, Xingyi Zhou, Philipp Krähenbühl.

--- a/docs/source/en/model_doc/detr.md
+++ b/docs/source/en/model_doc/detr.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DETR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=detr">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-detr-blueviolet">
+</div>
+
 ## Overview
 
 The DETR model was proposed in [End-to-End Object Detection with Transformers](https://arxiv.org/abs/2005.12872) by

--- a/docs/source/en/model_doc/dialogpt.md
+++ b/docs/source/en/model_doc/dialogpt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DialoGPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=dialogpt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-dialogpt-blueviolet">
+</div>
+
 ## Overview
 
 DialoGPT was proposed in [DialoGPT: Large-Scale Generative Pre-training for Conversational Response Generation](https://arxiv.org/abs/1911.00536) by Yizhe Zhang, Siqi Sun, Michel Galley, Yen-Chun Chen, Chris Brockett, Xiang Gao,

--- a/docs/source/en/model_doc/dinat.md
+++ b/docs/source/en/model_doc/dinat.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Dilated Neighborhood Attention Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=dinat">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-dinat-blueviolet">
+</div>
+
 ## Overview
 
 DiNAT was proposed in [Dilated Neighborhood Attention Transformer](https://arxiv.org/abs/2209.15001)

--- a/docs/source/en/model_doc/dinov2.md
+++ b/docs/source/en/model_doc/dinov2.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # DINOv2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=dinov2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-dinov2-blueviolet">
+</div>
+
 ## Overview
 
 The DINOv2 model was proposed in [DINOv2: Learning Robust Visual Features without Supervision](https://arxiv.org/abs/2304.07193) by

--- a/docs/source/en/model_doc/dit.md
+++ b/docs/source/en/model_doc/dit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DiT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=dit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-dit-blueviolet">
+</div>
+
 ## Overview
 
 DiT was proposed in [DiT: Self-supervised Pre-training for Document Image Transformer](https://arxiv.org/abs/2203.02378) by Junlong Li, Yiheng Xu, Tengchao Lv, Lei Cui, Cha Zhang, Furu Wei.

--- a/docs/source/en/model_doc/donut.md
+++ b/docs/source/en/model_doc/donut.md
@@ -15,6 +15,11 @@ specific language governing permissions and limitations under the License. -->
 
 # Donut
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=donut">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-donut-blueviolet">
+</div>
+
 ## Overview
 
 The Donut model was proposed in [OCR-free Document Understanding Transformer](https://arxiv.org/abs/2111.15664) by

--- a/docs/source/en/model_doc/dpt.md
+++ b/docs/source/en/model_doc/dpt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # DPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=dpt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-dpt-blueviolet">
+</div>
+
 ## Overview
 
 The DPT model was proposed in [Vision Transformers for Dense Prediction](https://arxiv.org/abs/2103.13413) by René Ranftl, Alexey Bochkovskiy, Vladlen Koltun.

--- a/docs/source/en/model_doc/efficientformer.md
+++ b/docs/source/en/model_doc/efficientformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # EfficientFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=efficientformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-efficientformer-blueviolet">
+</div>
+
 ## Overview
 
 The EfficientFormer model was proposed in [EfficientFormer: Vision Transformers at MobileNet Speed](https://arxiv.org/abs/2206.01191) 

--- a/docs/source/en/model_doc/efficientnet.md
+++ b/docs/source/en/model_doc/efficientnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # EfficientNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=efficientnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-efficientnet-blueviolet">
+</div>
+
 ## Overview
 
 The EfficientNet model was proposed in [EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks](https://arxiv.org/abs/1905.11946) 

--- a/docs/source/en/model_doc/encodec.md
+++ b/docs/source/en/model_doc/encodec.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # EnCodec
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=encodec">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-encodec-blueviolet">
+</div>
+
 ## Overview
 
 The EnCodec neural codec model was proposed in [High Fidelity Neural Audio Compression](https://arxiv.org/abs/2210.13438) by Alexandre Défossez, Jade Copet, Gabriel Synnaeve, Yossi Adi.

--- a/docs/source/en/model_doc/encoder-decoder.md
+++ b/docs/source/en/model_doc/encoder-decoder.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Encoder Decoder Models
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=encoder-decoder">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-encoder-decoder-blueviolet">
+</div>
+
 ## Overview
 
 The [`EncoderDecoderModel`] can be used to initialize a sequence-to-sequence model with any

--- a/docs/source/en/model_doc/ernie.md
+++ b/docs/source/en/model_doc/ernie.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ERNIE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=ernie">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-ernie-blueviolet">
+</div>
+
 ## Overview
 ERNIE is a series of powerful models proposed by baidu, especially in Chinese tasks,
 including [ERNIE1.0](https://arxiv.org/abs/1904.09223), [ERNIE2.0](https://ojs.aaai.org/index.php/AAAI/article/view/6428),

--- a/docs/source/en/model_doc/ernie_m.md
+++ b/docs/source/en/model_doc/ernie_m.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ErnieM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=ernie_m">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-ernie_m-blueviolet">
+</div>
+
 ## Overview
 
 The ErnieM model was proposed in [ERNIE-M: Enhanced Multilingual Representation by Aligning

--- a/docs/source/en/model_doc/esm.md
+++ b/docs/source/en/model_doc/esm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ESM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=esm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-esm-blueviolet">
+</div>
+
 ## Overview
 
 This page provides code and pre-trained weights for Transformer protein language models from Meta AI's Fundamental 

--- a/docs/source/en/model_doc/falcon.md
+++ b/docs/source/en/model_doc/falcon.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Falcon
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=falcon">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-falcon-blueviolet">
+</div>
+
 ## Overview
 
 Falcon is a class of causal decoder-only models built by [TII](https://www.tii.ae/). The largest Falcon checkpoints

--- a/docs/source/en/model_doc/flan-t5.md
+++ b/docs/source/en/model_doc/flan-t5.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FLAN-T5
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=flan-t5">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-flan-t5-blueviolet">
+</div>
+
 ## Overview
 
 FLAN-T5 was released in the paper [Scaling Instruction-Finetuned Language Models](https://arxiv.org/pdf/2210.11416.pdf) - it is an enhanced version of T5 that has been finetuned in a mixture of tasks.

--- a/docs/source/en/model_doc/flan-ul2.md
+++ b/docs/source/en/model_doc/flan-ul2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FLAN-UL2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=flan-ul2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-flan-ul2-blueviolet">
+</div>
+
 ## Overview
 
 Flan-UL2 is an encoder decoder model based on the T5 architecture. It uses the same configuration as the [UL2](ul2) model released earlier last year. 

--- a/docs/source/en/model_doc/flava.md
+++ b/docs/source/en/model_doc/flava.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FLAVA
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=flava">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-flava-blueviolet">
+</div>
+
 ## Overview
 
 The FLAVA model was proposed in [FLAVA: A Foundational Language And Vision Alignment Model](https://arxiv.org/abs/2112.04482) by Amanpreet Singh, Ronghang Hu, Vedanuj Goswami, Guillaume Couairon, Wojciech Galuba, Marcus Rohrbach, and Douwe Kiela and is accepted at CVPR 2022.

--- a/docs/source/en/model_doc/fnet.md
+++ b/docs/source/en/model_doc/fnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=fnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-fnet-blueviolet">
+</div>
+
 ## Overview
 
 The FNet model was proposed in [FNet: Mixing Tokens with Fourier Transforms](https://arxiv.org/abs/2105.03824) by

--- a/docs/source/en/model_doc/focalnet.md
+++ b/docs/source/en/model_doc/focalnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FocalNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=focalnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-focalnet-blueviolet">
+</div>
+
 ## Overview
 
 The FocalNet model was proposed in [Focal Modulation Networks](https://arxiv.org/abs/2203.11926) by Jianwei Yang, Chunyuan Li, Xiyang Dai, Lu Yuan, Jianfeng Gao.

--- a/docs/source/en/model_doc/fsmt.md
+++ b/docs/source/en/model_doc/fsmt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # FSMT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=fsmt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-fsmt-blueviolet">
+</div>
+
 ## Overview
 
 FSMT (FairSeq MachineTranslation) models were introduced in [Facebook FAIR's WMT19 News Translation Task Submission](https://arxiv.org/abs/1907.06616) by Nathan Ng, Kyra Yee, Alexei Baevski, Myle Ott, Michael Auli, Sergey Edunov.

--- a/docs/source/en/model_doc/fuyu.md
+++ b/docs/source/en/model_doc/fuyu.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Fuyu
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=fuyu">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-fuyu-blueviolet">
+</div>
+
 ## Overview
 
 The Fuyu model was created by [ADEPT](https://www.adept.ai/blog/fuyu-8b), and authored by Rohan Bavishi, Erich Elsen, Curtis Hawthorne, Maxwell Nye, Augustus Odena, Arushi Somani, Sağnak Taşırlar. 

--- a/docs/source/en/model_doc/git.md
+++ b/docs/source/en/model_doc/git.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GIT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=git">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-git-blueviolet">
+</div>
+
 ## Overview
 
 The GIT model was proposed in [GIT: A Generative Image-to-text Transformer for Vision and Language](https://arxiv.org/abs/2205.14100) by

--- a/docs/source/en/model_doc/glpn.md
+++ b/docs/source/en/model_doc/glpn.md
@@ -23,6 +23,11 @@ breaking changes to fix it in the future. If you see something strange, file a [
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=glpn">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-glpn-blueviolet">
+</div>
+
 ## Overview
 
 The GLPN model was proposed in [Global-Local Path Networks for Monocular Depth Estimation with Vertical CutDepth](https://arxiv.org/abs/2201.07436)  by Doyeon Kim, Woonghyun Ga, Pyungwhan Ahn, Donggyu Joo, Sehwan Chun, Junmo Kim.

--- a/docs/source/en/model_doc/gpt-sw3.md
+++ b/docs/source/en/model_doc/gpt-sw3.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPT-Sw3
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gpt-sw3">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gpt-sw3-blueviolet">
+</div>
+
 ## Overview
 
 The GPT-Sw3 model was first proposed in

--- a/docs/source/en/model_doc/gpt_bigcode.md
+++ b/docs/source/en/model_doc/gpt_bigcode.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPTBigCode
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gpt_bigcode">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gpt_bigcode-blueviolet">
+</div>
+
 ## Overview
 
 The GPTBigCode model was proposed in [SantaCoder: don't reach for the stars!](https://arxiv.org/abs/2301.03988) by BigCode. The listed authors are: Loubna Ben Allal, Raymond Li, Denis Kocetkov, Chenghao Mou, Christopher Akiki, Carlos Munoz Ferrandis, Niklas Muennighoff, Mayank Mishra, Alex Gu, Manan Dey, Logesh Kumar Umapathi, Carolyn Jane Anderson, Yangtian Zi, Joel Lamy Poirier, Hailey Schoelkopf, Sergey Troshin, Dmitry Abulkhanov, Manuel Romero, Michael Lappert, Francesco De Toni, Bernardo García del Río, Qian Liu, Shamik Bose, Urvashi Bhattacharyya, Terry Yue Zhuo, Ian Yu, Paulo Villegas, Marco Zocca, Sourab Mangrulkar, David Lansky, Huu Nguyen, Danish Contractor, Luis Villa, Jia Li, Dzmitry Bahdanau, Yacine Jernite, Sean Hughes, Daniel Fried, Arjun Guha, Harm de Vries, Leandro von Werra.

--- a/docs/source/en/model_doc/gpt_neo.md
+++ b/docs/source/en/model_doc/gpt_neo.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPT Neo
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gpt_neo">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gpt_neo-blueviolet">
+</div>
+
 ## Overview
 
 The GPTNeo model was released in the [EleutherAI/gpt-neo](https://github.com/EleutherAI/gpt-neo) repository by Sid

--- a/docs/source/en/model_doc/gpt_neox.md
+++ b/docs/source/en/model_doc/gpt_neox.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPT-NeoX
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gpt_neox">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gpt_neox-blueviolet">
+</div>
+
 ## Overview
 
 We introduce GPT-NeoX-20B, a 20 billion parameter autoregressive language model trained on the Pile, whose weights will

--- a/docs/source/en/model_doc/gpt_neox_japanese.md
+++ b/docs/source/en/model_doc/gpt_neox_japanese.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPT-NeoX-Japanese
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gpt_neox_japanese">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gpt_neox_japanese-blueviolet">
+</div>
+
 ## Overview
 
 We introduce GPT-NeoX-Japanese, which is an autoregressive language model for Japanese, trained on top of [https://github.com/EleutherAI/gpt-neox](https://github.com/EleutherAI/gpt-neox).

--- a/docs/source/en/model_doc/gptj.md
+++ b/docs/source/en/model_doc/gptj.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPT-J
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gptj">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gptj-blueviolet">
+</div>
+
 ## Overview
 
 The GPT-J model was released in the [kingoflolz/mesh-transformer-jax](https://github.com/kingoflolz/mesh-transformer-jax) repository by Ben Wang and Aran Komatsuzaki. It is a GPT-2-like

--- a/docs/source/en/model_doc/gptsan-japanese.md
+++ b/docs/source/en/model_doc/gptsan-japanese.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GPTSAN-japanese
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=gptsan-japanese">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-gptsan-japanese-blueviolet">
+</div>
+
 ## Overview
 
 The GPTSAN-japanese model was released in the repository by Toshiyuki Sakamoto (tanreinama).

--- a/docs/source/en/model_doc/graphormer.md
+++ b/docs/source/en/model_doc/graphormer.md
@@ -14,6 +14,11 @@ rendered properly in your Markdown viewer.
 
 # Graphormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=graphormer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-graphormer-blueviolet">
+</div>
+
 ## Overview
 
 The Graphormer model was proposed in [Do Transformers Really Perform Bad for Graph Representation?](https://arxiv.org/abs/2106.05234)  by 

--- a/docs/source/en/model_doc/groupvit.md
+++ b/docs/source/en/model_doc/groupvit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # GroupViT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=groupvit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-groupvit-blueviolet">
+</div>
+
 ## Overview
 
 The GroupViT model was proposed in [GroupViT: Semantic Segmentation Emerges from Text Supervision](https://arxiv.org/abs/2202.11094) by Jiarui Xu, Shalini De Mello, Sifei Liu, Wonmin Byeon, Thomas Breuel, Jan Kautz, Xiaolong Wang.

--- a/docs/source/en/model_doc/herbert.md
+++ b/docs/source/en/model_doc/herbert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # HerBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=herbert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-herbert-blueviolet">
+</div>
+
 ## Overview
 
 The HerBERT model was proposed in [KLEJ: Comprehensive Benchmark for Polish Language Understanding](https://www.aclweb.org/anthology/2020.acl-main.111.pdf) by Piotr Rybak, Robert Mroczkowski, Janusz Tracz, and

--- a/docs/source/en/model_doc/hubert.md
+++ b/docs/source/en/model_doc/hubert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Hubert
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=hubert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-hubert-blueviolet">
+</div>
+
 ## Overview
 
 Hubert was proposed in [HuBERT: Self-Supervised Speech Representation Learning by Masked Prediction of Hidden Units](https://arxiv.org/abs/2106.07447) by Wei-Ning Hsu, Benjamin Bolte, Yao-Hung Hubert Tsai, Kushal Lakhotia, Ruslan

--- a/docs/source/en/model_doc/ibert.md
+++ b/docs/source/en/model_doc/ibert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # I-BERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=ibert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-ibert-blueviolet">
+</div>
+
 ## Overview
 
 The I-BERT model was proposed in [I-BERT: Integer-only BERT Quantization](https://arxiv.org/abs/2101.01321) by

--- a/docs/source/en/model_doc/idefics.md
+++ b/docs/source/en/model_doc/idefics.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # IDEFICS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=idefics">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-idefics-blueviolet">
+</div>
+
 ## Overview
 
 The IDEFICS model was proposed in [OBELICS: An Open Web-Scale Filtered Dataset of Interleaved Image-Text Documents

--- a/docs/source/en/model_doc/imagegpt.md
+++ b/docs/source/en/model_doc/imagegpt.md
@@ -15,6 +15,11 @@ specific language governing permissions and limitations under the License. -->
 
 # ImageGPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=imagegpt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-imagegpt-blueviolet">
+</div>
+
 ## Overview
 
 The ImageGPT model was proposed in [Generative Pretraining from Pixels](https://openai.com/blog/image-gpt) by Mark

--- a/docs/source/en/model_doc/informer.md
+++ b/docs/source/en/model_doc/informer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Informer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=informer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-informer-blueviolet">
+</div>
+
 ## Overview
 
 The Informer model was proposed in [Informer: Beyond Efficient Transformer for Long Sequence Time-Series Forecasting ](https://arxiv.org/abs/2012.07436) by Haoyi Zhou, Shanghang Zhang, Jieqi Peng, Shuai Zhang, Jianxin Li, Hui Xiong, and Wancai Zhang.

--- a/docs/source/en/model_doc/instructblip.md
+++ b/docs/source/en/model_doc/instructblip.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # InstructBLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=instructblip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-instructblip-blueviolet">
+</div>
+
 ## Overview
 
 The InstructBLIP model was proposed in [InstructBLIP: Towards General-purpose Vision-Language Models with Instruction Tuning](https://arxiv.org/abs/2305.06500) by Wenliang Dai, Junnan Li, Dongxu Li, Anthony Meng Huat Tiong, Junqi Zhao, Weisheng Wang, Boyang Li, Pascale Fung, Steven Hoi.

--- a/docs/source/en/model_doc/jukebox.md
+++ b/docs/source/en/model_doc/jukebox.md
@@ -15,6 +15,11 @@ rendered properly in your Markdown viewer.
 -->
 # Jukebox
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=jukebox">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-jukebox-blueviolet">
+</div>
+
 ## Overview
 
 The Jukebox model was proposed in [Jukebox: A generative model for music](https://arxiv.org/pdf/2005.00341.pdf)

--- a/docs/source/en/model_doc/kosmos-2.md
+++ b/docs/source/en/model_doc/kosmos-2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # KOSMOS-2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=kosmos-2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-kosmos-2-blueviolet">
+</div>
+
 ## Overview
 
 The KOSMOS-2 model was proposed in [Kosmos-2: Grounding Multimodal Large Language Models to the World](https://arxiv.org/abs/2306.14824) by Zhiliang Peng, Wenhui Wang, Li Dong, Yaru Hao, Shaohan Huang, Shuming Ma, Furu Wei.

--- a/docs/source/en/model_doc/layoutlm.md
+++ b/docs/source/en/model_doc/layoutlm.md
@@ -18,6 +18,11 @@ rendered properly in your Markdown viewer.
 
 <a id='Overview'></a>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=layoutlm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-layoutlm-blueviolet">
+</div>
+
 ## Overview
 
 The LayoutLM model was proposed in the paper [LayoutLM: Pre-training of Text and Layout for Document Image

--- a/docs/source/en/model_doc/layoutlmv2.md
+++ b/docs/source/en/model_doc/layoutlmv2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LayoutLMV2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=layoutlmv2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-layoutlmv2-blueviolet">
+</div>
+
 ## Overview
 
 The LayoutLMV2 model was proposed in [LayoutLMv2: Multi-modal Pre-training for Visually-Rich Document Understanding](https://arxiv.org/abs/2012.14740) by Yang Xu, Yiheng Xu, Tengchao Lv, Lei Cui, Furu Wei, Guoxin Wang, Yijuan Lu,

--- a/docs/source/en/model_doc/layoutlmv3.md
+++ b/docs/source/en/model_doc/layoutlmv3.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LayoutLMv3
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=layoutlmv3">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-layoutlmv3-blueviolet">
+</div>
+
 ## Overview
 
 The LayoutLMv3 model was proposed in [LayoutLMv3: Pre-training for Document AI with Unified Text and Image Masking](https://arxiv.org/abs/2204.08387) by Yupan Huang, Tengchao Lv, Lei Cui, Yutong Lu, Furu Wei.

--- a/docs/source/en/model_doc/layoutxlm.md
+++ b/docs/source/en/model_doc/layoutxlm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LayoutXLM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=layoutxlm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-layoutxlm-blueviolet">
+</div>
+
 ## Overview
 
 LayoutXLM was proposed in [LayoutXLM: Multimodal Pre-training for Multilingual Visually-rich Document Understanding](https://arxiv.org/abs/2104.08836) by Yiheng Xu, Tengchao Lv, Lei Cui, Guoxin Wang, Yijuan Lu, Dinei Florencio, Cha

--- a/docs/source/en/model_doc/led.md
+++ b/docs/source/en/model_doc/led.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LED
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=led">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-led-blueviolet">
+</div>
+
 ## Overview
 
 The LED model was proposed in [Longformer: The Long-Document Transformer](https://arxiv.org/abs/2004.05150) by Iz

--- a/docs/source/en/model_doc/levit.md
+++ b/docs/source/en/model_doc/levit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LeViT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=levit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-levit-blueviolet">
+</div>
+
 ## Overview
 
 The LeViT model was proposed in [LeViT: Introducing Convolutions to Vision Transformers](https://arxiv.org/abs/2104.01136) by Ben Graham, Alaaeldin El-Nouby, Hugo Touvron, Pierre Stock, Armand Joulin, Hervé Jégou, Matthijs Douze. LeViT improves the [Vision Transformer (ViT)](vit) in performance and efficiency by a few architectural differences such as activation maps with decreasing resolutions in Transformers and the introduction of an attention bias to integrate positional information.

--- a/docs/source/en/model_doc/lilt.md
+++ b/docs/source/en/model_doc/lilt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LiLT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=lilt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-lilt-blueviolet">
+</div>
+
 ## Overview
 
 The LiLT model was proposed in [LiLT: A Simple yet Effective Language-Independent Layout Transformer for Structured Document Understanding](https://arxiv.org/abs/2202.13669) by Jiapeng Wang, Lianwen Jin, Kai Ding.

--- a/docs/source/en/model_doc/llama.md
+++ b/docs/source/en/model_doc/llama.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LLaMA
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=llama">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-llama-blueviolet">
+</div>
+
 ## Overview
 
 The LLaMA model was proposed in [LLaMA: Open and Efficient Foundation Language Models](https://arxiv.org/abs/2302.13971) by Hugo Touvron, Thibaut Lavril, Gautier Izacard, Xavier Martinet, Marie-Anne Lachaux, Timothée Lacroix, Baptiste Rozière, Naman Goyal, Eric Hambro, Faisal Azhar, Aurelien Rodriguez, Armand Joulin, Edouard Grave, Guillaume Lample. It is a collection of foundation language models ranging from 7B to 65B parameters.

--- a/docs/source/en/model_doc/llama2.md
+++ b/docs/source/en/model_doc/llama2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Llama2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=llama2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-llama2-blueviolet">
+</div>
+
 ## Overview
 
 The Llama2 model was proposed in [LLaMA: Open Foundation and Fine-Tuned Chat Models](https://ai.meta.com/research/publications/llama-2-open-foundation-and-fine-tuned-chat-models/) by Hugo Touvron, Louis Martin, Kevin Stone, Peter Albert, Amjad Almahairi, Yasmine Babaei, Nikolay Bashlykov, Soumya Batra, Prajjwal Bhargava, Shruti Bhosale, Dan Bikel, Lukas Blecher, Cristian Canton Ferrer, Moya Chen, Guillem Cucurull, David Esiobu, Jude Fernandes, Jeremy Fu, Wenyin Fu, Brian Fuller, Cynthia Gao, Vedanuj Goswami, Naman Goyal, Anthony Hartshorn, Saghar Hosseini, Rui Hou, Hakan Inan, Marcin Kardas, Viktor Kerkez Madian Khabsa, Isabel Kloumann, Artem Korenev, Punit Singh Koura, Marie-Anne Lachaux, Thibaut Lavril, Jenya Lee, Diana Liskovich, Yinghai Lu, Yuning Mao, Xavier Martinet, Todor Mihaylov, Pushka rMishra, Igor Molybog, Yixin Nie, Andrew Poulton, Jeremy Reizenstein, Rashi Rungta, Kalyan Saladi, Alan Schelten, Ruan Silva, Eric Michael Smith, Ranjan Subramanian, Xiaoqing EllenTan, Binh Tang, Ross Taylor, Adina Williams, Jian Xiang Kuan, Puxin Xu, Zheng Yan, Iliyan Zarov, Yuchen Zhang, Angela Fan, Melanie Kambadur, Sharan Narang, Aurelien Rodriguez, Robert Stojnic, Sergey Edunov, Thomas Scialom. It is a collection of foundation language models ranging from 7B to 70B parameters, with checkpoints finetuned for chat application!

--- a/docs/source/en/model_doc/longt5.md
+++ b/docs/source/en/model_doc/longt5.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LongT5
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=longt5">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-longt5-blueviolet">
+</div>
+
 ## Overview
 
 The LongT5 model was proposed in [LongT5: Efficient Text-To-Text Transformer for Long Sequences](https://arxiv.org/abs/2112.07916)

--- a/docs/source/en/model_doc/luke.md
+++ b/docs/source/en/model_doc/luke.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LUKE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=luke">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-luke-blueviolet">
+</div>
+
 ## Overview
 
 The LUKE model was proposed in [LUKE: Deep Contextualized Entity Representations with Entity-aware Self-attention](https://arxiv.org/abs/2010.01057) by Ikuya Yamada, Akari Asai, Hiroyuki Shindo, Hideaki Takeda and Yuji Matsumoto.

--- a/docs/source/en/model_doc/lxmert.md
+++ b/docs/source/en/model_doc/lxmert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # LXMERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=lxmert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-lxmert-blueviolet">
+</div>
+
 ## Overview
 
 The LXMERT model was proposed in [LXMERT: Learning Cross-Modality Encoder Representations from Transformers](https://arxiv.org/abs/1908.07490) by Hao Tan & Mohit Bansal. It is a series of bidirectional transformer encoders

--- a/docs/source/en/model_doc/m2m_100.md
+++ b/docs/source/en/model_doc/m2m_100.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # M2M100
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=m2m_100">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-m2m_100-blueviolet">
+</div>
+
 ## Overview
 
 The M2M100 model was proposed in [Beyond English-Centric Multilingual Machine Translation](https://arxiv.org/abs/2010.11125) by Angela Fan, Shruti Bhosale, Holger Schwenk, Zhiyi Ma, Ahmed El-Kishky,

--- a/docs/source/en/model_doc/madlad-400.md
+++ b/docs/source/en/model_doc/madlad-400.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MADLAD-400
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=madlad-400">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-madlad-400-blueviolet">
+</div>
+
 ## Overview
 
 MADLAD-400 models were released in the paper [MADLAD-400: A Multilingual And Document-Level Large Audited Dataset](MADLAD-400: A Multilingual And Document-Level Large Audited Dataset). 

--- a/docs/source/en/model_doc/markuplm.md
+++ b/docs/source/en/model_doc/markuplm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MarkupLM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=markuplm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-markuplm-blueviolet">
+</div>
+
 ## Overview
 
 The MarkupLM model was proposed in [MarkupLM: Pre-training of Text and Markup Language for Visually-rich Document

--- a/docs/source/en/model_doc/mask2former.md
+++ b/docs/source/en/model_doc/mask2former.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Mask2Former
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mask2former">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mask2former-blueviolet">
+</div>
+
 ## Overview
 
 The Mask2Former model was proposed in [Masked-attention Mask Transformer for Universal Image Segmentation](https://arxiv.org/abs/2112.01527) by Bowen Cheng, Ishan Misra, Alexander G. Schwing, Alexander Kirillov, Rohit Girdhar. Mask2Former is a unified framework for panoptic, instance and semantic segmentation and features significant performance and efficiency improvements over [MaskFormer](maskformer).

--- a/docs/source/en/model_doc/maskformer.md
+++ b/docs/source/en/model_doc/maskformer.md
@@ -23,6 +23,11 @@ breaking changes to fix it in the future. If you see something strange, file a [
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=maskformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-maskformer-blueviolet">
+</div>
+
 ## Overview
 
 The MaskFormer model was proposed in [Per-Pixel Classification is Not All You Need for Semantic Segmentation](https://arxiv.org/abs/2107.06278) by Bowen Cheng, Alexander G. Schwing, Alexander Kirillov. MaskFormer addresses semantic segmentation with a mask classification paradigm instead of performing classic pixel-level classification.

--- a/docs/source/en/model_doc/matcha.md
+++ b/docs/source/en/model_doc/matcha.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MatCha
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=matcha">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-matcha-blueviolet">
+</div>
+
 ## Overview
 
 MatCha has been proposed in the paper [MatCha: Enhancing Visual Language Pretraining with Math Reasoning and Chart Derendering](https://arxiv.org/abs/2212.09662), from Fangyu Liu, Francesco Piccinno, Syrine Krichene, Chenxi Pang, Kenton Lee, Mandar Joshi, Yasemin Altun, Nigel Collier, Julian Martin Eisenschlos.

--- a/docs/source/en/model_doc/mctct.md
+++ b/docs/source/en/model_doc/mctct.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mctct">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mctct-blueviolet">
+</div>
+
 ## Overview
 
 The M-CTC-T model was proposed in [Pseudo-Labeling For Massively Multilingual Speech Recognition](https://arxiv.org/abs/2111.00161) by Loren Lugosch, Tatiana Likhomanenko, Gabriel Synnaeve, and Ronan Collobert. The model is a 1B-param transformer encoder, with a CTC head over 8065 character labels and a language identification head over 60 language ID labels. It is trained on Common Voice (version 6.1, December 2020 release) and VoxPopuli. After training on Common Voice and VoxPopuli, the model is trained on Common Voice only. The labels are unnormalized character-level transcripts (punctuation and capitalization are not removed). The model takes as input Mel filterbank features from a 16Khz audio signal.

--- a/docs/source/en/model_doc/mega.md
+++ b/docs/source/en/model_doc/mega.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MEGA
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mega">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mega-blueviolet">
+</div>
+
 ## Overview
 
 The MEGA model was proposed in [Mega: Moving Average Equipped Gated Attention](https://arxiv.org/abs/2209.10655) by Xuezhe Ma, Chunting Zhou, Xiang Kong, Junxian He, Liangke Gui, Graham Neubig, Jonathan May, and Luke Zettlemoyer.

--- a/docs/source/en/model_doc/megatron-bert.md
+++ b/docs/source/en/model_doc/megatron-bert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MegatronBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=megatron-bert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-megatron-bert-blueviolet">
+</div>
+
 ## Overview
 
 The MegatronBERT model was proposed in [Megatron-LM: Training Multi-Billion Parameter Language Models Using Model

--- a/docs/source/en/model_doc/megatron_gpt2.md
+++ b/docs/source/en/model_doc/megatron_gpt2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MegatronGPT2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=megatron_gpt2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-megatron_gpt2-blueviolet">
+</div>
+
 ## Overview
 
 The MegatronGPT2 model was proposed in [Megatron-LM: Training Multi-Billion Parameter Language Models Using Model

--- a/docs/source/en/model_doc/mgp-str.md
+++ b/docs/source/en/model_doc/mgp-str.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MGP-STR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mgp-str">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mgp-str-blueviolet">
+</div>
+
 ## Overview
 
 The MGP-STR model was proposed in [Multi-Granularity Prediction for Scene Text Recognition](https://arxiv.org/abs/2209.03592) by Peng Wang, Cheng Da, and Cong Yao. MGP-STR is a conceptually **simple** yet **powerful** vision Scene Text Recognition (STR) model, which is built upon the [Vision Transformer (ViT)](vit). To integrate linguistic knowledge, Multi-Granularity Prediction (MGP) strategy is proposed to inject information from the language modality into the model in an implicit way.

--- a/docs/source/en/model_doc/mistral.md
+++ b/docs/source/en/model_doc/mistral.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Mistral
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mistral">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mistral-blueviolet">
+</div>
+
 ## Overview
 
 Mistral-7B-v0.1 is Mistral AI's first Large Language Model (LLM). 

--- a/docs/source/en/model_doc/mluke.md
+++ b/docs/source/en/model_doc/mluke.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # mLUKE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mluke">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mluke-blueviolet">
+</div>
+
 ## Overview
 
 The mLUKE model was proposed in [mLUKE: The Power of Entity Representations in Multilingual Pretrained Language Models](https://arxiv.org/abs/2110.08151) by Ryokan Ri, Ikuya Yamada, and Yoshimasa Tsuruoka. It's a multilingual extension

--- a/docs/source/en/model_doc/mms.md
+++ b/docs/source/en/model_doc/mms.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MMS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mms">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mms-blueviolet">
+</div>
+
 ## Overview
 
 The MMS model was proposed in [Scaling Speech Technology to 1,000+ Languages](https://arxiv.org/abs/2305.13516) 

--- a/docs/source/en/model_doc/mobilebert.md
+++ b/docs/source/en/model_doc/mobilebert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MobileBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mobilebert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mobilebert-blueviolet">
+</div>
+
 ## Overview
 
 The MobileBERT model was proposed in [MobileBERT: a Compact Task-Agnostic BERT for Resource-Limited Devices](https://arxiv.org/abs/2004.02984) by Zhiqing Sun, Hongkun Yu, Xiaodan Song, Renjie Liu, Yiming Yang, and Denny

--- a/docs/source/en/model_doc/mobilenet_v1.md
+++ b/docs/source/en/model_doc/mobilenet_v1.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MobileNet V1
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mobilenet_v1">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mobilenet_v1-blueviolet">
+</div>
+
 ## Overview
 
 The MobileNet model was proposed in [MobileNets: Efficient Convolutional Neural Networks for Mobile Vision Applications](https://arxiv.org/abs/1704.04861) by Andrew G. Howard, Menglong Zhu, Bo Chen, Dmitry Kalenichenko, Weijun Wang, Tobias Weyand, Marco Andreetto, Hartwig Adam.

--- a/docs/source/en/model_doc/mobilenet_v2.md
+++ b/docs/source/en/model_doc/mobilenet_v2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MobileNet V2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mobilenet_v2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mobilenet_v2-blueviolet">
+</div>
+
 ## Overview
 
 The MobileNet model was proposed in [MobileNetV2: Inverted Residuals and Linear Bottlenecks](https://arxiv.org/abs/1801.04381) by Mark Sandler, Andrew Howard, Menglong Zhu, Andrey Zhmoginov, Liang-Chieh Chen.

--- a/docs/source/en/model_doc/mobilevit.md
+++ b/docs/source/en/model_doc/mobilevit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MobileViT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mobilevit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mobilevit-blueviolet">
+</div>
+
 ## Overview
 
 The MobileViT model was proposed in [MobileViT: Light-weight, General-purpose, and Mobile-friendly Vision Transformer](https://arxiv.org/abs/2110.02178) by Sachin Mehta and Mohammad Rastegari. MobileViT introduces a new layer that replaces local processing in convolutions with global processing using transformers.

--- a/docs/source/en/model_doc/mobilevitv2.md
+++ b/docs/source/en/model_doc/mobilevitv2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MobileViTV2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mobilevitv2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mobilevitv2-blueviolet">
+</div>
+
 ## Overview
 
 The MobileViTV2 model was proposed in [Separable Self-attention for Mobile Vision Transformers](https://arxiv.org/abs/2206.02680) by Sachin Mehta and Mohammad Rastegari.

--- a/docs/source/en/model_doc/mpnet.md
+++ b/docs/source/en/model_doc/mpnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MPNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mpnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mpnet-blueviolet">
+</div>
+
 ## Overview
 
 The MPNet model was proposed in [MPNet: Masked and Permuted Pre-training for Language Understanding](https://arxiv.org/abs/2004.09297) by Kaitao Song, Xu Tan, Tao Qin, Jianfeng Lu, Tie-Yan Liu.

--- a/docs/source/en/model_doc/mpt.md
+++ b/docs/source/en/model_doc/mpt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mpt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mpt-blueviolet">
+</div>
+
 ## Overview
 
 The MPT model was proposed by the [MosaicML](https://www.mosaicml.com/) team and released with multiple sizes and finetuned variants. The MPT models is a series of open source and commercially usable LLMs pre-trained on 1T tokens. 

--- a/docs/source/en/model_doc/mra.md
+++ b/docs/source/en/model_doc/mra.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MRA
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mra">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mra-blueviolet">
+</div>
+
 ## Overview
 
 The MRA model was proposed in [Multi Resolution Analysis (MRA) for Approximate Self-Attention](https://arxiv.org/abs/2207.10284) by Zhanpeng Zeng, Sourav Pal, Jeffery Kline, Glenn M Fung, and Vikas Singh.

--- a/docs/source/en/model_doc/musicgen.md
+++ b/docs/source/en/model_doc/musicgen.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MusicGen
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=musicgen">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-musicgen-blueviolet">
+</div>
+
 ## Overview
 
 The MusicGen model was proposed in the paper [Simple and Controllable Music Generation](https://arxiv.org/abs/2306.05284)

--- a/docs/source/en/model_doc/mvp.md
+++ b/docs/source/en/model_doc/mvp.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # MVP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=mvp">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-mvp-blueviolet">
+</div>
+
 ## Overview
 
 The MVP model was proposed in [MVP: Multi-task Supervised Pre-training for Natural Language Generation](https://arxiv.org/abs/2206.12131) by Tianyi Tang, Junyi Li, Wayne Xin Zhao and Ji-Rong Wen.

--- a/docs/source/en/model_doc/nat.md
+++ b/docs/source/en/model_doc/nat.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Neighborhood Attention Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nat">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nat-blueviolet">
+</div>
+
 ## Overview
 
 NAT was proposed in [Neighborhood Attention Transformer](https://arxiv.org/abs/2204.07143)

--- a/docs/source/en/model_doc/nezha.md
+++ b/docs/source/en/model_doc/nezha.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Nezha
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nezha">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nezha-blueviolet">
+</div>
+
 ## Overview
 
 The Nezha model was proposed in [NEZHA: Neural Contextualized Representation for Chinese Language Understanding](https://arxiv.org/abs/1909.00204) by Junqiu Wei et al.

--- a/docs/source/en/model_doc/nllb-moe.md
+++ b/docs/source/en/model_doc/nllb-moe.md
@@ -17,6 +17,11 @@ rendered properly in your Markdown viewer.
 # NLLB-MOE
 
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nllb-moe">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nllb-moe-blueviolet">
+</div>
+
 ## Overview
 
 The NLLB model was presented in [No Language Left Behind: Scaling Human-Centered Machine Translation](https://arxiv.org/abs/2207.04672) by Marta R. Costa-jussà, James Cross, Onur Çelebi,

--- a/docs/source/en/model_doc/nllb.md
+++ b/docs/source/en/model_doc/nllb.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # NLLB
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nllb">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nllb-blueviolet">
+</div>
+
 ## Updated tokenizer behavior 
 
 **DISCLAIMER:** The default behaviour for the tokenizer was fixed and thus changed in April 2023.

--- a/docs/source/en/model_doc/nougat.md
+++ b/docs/source/en/model_doc/nougat.md
@@ -15,6 +15,11 @@ specific language governing permissions and limitations under the License. -->
 
 # Nougat
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nougat">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nougat-blueviolet">
+</div>
+
 ## Overview
 
 The Nougat model was proposed in [Nougat: Neural Optical Understanding for Academic Documents](https://arxiv.org/abs/2308.13418) by

--- a/docs/source/en/model_doc/nystromformer.md
+++ b/docs/source/en/model_doc/nystromformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Nyströmformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=nystromformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-nystromformer-blueviolet">
+</div>
+
 ## Overview
 
 The Nyströmformer model was proposed in [*Nyströmformer: A Nyström-Based Algorithm for Approximating Self-Attention*](https://arxiv.org/abs/2102.03902) by Yunyang Xiong, Zhanpeng Zeng, Rudrasis Chakraborty, Mingxing Tan, Glenn

--- a/docs/source/en/model_doc/oneformer.md
+++ b/docs/source/en/model_doc/oneformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # OneFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=oneformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-oneformer-blueviolet">
+</div>
+
 ## Overview
 
 The OneFormer model was proposed in [OneFormer: One Transformer to Rule Universal Image Segmentation](https://arxiv.org/abs/2211.06220) by Jitesh Jain, Jiachen Li, MangTik Chiu, Ali Hassani, Nikita Orlov, Humphrey Shi. OneFormer is a universal image segmentation framework that can be trained on a single panoptic dataset to perform semantic, instance, and panoptic segmentation tasks. OneFormer uses a task token to condition the model on the task in focus, making the architecture task-guided for training, and task-dynamic for inference.

--- a/docs/source/en/model_doc/open-llama.md
+++ b/docs/source/en/model_doc/open-llama.md
@@ -31,6 +31,11 @@ This model differs from the [OpenLLaMA models](https://huggingface.co/models?sea
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=open-llama">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-open-llama-blueviolet">
+</div>
+
 ## Overview
 
 The Open-Llama model was proposed in the open source Open-Llama project by community developer s-JoL.

--- a/docs/source/en/model_doc/opt.md
+++ b/docs/source/en/model_doc/opt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # OPT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=opt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-opt-blueviolet">
+</div>
+
 ## Overview
 
 The OPT model was proposed in [Open Pre-trained Transformer Language Models](https://arxiv.org/pdf/2205.01068) by Meta AI.

--- a/docs/source/en/model_doc/owlv2.md
+++ b/docs/source/en/model_doc/owlv2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # OWLv2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=owlv2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-owlv2-blueviolet">
+</div>
+
 ## Overview
 
 OWLv2 was proposed in [Scaling Open-Vocabulary Object Detection](https://arxiv.org/abs/2306.09683) by Matthias Minderer, Alexey Gritsenko, Neil Houlsby. OWLv2 scales up [OWL-ViT](owlvit) using self-training, which uses an existing detector to generate pseudo-box annotations on image-text pairs. This results in large gains over the previous state-of-the-art for zero-shot object detection.

--- a/docs/source/en/model_doc/owlvit.md
+++ b/docs/source/en/model_doc/owlvit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # OWL-ViT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=owlvit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-owlvit-blueviolet">
+</div>
+
 ## Overview
 
 The OWL-ViT (short for Vision Transformer for Open-World Localization) was proposed in [Simple Open-Vocabulary Object Detection with Vision Transformers](https://arxiv.org/abs/2205.06230) by Matthias Minderer, Alexey Gritsenko, Austin Stone, Maxim Neumann, Dirk Weissenborn, Alexey Dosovitskiy, Aravindh Mahendran, Anurag Arnab, Mostafa Dehghani, Zhuoran Shen, Xiao Wang, Xiaohua Zhai, Thomas Kipf, and Neil Houlsby. OWL-ViT is an open-vocabulary object detection network trained on a variety of (image, text) pairs. It can be used to query an image with one or multiple text queries to search for and detect target objects described in text.

--- a/docs/source/en/model_doc/patchtst.md
+++ b/docs/source/en/model_doc/patchtst.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # PatchTST
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=patchtst">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-patchtst-blueviolet">
+</div>
+
 ## Overview
 
 The PatchTST model was proposed in [A Time Series is Worth 64 Words: Long-term Forecasting with Transformers](https://arxiv.org/abs/2211.14730) by Yuqi Nie, Nam H. Nguyen, Phanwadee Sinthong and Jayant Kalagnanam.

--- a/docs/source/en/model_doc/pegasus_x.md
+++ b/docs/source/en/model_doc/pegasus_x.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # PEGASUS-X
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=pegasus_x">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-pegasus_x-blueviolet">
+</div>
+
 ## Overview
 
 The PEGASUS-X model was proposed in [Investigating Efficiently Extending Transformers for Long Input Summarization](https://arxiv.org/abs/2208.04347)  by Jason Phang, Yao Zhao and Peter J. Liu.

--- a/docs/source/en/model_doc/perceiver.md
+++ b/docs/source/en/model_doc/perceiver.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Perceiver
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=perceiver">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-perceiver-blueviolet">
+</div>
+
 ## Overview
 
 The Perceiver IO model was proposed in [Perceiver IO: A General Architecture for Structured Inputs &

--- a/docs/source/en/model_doc/persimmon.md
+++ b/docs/source/en/model_doc/persimmon.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Persimmon
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=persimmon">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-persimmon-blueviolet">
+</div>
+
 ## Overview
 
 The Persimmon model was created by [ADEPT](https://www.adept.ai/blog/persimmon-8b), and authored by Erich Elsen, Augustus Odena, Maxwell Nye, Sağnak Taşırlar, Tri Dao, Curtis Hawthorne, Deepak Moparthi, Arushi Somani.

--- a/docs/source/en/model_doc/phi.md
+++ b/docs/source/en/model_doc/phi.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Phi
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=phi">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-phi-blueviolet">
+</div>
+
 ## Overview
 
 The Phi-1 model was proposed in [Textbooks Are All You Need](https://arxiv.org/abs/2306.11644) by Suriya Gunasekar, Yi Zhang, Jyoti Aneja, Caio César Teodoro Mendes, Allie Del Giorno, Sivakanth Gopi, Mojan Javaheripi, Piero Kauffmann, Gustavo de Rosa, Olli Saarikivi, Adil Salim, Shital Shah, Harkirat Singh Behl, Xin Wang, Sébastien Bubeck, Ronen Eldan, Adam Tauman Kalai, Yin Tat Lee and Yuanzhi Li.

--- a/docs/source/en/model_doc/phobert.md
+++ b/docs/source/en/model_doc/phobert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # PhoBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=phobert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-phobert-blueviolet">
+</div>
+
 ## Overview
 
 The PhoBERT model was proposed in [PhoBERT: Pre-trained language models for Vietnamese](https://www.aclweb.org/anthology/2020.findings-emnlp.92.pdf) by Dat Quoc Nguyen, Anh Tuan Nguyen.

--- a/docs/source/en/model_doc/pix2struct.md
+++ b/docs/source/en/model_doc/pix2struct.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Pix2Struct
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=pix2struct">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-pix2struct-blueviolet">
+</div>
+
 ## Overview
 
 The Pix2Struct model was proposed in [Pix2Struct: Screenshot Parsing as Pretraining for Visual Language Understanding](https://arxiv.org/abs/2210.03347) by Kenton Lee, Mandar Joshi, Iulia Turc, Hexiang Hu, Fangyu Liu, Julian Eisenschlos, Urvashi Khandelwal, Peter Shaw, Ming-Wei Chang, Kristina Toutanova.

--- a/docs/source/en/model_doc/plbart.md
+++ b/docs/source/en/model_doc/plbart.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # PLBart
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=plbart">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-plbart-blueviolet">
+</div>
+
 ## Overview
 
 The PLBART model was proposed in [Unified Pre-training for Program Understanding and Generation](https://arxiv.org/abs/2103.06333) by Wasi Uddin Ahmad, Saikat Chakraborty, Baishakhi Ray, Kai-Wei Chang.

--- a/docs/source/en/model_doc/poolformer.md
+++ b/docs/source/en/model_doc/poolformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # PoolFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=poolformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-poolformer-blueviolet">
+</div>
+
 ## Overview
 
 The PoolFormer model was proposed in [MetaFormer is Actually What You Need for Vision](https://arxiv.org/abs/2111.11418)  by Sea AI Labs. Instead of designing complicated token mixer to achieve SOTA performance, the target of this work is to demonstrate the competence of transformer models largely stem from the general architecture MetaFormer.

--- a/docs/source/en/model_doc/pvt.md
+++ b/docs/source/en/model_doc/pvt.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # Pyramid Vision Transformer (PVT)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=pvt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-pvt-blueviolet">
+</div>
+
 ## Overview
 
 The PVT model was proposed in

--- a/docs/source/en/model_doc/qdqbert.md
+++ b/docs/source/en/model_doc/qdqbert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # QDQBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=qdqbert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-qdqbert-blueviolet">
+</div>
+
 ## Overview
 
 The QDQBERT model can be referenced in [Integer Quantization for Deep Learning Inference: Principles and Empirical

--- a/docs/source/en/model_doc/realm.md
+++ b/docs/source/en/model_doc/realm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # REALM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=realm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-realm-blueviolet">
+</div>
+
 ## Overview
 
 The REALM model was proposed in [REALM: Retrieval-Augmented Language Model Pre-Training](https://arxiv.org/abs/2002.08909) by Kelvin Guu, Kenton Lee, Zora Tung, Panupong Pasupat and Ming-Wei Chang. It's a

--- a/docs/source/en/model_doc/regnet.md
+++ b/docs/source/en/model_doc/regnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RegNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=regnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-regnet-blueviolet">
+</div>
+
 ## Overview
 
 The RegNet model was proposed in [Designing Network Design Spaces](https://arxiv.org/abs/2003.13678) by Ilija Radosavovic, Raj Prateek Kosaraju, Ross Girshick, Kaiming He, Piotr Dollár.

--- a/docs/source/en/model_doc/rembert.md
+++ b/docs/source/en/model_doc/rembert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RemBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=rembert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-rembert-blueviolet">
+</div>
+
 ## Overview
 
 The RemBERT model was proposed in [Rethinking Embedding Coupling in Pre-trained Language Models](https://arxiv.org/abs/2010.12821) by Hyung Won Chung, Thibault Févry, Henry Tsai, Melvin Johnson, Sebastian Ruder.

--- a/docs/source/en/model_doc/resnet.md
+++ b/docs/source/en/model_doc/resnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ResNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=resnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-resnet-blueviolet">
+</div>
+
 ## Overview
 
 The ResNet model was proposed in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385) by Kaiming He, Xiangyu Zhang, Shaoqing Ren and Jian Sun. Our implementation follows the small changes made by [Nvidia](https://catalog.ngc.nvidia.com/orgs/nvidia/resources/resnet_50_v1_5_for_pytorch), we apply the `stride=2` for downsampling in bottleneck's `3x3` conv and not in the first `1x1`. This is generally known as "ResNet v1.5".

--- a/docs/source/en/model_doc/retribert.md
+++ b/docs/source/en/model_doc/retribert.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=retribert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-retribert-blueviolet">
+</div>
+
 ## Overview
 
 The RetriBERT model was proposed in the blog post [Explain Anything Like I'm Five: A Model for Open Domain Long Form

--- a/docs/source/en/model_doc/roberta-prelayernorm.md
+++ b/docs/source/en/model_doc/roberta-prelayernorm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RoBERTa-PreLayerNorm
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=roberta-prelayernorm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-roberta-prelayernorm-blueviolet">
+</div>
+
 ## Overview
 
 The RoBERTa-PreLayerNorm model was proposed in [fairseq: A Fast, Extensible Toolkit for Sequence Modeling](https://arxiv.org/abs/1904.01038) by Myle Ott, Sergey Edunov, Alexei Baevski, Angela Fan, Sam Gross, Nathan Ng, David Grangier, Michael Auli.

--- a/docs/source/en/model_doc/roc_bert.md
+++ b/docs/source/en/model_doc/roc_bert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RoCBert
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=roc_bert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-roc_bert-blueviolet">
+</div>
+
 ## Overview
 
 The RoCBert model was proposed in [RoCBert: Robust Chinese Bert with Multimodal Contrastive Pretraining](https://aclanthology.org/2022.acl-long.65.pdf)  by HuiSu, WeiweiShi, XiaoyuShen, XiaoZhou, TuoJi, JiaruiFang, JieZhou.

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RoFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=roformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-roformer-blueviolet">
+</div>
+
 ## Overview
 
 The RoFormer model was proposed in [RoFormer: Enhanced Transformer with Rotary Position Embedding](https://arxiv.org/pdf/2104.09864v1.pdf) by Jianlin Su and Yu Lu and Shengfeng Pan and Bo Wen and Yunfeng Liu.

--- a/docs/source/en/model_doc/rwkv.md
+++ b/docs/source/en/model_doc/rwkv.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # RWKV
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=rwkv">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-rwkv-blueviolet">
+</div>
+
 ## Overview
 
 The RWKV model was proposed in [this repo](https://github.com/BlinkDL/RWKV-LM)

--- a/docs/source/en/model_doc/sam.md
+++ b/docs/source/en/model_doc/sam.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SAM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=sam">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-sam-blueviolet">
+</div>
+
 ## Overview
 
 SAM (Segment Anything Model) was proposed in [Segment Anything](https://arxiv.org/pdf/2304.02643v1.pdf) by Alexander Kirillov, Eric Mintun, Nikhila Ravi, Hanzi Mao, Chloe Rolland, Laura Gustafson, Tete Xiao, Spencer Whitehead, Alex Berg, Wan-Yen Lo, Piotr Dollar, Ross Girshick.

--- a/docs/source/en/model_doc/seamless_m4t.md
+++ b/docs/source/en/model_doc/seamless_m4t.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # SeamlessM4T
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=seamless_m4t">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-seamless_m4t-blueviolet">
+</div>
+
 ## Overview
 
 The SeamlessM4T model was proposed in [SeamlessM4T — Massively Multilingual & Multimodal Machine Translation](https://dl.fbaipublicfiles.com/seamless/seamless_m4t_paper.pdf) by the Seamless Communication team from Meta AI.

--- a/docs/source/en/model_doc/seamless_m4t_v2.md
+++ b/docs/source/en/model_doc/seamless_m4t_v2.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # SeamlessM4T-v2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=seamless_m4t_v2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-seamless_m4t_v2-blueviolet">
+</div>
+
 ## Overview
 
 The SeamlessM4T-v2 model was proposed in [Seamless: Multilingual Expressive and Streaming Speech Translation](https://ai.meta.com/research/publications/seamless-multilingual-expressive-and-streaming-speech-translation/) by the Seamless Communication team from Meta AI.

--- a/docs/source/en/model_doc/segformer.md
+++ b/docs/source/en/model_doc/segformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SegFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=segformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-segformer-blueviolet">
+</div>
+
 ## Overview
 
 The SegFormer model was proposed in [SegFormer: Simple and Efficient Design for Semantic Segmentation with Transformers](https://arxiv.org/abs/2105.15203) by Enze Xie, Wenhai Wang, Zhiding Yu, Anima Anandkumar, Jose M. Alvarez, Ping

--- a/docs/source/en/model_doc/sew-d.md
+++ b/docs/source/en/model_doc/sew-d.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SEW-D
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=sew-d">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-sew-d-blueviolet">
+</div>
+
 ## Overview
 
 SEW-D (Squeezed and Efficient Wav2Vec with Disentangled attention) was proposed in [Performance-Efficiency Trade-offs

--- a/docs/source/en/model_doc/sew.md
+++ b/docs/source/en/model_doc/sew.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SEW
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=sew">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-sew-blueviolet">
+</div>
+
 ## Overview
 
 SEW (Squeezed and Efficient Wav2Vec) was proposed in [Performance-Efficiency Trade-offs in Unsupervised Pre-training

--- a/docs/source/en/model_doc/speech-encoder-decoder.md
+++ b/docs/source/en/model_doc/speech-encoder-decoder.md
@@ -26,6 +26,11 @@ Alexis Conneau.
 
 An example of how to use a [`SpeechEncoderDecoderModel`] for inference can be seen in [Speech2Text2](speech_to_text_2).
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=speech-encoder-decoder">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-speech-encoder-decoder-blueviolet">
+</div>
+
 ## Randomly initializing `SpeechEncoderDecoderModel` from model configurations.
 
 [`SpeechEncoderDecoderModel`] can be randomly initialized from an encoder and a decoder config. In the following example, we show how to do this using the default [`Wav2Vec2Model`] configuration for the encoder

--- a/docs/source/en/model_doc/speech_to_text.md
+++ b/docs/source/en/model_doc/speech_to_text.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Speech2Text
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=speech_to_text">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-speech_to_text-blueviolet">
+</div>
+
 ## Overview
 
 The Speech2Text model was proposed in [fairseq S2T: Fast Speech-to-Text Modeling with fairseq](https://arxiv.org/abs/2010.05171) by Changhan Wang, Yun Tang, Xutai Ma, Anne Wu, Dmytro Okhonko, Juan Pino. It's a

--- a/docs/source/en/model_doc/speech_to_text_2.md
+++ b/docs/source/en/model_doc/speech_to_text_2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Speech2Text2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=speech_to_text_2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-speech_to_text_2-blueviolet">
+</div>
+
 ## Overview
 
 The Speech2Text2 model is used together with [Wav2Vec2](wav2vec2) for Speech Translation models proposed in

--- a/docs/source/en/model_doc/speecht5.md
+++ b/docs/source/en/model_doc/speecht5.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SpeechT5
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=speecht5">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-speecht5-blueviolet">
+</div>
+
 ## Overview
 
 The SpeechT5 model was proposed in [SpeechT5: Unified-Modal Encoder-Decoder Pre-Training for Spoken Language Processing](https://arxiv.org/abs/2110.07205) by Junyi Ao, Rui Wang, Long Zhou, Chengyi Wang, Shuo Ren, Yu Wu, Shujie Liu, Tom Ko, Qing Li, Yu Zhang, Zhihua Wei, Yao Qian, Jinyu Li, Furu Wei.

--- a/docs/source/en/model_doc/splinter.md
+++ b/docs/source/en/model_doc/splinter.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Splinter
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=splinter">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-splinter-blueviolet">
+</div>
+
 ## Overview
 
 The Splinter model was proposed in [Few-Shot Question Answering by Pretraining Span Selection](https://arxiv.org/abs/2101.00438) by Ori Ram, Yuval Kirstain, Jonathan Berant, Amir Globerson, Omer Levy. Splinter

--- a/docs/source/en/model_doc/squeezebert.md
+++ b/docs/source/en/model_doc/squeezebert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SqueezeBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=squeezebert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-squeezebert-blueviolet">
+</div>
+
 ## Overview
 
 The SqueezeBERT model was proposed in [SqueezeBERT: What can computer vision teach NLP about efficient neural networks?](https://arxiv.org/abs/2006.11316) by Forrest N. Iandola, Albert E. Shaw, Ravi Krishna, Kurt W. Keutzer. It's a

--- a/docs/source/en/model_doc/swiftformer.md
+++ b/docs/source/en/model_doc/swiftformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SwiftFormer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=swiftformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-swiftformer-blueviolet">
+</div>
+
 ## Overview
 
 The SwiftFormer model was proposed in [SwiftFormer: Efficient Additive Attention for Transformer-based Real-time Mobile Vision Applications](https://arxiv.org/abs/2303.15446) by Abdelrahman Shaker, Muhammad Maaz, Hanoona Rasheed, Salman Khan, Ming-Hsuan Yang, Fahad Shahbaz Khan.

--- a/docs/source/en/model_doc/swin.md
+++ b/docs/source/en/model_doc/swin.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Swin Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=swin">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-swin-blueviolet">
+</div>
+
 ## Overview
 
 The Swin Transformer was proposed in [Swin Transformer: Hierarchical Vision Transformer using Shifted Windows](https://arxiv.org/abs/2103.14030)

--- a/docs/source/en/model_doc/swin2sr.md
+++ b/docs/source/en/model_doc/swin2sr.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Swin2SR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=swin2sr">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-swin2sr-blueviolet">
+</div>
+
 ## Overview
 
 The Swin2SR model was proposed in [Swin2SR: SwinV2 Transformer for Compressed Image Super-Resolution and Restoration](https://arxiv.org/abs/2209.11345) by Marcos V. Conde, Ui-Jin Choi, Maxime Burchi, Radu Timofte.

--- a/docs/source/en/model_doc/swinv2.md
+++ b/docs/source/en/model_doc/swinv2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Swin Transformer V2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=swinv2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-swinv2-blueviolet">
+</div>
+
 ## Overview
 
 The Swin Transformer V2 model was proposed in [Swin Transformer V2: Scaling Up Capacity and Resolution](https://arxiv.org/abs/2111.09883) by Ze Liu, Han Hu, Yutong Lin, Zhuliang Yao, Zhenda Xie, Yixuan Wei, Jia Ning, Yue Cao, Zheng Zhang, Li Dong, Furu Wei, Baining Guo.

--- a/docs/source/en/model_doc/switch_transformers.md
+++ b/docs/source/en/model_doc/switch_transformers.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # SwitchTransformers
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=switch_transformers">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-switch_transformers-blueviolet">
+</div>
+
 ## Overview
 
 The SwitchTransformers model was proposed in [Switch Transformers: Scaling to Trillion Parameter Models with Simple and Efficient Sparsity](https://arxiv.org/abs/2101.03961) by William Fedus, Barret Zoph, Noam Shazeer.

--- a/docs/source/en/model_doc/t5v1.1.md
+++ b/docs/source/en/model_doc/t5v1.1.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # T5v1.1
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=t5v1.1">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-t5v1.1-blueviolet">
+</div>
+
 ## Overview
 
 T5v1.1 was released in the [google-research/text-to-text-transfer-transformer](https://github.com/google-research/text-to-text-transfer-transformer/blob/main/released_checkpoints.md#t511)

--- a/docs/source/en/model_doc/table-transformer.md
+++ b/docs/source/en/model_doc/table-transformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Table Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=table-transformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-table-transformer-blueviolet">
+</div>
+
 ## Overview
 
 The Table Transformer model was proposed in [PubTables-1M: Towards comprehensive table extraction from unstructured documents](https://arxiv.org/abs/2110.00061) by

--- a/docs/source/en/model_doc/tapas.md
+++ b/docs/source/en/model_doc/tapas.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # TAPAS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=tapas">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-tapas-blueviolet">
+</div>
+
 ## Overview
 
 The TAPAS model was proposed in [TAPAS: Weakly Supervised Table Parsing via Pre-training](https://www.aclweb.org/anthology/2020.acl-main.398)

--- a/docs/source/en/model_doc/tapex.md
+++ b/docs/source/en/model_doc/tapex.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=tapex">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-tapex-blueviolet">
+</div>
+
 ## Overview
 
 The TAPEX model was proposed in [TAPEX: Table Pre-training via Learning a Neural SQL Executor](https://arxiv.org/abs/2107.07653) by Qian Liu,

--- a/docs/source/en/model_doc/time_series_transformer.md
+++ b/docs/source/en/model_doc/time_series_transformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Time Series Transformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=time_series_transformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-time_series_transformer-blueviolet">
+</div>
+
 ## Overview
 
 The Time Series Transformer model is a vanilla encoder-decoder Transformer for time series forecasting.

--- a/docs/source/en/model_doc/timesformer.md
+++ b/docs/source/en/model_doc/timesformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # TimeSformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=timesformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-timesformer-blueviolet">
+</div>
+
 ## Overview
 
 The TimeSformer model was proposed in [TimeSformer: Is Space-Time Attention All You Need for Video Understanding?](https://arxiv.org/abs/2102.05095) by Facebook Research.

--- a/docs/source/en/model_doc/trajectory_transformer.md
+++ b/docs/source/en/model_doc/trajectory_transformer.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=trajectory_transformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-trajectory_transformer-blueviolet">
+</div>
+
 ## Overview
 
 The Trajectory Transformer model was proposed in [Offline Reinforcement Learning as One Big Sequence Modeling Problem](https://arxiv.org/abs/2106.02039)  by Michael Janner, Qiyang Li, Sergey Levine.

--- a/docs/source/en/model_doc/trocr.md
+++ b/docs/source/en/model_doc/trocr.md
@@ -15,6 +15,11 @@ specific language governing permissions and limitations under the License. -->
 
 # TrOCR
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=trocr">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-trocr-blueviolet">
+</div>
+
 ## Overview
 
 The TrOCR model was proposed in [TrOCR: Transformer-based Optical Character Recognition with Pre-trained

--- a/docs/source/en/model_doc/tvlt.md
+++ b/docs/source/en/model_doc/tvlt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # TVLT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=tvlt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-tvlt-blueviolet">
+</div>
+
 ## Overview
 
 The TVLT model was proposed in [TVLT: Textless Vision-Language Transformer](https://arxiv.org/abs/2209.14156)

--- a/docs/source/en/model_doc/tvp.md
+++ b/docs/source/en/model_doc/tvp.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # TVP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=tvp">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-tvp-blueviolet">
+</div>
+
 ## Overview
 
 The text-visual prompting (TVP) framework was proposed in the paper [Text-Visual Prompting for Efficient 2D Temporal Video Grounding](https://arxiv.org/abs/2303.04995) by Yimeng Zhang, Xin Chen, Jinghan Jia, Sijia Liu, Ke Ding.

--- a/docs/source/en/model_doc/ul2.md
+++ b/docs/source/en/model_doc/ul2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # UL2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=ul2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-ul2-blueviolet">
+</div>
+
 ## Overview
 
 The T5 model was presented in [Unifying Language Learning Paradigms](https://arxiv.org/pdf/2205.05131v1.pdf) by Yi Tay, Mostafa Dehghani, Vinh Q. Tran, Xavier Garcia, Dara Bahri, Tal Schuster, Huaixiu Steven Zheng, Neil Houlsby, Donald Metzler.

--- a/docs/source/en/model_doc/unispeech-sat.md
+++ b/docs/source/en/model_doc/unispeech-sat.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # UniSpeech-SAT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=unispeech-sat">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-unispeech-sat-blueviolet">
+</div>
+
 ## Overview
 
 The UniSpeech-SAT model was proposed in [UniSpeech-SAT: Universal Speech Representation Learning with Speaker Aware

--- a/docs/source/en/model_doc/unispeech.md
+++ b/docs/source/en/model_doc/unispeech.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # UniSpeech
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=unispeech">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-unispeech-blueviolet">
+</div>
+
 ## Overview
 
 The UniSpeech model was proposed in [UniSpeech: Unified Speech Representation Learning with Labeled and Unlabeled Data](https://arxiv.org/abs/2101.07597) by Chengyi Wang, Yu Wu, Yao Qian, Kenichi Kumatani, Shujie Liu, Furu Wei, Michael

--- a/docs/source/en/model_doc/univnet.md
+++ b/docs/source/en/model_doc/univnet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # UnivNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=univnet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-univnet-blueviolet">
+</div>
+
 ## Overview
 
 The UnivNet model was proposed in [UnivNet: A Neural Vocoder with Multi-Resolution Spectrogram Discriminators for High-Fidelity Waveform Generation](https://arxiv.org/abs/2106.07889) by Won Jang, Dan Lim, Jaesam Yoon, Bongwan Kin, and Juntae Kim.

--- a/docs/source/en/model_doc/upernet.md
+++ b/docs/source/en/model_doc/upernet.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # UPerNet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=upernet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-upernet-blueviolet">
+</div>
+
 ## Overview
 
 The UPerNet model was proposed in [Unified Perceptual Parsing for Scene Understanding](https://arxiv.org/abs/1807.10221)

--- a/docs/source/en/model_doc/van.md
+++ b/docs/source/en/model_doc/van.md
@@ -25,6 +25,11 @@ You can do so by running the following command: `pip install -U transformers==4.
 
 </Tip>
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=van">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-van-blueviolet">
+</div>
+
 ## Overview
 
 The VAN model was proposed in [Visual Attention Network](https://arxiv.org/abs/2202.09741) by Meng-Hao Guo, Cheng-Ze Lu, Zheng-Ning Liu, Ming-Ming Cheng, Shi-Min Hu.

--- a/docs/source/en/model_doc/videomae.md
+++ b/docs/source/en/model_doc/videomae.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # VideoMAE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=videomae">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-videomae-blueviolet">
+</div>
+
 ## Overview
 
 The VideoMAE model was proposed in [VideoMAE: Masked Autoencoders are Data-Efficient Learners for Self-Supervised Video Pre-Training](https://arxiv.org/abs/2203.12602) by Zhan Tong, Yibing Song, Jue Wang, Limin Wang.

--- a/docs/source/en/model_doc/vilt.md
+++ b/docs/source/en/model_doc/vilt.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ViLT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vilt">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vilt-blueviolet">
+</div>
+
 ## Overview
 
 The ViLT model was proposed in [ViLT: Vision-and-Language Transformer Without Convolution or Region Supervision](https://arxiv.org/abs/2102.03334)

--- a/docs/source/en/model_doc/vision-encoder-decoder.md
+++ b/docs/source/en/model_doc/vision-encoder-decoder.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Vision Encoder Decoder Models
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vision-encoder-decoder">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vision-encoder-decoder-blueviolet">
+</div>
+
 ## Overview
 
 The [`VisionEncoderDecoderModel`] can be used to initialize an image-to-text model with any

--- a/docs/source/en/model_doc/vision-text-dual-encoder.md
+++ b/docs/source/en/model_doc/vision-text-dual-encoder.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # VisionTextDualEncoder
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vision-text-dual-encoder">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vision-text-dual-encoder-blueviolet">
+</div>
+
 ## Overview
 
 The [`VisionTextDualEncoderModel`] can be used to initialize a vision-text dual encoder model with

--- a/docs/source/en/model_doc/visual_bert.md
+++ b/docs/source/en/model_doc/visual_bert.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # VisualBERT
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=visual_bert">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-visual_bert-blueviolet">
+</div>
+
 ## Overview
 
 The VisualBERT model was proposed in [VisualBERT: A Simple and Performant Baseline for Vision and Language](https://arxiv.org/pdf/1908.03557) by Liunian Harold Li, Mark Yatskar, Da Yin, Cho-Jui Hsieh, Kai-Wei Chang.

--- a/docs/source/en/model_doc/vit.md
+++ b/docs/source/en/model_doc/vit.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Vision Transformer (ViT)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vit-blueviolet">
+</div>
+
 ## Overview
 
 The Vision Transformer (ViT) model was proposed in [An Image is Worth 16x16 Words: Transformers for Image Recognition

--- a/docs/source/en/model_doc/vit_hybrid.md
+++ b/docs/source/en/model_doc/vit_hybrid.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Hybrid Vision Transformer (ViT Hybrid)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vit_hybrid">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vit_hybrid-blueviolet">
+</div>
+
 ## Overview
 
 The hybrid Vision Transformer (ViT) model was proposed in [An Image is Worth 16x16 Words: Transformers for Image Recognition

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ViTMAE
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vit_mae">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vit_mae-blueviolet">
+</div>
+
 ## Overview
 
 The ViTMAE model was proposed in [Masked Autoencoders Are Scalable Vision Learners](https://arxiv.org/abs/2111.06377v2) by Kaiming He, Xinlei Chen, Saining Xie, Yanghao Li,

--- a/docs/source/en/model_doc/vit_msn.md
+++ b/docs/source/en/model_doc/vit_msn.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # ViTMSN
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vit_msn">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vit_msn-blueviolet">
+</div>
+
 ## Overview
 
 The ViTMSN model was proposed in [Masked Siamese Networks for Label-Efficient Learning](https://arxiv.org/abs/2204.07141) by Mahmoud Assran, Mathilde Caron, Ishan Misra, Piotr Bojanowski, Florian Bordes,

--- a/docs/source/en/model_doc/vitdet.md
+++ b/docs/source/en/model_doc/vitdet.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # ViTDet
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vitdet">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vitdet-blueviolet">
+</div>
+
 ## Overview
 
 The ViTDet model was proposed in [Exploring Plain Vision Transformer Backbones for Object Detection](https://arxiv.org/abs/2203.16527) by Yanghao Li, Hanzi Mao, Ross Girshick, Kaiming He.

--- a/docs/source/en/model_doc/vitmatte.md
+++ b/docs/source/en/model_doc/vitmatte.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # ViTMatte
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vitmatte">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vitmatte-blueviolet">
+</div>
+
 ## Overview
 
 The ViTMatte model was proposed in [Boosting Image Matting with Pretrained Plain Vision Transformers](https://arxiv.org/abs/2305.15272) by Jingfeng Yao, Xinggang Wang, Shusheng Yang, Baoyuan Wang.

--- a/docs/source/en/model_doc/vits.md
+++ b/docs/source/en/model_doc/vits.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # VITS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vits">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vits-blueviolet">
+</div>
+
 ## Overview
 
 The VITS model was proposed in [Conditional Variational Autoencoder with Adversarial Learning for End-to-End Text-to-Speech](https://arxiv.org/abs/2106.06103) by Jaehyeon Kim, Jungil Kong, Juhee Son.

--- a/docs/source/en/model_doc/vivit.md
+++ b/docs/source/en/model_doc/vivit.md
@@ -12,6 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # Video Vision Transformer (ViViT)
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=vivit">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-vivit-blueviolet">
+</div>
+
 ## Overview
 
 The Vivit model was proposed in [ViViT: A Video Vision Transformer](https://arxiv.org/abs/2103.15691) by Anurag Arnab, Mostafa Dehghani, Georg Heigold, Chen Sun, Mario Lučić, Cordelia Schmid.

--- a/docs/source/en/model_doc/wav2vec2-conformer.md
+++ b/docs/source/en/model_doc/wav2vec2-conformer.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Wav2Vec2-Conformer
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=wav2vec2-conformer">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-wav2vec2-conformer-blueviolet">
+</div>
+
 ## Overview
 
 The Wav2Vec2-Conformer was added to an updated version of [fairseq S2T: Fast Speech-to-Text Modeling with fairseq](https://arxiv.org/abs/2010.05171) by Changhan Wang, Yun Tang, Xutai Ma, Anne Wu, Sravya Popuri, Dmytro Okhonko, Juan Pino.

--- a/docs/source/en/model_doc/wav2vec2.md
+++ b/docs/source/en/model_doc/wav2vec2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Wav2Vec2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=wav2vec2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-wav2vec2-blueviolet">
+</div>
+
 ## Overview
 
 The Wav2Vec2 model was proposed in [wav2vec 2.0: A Framework for Self-Supervised Learning of Speech Representations](https://arxiv.org/abs/2006.11477) by Alexei Baevski, Henry Zhou, Abdelrahman Mohamed, Michael Auli.

--- a/docs/source/en/model_doc/wav2vec2_phoneme.md
+++ b/docs/source/en/model_doc/wav2vec2_phoneme.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Wav2Vec2Phoneme
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=wav2vec2_phoneme">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-wav2vec2_phoneme-blueviolet">
+</div>
+
 ## Overview
 
 The Wav2Vec2Phoneme model was proposed in [Simple and Effective Zero-shot Cross-lingual Phoneme Recognition (Xu et al.,

--- a/docs/source/en/model_doc/wavlm.md
+++ b/docs/source/en/model_doc/wavlm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # WavLM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=wavlm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-wavlm-blueviolet">
+</div>
+
 ## Overview
 
 The WavLM model was proposed in [WavLM: Large-Scale Self-Supervised Pre-Training for Full Stack Speech Processing](https://arxiv.org/abs/2110.13900) by Sanyuan Chen, Chengyi Wang, Zhengyang Chen, Yu Wu, Shujie Liu, Zhuo Chen,

--- a/docs/source/en/model_doc/whisper.md
+++ b/docs/source/en/model_doc/whisper.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # Whisper
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=whisper">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-whisper-blueviolet">
+</div>
+
 ## Overview
 
 The Whisper model was proposed in [Robust Speech Recognition via Large-Scale Weak Supervision](https://cdn.openai.com/papers/whisper.pdf) by Alec Radford, Jong Wook Kim, Tao Xu, Greg Brockman, Christine McLeavey, Ilya Sutskever.

--- a/docs/source/en/model_doc/xclip.md
+++ b/docs/source/en/model_doc/xclip.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # X-CLIP
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xclip">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xclip-blueviolet">
+</div>
+
 ## Overview
 
 The X-CLIP model was proposed in [Expanding Language-Image Pretrained Models for General Video Recognition](https://arxiv.org/abs/2208.02816) by Bolin Ni, Houwen Peng, Minghao Chen, Songyang Zhang, Gaofeng Meng, Jianlong Fu, Shiming Xiang, Haibin Ling.

--- a/docs/source/en/model_doc/xglm.md
+++ b/docs/source/en/model_doc/xglm.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # XGLM
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xglm">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xglm-blueviolet">
+</div>
+
 ## Overview
 
 The XGLM model was proposed in [Few-shot Learning with Multilingual Language Models](https://arxiv.org/abs/2112.10668)

--- a/docs/source/en/model_doc/xlm-roberta-xl.md
+++ b/docs/source/en/model_doc/xlm-roberta-xl.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # XLM-RoBERTa-XL
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xlm-roberta-xl">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xlm-roberta-xl-blueviolet">
+</div>
+
 ## Overview
 
 The XLM-RoBERTa-XL model was proposed in [Larger-Scale Transformers for Multilingual Masked Language Modeling](https://arxiv.org/abs/2105.00572) by Naman Goyal, Jingfei Du, Myle Ott, Giri Anantharaman, Alexis Conneau. 

--- a/docs/source/en/model_doc/xlm-v.md
+++ b/docs/source/en/model_doc/xlm-v.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # XLM-V
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xlm-v">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xlm-v-blueviolet">
+</div>
+
 ## Overview
 
 XLM-V is multilingual language model with a one million token vocabulary trained on 2.5TB of data from Common Crawl (same as XLM-R).

--- a/docs/source/en/model_doc/xls_r.md
+++ b/docs/source/en/model_doc/xls_r.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # XLS-R
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xls_r">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xls_r-blueviolet">
+</div>
+
 ## Overview
 
 The XLS-R model was proposed in [XLS-R: Self-supervised Cross-lingual Speech Representation Learning at Scale](https://arxiv.org/abs/2111.09296) by Arun Babu, Changhan Wang, Andros Tjandra, Kushal Lakhotia, Qiantong Xu, Naman

--- a/docs/source/en/model_doc/xlsr_wav2vec2.md
+++ b/docs/source/en/model_doc/xlsr_wav2vec2.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # XLSR-Wav2Vec2
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xlsr_wav2vec2">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xlsr_wav2vec2-blueviolet">
+</div>
+
 ## Overview
 
 The XLSR-Wav2Vec2 model was proposed in [Unsupervised Cross-Lingual Representation Learning For Speech Recognition](https://arxiv.org/abs/2006.13979) by Alexis Conneau, Alexei Baevski, Ronan Collobert, Abdelrahman Mohamed, Michael

--- a/docs/source/en/model_doc/xmod.md
+++ b/docs/source/en/model_doc/xmod.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # X-MOD
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=xmod">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-xmod-blueviolet">
+</div>
+
 ## Overview
 
 The X-MOD model was proposed in [Lifting the Curse of Multilinguality by Pre-training Modular Transformers](http://dx.doi.org/10.18653/v1/2022.naacl-main.255) by Jonas Pfeiffer, Naman Goyal, Xi Lin, Xian Li, James Cross, Sebastian Riedel, and Mikel Artetxe.

--- a/docs/source/en/model_doc/yolos.md
+++ b/docs/source/en/model_doc/yolos.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # YOLOS
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=yolos">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-yolos-blueviolet">
+</div>
+
 ## Overview
 
 The YOLOS model was proposed in [You Only Look at One Sequence: Rethinking Transformer in Vision through Object Detection](https://arxiv.org/abs/2106.00666) by Yuxin Fang, Bencheng Liao, Xinggang Wang, Jiemin Fang, Jiyang Qi, Rui Wu, Jianwei Niu, Wenyu Liu.

--- a/docs/source/en/model_doc/yoso.md
+++ b/docs/source/en/model_doc/yoso.md
@@ -16,6 +16,11 @@ rendered properly in your Markdown viewer.
 
 # YOSO
 
+<div class="flex flex-wrap space-x-1">
+<a href="https://huggingface.co/models?filter=yoso">
+<img alt="Models" src="https://img.shields.io/badge/All_model_pages-yoso-blueviolet">
+</div>
+
 ## Overview
 
 The YOSO model was proposed in [You Only Sample (Almost) Once: Linear Cost Self-Attention Via Bernoulli Sampling](https://arxiv.org/abs/2111.09714)  


### PR DESCRIPTION
Adds a few additional links to the Hub. If there are ideas to do this even deeper, would love to incorporate them in this PR.
I would love loved to share initial collections as well but I have to check if I can embed collection visualisation in the doc page + it's not relevant for quite a few architecures.