### PR TITLE
4D `attention_mask` support

### DIFF
--- a/src/transformers/modeling_attn_mask_utils.py
+++ b/src/transformers/modeling_attn_mask_utils.py
@@ -302,10 +302,22 @@ def _prepare_4d_causal_attention_mask(
     key_value_length = input_shape[-1] + past_key_values_length
 
     # 4d mask is passed through the layers
-    if attention_mask is not None:
+    if attention_mask is not None and len(attention_mask.shape) == 2:
         attention_mask = attn_mask_converter.to_4d(
             attention_mask, input_shape[-1], key_value_length=key_value_length, dtype=inputs_embeds.dtype
         )
+    elif attention_mask is not None and len(attention_mask.shape) == 4:
+        expected_shape = (input_shape[0], 1, input_shape[1], key_value_length)
+        if tuple(attention_mask.shape) != expected_shape:
+            raise ValueError(
+                f"Incorrect 4D attention_mask shape: {tuple(attention_mask.shape)}; expected: {expected_shape}."
+            )
+        else:
+            # if the 4D mask has correct shape - invert it and fill with negative infinity
+            inverted_mask = 1.0 - attention_mask
+            attention_mask = inverted_mask.masked_fill(
+                inverted_mask.to(torch.bool), torch.finfo(inputs_embeds.dtype).min
+            )
     else:
         attention_mask = attn_mask_converter.to_causal_4d(
             input_shape[0], input_shape[-1], key_value_length, dtype=inputs_embeds.dtype, device=inputs_embeds.device

--- a/src/transformers/modeling_attn_mask_utils.py
+++ b/src/transformers/modeling_attn_mask_utils.py
@@ -352,7 +352,22 @@ def _prepare_4d_causal_attention_mask_for_sdpa(
     is_tracing = torch.jit.is_tracing()
 
     if attention_mask is not None:
-        if torch.all(attention_mask == 1):
+        # 4d mask is passed through
+        if len(attention_mask.shape) == 4:
+            expected_shape = (input_shape[0], 1, input_shape[1], key_value_length)
+            if tuple(attention_mask.shape) != expected_shape:
+                raise ValueError(
+                    f"Incorrect 4D attention_mask shape: {tuple(attention_mask.shape)}; expected: {expected_shape}."
+                )
+            else:
+                # if the 4D mask has correct shape - invert it and fill with negative infinity
+                inverted_mask = 1.0 - attention_mask.to(inputs_embeds.dtype)
+                attention_mask = inverted_mask.masked_fill(
+                    inverted_mask.to(torch.bool), torch.finfo(inputs_embeds.dtype).min
+                )
+                return attention_mask
+
+        elif torch.all(attention_mask == 1):
             if is_tracing:
                 pass
             elif query_length == 1:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1853,14 +1853,13 @@ class TestAttentionImplementation(unittest.TestCase):
         self.assertTrue("PyTorch SDPA requirements in Transformers are not met" in str(cm.exception))
 
 
-@require_torch
+@require_torch_gpu
 @slow
 class Mask4DTest(unittest.TestCase):
     def setUp(self):
-        self.device = torch.device("cuda:0")
         model_name = "JackFram/llama-160m"  # small Llama-like model from FlexFlow
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-        self.model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float32).to(self.device)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float32).to(torch_device)
 
     def tearDown(self):
         r"""
@@ -1873,7 +1872,7 @@ class Mask4DTest(unittest.TestCase):
     def get_test_data(self):
         texts = ["the cat sat", "the cat had", "the cat is"]
         encoded = [self.tokenizer.encode(t) for t in texts]
-        input_0 = torch.tensor(encoded, device=self.device)
+        input_0 = torch.tensor(encoded, device=torch_device)
         # tensor([[   1,  278, 6635, 3290],
         # [   1,  278, 6635,  750],
         # [   1,  278, 6635,  338]], device='cuda:0')
@@ -1901,7 +1900,7 @@ class Mask4DTest(unittest.TestCase):
         )
 
         # Creating a position_ids tensor. note the repeating figures in the end.
-        position_ids_1 = torch.tensor([[0, 1, 2, 3, 3, 3]], device=self.device, dtype=torch.int64)
+        position_ids_1 = torch.tensor([[0, 1, 2, 3, 3, 3]], device=torch_device, dtype=torch.int64)
 
         return input_0, input_1, mask_1, position_ids_1
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1853,6 +1853,8 @@ class TestAttentionImplementation(unittest.TestCase):
         self.assertTrue("PyTorch SDPA requirements in Transformers are not met" in str(cm.exception))
 
 
+@require_torch
+@slow
 class Mask4DTest(unittest.TestCase):
     def setUp(self):
         self.device = torch.device("cuda:0")

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1854,18 +1854,13 @@ class TestAttentionImplementation(unittest.TestCase):
         self.assertTrue("PyTorch SDPA requirements in Transformers are not met" in str(cm.exception))
 
 
-@require_torch
-@require_torch_gpu
 @slow
+@require_torch_gpu
 class Mask4DTestBase(unittest.TestCase):
-    @require_torch
-    @require_torch_gpu
     def tearDown(self):
         gc.collect()
         torch.cuda.empty_cache()
 
-    @require_torch
-    @require_torch_gpu
     def get_test_data(self):
         texts = ["the cat sat", "the cat had", "the cat is"]
         encoded = [self.tokenizer.encode(t) for t in texts]
@@ -1902,21 +1897,15 @@ class Mask4DTestBase(unittest.TestCase):
         return input_0, input_1, mask_1, position_ids_1
 
 
-@require_torch
-@require_torch_gpu
 @slow
+@require_torch_gpu
 class Mask4DTestFP32(Mask4DTestBase):
-    @require_torch
-    @require_torch_gpu
     def setUp(self):
         model_name = "JackFram/llama-68m"  # small Llama-like model from FlexFlow
         model_dtype = torch.float32
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=model_dtype).to(torch_device)
 
-    @require_torch
-    @require_torch_gpu
-    @slow
     def test_attention(self):
         """comparing outputs of attention layer"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
@@ -1935,9 +1924,6 @@ class Mask4DTestFP32(Mask4DTestBase):
         outs_1_last_tokens = outs_1[0, -3:, :]  # last three tokens
         assert torch.allclose(outs_0_last_tokens, outs_1_last_tokens)
 
-    @require_torch
-    @require_torch_gpu
-    @slow
     def test_inner_model(self):
         """comparing hidden outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
@@ -1952,9 +1938,6 @@ class Mask4DTestFP32(Mask4DTestBase):
             logits_1_last_tokens,
         )
 
-    @require_torch
-    @require_torch_gpu
-    @slow
     def test_causal_model_logits(self):
         """comparing logits outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
@@ -1970,23 +1953,17 @@ class Mask4DTestFP32(Mask4DTestBase):
         )
 
 
