### PR TITLE
Fix M4T v2 integration tests

### DIFF
--- a/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
+++ b/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
@@ -1014,8 +1014,9 @@ class SeamlessM4Tv2ModelIntegrationTest(unittest.TestCase):
         )
 
     def factory_test_task(self, class1, class2, inputs, class1_kwargs, class2_kwargs):
-        model1 = class1.from_pretrained(self.repo_id).to(torch_device)
-        model2 = class2.from_pretrained(self.repo_id).to(torch_device)
+        # half-precision loading to limit GPU usage
+        model1 = class1.from_pretrained(self.repo_id, torch_dtype=torch.float16).to(torch_device)
+        model2 = class2.from_pretrained(self.repo_id, torch_dtype=torch.float16).to(torch_device)
 
         set_seed(0)
         output_1 = model1.generate(**inputs, **class1_kwargs)


### PR DESCRIPTION
# What does this PR do?

Some M4T-v2 integration tests are [causing GPUs OOM](https://github.com/huggingface/transformers/actions/runs/7054968060/job/19204890066). It happens when we load two models together. I thus shifted some integration tests to half precision which should solve the issue.

cc @ydshieh @ArthurZucker 
