### PR TITLE
Improve forward signature test

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -52,7 +52,6 @@ from transformers.models.auto.modeling_auto import (
     MODEL_FOR_MASKED_LM_MAPPING_NAMES,
     MODEL_FOR_MULTIPLE_CHOICE_MAPPING_NAMES,
     MODEL_FOR_NEXT_SENTENCE_PREDICTION_MAPPING_NAMES,
-    MODEL_FOR_PRETRAINING_MAPPING_NAMES,
     MODEL_FOR_QUESTION_ANSWERING_MAPPING_NAMES,
     MODEL_FOR_SEMANTIC_SEGMENTATION_MAPPING_NAMES,
     MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES,
@@ -60,7 +59,6 @@ from transformers.models.auto.modeling_auto import (
     MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES,
     MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING_NAMES,
     MODEL_MAPPING_NAMES,
-    MODEL_WITH_LM_HEAD_MAPPING_NAMES,
 )
 from transformers.testing_utils import (
     CaptureLogger,
@@ -532,17 +530,12 @@ class ModelTesterMixin:
             arg_names = [*signature.parameters.keys()]
 
             if model.config.is_encoder_decoder:
-                if model_class.__name__ in [
-                    *get_values(MODEL_WITH_LM_HEAD_MAPPING_NAMES),
-                    *get_values(MODEL_FOR_PRETRAINING_MAPPING_NAMES),
-                    *get_values(MODEL_FOR_CAUSAL_LM_MAPPING_NAMES),
-                ]:
-                    expected_arg_names = [
-                        "input_ids",
-                        "attention_mask",
-                        "decoder_input_ids",
-                        "decoder_attention_mask",
-                    ]
+                expected_arg_names = [
+                    "input_ids",
+                    "attention_mask",
+                    "decoder_input_ids",
+                    "decoder_attention_mask",
+                ]
                 expected_arg_names.extend(
                     ["head_mask", "decoder_head_mask", "cross_attn_head_mask", "encoder_outputs"]
                     if "head_mask" and "decoder_head_mask" and "cross_attn_head_mask" in arg_names

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -542,10 +542,11 @@ class ModelTesterMixin:
                     else ["encoder_outputs"]
                 )
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
-            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)]:
+            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)] and self.has_attentions:
+                expected_arg_names = ["pixel_values", "output_hidden_states", "output_attentions", "return_dict"]
+                self.assertListEqual(arg_names, expected_arg_names)
+            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)] and not self.has_attentions:
                 expected_arg_names = ["pixel_values", "output_hidden_states", "return_dict"]
-                if self.has_attentions:
-                    expected_arg_names += ["output_attentions"]
                 self.assertListEqual(arg_names, expected_arg_names)
             else:
                 expected_arg_names = [model.main_input_name]

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -542,11 +542,10 @@ class ModelTesterMixin:
                     else ["encoder_outputs"]
                 )
                 self.assertListEqual(arg_names[: len(expected_arg_names)], expected_arg_names)
-            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)] and self.has_attentions:
-                expected_arg_names = ["pixel_values", "output_hidden_states", "output_attentions", "return_dict"]
-                self.assertListEqual(arg_names, expected_arg_names)
-            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)] and not self.has_attentions:
+            elif model_class.__name__ in [*get_values(MODEL_FOR_BACKBONE_MAPPING_NAMES)]:
                 expected_arg_names = ["pixel_values", "output_hidden_states", "return_dict"]
+                if self.has_attentions:
+                    expected_arg_names += ["output_attentions"]
                 self.assertListEqual(arg_names, expected_arg_names)
             else:
                 expected_arg_names = [model.main_input_name]


### PR DESCRIPTION
# What does this PR do?

As a follow-up of #27681, I'd like to make sure that every new backbone that is added to the library follows the same API. Hence, this PR extends the `test_forward_signature` test to make sure this is tested.

Rather than only checking the first keyword argument, it checks all of them. 