### PR TITLE
Generate: Update VisionEncoderDecoder test value

### DIFF
--- a/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
+++ b/tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py
@@ -800,7 +800,7 @@ class ViT2GPT2ModelIntegrationTest(unittest.TestCase):
 
         preds, scores = generate_step(pixel_values)
 
-        EXPECTED_SCORES = np.array([-0.59562886])
+        EXPECTED_SCORES = np.array([-0.64145195])
         max_diff = np.amax(np.abs(scores - EXPECTED_SCORES))
         self.assertLessEqual(max_diff, 1e-4)
 


### PR DESCRIPTION
# What does this PR do?

#27351 fixes a bug in beam search: the prompt length was being included in the length penalty computation, and this penalty should only be applied on newly generated tokens (otherwise decoder-only models would often see a big penalty, as the prompt is part of the output)

This PR updates the test results to account for the bug fix. I've double-checked that reverting those changes produces the old results!

(All tests in `RUN_SLOW=1 py.test tests/models/vision_encoder_decoder/test_modeling_vision_encoder_decoder.py -vv` pass)