### PR TITLE
make `LlamaDynamicNTKScalingRotaryEmbedding` work correctly

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -164,24 +164,21 @@ class LlamaDynamicNTKScalingRotaryEmbedding(LlamaRotaryEmbedding):
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):
         self.scaling_factor = scaling_factor
         super().__init__(dim, max_position_embeddings, base, device)
-
-    def _set_cos_sin_cache(self, seq_len, device, dtype):
-        self.max_seq_len_cached = seq_len
-
-        if seq_len > self.max_position_embeddings:
-            base = self.base * (
-                (self.scaling_factor * seq_len / self.max_position_embeddings) - (self.scaling_factor - 1)
-            ) ** (self.dim / (self.dim - 2))
-            inv_freq = 1.0 / (base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
-            self.register_buffer("inv_freq", inv_freq, persistent=False)
-
-        t = torch.arange(self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype)
-
-        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
-        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+    
+    def forward(self, x, seq_len=None):
+        if seq_len <= self.max_position_embeddings:
+            dynamic = 1.0
+        else:
+            dynamic = seq_len / self.max_position_embeddings
+        base = self.base * (
+            (self.scaling_factor * dynamic) - (self.scaling_factor - 1)
+        ) ** (self.dim / (self.dim - 2))
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.dim, 2).float().to(x.device) / self.dim))
+        t = torch.arange(seq_len, device=x.device, dtype=inv_freq.dtype)
+        freqs = torch.einsum("i,j->ij", t, inv_freq)
         emb = torch.cat((freqs, freqs), dim=-1)
-        self.register_buffer("cos_cached", emb.cos().to(dtype), persistent=False)
-        self.register_buffer("sin_cached", emb.sin().to(dtype), persistent=False)
+        cos, sin = emb.cos(), emb.sin()
+        return cos[:seq_len].to(dtype=x.dtype), sin[:seq_len].to(dtype=x.dtype)
 
 
 def rotate_half(x):


### PR DESCRIPTION
Fixes #27226 
to: @ArthurZucker, @younesbelkada 