-@require_torch
-@require_torch_gpu
 @slow
+@require_torch_gpu
 class Mask4DTestFP16(Mask4DTestBase):
     test_attention = Mask4DTestFP32.test_attention
 
-    @require_torch
-    @require_torch_gpu
     def setUp(self):
         model_name = "JackFram/llama-68m"  # small Llama-like model from FlexFlow
         model_dtype = torch.float16
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=model_dtype).to(torch_device)
 
-    @require_torch
-    @require_torch_gpu
-    @slow
     def test_causal_model_logits(self):
         """comparing logits outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1854,6 +1854,7 @@ class TestAttentionImplementation(unittest.TestCase):
         self.assertTrue("PyTorch SDPA requirements in Transformers are not met" in str(cm.exception))
 
 
+@require_torch
 @require_torch_gpu
 @slow
 class Mask4DTestBase(unittest.TestCase):
@@ -1908,8 +1909,6 @@ class Mask4DTestBase(unittest.TestCase):
         return input_0, input_1, mask_1, position_ids_1
 
 
-@require_torch_gpu
-@slow
 class Mask4DTestFP32(Mask4DTestBase):
     model_dtype = torch.float32
 
@@ -1945,8 +1944,6 @@ class Mask4DTestFP32(Mask4DTestBase):
             logits_1_last_tokens,
         )
 
-    @require_torch_gpu
-    @slow
     def test_causal_model_logits(self):
         """comparing logits outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1897,7 +1897,7 @@ class Mask4DTest(unittest.TestCase):
                 ]
             ],
             device="cuda:0",
-            dtype=torch.bool,
+            dtype=torch.int64,
         )
 
         # Creating a position_ids tensor. note the repeating figures in the end.

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1932,7 +1932,7 @@ class Mask4DTest(unittest.TestCase):
 
         logits_0_last_tokens = logits_0[:, -1, :]  # last tokens in each batch line
         logits_1_last_tokens = logits_1[0, -3:, :]  # last three tokens
