### PR TITLE
Fuyu Multi-image interleaved processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ tags
 
 # ruff
 .ruff_cache
+test.py

--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -441,9 +441,6 @@ class FuyuImageProcessor(BaseImageProcessor):
         rescale_factor = rescale_factor if rescale_factor is not None else self.rescale_factor
         patch_size = patch_size if patch_size is not None else self.patch_size
 
-        if isinstance(images, list) and any(isinstance(elem, list) and len(elem) >= 2 for elem in images):
-            raise ValueError("Multiple images for a single sample are not yet supported.")
-
         batch_images = make_list_of_list_of_images(images)
 
         if do_resize and size is None:
@@ -468,7 +465,7 @@ class FuyuImageProcessor(BaseImageProcessor):
             # We assume that all images have the same channel dimension format.
             input_data_format = infer_channel_dimension_format(batch_images[0][0])
 
-        original_image_sizes = [get_image_size(images[0], channel_dim=input_data_format) for images in batch_images]
+        original_image_sizes = [[get_image_size(image, channel_dim=input_data_format) for image in images] for images in batch_images]
 
         if do_resize:
             batch_images = [
@@ -476,14 +473,14 @@ class FuyuImageProcessor(BaseImageProcessor):
                 for images in batch_images
             ]
 
-        image_sizes = [get_image_size(images[0], channel_dim=input_data_format) for images in batch_images]
-        image_unpadded_heights = [[image_size[0]] for image_size in image_sizes]
-        image_unpadded_widths = [[image_size[1]] for image_size in image_sizes]
+        batch_image_sizes = [[get_image_size(image, channel_dim=input_data_format) for image in images] for images in batch_images]
+        image_unpadded_heights = [[[image_size[0]] for image_size in image_sizes] for image_sizes in batch_image_sizes]
+        image_unpadded_widths = [[[image_size[1]] for image_size in image_sizes] for image_sizes in batch_image_sizes]
 
         # scale_h is the same as scale_w
         image_scale_factors = [
-            [resized_size[0] / original_size[0]]
-            for original_size, resized_size in zip(original_image_sizes, image_sizes)
+            [[resized_size[0] / original_size[0]]
+            for original_size, resized_size in zip(original_sizes, resized_sizes)] for original_sizes, resized_sizes in zip(original_image_sizes, batch_image_sizes)
         ]
 
         if do_pad:

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -484,9 +484,10 @@ class FuyuProcessor(ProcessorMixin):
         # --- Check input validity ---
         if not return_attention_mask:
             raise ValueError("`return_attention_mask=False` is not supported for this model.")
-        if text is None and images is None:
+        if all(item is None for item in text) and all(item is None for item in images):
             raise ValueError("You have to specify either text or images. Both cannot be None.")
-        if text is not None and images is None:
+        # if text is not None and images is None:
+        if any(item is not None for item in text) and all(item is None for item in images):
             logger.warning("You are processing a text with no associated image. Make sure it is intended.")
             self.current_processor = self.tokenizer
             text_encoding = self.tokenizer(
@@ -509,10 +510,10 @@ class FuyuProcessor(ProcessorMixin):
             )
             return text_encoding
 
-        if text is None and images is not None:
+        if all(item is None for item in text) and any(item is not None for item in images):
             logger.warning("You are processing an image with no associated text. Make sure it is intended.")
