### PR TITLE
[`Fuyu`] Replace it to `BatchFeature`

### DIFF
--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -3,6 +3,7 @@ from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 
+from ...image_processing_utils import BatchFeature
 from ...image_utils import (
     ChannelDimension,
     get_image_size,
@@ -415,7 +416,7 @@ class FuyuProcessor(ProcessorMixin):
 
         return batch_images, torch.Tensor(image_unpadded_heights), torch.Tensor(image_unpadded_widths)
 
-    def __call__(self, text=None, images=None, return_tensors=None, **kwargs):
+    def __call__(self, text=None, images=None, return_tensors=None, **kwargs) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
         and `kwargs` arguments to LlamaTokenizerFast's [`~LlamaTokenizerFast.__call__`] if `text` is not `None` to
@@ -541,11 +542,13 @@ class FuyuProcessor(ProcessorMixin):
             )
 
             image_patches_tensor = torch.stack([img[0] for img in model_image_input["image_patches"]]).unsqueeze(1)
-            return {
-                "input_ids": image_padded_unpacked_tokens[0].unsqueeze(0),
-                "image_patches": image_patches_tensor[0][0].unsqueeze(0),
-                "image_patches_indices": image_patch_input_indices,
-            }
+            return BatchFeature(
+                data={
+                    "input_ids": image_padded_unpacked_tokens[0].unsqueeze(0),
+                    "image_patches": image_patches_tensor[0][0].unsqueeze(0),
+                    "image_patches_indices": image_patch_input_indices,
+                }
+            )
 
     def batch_decode(self, *args, **kwargs):
         """


### PR DESCRIPTION
# What does this PR do?

Right now users needs to manually loop over `FuyuProcessor`'s output and apply `to` to each element. One should use `BatchFeature` from `image_processing_utils` and call `to` directly to the processed elements

Before this PR users needed to do:

```python
model_inputs = processor(text=text_prompt, images=raw_image)
for k, v in model_inputs.items():
    if v.dtype != torch.long:
        v = v.to(torch.float16)
    model_inputs[k] = v.to("cuda")
```

To run inference on 4bit models

Now they just have to

```python
model_inputs = processor(text=text_prompt, images=raw_image, return_tensors="pt").to("cuda", torch.float16)
```

cc @ArthurZucker 

Script to run the model in 4bit:

```python
import torch
from transformers import FuyuProcessor, FuyuForCausalLM
from PIL import Image
import requests

# load model and processor
model_id = "adept/fuyu-8b"
processor = FuyuProcessor.from_pretrained(model_id)
model = FuyuForCausalLM.from_pretrained(model_id, device_map="cuda:0", load_in_4bit=True)

# prepare inputs for the model
text_prompt = "Generate a coco-style caption.\n"
img_url = 'https://huggingface.co/adept/fuyu-8b/resolve/main/bus.png'
raw_image = Image.open(requests.get(img_url, stream=True).raw).convert('RGB')

inputs = processor(text=text_prompt, images=raw_image, return_tensors="pt").to("cuda", torch.float16)

# autoregressively generate text
generation_output = model.generate(**inputs, max_new_tokens=7)
generation_text = processor.batch_decode(generation_output[:, -7:], skip_special_tokens=True)
```