### PR TITLE
Remove warning when Annotion enum is created

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -15,7 +15,6 @@
 
 import base64
 import os
-from enum import EnumMeta
 from io import BytesIO
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -76,16 +75,7 @@ class AnnotationFormat(ExplicitEnum):
     COCO_PANOPTIC = "coco_panoptic"
 
 
-class DeprecatedEnumMeta(EnumMeta):
-    def __init__(cls, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        logger.warning_once(
-            f"`{cls.__name__}` is deprecated and will be removed in v4.38. "
-            f"Please use `transformers.image_utils.AnnotationFormat` instead."
-        )
-
-
-class AnnotionFormat(ExplicitEnum, metaclass=DeprecatedEnumMeta):
+class AnnotionFormat(ExplicitEnum):
     COCO_DETECTION = AnnotationFormat.COCO_DETECTION.value
     COCO_PANOPTIC = AnnotationFormat.COCO_PANOPTIC.value
 
@@ -703,10 +693,17 @@ def validate_annotations(
     supported_annotation_formats: Tuple[AnnotationFormat, ...],
     annotations: List[Dict],
 ) -> None:
-    if promote_annotation_format(annotation_format) not in supported_annotation_formats:
+    if isinstance(annotation_format, AnnotionFormat):
+        logger.warning_once(
+            f"`{annotation_format.__class__.__name__}` is deprecated and will be removed in v4.38. "
+            f"Please use `{AnnotationFormat.__name__}` instead."
+        )
+        annotation_format = promote_annotation_format(annotation_format)
+
+    if annotation_format not in supported_annotation_formats:
         raise ValueError(f"Unsupported annotation format: {format} must be one of {supported_annotation_formats}")
 
-    if promote_annotation_format(annotation_format) is AnnotationFormat.COCO_DETECTION:
+    if annotation_format is AnnotationFormat.COCO_DETECTION:
         if not valid_coco_detection_annotations(annotations):
             raise ValueError(
                 "Invalid COCO detection annotations. Annotations must a dict (single image) or list of dicts "
@@ -714,7 +711,7 @@ def validate_annotations(
                 "being a list of annotations in the COCO format."
             )
 
-    if promote_annotation_format(annotation_format) is AnnotationFormat.COCO_PANOPTIC:
+    if annotation_format is AnnotationFormat.COCO_PANOPTIC:
         if not valid_coco_panoptic_annotations(annotations):
             raise ValueError(
                 "Invalid COCO panoptic annotations. Annotations must a dict (single image) or list of dicts "

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -39,7 +39,6 @@ from ...image_utils import (
     IMAGENET_DEFAULT_STD,
     AnnotationFormat,
     AnnotationType,
-    AnnotionFormat,  # noqa: F401
     ChannelDimension,
     ImageInput,
     PILImageResampling,

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -39,7 +39,6 @@ from ...image_utils import (
     IMAGENET_DEFAULT_STD,
     AnnotationFormat,
     AnnotationType,
-    AnnotionFormat,  # noqa: F401
     ChannelDimension,
     ImageInput,
     PILImageResampling,

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -35,7 +35,6 @@ from ...image_utils import (
     IMAGENET_DEFAULT_MEAN,
     IMAGENET_DEFAULT_STD,
     AnnotationFormat,
-    AnnotionFormat,  # noqa: F401
     ChannelDimension,
     ImageInput,
     PILImageResampling,

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -38,7 +38,6 @@ from ...image_utils import (
     IMAGENET_DEFAULT_STD,
     AnnotationFormat,
     AnnotationType,
-    AnnotionFormat,  # noqa: F401
     ChannelDimension,
     ImageInput,
     PILImageResampling,

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -37,7 +37,6 @@ from ...image_utils import (
     IMAGENET_DEFAULT_STD,
     AnnotationFormat,
     AnnotationType,
-    AnnotionFormat,  # noqa: F401
     ChannelDimension,
     ImageInput,
     PILImageResampling,


### PR DESCRIPTION
# What does this PR do?

The Annotion enum was deprecated in #26941. 

I asked for there to be a deprecation warning to let users know if they chose to use the enum. This was overly defensive and in light of recent [complaints of objects being removed/moved from the library](https://github.com/huggingface/transformers/issues/25948#issuecomment-1758537251) (even if they were never meant to be used directly).

However, complete oversight on my part is that the __init__ of the enum will be created any time any object from the `image_utils` module file is imported - resulting in verbose error messages unrelated to what the user was trying to do - my bad. 

This PR removed the warning from the enum itself and adds it into a validation check that happens on annotations. 

It ultimately means that we might break things when we remove `Annotion` - but this is likely to be very unlikely and with a simple, quick resolution. 

Partially resolves #28042

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

