### PR TITLE
Deberta can now be exported to TorchScript 

### DIFF
--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -447,8 +447,10 @@ class DebertaEncoder(nn.Module):
 
     def get_rel_pos(self, hidden_states, query_states=None, relative_pos=None):
         if self.relative_attention and relative_pos is None:
-            q = query_states.size(-2) if query_states is not None else hidden_states.size(-2)
-            relative_pos = build_relative_position(q, hidden_states.size(-2), hidden_states.device)
+            if query_states is not None:
+                relative_pos = build_relative_position(query_states, hidden_states)
+            else:
+                relative_pos = build_relative_position(hidden_states, hidden_states)
         return relative_pos
 
     def forward(
@@ -519,7 +521,8 @@ class DebertaEncoder(nn.Module):
         )
 
 
-def build_relative_position(query_size, key_size, device):
+@torch.jit.script
+def build_relative_position(query_layer, key_layer):
     """
     Build relative position according to the query and key
 
@@ -528,16 +531,19 @@ def build_relative_position(query_size, key_size, device):
     P_k\\)
 
     Args:
-        query_size (int): the length of query
-        key_size (int): the length of key
+        query_layer (Tensor): the query layer or tensor from which to infer size and device
+        key_layer (Tensor): the key layer or tensor from which to infer size and device
 
     Return:
-        `torch.LongTensor`: A tensor with shape [1, query_size, key_size]
+        `torch.LongTensor`: A tensor with shape [1, query_layer.size, key-layer.size]
 
     """
 
-    q_ids = torch.arange(query_size, dtype=torch.long, device=device)
-    k_ids = torch.arange(key_size, dtype=torch.long, device=device)
+    query_size = query_layer.size(-2)
+    key_size = key_layer.size(-2)
+
+    q_ids = torch.arange(query_size, dtype=torch.long, device=query_layer.device)
+    k_ids = torch.arange(key_size, dtype=torch.long, device=key_layer.device)
     rel_pos_ids = q_ids[:, None] - k_ids.view(1, -1).repeat(query_size, 1)
     rel_pos_ids = rel_pos_ids[:query_size, :]
     rel_pos_ids = rel_pos_ids.unsqueeze(0)
@@ -557,6 +563,18 @@ def p2c_dynamic_expand(c2p_pos, query_layer, key_layer):
 @torch.jit.script
 def pos_dynamic_expand(pos_index, p2c_att, key_layer):
     return pos_index.expand(p2c_att.size()[:2] + (pos_index.size(-2), key_layer.size(-2)))
+
+
+@torch.jit.script
+def get_attention_mask_on_device(device_discriminator, using_ids: bool):
+    input_shape = device_discriminator.size() if using_ids else device_discriminator.size()[:-1]
+    return torch.ones(input_shape, device=device_discriminator.device)
+
+
+@torch.jit.script
+def get_token_type_ids_on_device(device_discriminator, using_ids: bool):
+    input_shape = device_discriminator.size() if using_ids else device_discriminator.size()[:-1]
+    return torch.zeros(input_shape, dtype=torch.long, device=device_discriminator.device)
 
 
 class DisentangledSelfAttention(nn.Module):
@@ -703,8 +721,7 @@ class DisentangledSelfAttention(nn.Module):
 
     def disentangled_att_bias(self, query_layer, key_layer, relative_pos, rel_embeddings, scale_factor):
         if relative_pos is None:
-            q = query_layer.size(-2)
-            relative_pos = build_relative_position(q, key_layer.size(-2), query_layer.device)
+            relative_pos = build_relative_position(query_layer, key_layer)
         if relative_pos.dim() == 2:
             relative_pos = relative_pos.unsqueeze(0).unsqueeze(0)
         elif relative_pos.dim() == 3:
@@ -714,7 +731,7 @@ class DisentangledSelfAttention(nn.Module):
             raise ValueError(f"Relative position ids must be of dim 2 or 3 or 4. {relative_pos.dim()}")
 
         att_span = min(max(query_layer.size(-2), key_layer.size(-2)), self.max_relative_positions)
