### PR TITLE
Fix no split modules underlying modules

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1522,8 +1522,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         _no_split_modules = set()
         modules_to_check = [self]
-        while len(modules) > 0:
-            module = modules.pop(-1)
+        while len(modules_to_check) > 0:
+            module = modules_to_check.pop(-1)
             # if the module does not appear in _no_split_modules, we also check the children
             if module.__class__.__name__ not in _no_split_modules:
                 if isinstance(module, PreTrainedModel):
@@ -1534,7 +1534,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         )
                     else:
                         _no_split_modules = _no_split_modules | set(module._no_split_modules)
-                modules += list(module.children())
+                modules_to_check += list(module.children())
         return list(_no_split_modules)
 
     def resize_token_embeddings(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1521,7 +1521,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             `List[str]`: List of modules that should not be split
         """
         _no_split_modules = set()
-        modules = [self]
+        modules_to_check = [self]
         while len(modules) > 0:
             module = modules.pop(-1)
             # if the module does not appear in _no_split_modules, we also check the children

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3306,9 +3306,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             # Make sure tied weights are tied before creating the device map.
             model.tie_weights()
-            # device_map = {'shared': 0, 'text_encoder': 0, 'speech_encoder': 0, 'text_decoder': 0, 'lm_head': 0, 't2u_model': 0, 'vocoder.dur_predictor': 0, 'vocoder.unit_embedding': 0, 'vocoder.speaker_embedding': 1, 'vocoder.language_embedding': 0, 'vocoder.hifi_gan.conv_pre': 0, 'vocoder.hifi_gan.resblocks': 1, 'vocoder.hifi_gan.conv_post': 1, 'vocoder.hifi_gan.upsampler': 1}
             device_map = infer_auto_device_map(model, dtype=target_dtype, **device_map_kwargs)
-            print(device_map)
 
             if load_in_8bit or load_in_4bit:
                 # The LM head / tied weights or any last module can stay on disk / CPU

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1522,11 +1522,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         _no_split_modules = set()
         modules = [self]
-        while len(modules)>0:
+        while len(modules) > 0:
             module = modules.pop(-1)
             # if the module does not appear in _no_split_modules, we also check the children
             if module.__class__.__name__ not in _no_split_modules:
-                if isinstance(module, PreTrainedModel) :
+                if isinstance(module, PreTrainedModel):
                     if module._no_split_modules is None:
                         raise ValueError(
                             f"{module.__class__.__name__} does not support `device_map='{device_map}'`. To implement support, the model "
@@ -3306,7 +3306,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             # Make sure tied weights are tied before creating the device map.
             model.tie_weights()
-            #device_map = {'shared': 0, 'text_encoder': 0, 'speech_encoder': 0, 'text_decoder': 0, 'lm_head': 0, 't2u_model': 0, 'vocoder.dur_predictor': 0, 'vocoder.unit_embedding': 0, 'vocoder.speaker_embedding': 1, 'vocoder.language_embedding': 0, 'vocoder.hifi_gan.conv_pre': 0, 'vocoder.hifi_gan.resblocks': 1, 'vocoder.hifi_gan.conv_post': 1, 'vocoder.hifi_gan.upsampler': 1}
+            # device_map = {'shared': 0, 'text_encoder': 0, 'speech_encoder': 0, 'text_decoder': 0, 'lm_head': 0, 't2u_model': 0, 'vocoder.dur_predictor': 0, 'vocoder.unit_embedding': 0, 'vocoder.speaker_embedding': 1, 'vocoder.language_embedding': 0, 'vocoder.hifi_gan.conv_pre': 0, 'vocoder.hifi_gan.resblocks': 1, 'vocoder.hifi_gan.conv_post': 1, 'vocoder.hifi_gan.upsampler': 1}
             device_map = infer_auto_device_map(model, dtype=target_dtype, **device_map_kwargs)
             print(device_map)
 

--- a/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
@@ -2641,6 +2641,7 @@ class SeamlessM4THifiGan(nn.Module):
 class SeamlessM4TCodeHifiGan(PreTrainedModel):
     config_class = SeamlessM4TConfig
     main_input_name = "input_embeds"
+    _no_split_modules = []
 
     def __init__(self, config):
         super().__init__(config)


### PR DESCRIPTION
# What does this do ?

This PR fixes `_get_no_split_modules` introduced in #26949. Basically, we don't check the children modules if they appear in `_no_split_modules`. By doing that, we can decide to not split a children module (can be a `PretrainedModel`) without having to check if its `_no_split_modules` is set or not. This is particularly useful as we don't necessarily want to set it (small model, can't be split ...). 

This PR along with this [one](https://github.com/huggingface/transformers/pull/27089) should also fix the issues in the CI 