### PR TITLE
🚨🚨🚨 [`Quantization`] Store the original dtype in the config as a private attribute 🚨🚨🚨

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -854,6 +854,9 @@ class PretrainedConfig(PushToHubMixin):
                 else self.quantization_config
             )
 
+            # pop the `_pre_quantization_dtype` as torch.dtypes are not serializable.
+            _ = serializable_config_dict.pop("_pre_quantization_dtype", None)
+
         self.dict_torch_dtype_to_str(serializable_config_dict)
 
         if "_flash_attn_2_enabled" in serializable_config_dict:
@@ -895,6 +898,9 @@ class PretrainedConfig(PushToHubMixin):
                 if not isinstance(self.quantization_config, dict)
                 else self.quantization_config
             )
+
+            # pop the `_pre_quantization_dtype` as torch.dtypes are not serializable.
+            _ = output.pop("_pre_quantization_dtype", None)
 
         self.dict_torch_dtype_to_str(output)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3164,6 +3164,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if hasattr(model, "quantization_method"):
             model.is_quantized = True
 
+            # We store the original dtype for quantized models as we cannot easily retrieve them
+            # one the weights have been quantized
+            # Note that once you have loaded a quantized model, you can't change its dtype so this will
+            # remain a single source of truth
+            config._quantization_original_dtype = torch_dtype
+
         if isinstance(device_map, str):
             special_dtypes = {}
             if load_in_8bit or load_in_4bit:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3185,7 +3185,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model.is_quantized = True
 
             # We store the original dtype for quantized models as we cannot easily retrieve them
-            # one the weights have been quantized
+            # once the weights have been quantized
             # Note that once you have loaded a quantized model, you can't change its dtype so this will
             # remain a single source of truth
             config._pre_quantization_dtype = torch_dtype

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2178,7 +2178,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         elif getattr(self, "quantization_method", None) == QuantizationMethod.GPTQ:
-            # For GPTQ models, we force users to NOT cast the model into th edesired dtype
+            # For GPTQ models, we prevent users from casting the model to another dytpe to restrict unwanted behaviours. 
             # the correct API should be to load the model with the desired dtype directly through `from_pretrained`.
             dtype_present_in_args = False
 
@@ -2196,9 +2196,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     " `dtype` by passing the correct `torch_dtype` argument."
                 )
 
-            return super().to(*args, **kwargs)
-        else:
-            return super().to(*args, **kwargs)
+      return super().to(*args, **kwargs)
 
     def half(self, *args):
         # Checks if the model is quantized
@@ -3184,7 +3182,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if hasattr(model, "quantization_method"):
             model.is_quantized = True
 
-            # We store the original dtype for quantized models as we cannot easily retrieve them
+            # We store the original dtype for quantized models as we cannot easily retrieve it
             # once the weights have been quantized
             # Note that once you have loaded a quantized model, you can't change its dtype so this will
             # remain a single source of truth

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2178,7 +2178,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " model has already been set to the correct devices and casted to the correct `dtype`."
             )
         elif getattr(self, "quantization_method", None) == QuantizationMethod.GPTQ:
-            # For GPTQ models, we prevent users from casting the model to another dytpe to restrict unwanted behaviours. 
+            # For GPTQ models, we prevent users from casting the model to another dytpe to restrict unwanted behaviours.
             # the correct API should be to load the model with the desired dtype directly through `from_pretrained`.
             dtype_present_in_args = False
 
@@ -2195,8 +2195,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "You cannot cast a GPTQ model in a new `dtype`. Make sure to load the model using `from_pretrained` using the desired"
                     " `dtype` by passing the correct `torch_dtype` argument."
                 )
-
-      return super().to(*args, **kwargs)
+        return super().to(*args, **kwargs)
 
     def half(self, *args):
         # Checks if the model is quantized

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3188,7 +3188,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # one the weights have been quantized
             # Note that once you have loaded a quantized model, you can't change its dtype so this will
             # remain a single source of truth
-            config._quantization_original_dtype = torch_dtype
+            config._pre_quantization_dtype = torch_dtype
 
         if isinstance(device_map, str):
             special_dtypes = {}

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -160,9 +160,9 @@ class Bnb4BitTest(Base4bitTest):
         r"""
         A simple test to check if the model succesfully stores the original dtype
         """
