### PR TITLE
Track the number of tokens seen to metrics

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2650,7 +2650,7 @@ class Trainer:
         """
         if self.state.epoch is not None:
             logs["epoch"] = round(self.state.epoch, 2)
-        logs["num_tokens_seen"] = self.state.num_tokens_seen
+        logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
         self.state.log_history.append(output)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1838,8 +1838,9 @@ class Trainer:
             step = -1
             for step, inputs in enumerate(epoch_iterator):
                 total_batched_samples += 1
-                main_input_name = getattr(self.model, "main_input_name", "input_ids")
+                
                 if self.args.include_num_input_tokens_seen:
+                    main_input_name = getattr(self.model, "main_input_name", "input_ids")
                     if main_input_name not in inputs:
                         logger.warning(
                             "Tried to track the number of tokens seen, however could the current model is "
@@ -2650,7 +2651,8 @@ class Trainer:
         """
         if self.state.epoch is not None:
             logs["epoch"] = round(self.state.epoch, 2)
-        logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
+        if args.include_num_input_tokens_seen: 
+            logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
         self.state.log_history.append(output)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1843,7 +1843,7 @@ class Trainer:
                     main_input_name = getattr(self.model, "main_input_name", "input_ids")
                     if main_input_name not in inputs:
                         logger.warning(
-                            "Tried to track the number of tokens seen, however could the current model is "
+                            "Tried to track the number of tokens seen, however the current model is "
                             "not configured properly to know what item is the input. To fix this, add "
                             "a `main_input_name` attribute to the model class you are using."
                         )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1839,7 +1839,15 @@ class Trainer:
             for step, inputs in enumerate(epoch_iterator):
                 total_batched_samples += 1
                 main_input_name = getattr(self.model, "main_input_name", "input_ids")
-                self.state.num_tokens_seen += self.accelerator.gather(inputs[main_input_name]).numel()
+                if self.args.include_num_input_tokens_seen:
+                    if main_input_name not in inputs:
+                        logger.warning(
+                            "Tried to track the number of tokens seen, however could the current model is "
+                            "not configured properly to know what item is the input. To fix this, add "
+                            "a `main_input_name` attribute to the model class you are using."
+                        )
+                    else:
+                        self.state.num_input_tokens_seen += self.accelerator.gather(inputs[main_input_name]).numel()
                 if rng_to_sync:
                     self._load_rng_state(resume_from_checkpoint)
                     rng_to_sync = False

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1838,7 +1838,7 @@ class Trainer:
             step = -1
             for step, inputs in enumerate(epoch_iterator):
                 total_batched_samples += 1
-                
+
                 if self.args.include_num_input_tokens_seen:
                     main_input_name = getattr(self.model, "main_input_name", "input_ids")
                     if main_input_name not in inputs:
@@ -2651,7 +2651,7 @@ class Trainer:
         """
         if self.state.epoch is not None:
             logs["epoch"] = round(self.state.epoch, 2)
-        if args.include_num_input_tokens_seen: 
+        if self.args.include_num_input_tokens_seen:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1838,6 +1838,8 @@ class Trainer:
             step = -1
             for step, inputs in enumerate(epoch_iterator):
                 total_batched_samples += 1
+                main_input_name = getattr(self.model, "main_input_name", "input_ids")
+                self.state.num_tokens_seen += self.accelerator.gather(inputs[main_input_name]).numel()
                 if rng_to_sync:
                     self._load_rng_state(resume_from_checkpoint)
                     rng_to_sync = False
@@ -2640,6 +2642,7 @@ class Trainer:
         """
         if self.state.epoch is not None:
             logs["epoch"] = round(self.state.epoch, 2)
+        logs["num_tokens_seen"] = self.state.num_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
         self.state.log_history.append(output)

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -59,7 +59,7 @@ class TrainerState:
             Run an evaluation every X steps.
         save_steps (`int`, *optional*, defaults to 500):
             Save checkpoint every X updates steps.
-        num_tokens_seen (`int`, *optional*, defaults to 0):
+        num_input_tokens_seen (`int`, *optional*, defaults to 0):
             The number of tokens seen during training (number of input tokens, not the number of prediction tokens).
         total_flos (`float`, *optional*, defaults to 0):
             The total number of floating operations done by the model since the beginning of training (stored as floats
@@ -89,7 +89,7 @@ class TrainerState:
     eval_steps: int = 500
     save_steps: int = 500
     num_train_epochs: int = 0
-    num_tokens_seen: int = 0
+    num_input_tokens_seen: int = 0
     total_flos: float = 0
     log_history: List[Dict[str, float]] = None
     best_metric: Optional[float] = None

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -59,6 +59,8 @@ class TrainerState:
             Run an evaluation every X steps.
         save_steps (`int`, *optional*, defaults to 500):
             Save checkpoint every X updates steps.
+        num_tokens_seen (`int`, *optional*, defaults to 0):
+            The number of tokens seen during training (number of input tokens, not the number of prediction tokens).
         total_flos (`float`, *optional*, defaults to 0):
             The total number of floating operations done by the model since the beginning of training (stored as floats
             to avoid overflow).
@@ -87,6 +89,7 @@ class TrainerState:
     eval_steps: int = 500
     save_steps: int = 500
     num_train_epochs: int = 0
+    num_tokens_seen: int = 0
     total_flos: float = 0
     log_history: List[Dict[str, float]] = None
     best_metric: Optional[float] = None

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -637,6 +637,12 @@ class TrainingArguments:
             This will iterate over the entire training dataloader once beforehand,
 
             and will slow down the entire process.
+
+        include_num_input_tokens_seen (`bool`, *optional*):
+            Whether or not to track the number of input tokens seen throughout training.
+
+            May be slower in distributed training as gather operations must be called.
+
         neftune_noise_alpha (`Optional[float]`):
             If not `None`, this will activate NEFTune noise embeddings. This can drastically improve model performance
             for instruction fine-tuning. Check out the [original paper](https://arxiv.org/abs/2310.05914) and the
@@ -1256,6 +1262,13 @@ class TrainingArguments:
     include_tokens_per_second: Optional[bool] = field(
         default=False,
         metadata={"help": "If set to `True`, the speed metrics will include `tgs` (tokens per second per device)."},
+    )
+
+    include_num_input_tokens_seen: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "If set to `True`, will track the number of input tokens seen throughout training. (May be slower in distributed training)"
+        },
     )
 
     neftune_noise_alpha: float = field(


### PR DESCRIPTION
# What does this PR do?

This PR adds `num_tokens_seen` to the `TrainerState` allowing users to know how many tokens were passed in an individual batch. Uses `gather` to ensure that in DDP this can be known as well.

Fixes https://github.com/huggingface/transformers/issues/27027


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@pacman100 @amyeroberts 
