### PR TITLE
Log learning rate

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2655,7 +2655,7 @@ class Trainer:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
-        output["learning_rate"] = "{:.2e}".format(output["learning_rate"])
+        output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2652,11 +2652,9 @@ class Trainer:
             logs["epoch"] = round(self.state.epoch, 2)
         if self.args.include_num_input_tokens_seen:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
-        logs["learning_rate"] = self._get_learning_rate()
+        logs["learning_rate"] = f"{self._get_learning_rate():0.2e}"
 
         output = {**logs, **{"step": self.state.global_step}}
-        # Convert to scientific notation for space
-        output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2655,7 +2655,9 @@ class Trainer:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
-        output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
+        if "learning_rate" in logs:
+            # Conver to scientific notation for space
+            output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2652,8 +2652,7 @@ class Trainer:
             logs["epoch"] = round(self.state.epoch, 2)
         if self.args.include_num_input_tokens_seen:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
-        logs["learning_rate"] = f"{self._get_learning_rate():0.2e}"
-
+        logs["learning_rate"] = self._get_learning_rate()
         output = {**logs, **{"step": self.state.global_step}}
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2655,6 +2655,7 @@ class Trainer:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
 
         output = {**logs, **{"step": self.state.global_step}}
+        output["learning_rate"] = "{:.2e}".format(output["learning_rate"])
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2260,7 +2260,6 @@ class Trainer:
             tr_loss -= tr_loss
 
             logs["loss"] = round(tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged), 4)
-            logs["learning_rate"] = self._get_learning_rate()
 
             self._total_loss_scalar += tr_loss_scalar
             self._globalstep_last_logged = self.state.global_step
@@ -2653,11 +2652,11 @@ class Trainer:
             logs["epoch"] = round(self.state.epoch, 2)
         if self.args.include_num_input_tokens_seen:
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
+        logs["learning_rate"] = self._get_learning_rate()
 
         output = {**logs, **{"step": self.state.global_step}}
-        if "learning_rate" in logs:
-            # Conver to scientific notation for space
-            output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
+        # Convert to scientific notation for space
+        output["learning_rate"] = "{:.2e}".format(logs["learning_rate"])
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
 

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -517,6 +517,7 @@ class ProgressCallback(TrainerCallback):
     def on_log(self, args, state, control, logs=None, **kwargs):
         if state.is_local_process_zero and self.training_bar is not None:
             _ = logs.pop("total_flos", None)
+            logs["learning_rate"] = f"{logs['learning_rate']:0.2e}"
             self.training_bar.write(str(logs))
 
     def on_train_end(self, args, state, control, **kwargs):

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -333,11 +333,11 @@ class NotebookProgressCallback(TrainerCallback):
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
         if self.training_tracker is not None:
-            values = {"Training Loss": "No log", "Validation Loss": "No log"}
+            values = {"Training Loss": "No log", "Validation Loss": "No log", "Learning Rate": "No log"}
             for log in reversed(state.log_history):
                 if "loss" in log:
                     values["Training Loss"] = log["loss"]
-                    break
+                    values["Learning Rate"] = f"{log['learning_rate']:0.2e}"
 
             if self.first_column == "Epoch":
                 values["Epoch"] = int(state.epoch)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -291,7 +291,7 @@ class NotebookProgressCallback(TrainerCallback):
         self.first_column = "Epoch" if args.evaluation_strategy == IntervalStrategy.EPOCH else "Step"
         self.training_loss = 0
         self.last_log = 0
-        column_names = [self.first_column] + ["Training Loss", "Learning Rate"]
+        column_names = [self.first_column] + ["Training Loss"]
         if args.evaluation_strategy != IntervalStrategy.NO:
             column_names.append("Validation Loss")
         column_names.append("Learning Rate")

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -328,6 +328,7 @@ class NotebookProgressCallback(TrainerCallback):
             values = {"Training Loss": logs["loss"]}
             # First column is necessarily Step sine we're not in epoch eval strategy
             values["Step"] = state.global_step
+            values["Learning Rate"] = f"{logs['learning_rate']:0.2e}"
             self.training_tracker.write_line(values)
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -291,9 +291,9 @@ class NotebookProgressCallback(TrainerCallback):
         self.first_column = "Epoch" if args.evaluation_strategy == IntervalStrategy.EPOCH else "Step"
         self.training_loss = 0
         self.last_log = 0
-        column_names = [self.first_column] + ["Training Loss"]
         if args.evaluation_strategy != IntervalStrategy.NO:
             column_names.append("Validation Loss")
+        column_names.append("Learning Rate")
         self.training_tracker = NotebookTrainingTracker(state.max_steps, column_names)
 
     def on_step_end(self, args, state, control, **kwargs):
@@ -341,10 +341,7 @@ class NotebookProgressCallback(TrainerCallback):
             for log in reversed(state.log_history):
                 if "learning_rate" in log:
                     values["Learning Rate"] = f"{log['learning_rate']:0.2e}"
-                    print("FOUND A LEARNING RATE")
                     break
-                else:
-                    print("NO LEARNING RATE")
 
             if self.first_column == "Epoch":
                 values["Epoch"] = int(state.epoch)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -291,6 +291,7 @@ class NotebookProgressCallback(TrainerCallback):
         self.first_column = "Epoch" if args.evaluation_strategy == IntervalStrategy.EPOCH else "Step"
         self.training_loss = 0
         self.last_log = 0
+        column_names = [self.first_column] + ["Training Loss", "Learning Rate"]
         if args.evaluation_strategy != IntervalStrategy.NO:
             column_names.append("Validation Loss")
         column_names.append("Learning Rate")

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -337,7 +337,11 @@ class NotebookProgressCallback(TrainerCallback):
             for log in reversed(state.log_history):
                 if "loss" in log:
                     values["Training Loss"] = log["loss"]
+                    break
+            for log in reversed(state.log_history):
+                if "learning_rate" in log:
                     values["Learning Rate"] = f"{log['learning_rate']:0.2e}"
+                    break
 
             if self.first_column == "Epoch":
                 values["Epoch"] = int(state.epoch)

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -341,7 +341,10 @@ class NotebookProgressCallback(TrainerCallback):
             for log in reversed(state.log_history):
                 if "learning_rate" in log:
                     values["Learning Rate"] = f"{log['learning_rate']:0.2e}"
+                    print("FOUND A LEARNING RATE")
                     break
+                else:
+                    print("NO LEARNING RATE")
 
             if self.first_column == "Epoch":
                 values["Epoch"] = int(state.epoch)


### PR DESCRIPTION
# What does this PR do?

Logs the learning rate on each logging instance when training, and specifically uses scientific notation to save on space

Fulfills https://github.com/huggingface/transformers/issues/27631


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker 

Example output: 
![image](https://github.com/huggingface/transformers/assets/7831895/ea85f274-0390-4d83-8a2b-3db4b9f0bb3f)


We only use the scientific notation when printing on screen. Everything else gets the full float