### PR TITLE
[ASR Pipe] Fix num frames for bs > 1

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -549,7 +549,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                     generate_kwargs["return_token_timestamps"] = True
 
                     if stride is not None:
-                        generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
+                        if isinstance(stride, tuple):
+                            generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
+                        else:
+                            generate_kwargs["num_frames"] = stride[0][0] // self.feature_extractor.hop_length
 
             tokens = self.model.generate(
                 encoder_outputs=encoder(inputs, attention_mask=attention_mask),

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -689,7 +689,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         pipe = pipeline(
             task="automatic-speech-recognition",
             model="openai/whisper-tiny",
-            chunk_length_s=30,
+            chunk_length_s=2,
             return_timestamps="word",
         )
         data = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")


### PR DESCRIPTION
# What does this PR do?

Handles the case when the pipeline is batched and we want to return word-level timestamps. Here, we have a batch (list) of strides, which we slice to get the first stride value.