### PR TITLE
Add a default decoder_attention_mask for EncoderDecoderModel during training

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -620,6 +620,8 @@ class EncoderDecoderModel(PreTrainedModel):
             decoder_input_ids = shift_tokens_right(
                 labels, self.config.pad_token_id, self.config.decoder_start_token_id
             )
+            if decoder_attention_mask is None:
+                decoder_attention_mask = decoder_input_ids.new_tensor(labels != self.config.pad_token_id)
 
         # Decode
         decoder_outputs = self.decoder(

--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -621,7 +621,7 @@ class EncoderDecoderModel(PreTrainedModel):
                 labels, self.config.pad_token_id, self.config.decoder_start_token_id
             )
             if decoder_attention_mask is None:
-                decoder_attention_mask = decoder_input_ids.new_tensor(labels != self.config.pad_token_id)
+                decoder_attention_mask = decoder_input_ids.new_tensor(decoder_input_ids != self.config.pad_token_id)
 
         # Decode
         decoder_outputs = self.decoder(

--- a/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
+++ b/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
@@ -17,8 +17,8 @@
 import tempfile
 import unittest
 
-from transformers import is_torch_available
-from transformers.testing_utils import require_torch, slow, torch_device
+from transformers import is_torch_available, logging
+from transformers.testing_utils import CaptureLogger, require_torch, slow, torch_device
 
 from ...test_modeling_common import ids_tensor
 from ..bart.test_modeling_bart import BartStandaloneDecoderModelTester
@@ -765,6 +765,48 @@ class BertEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         summary = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
 
         self.assertEqual(summary, [EXPECTED_SUMMARY_SIGMA, EXPECTED_SUMMARY_AMERICA])
+
+    def test_bert2bert_training_loss(self):
+        torch.manual_seed(0)
+        test_dict = self.prepare_config_and_inputs()
+        encoder_config, decoder_config = test_dict["config"], test_dict["decoder_config"]
+
+        encoder_config.pad_token_id = 5
+        encoder_config.decoder_start_token_id = 2
+        decoder_config.pad_token_id = 5
+        decoder_config.decoder_start_token_id = 2
+
+        config = EncoderDecoderConfig.from_encoder_decoder_configs(encoder_config, decoder_config)
+        config.pad_token_id = 5
+        config.decoder_start_token_id = 2
+
+        encoder_model, decoder_model = self.get_encoder_decoder_model(encoder_config, decoder_config)
+        model = EncoderDecoderModel(config=config, encoder=encoder_model, decoder=decoder_model)
+
+        input_ids = torch.tensor(
+            [
+                [10, 55, 89, 11, 57, 32, 36, 78, 46, 28, 5, 5, 5],
+                [10, 21, 97, 71, 63, 19, 12, 57, 5, 5, 5, 5, 5],
+            ]
+        )
+        attention_mask = input_ids.new_tensor(input_ids != 5)
+        labels = torch.tensor(
+            [
+                [33, 23, 91, 12, 19, 96, 5, 5],
+                [87, 85, 13, 31, 5, 5, 5, 5],
+            ]
+        )
+
+        logger = logging.get_logger("transformers.modeling_utils")
+        logger.warning_once.cache_clear()
+
+        with CaptureLogger(logger) as cl:
+            output = model(input_ids, attention_mask, labels=labels)
+        self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
+
+        # Check the approximate value of the loss
+        loss = output[0]
+        self.assertAlmostEqual(loss.item(), 4.586653232574463)
 
 
 @require_torch

--- a/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
+++ b/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
@@ -814,9 +814,8 @@ class BertEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         ignore_pad_tokens_output = model(
             input_ids, attention_mask, labels=labels, decoder_attention_mask=attention_mask_ignoring_padding
         )
-        self.assertNotAlmostEqual(
-            output.loss.item(), ignore_pad_tokens_output.loss.item()
-        )
+        self.assertNotAlmostEqual(output.loss.item(), ignore_pad_tokens_output.loss.item())
+
 
 @require_torch
 class BertGenerationEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):

--- a/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
+++ b/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
@@ -803,7 +803,6 @@ class BertEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         with CaptureLogger(logger) as cl:
             torch.manual_seed(0)
             output = model(input_ids, attention_mask, labels=labels)
-            loss_for_default_decoder_attention_mask = output[0]
 
         # Assert that the warning does not show up since a default decoder_attention_mask should have been created.
         self.assertNotIn("We strongly recommend passing in an `attention_mask`", cl.out)
@@ -812,14 +811,12 @@ class BertEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         # and the default attention mask.
         attention_mask_ignoring_padding = torch.ones(labels.shape, dtype=torch.long)
         torch.manual_seed(0)
-        output = model(
+        ignore_pad_tokens_output = model(
             input_ids, attention_mask, labels=labels, decoder_attention_mask=attention_mask_ignoring_padding
         )
-        loss_for_attention_mask_ignoring_padding = output[0]
         self.assertNotAlmostEqual(
-            loss_for_default_decoder_attention_mask.item(), loss_for_attention_mask_ignoring_padding.item()
+            output.loss.item(), ignore_pad_tokens_output.loss.item()
         )
-
 
 @require_torch
 class BertGenerationEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Add a default decoder_attention_mask for EncoderDecoderModel during training. Since we are already creating the default decoder_input_ids from the labels, we should also create a default decoder_attention_mask to go with it.

Before this fix, the user was shown a warning message ("we strongly recommend passing an attention mask") when following the [new suggested](https://huggingface.co/docs/transformers/model_doc/encoder-decoder#training) [method of training](https://github.com/huggingface/transformers/blob/bef02fd6b9cde975c51607fb936050ef706ff6d8/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py#L42-L47) for EncoderDecoderModel. Although there has been no report of the bug in the wild yet as it would be a silent bug, I suspect it will likely cause [this particular issue](https://huggingface.co/docs/transformers/troubleshooting#incorrect-output-when-padding-tokens-arent-masked) if the pad tokens in the default decoder_input_ids are not taken into account.

Fixes #25271 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @StevenSong 

