### PR TITLE
Update doctest workflow file

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   run_doctests:
-    runs-on: [single-gpu, nvidia-gpu, t4, doctest-ci]
+    runs-on: [single-gpu, nvidia-gpu, t4, ci]
     container:
       image: huggingface/transformers-all-latest-gpu
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/


### PR DESCRIPTION
# What does this PR do?

@glegendre01 mentioned this to me, due to a change in AWS CI runner setting.

Without this, this CI could not find runner to  run.