### PR TITLE
Enable safetensors conversion from PyTorch to other frameworks without the torch requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ _deps = [
     "ruff==0.1.5",
     "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses",
-    "safetensors>=0.3.1",
+    "safetensors==0.4.1rc1",
     "sagemaker>=2.31.0",
     "scikit-learn",
     "sentencepiece>=0.1.91,!=0.1.92",

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ _deps = [
     "ruff==0.1.5",
     "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses",
-    "safetensors==0.4.1rc1",
+    "safetensors>=0.4.1",
     "sagemaker>=2.31.0",
     "scikit-learn",
     "sentencepiece>=0.1.91,!=0.1.92",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -64,7 +64,7 @@ deps = {
     "ruff": "ruff==0.1.5",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
-    "safetensors": "safetensors>=0.3.1",
+    "safetensors": "safetensors==0.4.1rc1",
     "sagemaker": "sagemaker>=2.31.0",
     "scikit-learn": "scikit-learn",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -64,7 +64,7 @@ deps = {
     "ruff": "ruff==0.1.5",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
-    "safetensors": "safetensors==0.4.1rc1",
+    "safetensors": "safetensors>=0.4.1",
     "sagemaker": "sagemaker>=2.31.0",
     "scikit-learn": "scikit-learn",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -22,7 +22,6 @@ from typing import Dict, Tuple
 import jax
 import jax.numpy as jnp
 import numpy as np
-import torch
 from flax.serialization import from_bytes
 from flax.traverse_util import flatten_dict, unflatten_dict
 
@@ -31,6 +30,9 @@ import transformers
 from . import is_safetensors_available, is_torch_available
 from .utils import logging
 
+
+if is_torch_available():
+    import torch
 
 if is_safetensors_available():
     from safetensors import safe_open

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -64,6 +64,8 @@ def load_pytorch_checkpoint_in_flax_state_dict(
         else:
             try:
                 import torch  # noqa: F401
+
+                from .pytorch_utils import is_torch_greater_or_equal_than_1_13  # noqa: F401
             except (ImportError, ModuleNotFoundError):
                 logger.error(
                     "Loading a PyTorch model in Flax, requires both PyTorch and Flax to be installed. Please see"
@@ -72,7 +74,7 @@ def load_pytorch_checkpoint_in_flax_state_dict(
                 )
                 raise
 
-            pt_state_dict = torch.load(pt_path, map_location="cpu", weights_only=True)
+            pt_state_dict = torch.load(pt_path, map_location="cpu", weights_only=is_torch_greater_or_equal_than_1_13)
             logger.info(f"PyTorch checkpoint contains {sum(t.numel() for t in pt_state_dict.values()):,} parameters.")
 
         flax_state_dict = convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model)

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -154,6 +154,8 @@ def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
     from_bin = is_torch_available() and isinstance(next(iter(pt_state_dict.values())), torch.Tensor)
     bfloat16 = torch.bfloat16 if from_bin else "bfloat16"
 
+    weight_dtypes = {k: v.dtype for k, v in pt_state_dict.items()}
+
     if from_bin:
         for k, v in pt_state_dict.items():
             # numpy currently does not support bfloat16, need to go over float32 in this case to not lose precision
@@ -187,7 +189,7 @@ def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
     # Need to change some parameters name to match Flax names
     for pt_key, pt_tensor in pt_state_dict.items():
         pt_tuple_key = tuple(pt_key.split("."))
-        is_bfloat_16 = pt_state_dict[pt_key].dtype == bfloat16
+        is_bfloat_16 = weight_dtypes[pt_key] == bfloat16
 
         # remove base model prefix if necessary
         has_base_model_prefix = pt_tuple_key[0] == model_prefix

--- a/src/transformers/modeling_flax_pytorch_utils.py
+++ b/src/transformers/modeling_flax_pytorch_utils.py
@@ -240,7 +240,7 @@ def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model):
             )
         else:
             # also add unexpected weight so that warning is thrown
-            flax_state_dict[("params",) + flax_key] = (
+            flax_state_dict[flax_key] = (
                 jnp.asarray(flax_tensor) if not is_bfloat_16 else jnp.asarray(flax_tensor, dtype=jnp.bfloat16)
             )
 

--- a/tests/models/vision_encoder_decoder/test_modeling_flax_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_flax_vision_encoder_decoder.py
@@ -429,6 +429,9 @@ class FlaxViT2GPT2EncoderDecoderModelTest(FlaxEncoderDecoderMixin, unittest.Test
             "google/vit-base-patch16-224-in21k", "gpt2"
         )
 
+    def test_pt_flax_equivalence(self):
+        super(FlaxViT2GPT2EncoderDecoderModelTest, self).test_pt_flax_equivalence()
+
 
 @require_flax
 class FlaxVisionEncoderDecoderModelTest(unittest.TestCase):

--- a/tests/models/vision_encoder_decoder/test_modeling_flax_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_flax_vision_encoder_decoder.py
@@ -429,9 +429,6 @@ class FlaxViT2GPT2EncoderDecoderModelTest(FlaxEncoderDecoderMixin, unittest.Test
             "google/vit-base-patch16-224-in21k", "gpt2"
         )
 
-    def test_pt_flax_equivalence(self):
-        super(FlaxViT2GPT2EncoderDecoderModelTest, self).test_pt_flax_equivalence()
-
 
 @require_flax
 class FlaxVisionEncoderDecoderModelTest(unittest.TestCase):

--- a/tests/test_modeling_flax_utils.py
+++ b/tests/test_modeling_flax_utils.py
@@ -19,7 +19,7 @@ import numpy as np
 from huggingface_hub import HfFolder, delete_repo, snapshot_download
 from requests.exceptions import HTTPError
 
-from transformers import BertConfig, BertModel, is_flax_available, is_torch_available
+from transformers import BertConfig, BertModel, is_flax_available
 from transformers.testing_utils import (
     TOKEN,
     USER,
@@ -251,7 +251,6 @@ class FlaxModelUtilsTest(unittest.TestCase):
 
         self.assertTrue(check_models_equal(flax_model, safetensors_model))
 
-    @require_torch
     @require_safetensors
     @is_pt_flax_cross_test
     def test_safetensors_load_from_hub_from_safetensors_pt(self):
@@ -265,7 +264,6 @@ class FlaxModelUtilsTest(unittest.TestCase):
         safetensors_model = FlaxBertModel.from_pretrained("hf-internal-testing/tiny-bert-pt-safetensors")
         self.assertTrue(check_models_equal(flax_model, safetensors_model))
 
-    @require_torch
     @require_safetensors
     @is_pt_flax_cross_test
     def test_safetensors_load_from_local_from_safetensors_pt(self):
@@ -283,39 +281,6 @@ class FlaxModelUtilsTest(unittest.TestCase):
             safetensors_model = FlaxBertModel.from_pretrained(location)
 
         self.assertTrue(check_models_equal(flax_model, safetensors_model))
-
-    @require_safetensors
-    def test_safetensors_load_from_hub_from_safetensors_pt_without_torch_installed(self):
-        """
-        This test checks that we cannot load safetensors from a checkpoint that only has safetensors
-        saved in the "pt" format if torch isn't installed.
-        """
-        if is_torch_available():
-            # This test verifies that a correct error message is shown when loading from a pt safetensors
-            # PyTorch shouldn't be installed for this to work correctly.
-            return
-
-        # Cannot load from the PyTorch-formatted checkpoint without PyTorch installed
-        with self.assertRaises(ModuleNotFoundError):
-            _ = FlaxBertModel.from_pretrained("hf-internal-testing/tiny-bert-pt-safetensors")
-
-    @require_safetensors
-    def test_safetensors_load_from_local_from_safetensors_pt_without_torch_installed(self):
-        """
-        This test checks that we cannot load safetensors from a checkpoint that only has safetensors
-        saved in the "pt" format if torch isn't installed.
-        """
-        if is_torch_available():
-            # This test verifies that a correct error message is shown when loading from a pt safetensors
-            # PyTorch shouldn't be installed for this to work correctly.
-            return
-
-        with tempfile.TemporaryDirectory() as tmp:
-            location = snapshot_download("hf-internal-testing/tiny-bert-pt-safetensors", cache_dir=tmp)
-
-            # Cannot load from the PyTorch-formatted checkpoint without PyTorch installed
-            with self.assertRaises(ModuleNotFoundError):
-                _ = FlaxBertModel.from_pretrained(location)
 
     @require_safetensors
     def test_safetensors_load_from_hub_msgpack_before_safetensors(self):

--- a/tests/test_modeling_flax_utils.py
+++ b/tests/test_modeling_flax_utils.py
@@ -272,6 +272,8 @@ class FlaxModelUtilsTest(unittest.TestCase):
         This test checks that we can load safetensors from a checkpoint that only has those on the Hub.
         saved in the "pt" format.
         """
+        import torch
+
         model = BertModel.from_pretrained("hf-internal-testing/tiny-bert-pt-safetensors")
         model.to(torch.bfloat16)
 

--- a/tests/test_modeling_flax_utils.py
+++ b/tests/test_modeling_flax_utils.py
@@ -16,7 +16,6 @@ import tempfile
 import unittest
 
 import numpy as np
-import torch
 from huggingface_hub import HfFolder, delete_repo, snapshot_download
 from requests.exceptions import HTTPError
 

--- a/tests/test_modeling_flax_utils.py
+++ b/tests/test_modeling_flax_utils.py
@@ -16,11 +16,10 @@ import tempfile
 import unittest
 
 import numpy as np
-import torch
 from huggingface_hub import HfFolder, delete_repo, snapshot_download
 from requests.exceptions import HTTPError
 
-from transformers import BertConfig, BertModel, is_flax_available
+from transformers import BertConfig, BertModel, is_flax_available, is_torch_available
 from transformers.testing_utils import (
     TOKEN,
     USER,
@@ -43,6 +42,9 @@ if is_flax_available():
     from transformers import FlaxBertModel
 
     os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.12"  # assumed parallelism: 8
+
+if is_torch_available():
+    import torch
 
 
 @require_flax


### PR DESCRIPTION
This removes the need to have `torch` installed to proceed to a safetensors (serialized from PyTorch) checkpoint converted into Flax.

This therefore, enables loading any model in Flax that has a safetensors file on the Hub.