### PR TITLE
fix docstring in get_maskformer_resize_output_image_size

### DIFF
--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -309,16 +309,18 @@ def get_mask2former_resize_output_image_size(
     Computes the output size given the desired size.
 
     Args:
-        input_image (`np.ndarray`):
+        image (`np.ndarray`):
             The input image.
-        size (`int`, `Tuple[int, int]`, `List[int]`, `Tuple[int]`):
+        size (`int` or `Tuple[int, int]` or `List[int]` or `Tuple[int]`):
             The size of the output image.
-        default_to_square (`bool`, *optional*, defaults to `True`):
-            Whether to default to square if no size is provided.
         max_size (`int`, *optional*):
             The maximum size of the output image.
-        size_divisible (`int`, *optional*, defaults to 0):
+        size_divisor (`int`, *optional*, defaults to 0):
             If size_divisible is given, the output image size will be divisible by the number.
+        default_to_square (`bool`, *optional*, defaults to `True`):
+            Whether to default to square if no size is provided.
+        input_data_format (`ChannelDimension` or `str`, *optional*):
+            The channel dimension format of the input image. If unset, will use the inferred format from the input.
 
     Returns:
         `Tuple[int, int]`: The output size.

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -316,7 +316,7 @@ def get_mask2former_resize_output_image_size(
         max_size (`int`, *optional*):
             The maximum size of the output image.
         size_divisor (`int`, *optional*, defaults to 0):
-            If size_divisible is given, the output image size will be divisible by the number.
+            If `size_divisor` is given, the output image size will be divisible by the number.
         default_to_square (`bool`, *optional*, defaults to `True`):
             Whether to default to square if no size is provided.
         input_data_format (`ChannelDimension` or `str`, *optional*):
@@ -473,7 +473,7 @@ class Mask2FormerImageProcessor(BaseImageProcessor):
             size (`Dict[str, int]`):
                 The size of the output image.
             size_divisor (`int`, *optional*, defaults to 0):
-                If size_divisor is given, the output image size will be divisible by the number.
+                If `size_divisor` is given, the output image size will be divisible by the number.
             resample (`PILImageResampling` resampling filter, *optional*, defaults to `PILImageResampling.BILINEAR`):
                 Resampling filter to use when resizing the image.
             data_format (`ChannelDimension` or `str`, *optional*):

--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -474,7 +474,7 @@ class Mask2FormerImageProcessor(BaseImageProcessor):
                 If size_divisor is given, the output image size will be divisible by the number.
             resample (`PILImageResampling` resampling filter, *optional*, defaults to `PILImageResampling.BILINEAR`):
                 Resampling filter to use when resizing the image.
-            data_format (`str` or `ChannelDimension`, *optional*):
+            data_format (`ChannelDimension` or `str`, *optional*):
                 The channel dimension format for the output image. If unset, the channel dimension format of the input
                 image is used.
             input_data_format (`ChannelDimension` or `str`, *optional*):

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -321,7 +321,7 @@ def get_maskformer_resize_output_image_size(
             If `size_divisor` is given, the output image size will be divisible by the number.
         default_to_square (`bool`, *optional*, defaults to `True`):
             Whether to default to square if no size is provided.
-        input_data_format (`str` or `ChannelDimension`, *optional*):
+        input_data_format (`ChannelDimension` or `str`, *optional*):
             The channel dimension format of the input image. If unset, will use the inferred format from the input.
 
     Returns:

--- a/src/transformers/models/maskformer/image_processing_maskformer.py
+++ b/src/transformers/models/maskformer/image_processing_maskformer.py
@@ -306,21 +306,23 @@ def get_maskformer_resize_output_image_size(
     size_divisor: int = 0,
     default_to_square: bool = True,
     input_data_format: Optional[Union[str, ChannelDimension]] = None,
-) -> tuple:
+) -> Tuple[int, int]:
     """
     Computes the output size given the desired size.
 
     Args:
-        input_image (`np.ndarray`):
+        image (`np.ndarray`):
             The input image.
-        size (`int`, `Tuple[int, int]`, `List[int]`, `Tuple[int]`):
+        size (`int` or `Tuple[int, int]` or `List[int]` or `Tuple[int]`):
             The size of the output image.
-        default_to_square (`bool`, *optional*, defaults to `True`):
-            Whether to default to square if no size is provided.
         max_size (`int`, *optional*):
             The maximum size of the output image.
-        size_divisible (`int`, *optional*, defaults to 0):
-            If size_divisible is given, the output image size will be divisible by the number.
+        size_divisor (`int`, *optional*, defaults to 0):
+            If `size_divisor` is given, the output image size will be divisible by the number.
+        default_to_square (`bool`, *optional*, defaults to `True`):
+            Whether to default to square if no size is provided.
+        input_data_format (`str` or `ChannelDimension`, *optional*):
+            The channel dimension format of the input image. If unset, will use the inferred format from the input.
 
     Returns:
         `Tuple[int, int]`: The output size.


### PR DESCRIPTION
# What does this PR do?
Fixes docstring in `get_maskformer_resize_output_image_size`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 
@rafaelpadilla 
