### PR TITLE
tokenizer_kwargs in text-generation pipeline __call__()

### DIFF
--- a/docs/source/en/preprocessing.md
+++ b/docs/source/en/preprocessing.md
@@ -216,6 +216,11 @@ array([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
 </tf>
 </frameworkcontent>
 
+<Tip>
+Some pipelines like `text-generation` and `fill-mask` support passing these parameters to the tokenizer as `tokenizer_kwargs`,
+e.g. `text_generation_pipeline('lorem ipsum...'*1000, tokenizer_kwargs={'truncation': True, 'max_length': 512})`
+</Tip>
+
 ## Audio
 
 For audio tasks, you'll need a [feature extractor](main_classes/feature_extractor) to prepare your dataset for the model. The feature extractor is designed to extract features from raw audio data, and convert them into tensors.

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -50,6 +50,19 @@ class TextGenerationPipeline(Pipeline):
     The models that this pipeline can use are models that have been trained with an autoregressive language modeling
     objective, which includes the uni-directional models in the library (e.g. gpt2). See the list of available models
     on [huggingface.co/models](https://huggingface.co/models?filter=text-generation).
+
+    <Tip>
+     This pipeline supports tokenizer_kwargs. This is especially useful for prompts that exceed the model's sequence length:
+     ```python
+     >>> from transformers import pipeline
+     >>> generator = pipeline("text-generation", model="bert-base-cased")
+     >>> tokenizer_kwargs = {"truncation": True, "max-length": 512}
+     >>> generator(
+     ...     "This is a long generation prompt." * 100,
+     ...     tokenizer_kwargs=tokenizer_kwargs,
+     ... )
+     ```
+     </Tip>
     """
 
     # Prefix text to help Transformer-XL and XLNet with short prompts as proposed by Aman Rusia

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -104,9 +104,11 @@ class TextGenerationPipeline(Pipeline):
         handle_long_generation=None,
         stop_sequence=None,
         add_special_tokens=False,
+        tokenizer_kwargs=None,
         **generate_kwargs,
     ):
-        preprocess_params = {"add_special_tokens": add_special_tokens}
+        preprocess_params = {"add_special_tokens": add_special_tokens,
+                             "tokenizer_kwargs": tokenizer_kwargs}
         if prefix is not None:
             preprocess_params["prefix"] = prefix
         if prefix:
@@ -208,10 +210,15 @@ class TextGenerationPipeline(Pipeline):
         return super().__call__(text_inputs, **kwargs)
 
     def preprocess(
-        self, prompt_text, prefix="", handle_long_generation=None, add_special_tokens=False, **generate_kwargs
+        self, prompt_text, prefix="", handle_long_generation=None, add_special_tokens=False,
+            tokenizer_kwargs=None, **generate_kwargs
     ):
+        tokenizer_kwargs = tokenizer_kwargs or {}
+        tokenizer_kwargs['padding'] = False
+        tokenizer_kwargs['add_special_tokens'] = add_special_tokens
+
         inputs = self.tokenizer(
-            prefix + prompt_text, padding=False, add_special_tokens=add_special_tokens, return_tensors=self.framework
+            prefix + prompt_text, return_tensors=self.framework, **tokenizer_kwargs
         )
         inputs["prompt_text"] = prompt_text
 

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -56,7 +56,7 @@ class TextGenerationPipeline(Pipeline):
      ```python
      >>> from transformers import pipeline
      >>> generator = pipeline("text-generation", model="bert-base-cased")
-     >>> tokenizer_kwargs = {"truncation": True, "max-length": 512}
+     >>> tokenizer_kwargs = {"truncation": True, "max_length": 512}
      >>> generator(
      ...     "This is a long generation prompt." * 100,
      ...     tokenizer_kwargs=tokenizer_kwargs,

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -107,8 +107,7 @@ class TextGenerationPipeline(Pipeline):
         tokenizer_kwargs=None,
         **generate_kwargs,
     ):
-        preprocess_params = {"add_special_tokens": add_special_tokens,
-                             "tokenizer_kwargs": tokenizer_kwargs}
+        preprocess_params = {"add_special_tokens": add_special_tokens, "tokenizer_kwargs": tokenizer_kwargs}
         if prefix is not None:
             preprocess_params["prefix"] = prefix
         if prefix:
@@ -210,16 +209,19 @@ class TextGenerationPipeline(Pipeline):
         return super().__call__(text_inputs, **kwargs)
 
     def preprocess(
-        self, prompt_text, prefix="", handle_long_generation=None, add_special_tokens=False,
-            tokenizer_kwargs=None, **generate_kwargs
+        self,
+        prompt_text,
+        prefix="",
+        handle_long_generation=None,
+        add_special_tokens=False,
+        tokenizer_kwargs=None,
+        **generate_kwargs,
     ):
         tokenizer_kwargs = tokenizer_kwargs or {}
-        tokenizer_kwargs['padding'] = False
-        tokenizer_kwargs['add_special_tokens'] = add_special_tokens
+        tokenizer_kwargs["padding"] = False
+        tokenizer_kwargs["add_special_tokens"] = add_special_tokens
 
-        inputs = self.tokenizer(
-            prefix + prompt_text, return_tensors=self.framework, **tokenizer_kwargs
-        )
+        inputs = self.tokenizer(prefix + prompt_text, return_tensors=self.framework, **tokenizer_kwargs)
         inputs["prompt_text"] = prompt_text
 
         if handle_long_generation == "hole":

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -57,7 +57,7 @@ class TextGenerationPipeline(Pipeline):
      >>> from transformers import pipeline
      >>> generator = pipeline("text-generation", model="bert-base-cased")
      >>> tokenizer_kwargs = {"truncation": True, "max_length": 512}
-     >>> generator(
+     >>> outputs = generator(
      ...     "This is a long generation prompt." * 100,
      ...     tokenizer_kwargs=tokenizer_kwargs,
      ... )

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -93,9 +93,16 @@ class TextGenerationPipelineTests(unittest.TestCase):
 
         ## -- test tokenizer_kwargs
         test_str = "testing tokenizer kwargs. using truncation must result in a different generation."
-        output_str, output_str_with_truncation = text_generator(test_str, do_sample=False, return_full_text=False)[0]['generated_text'], \
-            text_generator(test_str, do_sample=False, return_full_text=False, tokenizer_kwargs={'truncation': True, 'max_length': 3})[0]['generated_text']
-        assert output_str != output_str_with_truncation # results must be different because one hd truncation
+        output_str, output_str_with_truncation = (
+            text_generator(test_str, do_sample=False, return_full_text=False)[0]["generated_text"],
+            text_generator(
+                test_str,
+                do_sample=False,
+                return_full_text=False,
+                tokenizer_kwargs={"truncation": True, "max_length": 3},
+            )[0]["generated_text"],
+        )
+        assert output_str != output_str_with_truncation  # results must be different because one hd truncation
 
         # -- what is the point of this test? padding is hardcoded False in the pipeline anyway
         text_generator.tokenizer.pad_token_id = text_generator.model.config.eos_token_id
@@ -120,7 +127,6 @@ class TextGenerationPipelineTests(unittest.TestCase):
                 ],
             ],
         )
-
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -90,6 +90,17 @@ class TextGenerationPipelineTests(unittest.TestCase):
                 {"generated_token_ids": ANY(list)},
             ],
         )
+
+        ## -- test tokenizer_kwargs
+        test_str = "testing tokenizer kwargs. using truncation must result in a different generation."
+        output_str, output_str_with_truncation = text_generator(test_str, do_sample=False)[0]['generated_text'], \
+            text_generator(test_str, tokenizer_kwargs={'truncation': True, 'max_length': 3})[0]['generated_text']
+        assert test_str in output_str and test_str in output_str_with_truncation # generation pipeline includes the whole prompt by default
+        assert output_str != output_str_with_truncation # generated results must be different however
+
+
+
+        # -- what is the point of this test? padding is hardcoded False in the pipeline anyway
         text_generator.tokenizer.pad_token_id = text_generator.model.config.eos_token_id
         text_generator.tokenizer.pad_token = "<pad>"
         outputs = text_generator(
@@ -112,6 +123,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
                 ],
             ],
         )
+
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -93,12 +93,9 @@ class TextGenerationPipelineTests(unittest.TestCase):
 
         ## -- test tokenizer_kwargs
         test_str = "testing tokenizer kwargs. using truncation must result in a different generation."
-        output_str, output_str_with_truncation = text_generator(test_str, do_sample=False)[0]['generated_text'], \
-            text_generator(test_str, tokenizer_kwargs={'truncation': True, 'max_length': 3})[0]['generated_text']
-        assert test_str in output_str and test_str in output_str_with_truncation # generation pipeline includes the whole prompt by default
-        assert output_str != output_str_with_truncation # generated results must be different however
-
-
+        output_str, output_str_with_truncation = text_generator(test_str, do_sample=False, return_full_text=False)[0]['generated_text'], \
+            text_generator(test_str, do_sample=False, return_full_text=False, tokenizer_kwargs={'truncation': True, 'max_length': 3})[0]['generated_text']
+        assert output_str != output_str_with_truncation # results must be different because one hd truncation
 
         # -- what is the point of this test? padding is hardcoded False in the pipeline anyway
         text_generator.tokenizer.pad_token_id = text_generator.model.config.eos_token_id


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #25994 for `text-generation` pipelines. The primary use case is to have truncation in the pipeline. This is useful in e.g. RAG when the relevant documents are too long.


## Who can review?

@nmcahill @Narsil @ArthurZucker 

<!--

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
