### PR TITLE
Fix TensorFlow pakage check

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -168,6 +168,7 @@ else:
                 "tf-nightly",
                 "tf-nightly-cpu",
                 "tf-nightly-gpu",
+                "tf-nightly-rocm",
                 "intel-tensorflow",
                 "intel-tensorflow-avx512",
                 "tensorflow-rocm",


### PR DESCRIPTION
# What does this PR do?

This fixes the `_is_package_available` check for tensorflow variants (like tensorflow-rocm) where their meta-data differs from the package name. There is an list of available candidate names there, but they are never used since `_is_package_available` will return false preventing the candidate list from being checked.
This also adds `tf-nightly-rocm` to the list of candidates.

Fixes # (issue)
N/A

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

This fixes a small functional error, no documentation updates are required.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- tensorflow review: @gante and @Rocketknight1
