### PR TITLE
[`DocString`] Support a revision in the docstring `add_code_sample_docstrings` to facilitate integrations

### DIFF
--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -1267,14 +1267,14 @@ def overwrite_call_docstring(model_class, docstring):
     model_class.__call__ = add_start_docstrings_to_model_forward(docstring)(model_class.__call__)
 
 
-def append_call_sample_docstring(model_class, checkpoint, output_type, config_class, mask=None, revison=None):
+def append_call_sample_docstring(model_class, checkpoint, output_type, config_class, mask=None, revision=None):
     model_class.__call__ = copy_func(model_class.__call__)
     model_class.__call__ = add_code_sample_docstrings(
         checkpoint=checkpoint,
         output_type=output_type,
         config_class=config_class,
         model_cls=model_class.__name__,
-        revison=revison,
+        revision=revision,
     )(model_class.__call__)
 
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -1274,7 +1274,7 @@ def append_call_sample_docstring(model_class, checkpoint, output_type, config_cl
         output_type=output_type,
         config_class=config_class,
         model_cls=model_class.__name__,
-        revison=revison
+        revison=revison,
     )(model_class.__call__)
 
 

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -1267,13 +1267,14 @@ def overwrite_call_docstring(model_class, docstring):
     model_class.__call__ = add_start_docstrings_to_model_forward(docstring)(model_class.__call__)
 
 
-def append_call_sample_docstring(model_class, checkpoint, output_type, config_class, mask=None):
+def append_call_sample_docstring(model_class, checkpoint, output_type, config_class, mask=None, revison=None):
     model_class.__call__ = copy_func(model_class.__call__)
     model_class.__call__ = add_code_sample_docstrings(
         checkpoint=checkpoint,
         output_type=output_type,
         config_class=config_class,
         model_cls=model_class.__name__,
+        revison=revison
     )(model_class.__call__)
 
 

