### PR TITLE
fix-deprecated-exllama-arg

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -455,6 +455,7 @@ class GPTQConfig(QuantizationConfigMixin):
                 "The value of `use_exllama` will be overwritten by `disable_exllama` passed in `GPTQConfig` or stored in your config file."
             )
             self.use_exllama = not self.disable_exllama
+            self.disable_exllama = None
         elif self.disable_exllama is not None and self.use_exllama is not None:
             # Only happens if user explicitly passes in both arguments
             raise ValueError("Cannot specify both `disable_exllama` and `use_exllama`. Please use just `use_exllama`")


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes the logic with disable_exlllama so that it is BC compatible. It fixes the case were the user overwrite the `GPTQConfig`.

```py
checkpoint = "marcsun13/opt-350m-gptq-4bit"
quantization_config = GPTQConfig(bits=4, disable_exllama=True )
# True
print(quantization_config.use_exllama)
# False 
print(quantization_config.disable_exllama)
-> this will lead to an error as both are defined. 
model = AutoModelForCausalLM.from_pretrained(checkpoint, quantization_config=quantization_config)
```