### PR TITLE
Update chat template warnings/guides

### DIFF
--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -377,8 +377,9 @@ input formats. Our default template for models that don't have a class-specific 
 
 If you like this one, here it is in one-liner form, ready to copy into your code. The one-liner also includes
 handy support for [generation prompts](#what-are-generation-prompts), but note that it doesn't add BOS or EOS tokens!
-If your model expects those, they won't be added automatically by `apply_chat_template`, so be sure to include them
-in the template. This prevents mixing different processing logics such as the `add_special_tokens` logic.
+If your model expects those, they won't be added automatically by `apply_chat_template` - in other words, the
+text will be tokenized with `add_special_tokens=False`. This is to avoid potential conflicts between the template and
+the `add_special_tokens` logic. If your model expects special tokens, make sure to add them to the template!
 
 ```
 tokenizer.chat_template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -376,7 +376,9 @@ input formats. Our default template for models that don't have a class-specific 
 ```
 
 If you like this one, here it is in one-liner form, ready to copy into your code. The one-liner also includes
-handy support for "generation prompts" - see the next section for more!
+handy support for [generation prompts](#what-are-generation-prompts), but note that it doesn't add BOS or EOS tokens!
+If your model expects those, they won't be added automatically by `apply_chat_template`, so be sure to include them
+in the template.
 
 ```
 tokenizer.chat_template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -378,7 +378,7 @@ input formats. Our default template for models that don't have a class-specific 
 If you like this one, here it is in one-liner form, ready to copy into your code. The one-liner also includes
 handy support for [generation prompts](#what-are-generation-prompts), but note that it doesn't add BOS or EOS tokens!
 If your model expects those, they won't be added automatically by `apply_chat_template`, so be sure to include them
-in the template.
+in the template. This prevents mixing different processing logics such as the `add_special_tokens` logic.
 
 ```
 tokenizer.chat_template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1791,6 +1791,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             "See https://huggingface.co/docs/transformers/main/chat_templating for more information.\n"
         )
         return (
+            "{% if bos_token is defined %}{{ bos_token }}{% endif %}"
             "{% for message in messages %}"
             "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
             "{% endfor %}"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1786,12 +1786,11 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         """
         logger.warning_once(
             "\nNo chat template is defined for this tokenizer - using a default chat template "
-            "that implements the ChatML format. If the default is not appropriate for "
+            "that implements the ChatML format (without BOS/EOS tokens!). If the default is not appropriate for "
             "your model, please set `tokenizer.chat_template` to an appropriate template. "
             "See https://huggingface.co/docs/transformers/main/chat_templating for more information.\n"
         )
         return (
-            "{% if bos_token is defined %}{{ bos_token }}{% endif %}"
             "{% for message in messages %}"
             "{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}"
             "{% endfor %}"


### PR DESCRIPTION
The default ChatML template doesn't add a BOS token, but some models expect it. This PR makes a small update to the docs and warning messages to make users more aware of the potential issue here.