### PR TITLE
Run all tests if `circleci/create_circleci_config.py` is modified

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -948,7 +948,7 @@ def infer_tests_to_run(
     print(f"\n### IMPACTED FILES ###\n{_print_list(impacted_files)}")
 
     # Grab the corresponding test files:
-    if any(x in modified_files for x in ["setup.py", "circleci/create_circleci_config.py"]):
+    if any(x in modified_files for x in ["setup.py", ".circleci/create_circleci_config.py"]):
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
     # in order to trigger pipeline tests even if no code change at all

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -948,7 +948,7 @@ def infer_tests_to_run(
     print(f"\n### IMPACTED FILES ###\n{_print_list(impacted_files)}")
 
     # Grab the corresponding test files:
-    if "setup.py" in modified_files:
+    if any(x in modified_files for x in ["setup.py", "circleci/create_circleci_config.py"]):
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
     # in order to trigger pipeline tests even if no code change at all


### PR DESCRIPTION
# What does this PR do?

This file is also a central file related to tests. If it has some modification and only this file, currently no test job defined in it would run. (`empty` job). We have been cheated by green CI those were actually empty.

Let's run all tests in this case.