### PR TITLE
Fix yolos resizing

### DIFF
--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -82,6 +82,7 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 SUPPORTED_ANNOTATION_FORMATS = (AnnotationFormat.COCO_DETECTION, AnnotationFormat.COCO_PANOPTIC)
 
 
+# From the original repo: https://github.com/facebookresearch/detr/blob/3af9fa878e73b6894ce3596450a8d9b89d918ca9/datasets/transforms.py#L76
 def get_size_with_aspect_ratio(image_size, size, max_size=None) -> Tuple[int, int]:
     """
     Computes the output image size given the input image size and the desired output size.

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -99,7 +99,6 @@ def get_max_height_width(
     return (max_height, max_width)
 
 
-# Copied from transformers.models.detr.image_processing_detr.get_size_with_aspect_ratio
 def get_size_with_aspect_ratio(image_size, size, max_size=None) -> Tuple[int, int]:
     """
     Computes the output image size given the input image size and the desired output size.
@@ -120,15 +119,28 @@ def get_size_with_aspect_ratio(image_size, size, max_size=None) -> Tuple[int, in
             size = int(round(max_size * min_original_size / max_original_size))
 
     if (height <= width and height == size) or (width <= height and width == size):
-        return height, width
+        width_mod = np.mod(width, 16)
+        height_mod = np.mod(height, 16)
+        height = height - height_mod
+        width = width - width_mod
+        return (height, width)
 
     if width < height:
-        ow = size
-        oh = int(size * height / width)
+        output_w = size
+        output_h = int(size * height / width)
+        output_w_mod = np.mod(output_w, 16)
+        output_h_mod = np.mod(output_h, 16)
+        output_w = output_w - output_w_mod
+        output_h = output_h - output_h_mod
     else:
-        oh = size
-        ow = int(size * width / height)
-    return (oh, ow)
+        output_h = size
+        output_w = int(size * width / height)
+        output_w_mod = np.mod(output_w, 16)
+        output_h_mod = np.mod(output_h, 16)
+        output_w = output_w - output_w_mod
+        output_h = output_h - output_h_mod
+
+    return (output_h, output_w)
 
 
 # Copied from transformers.models.detr.image_processing_detr.get_resize_output_image_size

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -118,29 +118,17 @@ def get_size_with_aspect_ratio(image_size, size, max_size=None) -> Tuple[int, in
         if max_original_size / min_original_size * size > max_size:
             size = int(round(max_size * min_original_size / max_original_size))
 
-    if (height <= width and height == size) or (width <= height and width == size):
-        width_mod = np.mod(width, 16)
-        height_mod = np.mod(height, 16)
-        height = height - height_mod
-        width = width - width_mod
-        return (height, width)
-
-    if width < height:
-        output_w = size
-        output_h = int(size * height / width)
-        output_w_mod = np.mod(output_w, 16)
-        output_h_mod = np.mod(output_h, 16)
-        output_w = output_w - output_w_mod
-        output_h = output_h - output_h_mod
-    else:
-        output_h = size
-        output_w = int(size * width / height)
-        output_w_mod = np.mod(output_w, 16)
-        output_h_mod = np.mod(output_h, 16)
-        output_w = output_w - output_w_mod
-        output_h = output_h - output_h_mod
-
-    return (output_h, output_w)
+    if width < height and width != size:
+        height = int(size * height / width)
+        width = size
+    elif height < width and height != size:
+        width = int(size * width / height)
+        height = size
+    width_mod = np.mod(width, 16)
+    height_mod = np.mod(height, 16)
+    width = width - width_mod
+    height = height - height_mod
+    return (height, width)
 
 
 # Copied from transformers.models.detr.image_processing_detr.get_resize_output_image_size

--- a/tests/models/yolos/test_image_processing_yolos.py
+++ b/tests/models/yolos/test_image_processing_yolos.py
@@ -86,18 +86,28 @@ class YolosImageProcessingTester(unittest.TestCase):
         if not batched:
             image = image_inputs[0]
             if isinstance(image, Image.Image):
-                w, h = image.size
+                width, height = image.size
             else:
-                h, w = image.shape[1], image.shape[2]
-            if w < h:
-                expected_height = int(self.size["shortest_edge"] * h / w)
-                expected_width = self.size["shortest_edge"]
-            elif w > h:
-                expected_height = self.size["shortest_edge"]
-                expected_width = int(self.size["shortest_edge"] * w / h)
-            else:
-                expected_height = self.size["shortest_edge"]
-                expected_width = self.size["shortest_edge"]
+                height, width = image.shape[1], image.shape[2]
+
+            size = self.size["shortest_edge"]
+            max_size = self.size.get("longest_edge", None)
+            if max_size is not None:
+                min_original_size = float(min((height, width)))
+                max_original_size = float(max((height, width)))
+                if max_original_size / min_original_size * size > max_size:
+                    size = int(round(max_size * min_original_size / max_original_size))
+
+            if width < height and width != size:
+                height = int(size * height / width)
+                width = size
+            elif height < width and height != size:
+                width = int(size * width / height)
+                height = size
+            width_mod = width % 16
+            height_mod = height % 16
+            expected_width = width - width_mod
+            expected_height = height - height_mod
 
         else:
             expected_values = []

--- a/tests/models/yolos/test_image_processing_yolos.py
+++ b/tests/models/yolos/test_image_processing_yolos.py
@@ -183,6 +183,18 @@ class YolosImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMix
             torch.allclose(encoded_images_with_method["pixel_values"], encoded_images["pixel_values"], atol=1e-4)
         )
 
+    def test_resize_max_size_respected(self):
+        image_processor = self.image_processing_class(**self.image_processor_dict)
+
+        # create torch tensors as image
+        image = torch.randint(0, 256, (3, 100, 1500), dtype=torch.uint8)
+        processed_image = image_processor(
+            image, size={"longest_edge": 1333, "shortest_edge": 800}, do_pad=False, return_tensors="pt"
+        )["pixel_values"]
+
+        self.assertTrue(processed_image.shape[-1] <= 1333)
+        self.assertTrue(processed_image.shape[-2] <= 800)
+
     @slow
     def test_call_pytorch_with_coco_detection_annotations(self):
         # prepare image and target


### PR DESCRIPTION
# What does this PR do?

On main - running the following produces an image outside of the limits set by "longest_edge" in an images config: 

```py
from transformers import AutoProcessor
from PIL import Image
import requests

processor = AutoProcessor.from_pretrained("Xenova/yolos-small-300") # or hustvl/yolos-small-300
url = 'https://i.imgur.com/qOp3m0N.png' # very thin image

image = Image.open(requests.get(url, stream=True).raw).convert('RGB')
output = processor(image)
# Result
# main: (3, 89, 1335)
# branch: (3, 80, 1328)
print(output['pixel_values'][0].shape) 
``` 

This logic was copied from the DETR [image processing logic](https://github.com/huggingface/transformers/blob/8aca43bdb3cb9a5020f6d57589d85679dc873b1c/src/transformers/models/detr/image_processing_detr.py#L93) which comes from the [original DETR repo ](https://github.com/facebookresearch/detr/blob/3af9fa878e73b6894ce3596450a8d9b89d918ca9/datasets/transforms.py#L76). Note: this means the DETR models' image processors won't respect `longest_edge`.  

Yolos' image processor has been updated to reflect [the original model](https://github.com/hustvl/YOLOS/blob/5717fc29d727dab84ad585c56457b4de1225eddc/datasets/transforms.py#L76).

Note - this also differers from the output image size that would be obtained from using `torchvision`s `resize`. In the above example, it would be `(3, 88, 1333)`


Fixes #27381


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
