### PR TITLE
memory efficient attention (Flash V2) initial support - encoder-only and not combined with relative attention

### DIFF
--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -102,6 +102,7 @@ class T5Config(PretrainedConfig):
         eos_token_id=1,
         classifier_dropout=0.0,
         position_embedding_definitions=None,
+        memory_efficient_attention:bool=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -138,6 +139,7 @@ class T5Config(PretrainedConfig):
             self.dense_act_fn = "gelu_new"
         
         self.position_embedding_definitions = position_embedding_definitions or dict()
+        self.memory_efficient_attention = memory_efficient_attention
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -101,7 +101,7 @@ class T5Config(PretrainedConfig):
         pad_token_id=0,
         eos_token_id=1,
         classifier_dropout=0.0,
-        position_embedding_types=None,
+        position_embedding_definitions=None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -137,7 +137,7 @@ class T5Config(PretrainedConfig):
         if feed_forward_proj == "gated-gelu":
             self.dense_act_fn = "gelu_new"
         
-        self.position_embedding_types = position_embedding_types or dict()
+        self.position_embedding_definitions = position_embedding_definitions or dict()
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -101,6 +101,7 @@ class T5Config(PretrainedConfig):
         pad_token_id=0,
         eos_token_id=1,
         classifier_dropout=0.0,
+        position_embedding_types=None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -135,6 +136,8 @@ class T5Config(PretrainedConfig):
         # for backwards compatibility
         if feed_forward_proj == "gated-gelu":
             self.dense_act_fn = "gelu_new"
+        
+        self.position_embedding_types = position_embedding_types or dict()
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -967,12 +967,12 @@ class T5Stack(T5PreTrainedModel):
 
         self.embed_tokens = embed_tokens
         self.is_decoder = config.is_decoder
-        self.position_embedding_definitions = config.position_embedding_definitions 
+        self.position_embedding_definitions = config.position_embedding_definitions if hasattr(config, "position_embedding_definitions") else {}
 
         self.abs_position_embedding_dict = nn.ModuleDict()
         relative_position_embedding_definitions = {}
        
-        for position_embedding_name, embedding_config in config.position_embedding_definitions.items():
+        for position_embedding_name, embedding_config in self.position_embedding_definitions.items():
             if embedding_config.is_relative:
                 relative_position_embedding_definitions[position_embedding_name] = {k:v for k,v in embedding_config.items() if k!= "is_relative"}
             else:
@@ -1674,7 +1674,8 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         self.shared = nn.Embedding(config.vocab_size, config.d_model)
 
         # collect info on declared position types, for input validity test during forward
-        self.position_embedding_is_relative_dict = {k: v.is_relative for k,v in config.position_embedding_definitions.items()}  
+        position_embedding_definitions = config.position_embedding_definitions if hasattr(config, "position_embedding_definitions") else {}
+        self.position_embedding_is_relative_dict = {k: v.is_relative for k,v in position_embedding_definitions.items()}  
         self.position_embedding_is_relative_dict[POSITION_EMBEDDING_SINUSOIDAL] = False
 
         encoder_config = copy.deepcopy(config)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -48,7 +48,7 @@ from ...utils import (
 )
 from ...utils.model_parallel_utils import assert_device_map, get_device_map
 from .configuration_t5 import T5Config
-
+from xformers import ops as xops
 
 logger = logging.get_logger(__name__)
 
