### PR TITLE
Fix Past CI

### DIFF
--- a/.github/workflows/self-past.yml
+++ b/.github/workflows/self-past.yml
@@ -88,6 +88,10 @@ jobs:
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
+      - name: Update some packages
+        working-directory: /transformers
+        run: python3 -m pip install -U datasets
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -164,6 +168,10 @@ jobs:
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
+      - name: Update some packages
+        working-directory: /transformers
+        run: python3 -m pip install -U datasets
+
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
         # For folders like `models/bert`, set an env. var. (`matrix_folders`) to `models_bert`, which will be used to
@@ -239,6 +247,10 @@ jobs:
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
+      - name: Update some packages
+        working-directory: /transformers
+        run: python3 -m pip install -U datasets
 
       - name: Install
         working-directory: /transformers


### PR DESCRIPTION
# What does this PR do?

Since mid-November, we have hundreds of following failures in each past CI

> (line 1108)  NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.

It is caused by `fsspec==2023.10.0` with an old `datasets`.

This PR just updates `datasets` (at CI runtime) to avoid, and fix thousand failures in total in past CI 🚀 🤣 