### PR TITLE
Shorten the conversation tests for speed + fixing position overflows

### DIFF
--- a/tests/models/blenderbot/test_modeling_blenderbot.py
+++ b/tests/models/blenderbot/test_modeling_blenderbot.py
@@ -85,7 +85,7 @@ class BlenderbotModelTester:
         hidden_act="gelu",
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=20,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot/test_modeling_flax_blenderbot.py
+++ b/tests/models/blenderbot/test_modeling_flax_blenderbot.py
@@ -87,7 +87,7 @@ class FlaxBlenderbotModelTester:
         hidden_act="gelu",
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=32,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot/test_modeling_tf_blenderbot.py
+++ b/tests/models/blenderbot/test_modeling_tf_blenderbot.py
@@ -53,7 +53,7 @@ class TFBlenderbotModelTester:
         intermediate_size=37,
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=20,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -242,7 +242,7 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
     ):
-        if pipeline_test_casse_name == "TextGenerationPipelineTests":
+        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
             return True
         return False
 
@@ -280,10 +280,6 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
             model.half()
         model.generate(input_ids, attention_mask=attention_mask)
         model.generate(num_beams=4, do_sample=True, early_stopping=False, num_return_sequences=3)
-
-    @unittest.skip("Tiny random model has too few position embeddings for this.")
-    def test_pipeline_conversational(self):
-        pass
 
 
 def assert_tensors_close(a, b, atol=1e-12, prefix=""):

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -85,7 +85,7 @@ class BlenderbotSmallModelTester:
         hidden_act="gelu",
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=20,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -281,6 +281,10 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
         model.generate(input_ids, attention_mask=attention_mask)
         model.generate(num_beams=4, do_sample=True, early_stopping=False, num_return_sequences=3)
 
+    @unittest.skip("Tiny random model has too few position embeddings for this.")
+    def test_pipeline_conversational(self):
+        pass
+
 
 def assert_tensors_close(a, b, atol=1e-12, prefix=""):
     """If tensors have different shapes, different values or a and b are not both tensors, raise a nice Assertion error."""

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -242,9 +242,7 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
     ):
-        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
-            return True
-        return False
+        return pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests")
 
     def setUp(self):
         self.model_tester = BlenderbotSmallModelTester(self)

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -244,9 +244,6 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     ):
         if pipeline_test_casse_name == "TextGenerationPipelineTests":
             return True
-        # TODO @Rocketnight1 to fix
-        if pipeline_test_casse_name == "ConversationalPipelineTests":
-            return True
         return False
 
     def setUp(self):

--- a/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
@@ -320,6 +320,13 @@ class FlaxBlenderbotSmallModelTest(FlaxModelTesterMixin, unittest.TestCase, Flax
     )
     all_generative_model_classes = (FlaxBlenderbotSmallForConditionalGeneration,) if is_flax_available() else ()
 
+    def is_pipeline_test_to_skip(
+        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
+    ):
+        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
+            return True
+        return False
+
     def setUp(self):
         self.model_tester = FlaxBlenderbotSmallModelTester(self)
 
