### PR TITLE
fix:fix Deployment of web stream interface application, issue with me…

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2848,7 +2848,12 @@ class GenerationMixin:
             # stop if we exceed the maximum length
             if stopping_criteria(input_ids, scores):
                 this_peer_finished = True
-
+            if streamer is not None:
+                del next_tokens
+                del next_token_logits
+                del outputs
+                del model_inputs
+                torch.cuda.empty_cache()
             if this_peer_finished and not synced_gpus:
                 break
 


### PR DESCRIPTION
"When I deploy the Baichuan model using the streaming interface, I noticed that after each call, the GPU memory usage increases by more than ten gigabytes. Due to the inherent characteristics of the GPU, it's necessary to release the GPU memory during the token return process to ensure stable GPU memory usage."