-        relative_pos = relative_pos.long().to(query_layer.device)
+        relative_pos = relative_pos.long()
         rel_embeddings = rel_embeddings[
             self.max_relative_positions - att_span : self.max_relative_positions + att_span, :
         ].unsqueeze(0)
@@ -736,7 +753,7 @@ class DisentangledSelfAttention(nn.Module):
             pos_query_layer = self.transpose_for_scores(pos_query_layer)
             pos_query_layer /= torch.sqrt(torch.tensor(pos_query_layer.size(-1), dtype=torch.float) * scale_factor)
             if query_layer.size(-2) != key_layer.size(-2):
-                r_pos = build_relative_position(key_layer.size(-2), key_layer.size(-2), query_layer.device)
+                r_pos = build_relative_position(key_layer, key_layer)
             else:
                 r_pos = relative_pos
             p2c_pos = torch.clamp(-r_pos + att_span, 0, att_span * 2 - 1)
@@ -785,8 +802,12 @@ class DebertaEmbeddings(nn.Module):
     def forward(self, input_ids=None, token_type_ids=None, position_ids=None, mask=None, inputs_embeds=None):
         if input_ids is not None:
             input_shape = input_ids.size()
+            device_discriminator = input_ids
+            using_ids = True
         else:
             input_shape = inputs_embeds.size()[:-1]
+            device_discriminator = inputs_embeds
+            using_ids = False
 
         seq_length = input_shape[1]
 
@@ -794,7 +815,7 @@ class DebertaEmbeddings(nn.Module):
             position_ids = self.position_ids[:, :seq_length]
 
         if token_type_ids is None:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=self.position_ids.device)
+            token_type_ids = get_token_type_ids_on_device(device_discriminator, using_ids)
 
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
@@ -970,18 +991,18 @@ class DebertaModel(DebertaPreTrainedModel):
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
             self.warn_if_padding_and_no_attention_mask(input_ids, attention_mask)
-            input_shape = input_ids.size()
+            device_discriminator = input_ids
+            using_ids = True
         elif inputs_embeds is not None:
-            input_shape = inputs_embeds.size()[:-1]
+            device_discriminator = inputs_embeds
+            using_ids = False
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
-        device = input_ids.device if input_ids is not None else inputs_embeds.device
-
         if attention_mask is None:
-            attention_mask = torch.ones(input_shape, device=device)
+            attention_mask = get_attention_mask_on_device(device_discriminator, using_ids)
         if token_type_ids is None:
-            token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+            token_type_ids = get_token_type_ids_on_device(device_discriminator, using_ids)
 
         embedding_output = self.embeddings(
             input_ids=input_ids,

--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -108,15 +108,15 @@ def _get_float_min_value(
     tensor,
     f16_min=torch.tensor(torch.finfo(torch.float16).min),
     f32_min=torch.tensor(torch.finfo(torch.float32).min),
-    f64_min=torch.tensor(torch.finfo(torch.float64).min)
-    ):
+    f64_min=torch.tensor(torch.finfo(torch.float64).min),
+):
     if tensor.dtype == torch.float16:
         return f16_min
     elif tensor.dtype == torch.float32:
         return f32_min
     else:
         return f64_min
