### PR TITLE
Wrap `_prepare_4d_causal_attention_mask` as a leaf function

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -40,12 +40,19 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
+from ...utils.import_utils import is_torch_fx_available
 from .configuration_llama import LlamaConfig
 
 
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_func, flash_attn_varlen_func
     from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input  # noqa
+
+
+# This makes `_prepare_4d_causal_attention_mask` a leaf function in the FX graph.
+# It means that the function will not be traced through and simply appear as a node in the graph.
+if is_torch_fx_available():
+    _prepare_4d_causal_attention_mask = torch.fx.wrap(_prepare_4d_causal_attention_mask)
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
# What does this PR do?

This wraps the `_prepare_4d_causal_attention_mask` as a FX leaf function for similar reasons than [here](https://github.com/huggingface/transformers/pull/26414#issuecomment-1737443846).

The only consequence it has is that it will not be possible to edit this function by using `torch.fx`. It is not a big deal at all, but I will remove this constraint as soon as possible.