### PR TITLE
⚠️ [VitDet] Fix test

### DIFF
--- a/src/transformers/models/vitdet/modeling_vitdet.py
+++ b/src/transformers/models/vitdet/modeling_vitdet.py
@@ -815,8 +815,8 @@ class VitDetBackbone(VitDetPreTrainedModel, BackboneMixin):
     def forward(
         self,
         pixel_values: torch.Tensor,
-        output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> BackboneOutput:
         """


### PR DESCRIPTION
# What does this PR do?

After #27729, the `test_forward_signature` test fails for `VitDetBackbone` given that it uses the order of `output_hidden_states` first followed by `output_attentions` in its forward signature. The test is introduced to make sure new backbones always use the same order.

We have a couple of options here:
- either make the forward signature consistent with other models (as currently done in this PR). Is a breaking change, but given that this model is only used as internal building block of ViTMatte, and it is explicitly [hidden from the docs](https://github.com/huggingface/transformers/blob/e739a361bc19000f619cf248707914844456835f/utils/check_repo.py#L990), this might be acceptable.
- either overwrite the test in test_modeling_vitdet.py.