### PR TITLE
Fix bug with rotating checkpoints

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2382,8 +2382,10 @@ class Trainer:
             self._push_from_checkpoint(staging_output_dir)
 
         # Place checkpoint in final location after all saving is finished.
-        if staging_output_dir != output_dir and self.args.should_save:
-            os.rename(staging_output_dir, output_dir)
+        if staging_output_dir != output_dir:
+            with self.args.main_process_first(desc="Renaming model checkpoint folder to true location"):
+                if os.path.exists(staging_output_dir):
+                    os.rename(staging_output_dir, output_dir)
 
         # Maybe delete some older checkpoints.
         if self.args.should_save:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2382,6 +2382,9 @@ class Trainer:
             self._push_from_checkpoint(staging_output_dir)
 
         # Place checkpoint in final location after all saving is finished.
+        # First wait for everyone to finish writing
+        self.args.distributed_state.wait_for_everyone()
+        # Then go through the rewriting process starting on process 0
         if staging_output_dir != output_dir:
             with self.args.main_process_first(desc="Renaming model checkpoint folder to true location"):
                 if os.path.exists(staging_output_dir):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2382,7 +2382,7 @@ class Trainer:
             self._push_from_checkpoint(staging_output_dir)
 
         # Place checkpoint in final location after all saving is finished.
-        if staging_output_dir != output_dir:
+        if staging_output_dir != output_dir and self.args.should_save:
             os.rename(staging_output_dir, output_dir)
 
         # Maybe delete some older checkpoints.

--- a/tests/trainer/test_trainer_distributed.py
+++ b/tests/trainer/test_trainer_distributed.py
@@ -234,6 +234,7 @@ if __name__ == "__main__":
         if p.metrics["test_success"] is not True:
             logger.error(p.metrics)
             exit(1)
+        trainer.args.eval_accumulation_steps = None
 
     # Check that saving does indeed work with temp dir rotation
     # If this fails, will see a FileNotFoundError

--- a/tests/trainer/test_trainer_distributed.py
+++ b/tests/trainer/test_trainer_distributed.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Dict
 
 import numpy as np
@@ -234,7 +235,19 @@ if __name__ == "__main__":
             logger.error(p.metrics)
             exit(1)
 
-        trainer.args.eval_accumulation_steps = None
+    # Check that saving does indeed work with temp dir rotation
+    # If this fails, will see a FileNotFoundError
+    model = RegressionModel()
+    training_args.max_steps = 1
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    sched = torch.optim.lr_scheduler.LambdaLR(opt, lambda x: 1)
+    trainer = Trainer(
+        model, training_args, optimizers=(opt, sched), data_collator=DummyDataCollator(), eval_dataset=dataset
+    )
+    trainer._save_checkpoint(model=None, trial=None)
+    # Check that the temp folder does not exist
+    assert not (Path(training_args.output_dir) / "tmp-checkpoint-0").exists()
+    assert (Path(training_args.output_dir) / "checkpoint-0").exists()
 
     # Check that `dispatch_batches=False` will work on a finite iterable dataset
 

--- a/tests/trainer/test_trainer_distributed.py
+++ b/tests/trainer/test_trainer_distributed.py
@@ -234,7 +234,7 @@ if __name__ == "__main__":
         if p.metrics["test_success"] is not True:
             logger.error(p.metrics)
             exit(1)
-        
+
         trainer.args.eval_accumulation_steps = None
 
     # Check that saving does indeed work with temp dir rotation

--- a/tests/trainer/test_trainer_distributed.py
+++ b/tests/trainer/test_trainer_distributed.py
@@ -234,6 +234,7 @@ if __name__ == "__main__":
         if p.metrics["test_success"] is not True:
             logger.error(p.metrics)
             exit(1)
+        
         trainer.args.eval_accumulation_steps = None
 
     # Check that saving does indeed work with temp dir rotation


### PR DESCRIPTION
# What does this PR do?

There was a bug introduced in https://github.com/huggingface/transformers/pull/27820 where if we were on multi-GPU systems we would hit a race condition after saving on the processes because we cannot rename the staging directory multiple times. This PR ensures that it only happens on the main process. 

Fixes # (issue)

Fixes https://github.com/huggingface/transformers/issues/27925
Alternative to https://github.com/huggingface/transformers/pull/27929


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts 

I would recommend a patch release as this is fully blocking users on multi-GPU after the last release. 