### PR TITLE
Allow `# Ignore copy`

### DIFF
--- a/tests/models/longformer/test_tokenization_longformer.py
+++ b/tests/models/longformer/test_tokenization_longformer.py
@@ -30,7 +30,7 @@ from ...test_tokenization_common import TokenizerTesterMixin
 @require_tokenizers
 # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest with roberta-base->allenai/longformer-base-4096,Roberta->Longformer,roberta->longformer,
 class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
-    # ignore copied
+    # Ignore copy
     tokenizer_class = LongformerTokenizer
     test_slow_tokenizer = True
     rust_tokenizer_class = LongformerTokenizerFast

--- a/tests/models/longformer/test_tokenization_longformer.py
+++ b/tests/models/longformer/test_tokenization_longformer.py
@@ -28,7 +28,9 @@ from ...test_tokenization_common import TokenizerTesterMixin
 
 
 @require_tokenizers
+# Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest with roberta-base->allenai/longformer-base-4096,Roberta->Longformer,roberta->longformer,
 class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
+    # ignore copied
     tokenizer_class = LongformerTokenizer
     test_slow_tokenizer = True
     rust_tokenizer_class = LongformerTokenizerFast
@@ -71,23 +73,19 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         with open(self.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.get_tokenizer
     def get_tokenizer(self, **kwargs):
         kwargs.update(self.special_tokens_map)
         return self.tokenizer_class.from_pretrained(self.tmpdirname, **kwargs)
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.get_rust_tokenizer
     def get_rust_tokenizer(self, **kwargs):
         kwargs.update(self.special_tokens_map)
         return self.rust_tokenizer_class.from_pretrained(self.tmpdirname, **kwargs)
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.get_input_output_texts
     def get_input_output_texts(self, tokenizer):
         input_text = "lower newer"
         output_text = "lower newer"
         return input_text, output_text
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_full_tokenizer
     def test_full_tokenizer(self):
         tokenizer = self.tokenizer_class(self.vocab_file, self.merges_file, **self.special_tokens_map)
         text = "lower newer"
@@ -99,7 +97,6 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         input_bpe_tokens = [0, 1, 2, 15, 10, 9, 3, 2, 15, 19]
         self.assertListEqual(tokenizer.convert_tokens_to_ids(input_tokens), input_bpe_tokens)
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.roberta_dict_integration_testing with roberta->longformer
     def longformer_dict_integration_testing(self):
         tokenizer = self.get_tokenizer()
 
@@ -110,7 +107,6 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         )
 
     @slow
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_sequence_builders with roberta-base->allenai/longformer-base-4096
     def test_sequence_builders(self):
         tokenizer = self.tokenizer_class.from_pretrained("allenai/longformer-base-4096")
 
@@ -130,7 +126,6 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         assert encoded_sentence == encoded_text_from_decode
         assert encoded_pair == encoded_pair_from_decode
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_space_encoding
     def test_space_encoding(self):
         tokenizer = self.get_tokenizer()
 
@@ -171,11 +166,9 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         first_char = tokenizer.convert_ids_to_tokens(encoded[mask_loc + 1])[0]
         self.assertNotEqual(first_char, space_encoding)
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_pretokenized_inputs
     def test_pretokenized_inputs(self):
         pass
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_embeded_special_tokens
     def test_embeded_special_tokens(self):
         for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
             with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
