### PR TITLE
Bring back `set_epoch` for Accelerate-based dataloaders

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1745,7 +1745,7 @@ class Trainer:
                 sampler_kinds = [RandomSampler]
                 if version.parse(accelerate_version) > version.parse("0.23.0"):
                     sampler_kinds.append(SeedableRandomSampler)
-                is_random_sampler = isinstance(sampler, sampler_kinds)
+                is_random_sampler = isinstance(sampler, tuple(sampler_kinds))
                 if is_torch_less_than_1_11 or not is_random_sampler:
                     # We just need to begin an iteration to create the randomization of the sampler.
                     for _ in train_dataloader:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -203,6 +203,7 @@ if is_accelerate_available():
     DATA_SAMPLERS = [RandomSampler]
     if version.parse(accelerate_version) > version.parse("0.23.0"):
         from accelerate.data_loader import SeedableRandomSampler
+
         DATA_SAMPLERS += [SeedableRandomSampler]
 
     if is_deepspeed_available():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -200,8 +200,10 @@ if is_accelerate_available():
             save_fsdp_model,
             save_fsdp_optimizer,
         )
+    DATA_SAMPLERS = [RandomSampler]
     if version.parse(accelerate_version) > version.parse("0.23.0"):
         from accelerate.data_loader import SeedableRandomSampler
+        DATA_SAMPLERS += [SeedableRandomSampler]
 
     if is_deepspeed_available():
         from accelerate.utils import DeepSpeedSchedulerWrapper

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -200,6 +200,8 @@ if is_accelerate_available():
             save_fsdp_model,
             save_fsdp_optimizer,
         )
+    if version.parse(accelerate_version) > version.parse("0.23.0"):
+        from accelerate.data_loader import SeedableRandomSampler
 
     if is_deepspeed_available():
         from accelerate.utils import DeepSpeedSchedulerWrapper
@@ -1733,13 +1735,15 @@ class Trainer:
         model.zero_grad()
 
         self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
-        from accelerate.data_loader import SeedableRandomSampler
 
         # Skip the first epochs_trained epochs to get the random state of the dataloader at the right point.
         if not args.ignore_data_skip:
             for epoch in range(epochs_trained):
                 sampler = get_dataloader_sampler(train_dataloader)
-                is_random_sampler = isinstance(sampler, (RandomSampler, SeedableRandomSampler))
+                sampler_kinds = [RandomSampler]
+                if version.parse(accelerate_version) > version.parse("0.23.0"):
+                    sampler_kinds.append(SeedableRandomSampler)
+                is_random_sampler = isinstance(sampler, sampler_kinds)
                 if is_torch_less_than_1_11 or not is_random_sampler:
                     # We just need to begin an iteration to create the randomization of the sampler.
                     for _ in train_dataloader:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -83,6 +83,7 @@ from .trainer_pt_utils import (
     distributed_broadcast_scalars,
     distributed_concat,
     find_batch_size,
+    get_dataloader_sampler,
     get_model_param_count,
     get_module_class_from_name,
     get_parameter_names,
@@ -1737,14 +1738,7 @@ class Trainer:
         # Skip the first epochs_trained epochs to get the random state of the dataloader at the right point.
         if not args.ignore_data_skip:
             for epoch in range(epochs_trained):
-                from torch.utils.data import BatchSampler
-
-                # sampler = get_dataloader_sampler(train_dataloader)
-                sampler_is_batch_sampler = isinstance(train_dataloader.sampler, BatchSampler)
-                if sampler_is_batch_sampler:
-                    sampler = train_dataloader.sampler.sampler
-                else:
-                    sampler = train_dataloader.batch_sampler.sampler
+                sampler = get_dataloader_sampler(train_dataloader)
                 is_random_sampler = isinstance(sampler, (RandomSampler, SeedableRandomSampler))
                 if is_torch_less_than_1_11 or not is_random_sampler:
                     # We just need to begin an iteration to create the randomization of the sampler.


### PR DESCRIPTION
# What does this PR do?

This PR brings back the `set_epoch` logic and solves the last remaining regression from the accelerate integration. Resuming training should now be exactly identical. (Introduced due to an incomplete implementation in https://github.com/huggingface/transformers/pull/24028)

Linked with https://github.com/huggingface/accelerate/pull/2057

Fixes # (issue)

fixes https://github.com/huggingface/transformers/issues/26541


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik @ArthurZucker 