### PR TITLE
fix typo in dvclive callback

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1658,7 +1658,7 @@ class DVCLiveCallback(TrainerCallback):
         """
         from dvclive import Live
 
-        self._initalized = True
+        self._initialized = True
         if self._log_model is not None:
             log_model_env = os.getenv("HF_DVCLIVE_LOG_MODEL")
             if log_model_env.upper() in ENV_VARS_TRUE_VALUES:


### PR DESCRIPTION
# What does this PR do?

Fixes a typo in the dvclive callback that prevents it from being set as initialized.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts or @muellerzr Would one of you mind taking a look? Apologies for not catching this. Our internal tests missed this scenario where initialization depends on the `setup()` method.
