### PR TITLE
timm to pytorch conversion for vit model fix

### DIFF
--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -173,8 +173,6 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
     if not isinstance(timm_model.patch_embed, timm.layers.PatchEmbed):
         raise ValueError(f"{vit_name} is not supported in transformers because it is a hybrid ResNet-ViT.")
 
-    # non-overlapping position and class token embedding (to be added)
-
     # get patch size and image size from the patch embedding submodule
     config.patch_size = timm_model.patch_embed.patch_size[0]
     config.image_size = timm_model.patch_embed.img_size[0]

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -169,6 +169,10 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
     ):
         raise ValueError(f"{vit_name} is not supported in transformers because it uses a layer scale in its blocks.")
 
+    # Hybrid ResNet-ViTs
+    if not isinstance(timm_model.patch_embed, timm.layers.PatchEmbed):
+        raise ValueError(f"{vit_name} is not supported in transformers because it is a hybrid ResNet-ViT.")
+
     # non-overlapping position and class token embedding (to be added)
 
     # get patch size and image size from the patch embedding submodule

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -183,7 +183,6 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
     # load HuggingFace model
     if base_model:
         model = ViTModel(config, add_pooling_layer=False).eval()
-        # print(model.state_dict().keys())
     else:
         model = ViTForImageClassification(config).eval()
     model.load_state_dict(state_dict)
@@ -199,8 +198,6 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
 
     if base_model:
         timm_pooled_output = timm_model.forward_features(pixel_values)
-        print(timm_pooled_output)
-        print(outputs.last_hidden_state)
         assert timm_pooled_output.shape == outputs.last_hidden_state.shape
         assert torch.allclose(timm_pooled_output, outputs.last_hidden_state, atol=1e-1)
     else:


### PR DESCRIPTION
This PR fixes this issue #26219 with timm to PyTorch conversion. It removes the need for hard coded values for model dims by using the attributes of the timm model without needing the model name.

It does the following things :

- [x] Extract model dims from the timm model directly, no need for ifs
- [x] Decides whether the converted model will be a classification model or only a feature extractor using the num_classes attribute of the timm model.
- [x] In the case of a feature extractor only model : remove the pooling layers from the PyTorch model and compare the output to the last hidden state instead.

This works for a large number of models in the ViT family.

@ArthurZucker, @amyeroberts, @rwightman 