### PR TITLE
Fix `low_cpu_mem_usage` Flag Conflict with DeepSpeed Zero 3 in `from_pretrained` for Models with `keep_in_fp32_modules`"

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3280,7 +3280,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Check first if we are `from_pt`
         if use_keep_in_fp32_modules:
-            if is_accelerate_available():
+            if is_accelerate_available() and not is_deepspeed_zero3_enabled():
                 low_cpu_mem_usage = True
             keep_in_fp32_modules = model._keep_in_fp32_modules
         else:


### PR DESCRIPTION
## Summary

This pull request addresses a compatibility issue in the `from_pretrained` method. Specifically, when using models with `keep_in_fp32_modules` not set to None (e.g., BLIP2, T5) in conjunction with DeepSpeed's Zero 3, an unexpected error occurs due to the improper handling of the `low_cpu_mem_usage`.

##  Problem Description

Currently, in the `from_pretrained` method, the `low_cpu_mem_usage` flag is set to `True` if `use_keep_in_fp32_modules` is `True` and accelerate is available. This logic does not account for the incompatibility with DeepSpeed Zero 3. When Zero 3 is enabled, setting `low_cpu_mem_usage` to True can lead to unexpected errors.

## Proposed Change

I propose to modify the condition to check whether DeepSpeed Zero3 is enabled. The `low_cpu_mem_usage` should be set to `True` only if Accelerate is available and DeepSpeed Zero3 is not enabled. The revised code snippet is:

```python
if is_accelerate_available() and not is_deepspeed_zero3_enabled():
    low_cpu_mem_usage = True
```

This change prevents the `low_cpu_mem_usage` flag from being incorrectly set in scenarios where DeepSpeed Zero 3 is in use, thereby avoiding the aforementioned issue.


