### PR TITLE
add `modules_in_block_to_quantize` arg in GPTQconfig

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -383,7 +383,10 @@ class GPTQConfig(QuantizationConfigMixin):
         modules_in_block_to_quantize (`List[List[str]]`, *optional*):
             List of list of module names to quantize in the specified block. This argument is useful to exclude certain linear modules from being quantized.
             The block to quantize can be specified by setting `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
-            Example: `modules_in_block_to_quantize =[["self_attention.query_key_value"], ["mlp.dense_h_to_4h"]]`
+            Example: `modules_in_block_to_quantize =[["self_attention.query_key_value"], ["mlp.dense_h_to_4h"]]`. In this example, we will first quantize `self_attention.query_key_value`.
+            Then, we will quantize `mlp.dense_h_to_4h` layer with `self_attention.query_key_value` quantized. This way, we will get better results since it reflects
+            the real input `mlp.dense_h_to_4h` will get when the model is quantized. We can also do `modules_in_block_to_quantize =[["self_attention.query_key_value", "mlp.dense_h_to_4h"]]`
+            to simultaneously quantize the layers but this will result in reduced quality.
     """
 
     def __init__(

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -363,7 +363,7 @@ class GPTQConfig(QuantizationConfigMixin):
         model_seqlen (`int`, *optional*):
             The maximum sequence length that the model can take.
         block_name_to_quantize (`str`, *optional*):
-            The transformers block name to quantize.
+            The transformers block name to quantize. If None, we will infer the block name using common patterns (e.g. model.layers)
         module_name_preceding_first_block (`List[str]`, *optional*):
             The layers that are preceding the first Transformer block.
         batch_size (`int`, *optional*, defaults to 1):

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -380,8 +380,9 @@ class GPTQConfig(QuantizationConfigMixin):
             to `{"version": 1}` if unset.
         cache_block_outputs (`bool`, *optional*, defaults to `True`):
             Whether to cache block outputs to reuse as inputs for the succeeding block.
-        inside_layer_modules (`List`, *optional*):
-            List of module names to quantize inside block_name_to_quantize. If not set, we will quantize all the linear layers.
+        modules_to_quantize_inside_block (`List[List[str]]`, *optional*):
+            List list of module names to quantize in the block specified. The block to quantize can be specified by setting
+            `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
     """
 
     def __init__(
@@ -404,7 +405,7 @@ class GPTQConfig(QuantizationConfigMixin):
         max_input_length: Optional[int] = None,
         exllama_config: Optional[Dict[str, Any]] = None,
         cache_block_outputs: bool = True,
-        inside_layer_modules: Optional[List] = None,
+        modules_to_quantize_inside_block: Optional[List[List[str]]] = None,
         **kwargs,
     ):
         self.quant_method = QuantizationMethod.GPTQ
@@ -427,7 +428,7 @@ class GPTQConfig(QuantizationConfigMixin):
         self.exllama_config = exllama_config
         self.disable_exllama = kwargs.pop("disable_exllama", None)
         self.cache_block_outputs = cache_block_outputs
-        self.inside_layer_modules = inside_layer_modules
+        self.modules_to_quantize_inside_block = modules_to_quantize_inside_block
         self.post_init()
 
     def get_loading_attributes(self):
@@ -498,11 +499,11 @@ class GPTQConfig(QuantizationConfigMixin):
                     raise ValueError(
                         f"You need optimum > 1.13.2 and auto-gptq > 0.4.2 . Make sure to have that version installed - detected version : optimum {optimum_version} and autogptq {autogptq_version}"
                     )
-        if self.inside_layer_modules is not None:
+        if self.modules_to_quantize_inside_block is not None:
             optimum_version = version.parse(importlib.metadata.version("optimum"))
             if optimum_version < version.parse("1.15.0"):
                 raise ValueError(
-                    "You current version of `optimum` does not support `inside_layers_modules` quantization argument, please upgrade `optimum` package to a version superior than 1.15.0 ."
+                    "You current version of `optimum` does not support `modules_to_quantize_inside_block` quantization argument, please upgrade `optimum` package to a version superior than 1.15.0 ."
                 )
 
     def to_dict(self):

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -384,8 +384,9 @@ class GPTQConfig(QuantizationConfigMixin):
             List of list of module names to quantize in the specified block. This argument is useful to exclude certain linear modules from being quantized.
             The block to quantize can be specified by setting `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
             Example: `modules_in_block_to_quantize =[["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"], ["self_attn.o_proj"]]`.
-            In this example, we will first quantize the q,k,v layers simultaneously since they are independent. Then, we will quantize `self_attn.o_proj` layer with the q,k,v layers quantized.
-            This way, we will get better results since it reflects the real input `self_attn.o_proj` will get when the model is quantized.
+            In this example, we will first quantize the q,k,v layers simultaneously since they are independent. 
+            Then, we will quantize `self_attn.o_proj` layer with the q,k,v layers quantized. This way, we will get
+            better results since it reflects the real input `self_attn.o_proj` will get when the model is quantized.
     """
 
     def __init__(

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -381,9 +381,9 @@ class GPTQConfig(QuantizationConfigMixin):
         cache_block_outputs (`bool`, *optional*, defaults to `True`):
             Whether to cache block outputs to reuse as inputs for the succeeding block.
         modules_in_block_to_quantize (`List[List[str]]`, *optional*):
-            List list of module names to quantize in the block specified. This argument is useful to exclude certain linear modules from being quantized.
+            List of list of module names to quantize in the specified block. This argument is useful to exclude certain linear modules from being quantized.
             The block to quantize can be specified by setting `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
-            Example: `inside_layer_modules=[["self_attention.query_key_value"], ["mlp.dense_h_to_4h"]]`
+            Example: `modules_in_block_to_quantize =[["self_attention.query_key_value"], ["mlp.dense_h_to_4h"]]`
     """
 
     def __init__(

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -380,7 +380,7 @@ class GPTQConfig(QuantizationConfigMixin):
             to `{"version": 1}` if unset.
         cache_block_outputs (`bool`, *optional*, defaults to `True`):
             Whether to cache block outputs to reuse as inputs for the succeeding block.
-        inside_layer_modules (`List`, *optional*, defaults to `None`):
+        inside_layer_modules (`List`, *optional*):
             List of module names to quantize inside block_name_to_quantize. If not set, we will quantize all the linear layers.
     """
 

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -383,10 +383,9 @@ class GPTQConfig(QuantizationConfigMixin):
         modules_in_block_to_quantize (`List[List[str]]`, *optional*):
             List of list of module names to quantize in the specified block. This argument is useful to exclude certain linear modules from being quantized.
             The block to quantize can be specified by setting `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
-            Example: `modules_in_block_to_quantize =[["self_attention.query_key_value"], ["mlp.dense_h_to_4h"]]`. In this example, we will first quantize `self_attention.query_key_value`.
-            Then, we will quantize `mlp.dense_h_to_4h` layer with `self_attention.query_key_value` quantized. This way, we will get better results since it reflects
-            the real input `mlp.dense_h_to_4h` will get when the model is quantized. We can also do `modules_in_block_to_quantize =[["self_attention.query_key_value", "mlp.dense_h_to_4h"]]`
-            to simultaneously quantize the layers but this will result in reduced quality.
+            Example: `modules_in_block_to_quantize =[["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"], ["self_attn.o_proj"]]`.
+            In this example, we will first quantize the q,k,v layers simultaneously since they are independent. Then, we will quantize `self_attn.o_proj` layer with the q,k,v layers quantized.
+            This way, we will get better results since it reflects the real input `self_attn.o_proj` will get when the model is quantized.
     """
 
     def __init__(

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -384,7 +384,7 @@ class GPTQConfig(QuantizationConfigMixin):
             List of list of module names to quantize in the specified block. This argument is useful to exclude certain linear modules from being quantized.
             The block to quantize can be specified by setting `block_name_to_quantize`. We will quantize each list sequentially. If not set, we will quantize all linear layers.
             Example: `modules_in_block_to_quantize =[["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"], ["self_attn.o_proj"]]`.
-            In this example, we will first quantize the q,k,v layers simultaneously since they are independent. 
+            In this example, we will first quantize the q,k,v layers simultaneously since they are independent.
             Then, we will quantize `self_attn.o_proj` layer with the q,k,v layers quantized. This way, we will get
             better results since it reflects the real input `self_attn.o_proj` will get when the model is quantized.
     """


### PR DESCRIPTION
# What does this PR do?
This PR adds the `modules_in_block_to_quantize ` quantization arg for gptq. This is necessary for converting specific layers to quantized layers. With this PR, we should be able to run the gptq mixtral model. See related [PR](https://github.com/huggingface/optimum/pull/1585) in optimum.

```python 
from transformers import AutoModelForCausalLM, AutoTokenizer, GPTQConfig

model_name = "TheBloke/Mixtral-8x7B-v0.1-GPTQ"

tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForCausalLM.from_pretrained(model_name, device_map={"":0})
print(model)

inputs = tokenizer.encode("Hello, how are you today ?", return_tensors="pt").to(0)
outputs = model.generate(inputs, max_new_tokens=100)
print(tokenizer.decode(outputs[0]))
```