### PR TITLE
VSCode pylance auto-completion for `HfArgumentParser` (limited support)

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -21,7 +21,20 @@ from copy import copy
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Literal, NewType, Optional, Tuple, Union, get_type_hints, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    NewType,
+    Optional,
+    Tuple,
+    Union,
+    get_type_hints,
+    TypeVar,
+)
 
 import yaml
 
@@ -29,7 +42,6 @@ import yaml
 DataClass = NewType("DataClass", Any)
 DataClassType = NewType("DataClassType", Any)
 T = TypeVar("T")
-
 
 
 # From https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -21,13 +21,15 @@ from copy import copy
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Literal, NewType, Optional, Tuple, Union, get_type_hints
+from typing import Any, Callable, Dict, Iterable, List, Literal, NewType, Optional, Tuple, Union, get_type_hints, TypeVar
 
 import yaml
 
 
 DataClass = NewType("DataClass", Any)
 DataClassType = NewType("DataClassType", Any)
+T = TypeVar("T")
+
 
 
 # From https://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse
@@ -269,7 +271,7 @@ class HfArgumentParser(ArgumentParser):
         look_for_args_file=True,
         args_filename=None,
         args_file_flag=None,
-    ) -> Tuple[DataClass, ...]:
+    ) -> Tuple[T, ...]:
         """
         Parse command-line args into instances of the specified dataclass types.
 

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -31,9 +31,9 @@ from typing import (
     NewType,
     Optional,
     Tuple,
+    TypeVar,
     Union,
     get_type_hints,
-    TypeVar,
 )
 
 import yaml


### PR DESCRIPTION
# Problem description

This PR empowers limited support of VSCode auto-completion for `HfArgumentParser`.  Currently, the return type of `parse_args_into_dataclasses` is `DataClass = NewType("DataClass", Any)`, which limits pylance's ability to infer types even if we specifically assert a dataclass type fo the args.


<img width="672" alt="image" src="https://github.com/huggingface/transformers/assets/5555347/6c8cf0c2-40c7-4436-bdfb-e08a74ec4882">

# What does this PR do?

This PR modifies the return type to be `List[TypeVar("T")]`. So when **we assert the args to be of a certain type** (i.e., `assert isinstance(args, RewardConfig)`), auto-completion works as expected. 


<img width="595" alt="image" src="https://github.com/huggingface/transformers/assets/5555347/5d6de0e9-7f71-4291-a49e-0081f89a6de9">



## Alternatives considered

Some `argparse` libraries such as [tyro](https://github.com/brentyi/tyro) can automatically infer the type of the args, but it doesn't seem to work with the current `HfArgumentParser` paradigm for two reasons:

1. The inferred type seems only to support one type, so the inferred type is `args2: RewardConfig | Config2`, so we can't parse multiple dataclasses in `parse_args_into_dataclasses` and infer type correctly.
<img width="601" alt="image" src="https://github.com/huggingface/transformers/assets/5555347/de2a3f98-0014-48f3-b986-c56c7f73a602">

2. Automatic type detection also requires us to change the workflow: we need to do `parse_args_into_dataclasses([RewardConfig, Config2])` instead of `parse_args_into_dataclasses()`

<img width="428" alt="image" src="https://github.com/huggingface/transformers/assets/5555347/b0fbd3cb-f1c8-448d-bb25-1e9743f333fa">




<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

CC @muellerzr, @pacman100, @lewtun, @brentyi

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
