### PR TITLE
[`pytest`] Avoid flash attn test marker warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ known-first-party = ["transformers"]
 [tool.pytest.ini_options]
 doctest_optionflags="NUMBER NORMALIZE_WHITESPACE ELLIPSIS"
 doctest_glob="**/*.md"
+markers = [
+    "flash_attn_test: marks tests related to flash attention (deselect with '-m \"not flash_attn_test\"')",
+]


### PR DESCRIPTION
# What does this PR do?

Adds the `flash_attn_test` marker to the `pyproject.toml` to remove the following warning:
```python 
tests/test_modeling_common.py:3131
  /home/arthur/transformers/tests/test_modeling_common.py:3131: PytestUnknownMarkWarning: Unknown pytest.mark.flash_attn_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.flash_attn_test

tests/test_modeling_common.py:3174
  /home/arthur/transformers/tests/test_modeling_common.py:3174: PytestUnknownMarkWarning: Unknown pytest.mark.flash_attn_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @mark.flash_attn_test
```
Allows to de-select them with:
```python 
pytest ... -m "not flash_attn_test"
```