--- a/src/transformers/models/albert/modeling_flax_albert.py
+++ b/src/transformers/models/albert/modeling_flax_albert.py
@@ -829,7 +829,9 @@ class FlaxAlbertForMaskedLM(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForMaskedLMModule
 
 
-append_call_sample_docstring(FlaxAlbertForMaskedLM, _CHECKPOINT_FOR_DOC, FlaxMaskedLMOutput, _CONFIG_FOR_DOC)
+append_call_sample_docstring(
+    FlaxAlbertForMaskedLM, _CHECKPOINT_FOR_DOC, FlaxMaskedLMOutput, _CONFIG_FOR_DOC, revision="refs/pr/11"
+)
 
 
 class FlaxAlbertForSequenceClassificationModule(nn.Module):

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1368,7 +1368,9 @@ class FlaxT5Model(FlaxT5PreTrainedModel):
     module_class = FlaxT5Module
 
 
-append_call_sample_docstring(FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revison="refs/pr/11")
+append_call_sample_docstring(
+    FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revison="refs/pr/11"
+)
 
 FLAX_T5_MODEL_DOCSTRING = """
     Returns:

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1368,9 +1368,7 @@ class FlaxT5Model(FlaxT5PreTrainedModel):
     module_class = FlaxT5Module
 
 
-append_call_sample_docstring(
-    FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revision="refs/pr/11"
-)
+append_call_sample_docstring(FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC)
 
 FLAX_T5_MODEL_DOCSTRING = """
     Returns:

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1368,7 +1368,7 @@ class FlaxT5Model(FlaxT5PreTrainedModel):
     module_class = FlaxT5Module
 
 
-append_call_sample_docstring(FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC)
+append_call_sample_docstring(FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revison="refs/pr/11")
 
 FLAX_T5_MODEL_DOCSTRING = """
     Returns:

--- a/src/transformers/models/t5/modeling_flax_t5.py
+++ b/src/transformers/models/t5/modeling_flax_t5.py
@@ -1369,7 +1369,7 @@ class FlaxT5Model(FlaxT5PreTrainedModel):
 
 
 append_call_sample_docstring(
-    FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revison="refs/pr/11"
+    FlaxT5Model, _CHECKPOINT_FOR_DOC, FlaxSeq2SeqModelOutput, _CONFIG_FOR_DOC, revision="refs/pr/11"
 )
 
 FLAX_T5_MODEL_DOCSTRING = """

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1143,7 +1143,7 @@ def add_code_sample_docstrings(
         if real_checkpoint is not None:
             code_sample = FAKE_MODEL_DISCLAIMER + code_sample
         if revision is not None:
-            if "refs/pr/" not in revision:
+            if re.match(r'^refs/pr/\d*', revision):
                 raise ValueError(
                     f"The provided revision '{revision}' is incorrect. It should point to"
                     " a pull request reference on the hub like 'refs/pr/6'"

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1143,7 +1143,7 @@ def add_code_sample_docstrings(
         if real_checkpoint is not None:
             code_sample = FAKE_MODEL_DISCLAIMER + code_sample
         if revision is not None:
-            if re.match(r'^refs/pr/\d*', revision):
+            if re.match(r"^refs/pr/\d+", revision):
                 raise ValueError(
                     f"The provided revision '{revision}' is incorrect. It should point to"
                     " a pull request reference on the hub like 'refs/pr/6'"

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1147,7 +1147,7 @@ def add_code_sample_docstrings(
                     f"The provided revision '{revision}' is incorrect. It should point to"
                     " a pull request reference on the hub like 'refs/pr/6'"
                 )
-            code_sample.replace(
+            code_sample = code_sample.replace(
                 f'from_pretrained("{checkpoint}")', f'from_pretrained("{checkpoint}", revision="{revision}")'
             )
         func_doc = (fn.__doc__ or "") + "".join(docstr)

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1103,7 +1103,6 @@ def add_code_sample_docstrings(
             "real_checkpoint": real_checkpoint,
             "fake_checkpoint": checkpoint,
             "true": "{true}",  # For <Tip warning={true}> syntax that conflicts with formatting.
-            "revision": revision,
         }
 
         if ("SequenceClassification" in model_class or "AudioClassification" in model_class) and modality == "audio":

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1141,18 +1141,18 @@ def add_code_sample_docstrings(
         )
         if real_checkpoint is not None:
             code_sample = FAKE_MODEL_DISCLAIMER + code_sample
+        func_doc = (fn.__doc__ or "") + "".join(docstr)
+        output_doc = "" if output_type is None else _prepare_output_docstrings(output_type, config_class)
+        built_doc = code_sample.format(**doc_kwargs)
         if revision is not None:
             if re.match(r"^refs/pr/\\d+", revision):
                 raise ValueError(
                     f"The provided revision '{revision}' is incorrect. It should point to"
                     " a pull request reference on the hub like 'refs/pr/6'"
                 )
-            code_sample = code_sample.replace(
+            built_doc = built_doc.replace(
                 f'from_pretrained("{checkpoint}")', f'from_pretrained("{checkpoint}", revision="{revision}")'
             )
-        func_doc = (fn.__doc__ or "") + "".join(docstr)
-        output_doc = "" if output_type is None else _prepare_output_docstrings(output_type, config_class)
-        built_doc = code_sample.format(**doc_kwargs)
         fn.__doc__ = func_doc + output_doc + built_doc
         return fn
 

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1143,7 +1143,7 @@ def add_code_sample_docstrings(
         if real_checkpoint is not None:
             code_sample = FAKE_MODEL_DISCLAIMER + code_sample
         if revision is not None:
-            if re.match(r"^refs/pr/\d+", revision):
+            if re.match(r"^refs/pr/\\d+", revision):
                 raise ValueError(
                     f"The provided revision '{revision}' is incorrect. It should point to"
                     " a pull request reference on the hub like 'refs/pr/6'"

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1149,7 +1149,7 @@ def add_code_sample_docstrings(
                     " a pull request reference on the hub like 'refs/pr/6'"
                 )
             code_sample.replace(
-                f'from_pretrained("{checkpoint}")', 'from_pretrained("{checkpoint}", revision="{revision}")'
+                f'from_pretrained("{checkpoint}")', f'from_pretrained("{checkpoint}", revision="{revision}")'
             )
         func_doc = (fn.__doc__ or "") + "".join(docstr)
         output_doc = "" if output_type is None else _prepare_output_docstrings(output_type, config_class)

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -1075,6 +1075,7 @@ def add_code_sample_docstrings(
     expected_output=None,
     expected_loss=None,
     real_checkpoint=None,
+    revision=None,
 ):
     def docstring_decorator(fn):
         # model_class defaults to function's class if not specified otherwise
@@ -1102,6 +1103,7 @@ def add_code_sample_docstrings(
             "real_checkpoint": real_checkpoint,
             "fake_checkpoint": checkpoint,
             "true": "{true}",  # For <Tip warning={true}> syntax that conflicts with formatting.
+            "revision": revision,
         }
 
         if ("SequenceClassification" in model_class or "AudioClassification" in model_class) and modality == "audio":
@@ -1140,6 +1142,15 @@ def add_code_sample_docstrings(
         )
         if real_checkpoint is not None:
             code_sample = FAKE_MODEL_DISCLAIMER + code_sample
+        if revision is not None:
+            if "refs/pr/" not in revision:
+                raise ValueError(
+                    f"The provided revision '{revision}' is incorrect. It should point to"
+                    " a pull request reference on the hub like 'refs/pr/6'"
+                )
+            code_sample.replace(
+                f'from_pretrained("{checkpoint}")', 'from_pretrained("{checkpoint}", revision="{revision}")'
+            )
         func_doc = (fn.__doc__ or "") + "".join(docstr)
         output_doc = "" if output_type is None else _prepare_output_docstrings(output_type, config_class)
         built_doc = code_sample.format(**doc_kwargs)


### PR DESCRIPTION
# What does this PR do?
When PRs on the hub are not merged yet + sometimes for safety reasons we can pin a revision in the docstring code samples added. 

Seems like the CI is enough to test, dummy testing the build with a flax t5 model 😉 

Example: https://moon-ci-docs.huggingface.co/docs/transformers/pr_27645/en/model_doc/albert#transformers.FlaxAlbertForMaskedLM.__call__.example 