### PR TITLE
Fix tiny model script: not using `from_pt=True`

### DIFF
--- a/utils/create_dummy_models.py
+++ b/utils/create_dummy_models.py
@@ -916,7 +916,7 @@ def build_composite_models(config_class, output_dir):
             model.save_pretrained(model_path)
 
             if tf_model_class is not None:
-                model = tf_model_class.from_pretrained(model_path, from_pt=True)
+                model = tf_model_class.from_pretrained(model_path)
                 model.save_pretrained(model_path)
 
             # copy the processors
@@ -1204,7 +1204,7 @@ def build(config_class, models_to_create, output_dir):
             ckpt = get_checkpoint_dir(output_dir, pt_arch)
             # Use the same weights from PyTorch.
             try:
-                model = tensorflow_arch.from_pretrained(ckpt, from_pt=True)
+                model = tensorflow_arch.from_pretrained(ckpt)
                 model.save_pretrained(ckpt)
             except Exception as e:
                 # Conversion may fail. Let's not create a model with different weights to avoid confusion (for now).


### PR DESCRIPTION
# What does this PR do?

After #27064, the checkpoint is saved with format `safetensors`. If we specify `from_pretrained("...", from_pt=True)` while the checkpoint is in `safetensors` format, we get error like `invalid load key *\xa0* (or *\xd8* etc.)`.

This PR remove the usage of `from_pt=True` and therefore fix 1 issue in the failing CI (that checks the script working). 

### Code snippet

```python
from transformers import BertModel, TFBertModel


ckpt = "hf-internal-testing/tiny-random-BertModel"

bert_pt = BertModel.from_pretrained(ckpt)
bert_pt.save_pretrained("my-bert")

# this works
bert_tf = TFBertModel.from_pretrained("my-bert")

# this fail
bert_tf = TFBertModel.from_pretrained("my-bert", from_pt=True)
print(bert_tf)
```