### PR TITLE
Trigger CI if `tiny_model_summary.json` is modified

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -949,6 +949,10 @@ def infer_tests_to_run(
     if "setup.py" in modified_files:
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
+    # in order to trigger pipeline tests even if no code change at all
+    elif "tests/utils/tiny_model_summary.json" in modified_files:
+        test_files_to_run = ["tests"]
+        repo_utils_launch = any(f.split(os.path.sep)[0] == "utils" for f in modified_files)
     else:
         # All modified tests need to be run.
         test_files_to_run = [


### PR DESCRIPTION
# What does this PR do?

When `tests/utils/tiny_model_summary.json` is changed, currently it won't trigger tests, as it is not a python file.

However, we expect CI being triggered, as the modification of this file usually means there are new models enabling pipeline testing.

(So far, sometimes a PR (usually mine) may have green CI but later red CI on `main` due to this)