### PR TITLE
Deprecate `LegacyIndex` used in `RagRetriever`

### DIFF
--- a/docs/source/en/model_doc/rag.md
+++ b/docs/source/en/model_doc/rag.md
@@ -16,6 +16,15 @@ rendered properly in your Markdown viewer.
 
 # RAG
 
+<Tip warning={true}>
+
+The class `LegacyIndex` used to define the retriever component `RagRetriever` in the `RAG` architecture was deprecated
+due to security issues linked to `pickle.load`.
+
+For improved security, we recommend using `CanonicalHFIndex` or `CustomHFIndex` to build and load your index dataset.
+
+</Tip>
+
 <div class="flex flex-wrap space-x-1">
 <a href="https://huggingface.co/models?filter=rag">
 <img alt="Models" src="https://img.shields.io/badge/All_model_pages-rag-blueviolet">

--- a/src/transformers/models/rag/retrieval_rag.py
+++ b/src/transformers/models/rag/retrieval_rag.py
@@ -103,7 +103,6 @@ class LegacyIndex(Index):
     PASSAGE_FILENAME = "psgs_w100.tsv.pkl"
 
     def __init__(self, vector_size, index_path):
-
         logger.error(
             "`LegacyIndex` was deprecated due to security issues linked to `pickle.load`. See more details on this "
             "model's documentation page: "

--- a/src/transformers/models/rag/retrieval_rag.py
+++ b/src/transformers/models/rag/retrieval_rag.py
@@ -103,6 +103,13 @@ class LegacyIndex(Index):
     PASSAGE_FILENAME = "psgs_w100.tsv.pkl"
 
     def __init__(self, vector_size, index_path):
+
+        logger.error(
+            "`LegacyIndex` was deprecated due to security issues linked to `pickle.load`. See more details on this "
+            "model's documentation page: "
+            "`https://github.com/huggingface/transformers/blob/main/docs/source/en/model_doc/rag.md`."
+        )
+
         self.index_id_to_db_id = []
         self.index_path = index_path
         self.passages = self._load_passages()


### PR DESCRIPTION
# What does this PR do?

A first step to reduce the security issue of pickle for `RAG`.

In general, we can also ask users to set some environment variable to enable using the code block that contains `pickle.load` to have even better security. But that could be done in a follow up PR (which also applies to `TransfoXLTokenizer`)