### PR TITLE
fix: fix gradient accumulate step for learning rate

### DIFF
--- a/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
+++ b/examples/flax/speech-recognition/run_flax_speech_recognition_seq2seq.py
@@ -640,7 +640,7 @@ def main():
 
     # Create learning rate schedule
     linear_decay_lr_schedule_fn = create_learning_rate_fn(
-        len(vectorized_datasets["train"]),
+        total_train_steps,
         training_args.warmup_steps,
         training_args.learning_rate,
     )


### PR DESCRIPTION
Hi, 
I think this is the mistake seen the learning rate should take the param `num_train_steps` as `total_train_steps`, instead of `len(vectorized_datasets["train"])`
So I fix them to the right suitable that learning rate will go down to zero as init
I would like to cc @sanchit-gandhi to review my PR