### PR TITLE
Fixed typo in error message

### DIFF
--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -372,7 +372,7 @@ class MistralFlashAttention2(MistralAttention):
 
                 if past_key.shape[-2] != self.config.sliding_window - 1:
                     raise ValueError(
-                        f"past key much have a shape of (`batch_size, num_heads, self.config.sliding_window-1, head_dim`), got"
+                        f"past key must have a shape of (`batch_size, num_heads, self.config.sliding_window-1, head_dim`), got"
                         f" {past_key.shape}"
                     )
 


### PR DESCRIPTION
# What does this PR do?

"past key much have a shape" -> "past key must have a shape"

I was getting this error and the typo was bothering me. Still don't know why I'm getting the error, but it least it might bother me less.