### PR TITLE
Update deprecated torch.range in tests/models/ibert/test_modeling_ibert.py

### DIFF
--- a/tests/models/ibert/test_modeling_ibert.py
+++ b/tests/models/ibert/test_modeling_ibert.py
@@ -519,7 +519,7 @@ class IBertModelIntegrationTest(unittest.TestCase):
         gelu_q = IntGELU(quant_mode=True)
         gelu_dq = nn.GELU()
 
-        x_int = torch.range(-10000, 10000, 1)
+        x_int = torch.arange(-10000, 10001, 1)
         x_scaling_factor = torch.tensor(0.001)
         x = x_int * x_scaling_factor
 
@@ -534,7 +534,7 @@ class IBertModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(q_int, q_int.round(), atol=1e-4))
 
     def test_force_dequant_gelu(self):
-        x_int = torch.range(-10000, 10000, 1)
+        x_int = torch.arange(-10000, 10001, 1)
         x_scaling_factor = torch.tensor(0.001)
         x = x_int * x_scaling_factor
 

--- a/tests/models/ibert/test_modeling_ibert.py
+++ b/tests/models/ibert/test_modeling_ibert.py
@@ -565,7 +565,6 @@ class IBertModelIntegrationTest(unittest.TestCase):
         softmax_q = IntSoftmax(output_bit, quant_mode=True)
         softmax_dq = nn.Softmax()
 
-        # x_int = torch.range(-10000, 10000, 1)
         def _test(array):
             x_int = torch.tensor(array)
             x_scaling_factor = torch.tensor(0.1)


### PR DESCRIPTION
# What does this PR do?

`torch.range` is deprecated since PyTorch 0.4 and will be removed in a future PyTorch release.
This PR updates it to `torch.arange`.
Fixed with TorchFix https://github.com/pytorch/test-infra/tree/main/tools/torchfix

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @ydshieh 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
