### PR TITLE
Update processor mapping for hub snippets

### DIFF
--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -197,9 +197,9 @@ def get_frameworks_table() -> pd.DataFrame:
             processors[t] = "AutoProcessor"
         elif t in transformers_module.models.auto.tokenization_auto.TOKENIZER_MAPPING_NAMES:
             processors[t] = "AutoTokenizer"
-        elif t in transformers_module.models.auto.feature_extraction_auto.FEATURE_EXTRACTOR_MAPPING_NAMES:
-            processors[t] = "AutoFeatureExtractor"
         elif t in transformers_module.models.auto.image_processing_auto.IMAGE_PROCESSOR_MAPPING_NAMES:
+            processors[t] = "AutoImageProcessor"
+        elif t in transformers_module.models.auto.feature_extraction_auto.FEATURE_EXTRACTOR_MAPPING_NAMES:
             processors[t] = "AutoFeatureExtractor"
         else:
             # Default to AutoTokenizer if a model has nothing, for backward compatibility.


### PR DESCRIPTION
# What does this PR do?

Updates the processor mapping so that `AutoImageProcessor` is selected for vision models rather than the deprecated `AutoFeatureExtractor`.  This should resolve auto-generated snippets on the hub that still show using old classes. 