### PR TITLE
[Seamless v2] Add FE to auto mapping

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -78,6 +78,7 @@ FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
         ("regnet", "ConvNextFeatureExtractor"),
         ("resnet", "ConvNextFeatureExtractor"),
         ("seamless_m4t", "SeamlessM4TFeatureExtractor"),
+        ("seamless_m4t_v2", "SeamlessM4TFeatureExtractor"),
         ("segformer", "SegformerFeatureExtractor"),
         ("sew", "Wav2Vec2FeatureExtractor"),
         ("sew-d", "Wav2Vec2FeatureExtractor"),

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1117,6 +1117,23 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
     @require_torch
     @slow
+    def test_seamless_v2(self):
+        pipe = pipeline(
+            "automatic-speech-recognition",
+            model="facebook/seamless-m4t-v2-large",
+            device="cuda:0",
+        )
+
+        dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+        sample = dataset[0]["audio"]
+
+        result = pipe(sample, generate_kwargs={"tgt_lang": "eng"})
+        EXPECTED_RESULT = "mister quilter is the apostle of the middle classes and we are glad to welcome his gospel"
+
+        assert result["text"] == EXPECTED_RESULT
+
+    @require_torch
+    @slow
     def test_chunking_and_timestamps(self):
         model = Wav2Vec2ForCTC.from_pretrained("facebook/wav2vec2-base-960h")
         tokenizer = AutoTokenizer.from_pretrained("facebook/wav2vec2-base-960h")


### PR DESCRIPTION
As reported by @Vaibhavs10, Seamless M4T v2 is not compatible with the pipeline class. This is because the feature extractor is not present in the auto mapping. This PR adds the FE to the auto mapping, and implements a slow test to check Seamless M4T v2 works as expected with the pipeline.

### Example Usage

No chunking:
```python
from transformers import pipeline
import torch
from datasets import load_dataset

pipe = pipeline(
    "automatic-speech-recognition",
    model="facebook/seamless-m4t-v2-large",
    device="cuda:0",
    torch_dtype=torch.float16,
)

dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
sample = dataset[0]["audio"]

# eng -> fra speech translation
result = pipe(sample, generate_kwargs={"tgt_lang": "fra"})
```

Chunking (for long audio files):

```python
from transformers import pipeline
import torch
from datasets import load_dataset

pipe = pipeline(
    "automatic-speech-recognition",
    model="facebook/seamless-m4t-v2-large",
    device="cuda:0",
    chunk_length_s=30,
    batch_size=16,
    torch_dtype=torch.float16,
)

dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
sample = dataset[0]["audio"]

# eng -> fra speech translation
result = pipe(sample, generate_kwargs={"tgt_lang": "fra"})
```