### PR TITLE
[docs] Custom model doc update

### DIFF
--- a/docs/source/en/custom_models.md
+++ b/docs/source/en/custom_models.md
@@ -272,6 +272,22 @@ Note that there is no need to specify an auto class for the configuration (there
 [`AutoConfig`]) but it's different for models. Your custom model could be suitable for many different tasks, so you
 have to specify which one of the auto classes is the correct one for your model.
 
+<Tip>
+
+Use `register_for_auto_class()` if you want the code files to be copied. If you instead prefer to use code on the Hub from another repo, 
+you don't need to call it. In cases where there's more than one auto class, you can modify the `config.json` directly using the 
+following structure:
+
+```
+"auto_map": {     
+	"AutoConfig": "<your-repo-name>--<config-name>",     
+	"AutoModel": "<your-repo-name>--<config-name>",
+	"AutoModelFor<Task>": "<your-repo-name>--<config-name>",    
+},
+```
+
+</Tip>
+
 Next, let's create the config and models as we did before:
 
 ```py


### PR DESCRIPTION
This PR adds a documentation update to address the feedback left [here](https://huggingface.co/jinaai/jina-embeddings-v2-base-en/discussions/5#65380596ffe3e0513108cd3a), quote:

```
The clarity of the transformers documentation on custom models could be improved by describing 
the syntax of auto_map in config.json. We never used the register functions and would just directly 
modify the config.json. The behaviour that allowed one to use code on the Hub from another repo 
using "--" doesn't seem to be documented anywhere but we figured out that it was possible because 
save_pretrained saves in this format when using a custom model. The feature does seem to be pretty 
new though (I believe ~6 months ago?) so maybe that is why it hasn't been too well documented yet. 
But we think that if it was better communicated to users that it was possible to do this, more people 
would develop on the Hub as we did.
```