### PR TITLE
Fix stale bot for locked issues

### DIFF
--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -18,6 +18,7 @@ https://github.com/allenai/allennlp.
 from datetime import datetime as dt
 import os
 
+import github.GithubException
 from github import Github
 
 
@@ -36,8 +37,8 @@ def main():
     repo = g.get_repo("huggingface/transformers")
     open_issues = repo.get_issues(state="open")
 
-    for issue in open_issues:
-        print(issue)
+    for i, issue in enumerate(open_issues):
+        print(i, issue)
         comments = sorted([comment for comment in issue.get_comments()], key=lambda i: i.created_at, reverse=True)
         last_comment = comments[0] if len(comments) > 0 else None
         if (
@@ -47,20 +48,26 @@ def main():
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             # print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
-            issue.edit(state="closed")
+            try:
+                issue.edit(state="closed")
+            except github.GithubException as e:
+                print("Couldn't close the issue:", repr(e))
         elif (
             (dt.utcnow() - issue.updated_at.replace(tzinfo=None)).days > 23
             and (dt.utcnow() - issue.created_at.replace(tzinfo=None)).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             # print(f"Would add stale comment to {issue.number}")
-            issue.create_comment(
-                "This issue has been automatically marked as stale because it has not had "
-                "recent activity. If you think this still needs to be addressed "
-                "please comment on this thread.\n\nPlease note that issues that do not follow the "
-                "[contributing guidelines](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md) "
-                "are likely to be ignored."
-            )
+            try:
+                issue.create_comment(
+                    "This issue has been automatically marked as stale because it has not had "
+                    "recent activity. If you think this still needs to be addressed "
+                    "please comment on this thread.\n\nPlease note that issues that do not follow the "
+                    "[contributing guidelines](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md) "
+                    "are likely to be ignored."
+                )
+            except github.GithubException as e:
+                print("Couldn't create comment:", repr(e))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The stalebot has crashed once again due to the following error:

```
Traceback (most recent call last):
  File "scripts/stale.py", line 67, in <module>
    main()
  File "scripts/stale.py", line 57, in main
    issue.create_comment(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Issue.py", line 290, in create_comment
    headers, data = self._requester.requestJsonAndCheck("POST", f"{self.url}/comments", input=post_parameters)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Requester.py", line 494, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Requester.py", line 629, in requestJson
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Requester.py", line 726, in __requestEncode
    status, responseHeaders, output = self.__requestRaw(cnx, verb, url, requestHeaders, encoded_input)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Requester.py", line 760, in __requestRaw
    response = cnx.getresponse()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/Requester.py", line 174, in getresponse
    r = verb(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/urllib3/connectionpool.py", line 931, in urlopen
    retries = retries.increment(method, url, response=response, _pool=self)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/github/GithubRetry.py", line 179, in increment
    raise Requester.createException(response.status, response.headers, content)  # type: ignore
github.GithubException.GithubException: 403 {"message": "Unable to create comment because issue is locked.", "documentation_url": "https://docs.github.com/articles/locking-conversations/"}
```

I believe it's the first time it's encountering a locked issue, hence the failure. I tested locally that it ran fine on this specific issue.
