### PR TITLE
Removed the redundant SiLUActivation class.

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -213,8 +213,8 @@ ACT2CLS = {
     "relu2": ReLUSquaredActivation,
     "relu6": nn.ReLU6,
     "sigmoid": nn.Sigmoid,
-    "silu": nn.functional.silu,
-    "swish": nn.functional.silu,
+    "silu": nn.SiLU,
+    "swish": nn.SiLU,
     "tanh": nn.Tanh,
 }
 ACT2FN = ClassInstantier(ACT2CLS)

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -137,19 +137,6 @@ class AccurateGELUActivation(nn.Module):
         return 0.5 * input * (1 + torch.tanh(self.precomputed_constant * (input + 0.044715 * torch.pow(input, 3))))
 
 
-class SiLUActivation(nn.Module):
-    """
-    See Gaussian Error Linear Units (Hendrycks et al., https://arxiv.org/abs/1606.08415) where the SiLU (Sigmoid Linear
-    Unit) was originally introduced and coined, and see Sigmoid-Weighted Linear Units for Neural Network Function
-    Approximation in Reinforcement Learning (Elfwing et al., https://arxiv.org/abs/1702.03118) and Swish: a Self-Gated
-    Activation Function (Ramachandran et al., https://arxiv.org/abs/1710.05941v1) where the SiLU was experimented with
-    later.
-    """
-
-    def forward(self, input: Tensor) -> Tensor:
-        return nn.functional.silu(input)
-
-
 class MishActivation(nn.Module):
     """
     See Mish: A Self-Regularized Non-Monotonic Activation Function (Misra., https://arxiv.org/abs/1908.08681). Also
@@ -226,8 +213,8 @@ ACT2CLS = {
     "relu2": ReLUSquaredActivation,
     "relu6": nn.ReLU6,
     "sigmoid": nn.Sigmoid,
-    "silu": SiLUActivation,
-    "swish": SiLUActivation,
+    "silu": nn.functional.silu,
+    "swish": nn.functional.silu,
     "tanh": nn.Tanh,
 }
 ACT2FN = ClassInstantier(ACT2CLS)


### PR DESCRIPTION
Removed the redundant **SiLUActivation** class and now use **nn.SiLU** directly.

See now what looks like:
![Screenshot (7)](https://github.com/huggingface/transformers/assets/93595990/c2b33b4b-4028-4b01-92fd-daead767e174)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?



