### PR TITLE
Mark test_add_special_tokens as slow for Whisper

### DIFF
--- a/tests/models/whisper/test_tokenization_whisper.py
+++ b/tests/models/whisper/test_tokenization_whisper.py
@@ -307,6 +307,11 @@ class WhisperTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
         )
         self.assertEqual(decoded_output_diacritics, expected_output_diacritics)
 
+    @slow
+    def test_add_special_tokens(self):
+        # This test takes a long time for Whisper, so it's marked as slow for this model
+        super().test_add_special_tokens()
+
 
 class SpeechToTextTokenizerMultilinguialTest(unittest.TestCase):
     checkpoint_name = "openai/whisper-small.en"


### PR DESCRIPTION
test_add_special_tokens has been causing some CI timeouts, and the test seems to be very slow for Whisper when I test it locally. I'm marking the test as `@slow` so it stops causing CI issues, but still runs nightly.

cc @ydshieh 