### PR TITLE
Add `convert_hf_to_openai.py` script to Whisper documentation resources

### DIFF
--- a/docs/source/en/model_doc/whisper.md
+++ b/docs/source/en/model_doc/whisper.md
@@ -75,6 +75,19 @@ Here is a step-by-step guide to transcribing an audio sample using a pre-trained
 ' Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.'
 ```
 
+## Resources
+
+A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with Whisper. If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we'll review it! The resource should ideally demonstrate something new instead of duplicating an existing resource.
+
+- A fork with a script to [convert a Whisper model in Hugging Face format to OpenAI format](https://github.com/zuazo-forks/transformers/blob/convert_hf_to_openai/src/transformers/models/whisper/convert_hf_to_openai.py). 🌎
+Usage example:
+```bash
+pip install -U openai-whisper
+python convert_hf_to_openai.py \
+    --checkpoint openai/whisper-tiny \
+    --whisper_dump_path whisper-tiny-openai.pt
+```
+
 ## WhisperConfig
 
 [[autodoc]] WhisperConfig


### PR DESCRIPTION
# What does this PR do?

This PR updates the Whisper model documentation by adding a link to the [`convert_hf_to_openai.py`](https://github.com/zuazo-forks/transformers/blob/convert_hf_to_openai/src/transformers/models/whisper/convert_hf_to_openai.py) script in the Resources section. The script converts Whisper models from the Hugging Face format back to the original OpenAI format.

A brief example is included to demonstrate how to use the script. This addition will help users who prefer working with the original OpenAI implementation or require specific features from it.

Of course, any feedback is welcome! And sorry for the delay!

Fixes #26854

## Before submitting
- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Yes, see here: https://github.com/huggingface/transformers/pull/26854#issuecomment-1765861491
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? Yes, there are doctests inside the script code.


## Who can review?

Possible candidates:
- `convert_openai_to_hf.py` script creator: @ArthurZucker
- Speech models: @sanchit-gandhi