### PR TITLE
Add serialization logic to pytree types

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -28,6 +28,7 @@ logger = logging.get_logger(__name__)
 
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
+is_torch_greater_or_equal_than_2_2 = parsed_torch_version_base >= version.parse("2.2")
 is_torch_greater_or_equal_than_2_1 = parsed_torch_version_base >= version.parse("2.1")
 is_torch_greater_or_equal_than_2_0 = parsed_torch_version_base >= version.parse("2.0")
 is_torch_greater_or_equal_than_1_13 = parsed_torch_version_base >= version.parse("1.13")

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import unittest
 from dataclasses import dataclass
 from typing import Optional
 
+from transformers import AlbertForMaskedLM
 from transformers.testing_utils import require_torch
-from transformers.utils import ModelOutput
+from transformers.utils import ModelOutput, is_torch_available
+
+
+if is_torch_available():
+    import torch
+
+    from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_2
 
 
 @dataclass
@@ -144,13 +152,32 @@ class ModelOutputTester(unittest.TestCase):
         unflattened_x = pytree.tree_unflatten(actual_flat_outs, actual_tree_spec)
         self.assertEqual(x, unflattened_x)
 
-        from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_2
-
         if is_torch_greater_or_equal_than_2_2:
             self.assertEqual(
                 pytree.treespec_dumps(actual_tree_spec),
                 '[1, {"type": "tests.utils.test_model_output.ModelOutputTest", "context": ["a", "c"], "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]',
             )
+
+    @require_torch
+    def test_export_serialization(self):
+        if not is_torch_greater_or_equal_than_2_2:
+            return
+
+        model_cls = AlbertForMaskedLM
+        model_config = model_cls.config_class()
+        model = model_cls(model_config)
+
+        input_dict = {"input_ids": torch.randint(0, 30000, (1, 512), dtype=torch.int64, requires_grad=False)}
+
+        ep = torch.export.export(model, (), input_dict)
+
+        buffer = io.BytesIO()
+        torch.export.save(ep, buffer)
+        buffer.seek(0)
+        loaded_ep = torch.export.load(buffer)
+
+        input_dict = {"input_ids": torch.randint(0, 30000, (1, 512), dtype=torch.int64, requires_grad=False)}
+        assert torch.allclose(model(**input_dict).logits, loaded_ep(**input_dict).logits)
 
 
 class ModelOutputTestNoDataclass(ModelOutput):

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -146,6 +146,14 @@ class ModelOutputTester(unittest.TestCase):
         unflattened_x = pytree.tree_unflatten(actual_flat_outs, actual_tree_spec)
         self.assertEqual(x, unflattened_x)
 
+        from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_2
+
+        if is_torch_greater_or_equal_than_2_2:
+            self.assertEqual(
+                pytree.treespec_dumps(actual_tree_spec),
+                '[1, {"type": "tests.utils.test_model_output.ModelOutputTest", "context": ["tests.utils.test_model_output.ModelOutputTest", ["a", "c"]], "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]',
+            )
+
 
 class ModelOutputTestNoDataclass(ModelOutput):
     """Invalid test subclass of ModelOutput where @dataclass decorator is not used"""

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -135,9 +135,7 @@ class ModelOutputTester(unittest.TestCase):
         self.assertFalse(pytree._is_leaf(x))
 
         expected_flat_outs = [1.0, 2.0]
-        expected_tree_spec = pytree.TreeSpec(
-            ModelOutputTest, (ModelOutputTest, ["a", "c"]), [pytree.LeafSpec(), pytree.LeafSpec()]
-        )
+        expected_tree_spec = pytree.TreeSpec(ModelOutputTest, ["a", "c"], [pytree.LeafSpec(), pytree.LeafSpec()])
 
         actual_flat_outs, actual_tree_spec = pytree.tree_flatten(x)
         self.assertEqual(expected_flat_outs, actual_flat_outs)
@@ -151,7 +149,7 @@ class ModelOutputTester(unittest.TestCase):
         if is_torch_greater_or_equal_than_2_2:
             self.assertEqual(
                 pytree.treespec_dumps(actual_tree_spec),
-                '[1, {"type": "tests.utils.test_model_output.ModelOutputTest", "context": ["tests.utils.test_model_output.ModelOutputTest", ["a", "c"]], "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]',
+                '[1, {"type": "tests.utils.test_model_output.ModelOutputTest", "context": ["a", "c"], "children_spec": [{"type": null, "context": null, "children_spec": []}, {"type": null, "context": null, "children_spec": []}]}]',
             )
 
 


### PR DESCRIPTION
# What does this PR do?

[`torch.export`](https://pytorch.org/docs/main/export.html) produces a graph representation of the program which contains a pytree `TreeSpec` specifying how to flatten the inputs from whatever structure they were in before to a flattened list of inputs to pass to the graph, and unflatten the outputs from the graph to the original structure that eager mode PyTorch produces. We would like to serialize the artifact from `torch.export` and later pass it to a runtime. This means that we need a good BC/FC surface.

The pytree `TreeSpec` contains a structure telling us how the original input/output looked like. For example, if we had an input containing a tuple of a class `InputClass`, the `TreeSpec` would look something like: `TreeSpec(tuple, None, [TreeSpec[InputClass, None, []], TreeSpec[InputClass, None, []]])`. We want to serialize this into a json string consisting of the serialized type, serialized context, and recursively serialized children. Since we want to convert to a json format, only json types are allowed (strings, ints...). Therefore in this PR you can see logic to serialize a python type to a fully qualified string name.

Note that this field only exists starting from PyTorch version 2.2.

Here's an example:
```
import torch
import io
from transformers import AlbertForMaskedLM
from transformers import file_utils

model_cls = AlbertForMaskedLM
model_config = model_cls.config_class()
model = model_cls(model_config)
model.to("cuda", torch.float32)

input_dict = {"input_ids": torch.randint(0, 30000, (1, 512), device="cuda", dtype=torch.int64, requires_grad=False)}

ep = torch.export.export(model, (), input_dict)

print(ep.module_call_graph[0].signature.in_spec)
# TreeSpec(tuple, None, [TreeSpec(tuple, None, []), TreeSpec(dict, ['input_ids'], [*])])
print(ep.module_call_graph[0].signature.out_spec)
# TreeSpec(MaskedLMOutput, (<class 'transformers.modeling_outputs.MaskedLMOutput'>, ['logits']), [*])

buffer = io.BytesIO()
torch.export.save(ep, buffer)
buffer.seek(0)
loaded_ep = torch.export.load(buffer)

print(loaded_ep.module_call_graph[0].signature.in_spec)
# TreeSpec(tuple, None, [TreeSpec(tuple, None, []), TreeSpec(dict, ['input_ids'], [*])])
print(loaded_ep.module_call_graph[0].signature.out_spec)
# TreeSpec(MaskedLMOutput, (<class 'transformers.modeling_outputs.MaskedLMOutput'>, ['logits']), [*])

input_dict = {"input_ids": torch.randint(0, 30000, (1, 512), device="cuda", dtype=torch.int64, requires_grad=False)}
assert(torch.allclose(model(**input_dict).logits, loaded_ep(**input_dict).logits))
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ydshieh who seems to have reviewed pytree-related stuff before :) 