### PR TITLE
Add Flash Attention 2 to Persimmon

### DIFF
--- a/docs/source/en/perf_infer_gpu_one.md
+++ b/docs/source/en/perf_infer_gpu_one.md
@@ -36,7 +36,7 @@ FlashAttention-2 is experimental and may change considerably in future versions.
 1. additionally parallelizing the attention computation over sequence length
 2. partitioning the work between GPU threads to reduce communication and shared memory reads/writes between them
 
-FlashAttention-2 supports inference with Llama, Mistral, Falcon and Bark models. You can request to add FlashAttention-2 support for another model by opening a GitHub Issue or Pull Request.
+FlashAttention-2 supports inference with Llama, Mistral, Falcon, Persimmon and Bark models. You can request to add FlashAttention-2 support for another model by opening a GitHub Issue or Pull Request.
 
 Before you begin, make sure you have FlashAttention-2 installed (see the [installation](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#installation-and-features) guide for more details about prerequisites):
 
@@ -54,16 +54,16 @@ model_id = "tiiuae/falcon-7b"
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 model = AutoModelForCausalLM.from_pretrained(
-    model_id, 
-    torch_dtype=torch.bfloat16, 
+    model_id,
+    torch_dtype=torch.bfloat16,
     use_flash_attention_2=True,
 )
 ```
 
 <Tip>
 
-FlashAttention-2 can only be used when the model's dtype is  `fp16` or `bf16`, and it only runs on Nvidia GPUs. Make sure to cast your model to the appropriate dtype and load them on a supported device before using FlashAttention-2.
-  
+FlashAttention-2 can only be used when the model's dtype is `fp16` or `bf16`, and it only runs on Nvidia GPUs. Make sure to cast your model to the appropriate dtype and load them on a supported device before using FlashAttention-2.
+
 </Tip>
 
 FlashAttention-2 can be combined with other optimization techniques like quantization to further speedup inference. For example, you can combine FlashAttention-2 with 8-bit or 4-bit quantization:
@@ -77,14 +77,14 @@ tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # load in 8bit
 model = AutoModelForCausalLM.from_pretrained(
-    model_id, 
+    model_id,
     load_in_8bit=True,
     use_flash_attention_2=True,
 )
 
 # load in 4bit
 model = AutoModelForCausalLM.from_pretrained(
-    model_id, 
+    model_id,
     load_in_4bit=True,
     use_flash_attention_2=True,
 )

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -31,7 +31,11 @@ from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
 from ...modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
-from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast, SequenceClassifierOutputWithPast
+from ...modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+    SequenceClassifierOutputWithPast,
+)
 from ...modeling_utils import PreTrainedModel
 from ...utils import (
     add_start_docstrings,
@@ -41,7 +45,6 @@ from ...utils import (
     replace_return_docstrings,
 )
 from .configuration_mistral import MistralConfig
-
 
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_func, flash_attn_varlen_func

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -46,6 +46,7 @@ from ...utils import (
 )
 from .configuration_mistral import MistralConfig
 
+
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_func, flash_attn_varlen_func
     from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input  # noqa

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -82,9 +82,7 @@ class PersimmonRotaryEmbedding(nn.Module):
 
         # Build here to make `torch.jit.trace` work.
         self._set_cos_sin_cache(
-            seq_len=max_position_embeddings,
-            device=self.inv_freq.device,
-            dtype=torch.get_default_dtype(),
+            seq_len=max_position_embeddings, device=self.inv_freq.device, dtype=torch.get_default_dtype()
         )
 
     def _set_cos_sin_cache(self, seq_len, device, dtype):
@@ -112,14 +110,7 @@ class PersimmonRotaryEmbedding(nn.Module):
 class PersimmonLinearScalingRotaryEmbedding(PersimmonRotaryEmbedding):
     """PersimmonRotaryEmbedding extended with linear scaling. Credits to the Reddit user /u/kaiokendev"""
 
-    def __init__(
-        self,
-        dim,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        scaling_factor=1.0,
-    ):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):
         self.scaling_factor = scaling_factor
         super().__init__(dim, max_position_embeddings, base, device)
 
@@ -139,14 +130,7 @@ class PersimmonLinearScalingRotaryEmbedding(PersimmonRotaryEmbedding):
 class PersimmonDynamicNTKScalingRotaryEmbedding(PersimmonRotaryEmbedding):
     """PersimmonRotaryEmbedding extended with Dynamic NTK scaling. Credits to the Reddit users /u/bloc97 and /u/emozilla"""
 
-    def __init__(
-        self,
-        dim,
-        max_position_embeddings=2048,
-        base=10000,
-        device=None,
-        scaling_factor=1.0,
-    ):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):
         self.scaling_factor = scaling_factor
         super().__init__(dim, max_position_embeddings, base, device)
 
@@ -584,17 +568,14 @@ class PersimmonFlashAttention2(PersimmonAttention):
         batch_size, kv_seq_len, num_key_value_heads, head_dim = key_layer.shape
 
         key_layer = index_first_axis(
-            key_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
-            indices_k,
+            key_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim), indices_k
         )
         value_layer = index_first_axis(
-            value_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
-            indices_k,
+            value_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim), indices_k
         )
         if query_length == kv_seq_len:
             query_layer = index_first_axis(
-                query_layer.reshape(batch_size * kv_seq_len, self.num_heads, head_dim),
-                indices_k,
+                query_layer.reshape(batch_size * kv_seq_len, self.num_heads, head_dim), indices_k
             )
             cu_seqlens_q = cu_seqlens_k
             max_seqlen_in_batch_q = max_seqlen_in_batch_k
@@ -1089,12 +1070,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
 
     # Copied from transformers.models.llama.modeling_llama.LlamaForCausalLM.prepare_inputs_for_generation
     def prepare_inputs_for_generation(
-        self,
-        input_ids,
-        past_key_values=None,
-        attention_mask=None,
-        inputs_embeds=None,
-        **kwargs,
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
         if past_key_values is not None:
             past_length = past_key_values[0][0].shape[2]

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -494,7 +494,12 @@ class PersimmonFlashAttention2(PersimmonAttention):
         key_states = key_states.transpose(1, 2)
 
         attn_output = self._flash_attention_forward(
-            query_states, key_states, value_states, None, q_len, dropout=attn_dropout
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            q_len,
+            dropout=attn_dropout,
         )
 
         attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.head_dim)
@@ -578,6 +583,67 @@ class PersimmonFlashAttention2(PersimmonAttention):
             )
 
         return attn_output
+
+    # Copied from transformers.models.llama.modeling_llama.LlamaFlashAttention2._upad_input
+    def _upad_input(
+        self, query_layer, key_layer, value_layer, attention_mask, query_length
+    ):
+        indices_k, cu_seqlens_k, max_seqlen_in_batch_k = _get_unpad_data(attention_mask)
+        batch_size, kv_seq_len, num_key_value_heads, head_dim = key_layer.shape
+
+        key_layer = index_first_axis(
+            key_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+        value_layer = index_first_axis(
+            value_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+        if query_length == kv_seq_len:
+            query_layer = index_first_axis(
+                query_layer.reshape(batch_size * kv_seq_len, self.num_heads, head_dim),
+                indices_k,
+            )
+            cu_seqlens_q = cu_seqlens_k
+            max_seqlen_in_batch_q = max_seqlen_in_batch_k
+            indices_q = indices_k
+        elif query_length == 1:
+            max_seqlen_in_batch_q = 1
+            cu_seqlens_q = torch.arange(
+                batch_size + 1, dtype=torch.int32, device=query_layer.device
+            )  # There is a memcpy here, that is very bad.
+            indices_q = cu_seqlens_q[:-1]
+            query_layer = query_layer.squeeze(1)
+        else:
+            # The -q_len: slice assumes left padding.
+            attention_mask = attention_mask[:, -query_length:]
+            query_layer, indices_q, cu_seqlens_q, max_seqlen_in_batch_q = unpad_input(
+                query_layer, attention_mask
+            )
+
+        return (
+            query_layer,
+            key_layer,
+            value_layer,
+            indices_q,
+            (cu_seqlens_q, cu_seqlens_k),
+            (max_seqlen_in_batch_q, max_seqlen_in_batch_k),
+        )
+
+
+# Copied from transformers.models.llama.modeling_llama._get_unpad_data
+def _get_unpad_data(attention_mask):
+    seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+    max_seqlen_in_batch = seqlens_in_batch.max().item()
+    cu_seqlens = F.pad(
+        torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.torch.int32), (1, 0)
+    )
+    return (
+        indices,
+        cu_seqlens,
+        max_seqlen_in_batch,
+    )
 
 
 class PersimmonDecoderLayer(nn.Module):

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -124,15 +124,7 @@ class PersimmonModelTester:
 
         config = self.get_config()
 
-        return (
-            config,
-            input_ids,
-            token_type_ids,
-            input_mask,
-            sequence_labels,
-            token_labels,
-            choice_labels,
-        )
+        return config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
 
     def get_config(self):
         return PersimmonConfig(
@@ -152,24 +144,14 @@ class PersimmonModelTester:
         )
 
     def create_and_check_model(
-        self,
-        config,
-        input_ids,
-        token_type_ids,
-        input_mask,
-        sequence_labels,
-        token_labels,
-        choice_labels,
+        self, config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
     ):
         model = PersimmonModel(config=config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=input_mask)
         result = model(input_ids)
-        self.parent.assertEqual(
-            result.last_hidden_state.shape,
-            (self.batch_size, self.seq_length, self.hidden_size),
-        )
+        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
 
     def create_and_check_model_as_decoder(
         self,
@@ -199,10 +181,7 @@ class PersimmonModelTester:
             encoder_hidden_states=encoder_hidden_states,
         )
         result = model(input_ids, attention_mask=input_mask)
-        self.parent.assertEqual(
-            result.last_hidden_state.shape,
-            (self.batch_size, self.seq_length, self.hidden_size),
-        )
+        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
 
     def create_and_check_for_causal_lm(
         self,
@@ -352,10 +331,7 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(
-            result.logits.shape,
-            (self.model_tester.batch_size, self.model_tester.num_labels),
-        )
+        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_llama_sequence_classification_model_for_single_label with Llama->Persimmon,llama->persimmon
     def test_persimmon_sequence_classification_model_for_single_label(self):
@@ -369,10 +345,7 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(
-            result.logits.shape,
-            (self.model_tester.batch_size, self.model_tester.num_labels),
-        )
+        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_llama_sequence_classification_model_for_multi_label with Llama->Persimmon,llama->persimmon
     def test_persimmon_sequence_classification_model_for_multi_label(self):
@@ -382,17 +355,13 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         input_ids = input_dict["input_ids"]
         attention_mask = input_ids.ne(1).to(torch_device)
         sequence_labels = ids_tensor(
-            [self.model_tester.batch_size, config.num_labels],
-            self.model_tester.type_sequence_label_size,
+            [self.model_tester.batch_size, config.num_labels], self.model_tester.type_sequence_label_size
         ).to(torch.float)
         model = PersimmonForSequenceClassification(config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(
-            result.logits.shape,
-            (self.model_tester.batch_size, self.model_tester.num_labels),
-        )
+        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
     @unittest.skip("Persimmon buffers include complex numbers, which breaks this test")
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_save_load_fast_init_from_base

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -18,14 +18,18 @@
 import gc
 import unittest
 
+import pytest
 from parameterized import parameterized
 
 from transformers import PersimmonConfig, is_torch_available, set_seed
 from transformers.testing_utils import (
     backend_empty_cache,
+    require_bitsandbytes,
+    require_flash_attn,
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
+    require_torch_gpu,
     slow,
     torch_device,
 )
@@ -34,7 +38,6 @@ from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
 from ...test_pipeline_mixin import PipelineTesterMixin
-
 
 if is_torch_available():
     import torch
@@ -108,19 +111,33 @@ class PersimmonModelTester:
 
         token_type_ids = None
         if self.use_token_type_ids:
-            token_type_ids = ids_tensor([self.batch_size, self.seq_length], self.type_vocab_size)
+            token_type_ids = ids_tensor(
+                [self.batch_size, self.seq_length], self.type_vocab_size
+            )
 
         sequence_labels = None
         token_labels = None
         choice_labels = None
         if self.use_labels:
-            sequence_labels = ids_tensor([self.batch_size], self.type_sequence_label_size)
-            token_labels = ids_tensor([self.batch_size, self.seq_length], self.num_labels)
+            sequence_labels = ids_tensor(
+                [self.batch_size], self.type_sequence_label_size
+            )
+            token_labels = ids_tensor(
+                [self.batch_size, self.seq_length], self.num_labels
+            )
             choice_labels = ids_tensor([self.batch_size], self.num_choices)
 
         config = self.get_config()
 
-        return config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
+        return (
+            config,
+            input_ids,
+            token_type_ids,
+            input_mask,
+            sequence_labels,
+            token_labels,
+            choice_labels,
+        )
 
     def get_config(self):
         return PersimmonConfig(
@@ -140,14 +157,24 @@ class PersimmonModelTester:
         )
 
     def create_and_check_model(
-        self, config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
+        self,
+        config,
+        input_ids,
+        token_type_ids,
+        input_mask,
+        sequence_labels,
+        token_labels,
+        choice_labels,
     ):
         model = PersimmonModel(config=config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=input_mask)
         result = model(input_ids)
-        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
+        self.parent.assertEqual(
+            result.last_hidden_state.shape,
+            (self.batch_size, self.seq_length, self.hidden_size),
+        )
 
     def create_and_check_model_as_decoder(
         self,
@@ -177,7 +204,10 @@ class PersimmonModelTester:
             encoder_hidden_states=encoder_hidden_states,
         )
         result = model(input_ids, attention_mask=input_mask)
-        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
+        self.parent.assertEqual(
+            result.last_hidden_state.shape,
+            (self.batch_size, self.seq_length, self.hidden_size),
+        )
 
     def create_and_check_for_causal_lm(
         self,
@@ -195,7 +225,9 @@ class PersimmonModelTester:
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=input_mask, labels=token_labels)
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.vocab_size))
+        self.parent.assertEqual(
+            result.logits.shape, (self.batch_size, self.seq_length, self.vocab_size)
+        )
 
     def create_and_check_decoder_model_past_large_inputs(
         self,
@@ -251,13 +283,17 @@ class PersimmonModelTester:
 
         # select random slice
         random_slice_idx = ids_tensor((1,), output_from_past.shape[-1]).item()
-        output_from_no_past_slice = output_from_no_past[:, -3:, random_slice_idx].detach()
+        output_from_no_past_slice = output_from_no_past[
+            :, -3:, random_slice_idx
+        ].detach()
         output_from_past_slice = output_from_past[:, :, random_slice_idx].detach()
 
         self.parent.assertTrue(output_from_past_slice.shape[1] == next_tokens.shape[1])
 
         # test that outputs are equal for slice
-        self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
+        self.parent.assertTrue(
+            torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3)
+        )
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
@@ -275,9 +311,13 @@ class PersimmonModelTester:
 
 
 @require_torch
-class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
+class PersimmonModelTest(
+    ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase
+):
     all_model_classes = (
-        (PersimmonModel, PersimmonForCausalLM, PersimmonForSequenceClassification) if is_torch_available() else ()
+        (PersimmonModel, PersimmonForCausalLM, PersimmonForSequenceClassification)
+        if is_torch_available()
+        else ()
     )
     pipeline_model_mapping = (
         {
@@ -291,14 +331,18 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         else {}
     )
 
-    all_generative_model_classes = (PersimmonForCausalLM,) if is_torch_available() else ()
+    all_generative_model_classes = (
+        (PersimmonForCausalLM,) if is_torch_available() else ()
+    )
     test_headmasking = False
     test_pruning = False
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Persimmon
     def setUp(self):
         self.model_tester = PersimmonModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PersimmonConfig, hidden_size=37)
+        self.config_tester = ConfigTester(
+            self, config_class=PersimmonConfig, hidden_size=37
+        )
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config
     def test_config(self):
@@ -322,12 +366,17 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         config.num_labels = 3
         input_ids = input_dict["input_ids"]
         attention_mask = input_ids.ne(1).to(torch_device)
-        sequence_labels = ids_tensor([self.model_tester.batch_size], self.model_tester.type_sequence_label_size)
+        sequence_labels = ids_tensor(
+            [self.model_tester.batch_size], self.model_tester.type_sequence_label_size
+        )
         model = PersimmonForSequenceClassification(config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
+        self.assertEqual(
+            result.logits.shape,
+            (self.model_tester.batch_size, self.model_tester.num_labels),
+        )
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_llama_sequence_classification_model_for_single_label with Llama->Persimmon,llama->persimmon
     def test_persimmon_sequence_classification_model_for_single_label(self):
@@ -336,12 +385,17 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         config.problem_type = "single_label_classification"
         input_ids = input_dict["input_ids"]
         attention_mask = input_ids.ne(1).to(torch_device)
-        sequence_labels = ids_tensor([self.model_tester.batch_size], self.model_tester.type_sequence_label_size)
+        sequence_labels = ids_tensor(
+            [self.model_tester.batch_size], self.model_tester.type_sequence_label_size
+        )
         model = PersimmonForSequenceClassification(config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
+        self.assertEqual(
+            result.logits.shape,
+            (self.model_tester.batch_size, self.model_tester.num_labels),
+        )
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_llama_sequence_classification_model_for_multi_label with Llama->Persimmon,llama->persimmon
     def test_persimmon_sequence_classification_model_for_multi_label(self):
@@ -351,13 +405,17 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         input_ids = input_dict["input_ids"]
         attention_mask = input_ids.ne(1).to(torch_device)
         sequence_labels = ids_tensor(
-            [self.model_tester.batch_size, config.num_labels], self.model_tester.type_sequence_label_size
+            [self.model_tester.batch_size, config.num_labels],
+            self.model_tester.type_sequence_label_size,
         ).to(torch.float)
         model = PersimmonForSequenceClassification(config)
         model.to(torch_device)
         model.eval()
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
-        self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
+        self.assertEqual(
+            result.logits.shape,
+            (self.model_tester.batch_size, self.model_tester.num_labels),
+        )
 
     @unittest.skip("Persimmon buffers include complex numbers, which breaks this test")
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_save_load_fast_init_from_base
@@ -369,16 +427,22 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_model_rope_scaling(self, scaling_type):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         short_input = ids_tensor([1, 10], config.vocab_size)
-        long_input = ids_tensor([1, int(config.max_position_embeddings * 1.5)], config.vocab_size)
+        long_input = ids_tensor(
+            [1, int(config.max_position_embeddings * 1.5)], config.vocab_size
+        )
 
-        set_seed(42)  # Fixed seed at init time so the two models get the same random weights
+        set_seed(
+            42
+        )  # Fixed seed at init time so the two models get the same random weights
         original_model = PersimmonModel(config)
         original_model.to(torch_device)
         original_model.eval()
         original_short_output = original_model(short_input).last_hidden_state
         original_long_output = original_model(long_input).last_hidden_state
 
-        set_seed(42)  # Fixed seed at init time so the two models get the same random weights
+        set_seed(
+            42
+        )  # Fixed seed at init time so the two models get the same random weights
         config.rope_scaling = {"type": scaling_type, "factor": 10.0}
         scaled_model = PersimmonModel(config)
         scaled_model.to(torch_device)
@@ -389,12 +453,75 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         # Dynamic scaling does not change the RoPE embeddings until it receives an input longer than the original
         # maximum sequence length, so the outputs for the short input should match.
         if scaling_type == "dynamic":
-            self.assertTrue(torch.allclose(original_short_output, scaled_short_output, atol=1e-5))
+            self.assertTrue(
+                torch.allclose(original_short_output, scaled_short_output, atol=1e-5)
+            )
         else:
-            self.assertFalse(torch.allclose(original_short_output, scaled_short_output, atol=1e-5))
+            self.assertFalse(
+                torch.allclose(original_short_output, scaled_short_output, atol=1e-5)
+            )
 
         # The output should be different for long inputs
-        self.assertFalse(torch.allclose(original_long_output, scaled_long_output, atol=1e-5))
+        self.assertFalse(
+            torch.allclose(original_long_output, scaled_long_output, atol=1e-5)
+        )
+
+    @require_flash_attn
+    @require_torch_gpu
+    @require_bitsandbytes
+    @pytest.mark.flash_attn_test
+    @pytest.mark.skip("Persimmon configs do not have a pad nor eos token")
+    def test_flash_attn_2_generate_padding_right(self):
+        """
+        Overwritting the common test as the test is flaky on tiny models
+        """
+
+        model_id = "adept/persimmon-8b-chat"
+
+        _, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        dummy_input = inputs_dict["input_ids"]
+        if dummy_input.dtype in [torch.float32, torch.bfloat16]:
+            dummy_input = dummy_input.to(torch.float16)
+
+        dummy_attention_mask = inputs_dict.get(
+            "attention_mask", torch.ones_like(dummy_input)
+        )
+        # make sure we do right padding
+        dummy_attention_mask[:, :-1] = 1
+        dummy_attention_mask[:, -1:] = 0
+
+        model = PersimmonForCausalLM.from_pretrained(
+            model_id,
+            load_in_4bit=True,
+            device_map={"": 0},
+        )
+
+        out = model.generate(
+            dummy_input,
+            attention_mask=dummy_attention_mask,
+            max_new_tokens=1,
+            do_sample=False,
+        )
+
+        model = PersimmonForCausalLM.from_pretrained(
+            model_id,
+            load_in_4bit=True,
+            device_map={"": 0},
+            use_flash_attention_2=True,
+        )
+
+        out_fa = model.generate(
+            dummy_input,
+            attention_mask=dummy_attention_mask,
+            max_new_tokens=1,
+            do_sample=False,
+        )
+
+        print(out)
+        print(out_fa)
+
+        self.assertTrue(torch.equal(out, out_fa))
 
 
 @require_torch
@@ -403,22 +530,40 @@ class PersimmonIntegrationTest(unittest.TestCase):
     def test_model_8b_chat_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
         model = PersimmonForCausalLM.from_pretrained(
-            "adept/persimmon-8b-chat", load_in_8bit=True, device_map={"": 0}, torch_dtype=torch.float16
+            "adept/persimmon-8b-chat",
+            load_in_8bit=True,
+            device_map={"": 0},
+            torch_dtype=torch.float16,
         )
         out = model(torch.tensor([input_ids], device=torch_device)).logits
 
         EXPECTED_MEAN = torch.tensor(
-            [[-11.4726, -11.1495, -11.2694, -11.2223, -10.9452, -11.0663, -11.0031, -11.1028]]
+            [
+                [
+                    -11.4726,
+                    -11.1495,
+                    -11.2694,
+                    -11.2223,
+                    -10.9452,
+                    -11.0663,
+                    -11.0031,
+                    -11.1028,
+                ]
+            ]
         )
         # change dtype to `torch.float32` before calling `mean` to avoid `nan` values
-        torch.testing.assert_close(out.cpu().to(torch.float32).mean(-1), EXPECTED_MEAN, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(
+            out.cpu().to(torch.float32).mean(-1), EXPECTED_MEAN, atol=1e-4, rtol=1e-4
+        )
         # fmt: off
         EXPECTED_SLICE = torch.tensor(
             [-16.9062, -16.9062, -16.9062, -16.9062, -16.8906, -16.9062, -16.9531, -16.9062, -16.9062, -16.9062, -16.9531, -16.9062, -16.9531, -16.9062, -16.9062, -16.9062, -16.9062, -16.9062, -16.9531, -16.9062, -16.9062, -16.9062, -16.9062, -16.9062, -16.9062, -16.9531, -16.9062, -16.9531, -16.9062, -16.9062],
             dtype=torch.float16
         )
         # fmt: on
-        torch.testing.assert_close(out.cpu()[0, 0, :30], EXPECTED_SLICE, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(
+            out.cpu()[0, 0, :30], EXPECTED_SLICE, atol=1e-5, rtol=1e-5
+        )
 
         backend_empty_cache(torch_device)
         del model
@@ -430,10 +575,15 @@ class PersimmonIntegrationTest(unittest.TestCase):
     def test_model_8b_chat_greedy_generation(self):
         EXPECTED_TEXT_COMPLETION = """human: Simply put, the theory of relativity states that?\n\nadept: The theory of relativity states that the laws of physics are the same for all observers, regardless of their relative motion."""
         prompt = "human: Simply put, the theory of relativity states that?\n\nadept:"
-        tokenizer = AutoTokenizer.from_pretrained("adept/persimmon-8b-chat", use_fast=False)
+        tokenizer = AutoTokenizer.from_pretrained(
+            "adept/persimmon-8b-chat", use_fast=False
+        )
         input_ids = tokenizer.encode(prompt, return_tensors="pt").to(torch_device)
         model = PersimmonForCausalLM.from_pretrained(
-            "adept/persimmon-8b-chat", load_in_8bit=True, device_map={"": 0}, torch_dtype=torch.float16
+            "adept/persimmon-8b-chat",
+            load_in_8bit=True,
+            device_map={"": 0},
+            torch_dtype=torch.float16,
         )
 
         # greedy generation outputs

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -85,7 +85,6 @@ from transformers.utils import (
 )
 from transformers.utils.generic import ModelOutput
 
-
 if is_accelerate_available():
     from accelerate.utils import compute_module_sizes
 
@@ -119,7 +118,12 @@ if is_torch_fx_available():
 def _config_zero_init(config):
     configs_no_init = copy.deepcopy(config)
     for key in configs_no_init.__dict__.keys():
-        if "_range" in key or "_std" in key or "initializer_factor" in key or "layer_scale" in key:
+        if (
+            "_range" in key
+            or "_std" in key
+            or "initializer_factor" in key
+            or "layer_scale" in key
+        ):
             setattr(configs_no_init, key, 1e-10)
         if isinstance(getattr(configs_no_init, key, None), PretrainedConfig):
             no_init_subconfig = _config_zero_init(getattr(configs_no_init, key))
@@ -174,7 +178,9 @@ class ModelTesterMixin:
         inputs_dict = copy.deepcopy(inputs_dict)
         if model_class.__name__ in get_values(MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES):
             inputs_dict = {
-                k: v.unsqueeze(1).expand(-1, self.model_tester.num_choices, -1).contiguous()
+                k: v.unsqueeze(1)
+                .expand(-1, self.model_tester.num_choices, -1)
+                .contiguous()
                 if isinstance(v, torch.Tensor) and v.ndim > 1
                 else v
                 for k, v in inputs_dict.items()
@@ -183,8 +189,12 @@ class ModelTesterMixin:
             inputs_dict.pop("attention_mask")
 
         if return_labels:
-            if model_class.__name__ in get_values(MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES):
-                inputs_dict["labels"] = torch.ones(self.model_tester.batch_size, dtype=torch.long, device=torch_device)
+            if model_class.__name__ in get_values(
+                MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES
+            ):
+                inputs_dict["labels"] = torch.ones(
+                    self.model_tester.batch_size, dtype=torch.long, device=torch_device
+                )
             elif model_class.__name__ in [
                 *get_values(MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES),
                 *get_values(MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES),
@@ -213,15 +223,27 @@ class ModelTesterMixin:
                 *get_values(MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES),
             ]:
                 inputs_dict["labels"] = torch.zeros(
-                    (self.model_tester.batch_size, self.model_tester.seq_length), dtype=torch.long, device=torch_device
+                    (self.model_tester.batch_size, self.model_tester.seq_length),
+                    dtype=torch.long,
+                    device=torch_device,
                 )
-            elif model_class.__name__ in get_values(MODEL_FOR_MASKED_IMAGE_MODELING_MAPPING_NAMES):
-                num_patches = self.model_tester.image_size // self.model_tester.patch_size
+            elif model_class.__name__ in get_values(
+                MODEL_FOR_MASKED_IMAGE_MODELING_MAPPING_NAMES
+            ):
+                num_patches = (
+                    self.model_tester.image_size // self.model_tester.patch_size
+                )
                 inputs_dict["bool_masked_pos"] = torch.zeros(
-                    (self.model_tester.batch_size, num_patches**2), dtype=torch.long, device=torch_device
+                    (self.model_tester.batch_size, num_patches**2),
+                    dtype=torch.long,
+                    device=torch_device,
                 )
-            elif model_class.__name__ in get_values(MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING_NAMES):
-                batch_size, num_channels, height, width = inputs_dict["pixel_values"].shape
+            elif model_class.__name__ in get_values(
+                MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING_NAMES
+            ):
+                batch_size, num_channels, height, width = inputs_dict[
+                    "pixel_values"
+                ].shape
                 inputs_dict["labels"] = torch.zeros(
                     [self.model_tester.batch_size, height, width], device=torch_device
                 ).long()
@@ -254,13 +276,16 @@ class ModelTesterMixin:
                 # the config file (and the generation config file, if it can generate) should be saved
                 self.assertTrue(os.path.exists(os.path.join(tmpdirname, CONFIG_NAME)))
                 self.assertEqual(
-                    model.can_generate(), os.path.exists(os.path.join(tmpdirname, GENERATION_CONFIG_NAME))
+                    model.can_generate(),
+                    os.path.exists(os.path.join(tmpdirname, GENERATION_CONFIG_NAME)),
                 )
 
                 model = model_class.from_pretrained(tmpdirname)
                 model.to(torch_device)
                 with torch.no_grad():
-                    second = model(**self._prepare_for_class(inputs_dict, model_class))[0]
+                    second = model(**self._prepare_for_class(inputs_dict, model_class))[
+                        0
+                    ]
 
             if isinstance(first, tuple) and isinstance(second, tuple):
                 for tensor1, tensor2 in zip(first, second):
@@ -290,10 +315,14 @@ class ModelTesterMixin:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
 
-                model = model_class.from_pretrained(tmpdirname, torch_dtype=torch.float16)
+                model = model_class.from_pretrained(
+                    tmpdirname, torch_dtype=torch.float16
+                )
 
                 for name, param in model.named_parameters():
-                    if any(n in model_class._keep_in_fp32_modules for n in name.split(".")):
+                    if any(
+                        n in model_class._keep_in_fp32_modules for n in name.split(".")
+                    ):
                         self.assertTrue(param.dtype == torch.float32)
                     else:
                         self.assertTrue(param.dtype == torch.float16, name)
@@ -309,7 +338,9 @@ class ModelTesterMixin:
 
             # check the keys are in the original state_dict
             for k in _keys_to_ignore_on_save:
-                self.assertIn(k, model.state_dict().keys(), "\n".join(model.state_dict().keys()))
+                self.assertIn(
+                    k, model.state_dict().keys(), "\n".join(model.state_dict().keys())
+                )
 
             # check that certain keys didn't get saved with the model
             with tempfile.TemporaryDirectory() as tmpdirname:
@@ -318,7 +349,9 @@ class ModelTesterMixin:
                 state_dict_saved = safe_load_file(output_model_file)
 
                 for k in _keys_to_ignore_on_save:
-                    self.assertNotIn(k, state_dict_saved.keys(), "\n".join(state_dict_saved.keys()))
+                    self.assertNotIn(
+                        k, state_dict_saved.keys(), "\n".join(state_dict_saved.keys())
+                    )
 
                 # Test we can load the state dict in the model, necessary for the checkpointing API in Trainer.
                 load_result = model.load_state_dict(state_dict_saved, strict=False)
@@ -327,7 +360,10 @@ class ModelTesterMixin:
                 if hasattr(model, "_tied_weights_keys"):
                     keys_to_ignore.update(set(model._tied_weights_keys))
 
-                self.assertTrue(len(load_result.missing_keys) == 0 or set(load_result.missing_keys) == keys_to_ignore)
+                self.assertTrue(
+                    len(load_result.missing_keys) == 0
+                    or set(load_result.missing_keys) == keys_to_ignore
+                )
                 self.assertTrue(len(load_result.unexpected_keys) == 0)
 
     def test_gradient_checkpointing_backward_compatibility(self):
@@ -360,7 +396,8 @@ class ModelTesterMixin:
             for n, m in model.named_modules():
                 if hasattr(m, "gradient_checkpointing"):
                     self.assertTrue(
-                        m.gradient_checkpointing, f"Module {n} does not have gradient_checkpointing set to True"
+                        m.gradient_checkpointing,
+                        f"Module {n} does not have gradient_checkpointing set to True",
                     )
 
             # check disable works
@@ -371,7 +408,8 @@ class ModelTesterMixin:
             for n, m in model.named_modules():
                 if hasattr(m, "gradient_checkpointing"):
                     self.assertFalse(
-                        m.gradient_checkpointing, f"Module {n} does not have gradient_checkpointing set to False"
+                        m.gradient_checkpointing,
+                        f"Module {n} does not have gradient_checkpointing set to False",
                     )
 
     def test_save_load_fast_init_from_base(self):
@@ -416,14 +454,30 @@ class ModelTesterMixin:
                 torch.save(state_dict, os.path.join(tmpdirname, "pytorch_model.bin"))
 
                 model_fast_init = model_class_copy.from_pretrained(tmpdirname)
-                model_slow_init = model_class_copy.from_pretrained(tmpdirname, _fast_init=False)
+                model_slow_init = model_class_copy.from_pretrained(
+                    tmpdirname, _fast_init=False
+                )
                 # Before we test anything
 
                 for key in model_fast_init.state_dict().keys():
                     if isinstance(model_slow_init.state_dict()[key], torch.BoolTensor):
-                        max_diff = (model_slow_init.state_dict()[key] ^ model_fast_init.state_dict()[key]).sum().item()
+                        max_diff = (
+                            (
+                                model_slow_init.state_dict()[key]
+                                ^ model_fast_init.state_dict()[key]
+                            )
+                            .sum()
+                            .item()
+                        )
                     else:
-                        max_diff = (model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key]).sum().item()
+                        max_diff = (
+                            (
+                                model_slow_init.state_dict()[key]
+                                - model_fast_init.state_dict()[key]
+                            )
+                            .sum()
+                            .item()
+                        )
                     self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
     def test_save_load_fast_init_to_base(self):
@@ -468,16 +522,22 @@ class ModelTesterMixin:
                 torch.save(state_dict, os.path.join(tmpdirname, "pytorch_model.bin"))
 
                 model_fast_init = base_class_copy.from_pretrained(tmpdirname)
-                model_slow_init = base_class_copy.from_pretrained(tmpdirname, _fast_init=False)
+                model_slow_init = base_class_copy.from_pretrained(
+                    tmpdirname, _fast_init=False
+                )
 
                 for key in model_fast_init.state_dict().keys():
                     if isinstance(model_slow_init.state_dict()[key], torch.BoolTensor):
                         max_diff = torch.max(
-                            model_slow_init.state_dict()[key] ^ model_fast_init.state_dict()[key]
+                            model_slow_init.state_dict()[key]
+                            ^ model_fast_init.state_dict()[key]
                         ).item()
                     else:
                         max_diff = torch.max(
-                            torch.abs(model_slow_init.state_dict()[key] - model_fast_init.state_dict()[key])
+                            torch.abs(
+                                model_slow_init.state_dict()[key]
+                                - model_fast_init.state_dict()[key]
+                            )
                         ).item()
                     self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
@@ -537,11 +597,20 @@ class ModelTesterMixin:
                     "decoder_attention_mask",
                 ]
                 expected_arg_names.extend(
-                    ["head_mask", "decoder_head_mask", "cross_attn_head_mask", "encoder_outputs"]
-                    if "head_mask" and "decoder_head_mask" and "cross_attn_head_mask" in arg_names
+                    [
+                        "head_mask",
+                        "decoder_head_mask",
+                        "cross_attn_head_mask",
+                        "encoder_outputs",
+                    ]
+                    if "head_mask"
+                    and "decoder_head_mask"
+                    and "cross_attn_head_mask" in arg_names
                     else ["encoder_outputs"]
                 )
-                self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
+                self.assertListEqual(
+                    arg_names[: len(expected_arg_names)], expected_arg_names
+                )
             else:
                 expected_arg_names = ["input_ids"]
                 self.assertListEqual(arg_names[:1], expected_arg_names)
@@ -551,22 +620,33 @@ class ModelTesterMixin:
             return
 
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             config.use_cache = False
             config.return_dict = True
 
             if (
                 model_class.__name__
-                in [*get_values(MODEL_MAPPING_NAMES), *get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)]
+                in [
+                    *get_values(MODEL_MAPPING_NAMES),
+                    *get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES),
+                ]
                 or not model_class.supports_gradient_checkpointing
             ):
                 continue
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             model.to(torch_device)
-            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gradient_checkpointing_kwargs)
+            model.gradient_checkpointing_enable(
+                gradient_checkpointing_kwargs=gradient_checkpointing_kwargs
+            )
             model.train()
 
             # unfreeze additional layers
@@ -575,21 +655,29 @@ class ModelTesterMixin:
 
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
-            inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+            inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
             loss = model(**inputs).loss
             loss.backward()
             optimizer.step()
 
             for k, v in model.named_parameters():
                 if v.requires_grad:
-                    self.assertTrue(v.grad is not None, f"{k} in {model_class.__name__} has no gradient!")
+                    self.assertTrue(
+                        v.grad is not None,
+                        f"{k} in {model_class.__name__} has no gradient!",
+                    )
 
     def test_training(self):
         if not self.model_tester.is_training:
             return
 
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             config.return_dict = True
 
             if model_class.__name__ in [
@@ -601,7 +689,9 @@ class ModelTesterMixin:
             model = model_class(config)
             model.to(torch_device)
             model.train()
-            inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+            inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
             loss = model(**inputs).loss
             loss.backward()
 
@@ -612,12 +702,16 @@ class ModelTesterMixin:
     def test_training_gradient_checkpointing_use_reentrant(self):
         # Scenario - 2 with `use_reentrant=True` - this is the default value that is used in pytorch's
         # torch.utils.checkpoint.checkpoint
-        self.check_training_gradient_checkpointing(gradient_checkpointing_kwargs={"use_reentrant": True})
+        self.check_training_gradient_checkpointing(
+            gradient_checkpointing_kwargs={"use_reentrant": True}
+        )
 
     def test_training_gradient_checkpointing_use_reentrant_false(self):
         # Scenario - 3 with `use_reentrant=False` pytorch suggests users to use this value for
         # future releases: https://pytorch.org/docs/stable/checkpoint.html
-        self.check_training_gradient_checkpointing(gradient_checkpointing_kwargs={"use_reentrant": False})
+        self.check_training_gradient_checkpointing(
+            gradient_checkpointing_kwargs={"use_reentrant": False}
+        )
 
     def test_attention_outputs(self):
         if not self.has_attentions:
@@ -629,8 +723,12 @@ class ModelTesterMixin:
         seq_len = getattr(self.model_tester, "seq_length", None)
         decoder_seq_length = getattr(self.model_tester, "decoder_seq_length", seq_len)
         encoder_seq_length = getattr(self.model_tester, "encoder_seq_length", seq_len)
-        decoder_key_length = getattr(self.model_tester, "decoder_key_length", decoder_seq_length)
-        encoder_key_length = getattr(self.model_tester, "key_length", encoder_seq_length)
+        decoder_key_length = getattr(
+            self.model_tester, "decoder_key_length", decoder_seq_length
+        )
+        encoder_key_length = getattr(
+            self.model_tester, "key_length", encoder_seq_length
+        )
         chunk_length = getattr(self.model_tester, "chunk_length", None)
         if chunk_length is not None and hasattr(self.model_tester, "num_hashes"):
             encoder_seq_length = encoder_seq_length * self.model_tester.num_hashes
@@ -644,7 +742,11 @@ class ModelTesterMixin:
             model.eval()
             with torch.no_grad():
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
-            attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
+            attentions = (
+                outputs.encoder_attentions
+                if config.is_encoder_decoder
+                else outputs.attentions
+            )
             self.assertEqual(len(attentions), self.model_tester.num_hidden_layers)
 
             # check that output_attentions also work using config
@@ -655,18 +757,31 @@ class ModelTesterMixin:
             model.eval()
             with torch.no_grad():
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
-            attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
+            attentions = (
+                outputs.encoder_attentions
+                if config.is_encoder_decoder
+                else outputs.attentions
+            )
             self.assertEqual(len(attentions), self.model_tester.num_hidden_layers)
 
             if chunk_length is not None:
                 self.assertListEqual(
                     list(attentions[0].shape[-4:]),
-                    [self.model_tester.num_attention_heads, encoder_seq_length, chunk_length, encoder_key_length],
+                    [
+                        self.model_tester.num_attention_heads,
+                        encoder_seq_length,
+                        chunk_length,
+                        encoder_key_length,
+                    ],
                 )
             else:
                 self.assertListEqual(
                     list(attentions[0].shape[-3:]),
-                    [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
+                    [
+                        self.model_tester.num_attention_heads,
+                        encoder_seq_length,
+                        encoder_key_length,
+                    ],
                 )
             out_len = len(outputs)
 
@@ -681,7 +796,9 @@ class ModelTesterMixin:
                     *get_values(MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES),
                     *get_values(MODEL_FOR_DOCUMENT_QUESTION_ANSWERING_MAPPING_NAMES),
                 ]:
-                    correct_outlen += 1  # start_logits and end_logits instead of only 1 output
+                    correct_outlen += (
+                        1  # start_logits and end_logits instead of only 1 output
+                    )
                 if "past_key_values" in outputs:
                     correct_outlen += 1  # past_key_values have been returned
 
@@ -690,16 +807,24 @@ class ModelTesterMixin:
                 # decoder attentions
                 decoder_attentions = outputs.decoder_attentions
                 self.assertIsInstance(decoder_attentions, (list, tuple))
-                self.assertEqual(len(decoder_attentions), self.model_tester.num_hidden_layers)
+                self.assertEqual(
+                    len(decoder_attentions), self.model_tester.num_hidden_layers
+                )
                 self.assertListEqual(
                     list(decoder_attentions[0].shape[-3:]),
-                    [self.model_tester.num_attention_heads, decoder_seq_length, decoder_key_length],
+                    [
+                        self.model_tester.num_attention_heads,
+                        decoder_seq_length,
+                        decoder_key_length,
+                    ],
                 )
 
                 # cross attentions
                 cross_attentions = outputs.cross_attentions
                 self.assertIsInstance(cross_attentions, (list, tuple))
-                self.assertEqual(len(cross_attentions), self.model_tester.num_hidden_layers)
+                self.assertEqual(
+                    len(cross_attentions), self.model_tester.num_hidden_layers
+                )
                 self.assertListEqual(
                     list(cross_attentions[0].shape[-3:]),
                     [
@@ -726,18 +851,31 @@ class ModelTesterMixin:
                 added_hidden_states = 1
             self.assertEqual(out_len + added_hidden_states, len(outputs))
 
-            self_attentions = outputs.encoder_attentions if config.is_encoder_decoder else outputs.attentions
+            self_attentions = (
+                outputs.encoder_attentions
+                if config.is_encoder_decoder
+                else outputs.attentions
+            )
 
             self.assertEqual(len(self_attentions), self.model_tester.num_hidden_layers)
             if chunk_length is not None:
                 self.assertListEqual(
                     list(self_attentions[0].shape[-4:]),
-                    [self.model_tester.num_attention_heads, encoder_seq_length, chunk_length, encoder_key_length],
+                    [
+                        self.model_tester.num_attention_heads,
+                        encoder_seq_length,
+                        chunk_length,
+                        encoder_key_length,
+                    ],
                 )
             else:
                 self.assertListEqual(
                     list(self_attentions[0].shape[-3:]),
-                    [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
+                    [
+                        self.model_tester.num_attention_heads,
+                        encoder_seq_length,
+                        encoder_key_length,
+                    ],
                 )
 
     @slow
@@ -760,7 +898,9 @@ class ModelTesterMixin:
     # This is copied from `torch/testing/_internal/jit_utils.py::clear_class_registry`
     def clear_torch_jit_class_registry(self):
         torch._C._jit_clear_class_registry()
-        torch.jit._recursive.concrete_type_store = torch.jit._recursive.ConcreteTypeStore()
+        torch.jit._recursive.concrete_type_store = (
+            torch.jit._recursive.ConcreteTypeStore()
+        )
         # torch 1.8 has no `_clear_class_state` in `torch.jit._state`
         if hasattr(torch.jit._state, "_clear_class_state"):
             torch.jit._state._clear_class_state()
@@ -786,11 +926,24 @@ class ModelTesterMixin:
                     attention_mask = inputs["attention_mask"]
                     decoder_input_ids = inputs["decoder_input_ids"]
                     decoder_attention_mask = inputs["decoder_attention_mask"]
-                    model(main_input, attention_mask, decoder_input_ids, decoder_attention_mask)
-                    traced_model = torch.jit.trace(
-                        model, (main_input, attention_mask, decoder_input_ids, decoder_attention_mask)
+                    model(
+                        main_input,
+                        attention_mask,
+                        decoder_input_ids,
+                        decoder_attention_mask,
                     )
-                elif "bbox" in inputs and "image" in inputs:  # LayoutLMv2 requires additional inputs
+                    traced_model = torch.jit.trace(
+                        model,
+                        (
+                            main_input,
+                            attention_mask,
+                            decoder_input_ids,
+                            decoder_attention_mask,
+                        ),
+                    )
+                elif (
+                    "bbox" in inputs and "image" in inputs
+                ):  # LayoutLMv2 requires additional inputs
                     input_ids = inputs["input_ids"]
                     bbox = inputs["bbox"]
                     image = inputs["image"].tensor
@@ -840,10 +993,14 @@ class ModelTesterMixin:
                     non_persistent_buffers[key] = loaded_model_state_dict[key]
 
             loaded_model_state_dict = {
-                key: value for key, value in loaded_model_state_dict.items() if key not in non_persistent_buffers
+                key: value
+                for key, value in loaded_model_state_dict.items()
+                if key not in non_persistent_buffers
             }
 
-            self.assertEqual(set(model_state_dict.keys()), set(loaded_model_state_dict.keys()))
+            self.assertEqual(
+                set(model_state_dict.keys()), set(loaded_model_state_dict.keys())
+            )
 
             model_buffers = list(model.buffers())
             for non_persistent_buffer in non_persistent_buffers.values():
@@ -877,7 +1034,9 @@ class ModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         self._create_and_check_torch_fx_tracing(config, inputs_dict, output_loss=True)
 
-    def _create_and_check_torch_fx_tracing(self, config, inputs_dict, output_loss=False):
+    def _create_and_check_torch_fx_tracing(
+        self, config, inputs_dict, output_loss=False
+    ):
         if not is_torch_fx_available() or not self.fx_compatible:
             return
 
@@ -888,7 +1047,9 @@ class ModelTesterMixin:
             model = model_class(config=configs_no_init)
             model.to(torch_device)
             model.eval()
-            inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=output_loss)
+            inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=output_loss
+            )
 
             try:
                 if model.config.is_encoder_decoder:
@@ -905,7 +1066,9 @@ class ModelTesterMixin:
                     if labels is not None:
                         input_names.append("labels")
 
-                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+                    filtered_inputs = {
+                        k: v for (k, v) in inputs.items() if k in input_names
+                    }
                     input_names = list(filtered_inputs.keys())
 
                     model_output = model(**filtered_inputs)
@@ -935,11 +1098,16 @@ class ModelTesterMixin:
                     if end_positions is not None:
                         input_names.append("end_positions")
 
-                    filtered_inputs = {k: v for (k, v) in inputs.items() if k in input_names}
+                    filtered_inputs = {
+                        k: v for (k, v) in inputs.items() if k in input_names
+                    }
                     input_names = list(filtered_inputs.keys())
 
-                    if model.__class__.__name__ in set(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES.values()) and (
-                        not hasattr(model.config, "problem_type") or model.config.problem_type is None
+                    if model.__class__.__name__ in set(
+                        MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES.values()
+                    ) and (
+                        not hasattr(model.config, "problem_type")
+                        or model.config.problem_type is None
                     ):
                         model.config.problem_type = "single_label_classification"
 
@@ -1026,7 +1194,9 @@ class ModelTesterMixin:
             if model.config.is_encoder_decoder:
                 signature = inspect.signature(model.forward)
                 arg_names = [*signature.parameters.keys()]
-                if "decoder_head_mask" in arg_names:  # necessary diferentiation because of T5 model
+                if (
+                    "decoder_head_mask" in arg_names
+                ):  # necessary diferentiation because of T5 model
                     inputs["decoder_head_mask"] = head_mask
                 if "cross_attn_head_mask" in arg_names:
                     inputs["cross_attn_head_mask"] = head_mask
@@ -1039,7 +1209,9 @@ class ModelTesterMixin:
             multihead_outputs = head_mask.grad
 
             self.assertIsNotNone(multihead_outputs)
-            self.assertEqual(len(multihead_outputs), self.model_tester.num_hidden_layers)
+            self.assertEqual(
+                len(multihead_outputs), self.model_tester.num_hidden_layers
+            )
 
             def check_attentions_validity(attentions):
                 # Remove Nan
@@ -1051,12 +1223,24 @@ class ModelTesterMixin:
                     t.masked_fill(torch.isnan(t), 0.0) for t in attentions
                 ]  # remove them (the test is less complete)
 
-                self.assertAlmostEqual(attentions[0][..., 0, :, :].flatten().sum().item(), 0.0)
-                self.assertNotEqual(attentions[0][..., -1, :, :].flatten().sum().item(), 0.0)
-                if len(attentions) > 2:  # encoder-decoder models have only 2 layers in each module
-                    self.assertNotEqual(attentions[1][..., 0, :, :].flatten().sum().item(), 0.0)
-                self.assertAlmostEqual(attentions[-1][..., -2, :, :].flatten().sum().item(), 0.0)
-                self.assertNotEqual(attentions[-1][..., -1, :, :].flatten().sum().item(), 0.0)
+                self.assertAlmostEqual(
+                    attentions[0][..., 0, :, :].flatten().sum().item(), 0.0
+                )
+                self.assertNotEqual(
+                    attentions[0][..., -1, :, :].flatten().sum().item(), 0.0
+                )
+                if (
+                    len(attentions) > 2
+                ):  # encoder-decoder models have only 2 layers in each module
+                    self.assertNotEqual(
+                        attentions[1][..., 0, :, :].flatten().sum().item(), 0.0
+                    )
+                self.assertAlmostEqual(
+                    attentions[-1][..., -2, :, :].flatten().sum().item(), 0.0
+                )
+                self.assertNotEqual(
+                    attentions[-1][..., -1, :, :].flatten().sum().item(), 0.0
+                )
 
             if model.config.is_encoder_decoder:
                 check_attentions_validity(outputs.encoder_attentions)
@@ -1096,7 +1280,9 @@ class ModelTesterMixin:
             self.assertEqual(attentions[0].shape[-3], 1)
             # TODO: To have this check, we will need at least 3 layers. Do we really need it?
             # self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads)
-            self.assertEqual(attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1)
+            self.assertEqual(
+                attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1
+            )
 
     def test_head_pruning_save_load_from_pretrained(self):
         if not self.test_pruning:
@@ -1133,7 +1319,9 @@ class ModelTesterMixin:
             self.assertEqual(attentions[0].shape[-3], 1)
             # TODO: To have this check, we will need at least 3 layers. Do we really need it?
             # self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads)
-            self.assertEqual(attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1)
+            self.assertEqual(
+                attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1
+            )
 
     def test_head_pruning_save_load_from_config_init(self):
         if not self.test_pruning:
@@ -1168,7 +1356,9 @@ class ModelTesterMixin:
             self.assertEqual(attentions[0].shape[-3], 1)
             # TODO: To have this check, we will need at least 3 layers. Do we really need it?
             # self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads)
-            self.assertEqual(attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1)
+            self.assertEqual(
+                attentions[-1].shape[-3], self.model_tester.num_attention_heads - 1
+            )
 
     def test_head_pruning_integration(self):
         if not self.test_pruning:
@@ -1197,8 +1387,12 @@ class ModelTesterMixin:
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
             attentions = outputs[-1]
 
-            self.assertEqual(attentions[0].shape[-3], self.model_tester.num_attention_heads - 0)
-            self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads - 2)
+            self.assertEqual(
+                attentions[0].shape[-3], self.model_tester.num_attention_heads - 0
+            )
+            self.assertEqual(
+                attentions[1].shape[-3], self.model_tester.num_attention_heads - 2
+            )
 
             with tempfile.TemporaryDirectory() as temp_dir_name:
                 model.save_pretrained(temp_dir_name)
@@ -1209,8 +1403,12 @@ class ModelTesterMixin:
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
             attentions = outputs[-1]
 
-            self.assertEqual(attentions[0].shape[-3], self.model_tester.num_attention_heads - 0)
-            self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads - 2)
+            self.assertEqual(
+                attentions[0].shape[-3], self.model_tester.num_attention_heads - 0
+            )
+            self.assertEqual(
+                attentions[1].shape[-3], self.model_tester.num_attention_heads - 2
+            )
 
             heads_to_prune = {0: [0], 1: [1, 2]}
             model.prune_heads(heads_to_prune)
@@ -1219,8 +1417,12 @@ class ModelTesterMixin:
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
             attentions = outputs[-1]
 
-            self.assertEqual(attentions[0].shape[-3], self.model_tester.num_attention_heads - 1)
-            self.assertEqual(attentions[1].shape[-3], self.model_tester.num_attention_heads - 2)
+            self.assertEqual(
+                attentions[0].shape[-3], self.model_tester.num_attention_heads - 1
+            )
+            self.assertEqual(
+                attentions[1].shape[-3], self.model_tester.num_attention_heads - 2
+            )
 
             self.assertDictEqual(model.config.pruned_heads, {0: [0], 1: [1, 2]})
 
@@ -1233,16 +1435,25 @@ class ModelTesterMixin:
             with torch.no_grad():
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
 
-            hidden_states = outputs.encoder_hidden_states if config.is_encoder_decoder else outputs.hidden_states
+            hidden_states = (
+                outputs.encoder_hidden_states
+                if config.is_encoder_decoder
+                else outputs.hidden_states
+            )
 
             expected_num_layers = getattr(
-                self.model_tester, "expected_num_hidden_layers", self.model_tester.num_hidden_layers + 1
+                self.model_tester,
+                "expected_num_hidden_layers",
+                self.model_tester.num_hidden_layers + 1,
             )
             self.assertEqual(len(hidden_states), expected_num_layers)
 
             if hasattr(self.model_tester, "encoder_seq_length"):
                 seq_length = self.model_tester.encoder_seq_length
-                if hasattr(self.model_tester, "chunk_length") and self.model_tester.chunk_length > 1:
+                if (
+                    hasattr(self.model_tester, "chunk_length")
+                    and self.model_tester.chunk_length > 1
+                ):
                     seq_length = seq_length * self.model_tester.chunk_length
             else:
                 seq_length = self.model_tester.seq_length
@@ -1258,7 +1469,9 @@ class ModelTesterMixin:
                 self.assertIsInstance(hidden_states, (list, tuple))
                 self.assertEqual(len(hidden_states), expected_num_layers)
                 seq_len = getattr(self.model_tester, "seq_length", None)
-                decoder_seq_length = getattr(self.model_tester, "decoder_seq_length", seq_len)
+                decoder_seq_length = getattr(
+                    self.model_tester, "decoder_seq_length", seq_len
+                )
 
                 self.assertListEqual(
                     list(hidden_states[0].shape[-2:]),
@@ -1348,7 +1561,9 @@ class ModelTesterMixin:
             model.to(torch_device)
             model.eval()
 
-            hidden_states_no_chunk = model(**self._prepare_for_class(inputs_dict, model_class))[0]
+            hidden_states_no_chunk = model(
+                **self._prepare_for_class(inputs_dict, model_class)
+            )[0]
 
             torch.manual_seed(0)
             config.chunk_size_feed_forward = 1
@@ -1356,8 +1571,14 @@ class ModelTesterMixin:
             model.to(torch_device)
             model.eval()
 
-            hidden_states_with_chunk = model(**self._prepare_for_class(inputs_dict, model_class))[0]
-            self.assertTrue(torch.allclose(hidden_states_no_chunk, hidden_states_with_chunk, atol=1e-3))
+            hidden_states_with_chunk = model(
+                **self._prepare_for_class(inputs_dict, model_class)
+            )[0]
+            self.assertTrue(
+                torch.allclose(
+                    hidden_states_no_chunk, hidden_states_with_chunk, atol=1e-3
+                )
+            )
 
     def test_resize_position_vector_embeddings(self):
         if not self.test_resize_position_embeddings:
@@ -1380,7 +1601,10 @@ class ModelTesterMixin:
 
             # Retrieve the embeddings and clone theme
             if model.config.is_encoder_decoder:
-                encoder_model_embed, decoder_model_embed = model.get_position_embeddings()
+                (
+                    encoder_model_embed,
+                    decoder_model_embed,
+                ) = model.get_position_embeddings()
                 encoder_cloned_embeddings = encoder_model_embed.weight.clone()
                 decoder_cloned_embeddings = decoder_model_embed.weight.clone()
             else:
@@ -1390,16 +1614,29 @@ class ModelTesterMixin:
             # Check that resizing the position embeddings with a larger max_position_embeddings increases
             # the model's postion embeddings size
             model.resize_position_embeddings(max_position_embeddings + 10)
-            self.assertEqual(model.config.max_position_embeddings, max_position_embeddings + 10)
+            self.assertEqual(
+                model.config.max_position_embeddings, max_position_embeddings + 10
+            )
 
             # Check that it actually resizes the embeddings matrix
             if model.config.is_encoder_decoder:
-                encoder_model_embed, decoder_model_embed = model.get_position_embeddings()
-                self.assertEqual(encoder_model_embed.weight.shape[0], encoder_cloned_embeddings.shape[0] + 10)
-                self.assertEqual(decoder_model_embed.weight.shape[0], decoder_cloned_embeddings.shape[0] + 10)
+                (
+                    encoder_model_embed,
+                    decoder_model_embed,
+                ) = model.get_position_embeddings()
+                self.assertEqual(
+                    encoder_model_embed.weight.shape[0],
+                    encoder_cloned_embeddings.shape[0] + 10,
+                )
+                self.assertEqual(
+                    decoder_model_embed.weight.shape[0],
+                    decoder_cloned_embeddings.shape[0] + 10,
+                )
             else:
                 model_embed = model.get_position_embeddings()
-                self.assertEqual(model_embed.weight.shape[0], cloned_embeddings.shape[0] + 10)
+                self.assertEqual(
+                    model_embed.weight.shape[0], cloned_embeddings.shape[0] + 10
+                )
 
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             model(**self._prepare_for_class(inputs_dict, model_class))
@@ -1407,16 +1644,29 @@ class ModelTesterMixin:
             # Check that resizing the position embeddings with a smaller max_position_embeddings decreases
             # the model's max_position_embeddings
             model.resize_position_embeddings(max_position_embeddings - 5)
-            self.assertEqual(model.config.max_position_embeddings, max_position_embeddings - 5)
+            self.assertEqual(
+                model.config.max_position_embeddings, max_position_embeddings - 5
+            )
 
             # Check that it actually resizes the embeddings matrix
             if model.config.is_encoder_decoder:
-                encoder_model_embed, decoder_model_embed = model.get_position_embeddings()
-                self.assertEqual(encoder_model_embed.weight.shape[0], encoder_cloned_embeddings.shape[0] - 5)
-                self.assertEqual(decoder_model_embed.weight.shape[0], decoder_cloned_embeddings.shape[0] - 5)
+                (
+                    encoder_model_embed,
+                    decoder_model_embed,
+                ) = model.get_position_embeddings()
+                self.assertEqual(
+                    encoder_model_embed.weight.shape[0],
+                    encoder_cloned_embeddings.shape[0] - 5,
+                )
+                self.assertEqual(
+                    decoder_model_embed.weight.shape[0],
+                    decoder_cloned_embeddings.shape[0] - 5,
+                )
             else:
                 model_embed = model.get_position_embeddings()
-                self.assertEqual(model_embed.weight.shape[0], cloned_embeddings.shape[0] - 5)
+                self.assertEqual(
+                    model_embed.weight.shape[0], cloned_embeddings.shape[0] - 5
+                )
 
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             model(**self._prepare_for_class(inputs_dict, model_class))
@@ -1425,10 +1675,14 @@ class ModelTesterMixin:
             models_equal = True
 
             if model.config.is_encoder_decoder:
-                for p1, p2 in zip(encoder_cloned_embeddings, encoder_model_embed.weight):
+                for p1, p2 in zip(
+                    encoder_cloned_embeddings, encoder_model_embed.weight
+                ):
                     if p1.data.ne(p2.data).sum() > 0:
                         models_equal = False
-                for p1, p2 in zip(decoder_cloned_embeddings, decoder_model_embed.weight):
+                for p1, p2 in zip(
+                    decoder_cloned_embeddings, decoder_model_embed.weight
+                ):
                     if p1.data.ne(p2.data).sum() > 0:
                         models_equal = False
             else:
@@ -1463,7 +1717,9 @@ class ModelTesterMixin:
             model_embed = model.resize_token_embeddings(model_vocab_size + 10)
             self.assertEqual(model.config.vocab_size, model_vocab_size + 10)
             # Check that it actually resizes the embeddings matrix
-            self.assertEqual(model_embed.weight.shape[0], cloned_embeddings.shape[0] + 10)
+            self.assertEqual(
+                model_embed.weight.shape[0], cloned_embeddings.shape[0] + 10
+            )
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             model(**self._prepare_for_class(inputs_dict, model_class))
 
@@ -1471,7 +1727,9 @@ class ModelTesterMixin:
             model_embed = model.resize_token_embeddings(model_vocab_size - 15)
             self.assertEqual(model.config.vocab_size, model_vocab_size - 15)
             # Check that it actually resizes the embeddings matrix
-            self.assertEqual(model_embed.weight.shape[0], cloned_embeddings.shape[0] - 15)
+            self.assertEqual(
+                model_embed.weight.shape[0], cloned_embeddings.shape[0] - 15
+            )
 
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             # Input ids should be clamped to the maximum size of the vocabulary
@@ -1498,18 +1756,24 @@ class ModelTesterMixin:
             model.resize_token_embeddings(model_vocab_size + 10, pad_to_multiple_of=1)
             self.assertTrue(model.config.vocab_size + 10, model_vocab_size)
 
-            model_embed = model.resize_token_embeddings(model_vocab_size, pad_to_multiple_of=64)
+            model_embed = model.resize_token_embeddings(
+                model_vocab_size, pad_to_multiple_of=64
+            )
             self.assertTrue(model_embed.weight.shape[0] // 64, 0)
 
             self.assertTrue(model_embed.weight.shape[0], model.config.vocab_size)
             self.assertTrue(model.config.vocab_size, model.vocab_size)
 
-            model_embed = model.resize_token_embeddings(model_vocab_size + 13, pad_to_multiple_of=64)
+            model_embed = model.resize_token_embeddings(
+                model_vocab_size + 13, pad_to_multiple_of=64
+            )
             self.assertTrue(model_embed.weight.shape[0] // 64, 0)
 
             # Check that resizing a model to a multiple of pad_to_multiple leads to a model of exactly that size
             target_dimension = 128
-            model_embed = model.resize_token_embeddings(target_dimension, pad_to_multiple_of=64)
+            model_embed = model.resize_token_embeddings(
+                target_dimension, pad_to_multiple_of=64
+            )
             self.assertTrue(model_embed.weight.shape[0], target_dimension)
 
             with self.assertRaisesRegex(
@@ -1574,7 +1838,9 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             model = model_class(config)
-            self.assertIsInstance(model.get_input_embeddings(), (nn.Embedding, AdaptiveEmbedding))
+            self.assertIsInstance(
+                model.get_input_embeddings(), (nn.Embedding, AdaptiveEmbedding)
+            )
             model.set_input_embeddings(nn.Embedding(10, 10))
             x = model.get_output_embeddings()
             self.assertTrue(x is None or isinstance(x, nn.Linear))
@@ -1596,8 +1862,18 @@ class ModelTesterMixin:
             base_model_prefix = model.base_model_prefix
 
             if hasattr(model, base_model_prefix):
-                extra_params = {k: v for k, v in model.named_parameters() if not k.startswith(base_model_prefix)}
-                extra_params.update({k: v for k, v in model.named_buffers() if not k.startswith(base_model_prefix)})
+                extra_params = {
+                    k: v
+                    for k, v in model.named_parameters()
+                    if not k.startswith(base_model_prefix)
+                }
+                extra_params.update(
+                    {
+                        k: v
+                        for k, v in model.named_buffers()
+                        if not k.startswith(base_model_prefix)
+                    }
+                )
                 # Some models define this as None
                 if model._keys_to_ignore_on_load_missing:
                     for key in model._keys_to_ignore_on_load_missing:
@@ -1611,8 +1887,12 @@ class ModelTesterMixin:
 
                 with tempfile.TemporaryDirectory() as temp_dir_name:
                     model.base_model.save_pretrained(temp_dir_name)
-                    model, loading_info = model_class.from_pretrained(temp_dir_name, output_loading_info=True)
-                    self.assertGreater(len(loading_info["missing_keys"]), 0, model.__class__.__name__)
+                    model, loading_info = model_class.from_pretrained(
+                        temp_dir_name, output_loading_info=True
+                    )
+                    self.assertGreater(
+                        len(loading_info["missing_keys"]), 0, model.__class__.__name__
+                    )
 
     def test_tie_model_weights(self):
         if not self.test_torchscript:
@@ -1671,15 +1951,23 @@ class ModelTesterMixin:
                 try:
                     model_tied.save_pretrained(d, safe_serialization=True)
                 except Exception as e:
-                    raise Exception(f"Class {model_class.__name__} cannot be saved using safetensors: {e}")
+                    raise Exception(
+                        f"Class {model_class.__name__} cannot be saved using safetensors: {e}"
+                    )
 
-                model_reloaded, infos = model_class.from_pretrained(d, output_loading_info=True)
+                model_reloaded, infos = model_class.from_pretrained(
+                    d, output_loading_info=True
+                )
                 # Checking the state dicts are correct
                 reloaded_state = model_reloaded.state_dict()
                 for k, v in model_tied.state_dict().items():
-                    self.assertIn(k, reloaded_state, f"Key {k} is missing from reloaded")
+                    self.assertIn(
+                        k, reloaded_state, f"Key {k} is missing from reloaded"
+                    )
                     torch.testing.assert_close(
-                        v, reloaded_state[k], msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}"
+                        v,
+                        reloaded_state[k],
+                        msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}",
                     )
                 # Checking there was no complain of missing weights
                 self.assertEqual(infos["missing_keys"], [])
@@ -1707,13 +1995,19 @@ class ModelTesterMixin:
             with tempfile.TemporaryDirectory() as d:
                 model.save_pretrained(d)
 
-                model_reloaded, infos = model_class.from_pretrained(d, output_loading_info=True)
+                model_reloaded, infos = model_class.from_pretrained(
+                    d, output_loading_info=True
+                )
                 # Checking the state dicts are correct
                 reloaded_state = model_reloaded.state_dict()
                 for k, v in model.state_dict().items():
-                    self.assertIn(k, reloaded_state, f"Key {k} is missing from reloaded")
+                    self.assertIn(
+                        k, reloaded_state, f"Key {k} is missing from reloaded"
+                    )
                     torch.testing.assert_close(
-                        v, reloaded_state[k], msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}"
+                        v,
+                        reloaded_state[k],
+                        msg=lambda x: f"{model_class.__name__}: Tensor {k}: {x}",
                     )
                 # Checking there was no complain of missing weights
                 self.assertEqual(infos["missing_keys"], [])
@@ -1731,16 +2025,24 @@ class ModelTesterMixin:
             # These are all the pointers of shared tensors.
             tied_params = [names for _, names in ptrs.items() if len(names) > 1]
 
-            tied_weight_keys = model_tied._tied_weights_keys if model_tied._tied_weights_keys is not None else []
+            tied_weight_keys = (
+                model_tied._tied_weights_keys
+                if model_tied._tied_weights_keys is not None
+                else []
+            )
             # Detect we get a hit for each key
             for key in tied_weight_keys:
                 if not any(re.search(key, p) for group in tied_params for p in group):
-                    raise ValueError(f"{key} is not a tied weight key for {model_class}.")
+                    raise ValueError(
+                        f"{key} is not a tied weight key for {model_class}."
+                    )
 
             # Removed tied weights found from tied params -> there should only be one left after
             for key in tied_weight_keys:
                 for i in range(len(tied_params)):
-                    tied_params[i] = [p for p in tied_params[i] if re.search(key, p) is None]
+                    tied_params[i] = [
+                        p for p in tied_params[i] if re.search(key, p) is None
+                    ]
 
             tied_params = [group for group in tied_params if len(group) > 1]
             self.assertListEqual(
@@ -1759,13 +2061,22 @@ class ModelTesterMixin:
                 # We are nuking ALL weights on file, so every parameter should
                 # yell on load. We're going to detect if we yell too much, or too little.
                 placeholder_dict = {"tensor": torch.tensor([1, 2])}
-                safe_save_file(placeholder_dict, os.path.join(tmp_dir, "model.safetensors"), metadata={"format": "pt"})
-                model_reloaded, infos = model_class.from_pretrained(tmp_dir, output_loading_info=True)
+                safe_save_file(
+                    placeholder_dict,
+                    os.path.join(tmp_dir, "model.safetensors"),
+                    metadata={"format": "pt"},
+                )
+                model_reloaded, infos = model_class.from_pretrained(
+                    tmp_dir, output_loading_info=True
+                )
 
                 prefix = f"{model_reloaded.base_model_prefix}."
                 params = dict(model_reloaded.named_parameters())
                 params.update(dict(model_reloaded.named_buffers()))
-                param_names = {k[len(prefix) :] if k.startswith(prefix) else k for k in params.keys()}
+                param_names = {
+                    k[len(prefix) :] if k.startswith(prefix) else k
+                    for k in params.keys()
+                }
 
                 missing_keys = set(infos["missing_keys"])
 
@@ -1777,7 +2088,9 @@ class ModelTesterMixin:
                     ptrs[id_tensor_storage(tensor)].append(name)
                 tied_params = [names for _, names in ptrs.items() if len(names) > 1]
                 for group in tied_params:
-                    group = {k[len(prefix) :] if k.startswith(prefix) else k for k in group}
+                    group = {
+                        k[len(prefix) :] if k.startswith(prefix) else k for k in group
+                    }
                     # We remove the group from extra_missing if not all weights from group are in it
                     if len(group - extra_missing) > 0:
                         extra_missing = extra_missing - set(group)
@@ -1792,16 +2105,21 @@ class ModelTesterMixin:
                 missed_missing = param_names - missing_keys
                 # Remove nonpersistent buffers from missed_missing
                 buffers = [n for n, _ in model_reloaded.named_buffers()]
-                nonpersistent_buffers = {n for n in buffers if n not in model_reloaded.state_dict()}
                 nonpersistent_buffers = {
-                    k[len(prefix) :] if k.startswith(prefix) else k for k in nonpersistent_buffers
+                    n for n in buffers if n not in model_reloaded.state_dict()
+                }
+                nonpersistent_buffers = {
+                    k[len(prefix) :] if k.startswith(prefix) else k
+                    for k in nonpersistent_buffers
                 }
                 missed_missing = missed_missing - nonpersistent_buffers
 
                 if model_reloaded._keys_to_ignore_on_load_missing is None:
                     expected_missing = set()
                 else:
-                    expected_missing = set(model_reloaded._keys_to_ignore_on_load_missing)
+                    expected_missing = set(
+                        model_reloaded._keys_to_ignore_on_load_missing
+                    )
                 self.assertEqual(
                     missed_missing,
                     expected_missing,
@@ -1819,12 +2137,18 @@ class ModelTesterMixin:
 
         def check_equivalence(model, tuple_inputs, dict_inputs, additional_kwargs={}):
             with torch.no_grad():
-                tuple_output = model(**tuple_inputs, return_dict=False, **additional_kwargs)
-                dict_output = model(**dict_inputs, return_dict=True, **additional_kwargs).to_tuple()
+                tuple_output = model(
+                    **tuple_inputs, return_dict=False, **additional_kwargs
+                )
+                dict_output = model(
+                    **dict_inputs, return_dict=True, **additional_kwargs
+                ).to_tuple()
 
                 def recursive_check(tuple_object, dict_object):
                     if isinstance(tuple_object, (List, Tuple)):
-                        for tuple_iterable_value, dict_iterable_value in zip(tuple_object, dict_object):
+                        for tuple_iterable_value, dict_iterable_value in zip(
+                            tuple_object, dict_object
+                        ):
                             recursive_check(tuple_iterable_value, dict_iterable_value)
                     elif isinstance(tuple_object, Dict):
                         for tuple_iterable_value, dict_iterable_value in zip(
@@ -1836,7 +2160,9 @@ class ModelTesterMixin:
                     else:
                         self.assertTrue(
                             torch.allclose(
-                                set_nan_tensor_to_zero(tuple_object), set_nan_tensor_to_zero(dict_object), atol=1e-5
+                                set_nan_tensor_to_zero(tuple_object),
+                                set_nan_tensor_to_zero(dict_object),
+                                atol=1e-5,
                             ),
                             msg=(
                                 "Tuple and dict output are not equal. Difference:"
@@ -1857,31 +2183,58 @@ class ModelTesterMixin:
             dict_inputs = self._prepare_for_class(inputs_dict, model_class)
             check_equivalence(model, tuple_inputs, dict_inputs)
 
-            tuple_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-            dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+            tuple_inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
+            dict_inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
             check_equivalence(model, tuple_inputs, dict_inputs)
 
             tuple_inputs = self._prepare_for_class(inputs_dict, model_class)
             dict_inputs = self._prepare_for_class(inputs_dict, model_class)
-            check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
+            check_equivalence(
+                model, tuple_inputs, dict_inputs, {"output_hidden_states": True}
+            )
 
-            tuple_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-            dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-            check_equivalence(model, tuple_inputs, dict_inputs, {"output_hidden_states": True})
+            tuple_inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
+            dict_inputs = self._prepare_for_class(
+                inputs_dict, model_class, return_labels=True
+            )
+            check_equivalence(
+                model, tuple_inputs, dict_inputs, {"output_hidden_states": True}
+            )
 
             if self.has_attentions:
                 tuple_inputs = self._prepare_for_class(inputs_dict, model_class)
                 dict_inputs = self._prepare_for_class(inputs_dict, model_class)
-                check_equivalence(model, tuple_inputs, dict_inputs, {"output_attentions": True})
-
-                tuple_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-                dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-                check_equivalence(model, tuple_inputs, dict_inputs, {"output_attentions": True})
-
-                tuple_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
-                dict_inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
                 check_equivalence(
-                    model, tuple_inputs, dict_inputs, {"output_hidden_states": True, "output_attentions": True}
+                    model, tuple_inputs, dict_inputs, {"output_attentions": True}
+                )
+
+                tuple_inputs = self._prepare_for_class(
+                    inputs_dict, model_class, return_labels=True
+                )
+                dict_inputs = self._prepare_for_class(
+                    inputs_dict, model_class, return_labels=True
+                )
+                check_equivalence(
+                    model, tuple_inputs, dict_inputs, {"output_attentions": True}
+                )
+
+                tuple_inputs = self._prepare_for_class(
+                    inputs_dict, model_class, return_labels=True
+                )
+                dict_inputs = self._prepare_for_class(
+                    inputs_dict, model_class, return_labels=True
+                )
+                check_equivalence(
+                    model,
+                    tuple_inputs,
+                    dict_inputs,
+                    {"output_hidden_states": True, "output_attentions": True},
                 )
 
     # Don't copy this method to model specific test file!
@@ -1897,7 +2250,13 @@ class ModelTesterMixin:
                 # Put `1` at the beginning of sequences to make it still work when combining causal attention masks.
                 # TODO: remove this line once a fix regarding large negative values for attention mask is done.
                 attention_mask = torch.cat(
-                    [torch.ones_like(attention_mask[:, :1], dtype=attention_mask.dtype), attention_mask[:, 1:]], dim=-1
+                    [
+                        torch.ones_like(
+                            attention_mask[:, :1], dtype=attention_mask.dtype
+                        ),
+                        attention_mask[:, 1:],
+                    ],
+                    dim=-1,
                 )
 
                 # Here we make the first sequence with all 0s as attention mask.
@@ -1944,7 +2303,15 @@ class ModelTesterMixin:
         return new_tf_outputs, new_pt_outputs
 
     # Copied from tests.test_modeling_tf_common.TFModelTesterMixin.check_pt_tf_outputs
-    def check_pt_tf_outputs(self, tf_outputs, pt_outputs, model_class, tol=1e-5, name="outputs", attributes=None):
+    def check_pt_tf_outputs(
+        self,
+        tf_outputs,
+        pt_outputs,
+        model_class,
+        tol=1e-5,
+        name="outputs",
+        attributes=None,
+    ):
         """Check the outputs from PyTorch and TensorFlow models are close enough. Checks are done in a recursive way.
 
         Args:
@@ -1958,7 +2325,11 @@ class ModelTesterMixin:
 
         self.assertEqual(type(name), str)
         if attributes is not None:
-            self.assertEqual(type(attributes), tuple, f"{name}: The argument `attributes` should be a `tuple`")
+            self.assertEqual(
+                type(attributes),
+                tuple,
+                f"{name}: The argument `attributes` should be a `tuple`",
+            )
 
         # Allow `ModelOutput` (e.g. `CLIPOutput` has `text_model_output` and `vision_model_output`).
         if isinstance(tf_outputs, ModelOutput):
@@ -1969,24 +2340,41 @@ class ModelTesterMixin:
 
             # Don't copy this block to model specific test file!
             # TODO: remove this method and this line after issues are fixed
-            tf_outputs, pt_outputs = self._postprocessing_to_ignore_test_cases(tf_outputs, pt_outputs, model_class)
+            tf_outputs, pt_outputs = self._postprocessing_to_ignore_test_cases(
+                tf_outputs, pt_outputs, model_class
+            )
 
             tf_keys = [k for k, v in tf_outputs.items() if v is not None]
             pt_keys = [k for k, v in pt_outputs.items() if v is not None]
 
-            self.assertEqual(tf_keys, pt_keys, f"{name}: Output keys differ between TF and PyTorch")
+            self.assertEqual(
+                tf_keys, pt_keys, f"{name}: Output keys differ between TF and PyTorch"
+            )
 
             # convert to the case of `tuple`
             # appending each key to the current (string) `name`
             attributes = tuple([f"{name}.{k}" for k in tf_keys])
             self.check_pt_tf_outputs(
-                tf_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, tol=tol, name=name, attributes=attributes
+                tf_outputs.to_tuple(),
+                pt_outputs.to_tuple(),
+                model_class,
+                tol=tol,
+                name=name,
+                attributes=attributes,
             )
 
         # Allow `list` (e.g. `TransfoXLModelOutput.mems` is a list of tensors.)
         elif type(tf_outputs) in [tuple, list]:
-            self.assertEqual(type(tf_outputs), type(pt_outputs), f"{name}: Output types differ between TF and PyTorch")
-            self.assertEqual(len(tf_outputs), len(pt_outputs), f"{name}: Output lengths differ between TF and PyTorch")
+            self.assertEqual(
+                type(tf_outputs),
+                type(pt_outputs),
+                f"{name}: Output types differ between TF and PyTorch",
+            )
+            self.assertEqual(
+                len(tf_outputs),
+                len(pt_outputs),
+                f"{name}: Output lengths differ between TF and PyTorch",
+            )
 
             if attributes is not None:
                 # case 1: each output has assigned name (e.g. a tuple form of a `ModelOutput`)
@@ -2000,18 +2388,23 @@ class ModelTesterMixin:
                 attributes = tuple([f"{name}_{idx}" for idx in range(len(tf_outputs))])
 
             for tf_output, pt_output, attr in zip(tf_outputs, pt_outputs, attributes):
-                self.check_pt_tf_outputs(tf_output, pt_output, model_class, tol=tol, name=attr)
+                self.check_pt_tf_outputs(
+                    tf_output, pt_output, model_class, tol=tol, name=attr
+                )
 
         elif isinstance(tf_outputs, tf.Tensor):
             self.assertTrue(
-                isinstance(pt_outputs, torch.Tensor), f"{name}: `pt_outputs` should a tensor when `tf_outputs` is"
+                isinstance(pt_outputs, torch.Tensor),
+                f"{name}: `pt_outputs` should a tensor when `tf_outputs` is",
             )
 
             tf_outputs = tf_outputs.numpy()
             pt_outputs = pt_outputs.detach().to("cpu").numpy()
 
             self.assertEqual(
-                tf_outputs.shape, pt_outputs.shape, f"{name}: Output shapes differ between TF and PyTorch"
+                tf_outputs.shape,
+                pt_outputs.shape,
+                f"{name}: Output shapes differ between TF and PyTorch",
             )
 
             # deal with NumPy's scalars to make replacing nan values by 0 work.
@@ -2028,7 +2421,11 @@ class ModelTesterMixin:
             tf_outputs[pt_nans] = 0
 
             max_diff = np.amax(np.abs(tf_outputs - pt_outputs))
-            self.assertLessEqual(max_diff, tol, f"{name}: Difference between PyTorch and TF is {max_diff} (>= {tol}).")
+            self.assertLessEqual(
+                max_diff,
+                tol,
+                f"{name}: Difference between PyTorch and TF is {max_diff} (>= {tol}).",
+            )
         else:
             raise ValueError(
                 "`tf_outputs` should be an instance of `ModelOutput`, a `tuple`, or an instance of `tf.Tensor`. Got"
@@ -2042,16 +2439,26 @@ class ModelTesterMixin:
             if isinstance(tensor, bool):
                 tf_inputs_dict[key] = tensor
             elif key == "input_values":
-                tf_inputs_dict[key] = tf.convert_to_tensor(tensor.cpu().numpy(), dtype=tf.float32)
+                tf_inputs_dict[key] = tf.convert_to_tensor(
+                    tensor.cpu().numpy(), dtype=tf.float32
+                )
             elif key == "pixel_values":
-                tf_inputs_dict[key] = tf.convert_to_tensor(tensor.cpu().numpy(), dtype=tf.float32)
+                tf_inputs_dict[key] = tf.convert_to_tensor(
+                    tensor.cpu().numpy(), dtype=tf.float32
+                )
             elif key == "input_features":
-                tf_inputs_dict[key] = tf.convert_to_tensor(tensor.cpu().numpy(), dtype=tf.float32)
+                tf_inputs_dict[key] = tf.convert_to_tensor(
+                    tensor.cpu().numpy(), dtype=tf.float32
+                )
             # other general float inputs
             elif tensor.is_floating_point():
-                tf_inputs_dict[key] = tf.convert_to_tensor(tensor.cpu().numpy(), dtype=tf.float32)
+                tf_inputs_dict[key] = tf.convert_to_tensor(
+                    tensor.cpu().numpy(), dtype=tf.float32
+                )
             else:
-                tf_inputs_dict[key] = tf.convert_to_tensor(tensor.cpu().numpy(), dtype=tf.int32)
+                tf_inputs_dict[key] = tf.convert_to_tensor(
+                    tensor.cpu().numpy(), dtype=tf.int32
+                )
 
         return tf_inputs_dict
 
@@ -2060,7 +2467,8 @@ class ModelTesterMixin:
 
         # send pytorch inputs to the correct device
         pt_inputs_dict = {
-            k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs_dict.items()
+            k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v
+            for k, v in pt_inputs_dict.items()
         }
 
         # send pytorch model to the correct device
@@ -2087,9 +2495,14 @@ class ModelTesterMixin:
         import transformers
 
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
 
-            tf_model_class_name = "TF" + model_class.__name__  # Add the "TF" at the beginning
+            tf_model_class_name = (
+                "TF" + model_class.__name__
+            )  # Add the "TF" at the beginning
             if not hasattr(transformers, tf_model_class_name):
                 # transformers does not have this model in TF version yet
                 return
@@ -2113,7 +2526,9 @@ class ModelTesterMixin:
                 inputs_dict,
                 model_class,
                 # Not all models accept "labels" in the forward pass (yet :) )
-                return_labels=True if "labels" in inspect.signature(model_class.forward).parameters.keys() else False,
+                return_labels=True
+                if "labels" in inspect.signature(model_class.forward).parameters.keys()
+                else False,
             )
 
             # make sure only tf inputs are forward that actually exist in function args
@@ -2124,19 +2539,30 @@ class ModelTesterMixin:
             tf_input_keys.discard("cross_attn_head_mask")
             tf_input_keys.discard("decoder_head_mask")
 
-            pt_inputs_dict = {k: v for k, v in pt_inputs_dict.items() if k in tf_input_keys}
-            pt_inputs_dict_with_labels = {k: v for k, v in pt_inputs_dict_with_labels.items() if k in tf_input_keys}
+            pt_inputs_dict = {
+                k: v for k, v in pt_inputs_dict.items() if k in tf_input_keys
+            }
+            pt_inputs_dict_with_labels = {
+                k: v
+                for k, v in pt_inputs_dict_with_labels.items()
+                if k in tf_input_keys
+            }
 
             # For some models (e.g. base models), there is no label returned.
             # Set the input dict to `None` to avoid check outputs twice for the same input dicts.
-            if not set(pt_inputs_dict_with_labels.keys()).symmetric_difference(pt_inputs_dict.keys()):
+            if not set(pt_inputs_dict_with_labels.keys()).symmetric_difference(
+                pt_inputs_dict.keys()
+            ):
                 pt_inputs_dict_with_labels = None
 
             # Check we can load pt model in tf and vice-versa with model => model functions
             # Here requires `tf_inputs_dict` to build `tf_model`
             tf_inputs_dict = self.prepare_tf_inputs_from_pt_inputs(pt_inputs_dict)
             tf_model = transformers.load_pytorch_model_in_tf2_model(
-                tf_model, pt_model, tf_inputs=tf_inputs_dict, allow_missing_keys=allow_missing_keys
+                tf_model,
+                pt_model,
+                tf_inputs=tf_inputs_dict,
+                allow_missing_keys=allow_missing_keys,
             )
             pt_model = transformers.load_tf2_model_in_pytorch_model(
                 pt_model, tf_model, allow_missing_keys=allow_missing_keys
@@ -2170,9 +2596,19 @@ class ModelTesterMixin:
 
     def assert_almost_equals(self, a: np.ndarray, b: np.ndarray, tol: float):
         diff = np.abs((a - b)).max()
-        self.assertLessEqual(diff, tol, f"Difference between torch and flax is {diff} (>= {tol}).")
+        self.assertLessEqual(
+            diff, tol, f"Difference between torch and flax is {diff} (>= {tol})."
+        )
 
-    def check_pt_flax_outputs(self, fx_outputs, pt_outputs, model_class, tol=1e-5, name="outputs", attributes=None):
+    def check_pt_flax_outputs(
+        self,
+        fx_outputs,
+        pt_outputs,
+        model_class,
+        tol=1e-5,
+        name="outputs",
+        attributes=None,
+    ):
         """
         Args:
             model_class: The class of the model that is currently testing. For example, ..., etc.
@@ -2185,7 +2621,11 @@ class ModelTesterMixin:
 
         self.assertEqual(type(name), str)
         if attributes is not None:
-            self.assertEqual(type(attributes), tuple, f"{name}: The argument `attributes` should be a `tuple`")
+            self.assertEqual(
+                type(attributes),
+                tuple,
+                f"{name}: The argument `attributes` should be a `tuple`",
+            )
 
         # Allow `ModelOutput` (e.g. `CLIPOutput` has `text_model_output` and `vision_model_output`).
         if isinstance(fx_outputs, ModelOutput):
@@ -2197,22 +2637,33 @@ class ModelTesterMixin:
             fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
             pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
 
-            self.assertEqual(fx_keys, pt_keys, f"{name}: Output keys differ between Flax and PyTorch")
+            self.assertEqual(
+                fx_keys, pt_keys, f"{name}: Output keys differ between Flax and PyTorch"
+            )
 
             # convert to the case of `tuple`
             # appending each key to the current (string) `name`
             attributes = tuple([f"{name}.{k}" for k in fx_keys])
             self.check_pt_flax_outputs(
-                fx_outputs.to_tuple(), pt_outputs.to_tuple(), model_class, tol=tol, name=name, attributes=attributes
+                fx_outputs.to_tuple(),
+                pt_outputs.to_tuple(),
+                model_class,
+                tol=tol,
+                name=name,
+                attributes=attributes,
             )
 
         # Allow `list` (e.g. `TransfoXLModelOutput.mems` is a list of tensors.)
         elif type(fx_outputs) in [tuple, list]:
             self.assertEqual(
-                type(fx_outputs), type(pt_outputs), f"{name}: Output types differ between Flax and PyTorch"
+                type(fx_outputs),
+                type(pt_outputs),
+                f"{name}: Output types differ between Flax and PyTorch",
             )
             self.assertEqual(
-                len(fx_outputs), len(pt_outputs), f"{name}: Output lengths differ between Flax and PyTorch"
+                len(fx_outputs),
+                len(pt_outputs),
+                f"{name}: Output lengths differ between Flax and PyTorch",
             )
 
             if attributes is not None:
@@ -2227,11 +2678,14 @@ class ModelTesterMixin:
                 attributes = tuple([f"{name}_{idx}" for idx in range(len(fx_outputs))])
 
             for fx_output, pt_output, attr in zip(fx_outputs, pt_outputs, attributes):
-                self.check_pt_flax_outputs(fx_output, pt_output, model_class, tol=tol, name=attr)
+                self.check_pt_flax_outputs(
+                    fx_output, pt_output, model_class, tol=tol, name=attr
+                )
 
         elif isinstance(fx_outputs, jnp.ndarray):
             self.assertTrue(
-                isinstance(pt_outputs, torch.Tensor), f"{name}: `pt_outputs` should a tensor when `fx_outputs` is"
+                isinstance(pt_outputs, torch.Tensor),
+                f"{name}: `pt_outputs` should a tensor when `fx_outputs` is",
             )
 
             # Using `np.asarray` gives `ValueError: assignment destination is read-only` at the line `fx_outputs[fx_nans] = 0`.
@@ -2239,7 +2693,9 @@ class ModelTesterMixin:
             pt_outputs = pt_outputs.detach().to("cpu").numpy()
 
             self.assertEqual(
-                fx_outputs.shape, pt_outputs.shape, f"{name}: Output shapes differ between Flax and PyTorch"
+                fx_outputs.shape,
+                pt_outputs.shape,
+                f"{name}: Output shapes differ between Flax and PyTorch",
             )
 
             # deal with NumPy's scalars to make replacing nan values by 0 work.
@@ -2257,7 +2713,9 @@ class ModelTesterMixin:
 
             max_diff = np.amax(np.abs(fx_outputs - pt_outputs))
             self.assertLessEqual(
-                max_diff, tol, f"{name}: Difference between PyTorch and Flax is {max_diff} (>= {tol})."
+                max_diff,
+                tol,
+                f"{name}: Difference between PyTorch and Flax is {max_diff} (>= {tol}).",
             )
         else:
             raise ValueError(
@@ -2303,13 +2761,20 @@ class ModelTesterMixin:
 
                 # send pytorch inputs to the correct device
                 pt_inputs = {
-                    k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs.items()
+                    k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v
+                    for k, v in pt_inputs.items()
                 }
 
                 # convert inputs to Flax
-                fx_inputs = {k: np.array(v.to("cpu")) for k, v in pt_inputs.items() if torch.is_tensor(v)}
+                fx_inputs = {
+                    k: np.array(v.to("cpu"))
+                    for k, v in pt_inputs.items()
+                    if torch.is_tensor(v)
+                }
 
-                fx_state = convert_pytorch_state_dict_to_flax(pt_model.state_dict(), fx_model)
+                fx_state = convert_pytorch_state_dict_to_flax(
+                    pt_model.state_dict(), fx_model
+                )
                 fx_model.params = fx_state
 
                 # send pytorch model to the correct device
@@ -2327,11 +2792,15 @@ class ModelTesterMixin:
 
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     pt_model.save_pretrained(tmpdirname)
-                    fx_model_loaded = fx_model_class.from_pretrained(tmpdirname, from_pt=True)
+                    fx_model_loaded = fx_model_class.from_pretrained(
+                        tmpdirname, from_pt=True
+                    )
 
                 fx_outputs_loaded = fx_model_loaded(**fx_inputs)
 
-                fx_keys = tuple([k for k, v in fx_outputs_loaded.items() if v is not None])
+                fx_keys = tuple(
+                    [k for k, v in fx_outputs_loaded.items() if v is not None]
+                )
                 pt_keys = tuple([k for k, v in pt_outputs.items() if v is not None])
 
                 self.assertEqual(fx_keys, pt_keys)
@@ -2375,11 +2844,16 @@ class ModelTesterMixin:
 
                 # send pytorch inputs to the correct device
                 pt_inputs = {
-                    k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v for k, v in pt_inputs.items()
+                    k: v.to(device=torch_device) if isinstance(v, torch.Tensor) else v
+                    for k, v in pt_inputs.items()
                 }
 
                 # convert inputs to Flax
-                fx_inputs = {k: np.array(v.to("cpu")) for k, v in pt_inputs.items() if torch.is_tensor(v)}
+                fx_inputs = {
+                    k: np.array(v.to("cpu"))
+                    for k, v in pt_inputs.items()
+                    if torch.is_tensor(v)
+                }
 
                 pt_model = load_flax_weights_in_pytorch_model(pt_model, fx_model.params)
 
@@ -2401,7 +2875,9 @@ class ModelTesterMixin:
 
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     fx_model.save_pretrained(tmpdirname)
-                    pt_model_loaded = model_class.from_pretrained(tmpdirname, from_flax=True)
+                    pt_model_loaded = model_class.from_pretrained(
+                        tmpdirname, from_flax=True
+                    )
 
                 # send pytorch model to the correct device
                 pt_model_loaded.to(torch_device)
@@ -2411,7 +2887,9 @@ class ModelTesterMixin:
                     pt_outputs_loaded = pt_model_loaded(**pt_inputs)
 
                 fx_keys = tuple([k for k, v in fx_outputs.items() if v is not None])
-                pt_keys = tuple([k for k, v in pt_outputs_loaded.items() if v is not None])
+                pt_keys = tuple(
+                    [k for k, v in pt_outputs_loaded.items() if v is not None]
+                )
 
                 self.assertEqual(fx_keys, pt_keys)
                 self.check_pt_flax_outputs(fx_outputs, pt_outputs_loaded, model_class)
@@ -2451,7 +2929,11 @@ class ModelTesterMixin:
 
         # some params shouldn't be scattered by nn.DataParallel
         # so just remove them if they are present.
-        blacklist_non_batched_params = ["head_mask", "decoder_head_mask", "cross_attn_head_mask"]
+        blacklist_non_batched_params = [
+            "head_mask",
+            "decoder_head_mask",
+            "cross_attn_head_mask",
+        ]
         for k in blacklist_non_batched_params:
             inputs_dict.pop(k, None)
 
@@ -2526,7 +3008,9 @@ class ModelTesterMixin:
 
             # Assert that the memory use of device 1 is higher than it was when the entire model was loaded
             # on device 0 and device 1 wasn't used at all
-            self.assertGreater(memory_after_parallelization[1], memory_after_model_load[1])
+            self.assertGreater(
+                memory_after_parallelization[1], memory_after_model_load[1]
+            )
 
             del model
             gc.collect()
@@ -2561,10 +3045,14 @@ class ModelTesterMixin:
 
             for value, parallel_value in zip(output, parallel_output):
                 if isinstance(value, torch.Tensor):
-                    self.assertTrue(torch.allclose(value, parallel_value.to("cpu"), atol=1e-7))
+                    self.assertTrue(
+                        torch.allclose(value, parallel_value.to("cpu"), atol=1e-7)
+                    )
                 elif isinstance(value, (Tuple, List)):
                     for value_, parallel_value_ in zip(value, parallel_value):
-                        self.assertTrue(torch.allclose(value_, parallel_value_.to("cpu"), atol=1e-7))
+                        self.assertTrue(
+                            torch.allclose(value_, parallel_value_.to("cpu"), atol=1e-7)
+                        )
 
     def check_device_map_is_respected(self, model, device_map):
         for param_name, param in model.named_parameters():
@@ -2572,7 +3060,9 @@ class ModelTesterMixin:
             while len(param_name) > 0 and param_name not in device_map:
                 param_name = ".".join(param_name.split(".")[:-1])
             if param_name not in device_map:
-                raise ValueError("device map is incomplete, it does not contain any device for `param_name`.")
+                raise ValueError(
+                    "device map is incomplete, it does not contain any device for `param_name`."
+                )
 
             param_device = device_map[param_name]
             if param_device in ["cpu", "disk"]:
@@ -2604,19 +3094,26 @@ class ModelTesterMixin:
                     max_size = int(self.model_split_percents[0] * model_size)
                     max_memory = {0: max_size, "cpu": max_size}
                     # This errors out cause it's missing an offload folder
-                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    new_model = model_class.from_pretrained(
+                        tmp_dir, device_map="auto", max_memory=max_memory
+                    )
 
                 max_size = int(self.model_split_percents[1] * model_size)
                 max_memory = {0: max_size, "cpu": max_size}
                 new_model = model_class.from_pretrained(
-                    tmp_dir, device_map="auto", max_memory=max_memory, offload_folder=tmp_dir
+                    tmp_dir,
+                    device_map="auto",
+                    max_memory=max_memory,
+                    offload_folder=tmp_dir,
                 )
 
                 self.check_device_map_is_respected(new_model, new_model.hf_device_map)
                 torch.manual_seed(0)
                 new_output = new_model(**inputs_dict_class)
 
-                self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
+                self.assertTrue(
+                    torch.allclose(base_output[0], new_output[0], atol=1e-5)
+                )
 
     @require_accelerate
     @mark.accelerate_tests
@@ -2642,13 +3139,17 @@ class ModelTesterMixin:
                 max_memory = {0: max_size, "cpu": max_size}
 
                 # This doesn't error out as it's in safetensors and doesn't need an offload folder
-                new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                new_model = model_class.from_pretrained(
+                    tmp_dir, device_map="auto", max_memory=max_memory
+                )
 
                 self.check_device_map_is_respected(new_model, new_model.hf_device_map)
                 torch.manual_seed(0)
                 new_output = new_model(**inputs_dict_class)
 
-                self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
+                self.assertTrue(
+                    torch.allclose(base_output[0], new_output[0], atol=1e-5)
+                )
 
     @require_accelerate
     @mark.accelerate_tests
@@ -2675,16 +3176,24 @@ class ModelTesterMixin:
 
                 for max_size in max_gpu_sizes:
                     max_memory = {0: max_size, "cpu": model_size * 2}
-                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    new_model = model_class.from_pretrained(
+                        tmp_dir, device_map="auto", max_memory=max_memory
+                    )
                     # Making sure part of the model will actually end up offloaded
-                    self.assertSetEqual(set(new_model.hf_device_map.values()), {0, "cpu"})
+                    self.assertSetEqual(
+                        set(new_model.hf_device_map.values()), {0, "cpu"}
+                    )
 
-                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+                    self.check_device_map_is_respected(
+                        new_model, new_model.hf_device_map
+                    )
 
                     torch.manual_seed(0)
                     new_output = new_model(**inputs_dict_class)
 
-                    self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
+                    self.assertTrue(
+                        torch.allclose(base_output[0], new_output[0], atol=1e-5)
+                    )
 
     @require_accelerate
     @mark.accelerate_tests
@@ -2711,23 +3220,37 @@ class ModelTesterMixin:
 
                 for max_size in max_gpu_sizes:
                     max_memory = {0: max_size, 1: model_size * 2, "cpu": model_size * 2}
-                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    new_model = model_class.from_pretrained(
+                        tmp_dir, device_map="auto", max_memory=max_memory
+                    )
                     # Making sure part of the model will actually end up offloaded
                     self.assertSetEqual(set(new_model.hf_device_map.values()), {0, 1})
 
-                    self.check_device_map_is_respected(new_model, new_model.hf_device_map)
+                    self.check_device_map_is_respected(
+                        new_model, new_model.hf_device_map
+                    )
 
                     torch.manual_seed(0)
                     new_output = new_model(**inputs_dict_class)
 
-                    self.assertTrue(torch.allclose(base_output[0], new_output[0], atol=1e-5))
+                    self.assertTrue(
+                        torch.allclose(base_output[0], new_output[0], atol=1e-5)
+                    )
 
     def test_problem_types(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         problem_types = [
-            {"title": "multi_label_classification", "num_labels": 2, "dtype": torch.float},
-            {"title": "single_label_classification", "num_labels": 1, "dtype": torch.long},
+            {
+                "title": "multi_label_classification",
+                "num_labels": 2,
+                "dtype": torch.float,
+            },
+            {
+                "title": "single_label_classification",
+                "num_labels": 1,
+                "dtype": torch.long,
+            },
             {"title": "regression", "num_labels": 1, "dtype": torch.float},
         ]
 
@@ -2739,7 +3262,9 @@ class ModelTesterMixin:
                 continue
 
             for problem_type in problem_types:
-                with self.subTest(msg=f"Testing {model_class} with {problem_type['title']}"):
+                with self.subTest(
+                    msg=f"Testing {model_class} with {problem_type['title']}"
+                ):
                     config.problem_type = problem_type["title"]
                     config.num_labels = problem_type["num_labels"]
 
@@ -2747,10 +3272,16 @@ class ModelTesterMixin:
                     model.to(torch_device)
                     model.train()
 
-                    inputs = self._prepare_for_class(inputs_dict, model_class, return_labels=True)
+                    inputs = self._prepare_for_class(
+                        inputs_dict, model_class, return_labels=True
+                    )
 
                     if problem_type["num_labels"] > 1:
-                        inputs["labels"] = inputs["labels"].unsqueeze(1).repeat(1, problem_type["num_labels"])
+                        inputs["labels"] = (
+                            inputs["labels"]
+                            .unsqueeze(1)
+                            .repeat(1, problem_type["num_labels"])
+                        )
 
                     inputs["labels"] = inputs["labels"].to(problem_type["dtype"])
 
@@ -2761,7 +3292,10 @@ class ModelTesterMixin:
                     with warnings.catch_warnings(record=True) as warning_list:
                         loss = model(**inputs).loss
                     for w in warning_list:
-                        if "Using a target size that is different to the input size" in str(w.message):
+                        if (
+                            "Using a target size that is different to the input size"
+                            in str(w.message)
+                        ):
                             raise ValueError(
                                 f"Something is going wrong in the regression problem: intercepted {w.message}"
                             )
@@ -2774,7 +3308,9 @@ class ModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
-            if model_class.__name__ not in get_values(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES):
+            if model_class.__name__ not in get_values(
+                MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES
+            ):
                 continue
 
             with self.subTest(msg=f"Testing {model_class}"):
@@ -2784,9 +3320,13 @@ class ModelTesterMixin:
 
                     # Fails when we don't set ignore_mismatched_sizes=True
                     with self.assertRaises(RuntimeError):
-                        new_model = AutoModelForSequenceClassification.from_pretrained(tmp_dir, num_labels=42)
+                        new_model = AutoModelForSequenceClassification.from_pretrained(
+                            tmp_dir, num_labels=42
+                        )
                     with self.assertRaises(RuntimeError):
-                        new_model_without_prefix = AutoModel.from_pretrained(tmp_dir, vocab_size=10)
+                        new_model_without_prefix = AutoModel.from_pretrained(
+                            tmp_dir, vocab_size=10
+                        )
 
                     logger = logging.get_logger("transformers.modeling_utils")
 
@@ -2834,7 +3374,9 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
             model = model_class(config)
 
@@ -2853,15 +3395,19 @@ class ModelTesterMixin:
     @require_flash_attn
     @require_torch_gpu
     @mark.flash_attn_test
-    @slow
     def test_flash_attn_2_inference(self):
         import torch
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
@@ -2888,10 +3434,20 @@ class ModelTesterMixin:
                     dummy_attention_mask[:, :1] = 0
 
                 if model.config.is_encoder_decoder:
-                    decoder_input_ids = inputs_dict.get("decoder_input_ids", dummy_input)[:1]
+                    decoder_input_ids = inputs_dict.get(
+                        "decoder_input_ids", dummy_input
+                    )[:1]
 
-                    outputs = model(dummy_input, decoder_input_ids=decoder_input_ids, output_hidden_states=True)
-                    outputs_fa = model_fa(dummy_input, decoder_input_ids=decoder_input_ids, output_hidden_states=True)
+                    outputs = model(
+                        dummy_input,
+                        decoder_input_ids=decoder_input_ids,
+                        output_hidden_states=True,
+                    )
+                    outputs_fa = model_fa(
+                        dummy_input,
+                        decoder_input_ids=decoder_input_ids,
+                        output_hidden_states=True,
+                    )
                 else:
                     outputs = model(dummy_input, output_hidden_states=True)
                     outputs_fa = model_fa(dummy_input, output_hidden_states=True)
@@ -2956,9 +3512,14 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
@@ -2985,10 +3546,20 @@ class ModelTesterMixin:
                     dummy_attention_mask[:, -1:] = 0
 
                 if model.config.is_encoder_decoder:
-                    decoder_input_ids = inputs_dict.get("decoder_input_ids", dummy_input)[:1]
+                    decoder_input_ids = inputs_dict.get(
+                        "decoder_input_ids", dummy_input
+                    )[:1]
 
-                    outputs = model(dummy_input, decoder_input_ids=decoder_input_ids, output_hidden_states=True)
-                    outputs_fa = model_fa(dummy_input, decoder_input_ids=decoder_input_ids, output_hidden_states=True)
+                    outputs = model(
+                        dummy_input,
+                        decoder_input_ids=decoder_input_ids,
+                        output_hidden_states=True,
+                    )
+                    outputs_fa = model_fa(
+                        dummy_input,
+                        decoder_input_ids=decoder_input_ids,
+                        output_hidden_states=True,
+                    )
                 else:
                     outputs = model(dummy_input, output_hidden_states=True)
                     outputs_fa = model_fa(dummy_input, output_hidden_states=True)
@@ -3049,36 +3620,55 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
                 model = model_class.from_pretrained(
-                    tmpdirname, torch_dtype=torch.float16, use_flash_attention_2=False, low_cpu_mem_usage=True
+                    tmpdirname,
+                    torch_dtype=torch.float16,
+                    use_flash_attention_2=False,
+                    low_cpu_mem_usage=True,
                 ).to(torch_device)
 
                 dummy_input = inputs_dict[model.main_input_name]
                 if dummy_input.dtype in [torch.float32, torch.bfloat16]:
                     dummy_input = dummy_input.to(torch.float16)
 
-                dummy_attention_mask = inputs_dict.get("attention_mask", torch.ones_like(dummy_input))
+                dummy_attention_mask = inputs_dict.get(
+                    "attention_mask", torch.ones_like(dummy_input)
+                )
                 # make sure we do left padding
                 dummy_attention_mask[:, :-1] = 0
                 dummy_attention_mask[:, -1:] = 1
 
                 out = model.generate(
-                    dummy_input, attention_mask=dummy_attention_mask, max_new_tokens=1, do_sample=False
+                    dummy_input,
+                    attention_mask=dummy_attention_mask,
+                    max_new_tokens=1,
+                    do_sample=False,
                 )
 
                 model = model_class.from_pretrained(
-                    tmpdirname, torch_dtype=torch.float16, use_flash_attention_2=True, low_cpu_mem_usage=True
+                    tmpdirname,
+                    torch_dtype=torch.float16,
+                    use_flash_attention_2=True,
+                    low_cpu_mem_usage=True,
                 ).to(torch_device)
 
                 out_fa = model.generate(
-                    dummy_input, attention_mask=dummy_attention_mask, max_new_tokens=1, do_sample=False
+                    dummy_input,
+                    attention_mask=dummy_attention_mask,
+                    max_new_tokens=1,
+                    do_sample=False,
                 )
 
                 self.assertTrue(torch.equal(out, out_fa))
@@ -3092,36 +3682,55 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
                 model = model_class.from_pretrained(
-                    tmpdirname, torch_dtype=torch.float16, use_flash_attention_2=False, low_cpu_mem_usage=True
+                    tmpdirname,
+                    torch_dtype=torch.float16,
+                    use_flash_attention_2=False,
+                    low_cpu_mem_usage=True,
                 ).to(torch_device)
 
                 dummy_input = inputs_dict[model.main_input_name]
                 if dummy_input.dtype in [torch.float32, torch.bfloat16]:
                     dummy_input = dummy_input.to(torch.float16)
 
-                dummy_attention_mask = inputs_dict.get("attention_mask", torch.ones_like(dummy_input))
+                dummy_attention_mask = inputs_dict.get(
+                    "attention_mask", torch.ones_like(dummy_input)
+                )
                 # make sure we do right padding
                 dummy_attention_mask[:, :-1] = 1
                 dummy_attention_mask[:, -1:] = 0
 
                 out = model.generate(
-                    dummy_input, attention_mask=dummy_attention_mask, max_new_tokens=1, do_sample=False
+                    dummy_input,
+                    attention_mask=dummy_attention_mask,
+                    max_new_tokens=1,
+                    do_sample=False,
                 )
 
                 model = model_class.from_pretrained(
-                    tmpdirname, torch_dtype=torch.float16, use_flash_attention_2=True, low_cpu_mem_usage=True
+                    tmpdirname,
+                    torch_dtype=torch.float16,
+                    use_flash_attention_2=True,
+                    low_cpu_mem_usage=True,
                 ).to(torch_device)
 
                 out_fa = model.generate(
-                    dummy_input, attention_mask=dummy_attention_mask, max_new_tokens=1, do_sample=False
+                    dummy_input,
+                    attention_mask=dummy_attention_mask,
+                    max_new_tokens=1,
+                    do_sample=False,
                 )
 
                 self.assertTrue(torch.equal(out, out_fa))
@@ -3137,9 +3746,14 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
 
             dummy_input = inputs_dict[model_class.main_input_name]
             if dummy_input.dtype in [torch.float32, torch.bfloat16]:
@@ -3147,14 +3761,18 @@ class ModelTesterMixin:
 
             # make sure that all models have enough positions for generation
             if hasattr(config, "max_position_embeddings"):
-                config.max_position_embeddings = max_new_tokens + dummy_input.shape[1] + 1
+                config.max_position_embeddings = (
+                    max_new_tokens + dummy_input.shape[1] + 1
+                )
 
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
 
-                dummy_attention_mask = inputs_dict.get("attention_mask", torch.ones_like(dummy_input))
+                dummy_attention_mask = inputs_dict.get(
+                    "attention_mask", torch.ones_like(dummy_input)
+                )
 
                 model = model_class.from_pretrained(
                     tmpdirname,
@@ -3182,16 +3800,23 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
             model = model_class(config)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
 
                 dummy_input = inputs_dict[model.main_input_name]
-                dummy_attention_mask = inputs_dict.get("attention_mask", torch.ones_like(dummy_input))
+                dummy_attention_mask = inputs_dict.get(
+                    "attention_mask", torch.ones_like(dummy_input)
+                )
 
                 if model.config.is_encoder_decoder:
                     dummy_decoder_input_ids = inputs_dict["decoder_input_ids"]
@@ -3207,7 +3832,9 @@ class ModelTesterMixin:
 
                 for _, param in model.named_parameters():
                     # upcast only layer norms
-                    if (param.dtype == torch.float16) or (param.dtype == torch.bfloat16):
+                    if (param.dtype == torch.float16) or (
+                        param.dtype == torch.bfloat16
+                    ):
                         param.data = param.data.to(torch.float32)
 
                 if model.config.is_encoder_decoder:
@@ -3227,9 +3854,14 @@ class ModelTesterMixin:
     @is_pt_tf_cross_test
     def test_tf_from_pt_safetensors(self):
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
 
-            tf_model_class_name = "TF" + model_class.__name__  # Add the "TF" at the beginning
+            tf_model_class_name = (
+                "TF" + model_class.__name__
+            )  # Add the "TF" at the beginning
             if not hasattr(transformers, tf_model_class_name):
                 # transformers does not have this model in TF version yet
                 return
@@ -3252,9 +3884,14 @@ class ModelTesterMixin:
     @is_pt_flax_cross_test
     def test_flax_from_pt_safetensors(self):
         for model_class in self.all_model_classes:
-            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            (
+                config,
+                inputs_dict,
+            ) = self.model_tester.prepare_config_and_inputs_for_common()
 
-            flax_model_class_name = "Flax" + model_class.__name__  # Add the "Flax at the beginning
+            flax_model_class_name = (
+                "Flax" + model_class.__name__
+            )  # Add the "Flax at the beginning
             if not hasattr(transformers, flax_model_class_name):
                 # transformers does not have this model in Flax version yet
                 return
@@ -3265,10 +3902,14 @@ class ModelTesterMixin:
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 pt_model.save_pretrained(tmpdirname, safe_serialization=True)
-                flax_model_1 = flax_model_class.from_pretrained(tmpdirname, from_pt=True)
+                flax_model_1 = flax_model_class.from_pretrained(
+                    tmpdirname, from_pt=True
+                )
 
                 pt_model.save_pretrained(tmpdirname, safe_serialization=False)
-                flax_model_2 = flax_model_class.from_pretrained(tmpdirname, from_pt=True)
+                flax_model_2 = flax_model_class.from_pretrained(
+                    tmpdirname, from_pt=True
+                )
 
                 # Check models are equal
                 self.assertTrue(check_models_equal(flax_model_1, flax_model_2))
@@ -3282,7 +3923,9 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
+                self.skipTest(
+                    f"{model_class.__name__} does not support Flash Attention 2"
+                )
 
             config, _ = self.model_tester.prepare_config_and_inputs_for_common()
             # TODO: to change it in the future with other relevant auto classes
@@ -3290,8 +3933,12 @@ class ModelTesterMixin:
                 config, use_flash_attention_2=True, torch_dtype=torch.bfloat16
             ).to(torch_device)
 
-            dummy_input = torch.LongTensor([[0, 2, 3, 4], [0, 2, 3, 4]]).to(torch_device)
-            dummy_attention_mask = torch.LongTensor([[1, 1, 1, 1], [0, 1, 1, 1]]).to(torch_device)
+            dummy_input = torch.LongTensor([[0, 2, 3, 4], [0, 2, 3, 4]]).to(
+                torch_device
+            )
+            dummy_attention_mask = torch.LongTensor([[1, 1, 1, 1], [0, 1, 1, 1]]).to(
+                torch_device
+            )
 
             fa2_correctly_converted = False
 
@@ -3309,7 +3956,11 @@ class ModelTesterMixin:
 
                 model_from_pretrained = AutoModelForCausalLM.from_pretrained(tmpdirname)
 
-                self.assertFalse(getattr(model_from_pretrained.config, "_flash_attn_2_enabled", False))
+                self.assertFalse(
+                    getattr(
+                        model_from_pretrained.config, "_flash_attn_2_enabled", False
+                    )
+                )
 
                 fa2_correctly_converted = False
 
@@ -3337,7 +3988,11 @@ def ids_tensor(shape, vocab_size, rng=None, name=None):
     for _ in range(total_dims):
         values.append(rng.randint(0, vocab_size - 1))
 
-    return torch.tensor(data=values, dtype=torch.long, device=torch_device).view(shape).contiguous()
+    return (
+        torch.tensor(data=values, dtype=torch.long, device=torch_device)
+        .view(shape)
+        .contiguous()
+    )
 
 
 def random_attention_mask(shape, rng=None, name=None):
@@ -3361,4 +4016,8 @@ def floats_tensor(shape, scale=1.0, rng=None, name=None):
     for _ in range(total_dims):
         values.append(rng.random() * scale)
 
-    return torch.tensor(data=values, dtype=torch.float, device=torch_device).view(shape).contiguous()
+    return (
+        torch.tensor(data=values, dtype=torch.float, device=torch_device)
+        .view(shape)
+        .contiguous()
+    )

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3506,6 +3506,7 @@ class ModelTesterMixin:
     @require_flash_attn
     @require_torch_gpu
     @mark.flash_attn_test
+    @slow
     def test_flash_attn_2_inference_padding_right(self):
         import torch
 
@@ -3608,113 +3609,7 @@ class ModelTesterMixin:
                     else outputs_fa.decoder_hidden_states[-1]
                 )
 
-                for i in range(logits.shape[0]):
-                    if not torch.allclose(logits[i], logits_fa[i]):
-                        print(i)
-                print(logits_fa[:-1].shape)
                 assert torch.allclose(logits_fa[:-1], logits[:-1], atol=4e-2, rtol=4e-2)
-
-    @require_flash_attn
-    @require_torch_gpu
-    @mark.flash_attn_test
-    def test_flash_attn_2_inference_padding_right_by_1(self):
-        import torch
-
-        from transformers import MistralModel, PersimmonModel
-
-        for model_class in self.all_model_classes:
-            if model_class == PersimmonModel or model_class == MistralModel:
-                (
-                    config,
-                    inputs_dict,
-                ) = self.model_tester.prepare_config_and_inputs_for_common()
-
-                model = model_class(config)
-                print("Hello")
-                print("Model class: {}".format(model_class))
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    model.save_pretrained(tmpdirname)
-                    model_fa = model_class.from_pretrained(
-                        tmpdirname,
-                        torch_dtype=torch.bfloat16,
-                        use_flash_attention_2=True,
-                    )
-                    model_fa.to(torch_device)
-
-                    model = model_class.from_pretrained(
-                        tmpdirname,
-                        torch_dtype=torch.bfloat16,
-                        use_flash_attention_2=False,
-                    )
-                    model.to(torch_device)
-
-                    dummy_inputs = inputs_dict[model.main_input_name]
-                    if dummy_inputs.dtype in [torch.float32, torch.float16]:
-                        dummy_inputs = dummy_inputs.to(torch.bfloat16)
-
-                    dummy_attention_masks = inputs_dict.get("attention_mask", None)
-
-                    if dummy_attention_masks is not None:
-                        dummy_attention_masks[:, :-1] = 1
-                        dummy_attention_masks[:, -1:] = 0
-
-                    for i in range(dummy_inputs.shape[0]):
-                        print(f"Iteration {i}")
-                        idx = slice(0, i + 1)
-                        dummy_input = dummy_inputs[idx]
-                        dummy_attention_mask = dummy_attention_masks[idx]
-
-                        other_inputs = {
-                            "output_hidden_states": True,
-                        }
-
-                        if dummy_attention_mask is not None:
-                            other_inputs["attention_mask"] = dummy_attention_mask
-
-                        # Test no mask
-                        outputs = model(dummy_input, output_hidden_states=True)
-                        outputs_fa = model_fa(dummy_input, output_hidden_states=True)
-
-                        logits = (
-                            outputs.hidden_states[-1]
-                            if not model.config.is_encoder_decoder
-                            else outputs.decoder_hidden_states[-1]
-                        )
-                        logits_fa = (
-                            outputs_fa.hidden_states[-1]
-                            if not model.config.is_encoder_decoder
-                            else outputs_fa.decoder_hidden_states[-1]
-                        )
-
-                        if not torch.allclose(
-                            logits_fa[:-1], logits[:-1], atol=4e-2, rtol=4e-2
-                        ):
-                            print(
-                                f"Input shape {dummy_input.shape} logits with mask not equal"
-                            )
-                        # Test with mask
-                        outputs = model(dummy_input, **other_inputs)
-                        outputs_fa = model_fa(dummy_input, **other_inputs)
-
-                        logits = (
-                            outputs.hidden_states[-1]
-                            if not model.config.is_encoder_decoder
-                            else outputs.decoder_hidden_states[-1]
-                        )
-                        logits_fa = (
-                            outputs_fa.hidden_states[-1]
-                            if not model.config.is_encoder_decoder
-                            else outputs_fa.decoder_hidden_states[-1]
-                        )
-
-                        if not torch.allclose(
-                            logits_fa[:-1], logits[:-1], atol=4e-2, rtol=4e-2
-                        ):
-                            print(
-                                f"Input shape {dummy_input.shape} logits with mask not equal"
-                            )
-            else:
-                return
 
     @require_flash_attn
     @require_torch_gpu
@@ -3781,6 +3676,7 @@ class ModelTesterMixin:
     @require_flash_attn
     @require_torch_gpu
     @mark.flash_attn_test
+    @slow
     def test_flash_attn_2_generate_padding_right(self):
         import torch
 
@@ -3822,8 +3718,6 @@ class ModelTesterMixin:
                     attention_mask=dummy_attention_mask,
                     max_new_tokens=1,
                     do_sample=False,
-                    # return_dict_in_generate=True,
-                    # output_scores=True,
                 )
 
                 model = model_class.from_pretrained(
@@ -3838,19 +3732,9 @@ class ModelTesterMixin:
                     attention_mask=dummy_attention_mask,
                     max_new_tokens=1,
                     do_sample=False,
-                    # return_dict_in_generate=True,
-                    # output_scores=True,
                 )
-                # print(f"out={out}")
-                # print(f"out_fa={out_fa}")
-                print(f"config: {config}")
-                for i in range(out.shape[0]):
-                    if not torch.equal(out[i], out_fa[i]):
-                        print(f"i={i}")
-                        print(f"out[{i}]={out[i]}")
-                        print(f"out_fa[{i}]={out_fa[i]}")
 
-                # self.assertTrue(torch.equal(out, out_fa))
+                self.assertTrue(torch.equal(out, out_fa))
 
     @require_flash_attn
     @require_torch_gpu

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3013,9 +3013,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             model = model_class(config)
 
@@ -3039,9 +3037,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3149,9 +3145,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3183,9 +3177,7 @@ class ModelTesterMixin:
                     dummy_attention_mask[:, -1:] = 0
 
                 if model.config.is_encoder_decoder:
-                    decoder_input_ids = inputs_dict.get(
-                        "decoder_input_ids", dummy_input
-                    )[:1]
+                    decoder_input_ids = inputs_dict.get("decoder_input_ids", dummy_input)[:1]
 
                     outputs = model(
                         dummy_input,
@@ -3257,9 +3249,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3317,9 +3307,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3341,9 +3329,7 @@ class ModelTesterMixin:
                 if dummy_input.dtype in [torch.float32, torch.bfloat16]:
                     dummy_input = dummy_input.to(torch.float16)
 
-                dummy_attention_mask = inputs_dict.get(
-                    "attention_mask", torch.ones_like(dummy_input)
-                )
+                dummy_attention_mask = inputs_dict.get("attention_mask", torch.ones_like(dummy_input))
                 # make sure we do right padding
                 dummy_attention_mask[:, :-1] = 1
                 dummy_attention_mask[:, -1:] = 0
@@ -3382,9 +3368,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3432,9 +3416,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             (
                 config,
@@ -3543,9 +3525,7 @@ class ModelTesterMixin:
 
         for model_class in self.all_generative_model_classes:
             if not model_class._supports_flash_attn_2:
-                self.skipTest(
-                    f"{model_class.__name__} does not support Flash Attention 2"
-                )
+                self.skipTest(f"{model_class.__name__} does not support Flash Attention 2")
 
             config, _ = self.model_tester.prepare_config_and_inputs_for_common()
             # TODO: to change it in the future with other relevant auto classes
@@ -3553,12 +3533,8 @@ class ModelTesterMixin:
                 config, use_flash_attention_2=True, torch_dtype=torch.bfloat16
             ).to(torch_device)
 
-            dummy_input = torch.LongTensor([[0, 2, 3, 4], [0, 2, 3, 4]]).to(
-                torch_device
-            )
-            dummy_attention_mask = torch.LongTensor([[1, 1, 1, 1], [0, 1, 1, 1]]).to(
-                torch_device
-            )
+            dummy_input = torch.LongTensor([[0, 2, 3, 4], [0, 2, 3, 4]]).to(torch_device)
+            dummy_attention_mask = torch.LongTensor([[1, 1, 1, 1], [0, 1, 1, 1]]).to(torch_device)
 
             fa2_correctly_converted = False
 
@@ -3576,11 +3552,7 @@ class ModelTesterMixin:
 
                 model_from_pretrained = AutoModelForCausalLM.from_pretrained(tmpdirname)
 
-                self.assertFalse(
-                    getattr(
-                        model_from_pretrained.config, "_flash_attn_2_enabled", False
-                    )
-                )
+                self.assertFalse(getattr(model_from_pretrained.config, "_flash_attn_2_enabled", False))
 
                 fa2_correctly_converted = False
 


### PR DESCRIPTION
# What does this PR do?

Integrates FA2 to Persimmon per #26350, #27052 (former branch was messed up after trying to rebase, so PR'ing a new branch).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?
@younesbelkada @ArthurZucker 

## Notes

- Fixed comments per #27052.  Requesting new PR as former branch was messed up after trying to `rebase` on `main`.
- Tried making changes as suggested in #27661 for `generate_padding_right` test.  However, `Persimmon` tokenizer configs do not have either `eos` or `pad` tokens (both are set to `null` see [here](https://huggingface.co/adept/persimmon-8b-chat/blob/main/tokenizer_config.json)), so simply copying the `LlamaModelTest` `generate_padding_right` test override does not work.
  - Also tried running `dummy inputs` on the full pretrained model for the `generate_padding_right` test, no luck either -- this is left as the current implementation in `test_persimmon_modeling.py`.
  - Ran some additional experiments on the `generate_padding_test` for other models for FA2 -- see [comments](https://github.com/huggingface/transformers/pull/27052#issuecomment-1820156930).
  - Marking `generate_padding_right` test as `skip` for now.
- Files other than those related to `persimmon` were changed in this PR due to fixes from running `make {quality, style, fixup}`
    