### PR TITLE
[Bugfix] non_attended_tokens index

### DIFF
--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -415,6 +415,7 @@ class LlavaForConditionalGeneration(LlavaPreTrainedModel):
                     # that are set to 0
                     first_layer_past_key_value = past_key_values[0][0][:, 0, :, 0]
                     batch_index, non_attended_tokens = torch.where(first_layer_past_key_value == 0)
+                    non_attended_tokens = non_attended_tokens - attention_mask.shape[1]
                     # Get the target length
                     target_seqlen = first_layer_past_key_value.shape[-1] + 1
 


### PR DESCRIPTION
# What does this PR do?

```
batch_index, non_attended_tokens = torch.where(first_layer_past_key_value == 0)
# Get the target length
target_seqlen = first_layer_past_key_value.shape[-1] + 1

extended_attention_mask = torch.ones(
    (attention_mask.shape[0], target_seqlen - attention_mask.shape[1]),
    dtype=attention_mask.dtype,
    device=attention_mask.device,
)

# Zero-out the places where we don't need to attend
extended_attention_mask[batch_index, non_attended_tokens] = 0
attention_mask = torch.cat((attention_mask, extended_attention_mask), dim=1)
```

The shape of `extended_attention_mask` is `(attention_mask.shape[0], target_seqlen - attention_mask.shape[1])`, but `first_layer_past_key_value` is `(attention_mask.shape[0], target_seqlen)`.
This cause index error of `non_attended_tokens`.

I added an index fix line.

```
non_attended_tokens = non_attended_tokens - attention_mask.shape[1]
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
