### PR TITLE
Adding bbox transformatinos

### DIFF
--- a/src/transformers/utils/bounding_box_utils.py
+++ b/src/transformers/utils/bounding_box_utils.py
@@ -49,13 +49,13 @@ def _is_relative_format(format):
     return format.startswith("relative")
 
 
-def _xywh_to_xyxy(xywh: torch.Tensor, inplace: bool) -> torch.Tensor:
+def _xywh_to_xyxy(xywh: "torch.Tensor", inplace: bool) -> "torch.Tensor":
     """
     Convert bounding box format from XYWH to XYXY.
 
     Args:
-        xywh (torch.Tensor): The bounding box in XYWH format.
-        inplace (bool): If True, perform operation in-place.
+        xywh (`torch.Tensor`): The bounding box in XYWH format.
+        inplace (`bool`): If True, perform operation in-place.
 
     Returns:
         torch.Tensor: The bounding box in XYXY format.
@@ -65,13 +65,13 @@ def _xywh_to_xyxy(xywh: torch.Tensor, inplace: bool) -> torch.Tensor:
     return xyxy
 
 
-def _xyxy_to_xywh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
+def _xyxy_to_xywh(xyxy: "torch.Tensor", inplace: bool) -> "torch.Tensor":
     """
     Convert bounding box format from XYXY to XYWH.
 
     Args:
-        xyxy (torch.Tensor): The bounding box in XYXY format.
-        inplace (bool): If True, perform operation in-place.
+        xyxy (`torch.Tensor`): The bounding box in XYXY format.
+        inplace (`bool`): If True, perform operation in-place.
 
     Returns:
         torch.Tensor: The bounding box in XYWH format.
@@ -82,13 +82,13 @@ def _xyxy_to_xywh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
 
 
 # adapted from https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_meta.py
-def _xcycwh_to_xyxy(xcycwh: torch.Tensor, inplace: bool) -> torch.Tensor:
+def _xcycwh_to_xyxy(xcycwh: "torch.Tensor", inplace: bool) -> "torch.Tensor":
     """
     Convert bounding box format from XCYCWH to XYXY.
 
     Args:
-        xcycwh (torch.Tensor): The bounding box in XCYCWH format.
-        inplace (bool): If True, perform operation in-place.
+        xcycwh (`torch.Tensor`): The bounding box in XCYCWH format.
+        inplace (`bool`): If True, perform operation in-place.
 
     Returns:
         torch.Tensor: The bounding box in XYXY format.
@@ -105,13 +105,13 @@ def _xcycwh_to_xyxy(xcycwh: torch.Tensor, inplace: bool) -> torch.Tensor:
 
 
 # adapted from https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_meta.py
-def _xyxy_to_xcycwh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
+def _xyxy_to_xcycwh(xyxy: "torch.Tensor", inplace: bool) -> "torch.Tensor":
     """
     Convert bounding box format from XYXY to XCYCWH.
 
     Args:
-        xyxy (torch.Tensor): The bounding box in XYXY format.
-        inplace (bool): If True, perform operation in-place.
+        xyxy (`torch.Tensor`): The bounding box in XYXY format.
+        inplace (`bool`): If True, perform operation in-place.
 
     Returns:
         torch.Tensor: The bounding box in XCYCWH format.
@@ -127,14 +127,14 @@ def _xyxy_to_xcycwh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
     return xyxy
 
 
