### PR TITLE
Fix languages covered by M4Tv2

### DIFF
--- a/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
+++ b/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
@@ -4596,9 +4596,9 @@ class SeamlessM4Tv2Model(SeamlessM4Tv2PreTrainedModel):
         if tgt_lang is not None:
             # also accept __xxx__
             tgt_lang = tgt_lang.replace("__", "")
-            if generate_speech: 
+            if generate_speech:
                 keys_to_check = ["text_decoder_lang_to_code_id", "t2u_lang_code_to_id", "vocoder_lang_code_to_id"]
-            else: 
+            else:
                 keys_to_check = ["text_decoder_lang_to_code_id"]
             for key in keys_to_check:
                 lang_code_to_id = getattr(self.generation_config, key, None)

--- a/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
+++ b/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
@@ -4596,7 +4596,12 @@ class SeamlessM4Tv2Model(SeamlessM4Tv2PreTrainedModel):
         if tgt_lang is not None:
             # also accept __xxx__
             tgt_lang = tgt_lang.replace("__", "")
-            for key in ["text_decoder_lang_to_code_id", "t2u_lang_code_to_id", "vocoder_lang_code_to_id"]:
+            keys_to_check = (
+                ["text_decoder_lang_to_code_id", "t2u_lang_code_to_id", "vocoder_lang_code_to_id"]
+                if generate_speech
+                else ["text_decoder_lang_to_code_id"]
+            )
+            for key in keys_to_check:
                 lang_code_to_id = getattr(self.generation_config, key, None)
                 if lang_code_to_id is None:
                     raise ValueError(

--- a/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
+++ b/src/transformers/models/seamless_m4t_v2/modeling_seamless_m4t_v2.py
@@ -4596,11 +4596,10 @@ class SeamlessM4Tv2Model(SeamlessM4Tv2PreTrainedModel):
         if tgt_lang is not None:
             # also accept __xxx__
             tgt_lang = tgt_lang.replace("__", "")
-            keys_to_check = (
-                ["text_decoder_lang_to_code_id", "t2u_lang_code_to_id", "vocoder_lang_code_to_id"]
-                if generate_speech
-                else ["text_decoder_lang_to_code_id"]
-            )
+            if generate_speech: 
+                keys_to_check = ["text_decoder_lang_to_code_id", "t2u_lang_code_to_id", "vocoder_lang_code_to_id"]
+            else: 
+                keys_to_check = ["text_decoder_lang_to_code_id"]
             for key in keys_to_check:
                 lang_code_to_id = getattr(self.generation_config, key, None)
                 if lang_code_to_id is None:

--- a/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
+++ b/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
@@ -790,19 +790,16 @@ class SeamlessM4Tv2GenerationTest(unittest.TestCase):
 
         model.generation_config = generation_config
 
-    def prepare_text_input(self, is_rus=False):
+    def prepare_text_input(self, tgt_lang):
         config, inputs, decoder_input_ids, input_mask, lm_labels = self.text_model_tester.prepare_config_and_inputs()
 
         input_dict = {
             "input_ids": inputs,
             "attention_mask": input_mask,
-            "tgt_lang": "eng",
+            "tgt_lang": tgt_lang,
             "num_beams": 2,
             "do_sample": True,
         }
-
-        if is_rus:
-            input_dict["tgt_lang"] = "rus"
 
         return config, input_dict
 
@@ -847,7 +844,7 @@ class SeamlessM4Tv2GenerationTest(unittest.TestCase):
         return output
 
     def test_generation_languages(self):
-        config, input_text_rus = self.prepare_text_input(is_rus=True)
+        config, input_text_rus = self.prepare_text_input(tgt_lang="rus")
 
         model = SeamlessM4Tv2Model(config=config)
         self.update_generation(model)
@@ -860,6 +857,11 @@ class SeamlessM4Tv2GenerationTest(unittest.TestCase):
 
         # make sure that generating text only works
         model.generate(**input_text_rus, generate_speech=False)
+
+        # make sure it works for languages supported by both output modalities
+        config, input_text_eng = self.prepare_text_input(tgt_lang="eng")
+        model.generate(**input_text_eng)
+        model.generate(**input_text_eng, generate_speech=False)
 
     def test_speech_generation(self):
         config, input_speech, input_text = self.prepare_speech_and_text_input()


### PR DESCRIPTION
# What does this PR do?

Currently, M4Tv2 into-text tasks (ASR, S2TT, T2TT) do not work for languages outside of the 36 for which audio is supported. This is linked to a test at the beginning of the model generate. The model previously verified if the `tgt_lang` was in a bunch of dictionaries, independently from the output modality. This PR aims to fix that.

I've added a test to make sure it works.

cc @amyeroberts 