### PR TITLE
[`Docs` / `SAM` ] Reflect correct changes to run inference without OOM 

### DIFF
--- a/docs/source/en/model_doc/sam.md
+++ b/docs/source/en/model_doc/sam.md
@@ -57,7 +57,8 @@ raw_image = Image.open(requests.get(img_url, stream=True).raw).convert("RGB")
 input_points = [[[450, 600]]]  # 2D location of a window in the image
 
 inputs = processor(raw_image, input_points=input_points, return_tensors="pt").to(device)
-outputs = model(**inputs)
+with torch.no_grad():
+    outputs = model(**inputs)
 
 masks = processor.image_processor.post_process_masks(
     outputs.pred_masks.cpu(), inputs["original_sizes"].cpu(), inputs["reshaped_input_sizes"].cpu()


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/27266

One needs to always wrap the model forward pass to avoid OOM issues for SAM forward pass. In the orignal modeling code they force-use `torch.no_grad()` context manager in the forward pass: https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/modeling/sam.py#L53  - but we avoid that since we also support SAM fine-tuning. 

Check out my comment here for more details: https://github.com/huggingface/transformers/issues/27266#issuecomment-1792508065

cc @amyeroberts 
