### PR TITLE
Generate: fix flaky tests

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1301,8 +1301,9 @@ class InfNanRemoveLogitsProcessor(LogitsProcessor):
         # set all nan values to 0.0
         scores[scores != scores] = 0.0
 
-        # set all inf values to max possible value
+        # set all +/-inf values to max/min possible value
         scores[scores == float("inf")] = torch.finfo(scores.dtype).max
+        scores[scores == float("-inf")] = torch.finfo(scores.dtype).min
 
         return scores
 

--- a/tests/generation/test_logits_process.py
+++ b/tests/generation/test_logits_process.py
@@ -692,7 +692,7 @@ class LogitsProcessorTest(unittest.TestCase):
             torch.allclose(
                 scores,
                 torch.tensor(
-                    [[0.0, 0.7, 0.8, 0.0], [0.1, torch.finfo(scores.dtype).max, 0.3, float("-inf")]],
+                    [[0.0, 0.7, 0.8, 0.0], [0.1, torch.finfo(scores.dtype).max, 0.3, torch.finfo(scores.dtype).min]],
                     device=torch_device,
                 ),
                 atol=1e-6,

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -123,9 +123,12 @@ class GenerationTesterMixin:
         process_kwargs = {
             "min_length": input_length + 1 if max_length is None else max_length - 1,
             "bad_words_ids": [[1, 0]],
-            "no_repeat_ngram_size": 2,
             "repetition_penalty": 1.2,
+            "remove_invalid_values": True,
         }
+        if forced_bos_token_id is None and forced_eos_token_id is None:
+            process_kwargs["no_repeat_ngram_size"] = (2,)
+
         logits_processor = LogitsProcessorList(
             (
                 [
@@ -153,12 +156,16 @@ class GenerationTesterMixin:
                 if forced_eos_token_id is not None
                 else []
             )
-            + [
-                NoBadWordsLogitsProcessor(process_kwargs["bad_words_ids"], eos_token_id),
-                NoRepeatNGramLogitsProcessor(process_kwargs["no_repeat_ngram_size"]),
-                RepetitionPenaltyLogitsProcessor(process_kwargs["repetition_penalty"]),
-            ]
+            + [NoBadWordsLogitsProcessor(process_kwargs["bad_words_ids"], eos_token_id)]
+            + (
+                NoRepeatNGramLogitsProcessor(process_kwargs["no_repeat_ngram_size"])
+                if forced_bos_token_id is None and forced_eos_token_id is None
+                else []
+            )
+            + [RepetitionPenaltyLogitsProcessor(process_kwargs["repetition_penalty"])]
+            + [InfNanRemoveLogitsProcessor()]  # prevent flaky generation test failures
         )
+
         return process_kwargs, logits_processor
 
     @staticmethod
@@ -281,7 +288,6 @@ class GenerationTesterMixin:
             output_hidden_states=output_hidden_states,
             output_scores=output_scores,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **logits_process_kwargs,
             **model_kwargs,
         )
@@ -339,7 +345,6 @@ class GenerationTesterMixin:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **logits_warper_kwargs,
             **process_kwargs,
             **model_kwargs,
@@ -359,9 +364,6 @@ class GenerationTesterMixin:
             kwargs["encoder_outputs"] = encoder_outputs
         elif attention_mask is not None:
             attention_mask = attention_mask.repeat_interleave(num_return_sequences, dim=0)
-
-        # prevent flaky generation test failures
-        logits_processor.append(InfNanRemoveLogitsProcessor())
 
         with torch.no_grad():
             model_kwargs = {"attention_mask": attention_mask} if attention_mask is not None else {}
@@ -404,7 +406,6 @@ class GenerationTesterMixin:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **beam_kwargs,
             **logits_process_kwargs,
             **model_kwargs,
@@ -466,7 +467,6 @@ class GenerationTesterMixin:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **beam_kwargs,
             **logits_warper_kwargs,
             **model_kwargs,
@@ -533,7 +533,6 @@ class GenerationTesterMixin:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **beam_kwargs,
             **logits_process_kwargs,
             **model_kwargs,
@@ -595,7 +594,6 @@ class GenerationTesterMixin:
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             constraints=constraints,
             **beam_kwargs,
             **logits_process_kwargs,
@@ -670,7 +668,6 @@ class GenerationTesterMixin:
             output_hidden_states=output_hidden_states,
             output_scores=output_scores,
             return_dict_in_generate=return_dict_in_generate,
-            remove_invalid_values=True,
             **logits_process_kwargs,
             **model_kwargs,
             **contrastive_search_kwargs,
@@ -1283,13 +1280,8 @@ class GenerationTesterMixin:
 
             # check `generate()` and `constrained_beam_search()` are equal
             # Sample constraints
-            if not input_ids.dtype == torch.float32:
-                min_id = torch.min(input_ids) + 3
-                max_id = torch.max(input_ids)
-            else:
-                # otherwise this throws an error for Speech2TextModel since its inputs are floating points
-                min_id = 3
-                max_id = 100
+            min_id = 3
+            max_id = config.vocab_size
 
             force_tokens = torch.randint(min_id, max_id, (1, 2)).tolist()[0]
             constraints = [

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -126,8 +126,9 @@ class GenerationTesterMixin:
             "repetition_penalty": 1.2,
             "remove_invalid_values": True,
         }
+        # NoRepeatNGramLogitsProcessor + forced tokens may result in no valid continuations
         if forced_bos_token_id is None and forced_eos_token_id is None:
-            process_kwargs["no_repeat_ngram_size"] = (2,)
+            process_kwargs["no_repeat_ngram_size"] = 2
 
         logits_processor = LogitsProcessorList(
             (

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -159,7 +159,7 @@ class GenerationTesterMixin:
             )
             + [NoBadWordsLogitsProcessor(process_kwargs["bad_words_ids"], eos_token_id)]
             + (
-                NoRepeatNGramLogitsProcessor(process_kwargs["no_repeat_ngram_size"])
+                [NoRepeatNGramLogitsProcessor(process_kwargs["no_repeat_ngram_size"])]
                 if forced_bos_token_id is None and forced_eos_token_id is None
                 else []
             )

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -130,6 +130,7 @@ class GenerationTesterMixin:
         if forced_bos_token_id is None and forced_eos_token_id is None:
             process_kwargs["no_repeat_ngram_size"] = 2
 
+        # NOTE: the order of operations here should match `generate` for accurate testing
         logits_processor = LogitsProcessorList(
             (
                 [


### PR DESCRIPTION
# What does this PR do?

Fixes two flaky tests:
1. `tests/models/clvp/test_modeling_clvp.py::ClvpDecoderTest::test_constrained_beam_search_generate` was failing at a ~3% rate because the range for which we were sampling tokens to force in constrained beam search was based on the random input_ids and sometimes invalid. 👉 fix = hard code the valid range based on `config.vocab_size`
2. `tests/models/marian/test_modeling_marian.py::MarianStandaloneDecoderModelTest::test_sample_generate` was failing at a ~0.1% rate because of a combination of poor logits processor setup + random input_ids 👉 fix = don't set up the logits processor with a combination that may lead to no valid continuation being possible