### PR TITLE
[`CI-test_torch`] skip `test_tf_from_pt_safetensors` for 4 models

### DIFF
--- a/tests/models/mobilebert/test_modeling_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_mobilebert.py
@@ -303,7 +303,7 @@ class MobileBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         super().test_resize_tokens_embeddings()
 
     @unnittest.skip("This test is currently broken because of safetensors.")
-    def test_tf_from_pt_safetensors(self)
+    def test_tf_from_pt_safetensors(self):
         pass
 
     def setUp(self):

--- a/tests/models/mobilebert/test_modeling_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_mobilebert.py
@@ -302,7 +302,7 @@ class MobileBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def test_resize_tokens_embeddings(self):
         super().test_resize_tokens_embeddings()
 
-    @unnittest.skip("This test is currently broken because of safetensors.")
+    @unittest.skip("This test is currently broken because of safetensors.")
     def test_tf_from_pt_safetensors(self):
         pass
 

--- a/tests/models/mobilebert/test_modeling_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_mobilebert.py
@@ -302,6 +302,10 @@ class MobileBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def test_resize_tokens_embeddings(self):
         super().test_resize_tokens_embeddings()
 
+    @unnittest.skip("This test is currently broken because of safetensors.")
+    def test_tf_from_pt_safetensors(self)
+        pass
+
     def setUp(self):
         self.model_tester = MobileBertModelTester(self)
         self.config_tester = ConfigTester(self, config_class=MobileBertConfig, hidden_size=37)

--- a/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
+++ b/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
@@ -196,7 +196,6 @@ class Speech2Text2StandaloneDecoderModelTest(
     def test_inputs_embeds(self):
         pass
 
-
     @unnittest.skip("This test is currently broken because of safetensors.")
     def test_tf_from_pt_safetensors(self):
         pass

--- a/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
+++ b/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
@@ -196,6 +196,11 @@ class Speech2Text2StandaloneDecoderModelTest(
     def test_inputs_embeds(self):
         pass
 
+
+    @unnittest.skip("This test is currently broken because of safetensors.")
+    def test_tf_from_pt_safetensors(self)
+        pass
+
     # speech2text2 has no base model
     def test_save_load_fast_init_from_base(self):
         pass

--- a/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
+++ b/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
@@ -198,7 +198,7 @@ class Speech2Text2StandaloneDecoderModelTest(
 
 
     @unnittest.skip("This test is currently broken because of safetensors.")
-    def test_tf_from_pt_safetensors(self)
+    def test_tf_from_pt_safetensors(self):
         pass
 
     # speech2text2 has no base model

--- a/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
+++ b/tests/models/speech_to_text_2/test_modeling_speech_to_text_2.py
@@ -196,7 +196,7 @@ class Speech2Text2StandaloneDecoderModelTest(
     def test_inputs_embeds(self):
         pass
 
-    @unnittest.skip("This test is currently broken because of safetensors.")
+    @unittest.skip("This test is currently broken because of safetensors.")
     def test_tf_from_pt_safetensors(self):
         pass
 

--- a/tests/models/transfo_xl/test_modeling_transfo_xl.py
+++ b/tests/models/transfo_xl/test_modeling_transfo_xl.py
@@ -491,7 +491,7 @@ class TransfoXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         pass
 
     @unnittest.skip("This test is currently broken because of safetensors.")
-    def test_tf_from_pt_safetensors(self)
+    def test_tf_from_pt_safetensors(self):
         pass
 
 @require_torch

--- a/tests/models/transfo_xl/test_modeling_transfo_xl.py
+++ b/tests/models/transfo_xl/test_modeling_transfo_xl.py
@@ -490,6 +490,9 @@ class TransfoXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_left_padding_compatibility(self):
         pass
 
+    @unnittest.skip("This test is currently broken because of safetensors.")
+    def test_tf_from_pt_safetensors(self)
+        pass
 
 @require_torch
 class TransfoXLModelLanguageGenerationTest(unittest.TestCase):

--- a/tests/models/transfo_xl/test_modeling_transfo_xl.py
+++ b/tests/models/transfo_xl/test_modeling_transfo_xl.py
@@ -494,6 +494,7 @@ class TransfoXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_tf_from_pt_safetensors(self):
         pass
 
+
 @require_torch
 class TransfoXLModelLanguageGenerationTest(unittest.TestCase):
     @slow

--- a/tests/models/transfo_xl/test_modeling_transfo_xl.py
+++ b/tests/models/transfo_xl/test_modeling_transfo_xl.py
@@ -490,7 +490,7 @@ class TransfoXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_left_padding_compatibility(self):
         pass
 
-    @unnittest.skip("This test is currently broken because of safetensors.")
+    @unittest.skip("This test is currently broken because of safetensors.")
     def test_tf_from_pt_safetensors(self):
         pass
 

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -357,6 +357,9 @@ class XGLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     def test_model_parallelism(self):
         super().test_model_parallelism()
 
+    @unnittest.skip("This test is currently broken because of safetensors.")
+    def test_tf_from_pt_safetensors(self)
+        pass
 
 @require_torch
 class XGLMModelLanguageGenerationTest(unittest.TestCase):

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -358,7 +358,7 @@ class XGLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         super().test_model_parallelism()
 
     @unnittest.skip("This test is currently broken because of safetensors.")
-    def test_tf_from_pt_safetensors(self)
+    def test_tf_from_pt_safetensors(self):
         pass
 
 @require_torch

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -357,7 +357,7 @@ class XGLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     def test_model_parallelism(self):
         super().test_model_parallelism()
 
-    @unnittest.skip("This test is currently broken because of safetensors.")
+    @unittest.skip("This test is currently broken because of safetensors.")
     def test_tf_from_pt_safetensors(self):
         pass
 

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -361,6 +361,7 @@ class XGLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     def test_tf_from_pt_safetensors(self):
         pass
 
+
 @require_torch
 class XGLMModelLanguageGenerationTest(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
# What does this PR do?
Skip `test_tf_from_pt_safetensors` tests for MobileBert,  TransfoXL, SPeech2text and XGLM