### PR TITLE
update `create_model_card` to properly save peft details when using Trainer with PEFT

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3509,7 +3509,7 @@ class Trainer:
             dataset_args=dataset_args,
         )
         model_card = training_summary.to_model_card()
-        with open(os.path.join(self.args.output_dir, "README.md"), "w") as f:
+        with open(model_card_filepath, "w") as f:
             f.write(model_card)
 
         if is_peft_library:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -48,7 +48,7 @@ import huggingface_hub.utils as hf_hub_utils
 import numpy as np
 import torch
 import torch.distributed as dist
-from huggingface_hub import create_repo, upload_folder
+from huggingface_hub import ModelCard, create_repo, upload_folder
 from packaging import version
 from torch import nn
 from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
@@ -3489,6 +3489,13 @@ class Trainer:
         if not self.is_world_process_zero():
             return
 
+        model_card_filepath = os.path.join(self.args.output_dir, "README.md")
+        is_peft_library = False
+        if os.path.exists(model_card_filepath):
+            library_name = ModelCard.load(model_card_filepath).data["library_name"]
+            if library_name is not None and library_name == "peft":
+                is_peft_library = True
+
         training_summary = TrainingSummary.from_trainer(
             self,
             language=language,
@@ -3504,6 +3511,9 @@ class Trainer:
         model_card = training_summary.to_model_card()
         with open(os.path.join(self.args.output_dir, "README.md"), "w") as f:
             f.write(model_card)
+
+        if is_peft_library:
+            unwrap_model(self.model).create_or_update_model_card(self.args.output_dir)
 
     def _push_from_checkpoint(self, checkpoint_folder):
         # Only push from one node.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3492,9 +3492,8 @@ class Trainer:
         model_card_filepath = os.path.join(self.args.output_dir, "README.md")
         is_peft_library = False
         if os.path.exists(model_card_filepath):
-            library_name = ModelCard.load(model_card_filepath).data["library_name"]
-            if library_name is not None and library_name == "peft":
-                is_peft_library = True
+            library_name = ModelCard.load(model_card_filepath).data.get("library_name")
+            is_peft_library = library_name == "peft"
 
         training_summary = TrainingSummary.from_trainer(
             self,


### PR DESCRIPTION
# What does this PR do?
1. When using Trainer with PEFT, `model.save_pretrained` in PEFT adds PEFT-specific details to the existing model card or creates a new model card and adds these details. However, `trainer.create_model_card` is called after model is saved and it overwrites the entire file thereby nullifies the addition of details related to PEFT such as library name, quantization used and PEFT version.
2. This PR fixes the above issue and thereby adds backs the PEFT details to the model card. This will help in better organization and understanding usage of PEFT on Hub. 
3. Example of the repo with the PR usage: https://huggingface.co/smangrul/mistral_lora_clm_with_added_tokens