### PR TITLE
Hot-fix-mixstral-loss

### DIFF
--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -95,7 +95,7 @@ def load_balancing_loss_func(gate_logits: torch.Tensor, num_experts: torch.Tenso
 
     if isinstance(gate_logits, tuple):
         # cat along the layers?
-        gate_logits = torch.cat(gate_logits, dim=0)
+        gate_logits = torch.cat([gate.cpu() for gate in gate_logits], dim=0)
 
     routing_weights, selected_experts = torch.topk(gate_logits, top_k, dim=-1)
     routing_weights = routing_weights.softmax(dim=-1)

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -95,7 +95,8 @@ def load_balancing_loss_func(gate_logits: torch.Tensor, num_experts: torch.Tenso
 
     if isinstance(gate_logits, tuple):
         # cat along the layers?
-        gate_logits = torch.cat([gate.cpu() for gate in gate_logits], dim=0)
+        compute_device = gate_logits[0].device
+        gate_logits = torch.cat([gate.to(compute_device) for gate in gate_logits], dim=0)
 
     routing_weights, selected_experts = torch.topk(gate_logits, top_k, dim=-1)
     routing_weights = routing_weights.softmax(dim=-1)


### PR DESCRIPTION
# What does this PR do?
Fixes 
```python 
load_balancing_loss_func
    gate_logits = torch.cat(gate_logits, dim=0)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:3 and cuda:7! (when checking argument for argument tensors in method wrapper_cat)
    gate_logits = torch.cat(gate_logits, dim=0)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:2 and cuda:6! (when checking argument for argument tensors in method wrapper_cat)
```
which appears when computing the loss in parallel settings (accelerate) .
The actual tensors are pretty small ( batch x seq_length , 2) so putting them all on cpu should be alright. There is no perfect solution for now.

Either this or we use some gather operation