### PR TITLE
[Whisper] Block language/task args for English-only

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1841,6 +1841,22 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         else:
             generation_config.return_timestamps = False
 
+        if is_multilingual is not None:
+            if not hasattr(generation_config, "is_multilingual"):
+                raise ValueError(
+                    "The generation config is outdated and is thus not compatible with the `is_multilingual` argument "
+                    "to `generate`. Please update the generation config as per the instructions "
+                    "https://github.com/huggingface/transformers/issues/25084#issuecomment-1664398224"
+                )
+            generation_config.is_multilingual = is_multilingual
+
+        if hasattr(generation_config, "is_multilingual") and not generation_config.is_multilingual:
+            if task is not None or language is not None:
+                raise ValueError(
+                    "Cannot specify `task` or `langauge` for an English-only model. If the model is intended to be "
+                    "multilingual, pass `is_multilingual=True` to generate, or update the generation config."
+                )
+
         if language is not None:
             if not hasattr(generation_config, "lang_to_id"):
                 raise ValueError(

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1853,7 +1853,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
         if hasattr(generation_config, "is_multilingual") and not generation_config.is_multilingual:
             if task is not None or language is not None:
                 raise ValueError(
-                    "Cannot specify `task` or `langauge` for an English-only model. If the model is intended to be "
+                    "Cannot specify `task` or `language` for an English-only model. If the model is intended to be "
                     "multilingual, pass `is_multilingual=True` to generate, or update the generation config."
                 )
 


### PR DESCRIPTION
# What does this PR do?

The `language`/`task` args should only be forwarded to the multilingual Whisper models. Passing these args to the English-only models gives the wrong error message currently:
```
ValueError: The generation config is outdated and is thus not compatible with the `language` argument 
to `generate`. Either set the language using the `forced_decoder_ids` in the model config, or update 
the generation config as per the instructions https://github.com/huggingface/transformers/issues/25084#issuecomment-1664398224
```
This PR blocks these args for the English-only models with an appropriate error message.

cc @Vaibhavs10 
