### PR TITLE
remove failing tests and clean FE files

### DIFF
--- a/src/transformers/models/pop2piano/feature_extraction_pop2piano.py
+++ b/src/transformers/models/pop2piano/feature_extraction_pop2piano.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """ Feature extractor class for Pop2Piano"""
 
-import copy
 import warnings
 from typing import List, Optional, Union
 
@@ -447,17 +446,4 @@ class Pop2PianoFeatureExtractor(SequenceFeatureExtractor):
             return_tensors=return_tensors,
         )
 
-        return output
-
-    def to_dict(self):
-        """
-        Serializes this instance to a Python dictionary.
-
-        Returns:
-            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
-        """
-        output = copy.deepcopy(self.__dict__)
-        output["feature_extractor_type"] = self.__class__.__name__
-        if "mel_filters" in output:
-            del output["mel_filters"]
         return output

--- a/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
@@ -16,7 +16,6 @@
 Feature extractor class for SeamlessM4T
 """
 
-import copy
 from typing import List, Optional, Union
 
 import numpy as np
@@ -288,18 +287,3 @@ class SeamlessM4TFeatureExtractor(SequenceFeatureExtractor):
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)
 
         return padded_inputs
-
-    def to_dict(self):
-        """
-        Serializes this instance to a Python dictionary.
-
-        Returns:
-            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
-        """
-        output = copy.deepcopy(self.__dict__)
-        output["feature_extractor_type"] = self.__class__.__name__
-        if "mel_filters" in output:
-            del output["mel_filters"]
-        if "window" in output:
-            del output["window"]
-        return output

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -15,8 +15,7 @@
 """
 Feature extractor class for Whisper
 """
-import copy
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -262,16 +261,3 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)
 
         return padded_inputs
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serializes this instance to a Python dictionary.
-
-        Returns:
-            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
-        """
-        output = copy.deepcopy(self.__dict__)
-        output["feature_extractor_type"] = self.__class__.__name__
-        if "mel_filters" in output:
-            del output["mel_filters"]
-        return output

--- a/tests/models/tvlt/test_feature_extraction_tvlt.py
+++ b/tests/models/tvlt/test_feature_extraction_tvlt.py
@@ -15,9 +15,7 @@
 """ Testing suite for the TVLT feature extraction. """
 
 import itertools
-import os
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -122,21 +120,6 @@ class TvltFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Tes
         self.assertTrue(hasattr(feature_extractor, "hop_length"))
         self.assertTrue(hasattr(feature_extractor, "chunk_length"))
         self.assertTrue(hasattr(feature_extractor, "sampling_rate"))
-
-    def test_feat_extract_to_json_file(self):
-        feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)
-
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            json_file_path = os.path.join(tmpdirname, "feat_extract.json")
-            feat_extract_first.to_json_file(json_file_path)
-            feat_extract_second = self.feature_extraction_class.from_json_file(json_file_path)
-
-        dict_first = feat_extract_first.to_dict()
-        dict_second = feat_extract_second.to_dict()
-        mel_1 = dict_first.pop("mel_filters")
-        mel_2 = dict_second.pop("mel_filters")
-        self.assertTrue(np.allclose(mel_1, mel_2))
-        self.assertEqual(dict_first, dict_second)
 
     def test_call(self):
         # Initialize feature_extractor

--- a/tests/models/tvlt/test_feature_extraction_tvlt.py
+++ b/tests/models/tvlt/test_feature_extraction_tvlt.py
@@ -23,7 +23,7 @@ import unittest
 import numpy as np
 
 from transformers import TvltFeatureExtractor, is_datasets_available
-from transformers.testing_utils import check_json_file_has_correct_format, require_torch, require_torchaudio
+from transformers.testing_utils import require_torch, require_torchaudio
 from transformers.utils.import_utils import is_torch_available
 
 from ...test_sequence_feature_extraction_common import SequenceFeatureExtractionTestMixin
@@ -122,21 +122,6 @@ class TvltFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Tes
         self.assertTrue(hasattr(feature_extractor, "hop_length"))
         self.assertTrue(hasattr(feature_extractor, "chunk_length"))
         self.assertTrue(hasattr(feature_extractor, "sampling_rate"))
-
-    def test_feat_extract_from_and_save_pretrained(self):
-        feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)
-
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            saved_file = feat_extract_first.save_pretrained(tmpdirname)[0]
-            check_json_file_has_correct_format(saved_file)
-            feat_extract_second = self.feature_extraction_class.from_pretrained(tmpdirname)
-
-        dict_first = feat_extract_first.to_dict()
-        dict_second = feat_extract_second.to_dict()
-        mel_1 = dict_first.pop("mel_filters")
-        mel_2 = dict_second.pop("mel_filters")
-        self.assertTrue(np.allclose(mel_1, mel_2))
-        self.assertEqual(dict_first, dict_second)
 
     def test_feat_extract_to_json_file(self):
         feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)


### PR DESCRIPTION
# What does this PR do?

Fixes [this](https://app.circleci.com/pipelines/github/huggingface/transformers/77846/workflows/8ed051fc-a105-462e-9097-91e919374c6e/jobs/992100), which was introduced by #26339.

To explain a bit, in #26339 I've mutualised an overriding of `to_dict` which deleted `mel_filters` and `windows`. The failing test was testing to retrieve those parameters to assert equality.

I've also cleaned a bit feature extractors that overrode `to_dict`.