@@ -397,7 +404,3 @@ class FlaxBlenderbotSmallModelTest(FlaxModelTesterMixin, unittest.TestCase, Flax
             input_ids = np.ones((1, 1)) * model.config.eos_token_id
             outputs = model(input_ids)
             self.assertIsNotNone(outputs)
-
-    @unittest.skip("Tiny random model has too few position embeddings for this.")
-    def test_pipeline_conversational(self):
-        pass

--- a/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
@@ -323,9 +323,7 @@ class FlaxBlenderbotSmallModelTest(FlaxModelTesterMixin, unittest.TestCase, Flax
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
     ):
-        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
-            return True
-        return False
+        return pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests")
 
     def setUp(self):
         self.model_tester = FlaxBlenderbotSmallModelTester(self)

--- a/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
@@ -86,7 +86,7 @@ class FlaxBlenderbotSmallModelTester:
         hidden_act="gelu",
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=32,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_flax_blenderbot_small.py
@@ -397,3 +397,7 @@ class FlaxBlenderbotSmallModelTest(FlaxModelTesterMixin, unittest.TestCase, Flax
             input_ids = np.ones((1, 1)) * model.config.eos_token_id
             outputs = model(input_ids)
             self.assertIsNotNone(outputs)
+
+    @unittest.skip("Tiny random model has too few position embeddings for this.")
+    def test_pipeline_conversational(self):
+        pass

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -198,6 +198,13 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
     test_pruning = False
     test_onnx = False
 
+    def is_pipeline_test_to_skip(
+        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
+    ):
+        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
+            return True
+        return False
+
     def setUp(self):
         self.model_tester = TFBlenderbotSmallModelTester(self)
         self.config_tester = ConfigTester(self, config_class=BlenderbotSmallConfig)
@@ -208,10 +215,6 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
     def test_decoder_model_past_large_inputs(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs_for_common()
         self.model_tester.check_decoder_model_past_large_inputs(*config_and_inputs)
-
-    @unittest.skip("Tiny random model has too few position embeddings for this.")
-    def test_pipeline_conversational(self):
-        pass
 
 
 @require_tokenizers

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -244,3 +244,7 @@ class TFBlenderbot90MIntegrationTests(unittest.TestCase):
             "i'm not sure. i just feel like i've been feeling like i have to be in a certain place",
             "i'm not sure. i just feel like i've been in a bad situation.",
         )
+
+    @unittest.skip("Tiny random model has too few position embeddings for this.")
+    def test_pipeline_conversational(self):
+        pass

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -53,7 +53,7 @@ class TFBlenderbotSmallModelTester:
         intermediate_size=37,
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        max_position_embeddings=20,
+        max_position_embeddings=50,
         eos_token_id=2,
         pad_token_id=1,
         bos_token_id=0,

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -209,15 +209,6 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
         config_and_inputs = self.model_tester.prepare_config_and_inputs_for_common()
         self.model_tester.check_decoder_model_past_large_inputs(*config_and_inputs)
 
-    # TODO: Fix the failed tests when this model gets more usage
-    def is_pipeline_test_to_skip(
-        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
-    ):
-        # TODO @Rocketnight1 to fix
-        if pipeline_test_casse_name == "ConversationalPipelineTests":
-            return True
-        return False
-
 
 @require_tokenizers
 @require_tf

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -214,7 +214,6 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
         pass
 
 
-
 @require_tokenizers
 @require_tf
 class TFBlenderbot90MIntegrationTests(unittest.TestCase):

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -209,6 +209,11 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
         config_and_inputs = self.model_tester.prepare_config_and_inputs_for_common()
         self.model_tester.check_decoder_model_past_large_inputs(*config_and_inputs)
 
+    @unittest.skip("Tiny random model has too few position embeddings for this.")
+    def test_pipeline_conversational(self):
+        pass
+
+
 
 @require_tokenizers
 @require_tf
@@ -244,7 +249,3 @@ class TFBlenderbot90MIntegrationTests(unittest.TestCase):
             "i'm not sure. i just feel like i've been feeling like i have to be in a certain place",
             "i'm not sure. i just feel like i've been in a bad situation.",
         )
-
-    @unittest.skip("Tiny random model has too few position embeddings for this.")
-    def test_pipeline_conversational(self):
-        pass

--- a/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_tf_blenderbot_small.py
@@ -201,9 +201,7 @@ class TFBlenderbotSmallModelTest(TFModelTesterMixin, PipelineTesterMixin, unitte
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
     ):
-        if pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests"):
-            return True
-        return False
+        return pipeline_test_casse_name in ("TextGenerationPipelineTests", "ConversationalPipelineTests")
 
     def setUp(self):
         self.model_tester = TFBlenderbotSmallModelTester(self)

--- a/tests/pipelines/test_pipelines_conversational.py
+++ b/tests/pipelines/test_pipelines_conversational.py
@@ -77,14 +77,14 @@ class ConversationalPipelineTests(unittest.TestCase):
 
     def run_pipeline_test(self, conversation_agent, _):
         # Simple
-        outputs = conversation_agent(Conversation("Hi there!"), max_new_tokens=20)
+        outputs = conversation_agent(Conversation("Hi there!"), max_new_tokens=2)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
         )
 
         # Single list
