### PR TITLE
[fix] bug about label padding in data collator for seq2seq

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -563,6 +563,7 @@ class DataCollatorForSeq2Seq:
         # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
         # same length to return tensors.
         if labels is not None:
+            copied_features = [feature.copy() for feature in features]
             max_label_length = max(len(l) for l in labels)
             if self.pad_to_multiple_of is not None:
                 max_label_length = (
@@ -572,7 +573,7 @@ class DataCollatorForSeq2Seq:
                 )
 
             padding_side = self.tokenizer.padding_side
-            for feature in features:
+            for feature in copied_features:
                 remainder = [self.label_pad_token_id] * (max_label_length - len(feature["labels"]))
                 if isinstance(feature["labels"], list):
                     feature["labels"] = (
@@ -582,7 +583,8 @@ class DataCollatorForSeq2Seq:
                     feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
                 else:
                     feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
-
+            features = copied_features
+        
         features = self.tokenizer.pad(
             features,
             padding=self.padding,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

When I use `DataCollatorForSeq2Seq` with `Trainer` to fine-tune a model, an error of batch_size mismatch occurs at the beginning of the second epoch. After read the implementation of `DataCollatorForSeq2Seq.__call__`, I figure out the error is caused by the label padding logics. The `feature` dict is modified during the first epoch, leading to the batch_size mismatch error in the following epoches. I fix this by create a copy of the `feature` dict instead of directly modifying itself.

error message:
```
File "workspace/train.py", line 115, in train:22<10:44:27,  1.87it/s]
    trainer.train()                                                  
  File ".../lib/python3.9/site-packages/transformers/trainer.py", line 1591, in train                          
    return inner_training_loop(                                      
  File ".../lib/python3.9/site-packages/transformers/trainer.py", line 1892, in _inner_training_loop                                        
    tr_loss_step = self.training_step(model, inputs)                 
  File ".../lib/python3.9/site-packages/transformers/trainer.py", line 2776, in training_step                                              
    loss = self.compute_loss(model, inputs)                          
  File ".../lib/python3.9/site-packages/transformers/trainer.py", line 2801, in compute_loss                                               
    outputs = model(**inputs)                                        
  File ".../lib/python3.9/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl                                       
    return self._call_impl(*args, **kwargs)                          
  File ".../lib/python3.9/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl                                               
    return forward_call(*args, **kwargs)                              
  File ".../lib/python3.9/site-packages/transformers/models/gpt2/modeling_gpt2.py", line 1109, in forward                                   
    loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
  File ".../lib/python3.9/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl                                       
    return self._call_impl(*args, **kwargs)                           
  File ".../lib/python3.9/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl                                                
    return forward_call(*args, **kwargs)                              
  File ".../lib/python3.9/site-packages/torch/nn/modules/loss.py", line 1179, in forward                                                     
    return F.cross_entropy(input, target, weight=self.weight,
  File ".../lib/python3.9/site-packages/torch/nn/functional.py", line 3053, in cross_entropy
    return torch._C._nn.cross_entropy_loss(input, target, weight, _Reduction.get_enum(reduction), ignore_index, label_smoothing)
ValueError: Expected input batch_size (5856) to match target batch_size (6368).
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
Library:
- tokenizers: @ArthurZucker
- trainer: @muellerzr

