### PR TITLE
Add InstructBlip to VQA pipeline

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -69,7 +69,7 @@ IMAGE_PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("groupvit", "CLIPImageProcessor"),
         ("idefics", "IdeficsImageProcessor"),
         ("imagegpt", "ImageGPTImageProcessor"),
-        ("instructblip", "InstructBlipProcessor"),
+        ("instructblip", "BlipImageProcessor"),
         ("layoutlmv2", "LayoutLMv2ImageProcessor"),
         ("layoutlmv3", "LayoutLMv3ImageProcessor"),
         ("levit", "LevitImageProcessor"),

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -69,7 +69,7 @@ IMAGE_PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("groupvit", "CLIPImageProcessor"),
         ("idefics", "IdeficsImageProcessor"),
         ("imagegpt", "ImageGPTImageProcessor"),
-        ("instructblip", "BlipImageProcessor"),
+        ("instructblip", "InstructBlipProcessor"),
         ("layoutlmv2", "LayoutLMv2ImageProcessor"),
         ("layoutlmv3", "LayoutLMv3ImageProcessor"),
         ("levit", "LevitImageProcessor"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -850,6 +850,7 @@ MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
 MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         ("blip-2", "Blip2ForConditionalGeneration"),
+        ("instructblip", "InstructBlipForConditionalGeneration"),
         ("vilt", "ViltForQuestionAnswering"),
     ]
 )

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -995,7 +995,12 @@ def pipeline(
                 tokenizer_kwargs.pop("torch_dtype", None)
 
             qformer_tokenizer = AutoTokenizer.from_pretrained(
-                tokenizer_identifier, subfolder="qformer_tokenizer", use_fast=use_fast, _from_pipeline=task, **hub_kwargs, **tokenizer_kwargs
+                tokenizer_identifier,
+                subfolder="qformer_tokenizer",
+                use_fast=use_fast,
+                _from_pipeline=task,
+                **hub_kwargs,
+                **tokenizer_kwargs,
             )
 
     if load_image_processor:

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,5 +1,7 @@
 from typing import Union
 
+from transformers import InstructBlipProcessor
+
 from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging
 from .base import PIPELINE_INIT_ARGS, Pipeline
 
@@ -116,6 +118,9 @@ class VisualQuestionAnsweringPipeline(Pipeline):
 
     def preprocess(self, inputs, padding=False, truncation=False, timeout=None):
         image = load_image(inputs["image"], timeout=timeout)
+        if isinstance(self.image_processor, InstructBlipProcessor):
+            return self.image_processor(images=image, text=inputs["question"], return_tensors=self.framework)
+
         model_inputs = self.tokenizer(
             inputs["question"], return_tensors=self.framework, padding=padding, truncation=truncation
         )

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -171,6 +171,31 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
         self.assertEqual(outputs, [[{"answer": "two"}]] * 2)
 
+    @slow
+    @require_torch
+    @require_torch_gpu
+    def test_large_model_pt_instructblip(self):
+        vqa_pipeline = pipeline(
+            "visual-question-answering",
+            model="Salesforce/instructblip-flan-t5-xl",
+            model_kwargs={"torch_dtype": torch.float16},
+            device=0,
+        )
+        self.assertEqual(vqa_pipeline.model.device, torch.device(0))
+        self.assertEqual(vqa_pipeline.model.language_model.dtype, torch.float16)
+
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "Question: how many cats are there? Answer:"
+
+        outputs = vqa_pipeline(image=image, question=question)
+        self.assertEqual(outputs, [{"answer": "2"}])
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(outputs, [{"answer": "2"}])
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(outputs, [[{"answer": "2"}]] * 2)
+
     @require_tf
     @unittest.skip("Visual question answering not implemented in TF")
     def test_small_model_tf(self):


### PR DESCRIPTION
# What does this PR do?

This PR attempts to support InstructBlip as an acceptable model in the VQA pipeline. Currently, only Blip2 is supported.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@NielsRogge @amyeroberts @Narsil 

# Description

This PR is not complete, but I'd like some guidance so that I can finalize the contribution. One issue is that InstructBlip handles the tokenization a bit. I have a bit of an ugly check; maybe this can be improved.

The bigger issue is that the pipeline loads a `BlipImageProcessor` instead of `InstructBlipProcessor`. I think this comes from this [config](https://huggingface.co/Salesforce/instructblip-flan-t5-xl/blob/main/preprocessor_config.json). The wrinkle here is that the Q-former (the `InstructBlipProcessor` class) is a layer above the image processor (the `BlipImageProcessor` class). We need a handle to an instantiated `InstructBlipProcessor`, but the `pipeline` function doesn't seem to load it. I don't see a hook for subclasses to load additional processors either. Maybe add the `InstructBlipProcessor` as a kwarg to `__init__` in the `VisualQuestionAnsweringPipeline` class? Would love feedback from the core devs.

# Testing

The following code works with my changes:

```python
from transformers import pipeline

checkpoint = "Salesforce/instructblip-flan-t5-xl"
pipe = transformers.pipeline("vqa", model=checkpoint)

# This shouldn't be necessary, but I'm not sure why AutoImageProcessor loads the wrong processor:
image_processor = InstructBlipProcessor.from_pretrained(checkpoint)
pipe.image_processor = image_processor

image_url = "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/lena.png"
pipe(question="What is she wearing ?", image=image_url)
# [{'answer': 'hat'}]
```


