### PR TITLE
[MusicGen] Fix audio channel attribute

### DIFF
--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -1869,7 +1869,7 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
                     "disabled by setting `chunk_length=None` in the audio encoder."
                 )
 
-            if self.config.audio_channels == 2 and audio_codes.shape[2] == self.decoder.num_codebooks // 2:
+            if self.config.decoder.audio_channels == 2 and audio_codes.shape[2] == self.decoder.num_codebooks // 2:
                 # mono input through encodec that we convert to stereo
                 audio_codes = audio_codes.repeat_interleave(2, dim=2)
 


### PR DESCRIPTION
# What does this PR do?

`audio_channels` attribute is stored in the decoder sub-model config, not the overall top-level config. 

The logits test for MusicGen mono previously failed on the daily CI tests (cc @ydshieh): https://github.com/huggingface/transformers/actions/runs/6806630933/job/18508277638
It passes when we fix this bug.