### PR TITLE
Fix idx2sym not loaded from pretrained vocab file in Transformer XL

### DIFF
--- a/src/transformers/models/transfo_xl/tokenization_transfo_xl.py
+++ b/src/transformers/models/transfo_xl/tokenization_transfo_xl.py
@@ -223,7 +223,7 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
 
             if vocab_dict is not None:
                 for key, value in vocab_dict.items():
-                    if key not in self.__dict__ or key == "sym2idx":
+                    if key not in self.__dict__ or key in ["sym2idx", "idx2sym"]:
                         self.__dict__[key] = value
             elif vocab_file is not None:
                 self.build_vocab()

--- a/tests/models/transfo_xl/test_tokenization_transfo_xl.py
+++ b/tests/models/transfo_xl/test_tokenization_transfo_xl.py
@@ -15,6 +15,8 @@
 
 
 import os
+import pickle
+from collections import Counter, OrderedDict
 import unittest
 
 from transformers.models.transfo_xl.tokenization_transfo_xl import VOCAB_FILES_NAMES, TransfoXLTokenizer
@@ -46,6 +48,12 @@ class TransfoXLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
         with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
+
+        saved_dict = {"eos_idx": 0, "min_freq": 0, "vocab_file": None, "counter": Counter(["welcome home"]), "sym2idx": OrderedDict([("<eos>", 0), ("welcome", 1), ("home", 2)]), "delimiter": None, "idx2sym": ["<eos>", "welcome", "home"], "max_size": None, "lower_case": False, "special": ["<eos>"]}
+        self.pretrained_vocab_file = os.path.join(self.tmpdirname, "mock_folder", VOCAB_FILES_NAMES["pretrained_vocab_file"])
+        os.makedirs(os.path.dirname(self.pretrained_vocab_file), exist_ok=True)
+        with open(self.pretrained_vocab_file, "wb") as f:
+            pickle.dump(saved_dict, f)
 
     def get_tokenizer(self, **kwargs):
         kwargs["lower_case"] = True
@@ -128,3 +136,9 @@ class TransfoXLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         # Check that token is moved to specified id
         self.assertEqual(tokenizer.encode("new1"), [1])
         self.assertEqual(tokenizer.decode([1]), "new1")
+
+    def test_from_pretrained_vocab_file(self):
+
+        tokenizer = TransfoXLTokenizer.from_pretrained(os.path.join(self.tmpdirname, "mock_folder"))
+        sentence = "welcome home"
+        self.assertEqual(tokenizer.decode(tokenizer.encode(sentence)), sentence)

--- a/tests/models/transfo_xl/test_tokenization_transfo_xl.py
+++ b/tests/models/transfo_xl/test_tokenization_transfo_xl.py
@@ -16,8 +16,8 @@
 
 import os
 import pickle
-from collections import Counter, OrderedDict
 import unittest
+from collections import Counter, OrderedDict
 
 from transformers.models.transfo_xl.tokenization_transfo_xl import VOCAB_FILES_NAMES, TransfoXLTokenizer
 
@@ -49,8 +49,21 @@ class TransfoXLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
-        saved_dict = {"eos_idx": 0, "min_freq": 0, "vocab_file": None, "counter": Counter(["welcome home"]), "sym2idx": OrderedDict([("<eos>", 0), ("welcome", 1), ("home", 2)]), "delimiter": None, "idx2sym": ["<eos>", "welcome", "home"], "max_size": None, "lower_case": False, "special": ["<eos>"]}
-        self.pretrained_vocab_file = os.path.join(self.tmpdirname, "mock_folder", VOCAB_FILES_NAMES["pretrained_vocab_file"])
+        saved_dict = {
+            "eos_idx": 0,
+            "min_freq": 0,
+            "vocab_file": None,
+            "counter": Counter(["welcome home"]),
+            "sym2idx": OrderedDict([("<eos>", 0), ("welcome", 1), ("home", 2)]),
+            "delimiter": None,
+            "idx2sym": ["<eos>", "welcome", "home"],
+            "max_size": None,
+            "lower_case": False,
+            "special": ["<eos>"],
+        }
+        self.pretrained_vocab_file = os.path.join(
+            self.tmpdirname, "mock_folder", VOCAB_FILES_NAMES["pretrained_vocab_file"]
+        )
         os.makedirs(os.path.dirname(self.pretrained_vocab_file), exist_ok=True)
         with open(self.pretrained_vocab_file, "wb") as f:
             pickle.dump(saved_dict, f)
@@ -138,7 +151,6 @@ class TransfoXLTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         self.assertEqual(tokenizer.decode([1]), "new1")
 
     def test_from_pretrained_vocab_file(self):
-
         tokenizer = TransfoXLTokenizer.from_pretrained(os.path.join(self.tmpdirname, "mock_folder"))
         sentence = "welcome home"
         self.assertEqual(tokenizer.decode(tokenizer.encode(sentence)), sentence)


### PR DESCRIPTION
# What does this PR do?
Fixes [27584](https://github.com/huggingface/transformers/issues/27584).

When loading vocab file from a pretrained tokenizer for Transformer XL, although the pickled vocabulary file contains a idx2sym key, it isn't loaded, because it is discarded as the empty list already exists as an attribute.

Solution is to explicitly take it into account, just like for sym2idx.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @younesbelkada