### PR TITLE
When save a model on TPU, make a copy to be moved to CPU

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2803,9 +2803,7 @@ class Trainer:
             output_dir = self.args.output_dir
 
         if is_torch_tpu_available():
-            model = copy.deepcopy(self.model)
-            model.to("cpu")
-            self._save_tpu(model, output_dir)
+            self._save_tpu(output_dir)
         elif is_sagemaker_mp_enabled():
             # Calling the state_dict needs to be done on the wrapped model and on all processes.
             os.makedirs(output_dir, exist_ok=True)
@@ -2845,9 +2843,11 @@ class Trainer:
         if self.args.push_to_hub and not _internal_call:
             self.push_to_hub(commit_message="Model save")
 
-    def _save_tpu(self, model, output_dir: Optional[str] = None):
+    def _save_tpu(self, output_dir: Optional[str] = None):
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         logger.info(f"Saving model checkpoint to {output_dir}")
+        model = copy.deepcopy(self.model)
+        model.to("cpu")
 
         if xm.is_master_ordinal():
             os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
# What does this PR do?

When we save a model on TPU, we first move it to CPU because TPU tensors have no 
storage. However, we should do it with a copy of the model, so that the original model 
still on TPU. Because otherwise `model.to('cpu')` would also modify the model in-place.
Then, it would raise the following error when that model is used in compute:

```
indices should be either on cpu or on the same device as the indexed tensor (XLA). When using XLA, the indexed tensor must be an XLA tensor.
```

Tested by running this command on TPU v4-8:
```
python3 examples/pytorch/text-classification/run_glue.py \
        --model_name_or_path=distilbert-base-uncased \
        --task_name=MNLI \
        --do_train=true \
        --num_train_epochs=1 \
        --max_seq_length=128 \
        --learning_rate=3e-5 \
        --overwrite_output_dir=true \
        --save_steps=3000 \
        --save_strategy=no --output_dir=/workspace/mnli
```

cc @muellerzr and @pacman100