-        outputs = conversation_agent([Conversation("Hi there!")], max_new_tokens=20)
+        outputs = conversation_agent([Conversation("Hi there!")], max_new_tokens=2)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
@@ -96,7 +96,7 @@ class ConversationalPipelineTests(unittest.TestCase):
         self.assertEqual(len(conversation_1), 1)
         self.assertEqual(len(conversation_2), 1)
 
-        outputs = conversation_agent([conversation_1, conversation_2], max_new_tokens=20)
+        outputs = conversation_agent([conversation_1, conversation_2], max_new_tokens=2)
         self.assertEqual(outputs, [conversation_1, conversation_2])
         self.assertEqual(
             outputs,
@@ -118,7 +118,7 @@ class ConversationalPipelineTests(unittest.TestCase):
 
         # One conversation with history
         conversation_2.add_message({"role": "user", "content": "Why do you recommend it?"})
-        outputs = conversation_agent(conversation_2, max_new_tokens=20)
+        outputs = conversation_agent(conversation_2, max_new_tokens=2)
         self.assertEqual(outputs, conversation_2)
         self.assertEqual(
             outputs,

--- a/tests/pipelines/test_pipelines_conversational.py
+++ b/tests/pipelines/test_pipelines_conversational.py
@@ -77,14 +77,14 @@ class ConversationalPipelineTests(unittest.TestCase):
 
     def run_pipeline_test(self, conversation_agent, _):
         # Simple
-        outputs = conversation_agent(Conversation("Hi there!"), max_new_tokens=2)
+        outputs = conversation_agent(Conversation("Hi there!"), max_new_tokens=5)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
         )
 
         # Single list
-        outputs = conversation_agent([Conversation("Hi there!")], max_new_tokens=2)
+        outputs = conversation_agent([Conversation("Hi there!")], max_new_tokens=5)
         self.assertEqual(
             outputs,
             Conversation([{"role": "user", "content": "Hi there!"}, {"role": "assistant", "content": ANY(str)}]),
@@ -96,7 +96,7 @@ class ConversationalPipelineTests(unittest.TestCase):
         self.assertEqual(len(conversation_1), 1)
         self.assertEqual(len(conversation_2), 1)
 
-        outputs = conversation_agent([conversation_1, conversation_2], max_new_tokens=2)
+        outputs = conversation_agent([conversation_1, conversation_2], max_new_tokens=5)
         self.assertEqual(outputs, [conversation_1, conversation_2])
         self.assertEqual(
             outputs,
@@ -118,7 +118,7 @@ class ConversationalPipelineTests(unittest.TestCase):
 
         # One conversation with history
         conversation_2.add_message({"role": "user", "content": "Why do you recommend it?"})
-        outputs = conversation_agent(conversation_2, max_new_tokens=2)
+        outputs = conversation_agent(conversation_2, max_new_tokens=5)
         self.assertEqual(outputs, conversation_2)
         self.assertEqual(
             outputs,

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -313,7 +313,7 @@ class PipelineTesterMixin:
 
             out = []
             if task == "conversational":
-                for item in pipeline(data(10), batch_size=4, max_new_tokens=20):
+                for item in pipeline(data(10), batch_size=4, max_new_tokens=2):
                     out.append(item)
             else:
                 for item in pipeline(data(10), batch_size=4):

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -313,7 +313,7 @@ class PipelineTesterMixin:
 
             out = []
             if task == "conversational":
-                for item in pipeline(data(10), batch_size=4, max_new_tokens=2):
+                for item in pipeline(data(10), batch_size=4, max_new_tokens=5):
                     out.append(item)
             else:
                 for item in pipeline(data(10), batch_size=4):


### PR DESCRIPTION
Some of the conversation tests were still overflowing the maximum position embeddings for very short models like `BlenderBotSmall`. I reduced the limits a lot, which also speeds up those tests! cc @ydshieh