### PR TITLE
[`FA-2` / `Mistral`] Supprot fa-2 + right padding + forward

### DIFF
--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -876,6 +876,7 @@ class MistralModel(MistralPreTrainedModel):
             padding_mask is not None
             and hasattr(self.config, "_flash_attn_2_enabled")
             and self.config._flash_attn_2_enabled
+            and past_key_values is not None
         ):
             is_padding_right = padding_mask[:, -1].sum().item() != batch_size
             if is_padding_right:


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/26877

There should be no reason to not support right padding + pure forward as the reason to not support generate + right padding + fa-2 is the cache mechanism for that case that slices the cache from the left. 

cc @ArthurZucker 
