### PR TITLE
Install `python-Levenshtein` for `nougat` in CI image

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -67,6 +67,9 @@ RUN python3 -m pip install --no-cache-dir decord av==9.2.0
 # For `dinat` model
 RUN python3 -m pip install --no-cache-dir natten -f https://shi-labs.com/natten/wheels/$CUDA/
 
+# For `nougat` tokenizer
+RUN python3 -m pip install --no-cache-dir python-Levenshtein
+
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop


### PR DESCRIPTION
# What does this PR do?

We have already this in https://github.com/huggingface/transformers/blob/8f577dca4f2e9153d152afffe209fee643a90124/.circleci/create_circleci_config.py#L475. 

This PR just add the same thing to the CI image docker file to fix issues like in doctest

```
nougat.md
UNEXPECTED EXCEPTION: ImportError('\nNougatTokenizerFast requires the python-Levenshtein library but it was not found in your environment. You can install it with pip: pip\ninstall python-Levenshtein. Please note that you may need to restart your runtime after installation.\n')
```