### PR TITLE
Fix AMD scheduled CI not triggered

### DIFF
--- a/.github/workflows/self-scheduled-amd-mi210-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi210-caller.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run_amd_ci:
     name: AMD mi210
-    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
+    if: (cancelled() != true) && ((github.event_name == 'workflow_run') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
     uses: ./.github/workflows/self-scheduled-amd.yml
     with:
       gpu_flavor: mi210

--- a/.github/workflows/self-scheduled-amd-mi250-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi250-caller.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run_amd_ci:
     name: AMD mi250
-    if: (cancelled() != true) && ((github.event_name == 'schedule') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
+    if: (cancelled() != true) && ((github.event_name == 'workflow_run') || ((github.event_name == 'push') && startsWith(github.ref_name, 'run_amd_scheduled_ci_caller')))
     uses: ./.github/workflows/self-scheduled-amd.yml
     with:
       gpu_flavor: mi250


### PR DESCRIPTION
# What does this PR do?

A bug is introduced in #27743: the AMD scheduled CI is restructured, but the `github.event_name == 'schedule'` should be changed to `github.event_name == 'workflow_run'`.

Curretnly, the (actual) AMD scheduled CI is not triggered.