-        assert torch.allclose(
+        torch.testing.assert_close(
             logits_0_last_tokens, logits_1_last_tokens, atol=1e-5
         )  # note higher atol set to deal with noise
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1904,6 +1904,7 @@ class Mask4DTest(unittest.TestCase):
         return input_0, input_1, mask_1, position_ids_1
 
     def test_attention(self):
+        """comparing outputs of attention layer"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
 
         hid_0 = self.model.model.embed_tokens(input_0)
@@ -1921,6 +1922,7 @@ class Mask4DTest(unittest.TestCase):
         assert torch.allclose(outs_0_last_tokens, outs_1_last_tokens, atol=1e-8)
 
     def test_model(self):
+        """comparing hidden outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
 
         logits_0 = self.model.forward(input_0).logits
@@ -1928,4 +1930,19 @@ class Mask4DTest(unittest.TestCase):
 
         logits_0_last_tokens = logits_0[:, -1, :]  # last tokens in each batch line
         logits_1_last_tokens = logits_1[0, -3:, :]  # last three tokens
-        assert torch.allclose(logits_0_last_tokens, logits_1_last_tokens, atol=1e-5)
+        assert torch.allclose(
+            logits_0_last_tokens, logits_1_last_tokens, atol=1e-5
+        )  # note higher atol set to deal with noise
+
+    def test_causal_model_logits(self):
+        """comparing logits outputs of whole inner model"""
+        input_0, input_1, mask_1, position_ids_1 = self.get_test_data()
+
+        logits_0 = self.model.forward(input_0).logits
+        logits_1 = self.model.forward(input_1, attention_mask=mask_1.bool(), position_ids=position_ids_1).logits
+
+        logits_0_last_tokens = logits_0[:, -1, :]  # last tokens in each batch line
+        logits_1_last_tokens = logits_1[0, -3:, :]  # last three tokens
+        assert torch.allclose(
+            logits_0_last_tokens, logits_1_last_tokens, atol=1e-5
+        )  # note higher atol set to deal with noise

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1909,6 +1909,9 @@ class Mask4DTestBase(unittest.TestCase):
         return input_0, input_1, mask_1, position_ids_1
 
 
+@require_torch
+@require_torch_gpu
+@slow
 class Mask4DTestFP32(Mask4DTestBase):
     model_dtype = torch.float32
 
@@ -1959,6 +1962,9 @@ class Mask4DTestFP32(Mask4DTestBase):
         )
 
 
+@require_torch
+@require_torch_gpu
+@slow
 class Mask4DTestFP16(Mask4DTestBase):
     model_dtype = torch.float16
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1908,6 +1908,8 @@ class Mask4DTestBase(unittest.TestCase):
         return input_0, input_1, mask_1, position_ids_1
 
 
+@require_torch_gpu
+@slow
 class Mask4DTestFP32(Mask4DTestBase):
     model_dtype = torch.float32
 
@@ -1943,6 +1945,8 @@ class Mask4DTestFP32(Mask4DTestBase):
             logits_1_last_tokens,
         )
 
+    @require_torch_gpu
+    @slow
     def test_causal_model_logits(self):
         """comparing logits outputs of whole inner model"""
         input_0, input_1, mask_1, position_ids_1 = self.get_test_data()


### PR DESCRIPTION
This is implementation for feature request from #27493 [custom 4d attention_mask as transformers .forward() argument](https://github.com/huggingface/transformers/issues/27493).

1) Allowing 4d attention masks to pass thru `_prepare_4d_causal_attention_mask()` intact
2) support in OPT (need to build custom `positions` tensor)
3) support in Llama (while Llama can accept custom `position_ids`, I added code to generate them internally)

The benefits of the code are to enable more memory-efficient text generation with tree-based parallel decoding as described in [SpecInfer paper](https://arxiv.org/abs/2305.09781)

Tagging:
@gante (generate)
@patrickvonplaten (masks)
@younesbelkada @ArthurZucker (text models)

This PR is WiP:
- Will add tests
- Need advice on how to handle models beyond covered Llama and OPT
- May add example for memory-efficient generation

**IMPORTANT: this PR makes changes that can only used by few classes of models**
requirements to use:
- have `position_ids` argument in `.forward()` method
- use `modeling_attn_mask_utils.py::_prepare_4d_attention_mask()` function for 4d mask generation
- 

as of 20.12.2023, only a handful (under 20) of transformers model classes meet these criteria. Most of these classes are multimodal, which may require their own use cases for 4D masks. The pure language modelling classes fit to use the 4D mask changes from this PR are only `LlamaModel`, `FalconModel` and `XGLMModel`.