### PR TITLE
[docstring] Fix docstring for LukeConfig

### DIFF
--- a/src/transformers/models/luke/configuration_luke.py
+++ b/src/transformers/models/luke/configuration_luke.py
@@ -70,15 +70,18 @@ class LukeConfig(PretrainedConfig):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         layer_norm_eps (`float`, *optional*, defaults to 1e-12):
             The epsilon used by the layer normalization layers.
-        use_entity_aware_attention (`bool`, defaults to `True`, *optional*, defaults to `True`):
+        use_entity_aware_attention (`bool`, *optional*, defaults to `True`):
             Whether or not the model should use the entity-aware self-attention mechanism proposed in [LUKE: Deep
             Contextualized Entity Representations with Entity-aware Self-attention (Yamada et
             al.)](https://arxiv.org/abs/2010.01057).
         classifier_dropout (`float`, *optional*):
             The dropout ratio for the classification head.
-        pad_token_id (`<fill_type>`, *optional*, defaults to 1): <fill_docstring>
-        bos_token_id (`<fill_type>`, *optional*, defaults to 0): <fill_docstring>
-        eos_token_id (`<fill_type>`, *optional*, defaults to 2): <fill_docstring>
+        pad_token_id (`int`, *optional*, defaults to 1):
+            Padding token id.
+        bos_token_id (`int`, *optional*, defaults to 0):
+            Beginning of stream token id.
+        eos_token_id (`int`, *optional*, defaults to 2):
+            End of stream token id.
 
     Examples:
 

--- a/src/transformers/models/luke/configuration_luke.py
+++ b/src/transformers/models/luke/configuration_luke.py
@@ -38,7 +38,7 @@ class LukeConfig(PretrainedConfig):
 
 
     Args:
-        vocab_size (`int`, *optional*, defaults to 30522):
+        vocab_size (`int`, *optional*, defaults to 50267):
             Vocabulary size of the LUKE model. Defines the number of different tokens that can be represented by the
             `inputs_ids` passed when calling [`LukeModel`].
         entity_vocab_size (`int`, *optional*, defaults to 500000):
@@ -70,12 +70,15 @@ class LukeConfig(PretrainedConfig):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         layer_norm_eps (`float`, *optional*, defaults to 1e-12):
             The epsilon used by the layer normalization layers.
-        use_entity_aware_attention (`bool`, defaults to `True`):
+        use_entity_aware_attention (`bool`, defaults to `True`, *optional*, defaults to `True`):
             Whether or not the model should use the entity-aware self-attention mechanism proposed in [LUKE: Deep
             Contextualized Entity Representations with Entity-aware Self-attention (Yamada et
             al.)](https://arxiv.org/abs/2010.01057).
         classifier_dropout (`float`, *optional*):
             The dropout ratio for the classification head.
+        pad_token_id (`<fill_type>`, *optional*, defaults to 1): <fill_docstring>
+        bos_token_id (`<fill_type>`, *optional*, defaults to 0): <fill_docstring>
+        eos_token_id (`<fill_type>`, *optional*, defaults to 2): <fill_docstring>
 
     Examples:
 

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -356,7 +356,6 @@ OBJECTS_TO_IGNORE = [
     "LongformerConfig",
     "LongformerModel",
     "LongformerTokenizerFast",
-    "LukeConfig",
     "LukeModel",
     "LukeTokenizer",
     "LxmertTokenizerFast",


### PR DESCRIPTION
Part of Docstring Sprint #26638 

One small bug I noticed, which can be seen in my first commit, was that check_docstrings.py added a duplicate default specification for use_entity_aware_attention, which I deleted in my second commit.

## Before submitting
- [Y] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [Y] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [Y] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [N] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [N] Did you write any new necessary tests?