### PR TITLE
fix set_transform link docs

### DIFF
--- a/docs/source/en/preprocessing.md
+++ b/docs/source/en/preprocessing.md
@@ -412,7 +412,7 @@ If you wish to normalize images as a part of the augmentation transformation, us
 and `image_processor.image_std` values.
 </Tip>
 
-3. Then use 🤗 Datasets [`set_transform`](https://huggingface.co/docs/datasets/process.html#format-transform) to apply the transforms on the fly:
+3. Then use 🤗 Datasets [`set_transform`](https://huggingface.co/docs/datasets/v2.14.5/en/package_reference/main_classes#datasets.Dataset.set_transform) to apply the transforms on the fly:
 
 ```py
 >>> dataset.set_transform(transforms)

--- a/docs/source/en/preprocessing.md
+++ b/docs/source/en/preprocessing.md
@@ -412,7 +412,7 @@ If you wish to normalize images as a part of the augmentation transformation, us
 and `image_processor.image_std` values.
 </Tip>
 
-3. Then use 🤗 Datasets [`set_transform`](https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.Dataset.set_transform) to apply the transforms on the fly:
+3. Then use 🤗 Datasets[`~datasets.Dataset.set_transform`] to apply the transforms on the fly:
 ```py
 >>> dataset.set_transform(transforms)
 ```

--- a/docs/source/en/preprocessing.md
+++ b/docs/source/en/preprocessing.md
@@ -412,8 +412,7 @@ If you wish to normalize images as a part of the augmentation transformation, us
 and `image_processor.image_std` values.
 </Tip>
 
-3. Then use 🤗 Datasets [`set_transform`](https://huggingface.co/docs/datasets/v2.14.5/en/package_reference/main_classes#datasets.Dataset.set_transform) to apply the transforms on the fly:
-
+3. Then use 🤗 Datasets [`set_transform`](https://huggingface.co/docs/datasets/package_reference/main_classes#datasets.Dataset.set_transform) to apply the transforms on the fly:
 ```py
 >>> dataset.set_transform(transforms)
 ```


### PR DESCRIPTION
# What does this PR do?

This PR simply fix a link to set_transform documentation. 

<!-- Remove if not applicable -->

Fixes # (issue)

Broken link to set_transform docs

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@stevhliu  @MKhalusova 




