### PR TITLE
Fix AMD CI not showing GPU

### DIFF
--- a/.github/workflows/self-push-amd.yml
+++ b/.github/workflows/self-push-amd.yml
@@ -38,14 +38,16 @@ jobs:
     runs-on: [self-hosted, docker-gpu, amd-gpu, '${{ matrix.machine_type }}', '${{ inputs.gpu_flavor }}']
     container:
       image: huggingface/transformers-pytorch-amd-gpu-push-ci  # <--- We test only for PyTorch for now
-      options: --device /dev/kfd --device /dev/dri --env HIP_VISIBLE_DEVICES --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       - name: ROCM-SMI
         run: |
-          rocminfo  | grep "Agent" -A 14
-      - name: Show HIP environment
+          rocm-smi
+      - name: ROCM-INFO
         run: |
-          echo "HIP: $HIP_VISIBLE_DEVICES"
+          rocminfo  | grep "Agent" -A 14
+      - name: Show ROCR environment
+        run: |
           echo "ROCR: $ROCR_VISIBLE_DEVICES"
 
   setup_gpu:
@@ -57,7 +59,7 @@ jobs:
     runs-on: [self-hosted, docker-gpu, amd-gpu, '${{ matrix.machine_type }}', '${{ inputs.gpu_flavor }}']
     container:
       image: huggingface/transformers-pytorch-amd-gpu-push-ci  # <--- We test only for PyTorch for now
-      options: --device /dev/kfd --device /dev/dri --env HIP_VISIBLE_DEVICES --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       test_map: ${{ steps.set-matrix.outputs.test_map }}
@@ -155,7 +157,7 @@ jobs:
     runs-on: [self-hosted, docker-gpu, amd-gpu, '${{ matrix.machine_type }}', '${{ inputs.gpu_flavor }}']
     container:
       image: huggingface/transformers-pytorch-amd-gpu-push-ci  # <--- We test only for PyTorch for now
-      options: --device /dev/kfd --device /dev/dri --env HIP_VISIBLE_DEVICES --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --device /dev/kfd --device /dev/dri --env ROCR_VISIBLE_DEVICES --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
       # Necessary to get the correct branch name and commit SHA for `workflow_run` event
       # We also take into account the `push` event (we might want to test some changes in a branch)
@@ -207,10 +209,12 @@ jobs:
 
       - name: ROCM-SMI
         run: |
-          rocminfo  | grep "Agent" -A 14
-      - name: Show HIP environment
+          rocm-smi
+      - name: ROCM-INFO
         run: |
-          echo "HIP: $HIP_VISIBLE_DEVICES"
+          rocminfo  | grep "Agent" -A 14
+      - name: Show ROCR environment
+        run: |
           echo "ROCR: $ROCR_VISIBLE_DEVICES"
 
       - name: Environment


### PR DESCRIPTION
# What does this PR do?

For AMD CI jobs, like [this one](https://github.com/huggingface/transformers/actions/runs/6879141724/job/18711232327), in the `Environment` section, sometimes it shows `Number of GPUs available: 0`.

After investigation from the infra team (thanks to Guillaume), they told me the changes in this PR fix the issue: removing the environment variable `HIP_VISIBLE_DEVICES`.