### PR TITLE
Fixed spelling error in T5 tokenizer warning message (s/thouroughly/t…

### DIFF
--- a/src/transformers/models/t5/tokenization_t5.py
+++ b/src/transformers/models/t5/tokenization_t5.py
@@ -191,7 +191,7 @@ class T5Tokenizer(PreTrainedTokenizer):
                 f"You are using the default legacy behaviour of the {self.__class__}. This is"
                 " expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you."
                 " If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it"
-                " means, and thouroughly read the reason why this was added as explained in"
+                " means, and thoroughly read the reason why this was added as explained in"
                 " https://github.com/huggingface/transformers/pull/24565"
             )
             legacy = True


### PR DESCRIPTION
# Spelling correction 

This is a simple word change for a warning message generated by the T5 tokenizer ('src/transformers/models/t5/tokenization_t5.py') that appeared when converting LLAMA weights to HF format. 

