### PR TITLE
Fixed passing scheduler-specific kwargs via TrainingArguments lr_scheduler_kwargs

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1137,7 +1137,7 @@ class Trainer:
                 optimizer=self.optimizer if optimizer is None else optimizer,
                 num_warmup_steps=self.args.get_warmup_steps(num_training_steps),
                 num_training_steps=num_training_steps,
-                **self.args.lr_scheduler_kwargs,
+                scheduler_specific_kwargs=self.args.lr_scheduler_kwargs,
             )
             self._created_lr_scheduler = True
         return self.lr_scheduler


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `lr_scheduler_kwargs` argument of TrainingArguments being passed incorrectly to `get_scheduler()` in `src/transformers/optimization.py` which raises a TypeError.

Minimum code to reproduce the issue (code snippets taken from `test_trainer.py`):

```
import numpy as np
import torch
from torch import nn
from transformers import TrainingArguments, Trainer

class RegressionDataset:
    def __init__(self, a=2, b=3, length=64, seed=42, label_names=None):
        np.random.seed(seed)
        self.label_names = ["labels"] if label_names is None else label_names
        self.length = length
        self.x = np.random.normal(size=(length,)).astype(np.float32)
        self.ys = [a * self.x + b + np.random.normal(scale=0.1, size=(length,)) for _ in self.label_names]
        self.ys = [y.astype(np.float32) for y in self.ys]

    def __len__(self):
        return self.length

    def __getitem__(self, i):
        result = {name: y[i] for name, y in zip(self.label_names, self.ys)}
        result["input_x"] = self.x[i]
        return result

class RegressionModel(nn.Module):
    def __init__(self, a=0, b=0, double_output=False):
        super().__init__()
        self.a = nn.Parameter(torch.tensor(a).float())
        self.b = nn.Parameter(torch.tensor(b).float())
        self.double_output = double_output
        self.config = None

    def forward(self, input_x, labels=None, **kwargs):
        y = input_x * self.a + self.b
        if labels is None:
            return (y, y) if self.double_output else (y,)
        loss = nn.functional.mse_loss(y, labels)
        return (loss, y, y) if self.double_output else (loss, y)

train_dataset = RegressionDataset(length=64)
eval_dataset = RegressionDataset(length=64)

args = TrainingArguments(
            "./regression",
            lr_scheduler_type="reduce_lr_on_plateau",
            lr_scheduler_kwargs={'factor':0.5, 'verbose':True},
            evaluation_strategy="epoch",
            metric_for_best_model="eval_loss",
            num_train_epochs=10,
            learning_rate=0.2,
        )
model = RegressionModel()
trainer = Trainer(model, args, train_dataset=train_dataset, eval_dataset=eval_dataset)
trainer.train()
```

Please let me know if any modification (such as extra tests) is needed, and I will follow up on it.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@muellerzr and @pacman100