### PR TITLE
fix roformer prepare_inputs_for_generation not return model_kwargs

### DIFF
--- a/src/transformers/models/roformer/modeling_roformer.py
+++ b/src/transformers/models/roformer/modeling_roformer.py
@@ -1043,7 +1043,7 @@ class RoFormerForMaskedLM(RoFormerPreTrainedModel):
         )
         input_ids = torch.cat([input_ids, dummy_token], dim=1)
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask}
+        return {"input_ids": input_ids, "attention_mask": attention_mask, **model_kwargs}
 
 
 @add_start_docstrings(
@@ -1191,7 +1191,7 @@ class RoFormerForCausalLM(RoFormerPreTrainedModel):
 
             input_ids = input_ids[:, remove_prefix_length:]
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past_key_values}
+        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past_key_values, **model_kwargs}
 
     def _reorder_cache(self, past_key_values, beam_idx):
         reordered_past = ()


### PR DESCRIPTION
Fixes Roformer prepare_inputs_for_generation not return model_kwargs

### Motivation
This bug causes the parameters passed into the **generate** function to be unable to be received by the model's **forward** function.
This PR is aimed at fixing this issue.