### PR TITLE
Safe import of rgb_to_id from FE modules

### DIFF
--- a/src/transformers/models/conditional_detr/feature_extraction_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/feature_extraction_conditional_detr.py
@@ -16,11 +16,21 @@
 
 import warnings
 
+from ...image_transforms import rgb_to_id as _rgb_to_id
 from ...utils import logging
 from .image_processing_conditional_detr import ConditionalDetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
+
+
+def rgb_to_id(x):
+    warnings.warn(
+        "rgb_to_id has moved and will not be importable from this module from v5. "
+        "Please import from transformers.image_transforms instead.",
+        FutureWarning,
+    )
+    return _rgb_to_id(x)
 
 
 class ConditionalDetrFeatureExtractor(ConditionalDetrImageProcessor):

--- a/src/transformers/models/deformable_detr/feature_extraction_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/feature_extraction_deformable_detr.py
@@ -16,11 +16,21 @@
 
 import warnings
 
+from ...image_transforms import rgb_to_id as _rgb_to_id
 from ...utils import logging
 from .image_processing_deformable_detr import DeformableDetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
+
+
+def rgb_to_id(x):
+    warnings.warn(
+        "rgb_to_id has moved and will not be importable from this module from v5. "
+        "Please import from transformers.image_transforms instead.",
+        FutureWarning,
+    )
+    return _rgb_to_id(x)
 
 
 class DeformableDetrFeatureExtractor(DeformableDetrImageProcessor):

--- a/src/transformers/models/detr/feature_extraction_detr.py
+++ b/src/transformers/models/detr/feature_extraction_detr.py
@@ -16,11 +16,21 @@
 
 import warnings
 
+from ...image_transforms import rgb_to_id as _rgb_to_id
 from ...utils import logging
 from .image_processing_detr import DetrImageProcessor
 
 
 logger = logging.get_logger(__name__)
+
+
+def rgb_to_id(x):
+    warnings.warn(
+        "rgb_to_id has moved and will not be importable from this module from v5. "
+        "Please import from transformers.image_transforms instead.",
+        FutureWarning,
+    )
+    return _rgb_to_id(x)
 
 
 class DetrFeatureExtractor(DetrImageProcessor):

--- a/src/transformers/models/yolos/feature_extraction_yolos.py
+++ b/src/transformers/models/yolos/feature_extraction_yolos.py
@@ -16,11 +16,21 @@
 
 import warnings
 
+from ...image_transforms import rgb_to_id as _rgb_to_id
 from ...utils import logging
 from .image_processing_yolos import YolosImageProcessor
 
 
 logger = logging.get_logger(__name__)
+
+
+def rgb_to_id(x):
+    warnings.warn(
+        "rgb_to_id has moved and will not be importable from this module from v5. "
+        "Please import from transformers.image_transforms instead.",
+        FutureWarning,
+    )
+    return _rgb_to_id(x)
 
 
 class YolosFeatureExtractor(YolosImageProcessor):


### PR DESCRIPTION
# What does this PR do?

Small change which makes `rgb_to_id` importable from the feature extraction modules. Previously this was removed and moved to the `image_transforms` module. However, this was a breaking change and should have been more safely handled with a warning telling users how to update their code. 

This was flagged in this issue: https://huggingface.co/facebook/detr-resnet-50-panoptic/discussions/6#6537952c25f780fed22f6285


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?