### PR TITLE
Avoid many failing tests in doctesting

### DIFF
--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -54,7 +54,7 @@ def clean_doctest_list(doctest_file: str, overwrite: bool = False):
     all_paths = []
     with open(doctest_file, "r", encoding="utf-8") as f:
         for line in f:
-            line = line.strip()
+            line = line.strip().split(" ")[0]
             path = os.path.join(REPO_PATH, line)
             if not (os.path.isfile(path) or os.path.isdir(path)):
                 non_existent_paths.append(line)

--- a/utils/not_doctested.txt
+++ b/utils/not_doctested.txt
@@ -293,7 +293,7 @@ docs/source/en/serialization.md
 docs/source/en/tasks/asr.md
 docs/source/en/tasks/audio_classification.md
 docs/source/en/tasks/document_question_answering.md
-docs/source/en/tasks/idefics.md  # cause other test failing
+docs/source/en/tasks/idefics.md  # causes other tests to fail
 docs/source/en/tasks/image_captioning.md
 docs/source/en/tasks/image_classification.md
 docs/source/en/tasks/language_modeling.md
@@ -431,7 +431,7 @@ src/transformers/models/blip/modeling_blip_text.py
 src/transformers/models/blip/modeling_tf_blip_text.py
 src/transformers/models/blip_2/configuration_blip_2.py
 src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
-src/transformers/models/blip_2/modeling_blip_2.py  # cause other test failing
+src/transformers/models/blip_2/modeling_blip_2.py  # causes other tests to fail
 src/transformers/models/bloom/convert_bloom_original_checkpoint_to_pytorch.py
 src/transformers/models/bloom/modeling_bloom.py
 src/transformers/models/bloom/modeling_flax_bloom.py

--- a/utils/not_doctested.txt
+++ b/utils/not_doctested.txt
@@ -293,6 +293,7 @@ docs/source/en/serialization.md
 docs/source/en/tasks/asr.md
 docs/source/en/tasks/audio_classification.md
 docs/source/en/tasks/document_question_answering.md
+docs/source/en/tasks/idefics.md
 docs/source/en/tasks/image_captioning.md
 docs/source/en/tasks/image_classification.md
 docs/source/en/tasks/language_modeling.md
@@ -430,6 +431,7 @@ src/transformers/models/blip/modeling_blip_text.py
 src/transformers/models/blip/modeling_tf_blip_text.py
 src/transformers/models/blip_2/configuration_blip_2.py
 src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
+src/transformers/models/blip_2/modeling_blip_2.py
 src/transformers/models/bloom/convert_bloom_original_checkpoint_to_pytorch.py
 src/transformers/models/bloom/modeling_bloom.py
 src/transformers/models/bloom/modeling_flax_bloom.py

--- a/utils/not_doctested.txt
+++ b/utils/not_doctested.txt
@@ -293,7 +293,7 @@ docs/source/en/serialization.md
 docs/source/en/tasks/asr.md
 docs/source/en/tasks/audio_classification.md
 docs/source/en/tasks/document_question_answering.md
-docs/source/en/tasks/idefics.md
+docs/source/en/tasks/idefics.md  # cause other test failing
 docs/source/en/tasks/image_captioning.md
 docs/source/en/tasks/image_classification.md
 docs/source/en/tasks/language_modeling.md
@@ -431,7 +431,7 @@ src/transformers/models/blip/modeling_blip_text.py
 src/transformers/models/blip/modeling_tf_blip_text.py
 src/transformers/models/blip_2/configuration_blip_2.py
 src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
-src/transformers/models/blip_2/modeling_blip_2.py
+src/transformers/models/blip_2/modeling_blip_2.py  # cause other test failing
 src/transformers/models/bloom/convert_bloom_original_checkpoint_to_pytorch.py
 src/transformers/models/bloom/modeling_bloom.py
 src/transformers/models/bloom/modeling_flax_bloom.py

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -387,7 +387,7 @@ def get_all_doctest_files() -> List[str]:
 
     # These are files not doctested yet.
     with open("utils/not_doctested.txt") as fp:
-        not_doctested = set([x.split(" ")[0] for x in fp.read().strip().split("\n")])
+        not_doctested = {x.split(" ")[0] for x in fp.read().strip().split("\n")}
 
     # So far we don't have 100% coverage for doctest. This line will be removed once we achieve 100%.
     test_files_to_run = [x for x in test_files_to_run if x not in not_doctested]
