### PR TITLE
Enable split_batches through TrainingArguments

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3847,6 +3847,7 @@ class Trainer:
         # create accelerator object
         self.accelerator = Accelerator(
             dispatch_batches=self.args.dispatch_batches,
+            split_batches=self.args.split_batches,
             deepspeed_plugin=self.args.deepspeed_plugin,
             gradient_accumulation_plugin=gradient_accumulation_plugin,
         )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1213,6 +1213,24 @@ class TrainingArguments:
         },
     )
 
+    dispatch_batches: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "Whether to dispatch batches across devices in distributed training. If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process "
+            "and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose"
+            "underlying dataset is an `IterableDataset`, `False` otherwise."
+        },
+    )
+
+    split_batches: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "Whether or not the accelerator should split the batches yielded by the dataloaders across the devices during distributed training. If"
+            "set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it must be a"
+            "round multiple of the number of processes you are using (such as GPUs)."
+        },
+    )
+
     include_tokens_per_second: Optional[bool] = field(
         default=False,
         metadata={"help": "If set to `True`, the speed metrics will include `tgs` (tokens per second per device)."},

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -620,10 +620,12 @@ class TrainingArguments:
 
             This flag is experimental and subject to change in future releases.
         split_batches (`bool`, *optional*):
-            Whether or not the accelerator should split the batches yielded by the dataloaders across the devices during distributed training. If
-            
-            set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it must be a
-            
+            Whether or not the accelerator should split the batches yielded by the dataloaders across the devices
+            during distributed training. If
+
+            set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it
+            must be a
+
             round multiple of the number of processes you are using (such as GPUs).
         include_tokens_per_second (`bool`, *optional*):
             Whether or not to compute the number of tokens per second per device for training speed metrics.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1213,15 +1213,6 @@ class TrainingArguments:
         },
     )
 
-    dispatch_batches: Optional[bool] = field(
-        default=None,
-        metadata={
-            "help": "Whether to dispatch batches across devices in distributed training. If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process "
-            "and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose"
-            "underlying dataset is an `IterableDataset`, `False` otherwise."
-        },
-    )
-
     split_batches: Optional[bool] = field(
         default=None,
         metadata={

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -619,6 +619,12 @@ class TrainingArguments:
             Refer to the PyTorch doc for possible values and note that they may change across PyTorch versions.
 
             This flag is experimental and subject to change in future releases.
+        split_batches (`bool`, *optional*):
+            Whether or not the accelerator should split the batches yielded by the dataloaders across the devices during distributed training. If
+            
+            set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it must be a
+            
+            round multiple of the number of processes you are using (such as GPUs).
         include_tokens_per_second (`bool`, *optional*):
             Whether or not to compute the number of tokens per second per device for training speed metrics.
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1214,7 +1214,7 @@ class TrainingArguments:
     )
 
     split_batches: Optional[bool] = field(
-        default=None,
+        default=False,
         metadata={
             "help": "Whether or not the accelerator should split the batches yielded by the dataloaders across the devices during distributed training. If"
             "set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it must be a"

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -30,9 +30,7 @@ from logging import (
     WARN,  # NOQA
     WARNING,  # NOQA
 )
-from logging import (
-    captureWarnings as _captureWarnings,
-)
+from logging import captureWarnings as _captureWarnings
 from typing import Optional
 
 import huggingface_hub.utils as hf_hub_utils

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -31,7 +31,7 @@ from logging import (
     WARNING,  # NOQA
 )
 from logging import (
-    captureWarnings as _captureWarnings
+    captureWarnings as _captureWarnings,
 )
 from typing import Optional
 

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -30,7 +30,9 @@ from logging import (
     WARN,  # NOQA
     WARNING,  # NOQA
 )
-from logging import captureWarnings as _captureWarnings
+from logging import (
+    captureWarnings as _captureWarnings
+)
 from typing import Optional
 
 import huggingface_hub.utils as hf_hub_utils


### PR DESCRIPTION
# What does this PR do?

This PR passes `split_batches` in the `TrainingArguments` to the `Accelerator()`, the same way that `dispatch_batches` is currently done.

In the future we should consider whether we want to make a dataclass with the args for `Accelerator` that a user can pass instead. (Or a raw Accelerator potentially with guards)

Fixes # (issue)

Solves https://github.com/huggingface/accelerate/issues/2023


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @LysandreJik @pacman100 