-            prompts = [[""]]
-        if text is not None and images is not None:
+            prompts = [[""] for _ in range(len(images))]
+        if any(item is not None for item in text) and any(item is not None for item in images):
             if isinstance(text, str):
                 prompts = [[text]]
             elif isinstance(text, list):

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -255,6 +255,7 @@ def _tokenize_prompts_with_image_and_batch(
     #   - make all the sequences equal length.
     # Get the prompts length.
 
+    # we should delete everything below and just return prompts_tokens. We don't need the lengths for subsequent processing.
     prompts_length = [[len(x) for x in prompts_tokens_seq] for prompts_tokens_seq in prompts_tokens]
     # Get the max prompts length.
     max_prompt_len: int = np.max(prompts_length)
@@ -432,6 +433,7 @@ class FuyuProcessor(ProcessorMixin):
         tokens_to_place = min(max_seq_len_batch, max(0, image_padded_unpacked_tokens[0].shape[0]))
 
         # Use same packing logic for the image patch indices.
+        # this is where image_patch_input_indices +10 tokens really happens. need to check if this is for model forward.
         image_patch_input_indices = full_unpacked_stream_to_tensor(
             all_bi_tokens_to_place=[tokens_to_place],
             full_unpacked_stream=unpacked_image_patch_indices_per_batch,

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -245,7 +245,7 @@ def _tokenize_prompts_with_image_and_batch(
             for j, (prompt, image_token) in enumerate(zip(single_prompt, image_tokens)):
                 image_indicator_count = prompt.count('|IMAGESTART|')
                 if image_indicator_count > len(image_token):
-                    raise ValueError("Image place indicators exceed the number of images provided.")
+                    raise ValueError(f"Image place indicators exceed the number of images provided. Have {image_indicator_count} images?")
                 elif image_indicator_count < len(image_token):
                     insert_count = len(image_token) - image_indicator_count
                     logger.warning(f"Inserting {insert_count} image place indicators before the prompt.")
@@ -434,7 +434,7 @@ class FuyuProcessor(ProcessorMixin):
             new_seq_len=max_seq_len_batch,
             offset=0,
         )
-        image_patches_tensor = torch.stack([img[0] for img in model_image_input["image_patches"]])
+        image_patches_tensor = torch.stack([torch.concat(img, dim=0) for img in model_image_input["image_patches"]])
         batch_encoding = {
             "input_ids": image_padded_unpacked_tokens[0].unsqueeze(0),
             "image_patches": image_patches_tensor,
@@ -525,7 +525,7 @@ class FuyuProcessor(ProcessorMixin):
             if isinstance(text, str):
                 prompts = [[text]]
             elif isinstance(text, list):
-                prompts = [[text_seq] for text_seq in text]
+                prompts = [[text_seq if text_seq is not None else ""] for text_seq in text]
 
         # --- Preprocess images using self.image_processor ---
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fuyu Multi-image interleaved processor. Test example:
```python
from transformers import FuyuProcessor, FuyuForCausalLM
from PIL import Image
import requests
import torch

# load model and processor
model_id = "adept/fuyu-8b"
processor = FuyuProcessor.from_pretrained(model_id)
model = FuyuForCausalLM.from_pretrained(model_id, device_map="cuda:0", torch_dtype=torch.bfloat16)

def convert(list_of_dicts):# Convert to a dictionary of lists
    dict_of_lists = {}
    for d in list_of_dicts:
        for key, value in d.items():
            if key not in dict_of_lists:
                dict_of_lists[key] = []
            dict_of_lists[key].append(value)
    return dict_of_lists

text_prompt1 = "|IMAGESTART| Generate a coco-style caption. |IMAGESTART| Be reminded that the caption should be longer than 2000 words but shorter than 1 million words. \n"
url1 = "https://huggingface.co/adept/fuyu-8b/resolve/main/bus.png"
image1 = Image.open(requests.get(url1, stream=True).raw)

text_prompt2 = "What doesn this chart describe?\n"
url2 = "https://huggingface.co/adept/fuyu-8b/resolve/main/chart.png"
image2 = Image.open(requests.get(url2, stream=True).raw)

test_examples = [
    # {"text": "|IMAGESTART| Generate a coco-style caption. |IMAGESTART| Be reminded that the caption should be longer than 2000 words but shorter than 1 million words. \n", "images": image1}, # should assert error
    {"text": text_prompt1, "images": [image1, image2]}, # normal
    {"text": text_prompt2, "images": [image2 for i in range(40)]}, # should add indicator
    {"text": "|IMAGESTART||IMAGESTART| Generate a coco-style caption. Be reminded that the caption should be longer than 2000 words but shorter than 1 million words. \n", "images": [image1, image2]}, # normal
    {"text": " Generate a coco-style caption. Be reminded that the caption should be longer than 2000 words but shorter than 1 million words. \n|IMAGESTART||IMAGESTART|", "images": [image1, image2]}, # normal
    # {"text": " Generate a coco-style caption. Be reminded that the caption should be longer than 2000 words but shorter than 1 million words.", "images": None}, # no image, we had error with this case
    {"text": None, "images": [image1]}, # no text
    
]
inputs_to_model = processor(**convert(test_examples), return_tensors="pt", truncation=True).to("cuda:0")
```
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
@amyeroberts, @ArthurZucker and @younesbelkada