### PR TITLE
Fix id_tensor_storage in case the tensor is a view of an other tensor

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -297,4 +297,5 @@ def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
     else:
         unique_id = storage_ptr(tensor)
 
-    return tensor.device, unique_id, storage_size(tensor)
+    # We need to add storage_offset here as views of a tensor may share the same storage ptr.
+    return tensor.device, unique_id, storage_size(tensor), tensor.storage_offset()


### PR DESCRIPTION
As per title and discussed offline @LysandreJik 

Currently `safe_serialization=True` may unexpectedly erase tensors from the state_dict due to this issue.

A release or patch release including https://github.com/huggingface/safetensors/pull/379 will be needed to work with this PR, to avoid this error with the current latest release of safetensors:

```
E           RuntimeError: 
E                       Some tensors share memory, this will lead to duplicate memory on disk and potential differences when loading them again:
```
here: https://github.com/huggingface/safetensors/blob/96061e97bb7fc4ea6cdd1f79f58701efc4710d22/bindings/python/py_src/safetensors/torch.py#L467