### PR TITLE
fix: handle multiprocess properly in trainer checkpointing

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2288,12 +2288,13 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
     @slow
     @require_torch_multi_accelerator
     def test_end_to_end_example(self):
-        # Tests that `translation.py` will run without issues
+        # Tests that `run_translation.py` will run without issues.
         script_path = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__), "..", "..", "examples", "pytorch", "translation", "run_translation.py"
             )
         )
+        save_steps = 10
 
         with tempfile.TemporaryDirectory() as tmpdir:
             command = [
@@ -2326,9 +2327,12 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 "--predict_with_generate",
                 "--ddp_timeout",
                 "60",
+                "--save_steps",
+                str(save_steps),
             ]
             execute_subprocess_async(command)
             # successful return here == success - any errors would have caused an error or a timeout in the sub-call
+            self.check_saved_checkpoints(tmpdir, freq=save_steps, total=32 // save_steps, is_pretrained=False)
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

Follow-up to https://github.com/huggingface/transformers/pull/27820 which is bugged for multi-device/multiprocess training. I made the error of thinking that in multiprocess training the `._save_checkpoint()` method was already restricted to a single writer.

I've fixed that now and augmented an existing multiprocess test to validate checkpointing functionality. 

I've also noted with a `TODO` something I found pretty confusing in the current code. `store_flos()` isn't checkpointing related in my opinion, but it does an `all_gather` and thus if all processes don't enter the `store_flos()` fn the training program hangs. In my opinion this code should be moved out of the checkpointing method so that this method conceptually supports entrance and execution by a single writer (the process with `self.args.should_save == True`).

I didn't setup a multi-GPU VM to run the test, but this multi-GPU Modal script runs and passes the test:

```python
import modal
import subprocess

GIT_SHA = "d867b232d46a0652e1bfe6eda7bc0804b9ad5ea4" # my fork's latest commit

image = (
    modal.Image.debian_slim(python_version="3.10")
    .apt_install("git").pip_install("pytest")
    .run_commands(
        "cd /root && git init .",
        "cd /root && git remote add origin https://github.com/thundergolfer/transformers",
        f"cd /root && git fetch --depth=1 origin {GIT_SHA} && git checkout {GIT_SHA}",
        "cd /root && pip install -e \".[dev]\"",
    )
)
stub = modal.Stub(image=image)

@stub.function(
    gpu=modal.gpu.T4(count=2),
    # Can uncomment this to quickly modify local test implementation
    # and sync with remote container.
    # mounts=[modal.Mount.from_local_file(
    #     local_path="./tests/trainer/test_trainer.py",
    #     remote_path="/root/tests/trainer/test_trainer.py",
    # )],
    secrets=[modal.Secret.from_dict({"RUN_SLOW": "1", "NCCL_P2P_LEVEL": "PIX"})],
    timeout=600,
)
def run():
    subprocess.run("nvidia-smi", shell=True, check=True)
    test_module = "tests/trainer/test_trainer.py"
    test_identifier = f"{test_module}::TrainerIntegrationTest::test_end_to_end_example"
    subprocess.run(f"pytest -s -v {test_identifier}", shell=True, check=True)
```

**Fixes** https://github.com/huggingface/transformers/issues/27925


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@muellerzr, @pacman100