-        self.assertTrue(hasattr(self.model_4bit.config, "_quantization_original_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
-        self.assertTrue(self.model_4bit.config._quantization_original_dtype == torch.float16)
+        self.assertTrue(hasattr(self.model_4bit.config, "_pre_quantization_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
+        self.assertTrue(self.model_4bit.config._pre_quantization_dtype == torch.float16)
 
     def test_linear_are_4bit(self):
         r"""

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -161,7 +161,7 @@ class Bnb4BitTest(Base4bitTest):
         A simple test to check if the model succesfully stores the original dtype
         """
         self.assertTrue(hasattr(self.model_4bit.config, "_quantization_original_dtype"))
-        self.assertFalse(hasattr(self.model_16bit.config, "_quantization_original_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
         self.assertTrue(self.model_4bit.config._quantization_original_dtype == torch.float16)
 
     def test_linear_are_4bit(self):

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -156,6 +156,14 @@ class Bnb4BitTest(Base4bitTest):
         linear = get_some_linear_layer(self.model_4bit)
         self.assertTrue(linear.weight.__class__ == Params4bit)
 
+    def test_original_dtype(self):
+        r"""
+        A simple test to check if the model succesfully stores the original dtype
+        """
+        self.assertTrue(hasattr(self.model_4bit.config, "_quantization_original_dtype"))
+        self.assertFalse(hasattr(self.model_16bit.config, "_quantization_original_dtype"))
+        self.assertTrue(self.model_4bit.config._quantization_original_dtype == torch.float16)
+
     def test_linear_are_4bit(self):
         r"""
         A simple test to check if the model conversion has been done correctly by checking on the

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -191,7 +191,7 @@ class MixedInt8Test(BaseMixedInt8Test):
         A simple test to check if the model succesfully stores the original dtype
         """
         self.assertTrue(hasattr(self.model_8bit.config, "_quantization_original_dtype"))
-        self.assertFalse(hasattr(self.model_16bit.config, "_quantization_original_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
         self.assertTrue(self.model_8bit.config._quantization_original_dtype == torch.float16)
 
     def test_memory_footprint(self):

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -190,9 +190,9 @@ class MixedInt8Test(BaseMixedInt8Test):
         r"""
         A simple test to check if the model succesfully stores the original dtype
         """
-        self.assertTrue(hasattr(self.model_8bit.config, "_quantization_original_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
-        self.assertTrue(self.model_8bit.config._quantization_original_dtype == torch.float16)
+        self.assertTrue(hasattr(self.model_8bit.config, "_pre_quantization_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
+        self.assertTrue(self.model_8bit.config._pre_quantization_dtype == torch.float16)
 
     def test_memory_footprint(self):
         r"""

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -186,6 +186,14 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         _ = config.to_json_string()
 
+    def test_original_dtype(self):
+        r"""
+        A simple test to check if the model succesfully stores the original dtype
+        """
+        self.assertTrue(hasattr(self.model_8bit.config, "_quantization_original_dtype"))
+        self.assertFalse(hasattr(self.model_16bit.config, "_quantization_original_dtype"))
+        self.assertTrue(self.model_8bit.config._quantization_original_dtype == torch.float16)
+
     def test_memory_footprint(self):
         r"""
         A simple test to check if the model conversion has been done correctly by checking on the

--- a/tests/quantization/gptq/test_gptq.py
+++ b/tests/quantization/gptq/test_gptq.py
@@ -161,9 +161,9 @@ class GPTQTest(unittest.TestCase):
         r"""
         A simple test to check if the model succesfully stores the original dtype
         """
-        self.assertTrue(hasattr(self.quantized_model.config, "_quantization_original_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
-        self.assertTrue(self.quantized_model.config._quantization_original_dtype == torch.float16)
+        self.assertTrue(hasattr(self.quantized_model.config, "_pre_quantization_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
+        self.assertTrue(self.quantized_model.config._pre_quantization_dtype == torch.float16)
 
     def test_quantized_layers_class(self):
         """

--- a/tests/quantization/gptq/test_gptq.py
+++ b/tests/quantization/gptq/test_gptq.py
@@ -145,6 +145,14 @@ class GPTQTest(unittest.TestCase):
 
         self.assertAlmostEqual(self.mem_fp16 / mem_quantized, self.EXPECTED_RELATIVE_DIFFERENCE)
 
+    def test_original_dtype(self):
+        r"""
+        A simple test to check if the model succesfully stores the original dtype
+        """
+        self.assertTrue(hasattr(self.quantized_model.config, "_quantization_original_dtype"))
+        self.assertFalse(hasattr(self.model_fp16.config, "_quantization_original_dtype"))
+        self.assertTrue(self.quantized_model.config._quantization_original_dtype == torch.float16)
+
     def test_quantized_layers_class(self):
         """
         Simple test to check if the model conversion has been done correctly by checking on

--- a/tests/quantization/gptq/test_gptq.py
+++ b/tests/quantization/gptq/test_gptq.py
@@ -145,6 +145,18 @@ class GPTQTest(unittest.TestCase):
 
         self.assertAlmostEqual(self.mem_fp16 / mem_quantized, self.EXPECTED_RELATIVE_DIFFERENCE)
 
+    def test_device_and_dtype_assignment(self):
+        r"""
+        Test whether trying to cast (or assigning a device to) a model after converting it in 8-bit will throw an error.
+        Checks also if other models are casted correctly.
+        """
+        # This should work
+        _ = self.quantized_model.to(0)
+
+        with self.assertRaises(ValueError):
+            # Tries with a `dtype``
+            self.quantized_model.to(torch.float16)
+
     def test_original_dtype(self):
         r"""
         A simple test to check if the model succesfully stores the original dtype


### PR DESCRIPTION
# What does this PR do?

First step of an alternative design of https://github.com/huggingface/transformers/pull/26560 

For quantized models, instead of introducing a complex logic of retrieving the original weights dtype, I propose to simply add a private attribute `_quantization_original_dtype` in the config object. 

`to` method does not need to be touched here as `to` cannot be called on quantized models (but for GPTQ models you can call `to` to perform device placement only - **not** for dtype casting)

that way we could adapt #26560 to simply check if the config has the attribute `_quantization_original_dtype` which is the case only for quantized models, else retrieve the dtype by retrieving the dtype of the linear layer weights in a classic manner.

cc @LysandreJik 