-def _relxywh_to_xyxy(relxywh: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+def _relxywh_to_xyxy(relxywh: "torch.Tensor", img_shape: Tuple[int, int], inplace: bool) -> "torch.Tensor":
     """
     Convert relative XYWH bounding box format to absolute XYXY format.
 
     Args:
-        relxywh (torch.Tensor): The bounding box in relative XYWH format.
+        relxywh (`torch.Tensor`): The bounding box in relative XYWH format.
         img_shape (Tuple[int, int]): The shape of the image (height, width).
-        inplace (bool): If True, perform operation in-place.
+        inplace (`bool`): If True, perform operation in-place.
 
     Returns:
         torch.Tensor: The bounding box in absolute XYXY format.
@@ -147,7 +147,7 @@ def _relxywh_to_xyxy(relxywh: torch.Tensor, img_shape: Tuple[int, int], inplace:
     return relxywh
 
 
-def _relxcycwh_to_xyxy(relxcycwh: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+def _relxcycwh_to_xyxy(relxcycwh: "torch.Tensor", img_shape: Tuple[int, int], inplace: bool) -> "torch.Tensor":
     relxcycwh = relxcycwh if inplace else relxcycwh.clone()
     # convert to relative_xyxy
     relxyxy = _xcycwh_to_xyxy(relxcycwh, inplace)
@@ -156,7 +156,7 @@ def _relxcycwh_to_xyxy(relxcycwh: torch.Tensor, img_shape: Tuple[int, int], inpl
     return relxyxy
 
 
-def _xyxy_to_relxywh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+def _xyxy_to_relxywh(xyxy: "torch.Tensor", img_shape: Tuple[int, int], inplace: bool) -> "torch.Tensor":
     xyxy = xyxy if inplace else xyxy.clone()
     # to xywh
     xyxy = _xyxy_to_xywh(xyxy, inplace)
@@ -165,7 +165,7 @@ def _xyxy_to_relxywh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: bo
     return xyxy
 
 
-def _xyxy_to_relxcycwh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+def _xyxy_to_relxcycwh(xyxy: "torch.Tensor", img_shape: Tuple[int, int], inplace: bool) -> "torch.Tensor":
     xyxy = xyxy if inplace else xyxy.clone()
     # to xcycwh
     xyxy = _xyxy_to_xcycwh(xyxy, inplace)
@@ -175,7 +175,7 @@ def _xyxy_to_relxcycwh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: 
 
 
 def transform_box_format(
-    bbox: torch.Tensor,
+    bbox: "torch.Tensor",
     orig_format: BoundingBoxFormat,
     dest_format: BoundingBoxFormat,
     img_shape: Optional[Union[Tuple[int, int], torch.Tensor]] = None,
@@ -186,11 +186,11 @@ def transform_box_format(
     Transform a bounding box from one format to another.
 
     Args:
-        bbox (torch.Tensor): The bounding box to transform. orig_format (BoundingBoxFormat): The
+        bbox (`torch.Tensor`): The bounding box to transform. orig_format (BoundingBoxFormat): The
         original format of the bounding box. dest_format (BoundingBoxFormat): The desired destination format of the
         bounding box. img_shape (Optional[Tuple[int, int]]): The shape of the image (height, width), required for
-        relative formats. inplace (bool): If True, perform operation in-place.
-        do_round (bool):
+        relative formats. inplace (`bool`): If True, perform operation in-place.
+        do_round (`bool`):
             If True, and the destination format is not a relative format, the coordinates of boxes are rounded.
 
     Returns:

--- a/src/transformers/utils/bounding_box_utils.py
+++ b/src/transformers/utils/bounding_box_utils.py
@@ -1,0 +1,253 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Tuple, Union
+
+from transformers.utils import (
+    ExplicitEnum,
+)
+
+from .import_utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+
+
+class BoundingBoxFormat(ExplicitEnum):
+    """Coordinate formats to represent a bounding box."""
+
+    XYXY = "xyxy"  # absolute coordinates
+    XYWH = "xywh"  # absolute coordinates
+    XCYCWH = "xcycwh"  # absolute coordinates
+    RELATIVE_XYWH = "relative_xywh"  # relative coordinates
+    RELATIVE_XCYCWH = "relative_xcycwh"  # relative coordinates
+
+
+def _is_relative_format(format):
+    """
+    Check if the bounding box format is relative.
+
+    Args:
+        format (str): The format of the bounding box.
+
+    Returns:
+        bool: True if the format is relative, False otherwise.
+    """
+    return format.startswith("relative")
+
+
+def _xywh_to_xyxy(xywh: torch.Tensor, inplace: bool) -> torch.Tensor:
+    """
+    Convert bounding box format from XYWH to XYXY.
+
+    Args:
+        xywh (torch.Tensor): The bounding box in XYWH format.
+        inplace (bool): If True, perform operation in-place.
+
+    Returns:
+        torch.Tensor: The bounding box in XYXY format.
+    """
+    xyxy = xywh if inplace else xywh.clone()
+    xyxy[..., 2:].add_(xyxy[..., :2])
+    return xyxy
+
+
+def _xyxy_to_xywh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
+    """
+    Convert bounding box format from XYXY to XYWH.
+
+    Args:
+        xyxy (torch.Tensor): The bounding box in XYXY format.
+        inplace (bool): If True, perform operation in-place.
+
+    Returns:
+        torch.Tensor: The bounding box in XYWH format.
+    """
+    xyxy = xyxy if inplace else xyxy.clone()
+    xyxy[..., 2:].sub_(xyxy[..., :2])
+    return xyxy
+
+
+# adapted from https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_meta.py
+def _xcycwh_to_xyxy(xcycwh: torch.Tensor, inplace: bool) -> torch.Tensor:
+    """
+    Convert bounding box format from XCYCWH to XYXY.
+
+    Args:
+        xcycwh (torch.Tensor): The bounding box in XCYCWH format.
+        inplace (bool): If True, perform operation in-place.
+
+    Returns:
+        torch.Tensor: The bounding box in XYXY format.
+    """
+    xcycwh = xcycwh if inplace else xcycwh.clone()
+    # Trick to do fast division by 2 and ceil
+    rounding_mode = None if xcycwh.is_floating_point() else "floor"
+    half_wh = xcycwh[..., 2:].div(-2, rounding_mode=rounding_mode).abs_()
+    # (xc - width / 2) = x1 and (yc - height / 2) = x1
+    xcycwh[..., :2].sub_(half_wh)
+    # (x1 + width) = x2 and (y1 + height) = y2
+    xcycwh[..., 2:].add_(xcycwh[..., :2])
+    return xcycwh
+
+
+# adapted from https://github.com/pytorch/vision/blob/main/torchvision/transforms/v2/functional/_meta.py
+def _xyxy_to_xcycwh(xyxy: torch.Tensor, inplace: bool) -> torch.Tensor:
+    """
+    Convert bounding box format from XYXY to XCYCWH.
+
+    Args:
+        xyxy (torch.Tensor): The bounding box in XYXY format.
+        inplace (bool): If True, perform operation in-place.
+
+    Returns:
+        torch.Tensor: The bounding box in XCYCWH format.
+    """
+    xyxy = xyxy if inplace else xyxy.clone()
+    # (x2 - x1) = width and (y2 - y1) = height
+    xyxy[..., 2:].sub_(xyxy[..., :2])  # => x, y, width, height
+    # cx and cy can be written with different terms
+    # (x1 * 2 + width)/2 = x1 + width/2 = x1 + (x2-x1)/2 = (x1 + x2)/2 = cy
+    # (y1 * 2 + height)/2 = y1 + height/2 = y1 + (y2-y1)/2 = (y1 + y2)/2 = cy
+    rounding_mode = None if xyxy.is_floating_point() else "floor"
+    xyxy[..., :2].mul_(2).add_(xyxy[..., 2:]).div_(2, rounding_mode=rounding_mode)
+    return xyxy
+
+
+def _relxywh_to_xyxy(relxywh: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+    """
+    Convert relative XYWH bounding box format to absolute XYXY format.
+
+    Args:
+        relxywh (torch.Tensor): The bounding box in relative XYWH format.
+        img_shape (Tuple[int, int]): The shape of the image (height, width).
+        inplace (bool): If True, perform operation in-place.
+
+    Returns:
+        torch.Tensor: The bounding box in absolute XYXY format.
+    """
+    relxywh = relxywh if inplace else relxywh.clone()
+    # convert to relative_xyxy
+    relxywh[..., 2:].add_(relxywh[..., :2])
+    # convert to xywh
+    relxywh.multiply_(img_shape.repeat(2).flip(0))
+    return relxywh
+
+
+def _relxcycwh_to_xyxy(relxcycwh: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+    relxcycwh = relxcycwh if inplace else relxcycwh.clone()
+    # convert to relative_xyxy
+    relxyxy = _xcycwh_to_xyxy(relxcycwh, inplace)
+    # convert to xyxy
+    relxyxy.multiply_(img_shape.repeat(2).flip(0))
+    return relxyxy
+
+
+def _xyxy_to_relxywh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+    xyxy = xyxy if inplace else xyxy.clone()
+    # to xywh
+    xyxy = _xyxy_to_xywh(xyxy, inplace)
+    # divide by (height, width) to make coordinates in relative format (rel_xywh)
+    xyxy.divide_(img_shape.repeat(2).flip(0))
+    return xyxy
+
+
+def _xyxy_to_relxcycwh(xyxy: torch.Tensor, img_shape: Tuple[int, int], inplace: bool) -> torch.Tensor:
+    xyxy = xyxy if inplace else xyxy.clone()
+    # to xcycwh
+    xyxy = _xyxy_to_xcycwh(xyxy, inplace)
+    # divide by (height, width) to make coordinates in relative format (rel_xcycwh)
+    xyxy.divide_(img_shape.repeat(2).flip(0))
+    return xyxy
+
+
+def transform_box_format(
+    bbox: torch.Tensor,
+    orig_format: BoundingBoxFormat,
+    dest_format: BoundingBoxFormat,
+    img_shape: Optional[Union[Tuple[int, int], torch.Tensor]] = None,
+    inplace: bool = False,
+    do_round: bool = False,
+):
+    """
+    Transform a bounding box from one format to another.
+
+    Args:
+        bbox (torch.Tensor): The bounding box to transform. orig_format (BoundingBoxFormat): The
+        original format of the bounding box. dest_format (BoundingBoxFormat): The desired destination format of the
+        bounding box. img_shape (Optional[Tuple[int, int]]): The shape of the image (height, width), required for
+        relative formats. inplace (bool): If True, perform operation in-place.
+        do_round (bool):
+            If True, and the destination format is not a relative format, the coordinates of boxes are rounded.
+
+    Returns:
+        Union[torch.Tensor, np.ndarray]: The transformed bounding box.
+
+    Raises:
+        ValueError: If image shape is required but not provided.
+    """
+    # no transformation is needed
+    if orig_format == dest_format:
+        return bbox
+
+    bbx_format_members = BoundingBoxFormat.__members__.values()
+    if orig_format not in bbx_format_members:
+        raise ValueError("orig_format is not a valid BoundingBoxFormat.")
+    if dest_format not in bbx_format_members:
+        raise ValueError("dest_format is not a valid BoundingBoxFormat.")
+
+    if _is_relative_format(orig_format):
+        bbox = bbox.type(torch.float32)
+        if img_shape is None:
+            raise ValueError(f"Image shape (height, width) is required if the input format format is {dest_format}")
+        if not isinstance(img_shape, torch.Tensor):
+            img_shape = torch.Tensor(img_shape)
+
+    if _is_relative_format(dest_format):
+        if img_shape is None:
+            raise ValueError(
+                f"Image shape (height, width) is required if the desired destination format is {dest_format}"
+            )
+        if not isinstance(img_shape, torch.Tensor):
+            img_shape = torch.Tensor(img_shape)
+
+    bbox = bbox.type(torch.float)
+    # convert to xyxy
+    if orig_format == BoundingBoxFormat.XYWH:
+        bbox = _xywh_to_xyxy(bbox, inplace)
+    elif orig_format == BoundingBoxFormat.XCYCWH:
+        bbox = _xcycwh_to_xyxy(bbox, inplace)
+    elif orig_format == BoundingBoxFormat.RELATIVE_XYWH:
+        bbox = _relxywh_to_xyxy(bbox, img_shape, inplace)
+    elif orig_format == BoundingBoxFormat.RELATIVE_XCYCWH:
+        bbox = _relxcycwh_to_xyxy(bbox, img_shape, inplace)
+
+    # boxes are now in xyxy format
+
+    if dest_format == BoundingBoxFormat.XYWH:
+        bbox = _xyxy_to_xywh(bbox, inplace)
+    elif dest_format == BoundingBoxFormat.XCYCWH:
+        bbox = _xyxy_to_xcycwh(bbox, inplace)
+    elif dest_format == BoundingBoxFormat.RELATIVE_XYWH:
+        bbox = _xyxy_to_relxywh(bbox, img_shape, inplace)
+    elif dest_format == BoundingBoxFormat.RELATIVE_XCYCWH:
+        bbox = _xyxy_to_relxcycwh(bbox, img_shape, inplace)
+
+    # If rounded is requested and destination format is not a relative format, round coordinates.
+    if do_round and not _is_relative_format(dest_format):
+        bbox = torch.round(bbox, decimals=1)
+
+    return bbox

--- a/src/transformers/utils/bounding_box_utils.py
+++ b/src/transformers/utils/bounding_box_utils.py
@@ -58,7 +58,7 @@ def _xywh_to_xyxy(xywh: "torch.Tensor", inplace: bool) -> "torch.Tensor":
         inplace (`bool`): If True, perform operation in-place.
 
     Returns:
-        torch.Tensor: The bounding box in XYXY format.
+        The bounding box in XYXY format.
     """
     xyxy = xywh if inplace else xywh.clone()
     xyxy[..., 2:].add_(xyxy[..., :2])
@@ -74,7 +74,7 @@ def _xyxy_to_xywh(xyxy: "torch.Tensor", inplace: bool) -> "torch.Tensor":
         inplace (`bool`): If True, perform operation in-place.
 
     Returns:
-        torch.Tensor: The bounding box in XYWH format.
+        The bounding box in XYWH format.
     """
     xyxy = xyxy if inplace else xyxy.clone()
     xyxy[..., 2:].sub_(xyxy[..., :2])
@@ -91,7 +91,7 @@ def _xcycwh_to_xyxy(xcycwh: "torch.Tensor", inplace: bool) -> "torch.Tensor":
         inplace (`bool`): If True, perform operation in-place.
 
     Returns:
-        torch.Tensor: The bounding box in XYXY format.
+        The bounding box in XYXY format.
     """
     xcycwh = xcycwh if inplace else xcycwh.clone()
     # Trick to do fast division by 2 and ceil
@@ -114,7 +114,7 @@ def _xyxy_to_xcycwh(xyxy: "torch.Tensor", inplace: bool) -> "torch.Tensor":
         inplace (`bool`): If True, perform operation in-place.
 
     Returns:
-        torch.Tensor: The bounding box in XCYCWH format.
+        The bounding box in XCYCWH format.
     """
     xyxy = xyxy if inplace else xyxy.clone()
     # (x2 - x1) = width and (y2 - y1) = height
@@ -137,7 +137,7 @@ def _relxywh_to_xyxy(relxywh: "torch.Tensor", img_shape: Tuple[int, int], inplac
         inplace (`bool`): If True, perform operation in-place.
 
     Returns:
-        torch.Tensor: The bounding box in absolute XYXY format.
+        The bounding box in absolute XYXY format.
     """
     relxywh = relxywh if inplace else relxywh.clone()
     # convert to relative_xyxy
@@ -178,7 +178,7 @@ def transform_box_format(
     bbox: "torch.Tensor",
     orig_format: BoundingBoxFormat,
     dest_format: BoundingBoxFormat,
-    img_shape: Optional[Union[Tuple[int, int], torch.Tensor]] = None,
+    img_shape: Optional[Union[Tuple[int, int], "torch.Tensor"]] = None,
     inplace: bool = False,
     do_round: bool = False,
 ):
@@ -194,7 +194,7 @@ def transform_box_format(
             If True, and the destination format is not a relative format, the coordinates of boxes are rounded.
 
     Returns:
-        Union[torch.Tensor, np.ndarray]: The transformed bounding box.
+        The transformed bounding box.
 
     Raises:
         ValueError: If image shape is required but not provided.

--- a/tests/utils/test_bounding_box_utils.py
+++ b/tests/utils/test_bounding_box_utils.py
@@ -26,6 +26,20 @@ if is_torch_available():
 
 @require_torch
 class UtilBoundingBoxConverters(unittest.TestCase):
+    def test_exceptions(self):
+        # test case when input format is relative and image shape is not passed
+        bbox = torch.Tensor([[100, 200, 300, 400]])
+        with self.assertRaises(ValueError):
+            transform_box_format(bbox=bbox, orig_format="relative_xywh", dest_format="xyxy")
+        with self.assertRaises(ValueError):
+            transform_box_format(bbox=bbox, orig_format="relative_xcycwh", dest_format="xyxy")
+
+        # test case when formats are invalid
+        with self.assertRaises(ValueError):
+            transform_box_format(bbox=bbox, orig_format="abc", dest_format="xyxy")
+        with self.assertRaises(ValueError):
+            transform_box_format(bbox=bbox, orig_format="xyxy", dest_format="abc")
+
     def test_enumerators(self):
         self.assertEqual(BoundingBoxFormat.XYXY, "xyxy")
         self.assertEqual(BoundingBoxFormat.XYWH, "xywh")

--- a/tests/utils/test_bounding_box_utils.py
+++ b/tests/utils/test_bounding_box_utils.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+# Copyright 2023 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import is_torch_available
+from transformers.testing_utils import require_torch
+from transformers.utils.bounding_box_utils import BoundingBoxFormat, transform_box_format
+
+
+if is_torch_available():
+    import torch
+
+
+@require_torch
+class UtilBoundingBoxConverters(unittest.TestCase):
+    def test_enumerators(self):
+        self.assertEqual(BoundingBoxFormat.XYXY, "xyxy")
+        self.assertEqual(BoundingBoxFormat.XYWH, "xywh")
+        self.assertEqual(BoundingBoxFormat.XCYCWH, "xcycwh")
+        self.assertEqual(BoundingBoxFormat.RELATIVE_XYWH, "relative_xywh")
+        self.assertEqual(BoundingBoxFormat.RELATIVE_XCYCWH, "relative_xcycwh")
+
+    def test_conversion_cases(self):
+        # Identical bounding boxes differing in format only
+        testing_cases = {
+            "xywh": [
+                [387, 441, 44, 9],
+                [134, 57, 434, 383],
+                [306, 274, 36, 154],
+                [22, 252, 479, 56],
+                [498, 349, 120, 79],
+            ],
+            "xyxy": [
+                [387, 441, 431, 450.0],
+                [134, 57, 568, 440.0],
+                [306, 274, 342, 428.0],
+                [22, 252, 501, 308.0],
+                [498, 349, 618, 428],
+            ],
+            "xcycwh": [
+                [409.0, 445.5, 44.0, 9.0],
+                [351.0, 248.5, 434.0, 383.0],
+                [324.0, 351.0, 36.0, 154.0],
+                [261.5, 280.0, 479.0, 56.0],
+                [558.0, 388.5, 120.0, 79.0],
+            ],
+            "relative_xywh": [
+                [0.6047, 0.9587, 0.0688, 0.0196],
+                [0.2094, 0.1239, 0.6781, 0.8326],
+                [0.4781, 0.5957, 0.05625, 0.3348],
+                [0.0344, 0.5478, 0.7484, 0.1217],
+                [0.7781, 0.7587, 0.1875, 0.1717],
+            ],
+            "relative_xcycwh": [
+                [0.6391, 0.9685, 0.0688, 0.0196],
+                [0.5484, 0.5402, 0.6781, 0.8326],
+                [0.5063, 0.7630, 0.0563, 0.3348],
+                [0.4086, 0.6087, 0.7484, 0.1217],
+                [0.8719, 0.8446, 0.1875, 0.1717],
+            ],
+        }
+        # Resolution of the image where the boxes belong to
+        original_img_shape = [460, 640]
+
+        # Define which formats are relative and absolute
+        rel_formats = ("relative_xywh", "relative_xcycwh")
+
+        # Loop through each format in the testing cases
+        for origin_format, bboxes in testing_cases.items():
+            origin_format = BoundingBoxFormat(origin_format)
+            bboxes = torch.Tensor(bboxes)
+
+            # Loop through all formats to be used as destination formats
+            for dest_format, expected_bboxes in testing_cases.items():
+                dest_format = BoundingBoxFormat(dest_format)
+                expected_bboxes = torch.Tensor(expected_bboxes)
+                img_shape = None
+                # If original or destination formats are relative, the image shape is required
+                if dest_format in rel_formats or origin_format in rel_formats:
+                    img_shape = original_img_shape
+
+                # Apply transformation
+                result = transform_box_format(
+                    bboxes, orig_format=origin_format, dest_format=dest_format, img_shape=img_shape, do_round=True
+                )
+                # Compare results
+                self.assertTrue(torch.allclose(result, expected_bboxes, atol=1e-4))


### PR DESCRIPTION
# What does this PR do?

This PR implements bounding box transformations among different formats:
`XYXY` <-> `XYWH` <-> `XCYCWH` <-> `RELATIVE_XYWH` <-> `RELATIVE_XCYCWH`

Object detection models can output boxes in different formats, requesting manual transformations while porting these models. The idea to have a flexible function such as the proposed `transform_box_format` is similar to our image transformation functions such as `normalize`, `center_crop`, `resize`, etc, that can be used by any model.

We currently have 2 functions that make bboxes transformations: `center_to_corners_format`, `corners_to_center_format`, which are useful, but still require an image processor to do other conversions, as transforming relative to absolute. An example is shown below - performed by [image_processing_detr.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/detr/image_processing_detr.py#L1352-L1357):

```python
# convert to [x0, y0, x1, y1] format
boxes = center_to_corners_format(out_bbox)
# and from relative [0, 1] to absolute [0, height] coordinates
img_h, img_w = target_sizes.unbind(1)
scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
boxes = boxes * scale_fct[:, None, :]
```

This could simply be replaced by:
```python
new_boxes = transform_box_format(out_bbox, orig_format="relative_xcycwh", dest_format="xyxy", img_shape=target_sizes.squeeze())
```
which leads to the same results, so that `torch.isclose(boxes, new_boxes)` is `True`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@amyeroberts 