### PR TITLE
Update `VitDetModelTester.get_config` to use `pretrain_image_size`

### DIFF
--- a/tests/models/vitdet/test_modeling_vitdet.py
+++ b/tests/models/vitdet/test_modeling_vitdet.py
@@ -90,6 +90,7 @@ class VitDetModelTester:
     def get_config(self):
         return VitDetConfig(
             image_size=self.image_size,
+            pretrain_image_size=self.image_size,
             patch_size=self.patch_size,
             num_channels=self.num_channels,
             hidden_size=self.hidden_size,


### PR DESCRIPTION
# What does this PR do?

`torch.nn.init.trunc_normal_` has strange behavior (at least, on CPU) if the input tensor is large, say `size=(4096, 32)`, and sometimes produces very large item in a tensor, even if `mean=0 and std=1e10`.

This PR updates `VitDetModelTester.get_config` to use `pretrain_image_size=self.image` (224 before --> 30 now), so the `position_embeddings` is of much smaller size. This is always welcome no matter if we have the above issue or not.

I will open an issue in pytorch repository, but I think the issue is well known ...