### PR TITLE
docs: add docs for map, and add num procs to load_dataset

### DIFF
--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -439,6 +439,7 @@ def main():
             data_args.dataset_config_name,
             split=data_args.train_split_name,
             cache_dir=data_args.dataset_cache_dir,
+            num_proc=data_args.preprocessing_num_workers,
             token=True if model_args.use_auth_token else None,
         )
 
@@ -448,6 +449,7 @@ def main():
             data_args.dataset_config_name,
             split=data_args.eval_split_name,
             cache_dir=data_args.dataset_cache_dir,
+            num_proc=data_args.preprocessing_num_workers,
             token=True if model_args.use_auth_token else None,
         )
 
@@ -551,7 +553,7 @@ def main():
         prepare_dataset,
         remove_columns=next(iter(raw_datasets.values())).column_names,
         num_proc=num_workers,
-        desc="preprocess train dataset",
+        desc="preprocess train and eval dataset",
     )
 
     # filter training data with inputs longer than max_input_length


### PR DESCRIPTION
Hi,
In the .map, this do both for train and eval dataset, so I add description of .map train and eval to make them clear and logs in terminal look clear
I also add num_proc in load_dataset with the purpose of faster

I would like to cc @stevhliu review my PR.