### PR TITLE
[Proposal, open for discussion] Better way of extracting hidden states

### DIFF
--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -249,6 +249,7 @@ class ConvNextV2Stage(nn.Module):
 class ConvNextV2Encoder(nn.Module):
     def __init__(self, config):
         super().__init__()
+        self.config = config
         self.stages = nn.ModuleList()
         drop_path_rates = [
             x.tolist() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths)).split(config.depths)
@@ -275,13 +276,13 @@ class ConvNextV2Encoder(nn.Module):
     ) -> Union[Tuple, BaseModelOutputWithNoAttention]:
         all_hidden_states = () if output_hidden_states else None
 
-        for i, layer_module in enumerate(self.stages):
-            if output_hidden_states:
+        for idx, layer_module in enumerate(self.stages):
+            if output_hidden_states and idx in self.config.out_indices:
                 all_hidden_states = all_hidden_states + (hidden_states,)
 
             hidden_states = layer_module(hidden_states)
 
-        if output_hidden_states:
+        if output_hidden_states and len(self.stages) in self.config.out_indices:
             all_hidden_states = all_hidden_states + (hidden_states,)
 
         if not return_dict:
@@ -558,10 +559,9 @@ class ConvNextV2Backbone(ConvNextV2PreTrainedModel, BackboneMixin):
         hidden_states = outputs.hidden_states if return_dict else outputs[1]
 
         feature_maps = ()
-        for stage, hidden_state in zip(self.stage_names, hidden_states):
-            if stage in self.out_features:
-                hidden_state = self.hidden_states_norms[stage](hidden_state)
-                feature_maps += (hidden_state,)
+        for stage, hidden_state in zip(self.out_features, hidden_states):
+            hidden_state = self.hidden_states_norms[stage](hidden_state)
+            feature_maps += (hidden_state,)
 
         if not return_dict:
             output = (feature_maps,)

--- a/tests/models/convnext/test_modeling_convnext.py
+++ b/tests/models/convnext/test_modeling_convnext.py
@@ -230,18 +230,19 @@ class ConvNextModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
 
             hidden_states = outputs.encoder_hidden_states if config.is_encoder_decoder else outputs.hidden_states
 
-            expected_num_stages = self.model_tester.num_stages
-            self.assertEqual(len(hidden_states), expected_num_stages + 1)
+            expected_num_stages = len(self.model_tester.out_indices)
+            self.assertEqual(len(hidden_states), expected_num_stages)
 
             # ConvNext's feature maps are of shape (batch_size, num_channels, height, width)
             self.assertListEqual(
                 list(hidden_states[0].shape[-2:]),
-                [self.model_tester.image_size // 4, self.model_tester.image_size // 4],
+                [self.model_tester.image_size // 8, self.model_tester.image_size // 8],
             )
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
+            print("Model class:", model_class)
             inputs_dict["output_hidden_states"] = True
             check_hidden_states_output(inputs_dict, config, model_class)
 

--- a/tests/models/upernet/test_modeling_upernet.py
+++ b/tests/models/upernet/test_modeling_upernet.py
@@ -205,13 +205,13 @@ class UperNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
 
             hidden_states = outputs.encoder_hidden_states if config.is_encoder_decoder else outputs.hidden_states
 
-            expected_num_stages = self.model_tester.num_stages
-            self.assertEqual(len(hidden_states), expected_num_stages + 1)
+            expected_num_stages = len(self.model_tester.out_features)
+            self.assertEqual(len(hidden_states), expected_num_stages)
 
             # ConvNext's feature maps are of shape (batch_size, num_channels, height, width)
             self.assertListEqual(
                 list(hidden_states[0].shape[-2:]),
-                [self.model_tester.image_size // 4, self.model_tester.image_size // 4],
+                [self.model_tester.image_size // 8, self.model_tester.image_size // 8],
             )
 
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

Currently, our `AutoBackbone` classes allow to get specific feature maps out of a certain vision model. For example:

```
from transformers import ConvNextBackbone
import torch

model = ConvNextBackbone.from_pretrained("facebook/convnext-small-224", out_indices=[0,1,2,3])

pixel_values = torch.randn(1, 3, 224, 224)

feature_maps = model(pixel_values)
for i in feature_maps:
   print(i.shape)
```
However, they currently [extract all intermediate hidden states](https://github.com/huggingface/transformers/blob/main/src/transformers/models/convnext/modeling_convnext.py#L531), store them in memory, and return the ones required by the user. This is not efficient, we should store only activations required by the user in memory.

This current PR proposes to only return the hidden states specified by `config.out_indices` when the user sets `output_hidden_states=True`. However, this is not backwards compatible (as by default we do return all hidden states). So I'm open for suggestions on how we could improve this. Alternatively, we could make it backwards compatible by setting `out_indices` to all stages by default.

I think this could be an argument that is part of all configs, or at least vision encoders, which typically only require certain hidden states to be extracted.

Curious to hear opinions of @ArthurZucker @amyeroberts 