### PR TITLE
Put doctest options back to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ line-length = 119
 lines-after-imports = 2
 known-first-party = ["transformers"]
 
-# This is ignored, maybe because of the header? If someone finds a fix, we can uncomment and remove setup.cfg
-# [tool.pytest]
-# doctest_optionflags="NUMBER NORMALIZE_WHITESPACE ELLIPSIS"
+[tool.pytest.ini_options]
+doctest_optionflags="NUMBER NORMALIZE_WHITESPACE ELLIPSIS"
+doctest_glob="**/*.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[tool:pytest]
-doctest_optionflags=NUMBER NORMALIZE_WHITESPACE ELLIPSIS
-doctest_glob=**/*.md


### PR DESCRIPTION
# What does this PR do?

Put doctest options back to `pyproject.toml`.

Fix #27345

Checked with a run https://github.com/huggingface/transformers/actions/runs/6800607292. The list of failing doctests is the same as before, so we are good with this change.