### PR TITLE
Remove token_type_ids from default TF GPT-2 signature

### DIFF
--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -521,6 +521,16 @@ class TFGPT2PreTrainedModel(TFPreTrainedModel):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"h.\d+.attn.bias", r"h.\d+.crossattention.bias"]
 
+    @property
+    def input_signature(self):
+        # Although GPT-2 supports token_type_ids in theory, in practice they are rarely used, and the implementation
+        # means that passing token_type_ids=0 yields different outputs from token_type_ids=None.
+        # Therefore, we remove the token_type_ids argument by default, even though it would usually be included.
+        return {
+            "input_ids": tf.TensorSpec((None, None), tf.int32, name="input_ids"),
+            "attention_mask": tf.TensorSpec((None, None), tf.int32, name="attention_mask"),
+        }
+
 
 @dataclass
 class TFGPT2DoubleHeadsModelOutput(ModelOutput):


### PR DESCRIPTION
Although GPT-2 supports `token_type_ids`, the implementation is very weird (token embeddings are also used as token type embeddings!) and in practice `token_type_ids=None` is used almost exclusively.

For most models, you could mimic the effects of `token_type_ids=None` by just passing an all-zeros array, but this does not work for GPT-2 because it completely skips the embeddings when `token_type_ids=None`. This means that a model exported with a `token_type_ids` input cannot be coerced to behave correctly.

To stop this tripping up other users, we remove `token_type_ids` from the GPT-2 input sig. This issue is specific to GPT-2 - most other models have more reasonable ways of handling `token_type_ids` and shouldn't be affected.

Fixes #26783