@@ -415,7 +415,9 @@ def get_new_doctest_files(repo, base_commit, branching_commit) -> List[str]:
         with open(folder / "utils/not_doctested.txt", "r", encoding="utf-8") as f:
             new_content = f.read()
         # Compute the removed lines and return them
-        removed_content = set(x.split(" ")[0] for x in old_content.split("\n")) - set(x.split(" ")[0] for x in new_content.split("\n"))
+        removed_content = {x.split(" ")[0] for x in old_content.split("\n")} - {
+            x.split(" ")[0] for x in new_content.split("\n")
+        }
         return sorted(removed_content)
     return []
 

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -387,7 +387,7 @@ def get_all_doctest_files() -> List[str]:
 
     # These are files not doctested yet.
     with open("utils/not_doctested.txt") as fp:
-        not_doctested = set(fp.read().strip().split("\n"))
+        not_doctested = set([x.split(" ")[0] for x in fp.read().strip().split("\n")])
 
     # So far we don't have 100% coverage for doctest. This line will be removed once we achieve 100%.
     test_files_to_run = [x for x in test_files_to_run if x not in not_doctested]
@@ -415,7 +415,7 @@ def get_new_doctest_files(repo, base_commit, branching_commit) -> List[str]:
         with open(folder / "utils/not_doctested.txt", "r", encoding="utf-8") as f:
             new_content = f.read()
         # Compute the removed lines and return them
-        removed_content = set(old_content.split("\n")) - set(new_content.split("\n"))
+        removed_content = set(x.split(" ")[0] for x in old_content.split("\n")) - set(x.split(" ")[0] for x in new_content.split("\n"))
         return sorted(removed_content)
     return []
 


### PR DESCRIPTION
# What does this PR do?

Avoid many failing tests in doctesting: currently, src/transformers/models/blip_2/modeling_blip_2.py and docs/source/en/tasks/idefics.md cause problem to other tests

With this PR: the failing list is much shorter
```
transformers.generation.configuration_utils.GenerationConfig.from_pretrained
transformers.generation.logits_process.ExponentialDecayLengthPenalty
transformers.generation.logits_process.WhisperTimeStampLogitsProcessor
transformers.models.wav2vec2.tokenization_wav2vec2.Wav2Vec2CTCTokenizer.decode
transformers.models.wav2vec2_with_lm.processing_wav2vec2_with_lm.Wav2Vec2ProcessorWithLM.decode
transformers.models.whisper.modeling_whisper.WhisperForCausalLM.forward
```

Currently failing tests without this PR

```
transformers.generation.configuration_utils.GenerationConfig.from_pretrained
transformers.generation.logits_process.ExponentialDecayLengthPenalty
transformers.generation.logits_process.WhisperTimeStampLogitsProcessor
transformers.models.mbart.modeling_tf_mbart.TFMBartForConditionalGeneration.call
transformers.models.mbart.modeling_tf_mbart.TFMBartModel.call
transformers.models.mobilevit.modeling_tf_mobilevit.TFMobileViTForSemanticSegmentation.call
transformers.models.opt.modeling_tf_opt.TFOPTForCausalLM.call
transformers.models.opt.modeling_tf_opt.TFOPTModel.call
transformers.models.regnet.modeling_tf_regnet.TFRegNetForImageClassification.call
transformers.models.regnet.modeling_tf_regnet.TFRegNetModel.call
transformers.models.resnet.modeling_tf_resnet.TFResNetForImageClassification.call
transformers.models.resnet.modeling_tf_resnet.TFResNetModel.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForCausalLM.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForMaskedLM.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForMultipleChoice.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForQuestionAnswering.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForSequenceClassification.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaForTokenClassification.call
transformers.models.roberta.modeling_tf_roberta.TFRobertaModel.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForCausalLM.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForMaskedLM.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForMultipleChoice.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForQuestionAnswering.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForSequenceClassification.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormForTokenClassification.call
transformers.models.roberta_prelayernorm.modeling_tf_roberta_prelayernorm.TFRobertaPreLayerNormModel.call
transformers.models.segformer.modeling_tf_segformer.TFSegformerForImageClassification.call
transformers.models.segformer.modeling_tf_segformer.TFSegformerForSemanticSegmentation.call
transformers.models.segformer.modeling_tf_segformer.TFSegformerModel.call
transformers.models.vision_text_dual_encoder.modeling_tf_vision_text_dual_encoder.TFVisionTextDualEncoderModel.call
transformers.models.vision_text_dual_encoder.modeling_tf_vision_text_dual_encoder.TFVisionTextDualEncoderModel.from_vision_text_pretrained
```