### PR TITLE
Allow `resume_from_checkpoint` to handle `auto_find_batch_size`

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1507,6 +1507,10 @@ class Trainer:
             and not self.is_fsdp_enabled
         ):
             self._load_from_checkpoint(resume_from_checkpoint)
+            # In case of repeating the find_executable_batch_size, set `self._train_batch_size` properly
+            state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
+            if state["train_batch_size"] is not None:
+                self._train_batch_size = state["train_batch_size"]
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:
@@ -1542,6 +1546,8 @@ class Trainer:
     ):
         self.accelerator.free_memory()
         self._train_batch_size = batch_size
+        if self.args.auto_find_batch_size:
+            self.state.train_batch_size = self._train_batch_size
         logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
         # Data loader and number of training steps
         train_dataloader = self.get_train_dataloader()
@@ -1618,6 +1624,7 @@ class Trainer:
 
         self.state = TrainerState()
         self.state.is_hyper_param_search = trial is not None
+        self.state.train_batch_size = self._train_batch_size
 
         # Compute absolute values for logging, eval, and save if given as ratio
         if args.logging_steps is not None:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1509,8 +1509,8 @@ class Trainer:
             self._load_from_checkpoint(resume_from_checkpoint)
             # In case of repeating the find_executable_batch_size, set `self._train_batch_size` properly
             state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
-            if state["train_batch_size"] is not None:
-                self._train_batch_size = state["train_batch_size"]
+            if state.train_batch_size is not None:
+                self._train_batch_size = state.train_batch_size
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped
         if model_reloaded:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -59,7 +59,7 @@ class TrainerState:
             Run an evaluation every X steps.
         save_steps (`int`, *optional*, defaults to 500):
             Save checkpoint every X updates steps.
-        training_batch_size (`int`, *optional*):
+        train_batch_size (`int`, *optional*):
             The batch size for the training dataloader. Only needed when
             `auto_find_batch_size` has been used.
         num_input_tokens_seen (`int`, *optional*, defaults to 0):

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -59,6 +59,9 @@ class TrainerState:
             Run an evaluation every X steps.
         save_steps (`int`, *optional*, defaults to 500):
             Save checkpoint every X updates steps.
+        training_batch_size (`int`, *optional*):
+            The batch size for the training dataloader. Only needed when
+            `auto_find_batch_size` has been used.
         num_input_tokens_seen (`int`, *optional*, defaults to 0):
             The number of tokens seen during training (number of input tokens, not the number of prediction tokens).
         total_flos (`float`, *optional*, defaults to 0):
@@ -88,6 +91,7 @@ class TrainerState:
     logging_steps: int = 500
     eval_steps: int = 500
     save_steps: int = 500
+    train_batch_size: int = None
     num_train_epochs: int = 0
     num_input_tokens_seen: int = 0
     total_flos: float = 0

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1562,6 +1562,8 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
         # We can then make a new Trainer
         trainer = Trainer(model, args, train_dataset=train_dataset)
+        # Check we are at 16 to start
+        self.assertEqual(trainer._train_batch_size, 16)
         trainer.train(resume_from_checkpoint=True)
         # We should be back to 8 again
         self.assertEqual(trainer._train_batch_size, 8)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1544,7 +1544,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             do_train=True,
             max_steps=2,
             save_steps=1,
-            per_device_train_batch_size=8,
+            per_device_train_batch_size=16,
             auto_find_batch_size=True,
         )
         trainer = Trainer(model, args, train_dataset=train_dataset)
@@ -1552,7 +1552,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         # assume that `auto_find_bs` set it to 8, and we were originally at 16
         trainer.args.per_device_train_batch_size = 16
         trainer.train(resume_from_checkpoint=True)
-        # We should be back to 16 again
+        # We should be back to 8 again
         self.assertEqual(trainer._train_batch_size, 8)
 
     # regression for this issue: https://github.com/huggingface/transformers/issues/12970

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1544,16 +1544,16 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             do_train=True,
             max_steps=2,
             save_steps=1,
-            per_device_train_batch_size=16,
+            per_device_train_batch_size=8,
             auto_find_batch_size=True,
         )
         trainer = Trainer(model, args, train_dataset=train_dataset)
         trainer.train()
-        # assume that `auto_find_bs` set it to 8
-        trainer.args.per_device_train_batch_size = 8
+        # assume that `auto_find_bs` set it to 8, and we were originally at 16
+        trainer.args.per_device_train_batch_size = 16
         trainer.train(resume_from_checkpoint=True)
         # We should be back to 16 again
-        self.assertEqual(trainer._train_batch_size, 16)
+        self.assertEqual(trainer._train_batch_size, 8)
 
     # regression for this issue: https://github.com/huggingface/transformers/issues/12970
     def test_training_with_resume_from_checkpoint_false(self):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1565,7 +1565,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         # Check we are at 16 to start
         self.assertEqual(trainer._train_batch_size, 16)
         trainer.train(resume_from_checkpoint=True)
-        # We should be back to 8 again
+        # We should be back to 8 again, picking up based upon the last ran Trainer
         self.assertEqual(trainer._train_batch_size, 8)
 
     # regression for this issue: https://github.com/huggingface/transformers/issues/12970


### PR DESCRIPTION
# What does this PR do?

This PR adds the training batch size as part of the `TrainerState`. We do this because the `TrainerState` can be loaded in on `resume_from_checkpoint`, and so if a user has set `auto_find_batch_size` to be `True`, we can keep what that batch size was in there and load it back in if it were saved

Fixes https://github.com/huggingface/transformers/issues/25956


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts 