### PR TITLE
[`CI slow`] Fix expected values

### DIFF
--- a/tests/models/vit_msn/test_modeling_vit_msn.py
+++ b/tests/models/vit_msn/test_modeling_vit_msn.py
@@ -210,7 +210,7 @@ class ViTMSNModelIntegrationTest(unittest.TestCase):
     def default_image_processor(self):
         return ViTImageProcessor.from_pretrained("facebook/vit-msn-small") if is_vision_available() else None
 
-    # @slow
+    @slow
     def test_inference_image_classification_head(self):
         torch.manual_seed(2)
         model = ViTMSNForImageClassification.from_pretrained("facebook/vit-msn-small").to(torch_device)

--- a/tests/models/vit_msn/test_modeling_vit_msn.py
+++ b/tests/models/vit_msn/test_modeling_vit_msn.py
@@ -227,6 +227,6 @@ class ViTMSNModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size((1, 1000))
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([ 0.5588,  0.6853, -0.5929]).to(torch_device)
+        expected_slice = torch.tensor([0.5588, 0.6853, -0.5929]).to(torch_device)
 
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))

--- a/tests/models/vit_msn/test_modeling_vit_msn.py
+++ b/tests/models/vit_msn/test_modeling_vit_msn.py
@@ -210,7 +210,7 @@ class ViTMSNModelIntegrationTest(unittest.TestCase):
     def default_image_processor(self):
         return ViTImageProcessor.from_pretrained("facebook/vit-msn-small") if is_vision_available() else None
 
-    @slow
+    # @slow
     def test_inference_image_classification_head(self):
         torch.manual_seed(2)
         model = ViTMSNForImageClassification.from_pretrained("facebook/vit-msn-small").to(torch_device)
@@ -227,6 +227,6 @@ class ViTMSNModelIntegrationTest(unittest.TestCase):
         expected_shape = torch.Size((1, 1000))
         self.assertEqual(outputs.logits.shape, expected_shape)
 
-        expected_slice = torch.tensor([-0.0803, -0.4454, -0.2375]).to(torch_device)
+        expected_slice = torch.tensor([ 0.5588,  0.6853, -0.5929]).to(torch_device)
 
         self.assertTrue(torch.allclose(outputs.logits[0, :3], expected_slice, atol=1e-4))


### PR DESCRIPTION
# What does this PR do?
Fix slow test. The init was probably done twice because:

```pyton 
Some weights of ViTMSNForImageClassification were not initialized from the model checkpoint at facebook/vit-msn-small and are newly initialized: ['classifier.bias', 'classifier.weight']
```
so the weights should no be initialized by the form_pretrained but by the `_init_weights`