-    
+
 
 def get_min_for_tensor(tensor):
     """
@@ -135,6 +135,7 @@ def get_min_for_tensor(tensor):
         return _get_float_min_value(tensor)
     # Will be baked in during tracing
     return torch.tensor(torch.finfo(tensor.dtype).min)
+
 
 @_traceable
 class XSoftmax(torch.autograd.Function):
@@ -611,7 +612,7 @@ def get_token_type_ids_on_device(device_discriminator, using_ids: bool):
 
 
 @torch.jit.script
-def scaled_size_sqrt(query_layer, scale_factor:int):
+def scaled_size_sqrt(query_layer, scale_factor: int):
     return torch.sqrt(torch.tensor(query_layer.size(-1), dtype=torch.float) * scale_factor)
 
 
@@ -621,12 +622,12 @@ def build_rpos(query_layer, key_layer, relative_pos):
         return build_relative_position(key_layer, key_layer)
     else:
         return relative_pos
-    
+
+
 @torch.jit.script
-def compute_attention_span(query_layer, key_layer, max_relative_positions:int):
-    return torch.tensor(
-        min(max(query_layer.size(-2), key_layer.size(-2)), max_relative_positions)
-    )
+def compute_attention_span(query_layer, key_layer, max_relative_positions: int):
+    return torch.tensor(min(max(query_layer.size(-2), key_layer.size(-2)), max_relative_positions))
+
 
 @torch.jit.script
 def uneven_size_corrected(p2c_att, query_layer, key_layer, relative_pos):
@@ -635,6 +636,7 @@ def uneven_size_corrected(p2c_att, query_layer, key_layer, relative_pos):
         return torch.gather(p2c_att, dim=2, index=pos_dynamic_expand(pos_index, p2c_att, key_layer))
     else:
         return p2c_att
+
 
 class DisentangledSelfAttention(nn.Module):
     """

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -189,7 +189,6 @@ def _compute_mask_indices(
     return spec_aug_mask
 
 
-# Copied from transformers.models.deberta_v2.modeling_deberta_v2.make_log_bucket_position
 def make_log_bucket_position(relative_pos, bucket_size, max_position):
     sign = torch.sign(relative_pos)
     mid = bucket_size // 2
@@ -205,7 +204,6 @@ def make_log_bucket_position(relative_pos, bucket_size, max_position):
     return bucket_pos
 
 
-# Copied from transformers.models.deberta_v2.modeling_deberta_v2.build_relative_position
 def build_relative_position(query_size, key_size, bucket_size=-1, max_position=-1, device=None):
     """
     Build relative position according to the query and key
@@ -675,7 +673,6 @@ class SEWDSelfOutput(nn.Module):
         return hidden_states
 
 
-# Copied from transformers.models.deberta_v2.modeling_deberta_v2.DisentangledSelfAttention with attention_probs_dropout_prob->attention_dropout, hidden_dropout_prob->activation_dropout
 class DisentangledSelfAttention(nn.Module):
     """
     Disentangled self-attention module
@@ -997,7 +994,6 @@ class SEWDLayer(nn.Module):
             return layer_output
 
 
-# Copied from transformers.models.deberta_v2.modeling_deberta_v2.ConvLayer
 class ConvLayer(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -1034,7 +1030,6 @@ class ConvLayer(nn.Module):
         return output_states
 
 
-# Copied from transformers.models.deberta_v2.modeling_deberta_v2.DebertaV2Encoder with DebertaV2->SEWD
 class SEWDTransformerEncoder(nn.Module):
     """Modified BertEncoder with relative position bias support"""
 

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -495,7 +495,6 @@ class ContextPooler(nn.Module):
         return self.config.hidden_size
 
 
-# Copied from transformers.models.deberta.modeling_deberta.XSoftmax with deberta->deberta_v2
 class XSoftmax(torch.autograd.Function):
     """
     Masked Softmax which is optimized for saving memory

--- a/tests/models/deberta/test_modeling_deberta.py
+++ b/tests/models/deberta/test_modeling_deberta.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
 import unittest
+from copy import deepcopy
 
 from transformers import DebertaConfig, is_torch_available
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
@@ -198,6 +200,31 @@ class DebertaModelTester(object):
         self.parent.assertEqual(result.start_logits.shape, (self.batch_size, self.seq_length))
         self.parent.assertEqual(result.end_logits.shape, (self.batch_size, self.seq_length))
 
+    def create_and_check_deberta_for_tracing_output_validity(
+        self, config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
+    ):
+        config_trace = deepcopy(config)
+        config_trace.torchscript = True
+
+        model = DebertaModel(config=config_trace)
+        model.to(torch_device)
+        model.eval()
+        sequence_output = model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids)
+        sequence_output = sequence_output[0].flatten().tolist()
+
+        trace_input = (input_ids, input_mask, token_type_ids)
+        traced_model_data = torch.jit.trace(model, trace_input)
+        model_bytes = io.BytesIO()
+        torch.jit.save(traced_model_data, model_bytes)
+        model_bytes.seek(0)
+
+        traced_model = torch.jit.load(model_bytes)
+        traced_model.eval()
+        traced_sequence_output = traced_model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids)
+        traced_sequence_output = traced_sequence_output[0].flatten().tolist()
+
+        self.parent.assertListEqual(sequence_output, traced_sequence_output)
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -267,6 +294,10 @@ class DebertaModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     def test_for_question_answering(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_deberta_for_question_answering(*config_and_inputs)
+
+    def test_for_tracing_output_validity(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_deberta_for_tracing_output_validity(*config_and_inputs)
 
     def test_for_token_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/deberta_v2/test_modeling_deberta_v2.py
+++ b/tests/models/deberta_v2/test_modeling_deberta_v2.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
 import unittest
+from copy import deepcopy
 
 from transformers import DebertaV2Config, is_torch_available
 from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
@@ -211,6 +213,31 @@ class DebertaV2ModelTester(object):
         )
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_choices))
 
+    def create_and_check_deberta_for_tracing_output_validity(
+        self, config, input_ids, token_type_ids, input_mask, sequence_labels, token_labels, choice_labels
+    ):
+        config_trace = deepcopy(config)
+        config_trace.torchscript = True
+
+        model = DebertaV2Model(config=config_trace)
+        model.to(torch_device)
+        model.eval()
+        sequence_output = model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids)
+        sequence_output = sequence_output[0].flatten().tolist()
+
+        trace_input = (input_ids, input_mask, token_type_ids)
+        traced_model_data = torch.jit.trace(model, trace_input)
+        model_bytes = io.BytesIO()
+        torch.jit.save(traced_model_data, model_bytes)
+        model_bytes.seek(0)
+
+        traced_model = torch.jit.load(model_bytes)
+        traced_model.eval()
+        traced_sequence_output = traced_model(input_ids, attention_mask=input_mask, token_type_ids=token_type_ids)
+        traced_sequence_output = traced_sequence_output[0].flatten().tolist()
+
+        self.parent.assertListEqual(sequence_output, traced_sequence_output)
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -281,6 +308,10 @@ class DebertaV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     def test_for_question_answering(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_deberta_for_question_answering(*config_and_inputs)
+
+    def test_for_tracing_output_validity(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_deberta_for_tracing_output_validity(*config_and_inputs)
 
     def test_for_token_classification(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #20815

Generally, `torch.autograd.Functions` cannot be traced in Torch, as per this open issue: https://github.com/pytorch/pytorch/issues/32822
This issue is thus more of a PyTorch problem, but nevertheless can be resolved. 🤗 Transformers' implementation is basically the same as the original https://github.com/microsoft/DeBERTa, which was tracable with a dirty trick of using a tracing context: 
https://github.com/microsoft/DeBERTa/blob/4d7fe0bd4fb3c7d4f4005a7cafabde9800372098/DeBERTa/utils/jit_tracing.py#L10C1-L17C6
Of course such a solution is not applicable here as it would conflict with the existing API and usage of the 🤗 Transformers. I have decided to explore a bit the recent development in PyTorch and it seems `is_tracing` is now publicly accessible through `torch.jit` (though it is not yet documented), which gets rid of the context problem. So I have basically implemented the original solution but with the newly available `is_tracing` call. 

I have also added tests to check if the traced model outputs the same tensors as the model that is being traced.
This was not mentioned in the issue but I have applied the same changes to Deberta_v2 since it is obviously also affected.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@ArthurZucker 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
