### PR TITLE
[`FA-2`] Fix fa-2 issue when passing `config` to `from_pretrained`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2958,11 +2958,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # In case one passes a config to `from_pretrained` + "attn_implementation"
             # override the `_attn_implementation` attribute to `attn_implementation` of the kwargs
             # Please see: https://github.com/huggingface/transformers/issues/28038
+
+            # Overwrite `config._attn_implementation` by the one from the kwargs --> in auto-factory
+            # we pop attn_implementation from the kwargs but this handles the case where users
+            # passes manually the config to `from_pretrained`.
             config = copy.deepcopy(config)
-            
-            # Overwrite `config._attn_implementation` by the one from the kwargs --> in auto-factory 
-            # we pop attn_implementation from the kwargs
-            if getattr(config, "_attn_implementation", None) != kwargs.get("attn_implementation", None):
+
+            if kwargs.get("attn_implementation", None) is not None and getattr(
+                config, "_attn_implementation", None
+            ) != kwargs.get("attn_implementation", None):
                 config._attn_implementation = kwargs.get("attn_implementation", None)
             model_kwargs = kwargs
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2964,9 +2964,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # passes manually the config to `from_pretrained`.
             config = copy.deepcopy(config)
 
-            if kwargs.get("attn_implementation", None) is not None and getattr(
-                config, "_attn_implementation", None
-            ) != kwargs.get("attn_implementation", None):
+            if kwargs.get("attn_implementation", None) is not None and config._attn_implementation != kwargs.get("attn_implementation", None):
                 config._attn_implementation = kwargs.get("attn_implementation", None)
             model_kwargs = kwargs
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2964,7 +2964,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # passes manually the config to `from_pretrained`.
             config = copy.deepcopy(config)
 
-            if kwargs.get("attn_implementation", None) is not None and config._attn_implementation != kwargs.get("attn_implementation", None):
+            if kwargs.get("attn_implementation", None) is not None and config._attn_implementation != kwargs.get(
+                "attn_implementation", None
+            ):
                 config._attn_implementation = kwargs.get("attn_implementation", None)
             model_kwargs = kwargs
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2964,10 +2964,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # passes manually the config to `from_pretrained`.
             config = copy.deepcopy(config)
 
-            if kwargs.get("attn_implementation", None) is not None and config._attn_implementation != kwargs.get(
-                "attn_implementation", None
-            ):
-                config._attn_implementation = kwargs.get("attn_implementation", None)
+            kwarg_attn_imp = kwargs.get("attn_implementation", None)
+            if kwarg_attn_imp is not None and config._attn_implementation != kwarg_attn_imp:
+                config._attn_implementation = kwarg_attn_imp
             model_kwargs = kwargs
 
         quantizer = None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2959,8 +2959,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # override the `_attn_implementation` attribute to `attn_implementation` of the kwargs
             # Please see: https://github.com/huggingface/transformers/issues/28038
             config = copy.deepcopy(config)
-            if getattr(config, "_attn_implementation", "eager") != kwargs.get("attn_implementation", None):
-                config._attn_implementation = kwargs.pop("attn_implementation", None)
+            
+            # Overwrite `config._attn_implementation` by the one from the kwargs --> in auto-factory 
+            # we pop attn_implementation from the kwargs
+            if getattr(config, "_attn_implementation", None) != kwargs.get("attn_implementation", None):
+                config._attn_implementation = kwargs.get("attn_implementation", None)
             model_kwargs = kwargs
 
         quantizer = None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2959,7 +2959,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # override the `_attn_implementation` attribute to `attn_implementation` of the kwargs
             # Please see: https://github.com/huggingface/transformers/issues/28038
             config = copy.deepcopy(config)
-            config._attn_implementation = kwargs.get("attn_implementation", None)
+            if getattr(config, "_attn_implementation", "eager") != kwargs.get("attn_implementation", None):
+                config._attn_implementation = kwargs.pop("attn_implementation", None)
             model_kwargs = kwargs
 
         quantizer = None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2957,6 +2957,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         else:
             model_kwargs = kwargs
 
+            # In case one passes a config to `from_pretrained` + "attn_implementation"
+            # override the `_attn_implementation` attribute to `attn_implementation` of the kwargs
+            # Please see: https://github.com/huggingface/transformers/issues/28038
+            if config is not None:
+                config._attn_implementation = model_kwargs.pop("attn_implementation", None)
+
         quantizer = None
         quantization_method_from_config = None
         if hasattr(config, "quantization_config"):
@@ -3441,6 +3447,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             init_contexts.append(init_empty_weights())
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in from_pretrained.
+
         config = cls._autoset_attn_implementation(
             config, use_flash_attention_2=use_flash_attention_2, torch_dtype=torch_dtype, device_map=device_map
         )

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2964,7 +2964,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # passes manually the config to `from_pretrained`.
             config = copy.deepcopy(config)
 
-            kwarg_attn_imp = kwargs.get("attn_implementation", None)
+            kwarg_attn_imp = kwargs.pop("attn_implementation", None)
             if kwarg_attn_imp is not None and config._attn_implementation != kwarg_attn_imp:
                 config._attn_implementation = kwarg_attn_imp
             model_kwargs = kwargs

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2955,13 +2955,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 **kwargs,
             )
         else:
