### PR TITLE
Save TB logs as part of push_to_hub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ _deps = [
     "starlette",
     "sudachipy>=0.6.6",
     "sudachidict_core>=20220729",
+    "tensorboard",
     # TensorFlow pin. When changing this value, update examples/tensorflow/_tests_requirements.txt accordingly
     "tensorflow-cpu>=2.6,<2.15",
     "tensorflow>=2.6,<2.15",
@@ -319,6 +320,7 @@ extras["testing"] = (
         "sacremoses",
         "rjieba",
         "beautifulsoup4",
+        "tensorboard",
     )
     + extras["retrieval"]
     + extras["modelcreation"]

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -73,6 +73,7 @@ deps = {
     "starlette": "starlette",
     "sudachipy": "sudachipy>=0.6.6",
     "sudachidict_core": "sudachidict_core>=20220729",
+    "tensorboard": "tensorboard",
     "tensorflow-cpu": "tensorflow-cpu>=2.6,<2.15",
     "tensorflow": "tensorflow>=2.6,<2.15",
     "tensorflow-text": "tensorflow-text<2.15",

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -45,6 +45,7 @@ from .integrations import (
     is_optuna_available,
     is_ray_available,
     is_sigopt_available,
+    is_tensorboard_available,
     is_wandb_available,
 )
 from .integrations.deepspeed import is_deepspeed_available
@@ -889,6 +890,13 @@ def require_optimum(test_case):
     Decorator for optimum dependency
     """
     return unittest.skipUnless(is_optimum_available(), "test requires optimum")(test_case)
+
+
+def require_tensorboard(test_case):
+    """
+    Decorator for `tensorboard` dependency
+    """
+    return unittest.skipUnless(is_tensorboard_available(), "test requires tensorboard")
 
 
 def require_auto_gptq(test_case):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3550,7 +3550,7 @@ class Trainer:
             commit_message=commit_message,
             token=self.args.hub_token,
             run_as_future=True,
-            ignore_patterns=["_*", "[!runs]**/*"],
+            ignore_patterns=["_*", f"{PREFIX_CHECKPOINT_DIR}-*"],
         )
 
         push_jobs = [model_push_job]
@@ -3626,7 +3626,7 @@ class Trainer:
             commit_message=commit_message,
             token=self.args.hub_token,
             run_as_future=not blocking,
-            ignore_patterns=["_*", "[!runs]**/*"],
+            ignore_patterns=["_*", f"{PREFIX_CHECKPOINT_DIR}-*"],
         )
 
     #

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3550,8 +3550,7 @@ class Trainer:
             commit_message=commit_message,
             token=self.args.hub_token,
             run_as_future=True,
-            ignore_patterns=["_*", "**/*"],
-            allow_patterns=["runs/*"],
+            ignore_patterns=["_*", "[!runs]**/*"],
         )
 
         push_jobs = [model_push_job]
@@ -3621,14 +3620,13 @@ class Trainer:
 
         # Wait for the current upload to be finished.
         self._finish_current_push()
-
         return upload_folder(
             repo_id=self.hub_model_id,
             folder_path=self.args.output_dir,
             commit_message=commit_message,
             token=self.args.hub_token,
             run_as_future=not blocking,
-            ignore_patterns=["_*", "**/*"],
+            ignore_patterns=["_*", "[!runs]**/*"],
         )
 
     #

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3551,6 +3551,7 @@ class Trainer:
             token=self.args.hub_token,
             run_as_future=True,
             ignore_patterns=["_*", "**/*"],
+            allow_patterns=["runs/*"],
         )
 
         push_jobs = [model_push_job]

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2161,7 +2161,7 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for model in ["test-trainer", "test-trainer-epoch", "test-trainer-step"]:
+        for model in ["test-trainer", "test-trainer-epoch", "test-trainer-step", "test-trainer-tensorboard"]:
             try:
                 delete_repo(token=cls._token, repo_id=model)
             except HTTPError:
@@ -2289,6 +2289,7 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         for f in files:
             if len(f.split("runs")) > 1 and "events.out.tfevents" in f:
                 found_log = True
+
         assert found_log is True, "No tensorboard log found in repo"
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -30,7 +30,7 @@ from typing import Dict, List
 from unittest.mock import Mock, patch
 
 import numpy as np
-from huggingface_hub import HfFolder, delete_repo, list_repo_commits
+from huggingface_hub import HfFolder, delete_repo, list_repo_commits, list_repo_files
 from parameterized import parameterized
 from requests.exceptions import HTTPError
 
@@ -138,11 +138,14 @@ class RegressionDataset:
 class RegressionTrainingArguments(TrainingArguments):
     a: float = 0.0
     b: float = 0.0
+    keep_report_to: bool = False
 
     def __post_init__(self):
         super().__post_init__()
-        # save resources not dealing with reporting (also avoids the warning when it's not set)
-        self.report_to = []
+        # save resources not dealing with reporting unless specified (also avoids the warning when it's not set)
+        # can be explicitly disabled via `keep_report_to`
+        if not self.keep_report_to:
+            self.report_to = []
 
 
 class RepeatDataset:
@@ -319,7 +322,9 @@ if is_torch_available():
             h = nn.functional.relu(self.linear2(x))
             return self.ln2(x + h + self.bias)
 
-    def get_regression_trainer(a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, **kwargs):
+    def get_regression_trainer(
+        a=0, b=0, double_output=False, train_len=64, eval_len=64, pretrained=True, keep_report_to=False, **kwargs
+    ):
         label_names = kwargs.get("label_names", None)
         train_dataset = RegressionDataset(length=train_len, label_names=label_names)
         eval_dataset = RegressionDataset(length=eval_len, label_names=label_names)
@@ -340,7 +345,7 @@ if is_torch_available():
         output_dir = kwargs.pop("output_dir", "./regression")
         preprocess_logits_for_metrics = kwargs.pop("preprocess_logits_for_metrics", None)
 
-        args = RegressionTrainingArguments(output_dir, a=a, b=b, **kwargs)
+        args = RegressionTrainingArguments(output_dir, a=a, b=b, keep_report_to=keep_report_to, **kwargs)
         return Trainer(
             model,
             args,
@@ -2263,6 +2268,26 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         max_steps = math.ceil(trainer.args.num_train_epochs * len(trainer.get_train_dataloader()))
         for i in range(5, max_steps, 5):
             self.assertIn(f"Training in progress, step {i}", commits)
+
+    def test_push_to_hub_with_tensorboard_logs(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            trainer = get_regression_trainer(
+                output_dir=os.path.join(tmp_dir, "test-trainer-tensorboard"),
+                hub_token=self._token,
+                save_strategy="epoch",
+                report_to=["tensorboard"],
+                keep_report_to=True,
+            )
+            trainer.train()
+            # Push the runs via `push_to_hub()`
+            trainer.push_to_hub()
+
+        files = list_repo_files(f"{USER}/test-trainer-tensorboard", token=self._token)
+        found_log = False
+        for f in files:
+            if len(f.split("runs")) > 1 and "events.out.tfevents" in f:
+                found_log = True
+        assert found_log is True, "No tensorboard log found in repo"
 
 
 @require_torch

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -60,6 +60,7 @@ from transformers.testing_utils import (
     require_safetensors,
     require_sentencepiece,
     require_sigopt,
+    require_tensorboard,
     require_tokenizers,
     require_torch,
     require_torch_bf16_cpu,
@@ -2269,6 +2270,7 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         for i in range(5, max_steps, 5):
             self.assertIn(f"Training in progress, step {i}", commits)
 
+    @require_tensorboard
     def test_push_to_hub_with_tensorboard_logs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             trainer = get_regression_trainer(


### PR DESCRIPTION
# What does this PR do?
This PR brings back the default capability of pushing tensorboard logs as part of `.push_to_hub()` by modifying the `glob` exclusion filter to specifically ignore intermediate checkpoints.

You can see an example here where logs were successfully uploaded: https://huggingface.co/muellerzr/sequence_classification/tree/main

Was removed in https://github.com/huggingface/transformers/pull/25095, likely because we didn't think about the fact that users would want to push their logs with tensorboard

Fixes # (issue)

fixes https://github.com/huggingface/transformers/issues/26321


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @LysandreJik 