### PR TITLE
Add version check for Jinja

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1762,10 +1762,15 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
     @lru_cache
     def _compile_jinja_template(self, chat_template):
         try:
+            import jinja2
             from jinja2.exceptions import TemplateError
             from jinja2.sandbox import ImmutableSandboxedEnvironment
         except ImportError:
             raise ImportError("apply_chat_template requires jinja2 to be installed.")
+
+        if version.parse(jinja2.__version__) < version.parse("3.0.0"):
+            raise ImportError("apply_chat_template requires jinja2>=3.0.0 to be installed. Your version is "
+                              f"{jinja2.__version__}.")
 
         def raise_exception(message):
             raise TemplateError(message)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1768,7 +1768,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         except ImportError:
             raise ImportError("apply_chat_template requires jinja2 to be installed.")
 
-        if version.parse(jinja2.__version__) < version.parse("3.0.0"):
+        if version.parse(jinja2.__version__) <= version.parse("3.0.0"):
             raise ImportError("apply_chat_template requires jinja2>=3.0.0 to be installed. Your version is "
                               f"{jinja2.__version__}.")
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1769,8 +1769,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             raise ImportError("apply_chat_template requires jinja2 to be installed.")
 
         if version.parse(jinja2.__version__) <= version.parse("3.0.0"):
-            raise ImportError("apply_chat_template requires jinja2>=3.0.0 to be installed. Your version is "
-                              f"{jinja2.__version__}.")
+            raise ImportError(
+                "apply_chat_template requires jinja2>=3.0.0 to be installed. Your version is " f"{jinja2.__version__}."
+            )
 
         def raise_exception(message):
             raise TemplateError(message)


### PR DESCRIPTION
As @philschmid noticed, `apply_chat_template` requires `jinja` version 3.x, but it's possible for some users to still have `2.x` installed. We now raise a useful error in this case.