### PR TITLE
Fix and re-enable ConversationalPipeline tests

### DIFF
--- a/tests/pipelines/test_pipelines_conversational.py
+++ b/tests/pipelines/test_pipelines_conversational.py
@@ -77,14 +77,14 @@ class ConversationalPipelineTests(unittest.TestCase):
 
     def run_pipeline_test(self, conversation_agent, _):
         # Simple
-        outputs = conversation_agent(Conversation("Hi there!"))
+        outputs = conversation_agent(Conversation("Hi there!"), max_new_tokens=20)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
         )
 
         # Single list
-        outputs = conversation_agent([Conversation("Hi there!")])
+        outputs = conversation_agent([Conversation("Hi there!")], max_new_tokens=20)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
@@ -96,7 +96,7 @@ class ConversationalPipelineTests(unittest.TestCase):
         self.assertEqual(len(conversation_1), 1)
         self.assertEqual(len(conversation_2), 1)
 
-        outputs = conversation_agent([conversation_1, conversation_2])
+        outputs = conversation_agent([conversation_1, conversation_2], max_new_tokens=20)
         self.assertEqual(outputs, [conversation_1, conversation_2])
         self.assertEqual(
             outputs,
@@ -118,7 +118,7 @@ class ConversationalPipelineTests(unittest.TestCase):
 
         # One conversation with history
         conversation_2.add_message({"role": "user", "content": "Why do you recommend it?"})
-        outputs = conversation_agent(conversation_2)
+        outputs = conversation_agent(conversation_2, max_new_tokens=20)
         self.assertEqual(outputs, conversation_2)
         self.assertEqual(
             outputs,

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -312,8 +312,12 @@ class PipelineTesterMixin:
                     yield copy.deepcopy(random.choice(examples))
 
             out = []
-            for item in pipeline(data(10), batch_size=4, max_new_tokens=20):
-                out.append(item)
+            if task == "conversational":
+                for item in pipeline(data(10), batch_size=4, max_new_tokens=20):
+                    out.append(item)
+            else:
+                for item in pipeline(data(10), batch_size=4):
+                    out.append(item)
             self.assertEqual(len(out), 10)
 
         run_batch_test(pipeline, examples)

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -312,7 +312,7 @@ class PipelineTesterMixin:
                     yield copy.deepcopy(random.choice(examples))
 
             out = []
-            for item in pipeline(data(10), batch_size=4):
+            for item in pipeline(data(10), batch_size=4, max_new_tokens=20):
                 out.append(item)
             self.assertEqual(len(out), 10)
 
@@ -327,7 +327,6 @@ class PipelineTesterMixin:
         self.run_task_tests(task="automatic-speech-recognition")
 
     @is_pipeline_test
-    @unittest.skip("Conversational tests are currently broken for several models, will fix ASAP - Matt")
     def test_pipeline_conversational(self):
         self.run_task_tests(task="conversational")
 


### PR DESCRIPTION
The bug didn't turn out to be too bad - some models just had very short `max_position_embeddings` in their test configs, which meant the conversation tests generated outputs that were too long. Limiting `max_new_tokens` seems to have fixed it, but I'm running other tests to be sure!