### PR TITLE
Fix docstring and type hint for resize

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -274,7 +274,7 @@ def get_resize_output_image_size(
 
 
 def resize(
-    image,
+    image: np.ndarray,
     size: Tuple[int, int],
     resample: "PILImageResampling" = None,
     reducing_gap: Optional[int] = None,
@@ -286,7 +286,7 @@ def resize(
     Resizes `image` to `(height, width)` specified by `size` using the PIL library.
 
     Args:
-        image (`PIL.Image.Image` or `np.ndarray` or `torch.Tensor`):
+        image (`np.ndarray`):
             The image to resize.
         size (`Tuple[int, int]`):
             The size to use for resizing the image.


### PR DESCRIPTION
# What does this PR do?

Updates the type hint and the docstring for `resize` since the image transformation functions should work with numpy arrays.

Closes #26986 


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@rafaelpadilla

