### PR TITLE
[`ModelOnTheFlyConversionTester`] Mark as slow for now

### DIFF
--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1166,7 +1166,7 @@ class ModelUtilsTest(TestCasePlus):
         for p1, p2 in zip(model.parameters(), new_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
-
+@slow
 @require_torch
 class ModelOnTheFlyConversionTester(unittest.TestCase):
     @classmethod

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1166,6 +1166,7 @@ class ModelUtilsTest(TestCasePlus):
         for p1, p2 in zip(model.parameters(), new_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
+
 @slow
 @require_torch
 class ModelOnTheFlyConversionTester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?
The ModelOnTheFlyConversionTester were run on each individual PRs, should not be the case IMO this should only be a slow / only be run on the main branch and not fetched all the time. 