### PR TITLE
[`NLLB-MoE`] Fix NLLB MoE 4bit inference

### DIFF
--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -417,7 +417,7 @@ class NllbMoeDenseActDense(nn.Module):
         if (
             isinstance(self.fc2.weight, torch.Tensor)
             and hidden_states.dtype != self.fc2.weight.dtype
-            and self.fc2.weight.dtype != torch.int8
+            and (self.fc2.weight.dtype != torch.int8 and self.fc2.weight.dtype != torch.uint8)
         ):
             hidden_states = hidden_states.to(self.fc2.weight.dtype)
         hidden_states = self.fc2(hidden_states)


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/26898

The hidden states gets silenty casted in `unint8` leading to the error described in #26898

The check `and self.fc2.weight.dtype != torch.int8` is not sufficient in order to cover 4bit models, for these models the weights are in `uint8`, hence adding an extra condition to cover 4bit models fixes the inference issue

cc @ArthurZucker 
