### PR TITLE
Fix slack report failing for doctest

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -314,7 +314,7 @@ class Message:
         return entries_changed
 
     @property
-    def model_failures(self) -> Dict:
+    def model_failures(self) -> List[Dict]:
         # Obtain per-model failures
         def per_model_sum(model_category_dict):
             return dicts_to_sum(model_category_dict["failed"].values())

--- a/utils/notification_service_doc_tests.py
+++ b/utils/notification_service_doc_tests.py
@@ -133,7 +133,6 @@ class Message:
 
     @property
     def category_failures(self) -> List[Dict]:
-
         failure_blocks = []
 
         MAX_ERROR_TEXT = 3000 - len("The following examples had failures:\n\n\n\n") - len("[Truncated]\n")

--- a/utils/notification_service_doc_tests.py
+++ b/utils/notification_service_doc_tests.py
@@ -19,7 +19,7 @@ import os
 import re
 import time
 from fnmatch import fnmatch
-from typing import Dict
+from typing import Dict, List
 
 import requests
 from slack_sdk import WebClient
@@ -132,47 +132,43 @@ class Message:
         }
 
     @property
-    def category_failures(self) -> Dict:
-        MAX_ERROR_TEXT = 3000 - len("The following examples had failures:\n\n\n\n")
+    def category_failures(self) -> List[Dict]:
+
+        failure_blocks = []
+
+        MAX_ERROR_TEXT = 3000 - len("The following examples had failures:\n\n\n\n") - len("[Truncated]\n")
         line_length = 40
         category_failures = {k: v["failed"] for k, v in doc_test_results.items() if isinstance(v, dict)}
 
-        def single_category_failures(category, failures, target_max_len, report):
+        def single_category_failures(category, failures):
             text = ""
             if len(failures) == 0:
                 return ""
-
-            if report != "":
-                text += "\n"
-
             text += f"*{category} failures*:".ljust(line_length // 2).rjust(line_length // 2) + "\n"
 
             for idx, failure in enumerate(failures):
-                new_text = text
-                new_text += f"`{failure}`\n"
-                if len(new_text) > target_max_len - len("[Truncated]\n"):
+                new_text = text + f"`{failure}`\n"
+                if len(new_text) > MAX_ERROR_TEXT:
                     text = text + "[Truncated]\n"
                     break
                 text = new_text
 
             return text
 
-        report = ""
         for category, failures in category_failures.items():
-            max_len = MAX_ERROR_TEXT - len(report) - len("\n[Truncated]")
-            new_text = single_category_failures(category, failures, target_max_len=max_len, report=report)
-            if len(new_text) > max_len:
-                report += "\n[Truncated]"
-                break
-            report += new_text
+            report = single_category_failures(category, failures)
+            if len(report) == 0:
+                continue
+            block = {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"The following examples had failures:\n\n\n{report}\n",
+                },
+            }
+            failure_blocks.append(block)
 
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"The following examples had failures:\n\n\n{report}\n",
-            },
-        }
+        return failure_blocks
 
     @property
     def payload(self) -> str:
@@ -182,7 +178,7 @@ class Message:
             blocks.append(self.failures)
 
         if self.n_failures > 0:
-            blocks.extend([self.category_failures])
+            blocks.extend(self.category_failures)
 
         if self.n_failures == 0:
             blocks.append(self.no_failures)


### PR DESCRIPTION
# What does this PR do?

By truncating the long reports.

The failing of the (a bit) many TF models is not related to `torch 2.2`. Previous we didn't see those failures, as `Blip2` causes OOM, and later tests may get more GPU memory due to this. (This is what I observed by re-run the doctest with different commits/torc versions).

Still need to figure if there is a way to avoid this.