### PR TITLE
[`Flava`] Fix flava doc

### DIFF
--- a/src/transformers/models/flava/modeling_flava.py
+++ b/src/transformers/models/flava/modeling_flava.py
@@ -1375,8 +1375,15 @@ class FlavaModel(FlavaPreTrainedModel):
         >>> image_embeddings = outputs.image_embeddings
         >>> text_embeddings = outputs.text_embeddings
         >>> multimodal_embeddings = outputs.multimodal_embeddings
-        >>> print(image_embeddings.shape, text_embeddings.shape, multimodal_embeddings.shape)
-        torch.Size([1, 197, 768]) torch.Size([1, 7, 768]) torch.Size([1, 205, 768])
+
+        >>> outputs.image_embeddings.shape
+        torch.Size([1, 197, 768])
+
+        >>> text_embeddings.shape
+        torch.Size([1, 7, 768])
+
+        >>> multimodal_embeddings.shape
+        torch.Size([1, 205, 768])
         ```
         """
 

--- a/src/transformers/models/flava/modeling_flava.py
+++ b/src/transformers/models/flava/modeling_flava.py
@@ -1375,6 +1375,8 @@ class FlavaModel(FlavaPreTrainedModel):
         >>> image_embeddings = outputs.image_embeddings
         >>> text_embeddings = outputs.text_embeddings
         >>> multimodal_embeddings = outputs.multimodal_embeddings
+        >>> print(image_embeddings.shape, text_embeddings.shape, multimodal_embeddings.shape)
+        torch.Size([1, 197, 768]) torch.Size([1, 7, 768]) torch.Size([1, 205, 768])
         ```
         """
 

--- a/src/transformers/models/flava/modeling_flava.py
+++ b/src/transformers/models/flava/modeling_flava.py
@@ -1371,8 +1371,10 @@ class FlavaModel(FlavaPreTrainedModel):
         >>> inputs = processor(text=["a photo of a cat"], images=image, return_tensors="pt", padding=True)
 
         >>> outputs = model(**inputs)
-        >>> logits_per_image = outputs.contrastive_logits_per_image  # this is the image-text similarity score
-        >>> probs = logits_per_image.softmax(dim=1)  # we can take the softmax to get the label probabilities
+
+        >>> image_embeddings = outputs.image_embeddings
+        >>> text_embeddings = outputs.text_embeddings
+        >>> multimodal_embeddings = outputs.multimodal_embeddings
         ```
         """
 


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/26078

In fact the current flava docstring fails, running:

```bash
pytest --doctest-modules src/transformers/models/flava/modeling_flava.py::transformers.models.flava.modeling_flava.FlavaModel.forward
```

Leads to a failure. This PR fixes it

`contrastive_logits_per_image` cannot be retrieved from `FlavaModel` as detailed here: https://github.com/huggingface/transformers/issues/26078#issuecomment-1713369568 , therefore I have decided to modify the docstring to reflect the correct way of retrieving outputs from `FlavaModel`


