### PR TITLE
Generate: `GenerationConfig.from_pretrained` can return unused kwargs

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -750,9 +750,14 @@ class GenerationConfig(PushToHubMixin):
         else:
             logger.info(f"loading configuration file {configuration_file} from cache at {resolved_config_file}")
 
-        config = cls.from_dict(config_dict, **kwargs)
-        config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
-        return config
+        if kwargs.get("return_unused_kwargs") is True:
+            config, unused_kwargs = cls.from_dict(config_dict, **kwargs)
+            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
+            return config, unused_kwargs
+        else:
+            config = cls.from_dict(config_dict, **kwargs)
+            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
+            return config
 
     @classmethod
     def _dict_from_json_file(cls, json_file: Union[str, os.PathLike]):


### PR DESCRIPTION
# What does this PR do?

I wrote the doctest for the feature described above, but forgot to add the feature itself in the original `GenerationConfig` commit 🙃 

Fixes the failing `pytest --doctest-modules src/transformers/generation/configuration_utils.py::transformers.generation.configuration_utils.GenerationConfig.from_pretrained`