### PR TITLE
Fix Seq2seqTrainer decoder attention mask 

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -288,7 +288,9 @@ class Seq2SeqTrainer(Trainer):
             and "decoder_input_ids" in generation_inputs
             and generation_inputs["labels"].shape == generation_inputs["decoder_input_ids"].shape
         ):
-            generation_inputs = {k: v for k, v in inputs.items() if k != "decoder_input_ids"}
+            generation_inputs = {
+                k: v for k, v in inputs.items() if k not in ("decoder_input_ids", "decoder_attention_mask")
+            }
         generated_tokens = self.model.generate(**generation_inputs, **gen_kwargs)
 
         # Temporary hack to ensure the generation config is not initialized for each iteration of the evaluation loop


### PR DESCRIPTION
The Seq2SeqTrainer drops `decoder_input_ids` during the generation step for metrics that expect text generation (like `rouge`) when `labels` is present. However, it doesn't drop `decoder_attention_mask` when it does this, which means that in some cases, we pass `decoder_attention_mask` with no `decoder_input_ids`, resulting in the model getting very confused and throwing a shape error.

This PR fixes the issue.

Fixes #24567