### PR TITLE
Generate: Update docs regarding reusing `past_key_values` in `generate`

### DIFF
--- a/docs/source/en/llm_tutorial_optimization.md
+++ b/docs/source/en/llm_tutorial_optimization.md
@@ -670,7 +670,7 @@ Note that, despite our advice to use key-value caches, your LLM output may be sl
 
 </Tip>
 
-### Multi-round conversation
+#### 3.2.1 Multi-round conversation
 
 The key-value cache is especially useful for applications such as chat where multiple passes of auto-regressive decoding are required. Let's look at an example.
 
@@ -739,7 +739,7 @@ config = model.config
 Roughly 8 billion float values! Storing 8 billion float values in `float16` precision requires around 15 GB of RAM which is circa half as much as the model weights themselves!
 Researchers have proposed two methods that allow to significantly reduce the memory cost of storing the key-value cache, which are explored in the next subsections.
 
-### Multi-Query-Attention (MQA)
+#### 3.2.2 Multi-Query-Attention (MQA)
 
 [Multi-Query-Attention](https://arxiv.org/abs/1911.02150) was proposed in Noam Shazeer's *Fast Transformer Decoding: One Write-Head is All You Need* paper. As the title says, Noam found out that instead of using `n_head` key-value projections weights, one can use a single head-value projection weight pair that is shared across all attention heads without that the model's performance significantly degrades.
 
@@ -761,7 +761,7 @@ MQA has seen wide adoption by the community and is now used by many of the most 
 
 Also, the checkpoint used in this notebook - `bigcode/octocoder` - makes use of MQA.
 
-### Grouped-Query-Attention (GQA)
+#### 3.2.3 Grouped-Query-Attention (GQA)
 
 [Grouped-Query-Attention](https://arxiv.org/abs/2305.13245), as proposed by Ainslie et al. from Google, found that using MQA can often lead to quality degradation compared to using vanilla multi-key-value head projections. The paper argues that more model performance can be kept by less drastically reducing the number of query head projection weights. Instead of using just a single key-value projection weight, `n < n_head` key-value projection weights should be used. By choosing `n` to a significantly smaller value than `n_head`, such as 2,4 or 8 almost all of the memory and speed gains from MQA can be kept while sacrificing less model capacity and thus arguably less performance.
 

--- a/docs/source/en/llm_tutorial_optimization.md
+++ b/docs/source/en/llm_tutorial_optimization.md
@@ -664,7 +664,7 @@ Using the key-value cache has two advantages:
 
 > One should *always* make use of the key-value cache as it leads to identical results and a significant speed-up for longer input sequences. Transformers has the key-value cache enabled by default when making use of the text pipeline or the [`generate` method](https://huggingface.co/docs/transformers/main_classes/text_generation).
 
-Tip warning={true}>
+<Tip warning={true}>
 
 Note that, despite our advice to use key-value caches, your LLM output may be slightly different when you use them. This is a property of the matrix multiplication kernels themselves -- you can read more about it [here](https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535).
 


### PR DESCRIPTION
# What does this PR do?

Due to a [recent PR](https://github.com/huggingface/transformers/pull/25086), which enables `generate` to return `past_key_values`, we can now reuse `past_key_values` to speed up multi-round conversations with LLMs. This was already described in the [LLM optimization docs](https://huggingface.co/docs/transformers/llm_tutorial_optimization), even though there was no corresponding code back when it was written.

This PR updates the doc with a code example of how to return and reuse `past_key_values`, polishing a few nits encountered along the way.

Related issue: https://github.com/huggingface/transformers/issues/27546