### PR TITLE
Limit to inferior fsspec version

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -127,6 +127,7 @@ class CircleCIJob:
             },
         ]
         steps.extend([{"run": l} for l in self.install_steps])
+        steps.extend([{"run": 'pip install "fsspec>=2023.5.0,<2023.10.0"'}])
         steps.extend([{"run": "pip install pytest-subtests"}])
         steps.append(
             {

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ _deps = [
     "fastapi",
     "filelock",
     "flax>=0.4.1,<=0.7.0",
+    "fsspec<2023.10.0",
     "ftfy",
     "fugashi>=1.0",
     "GitPython<3.1.19",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -20,6 +20,7 @@ deps = {
     "fastapi": "fastapi",
     "filelock": "filelock",
     "flax": "flax>=0.4.1,<=0.7.0",
+    "fsspec": "fsspec<2023.10.0",
     "ftfy": "ftfy",
     "fugashi": "fugashi>=1.0",
     "GitPython": "GitPython<3.1.19",


### PR DESCRIPTION
The newly released fsspec version breaks the implementation in transformers' CI, see the following error:

```
"/home/circleci/.pyenv/versions/3.8.12/lib/python3.8/site-packages/datasets/builder.py", line 1173, in as_dataset
    raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.
/home/circleci/transformers/src/transformers/models/beit/modeling_beit.py:737: UnexpectedException
```

Additionally:
https://github.com/huggingface/datasets/pull/6331 and https://github.com/huggingface/huggingface_hub/pull/1773