### PR TITLE
Fix typo in warning message

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -90,7 +90,7 @@ if (
     and "TRANSFORMERS_CACHE" not in os.environ
 ):
     logger.warning(
-        "In Transformers v4.0.0, the default path to cache downloaded models changed from"
+        "In Transformers v4.22.0, the default path to cache downloaded models changed from"
         " '~/.cache/torch/transformers' to '~/.cache/huggingface/hub'. Since you don't seem to have"
         " overridden and '~/.cache/torch/transformers' is a directory that exists, we're moving it to"
         " '~/.cache/huggingface/hub' to avoid redownloading models you have already in the cache. You should"

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -1150,7 +1150,7 @@ def move_cache(cache_dir=None, new_cache_dir=None, token=None):
     if new_cache_dir is None:
         new_cache_dir = TRANSFORMERS_CACHE
     if cache_dir is None:
-        # Migrate from old cache in .cache/huggingface/hub
+        # Migrate from old cache in .cache/huggingface/transformers
         old_cache = Path(TRANSFORMERS_CACHE).parent / "transformers"
         if os.path.isdir(str(old_cache)):
             cache_dir = str(old_cache)

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -91,9 +91,9 @@ if (
 ):
     logger.warning(
         "In Transformers v4.0.0, the default path to cache downloaded models changed from"
-        " '~/.cache/torch/transformers' to '~/.cache/huggingface/transformers'. Since you don't seem to have"
+        " '~/.cache/torch/transformers' to '~/.cache/huggingface/hub'. Since you don't seem to have"
         " overridden and '~/.cache/torch/transformers' is a directory that exists, we're moving it to"
-        " '~/.cache/huggingface/transformers' to avoid redownloading models you have already in the cache. You should"
+        " '~/.cache/huggingface/hub' to avoid redownloading models you have already in the cache. You should"
         " only see this message once."
     )
     shutil.move(old_default_cache_path, default_cache_path)


### PR DESCRIPTION
Fix a typo in the warning message. The value of `default_cache_path` is `~/.cache/huggingface/hub` not `~/.cache/huggingface/transformers`.

v4.22.0 is the earlist version that contains those changes in PR https://github.com/huggingface/transformers/pull/18492
