### PR TITLE
[DataCollator] Warn on identical `eos_token_id` and `pad_token_id`

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -649,6 +649,14 @@ class DataCollatorForLanguageModeling(DataCollatorMixin):
 
             self.tf_mask_tokens = tf.function(self.tf_mask_tokens, jit_compile=True)
 
+        if not self.mlm and self.tokenizer.pad_token_id == self.tokenizer.eos_token_id:
+            warnings.warn(
+                "The pad_token_id and eos_token_id values of this tokenizer are identical. "
+                "If you are planning for multi-turn training, "
+                "it can result in the model continuously generating questions and answers without interruption. "
+                "To avoid this, set the pad_token_id to a different value."
+            )
+
     @staticmethod
     def tf_bernoulli(shape, probability):
         import tensorflow as tf


### PR DESCRIPTION
# What does this PR do?
This PR displays a warning message when the values of `pad_token_id` and `eos_token_id` are identical. This is to prevent unexpected behavior during multi-turn training.

After the multi-turn data training with [DataCollatorForCompletionOnlyLM](https://github.com/huggingface/trl/blob/9e9f024399b76842ece3552884bbc4f304fd4153/trl/trainer/utils.py#L56), I encountered an issue where the model continued generating outputs even after the assistant's turn had been completed. This issue was due to the equivalence of the tokenizer's eos token and pad token by default, resulting in the eos token not being properly trained.

For instance, in the torch_call() function within [data_collator.py](https://github.com/huggingface/transformers/blob/7ee995fd9c692761c4601ddbffa2ac2ec9f27b0b/src/transformers/data/data_collator.py#L740C10-L740C10), the pad_token_id is converted to ignore_id(-100).

```python
if self.mlm:
    batch["input_ids"], batch["labels"] = self.torch_mask_tokens(
        batch["input_ids"], special_tokens_mask=special_tokens_mask
    )
else:
    labels = batch["input_ids"].clone()
    if self.tokenizer.pad_token_id is not None:
        labels[labels == self.tokenizer.pad_token_id] = -100
    batch["labels"] = labels
```

If the multi-turn data is formatted as shown below, and `eos_token_id` and `pad_token_id` are identical, the eos_token would not be properly trained. This could lead to a scenario where the model continuously generates both user and assistant turns without recognizing the end of sequence (eos) token.
```
<s>### User: What is up?
### Assistant: Hello! How can I help you today?</s>
### User: Goodbye
### Assistant: Goodbye! If you have any more questions in the future, don't hesitate to ask.</s>
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerz @pacman100