### PR TITLE
restructure AMD scheduled CI

### DIFF
--- a/.github/workflows/self-scheduled-amd-caller.yml
+++ b/.github/workflows/self-scheduled-amd-caller.yml
@@ -3,23 +3,12 @@ name: Self-hosted runner (AMD scheduled CI caller)
 on:
   schedule:
     - cron: "17 2 * * *"
-  push:
-    branches:
-      - run_amd_scheduled_ci_caller*
 
 jobs:
-  run_amd_ci_mi210:
-    name: AMD mi210
-    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
-    uses: ./.github/workflows/self-scheduled-amd.yml
-    with:
-      gpu_flavor: mi210
-    secrets: inherit
-
-  run_amd_ci_mi250:
-    name: AMD mi250
-    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
-    uses: ./.github/workflows/self-scheduled-amd.yml
-    with:
-      gpu_flavor: mi250
-    secrets: inherit
+  run_scheduled_amd_ci:
+    name: Trigger Scheduled AMD CI
+    runs-on: ubuntu-22.04
+    if: ${{ always() }}
+    steps:
+      - name: Trigger scheduled AMD CI via workflow_run
+        run: echo "Trigger scheduled AMD CI via workflow_run"

--- a/.github/workflows/self-scheduled-amd-mi210-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi210-caller.yml
@@ -1,0 +1,19 @@
+name: Self-hosted runner (AMD mi210 scheduled CI caller)
+
+on:
+  workflow_run:
+    workflows: ["Self-hosted runner (AMD scheduled CI caller)"]
+    branches: ["main"]
+    types: [completed]
+  push:
+    branches:
+      - run_amd_scheduled_ci_caller*
+
+jobs:
+  run_amd_ci:
+    name: AMD mi210
+    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
+    uses: ./.github/workflows/self-scheduled-amd.yml
+    with:
+      gpu_flavor: mi210
+    secrets: inherit

--- a/.github/workflows/self-scheduled-amd-mi250-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi250-caller.yml
@@ -1,0 +1,19 @@
+name: Self-hosted runner (AMD mi250 scheduled CI caller)
+
+on:
+  workflow_run:
+    workflows: ["Self-hosted runner (AMD scheduled CI caller)"]
+    branches: ["main"]
+    types: [completed]
+  push:
+    branches:
+      - run_amd_scheduled_ci_caller*
+
+jobs:
+  run_amd_ci:
+    name: AMD mi250
+    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
+    uses: ./.github/workflows/self-scheduled-amd.yml
+    with:
+      gpu_flavor: mi250
+    secrets: inherit

--- a/.github/workflows/self-scheduled-amd.yml
+++ b/.github/workflows/self-scheduled-amd.yml
@@ -438,7 +438,7 @@ jobs:
           CI_SLACK_CHANNEL_DUMMY_TESTS: ${{ secrets.CI_SLACK_CHANNEL_DUMMY_TESTS }}
           CI_SLACK_REPORT_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID_DAILY_AMD }}
           ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
-          CI_EVENT: Scheduled CI (AMD)
+          CI_EVENT: Scheduled CI (AMD) - ${{ inputs.gpu_flavor }}
           CI_SHA: ${{ github.sha }}
           CI_WORKFLOW_REF: ${{ github.workflow_ref }}
           RUNNER_STATUS: ${{ needs.check_runner_status.result }}

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -118,8 +118,21 @@ class Message:
 
         # Failures and success of the additional tests
         self.n_additional_success = sum(r["success"] for r in additional_results.values())
-
+        if len(additional_results) == 0:
+            # `dicts_to_sum` uses `dicts_to_sum` which requires a non empty dictionary. Let's just add an empty entry.
+            additional_results = {
+                "dummy": {
+                    "failed": {"unclassified": 0, "single": 0, "multi": 0},
+                    "success": 0,
+                    "time_spent": "",
+                    "error": False,
+                    "failures": {},
+                    "job_link": {},
+                    }
+                }
         all_additional_failures = dicts_to_sum([r["failed"] for r in additional_results.values()])
+        if "dummy" in additional_results:
+            del additional_results["dummy"]
         self.n_additional_single_gpu_failures = all_additional_failures["single"]
         self.n_additional_multi_gpu_failures = all_additional_failures["multi"]
         self.n_additional_unknown_gpu_failures = all_additional_failures["unclassified"]

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -903,6 +903,9 @@ if __name__ == "__main__":
     elif ci_event.startswith("Push CI (AMD) - "):
         flavor = ci_event.replace("Push CI (AMD) - ", "")
         job_name_prefix = f"AMD {flavor}"
+    elif ci_event.startswith("Scheduled CI (AMD) - "):
+        flavor = ci_event.replace("Scheduled CI (AMD) - ", "")
+        job_name_prefix = f"AMD {flavor}"
 
     for model in model_results.keys():
         for artifact_path in available_artifacts[f"run_all_tests_gpu_{model}_test_reports"].paths:

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -118,24 +118,18 @@ class Message:
 
         # Failures and success of the additional tests
         self.n_additional_success = sum(r["success"] for r in additional_results.values())
-        if len(additional_results) == 0:
+
+        if len(additional_results) > 0:
             # `dicts_to_sum` uses `dicts_to_sum` which requires a non empty dictionary. Let's just add an empty entry.
-            additional_results = {
-                "dummy": {
-                    "failed": {"unclassified": 0, "single": 0, "multi": 0},
-                    "success": 0,
-                    "time_spent": "",
-                    "error": False,
-                    "failures": {},
-                    "job_link": {},
-                    }
-                }
-        all_additional_failures = dicts_to_sum([r["failed"] for r in additional_results.values()])
-        if "dummy" in additional_results:
-            del additional_results["dummy"]
-        self.n_additional_single_gpu_failures = all_additional_failures["single"]
-        self.n_additional_multi_gpu_failures = all_additional_failures["multi"]
-        self.n_additional_unknown_gpu_failures = all_additional_failures["unclassified"]
+            all_additional_failures = dicts_to_sum([r["failed"] for r in additional_results.values()])
+            self.n_additional_single_gpu_failures = all_additional_failures["single"]
+            self.n_additional_multi_gpu_failures = all_additional_failures["multi"]
+            self.n_additional_unknown_gpu_failures = all_additional_failures["unclassified"]
+        else:
+            self.n_additional_single_gpu_failures = 0
+            self.n_additional_multi_gpu_failures = 0
+            self.n_additional_unknown_gpu_failures = 0
+
         self.n_additional_failures = (
             self.n_additional_single_gpu_failures
             + self.n_additional_multi_gpu_failures


### PR DESCRIPTION
# What does this PR do?

So far, the AMD scheduled CI is run as a single workflow with `mi210` and `mi250` both in it (each has ~500 jobs): see [here](https://github.com/huggingface/transformers/actions/runs/6999845840)

<img width="791" alt="Screenshot 2023-11-28 140000" src="https://github.com/huggingface/transformers/assets/2521628/b16b47f4-d5bf-426f-9eb2-e964e09455ee">

This causes 2 issues:

  - the workflow run page is too large to display (A unicorn image with `This page is taking too long to load.`)
  - the artifact produced by the runs of `mi210` and `mi250` are mixed (overwritten by each other), so the report might be inaccurate.

This PR restructure AMD scheduled CI to make  `mi210` and `mi250` run in 2 workflow run, so avoid the above 2 issues.