### PR TITLE
Fix `PerceiverModelIntegrationTest::test_inference_masked_lm`

### DIFF
--- a/tests/models/perceiver/test_modeling_perceiver.py
+++ b/tests/models/perceiver/test_modeling_perceiver.py
@@ -888,7 +888,7 @@ class PerceiverModelIntegrationTest(unittest.TestCase):
         logits = outputs.logits
 
         # verify logits
-        expected_shape = torch.Size((1, tokenizer.model_max_length, tokenizer.vocab_size))
+        expected_shape = torch.Size((1, tokenizer.model_max_length, len(tokenizer)))
         self.assertEqual(logits.shape, expected_shape)
 
         expected_slice = torch.tensor(


### PR DESCRIPTION
# What does this PR do?

The PR #23909 changed the result of `vocab_size` of 

```
tokenizer = PerceiverTokenizer.from_pretrained("deepmind/language-perceiver")
```
from `262` to `256`, but the logit has shape `[1, 2048, 262]`.

Let's use `len` here.


## To reproduce:
```
from transformers import PerceiverTokenizer

tokenizer = PerceiverTokenizer.from_pretrained("deepmind/language-perceiver")
# 256 on `2da88537` but `262` on one commit before (`835b0a05`)
print(tokenizer.vocab_size)
```