### PR TITLE
single word should be set to False

### DIFF
--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -183,7 +183,7 @@ class T5Tokenizer(PreTrainedTokenizer):
         self._added_tokens_decoder = {}
         for i in range(len(extra_tokens)):
             self._added_tokens_decoder[len(self.sp_model) - 1 + extra_ids - i] = AddedToken(
-                f"<extra_id_{i}>", single_word=True, lstrip=True, rstrip=True, special=True
+                f"<extra_id_{i}>", single_word=False, lstrip=True, rstrip=True, special=True, normalized=False
             )
 
         if legacy is None:


### PR DESCRIPTION
# What does this PR do?
Fixes qn issue reported on the hub: 

```python
from transformers import AutoTokenizer, MT5Tokenizer
tokenizer = MT5Tokenizer.from_pretrained("google/mt5-base", extra_ids = 100)
```
(this is rarely tested) trigers this
```diff
        # for legacy purpose, we keep this. Will be removed and tests updated. (when `added_tokens_decoder` is not passed as kwargs)
        self._added_tokens_decoder = {}
        for i in range(len(extra_tokens)):
            self._added_tokens_decoder[len(self.sp_model) - 1 + extra_ids - i] = 
-AddedToken(f"<extra_id_{i}>", single_word=True, lstrip=True, rstrip=True, special=True, normalized=False)
+AddedToken(f"<extra_id_{i}>", single_word=False, lstrip=True, rstrip=True, special=True, normalized=False)
```