### PR TITLE
Move tensors to same device to enable IDEFICS naive MP training

### DIFF
--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -1510,9 +1510,10 @@ class IdeficsForVisionText2Text(IdeficsPreTrainedModel):
 
         loss = None
         if labels is not None:
+            labels = labels.to(logits.device)
             # Shift so that tokens < n predict n
             if attention_mask is not None:
-                shift_attention_mask = attention_mask[..., 1:]
+                shift_attention_mask = attention_mask[..., 1:].to(logits.device)
                 shift_logits = logits[..., :-1, :][shift_attention_mask != 0].contiguous()
                 shift_labels = labels[..., 1:][shift_attention_mask != 0].contiguous()
             else:


### PR DESCRIPTION
# What does this PR do?

Fixes #27736

`logits`, `labels`, and `attention_mask` are expected to be on the same device. 
This PR moves these tensors to the same device, making IDEFICS training compatible with naive model parallelism.

See also #22561 


@amyeroberts @ArthurZucker @younesbelkada