### PR TITLE
Fix SDPA correctness following torch==2.1.2 regression

### DIFF
--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -583,7 +583,7 @@ class BartSdpaAttention(BartAttention):
 
         query_states = self._shape(query_states, tgt_len, bsz)
 
-        # NOTE: SDPA with memory-efficient backend is bugged when using non-contiguous inputs and a custom attn_mask,
+        # NOTE: SDPA with memory-efficient backend is currently (torch==2.1.2) bugged when using non-contiguous inputs and a custom attn_mask,
         # but we are fine here as `_shape` do call `.contiguous()`. Reference: https://github.com/pytorch/pytorch/issues/112577
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -583,6 +583,8 @@ class BartSdpaAttention(BartAttention):
 
         query_states = self._shape(query_states, tgt_len, bsz)
 
+        # NOTE: SDPA with memory-efficient backend is bugged when using non-contiguous inputs and a custom attn_mask,
+        # but we are fine here as `_shape` do call `.contiguous()`. Reference: https://github.com/pytorch/pytorch/issues/112577
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
             key_states,

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -550,7 +550,7 @@ class GPTBigCodeSdpaAttention(GPTBigCodeAttention):
             # key = key.expand(-1, self.num_heads, -1, -1)
             # value = value.expand(-1, self.num_heads, -1, -1)
             #
-            # However SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs,
+            # However SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
             # so we always dispatch to the math path: https://github.com/pytorch/pytorch/issues/112577.
             # Arguably we could still do expand + contiguous when `query.device.type == "cuda"` in order to dispatch on memory-efficient
             # backend, but it feels very hacky.
@@ -558,7 +558,7 @@ class GPTBigCodeSdpaAttention(GPTBigCodeAttention):
             query_length = query_shape[-1]
 
             # See the comment above.
-            if query.device.type == "cuda":
+            if query.device.type == "cuda" and attention_mask is not None:
                 query = query.contiguous()
                 key = key.contiguous()
                 value = value.contiguous()

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -532,23 +532,36 @@ class GPTBigCodeSdpaAttention(GPTBigCodeAttention):
         if self.multi_query:
             query_length = query_shape[1]
 
-            # NOTE: Maybe there is better than this?
+            # SDPA requires the dimension [..., sequence_length, head_dim].
             query = query.view(batch_size, query_length, self.num_heads, self.head_dim).transpose(1, 2)
 
             # Without these unsqueeze, SDPA complains as the query and key/value have a different number of dimensions.
             key = key.unsqueeze(1)
             value = value.unsqueeze(1)
 
-            # Although these expand are not numerically useful, PyTorch 2.1 can not dispatch to mem-efficient attention
-            # and flash attention (No available kernel.  Aborting execution.) from the shapes
+            # Although these expand are not numerically useful, PyTorch 2.1 can not dispatch to memory-efficient backend
+            # and flash attention backend (No available kernel.  Aborting execution.) from the shapes
             # query = [batch_size, num_heads, query_length, head_dim]
             # key = [batch_size, 1, past_length, head_dim]
             # value = [batch_size, 1, past_length, head_dim]
-            # which is unfortunate. Hopefully can be improved in the future. These expand should not be too expansive as they do not do memory copy.
-            key = key.expand(-1, self.num_heads, -1, -1)
-            value = value.expand(-1, self.num_heads, -1, -1)
+            #
+            # so we could do:
+            #
+            # key = key.expand(-1, self.num_heads, -1, -1)
+            # value = value.expand(-1, self.num_heads, -1, -1)
+            #
+            # However SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs,
+            # so we always dispatch to the math path: https://github.com/pytorch/pytorch/issues/112577.
+            # Arguably we could still do expand + contiguous when `query.device.type == "cuda"` in order to dispatch on memory-efficient
+            # backend, but it feels very hacky.
         else:
             query_length = query_shape[-1]
