### PR TITLE
Fix docstring for `gradient_checkpointing_kwargs`

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -574,7 +574,7 @@ class TrainingArguments:
             Unless this is `True`, the `Trainer` will skip pushing a checkpoint when the previous push is not finished.
         gradient_checkpointing (`bool`, *optional*, defaults to `False`):
             If True, use gradient checkpointing to save memory at the expense of slower backward pass.
-        gradient_checkpointing_args (`dict`, *optional*, defaults to `None`):
+        gradient_checkpointing_kwargs (`dict`, *optional*, defaults to `None`):
             Key word arguments to be passed to the `gradient_checkpointing_enable` method.
         include_inputs_for_metrics (`bool`, *optional*, defaults to `False`):
             Whether or not the inputs will be passed to the `compute_metrics` function. This is intended for metrics


### PR DESCRIPTION
# What does this PR do?

Docstring entry for `gradient_checkpointing_kwargs` was `gradient_checkpointing_args`.

Fixes #27469

@stevhliu @MKhalusova
