### PR TITLE
Make `examples_torch_job` faster

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -397,6 +397,7 @@ custom_tokenizers_job = CircleCIJob(
 
 examples_torch_job = CircleCIJob(
     "examples_torch",
+    additional_env={"OMP_NUM_THREADS": 8},
     cache_name="torch_examples",
     install_steps=[
         "sudo apt-get -y update && sudo apt-get install -y libsndfile1-dev espeak-ng",
@@ -405,6 +406,7 @@ examples_torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager -r examples/pytorch/_tests_requirements.txt",
         "pip install -U --upgrade-strategy eager -e git+https://github.com/huggingface/accelerate@main#egg=accelerate",
     ],
+    pytest_num_workers=1,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

This job sometimes having some test timeout (> 120s.). Even if job passes, the log looks like
```
115.55s call     examples/pytorch/test_pytorch_examples.py::ExamplesTests::test_run_semantic_segmentation
66.07s call     examples/pytorch/test_pytorch_examples.py::ExamplesTests::test_run_squad
48.24s call     examples/pytorch/test_pytorch_examples.py::ExamplesTests::test_run_speech_recognition_seq2seq
```

It turns out that setting `OMP_NUM_THREADS=1` has a huge impact on this job. 

This PR sets `OMP_NUM_THREADS=8` to make it run faster. It now looks like 
```
25.78s call     examples/pytorch/test_pytorch_examples.py::ExamplesTests::test_run_semantic_segmentation
22.82s call     examples/pytorch/test_accelerate_examples.py::ExamplesTestsNoTrainer::test_run_swag_no_trainer
20.69s call     examples/pytorch/test_pytorch_examples.py::ExamplesTests::test_run_speech_recognition_seq2seq
```

Note that setting `OMP_NUM_THREADS>1` with `pytest -n` where `n > 1` is going to break things (timeout, blocked etc.).