+
+            # See the comment above.
+            if query.device.type == "cuda":
+                query = query.contiguous()
+                key = key.contiguous()
+                value = value.contiguous()
 
         sdpa_result = torch.nn.functional.scaled_dot_product_attention(
             query,

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -506,7 +506,6 @@ class LlamaFlashAttention2(LlamaAttention):
         if past_key_value is not None:
             kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -701,6 +701,7 @@ class LlamaSdpaAttention(LlamaAttention):
         if past_key_value is not None:
             kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
         if past_key_value is not None:
@@ -715,6 +716,13 @@ class LlamaSdpaAttention(LlamaAttention):
                 raise ValueError(
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
                 )
+
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
+        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        if query_states.device.type == "cuda" and attention_mask is not None:
+            query_states = query_states.contiguous()
+            key_states = key_states.contiguous()
+            value_states = value_states.contiguous()
 
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -764,7 +764,7 @@ class WhisperSdpaAttention(WhisperAttention):
 
         query_states = self._shape(query_states, tgt_len, bsz)
 
-        # NOTE: SDPA with memory-efficient backend is bugged when using non-contiguous inputs and a custom attn_mask,
+        # NOTE: SDPA with memory-efficient backend is currently (torch==2.1.2) bugged when using non-contiguous inputs and a custom attn_mask,
         # but we are fine here as `_shape` do call `.contiguous()`. Reference: https://github.com/pytorch/pytorch/issues/112577
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -764,6 +764,8 @@ class WhisperSdpaAttention(WhisperAttention):
 
         query_states = self._shape(query_states, tgt_len, bsz)
 
+        # NOTE: SDPA with memory-efficient backend is bugged when using non-contiguous inputs and a custom attn_mask,
+        # but we are fine here as `_shape` do call `.contiguous()`. Reference: https://github.com/pytorch/pytorch/issues/112577
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
             key_states,


### PR DESCRIPTION
As explained in https://github.com/pytorch/pytorch/issues/112577, `torch==2.1.2` reintroduces a bug (that was first introduced in 2.1.0 and fixed in 2.1.1) in SDPA where the operator produces wrong outputs when using a custom `attn_mask`, cuda device and memory-efficient attention backend.

This PR makes it so that we don't silently fall into this bug.

Running `RUN_SLOW=1 CUDA_VISIBLE_DEVICES=0 pytest tests/models/gpt_bigcode/ -s -vvvvv`, we have:

### With `torch==2.1.1` without this patch

all tests pass

### With `torch==2.1.2` without this patch (regression)
```
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_beam_sample_generate - RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_beam_search_generate - AssertionError: Lists differ: [[15, 95, 23, 94, 98, 62], [82, 51, 84, 98, 1, 0]] != [[15, 95, 23, 94, 98, 62], [82, 51, 84, 98, 66, 21]]
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_constrained_beam_search_generate - AssertionError: Lists differ: [[29,[207 chars] 48, 73, 79, 64, 93, 83, 40], [74, 76, 22, 92,[58 chars] 40]] != [[29,[207 chars] 48, 14, 82, 4, 46, 83, 4...
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_flash_attn_2_generate_padding_right - AssertionError: False is not true
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_generate_continue_from_past_key_values - AssertionError: False is not true
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelTest::test_group_beam_search_generate - AssertionError: Lists differ: [[85,[33 chars] 31, 68, 25], [93, 70, 87, 4, 69, 8], [93, 70, 87, 31, 68, 91]] != [[85,[33 chars] 31, 68, 7], [93, 70, 87,...
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelLanguageGenerationTest::test_generate_batched - AssertionError: Lists differ: ['def[78 chars]say_hello():\n    // 1. Create a new array with the values of'] != ['def[78 chars]say_hello():\n    print("...
FAILED tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py::GPTBigCodeModelLanguageGenerationTest::test_generate_simple - AssertionError: 'def print_hello_world():\n    print("Hello World")\n\ndef print_hello_' != 'def print_hello_world():\n    print("Hello World!")\n\n\nde...
```

### With `torch==2.1.2` & `torch==2.1.1` with this patch

All tests pass.

For the other archs supporting SDPA (llama, whisper, falcon, idefics, bart), the tests are running fine & manual tests go fine as well.