### PR TITLE
Support PeftModel signature inspect

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -695,7 +695,10 @@ class Trainer:
     def _set_signature_columns_if_needed(self):
         if self._signature_columns is None:
             # Inspect model forward signature to keep only the arguments it accepts.
-            signature = inspect.signature(self.model.forward)
+            model_to_inspect = self.model
+            if is_peft_available() and isinstance(self.model, PeftModel):
+                model_to_inspect = self.model.base_model.model
+            signature = inspect.signature(model_to_inspect.forward)
             self._signature_columns = list(signature.parameters.keys())
             # Labels may be named label or label_ids, the default data collator handles that.
             self._signature_columns += list(set(["label", "label_ids"] + self.label_names))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -697,7 +697,7 @@ class Trainer:
             # Inspect model forward signature to keep only the arguments it accepts.
             model_to_inspect = self.model
             if is_peft_available() and isinstance(self.model, PeftModel):
-                model_to_inspect = self.model.base_model.model
+                model_to_inspect = self.model.get_base_model()
             signature = inspect.signature(model_to_inspect.forward)
             self._signature_columns = list(signature.parameters.keys())
             # Labels may be named label or label_ids, the default data collator handles that.


### PR DESCRIPTION
# What does this PR do?

If we set `remove_unused_columns` to 'True' while training a `LoRA` model, the all dataset columns will be removed.
This is because the `_set_signature_columns_if_needed` function directly checks the signature of `self.model`. If `self.model` is a `PeftModel`, the signature will become `['args', 'kwargs']` , causing the valid columns in the dataset to be deleted.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@muellerz @pacman100 