-            model_kwargs = kwargs
-
             # In case one passes a config to `from_pretrained` + "attn_implementation"
             # override the `_attn_implementation` attribute to `attn_implementation` of the kwargs
             # Please see: https://github.com/huggingface/transformers/issues/28038
-            if config is not None:
-                config._attn_implementation = model_kwargs.pop("attn_implementation", None)
+            config = copy.deepcopy(config)
+            config._attn_implementation = kwargs.get("attn_implementation", None)
+            model_kwargs = kwargs
 
         quantizer = None
         quantization_method_from_config = None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3446,7 +3446,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             init_contexts.append(init_empty_weights())
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in from_pretrained.
-
         config = cls._autoset_attn_implementation(
             config, use_flash_attention_2=use_flash_attention_2, torch_dtype=torch_dtype, device_map=device_map
         )

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -538,6 +538,8 @@ class _BaseAutoModelClass:
                 kwargs["torch_dtype"] = "auto"
             if kwargs_orig.get("quantization_config", None) is not None:
                 kwargs["quantization_config"] = kwargs_orig["quantization_config"]
+            if kwargs_orig.get("attn_implementation", None) is not None:
+                kwargs["attn_implementation"] = kwargs_orig["attn_implementation"]
 
         has_remote_code = hasattr(config, "auto_map") and cls.__name__ in config.auto_map
         has_local_code = type(config) in cls._model_mapping.keys()

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -538,8 +538,6 @@ class _BaseAutoModelClass:
                 kwargs["torch_dtype"] = "auto"
             if kwargs_orig.get("quantization_config", None) is not None:
                 kwargs["quantization_config"] = kwargs_orig["quantization_config"]
-            if kwargs_orig.get("attn_implementation", None) is not None:
-                kwargs["attn_implementation"] = kwargs_orig["attn_implementation"]
 
         has_remote_code = hasattr(config, "auto_map") and cls.__name__ in config.auto_map
         has_local_code = type(config) in cls._model_mapping.keys()

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1850,6 +1850,21 @@ class TestAttentionImplementation(unittest.TestCase):
 
         self.assertTrue("the package flash_attn seems to be not installed" in str(cm.exception))
 
+    def test_not_available_flash_with_config(self):
+        if is_flash_attn_2_available():
+            self.skipTest("Please uninstall flash-attn package to run test_not_available_flash")
+
+        config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-GPTBigCodeModel")
+
+        with self.assertRaises(ImportError) as cm:
+            _ = AutoModel.from_pretrained(
+                "hf-internal-testing/tiny-random-GPTBigCodeModel",
+                config=config,
+                attn_implementation="flash_attention_2",
+            )
+
+        self.assertTrue("the package flash_attn seems to be not installed" in str(cm.exception))
+
     def test_not_available_sdpa(self):
         if is_torch_sdpa_available():
             self.skipTest("This test requires torch<=2.0")

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1823,6 +1823,16 @@ class TestAttentionImplementation(unittest.TestCase):
 
         self.assertTrue("does not support Flash Attention 2.0" in str(cm.exception))
 
+    def test_error_no_flash_available_with_config(self):
+        with self.assertRaises(ValueError) as cm:
+            config = AutoConfig.from_pretrained("hf-tiny-model-private/tiny-random-MCTCTModel")
+
+            _ = AutoModel.from_pretrained(
+                "hf-tiny-model-private/tiny-random-MCTCTModel", config=config, attn_implementation="flash_attention_2"
+            )
+
+        self.assertTrue("does not support Flash Attention 2.0" in str(cm.exception))
+
     def test_error_wrong_attn_implementation(self):
         with self.assertRaises(ValueError) as cm:
             _ = AutoModel.from_pretrained("hf-tiny-model-private/tiny-random-MCTCTModel", attn_implementation="foo")


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/28038

Some users pass the `config` attribute to `from_pretrained` in order to modify model's hyperparameters to modify the undelrying architecture. 

Note in previous versions before the attention refactor, it was possible to perform

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, LlamaForCausalLM, AutoConfig

model_id = "tiiuae/falcon-7b"
tokenizer = AutoTokenizer.from_pretrained(model_id)
config = AutoConfig.from_pretrained(model_id)

model = AutoModelForCausalLM.from_pretrained(
    model_id, 
    config=config,
    torch_dtype=torch.bfloat16, 
    use_flash_attention_2="flash_attention_2",
    low_cpu_mem_usage=True,
)
```

Now users get an issue while trying to perform the operation above because the logic of handling model's config for fa2 changed a bit.

I propose a simple fix to mitigate this issue which is overwriting the attribute `_attn_implementation` of `config` only in case it has been passed by the user. I can confirm with this fix the snippet:

```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer, LlamaForCausalLM, AutoConfig

model_id = "tiiuae/falcon-7b"
tokenizer = AutoTokenizer.from_pretrained(model_id)
config = AutoConfig.from_pretrained(model_id)

model = AutoModelForCausalLM.from_pretrained(
    model_id, 
    config=config,
    torch_dtype=torch.bfloat16, 
    attn_implementation="flash_attention_2",
    low_cpu_mem_usage=True,
)
```

Works as expected as in the earlier versions of transformers


cc @amyeroberts @fxmarty 