### PR TITLE
Remove unused param from example script tests

### DIFF
--- a/examples/pytorch/test_accelerate_examples.py
+++ b/examples/pytorch/test_accelerate_examples.py
@@ -28,7 +28,6 @@ from accelerate.utils import write_basic_config
 from transformers.testing_utils import (
     TestCasePlus,
     backend_device_count,
-    is_torch_fp16_available_on_device,
     run_command,
     slow,
     torch_device,
@@ -92,9 +91,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --checkpointing_steps epoch
             --with_tracking
         """.split()
-
-        if is_torch_fp16_available_on_device(torch_device):
-            testargs.append("--fp16")
 
         run_command(self._launch_args + testargs)
         result = get_results(tmp_dir)
@@ -324,9 +320,6 @@ class ExamplesTestsNoTrainer(TestCasePlus):
             --with_tracking
             --checkpointing_steps 1
         """.split()
-
-        if is_torch_fp16_available_on_device(torch_device):
-            testargs.append("--fp16")
 
         run_command(self._launch_args + testargs)
         result = get_results(tmp_dir)


### PR DESCRIPTION
# What does this PR do?

Removes a very old and unused param in the example script tests (`--fp16`) that wasn't ever really *part* of the example scripts, I think it was just a bad copy/paste when writing the tests potentially. 

Fixes # (issue)

A few tests that were giving notice of weird args/params being passed to it.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts 