@@ -498,6 +498,154 @@ class T5Attention(nn.Module):
         return values
 
     def forward(
+        self,
+        hidden_states,
+        mask=None,
+        key_value_states=None,
+        position_bias=None,
+        past_key_value=None,
+        layer_head_mask=None,
+        query_length=None,
+        use_cache=False,
+        output_attentions=False,
+        position_ids_info_list=None,
+    ):
+        """
+        Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).
+        """
+        # Input is (batch_size, seq_length, dim)
+        # Mask is (batch_size, key_length) (non-causal) or (batch_size, key_length, key_length)
+        # past_key_value[0] is (batch_size, n_heads, q_len - 1, dim_per_head)
+        batch_size, seq_length = hidden_states.shape[:2]
+
+        real_seq_length = seq_length
+
+        if past_key_value is not None:
+            if len(past_key_value) != 2:
+                raise ValueError(
+                    f"past_key_value should have 2 past states: keys and values. Got { len(past_key_value)} past states"
+                )
+            real_seq_length += past_key_value[0].shape[2] if query_length is None else query_length
+
+        key_length = real_seq_length if key_value_states is None else key_value_states.shape[1]
+
+        def shape(states):
+            """projection"""
+            return states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+
+        def unshape(states):
+            """reshape"""
+            return states.transpose(1, 2).contiguous().view(batch_size, -1, self.inner_dim)
+
+        def project(hidden_states, proj_layer, key_value_states, past_key_value):
+            """projects hidden states correctly to key/query states"""
+            if key_value_states is None:
+                # self-attn
+                # (batch_size, n_heads, seq_length, dim_per_head)
+                hidden_states = shape(proj_layer(hidden_states))
+            elif past_key_value is None:
+                # cross-attn
+                # (batch_size, n_heads, seq_length, dim_per_head)
+                hidden_states = shape(proj_layer(key_value_states))
+
+            if past_key_value is not None:
+                if key_value_states is None:
+                    # self-attn
+                    # (batch_size, n_heads, key_length, dim_per_head)
+                    hidden_states = torch.cat([past_key_value, hidden_states], dim=2)
+                elif past_key_value.shape[2] != key_value_states.shape[1]:
+                    # checking that the `sequence_length` of the `past_key_value` is the same as
+                    # the provided `key_value_states` to support prefix tuning
+                    # cross-attn
+                    # (batch_size, n_heads, seq_length, dim_per_head)
+                    hidden_states = shape(proj_layer(key_value_states))
+                else:
+                    # cross-attn
+                    hidden_states = past_key_value
+            return hidden_states
+
+        # get query states
+        query_states = shape(self.q(hidden_states))  # (batch_size, n_heads, seq_length, dim_per_head)
+
+        # get key/value states
+        key_states = project(
+            hidden_states, self.k, key_value_states, past_key_value[0] if past_key_value is not None else None
+        )
+        value_states = project(
+            hidden_states, self.v, key_value_states, past_key_value[1] if past_key_value is not None else None
+        )
+
+        ## flash attention based
+        # print('WARNING! verify that xops.memory_efficient_attention dropout arg behaves correctly in inference mode')
+        # attn_weights = xops.memory_efficient_attention(
+        #     query=query_states.permute(0,2,1,3), #BHMK -> BMHK
+        #     key=key_states.permute(0,2,1,3), #BHMK -> BMHK
+        #     value=value_states.permute(0,2,1,3), #BHMK -> BMHK
+        #     p=self.dropout, 
+        #     attn_bias=mask, 
+        # )
+
+
+        # compute scores
+        scores = torch.matmul(
+            query_states, key_states.transpose(3, 2)
+        )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
+
+        if position_ids_info_list:
+            if position_bias is None:
+                if not self.has_relative_attention_bias:
+                    position_bias = torch.zeros(
+                        (1, self.n_heads, real_seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    )
+                    if self.gradient_checkpointing and self.training:
+                        position_bias.requires_grad = True
+                else:
+                    for position_ids, position_embedding_name in position_ids_info_list:
+                        curr_position_bias = self.compute_bias_for_position_embedding_name(position_embedding_name=position_embedding_name, position_ids=position_ids, query_length=real_seq_length, key_length=key_length, device=scores.device)
+                        position_bias = curr_position_bias if position_bias is None else (position_bias+curr_position_bias)  # michal: shape don't match
+                # if key and values are already calculated
+                # we want only the last query position bias
+                if past_key_value is not None:
+                    position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
+
+                if mask is not None:
+                    position_bias = position_bias + mask  # (batch_size, n_heads, seq_length, key_length)
+
+            if self.pruned_heads:
+                mask = torch.ones(position_bias.shape[1])
+                mask[list(self.pruned_heads)] = 0
+                position_bias_masked = position_bias[:, mask.bool()]
+            else:
+                position_bias_masked = position_bias
+
+            scores += position_bias_masked
+        else:
+            if mask is not None:  
+                # MICHAL see above that mask is added to position_bias. Also in length-generalization.
+                scores += mask  # (batch_size, n_heads, seq_length, key_length)  
+
+        attn_weights = nn.functional.softmax(scores.float(), dim=-1).type_as(
+            scores
+        )  # (batch_size, n_heads, seq_length, key_length)
+        attn_weights = nn.functional.dropout(
+            attn_weights, p=self.dropout, training=self.training
+        )  # (batch_size, n_heads, seq_length, key_length)
+
+        # Mask heads if we want to
+        if layer_head_mask is not None:
+            attn_weights = attn_weights * layer_head_mask
+
+        attn_output = unshape(torch.matmul(attn_weights, value_states))  # (batch_size, seq_length, dim)
+        attn_output = self.o(attn_output)
+
+        present_key_value_state = (key_states, value_states) if (self.is_decoder and use_cache) else None
+        outputs = (attn_output,) + (present_key_value_state,) + (position_bias,)
+
+        if output_attentions:
+            outputs = outputs + (attn_weights,)
+        return outputs
+
+    def ORIG_forward(
         self,
         hidden_states,
         mask=None,

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1293,16 +1293,8 @@ class T5Stack(T5PreTrainedModel):
 
         position_ids_info_list_for_relative_embeddings = []
         if add_t5_relative_position_embedding:
-                position_ids_info_list_for_relative_embeddings.append( (None, POSITION_EMBEDDING_T5_RELATIVE))
+            position_ids_info_list_for_relative_embeddings.append( (None, POSITION_EMBEDDING_T5_RELATIVE))
         for position_ids, position_embedding_names  in position_ids_dict.values(): #orig
-        # for ids_elem  in position_ids_dict.values(): #orig
-        #     if isinstance(ids_elem, list):
-        #         position_ids = torch.concat([x[None,...] for (x,name) in ids_elem ])
-        #         position_embedding_names = [x[1] for x in ids_elem]
-        #     else:
-        #         assert isinstance(ids_elem, tuple)      
-        #         assert len(ids_elem) == 2          
-        #         position_ids, position_embedding_names = ids_elem
             position_embedding_name = position_embedding_names[0]  # till collate if fixed, we move a list of identical embedding names of batch_size
             if position_ids is None:
                 device = input_ids.device if input_ids is not None else inputs_embeds.device

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -56,6 +56,7 @@ _CONFIG_FOR_DOC = "T5Config"
 _CHECKPOINT_FOR_DOC = "t5-small"
 
 POSITION_EMBEDDING_SINUSOIDAL = "abs_sinusoidal"
+POSITION_EMBEDDING_T5_RELATIVE = "t5_relative"
 
 class SinusoidalPositionalEmbedding(nn.Module):
     def __init__(self, dim, max_num_tokens=10000):
@@ -361,10 +362,11 @@ class T5LayerFF(nn.Module):
 
 
 class T5Attention(nn.Module):
-    def __init__(self, config: T5Config, has_relative_attention_bias=False):
+    def __init__(self, config: T5Config, relative_position_embedding_definitions=None):
         super().__init__()
         self.is_decoder = config.is_decoder
-        self.has_relative_attention_bias = has_relative_attention_bias
+        self.relative_position_embedding_definitions = relative_position_embedding_definitions
+        self.has_relative_attention_bias = self.relative_position_embedding_definitions is not None
         self.relative_attention_num_buckets = config.relative_attention_num_buckets
         self.relative_attention_max_distance = config.relative_attention_max_distance
         self.d_model = config.d_model
@@ -380,7 +382,11 @@ class T5Attention(nn.Module):
         self.o = nn.Linear(self.inner_dim, self.d_model, bias=False)
 
         if self.has_relative_attention_bias:
-            self.relative_attention_bias = nn.Embedding(self.relative_attention_num_buckets, self.n_heads)
+            self.relative_attention_bias = nn.Embedding(self.relative_attention_num_buckets, self.n_heads)  # regular weights of T5. to support pretrained weights
+            self.relative_attention_bias_dict = nn.ModuleDict()
+            for position_embedding_name, position_embedding_config in self.relative_position_embedding_definitions.items():
+                relative_attention_num_buckets = position_embedding_config.get("num_buckets", self.relative_attention_num_buckets)
+                self.relative_attention_bias_dict[position_embedding_name] = nn.Embedding(relative_attention_num_buckets, self.n_heads)
         self.pruned_heads = set()
         self.gradient_checkpointing = False
 
@@ -448,21 +454,41 @@ class T5Attention(nn.Module):
         relative_buckets += torch.where(is_small, relative_position, relative_position_if_large)
         return relative_buckets
 
-    def compute_bias(self, query_length, key_length, device=None):
+    def compute_bias_for_position_embedding_name(self, position_embedding_name, position_ids, query_length, key_length, device=None):
+        """Compute binned relative position bias"""
+        if position_embedding_name == POSITION_EMBEDDING_T5_RELATIVE:
+            relative_attention_bias = self.relative_attention_bias
+            num_buckets=self.relative_attention_num_buckets
+            max_distance=self.relative_attention_max_distance                
+        else:
+            relative_attention_bias = self.relative_attention_bias_dict[position_embedding_name]
+            num_buckets =self.relative_position_embedding_definitions[position_embedding_name].get("num_buckets", self.relative_attention_num_buckets)
+            max_distance=self.relative_position_embedding_definitions[position_embedding_name].get("max_distance", self.relative_attention_max_distance)
+
+        return self.compute_bias(relative_attention_bias=relative_attention_bias, position_ids=position_ids, num_buckets=num_buckets, max_distance=max_distance, query_length=query_length, key_length=key_length, device=device)
+
+    def compute_bias(self, relative_attention_bias, position_ids, num_buckets, max_distance, query_length, key_length, device=None):
         """Compute binned relative position bias"""
         if device is None:
-            device = self.relative_attention_bias.weight.device
-        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
-        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
+            device = relative_attention_bias.weight.device
+        if position_ids is not None:
+            context_position = position_ids.unsqueeze(2)
+            memory_position = position_ids.unsqueeze(1)
+        else:
+            context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
+            memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
         relative_position = memory_position - context_position  # shape (query_length, key_length)
         relative_position_bucket = self._relative_position_bucket(
             relative_position,  # shape (query_length, key_length)
             bidirectional=(not self.is_decoder),
-            num_buckets=self.relative_attention_num_buckets,
-            max_distance=self.relative_attention_max_distance,
+            num_buckets=num_buckets,
+            max_distance=max_distance,
         )
         values = self.relative_attention_bias(relative_position_bucket)  # shape (query_length, key_length, num_heads)
-        values = values.permute([2, 0, 1]).unsqueeze(0)  # shape (1, num_heads, query_length, key_length)
+        if position_ids is not None:
+            values = values.permute([0, 3, 1, 2])
+        else:
+            values = values.permute([2, 0, 1]).unsqueeze(0)  # shape (1, num_heads, query_length, key_length)
         return values
 
     def forward(
@@ -476,7 +502,7 @@ class T5Attention(nn.Module):
         query_length=None,
         use_cache=False,
         output_attentions=False,
-        add_t5_relative_position_embedding=True,
+        position_ids_info_list=None,
     ):
         """
         Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).
@@ -548,7 +574,7 @@ class T5Attention(nn.Module):
             query_states, key_states.transpose(3, 2)
         )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
 
-        if add_t5_relative_position_embedding:
+        if position_ids_info_list:
             if position_bias is None:
                 if not self.has_relative_attention_bias:
                     position_bias = torch.zeros(
@@ -557,8 +583,9 @@ class T5Attention(nn.Module):
                     if self.gradient_checkpointing and self.training:
                         position_bias.requires_grad = True
                 else:
-                    position_bias = self.compute_bias(real_seq_length, key_length, device=scores.device)
-
+                    for position_ids, position_embedding_name in position_ids_info_list:
+                        curr_position_bias = self.compute_bias_for_position_embedding_name(position_embedding_name=position_embedding_name, position_ids=position_ids, query_length=real_seq_length, key_length=key_length, device=scores.device)
+                        position_bias = curr_position_bias if position_bias is None else (position_bias+curr_position_bias)  # michal: shape don't match
                 # if key and values are already calculated
                 # we want only the last query position bias
                 if past_key_value is not None:
@@ -603,9 +630,9 @@ class T5Attention(nn.Module):
 
 
 class T5LayerSelfAttention(nn.Module):
-    def __init__(self, config, has_relative_attention_bias=False):
+    def __init__(self, config, relative_position_embedding_definitions=None):
         super().__init__()
-        self.SelfAttention = T5Attention(config, has_relative_attention_bias=has_relative_attention_bias)
+        self.SelfAttention = T5Attention(config, relative_position_embedding_definitions=relative_position_embedding_definitions)
         self.layer_norm = T5LayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)
 
@@ -618,7 +645,7 @@ class T5LayerSelfAttention(nn.Module):
         past_key_value=None,
         use_cache=False,
         output_attentions=False,
-        add_t5_relative_position_embedding=True,
+        position_ids_info_list=None,
     ):
         normed_hidden_states = self.layer_norm(hidden_states)
         attention_output = self.SelfAttention(
@@ -629,7 +656,7 @@ class T5LayerSelfAttention(nn.Module):
             past_key_value=past_key_value,
             use_cache=use_cache,
             output_attentions=output_attentions,
-            add_t5_relative_position_embedding=add_t5_relative_position_embedding,
+            position_ids_info_list=position_ids_info_list,
         )
         hidden_states = hidden_states + self.dropout(attention_output[0])
         outputs = (hidden_states,) + attention_output[1:]  # add attentions if we output them
@@ -639,7 +666,7 @@ class T5LayerSelfAttention(nn.Module):
 class T5LayerCrossAttention(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.EncDecAttention = T5Attention(config, has_relative_attention_bias=False)
+        self.EncDecAttention = T5Attention(config, relative_position_embedding_definitions=None)
         self.layer_norm = T5LayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)
 
@@ -654,7 +681,7 @@ class T5LayerCrossAttention(nn.Module):
         use_cache=False,
         query_length=None,
         output_attentions=False,
-        add_t5_relative_position_embedding=True,
+        position_ids_info_list=None,
     ):
         normed_hidden_states = self.layer_norm(hidden_states)
         attention_output = self.EncDecAttention(
@@ -667,7 +694,7 @@ class T5LayerCrossAttention(nn.Module):
             use_cache=use_cache,
             query_length=query_length,
             output_attentions=output_attentions,
-            add_t5_relative_position_embedding=add_t5_relative_position_embedding,
+            position_ids_info_list=position_ids_info_list,
         )
         layer_output = hidden_states + self.dropout(attention_output[0])
         outputs = (layer_output,) + attention_output[1:]  # add attentions if we output them
@@ -675,11 +702,11 @@ class T5LayerCrossAttention(nn.Module):
 
 
 class T5Block(nn.Module):
-    def __init__(self, config, has_relative_attention_bias=False):
+    def __init__(self, config, relative_position_embedding_definitions=None):
         super().__init__()
         self.is_decoder = config.is_decoder
         self.layer = nn.ModuleList()
-        self.layer.append(T5LayerSelfAttention(config, has_relative_attention_bias=has_relative_attention_bias))
+        self.layer.append(T5LayerSelfAttention(config, relative_position_embedding_definitions=relative_position_embedding_definitions))
         if self.is_decoder:
             self.layer.append(T5LayerCrossAttention(config))
 
@@ -697,7 +724,7 @@ class T5Block(nn.Module):
         cross_attn_layer_head_mask=None,
         past_key_value=None,
         use_cache=False,
-        add_t5_relative_position_embedding=True,
+        position_ids_info_list=None,
         output_attentions=False,
         return_dict=True,
     ):
@@ -726,7 +753,7 @@ class T5Block(nn.Module):
             past_key_value=self_attn_past_key_value,
             use_cache=use_cache,
             output_attentions=output_attentions,
-            add_t5_relative_position_embedding=add_t5_relative_position_embedding,
+            position_ids_info_list=position_ids_info_list,
         )
         hidden_states, present_key_value_state = self_attention_outputs[:2]
         attention_outputs = self_attention_outputs[2:]  # Keep self-attention outputs and relative position weights
@@ -759,7 +786,7 @@ class T5Block(nn.Module):
                 query_length=query_length,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
-                add_t5_relative_position_embedding=add_t5_relative_position_embedding,
+                position_ids_info_list=position_ids_info_list,
             )
             hidden_states = cross_attention_outputs[0]
 
@@ -939,18 +966,25 @@ class T5Stack(T5PreTrainedModel):
 
         self.embed_tokens = embed_tokens
         self.is_decoder = config.is_decoder
-        self.position_embedding_types = config.position_embedding_types
+        self.position_embedding_definitions = config.position_embedding_definitions 
+
+        self.abs_position_embedding_dict = nn.ModuleDict()
+        relative_position_embedding_definitions = {}
+        self.abs_position_embedding_dict[POSITION_EMBEDDING_SINUSOIDAL] = SinusoidalPositionalEmbedding(config.d_model)
+        for position_embedding_name, embedding_config in config.position_embedding_definitions.items():
+            if embedding_config.is_relative:
+                relative_position_embedding_definitions[position_embedding_name] = {k:v for k,v in embedding_config.items() if k!= "is_relative"}
+            else:
+                self.abs_position_embedding_dict[position_embedding_name] =  nn.Embedding(embedding_config.num_embeddings, config.d_model)
+
 
         self.block = nn.ModuleList(
-            [T5Block(config, has_relative_attention_bias=bool(i == 0)) for i in range(config.num_layers)]
+            [T5Block(config, relative_position_embedding_definitions=relative_position_embedding_definitions if i==0 else None) for i in range(config.num_layers)]
         )
         self.final_layer_norm = T5LayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)
 
-        self.position_embedding_dict = nn.ModuleDict()
-        self.position_embedding_dict[POSITION_EMBEDDING_SINUSOIDAL] = SinusoidalPositionalEmbedding(config.d_model)
-        for position_embedding_name, num_embeddings in config.position_embedding_types.items():
-            self.position_embedding_dict[position_embedding_name] =  nn.Embedding(num_embeddings, config.d_model)
+
         # Initialize weights and apply final processing
         self.post_init()
         # Model parallel
@@ -1058,7 +1092,11 @@ class T5Stack(T5PreTrainedModel):
         if position_ids_dict is None:
             position_ids_dict = {}
 
-        for position_ids, position_embedding_types  in position_ids_dict.values():
+        position_ids_info_list_for_relative_embeddings = []
+        if add_t5_relative_position_embedding:
+                position_ids_info_list_for_relative_embeddings.append( (None, POSITION_EMBEDDING_T5_RELATIVE))
+        for position_ids, position_embedding_names  in position_ids_dict.values():
+            position_embedding_name = position_embedding_names[0]  # till collate if fixed, we move a list of identical embedding names of batch_size
             if position_ids is None:
                 device = input_ids.device if input_ids is not None else inputs_embeds.device
                 past_length = past_key_values[0][0].size(-2) if past_key_values is not None else 0
@@ -1070,12 +1108,18 @@ class T5Stack(T5PreTrainedModel):
                     device=device,
                 )
                 position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
+                
             else:
                 position_ids = position_ids.view(-1, input_shape[-1])
             
+            if position_embedding_name in self.abs_position_embedding_dict:
+                position_embeds = self.abs_position_embedding_dict[position_embedding_name](position_ids)
+                inputs_embeds += position_embeds
+            else:
+                position_ids_info_list_for_relative_embeddings.append((position_ids, position_embedding_name))
             
-            position_embeds = self.position_embedding_dict[position_embedding_types[0]](position_ids)
-            inputs_embeds += position_embeds
+            
+           
             
         batch_size, seq_length = input_shape
 
@@ -1164,7 +1208,7 @@ class T5Stack(T5PreTrainedModel):
 
                     return custom_forward
 
-                layer_outputs = checkpoint(
+                layer_outputs = checkpoint(  
                     create_custom_forward(layer_module),
                     hidden_states,
                     extended_attention_mask,
@@ -1175,7 +1219,7 @@ class T5Stack(T5PreTrainedModel):
                     layer_head_mask,
                     cross_attn_layer_head_mask,
                     None,  # past_key_value is always None with gradient checkpointing
-                    add_t5_relative_position_embedding,
+                    position_ids_info_list_for_relative_embeddings,
                 )
             else:
                 layer_outputs = layer_module(
@@ -1188,7 +1232,7 @@ class T5Stack(T5PreTrainedModel):
                     layer_head_mask=layer_head_mask,
                     cross_attn_layer_head_mask=cross_attn_layer_head_mask,
                     past_key_value=past_key_value,
-                    add_t5_relative_position_embedding=add_t5_relative_position_embedding,
+                    position_ids_info_list=position_ids_info_list_for_relative_embeddings,
                     use_cache=use_cache,
                     output_attentions=output_attentions,
                 )
@@ -1626,8 +1670,8 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         self.shared = nn.Embedding(config.vocab_size, config.d_model)
 
         # collect info on declared position types, for input validity test during forward
-        self.position_embedding_types = set(config.position_embedding_types.keys())
-        self.position_embedding_types.add(POSITION_EMBEDDING_SINUSOIDAL)
+        self.position_embedding_is_relative_dict = {k: v.is_relative for k,v in config.position_embedding_definitions.items()}  
+        self.position_embedding_is_relative_dict[POSITION_EMBEDDING_SINUSOIDAL] = False
 
         encoder_config = copy.deepcopy(config)
         encoder_config.is_decoder = False
@@ -1770,11 +1814,11 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         if add_t5_relative_position_embedding is None:
             add_t5_relative_position_embedding = True
 
-        for _, position_embedding_types in encoder_position_ids_dict.values():
-            assert position_embedding_types[0] in self.position_embedding_types
+        for _, position_embedding_types in encoder_position_ids_dict.values():  # each entry in values is a tupple of (tensor of position ods, list of position_embedding_names ) # consider using collate to transform the list to a single item
+            assert position_embedding_types[0] in self.position_embedding_is_relative_dict
         
         for _, position_embedding_types in decoder_position_ids_dict.values():
-            assert position_embedding_types[0] in self.position_embedding_types
+            assert position_embedding_types[0] in self.position_embedding_is_relative_dict
 
         use_cache = use_cache if use_cache is not None else self.config.use_cache
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict


### PR DESCRIPTION
# What does this PR do?

adds support for memory efficient attention, based on using xformers library memory_efficient_attention() op.

it only supports the following:
1. Encoder-only (no causal attention)
2. Relative attention (which gets injected into the "scores" (the results of Q@K.transpose()) is NOT supported, as it would case Flash v2 to not be used.

