### PR TITLE
🚨🚨 Generate: change order of ops in beam sample to avoid nans

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -821,7 +821,7 @@ class GenerationMixin:
         warpers = LogitsProcessorList()
 
         # In beam methods, we need to keep at least one non-eos token to explore continuations that might have a
-        # better score (i.e. keep len(generation_config.eos_token_id) + 1)
+        # better score (i.e. keep len(list(generation_config.eos_token_id)) + 1)
         if generation_config.num_beams > 1:
             if isinstance(generation_config.eos_token_id, list):
                 min_tokens_to_keep = len(generation_config.eos_token_id) + 1

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -824,7 +824,7 @@ class GenerationMixin:
         # all samplers can be found in `generation_utils_samplers.py`
         if generation_config.temperature is not None and generation_config.temperature != 1.0:
             warpers.append(TemperatureLogitsWarper(generation_config.temperature))
-        min_tokens_to_keep = 2 if generation_config.num_beams > 1 else 1
+        min_tokens_to_keep = 2 * generation_config.num_beams if generation_config.num_beams > 1 else 1
         if generation_config.top_k is not None and generation_config.top_k != 0:
             warpers.append(TopKLogitsWarper(top_k=generation_config.top_k, min_tokens_to_keep=min_tokens_to_keep))
         if generation_config.top_p is not None and generation_config.top_p < 1.0:
@@ -3406,18 +3406,15 @@ class GenerationMixin:
             )  # (batch_size * num_beams, vocab_size)
 
             next_token_scores_processed = logits_processor(input_ids, next_token_scores)
+            next_token_scores_processed = logits_warper(input_ids, next_token_scores_processed)
             next_token_scores = next_token_scores_processed + beam_scores[:, None].expand_as(
                 next_token_scores_processed
             )
-            # Note: logits warpers are intentionally applied after adding running beam scores. On some logits warpers
-            # (like top_p) this is indiferent, but on others (like temperature) it is not. For reference, see
-            # https://github.com/huggingface/transformers/pull/5420#discussion_r449779867
-            next_token_scores = logits_warper(input_ids, next_token_scores)
 
             # Store scores, attentions and hidden_states when required
             if return_dict_in_generate:
                 if output_scores:
-                    scores += (logits_warper(input_ids, next_token_scores_processed),)
+                    scores += (next_token_scores_processed,)
                 if output_attentions:
                     decoder_attentions += (
                         (outputs.decoder_attentions,) if self.config.is_encoder_decoder else (outputs.attentions,)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/26332 -- see [this](https://github.com/huggingface/transformers/issues/26332#issuecomment-1764736970) comment for a full explanation.

TL;DR: in `beam_sample`, `logits_warper` are now applied BEFORE adding the beam scores. We have been postponing this change to avoid introducing output differences, but the truth is that the order of operations causes issues (e.g. [1](https://github.com/huggingface/transformers/issues/26332) [2](https://github.com/huggingface/transformers/issues/22914))

This is technically a bug fix (`beam_sample` is unusable for long generations with `temperature < 1.0` before this change), hence the lack of a deprecation cycle. However, it may alter some generated outputs (short generations with low temperature), hence the 🚨🚨.

Please note that other common operators, like `top_p` and `top_k`, are unaltered by this change.