@@ -208,7 +201,6 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                     tokens_r_str, ["<s>", "A", ",", "<mask>", "ĠAllen", "N", "LP", "Ġsentence", ".", "</s>"]
                 )
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_change_add_prefix_space_and_trim_offsets_args
     def test_change_add_prefix_space_and_trim_offsets_args(self):
         for trim_offsets, add_prefix_space in itertools.product([True, False], repeat=2):
             tokenizer_r = self.rust_tokenizer_class.from_pretrained(
@@ -223,7 +215,6 @@ class LongformerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertEqual(post_processor_state["add_prefix_space"], add_prefix_space)
             self.assertEqual(post_processor_state["trim_offsets"], trim_offsets)
 
-    # Copied from tests.models.roberta.test_tokenization_roberta.RobertaTokenizationTest.test_offsets_mapping_with_different_add_prefix_space_and_trim_space_arguments
     def test_offsets_mapping_with_different_add_prefix_space_and_trim_space_arguments(self):
         # Test which aims to verify that the offsets are well adapted to the argument `add_prefix_space` and
         # `trim_offsets`

--- a/tests/repo_utils/test_check_copies.py
+++ b/tests/repo_utils/test_check_copies.py
@@ -120,7 +120,7 @@ class RobertaBertDummyModel:
         self.a = a
         self.b = b
 
-    # ignore copied
+    # Ignore copy
     def only_in_roberta_to_be_ignored(self, c):
         return 3
 
@@ -131,7 +131,7 @@ class RobertaBertDummyModel:
     def existing_common(self, c):
         return 4
 
-    # ignore copied
+    # Ignore copy
     def existing_diff_to_be_ignored(self, c):
         return 6
 """
@@ -168,7 +168,7 @@ class RobertaBertDummyModel:
         self.a = a
         self.b = b
 
-    # ignore copied
+    # Ignore copy
     def only_in_roberta_to_be_ignored(self, c):
         return 3
 
@@ -185,7 +185,7 @@ class RobertaBertDummyModel:
     def existing_diff_not_ignored(self, c):
         return 5
 
-    # ignore copied
+    # Ignore copy
     def existing_diff_to_be_ignored(self, c):
         return 6
 """
@@ -211,11 +211,11 @@ class RobertaBertDummyModel:
     def existing_diff_not_ignored(self, c):
         return 8
 
-    # ignore copied
+    # Ignore copy
     def existing_diff_to_be_ignored(self, c):
         return 6
 
-    # ignore copied
+    # Ignore copy
     def only_in_roberta_to_be_ignored(self, c):
         return 3
 """

--- a/tests/repo_utils/test_check_copies.py
+++ b/tests/repo_utils/test_check_copies.py
@@ -248,8 +248,8 @@ def create_tmp_repo(tmp_dir):
         "bertcopy": MOCK_BERT_COPY_CODE,
         "dummy_bert_match": MOCK_DUMMY_BERT_CODE_MATCH,
         "dummy_roberta_match": MOCK_DUMMY_ROBERTA_CODE_MATCH,
-        "dummy_bert_not_match": MOCK_DUMMY_BERT_CODE_NOT_MATCH,
-        "dummy_roberta_not_match": MOCK_DUMMY_ROBERTA_CODE_NOT_MATCH,
+        "dummy_bert_no_match": MOCK_DUMMY_BERT_CODE_NOT_MATCH,
+        "dummy_roberta_no_match": MOCK_DUMMY_ROBERTA_CODE_NOT_MATCH,
     }
     for model, code in models.items():
         model_subdir = model_dir / model

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -431,7 +431,7 @@ def replace_code(code: str, replace_pattern: str) -> str:
     return code
 
 
-def find_code_and_splits(object_name: str, base_path: str, buf: dict = None):
+def find_code_and_splits(object_name: str, base_path: str, buffer: dict = None):
     """Find the code of an object (specified by `object_name`) and split it into blocks.
 
     Args:
@@ -560,7 +560,7 @@ def check_codes_match(observed_code: str, theoretical_code: str) -> Optional[int
         diff_index += 1
 
 
-def is_copy_consistent(filename: str, overwrite: bool = False, buf: dict = None) -> Optional[List[Tuple[str, int]]]:
+def is_copy_consistent(filename: str, overwrite: bool = False, buffer: dict = None) -> Optional[List[Tuple[str, int]]]:
     """
     Check if the code commented as a copy in a file matches the original.
 
@@ -569,7 +569,7 @@ def is_copy_consistent(filename: str, overwrite: bool = False, buf: dict = None)
             The name of the file to check.
         overwrite (`bool`, *optional*, defaults to `False`):
             Whether or not to overwrite the copies when they don't match.
-        buf (`dict`, *optional*):
+        buffer (`dict`, *optional*):
             The buffer used to store the previous results in order to speed up the process.
 
     Returns:
@@ -597,7 +597,7 @@ def is_copy_consistent(filename: str, overwrite: bool = False, buf: dict = None)
         indent, object_name, replace_pattern = search.groups()
 
         # Find the file lines, the object's code, and its blocks
-        target_lines, theoretical_code, theoretical_code_splits = find_code_and_splits(object_name, base_path, buf=buf)
+        target_lines, theoretical_code, theoretical_code_splits = find_code_and_splits(object_name, base_path, buffer=buffer)
 
         # code replaced by the patterns
         theoretical_code_blocks = OrderedDict()
@@ -761,7 +761,7 @@ def check_copies(overwrite: bool = False, file: str = None):
         file (`bool`, *optional*):
             The path to a specific file to check and/or fix.
     """
-    buf = {}
+    buffer = {}
 
     if file is None:
         all_files = glob.glob(os.path.join(TRANSFORMERS_PATH, "**/*.py"), recursive=True)
@@ -772,7 +772,7 @@ def check_copies(overwrite: bool = False, file: str = None):
 
     diffs = []
     for filename in all_files:
-        new_diffs = is_copy_consistent(filename, overwrite, buf)
+        new_diffs = is_copy_consistent(filename, overwrite, buffer)
         diffs += [f"- {filename}: copy does not match {d[0]} at line {d[1]}" for d in new_diffs]
     if not overwrite and len(diffs) > 0:
         diff = "\n".join(diffs)

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -597,7 +597,9 @@ def is_copy_consistent(filename: str, overwrite: bool = False, buffer: dict = No
         indent, object_name, replace_pattern = search.groups()
 
         # Find the file lines, the object's code, and its blocks
-        target_lines, theoretical_code, theoretical_code_splits = find_code_and_splits(object_name, base_path, buffer=buffer)
+        target_lines, theoretical_code, theoretical_code_splits = find_code_and_splits(
+            object_name, base_path, buffer=buffer
+        )
 
         # code replaced by the patterns
         theoretical_code_blocks = OrderedDict()

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -177,18 +177,28 @@ def _sanity_check_splits(splits_1, splits_2, is_class):
     for block in splits_1[1:]:
         if block[0].startswith("_block_without_name_"):
             block_names_1.append("block_without_name")
-        elif not block[0].startswith("_empty_block_") and (not is_class or len(block_names_1) == 0 or block_names_1[-1].startswith("block_without_name")):
+        elif not block[0].startswith("_empty_block_") and (
+            not is_class or len(block_names_1) == 0 or block_names_1[-1].startswith("block_without_name")
+        ):
             block_names_1.append("block_with_name")
 
     for block in splits_2[1:]:
         if block[0].startswith("_block_without_name_"):
             block_names_2.append("block_without_name")
-        elif not block[0].startswith("_empty_block_") and (not is_class or len(block_names_2) == 0 or block_names_2[-1].startswith("block_without_name")):
+        elif not block[0].startswith("_empty_block_") and (
+            not is_class or len(block_names_2) == 0 or block_names_2[-1].startswith("block_without_name")
+        ):
             block_names_2.append("block_with_name")
 
     if is_class:
-        if not block_names_1 in [["block_without_name"], ["block_with_name"], ["block_without_name", "block_with_name"]]:
-            raise ValueError("For a class, it must have a specific structure. See the docstring of `_sanity_check_splits` in the file `utils/check_copies.py`")
+        if block_names_1 not in [
+            ["block_without_name"],
+            ["block_with_name"],
+            ["block_without_name", "block_with_name"],
+        ]:
+            raise ValueError(
+                "For a class, it must have a specific structure. See the docstring of `_sanity_check_splits` in the file `utils/check_copies.py`"
+            )
 
     if block_names_1 != block_names_2:
         raise ValueError("The structures in the 2 code blocks differ.")

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -441,7 +441,7 @@ def find_code_and_splits(object_name: str, base_path: str, buffer: dict = None):
         base_path (`str`):
             The path to the base directory within which the search will be performed. It could be either
             `TRANSFORMERS_PATH` or `MODEL_TEST_PATH`.
-        buf (`dict`, *optional*):
+        buffer (`dict`, *optional*):
             The buffer used to store the previous results in order to speed up the process.
 
     Returns:
@@ -452,11 +452,11 @@ def find_code_and_splits(object_name: str, base_path: str, buffer: dict = None):
         code_splits (`List[Tuple[str, int, int]]`):
             `code` splitted into blocks. See `split_code_into_blocks`.
     """
-    if buf is None:
-        buf = {}
+    if buffer is None:
+        buffer = {}
 
-    if (object_name, base_path) in buf:
-        lines, code, code_splits = buf[(object_name, base_path)]
+    if (object_name, base_path) in buffer:
+        lines, code, code_splits = buffer[(object_name, base_path)]
     else:
         code, (lines, target_start_index, target_end_index) = find_code_in_transformers(
             object_name, base_path=base_path, return_indices=True
@@ -469,7 +469,7 @@ def find_code_and_splits(object_name: str, base_path: str, buffer: dict = None):
         code_splits = split_code_into_blocks(
             lines, target_start_index, target_end_index, len(indent) + 4, backtrace=True
         )
-        buf[(object_name, base_path)] = lines, code, code_splits
+        buffer[(object_name, base_path)] = lines, code, code_splits
 
     return lines, code, code_splits
 

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -652,7 +652,7 @@ def is_copy_consistent(filename: str, overwrite: bool = False, buf: dict = None)
         name_mappings_2 = {k: k for k in observed_code_blocks.keys()}
 
         # Update code blocks' name and content:
-        #   If `"# ignore copied"` is found in a block of the observed code:
+        #   If `"# Ignore copy"` is found in a block of the observed code:
         #     1. if it's a block only in the observed code --> add it to the theoretical code.
         #     2. if it's also in the theoretical code () --> put its content (body) to the corresponding block under the
         #        same name in the theoretical code.
@@ -662,7 +662,7 @@ def is_copy_consistent(filename: str, overwrite: bool = False, buf: dict = None)
         ignored_new_block_index = 0
         for name in list(observed_code_blocks.keys()):
             code = observed_code_blocks[name]
-            if "# ignore copied" in code:
+            if "# Ignore copy" in code:
                 if name in theoretical_code_blocks:
                     # in the target --> just copy the content
                     del theoretical_code_blocks[name]

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -140,23 +140,21 @@ def _should_continue(line: str, indent: str) -> bool:
 def _sanity_check_splits(splits_1, splits_2, is_class):
     """Check the two (inner) block structures of the corresponding code block given by `split_code_into_blocks` match.
 
-    For the case of `class`, a consecutive sequence of blocks which names (e.g. inner class/func/method) is considered
-    as `a single block with name` in this check, because we want to allow new inner blocks in one of the 2 classes.
-    However, it must be one of the following 3 cases:
+    For the case of `class`, they must be of one of the following 3 cases:
 
         - a single block without name:
 
             class foo:
                 a = 1
 
-        - a consecutive sequence of blocks with name
+        - a consecutive sequence of (1 or more) blocks with name
 
             class foo:
 
                 def f(x):
                     return x
 
-        - a block without name, followed by a consecutive sequence of blocks with name
+        - a block without name, followed by a consecutive sequence of (1 or more) blocks with name
 
             class foo:
                 a = 1
@@ -167,9 +165,12 @@ def _sanity_check_splits(splits_1, splits_2, is_class):
                 def g(x):
                     return None
 
-    For the case of `function or method`, we don't **merge** a consecutive sequence of blocks which names:
-    the 2 code blocks must contain exactly the same structure. However, we don't require that structure to match a
-    pre-defined structure.
+    The 2 code snippets that give `splits_1` and `splits_2` have to be in the same case to pass this check, but the
+    number of blocks with name in the consecutive sequence is not taken into account.
+
+    For the case of `function or method`, we don't require it to be in one of the above 3 cases. However, the structure
+    of`splits_1` and `splits_2` have to match exactly. In particular, the number of blocks with name in a consecutive
+    sequence is taken into account.
     """
     block_names_1 = []
     block_names_2 = []


### PR DESCRIPTION
# What does this PR do?

Allow `# ignore copied` as suggested in https://github.com/huggingface/transformers/pull/26713#discussion_r1354625364

The runtime of `check_copies` is the same as before.

See the comment below for an example.