### PR TITLE
[`tests` / `Quantization`] Fix bnb test

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -124,6 +124,25 @@ class MixedInt8Test(BaseMixedInt8Test):
         gc.collect()
         torch.cuda.empty_cache()
 
+    @unittest.skip("Un-skip once https://github.com/mosaicml/llm-foundry/issues/703 is resolved")
+    def test_get_keys_to_not_convert_trust_remote_code(self):
+        r"""
+        Test the `get_keys_to_not_convert` function with `trust_remote_code` models.
+        """
+        from accelerate import init_empty_weights
+
+        from transformers.integrations.bitsandbytes import get_keys_to_not_convert
+
+        model_id = "mosaicml/mpt-7b"
+        config = AutoConfig.from_pretrained(
+            model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+        )
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(
+                config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+            )
+        self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
+
     def test_get_keys_to_not_convert(self):
         r"""
         Test the `get_keys_to_not_convert` function.
@@ -134,17 +153,6 @@ class MixedInt8Test(BaseMixedInt8Test):
         from transformers.integrations.bitsandbytes import get_keys_to_not_convert
 
         model_id = "mosaicml/mpt-7b"
-        # TODO: to revert once: https://huggingface.co/mosaicml/mpt-7b/discussions/83 is fixed
-        # config = AutoConfig.from_pretrained(
-        #     model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
-        # )
-        # with init_empty_weights():
-        #     model = AutoModelForCausalLM.from_config(
-        #         config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
-        #     )
-        # self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
-
-        # without trust_remote_code
         config = AutoConfig.from_pretrained(model_id, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")
         with init_empty_weights():
             model = MptForCausalLM(config)

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -134,14 +134,16 @@ class MixedInt8Test(BaseMixedInt8Test):
         from transformers.integrations.bitsandbytes import get_keys_to_not_convert
 
         model_id = "mosaicml/mpt-7b"
-        config = AutoConfig.from_pretrained(
-            model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
-        )
-        with init_empty_weights():
-            model = AutoModelForCausalLM.from_config(
-                config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
-            )
-        self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
+        # TODO: to revert once: https://huggingface.co/mosaicml/mpt-7b/discussions/83 is fixed
+        # config = AutoConfig.from_pretrained(
+        #     model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+        # )
+        # with init_empty_weights():
+        #     model = AutoModelForCausalLM.from_config(
+        #         config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
+        #     )
+        # self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
+
         # without trust_remote_code
         config = AutoConfig.from_pretrained(model_id, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")
         with init_empty_weights():


### PR DESCRIPTION
# What does this PR do?

Fixes the currently bnb failing test ([Link to failing job](https://github.com/huggingface/transformers/actions/runs/6680718296))

```
tests/quantization/bnb/test_mixed_int8.py::MixedInt8GPT2Test::test_get_keys_to_not_convert
```

The issue is related to the fact that currently the `trust_remote_code` version of MPT models cannot be loaded from transformers main since https://github.com/huggingface/transformers/pull/27086 removed some private methods from the modeling files, i.e. this simple script fails on main:

```python
from accelerate import init_empty_weights
from transformers import AutoModelForCausalLM, AutoConfig

model_id = "mosaicml/mpt-7b"
config = AutoConfig.from_pretrained(
    model_id, trust_remote_code=True, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
)
with init_empty_weights():
    model = AutoModelForCausalLM.from_config(
        config, trust_remote_code=True, code_revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7"
    )
```

I raised an issue on the Hub https://huggingface.co/mosaicml/mpt-7b/discussions/83 so the issue should be hopefully fixed soon. I proposed to temporary skip the test for trust_remote_code version of MPT models and revert it back once that issue gets resolved. I believe that should be fine
