### PR TITLE
Fix `max_steps` documentation regarding the end-of-training condition

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -234,8 +234,8 @@ class TrainingArguments:
             the last epoch before stopping training).
         max_steps (`int`, *optional*, defaults to -1):
             If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-            In case of using a finite iterable dataset the training may stop before reaching the set number of steps
-            when all data is exhausted
+            In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+            `max_steps` is reached.
         lr_scheduler_type (`str` or [`SchedulerType`], *optional*, defaults to `"linear"`):
             The scheduler type to use. See the documentation of [`SchedulerType`] for all possible values.
         lr_scheduler_kwargs ('dict', *optional*, defaults to {}):
@@ -2181,9 +2181,9 @@ class TrainingArguments:
                 Total number of training epochs to perform (if not an integer, will perform the decimal part percents
                 of the last epoch before stopping training).
             max_steps (`int`, *optional*, defaults to -1):
-                If set to a positive number, the total number of training steps to perform. Overrides
-                `num_train_epochs`. In case of using a finite iterable dataset the training may stop before reaching
-                the set number of steps when all data is exhausted.
+                If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
+                In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+                `max_steps` is reached.
             gradient_accumulation_steps (`int`, *optional*, defaults to 1):
                 Number of updates steps to accumulate the gradients for, before performing a backward/update pass.
 
@@ -2588,9 +2588,9 @@ class TrainingArguments:
                 Total number of training epochs to perform (if not an integer, will perform the decimal part percents
                 of the last epoch before stopping training).
             max_steps (`int`, *optional*, defaults to -1):
-                If set to a positive number, the total number of training steps to perform. Overrides
-                `num_train_epochs`. In case of using a finite iterable dataset the training may stop before reaching
-                the set number of steps when all data is exhausted.
+                If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
+                In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+                `max_steps` is reached.
             warmup_ratio (`float`, *optional*, defaults to 0.0):
                 Ratio of total training steps used for a linear warmup from 0 to `learning_rate`.
             warmup_steps (`int`, *optional*, defaults to 0):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -234,7 +234,7 @@ class TrainingArguments:
             the last epoch before stopping training).
         max_steps (`int`, *optional*, defaults to -1):
             If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-            For a finite dataset, training is reiterated through a dataset (if all data is exhausted) until
+            For a finite dataset, training is reiterated through the dataset (if all data is exhausted) until
             `max_steps` is reached.
         lr_scheduler_type (`str` or [`SchedulerType`], *optional*, defaults to `"linear"`):
             The scheduler type to use. See the documentation of [`SchedulerType`] for all possible values.
@@ -2182,7 +2182,7 @@ class TrainingArguments:
                 of the last epoch before stopping training).
             max_steps (`int`, *optional*, defaults to -1):
                 If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-                In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+                For a finite dataset, training is reiterated through the dataset (if all data is exhausted) until
                 `max_steps` is reached.
             gradient_accumulation_steps (`int`, *optional*, defaults to 1):
                 Number of updates steps to accumulate the gradients for, before performing a backward/update pass.
@@ -2589,7 +2589,7 @@ class TrainingArguments:
                 of the last epoch before stopping training).
             max_steps (`int`, *optional*, defaults to -1):
                 If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-                In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+                For a finite dataset, training is reiterated through the dataset (if all data is exhausted) until
                 `max_steps` is reached.
             warmup_ratio (`float`, *optional*, defaults to 0.0):
                 Ratio of total training steps used for a linear warmup from 0 to `learning_rate`.

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -234,7 +234,7 @@ class TrainingArguments:
             the last epoch before stopping training).
         max_steps (`int`, *optional*, defaults to -1):
             If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-            In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+            For a finite dataset, training is reiterated through a dataset (if all data is exhausted) until
             `max_steps` is reached.
         lr_scheduler_type (`str` or [`SchedulerType`], *optional*, defaults to `"linear"`):
             The scheduler type to use. See the documentation of [`SchedulerType`] for all possible values.

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -92,6 +92,8 @@ class TFTrainingArguments(TrainingArguments):
             Total number of training epochs to perform.
         max_steps (`int`, *optional*, defaults to -1):
             If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
+            In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+            `max_steps` is reached.
         warmup_ratio (`float`, *optional*, defaults to 0.0):
             Ratio of total training steps used for a linear warmup from 0 to `learning_rate`.
         warmup_steps (`int`, *optional*, defaults to 0):

--- a/src/transformers/training_args_tf.py
+++ b/src/transformers/training_args_tf.py
@@ -92,7 +92,7 @@ class TFTrainingArguments(TrainingArguments):
             Total number of training epochs to perform.
         max_steps (`int`, *optional*, defaults to -1):
             If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
-            In case of using a finite dataset, the training will cycle through the dataset repeatedly until
+            For a finite dataset, training is reiterated through the dataset (if all data is exhausted) until
             `max_steps` is reached.
         warmup_ratio (`float`, *optional*, defaults to 0.0):
             Ratio of total training steps used for a linear warmup from 0 to `learning_rate`.


### PR DESCRIPTION
# What does this PR do?

Fixes #26635 


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @pacman100 @stevhliu @MKhalusova


Quick explanation, the document currently states that


> max_steps (`int`, *optional*, defaults to -1):
>         If set to a positive number, the total number of training steps to perform. Overrides `num_train_epochs`.
>         In case of using a finite iterable dataset the training may stop before reaching the set number of steps
>         when all data is exhausted.

But, when you use finite iterable dataset, the training doesn't stop as expected:

```python
import torch
from datasets import Dataset
from torch import nn
from transformers import Trainer, TrainingArguments

class MyModule(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = nn.Linear(2, 2)

    def forward(self, a, return_loss=True):
        output = self.linear(a)
        return {"loss": output.sum().abs()}

data = torch.tensor([[i, i] for i in range(10)], dtype=torch.float32)  # [[0., 0.], [1., 1.], [2., 2.], ...]
dataset = Dataset.from_dict({"a": data}).to_iterable_dataset()  # finite iterable dataset

args = TrainingArguments(output_dir=".", per_device_train_batch_size=1, max_steps=20)
trainer = Trainer(model=MyModule(), args=args, train_dataset=dataset)
trainer.train()
```

It trains for 20 steps, by looping twice through the dataset twice, instead of "stopping before reaching the set number of steps when all data is exhausted".

It's because the logic in the trainer is the following:

```python
global_step = 0
for epoch in range(num_train_epochs):
    for step, inputs in enumerate(epoch_iterator):
        global_step += 1
        if global_step >= max_steps:
            break
    if global_step >= max_steps:
        break
```

Therefore, the doc should be updated.
