### PR TITLE
Better key error for AutoConfig

### DIFF
--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1098,7 +1098,7 @@ class AutoConfig:
             try:
                 config_class = CONFIG_MAPPING[config_dict["model_type"]]
             except KeyError:
-                raise KeyError(f"The checkpoint you are trying to load has a model type of {config_dict['model_type']} "
+                raise KeyError(f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                                "but Transformers does not recognize this architecture. This could be because of an "
                                "issue with the checkpoint, or because your version of Transformers is out of date.")
             return config_class.from_dict(config_dict, **unused_kwargs)

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1098,7 +1098,7 @@ class AutoConfig:
             try:
                 config_class = CONFIG_MAPPING[config_dict["model_type"]]
             except KeyError:
-                raise KeyError(f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
+                raise ValueError(f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                                "but Transformers does not recognize this architecture. This could be because of an "
                                "issue with the checkpoint, or because your version of Transformers is out of date.")
             return config_class.from_dict(config_dict, **unused_kwargs)

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1095,7 +1095,12 @@ class AutoConfig:
                 config_class.register_for_auto_class()
             return config_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
         elif "model_type" in config_dict:
-            config_class = CONFIG_MAPPING[config_dict["model_type"]]
+            try:
+                config_class = CONFIG_MAPPING[config_dict["model_type"]]
+            except KeyError:
+                raise KeyError(f"The checkpoint you are trying to load has a model type of {config_dict['model_type']} "
+                               "but Transformers does not recognize this architecture. This could be because of an "
+                               "issue with the checkpoint, or because your version of Transformers is out of date.")
             return config_class.from_dict(config_dict, **unused_kwargs)
         else:
             # Fallback: use pattern matching on the string.

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1098,9 +1098,11 @@ class AutoConfig:
             try:
                 config_class = CONFIG_MAPPING[config_dict["model_type"]]
             except KeyError:
-                raise ValueError(f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
-                               "but Transformers does not recognize this architecture. This could be because of an "
-                               "issue with the checkpoint, or because your version of Transformers is out of date.")
+                raise ValueError(
+                    f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
+                    "but Transformers does not recognize this architecture. This could be because of an "
+                    "issue with the checkpoint, or because your version of Transformers is out of date."
+                )
             return config_class.from_dict(config_dict, **unused_kwargs)
         else:
             # Fallback: use pattern matching on the string.


### PR DESCRIPTION
When users try to load a model with AutoModel/AutoConfig but the model type isn't recognized, they get a confusing error about missing keys. However, these errors are usually caused by their version of `Transformers` being out of date. I've seen several users asking for help with this issue trying to load `mixtral`, so I wrote a better error message for next time!