### PR TITLE
Make GPT2 traceable in meta state

### DIFF
--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -185,7 +185,7 @@ class DecisionTransformerGPT2Attention(nn.Module):
             mask_value = torch.finfo(attn_weights.dtype).min
             # Need to be a tensor, otherwise we get error: `RuntimeError: expected scalar type float but found double`.
             # Need to be on the same device, otherwise `RuntimeError: ..., x and y to be on the same device`
-            mask_value = torch.full([], mask_value, dtype=attn_weights.dtype).to(attn_weights.device)
+            mask_value = torch.full([], mask_value, dtype=attn_weights.dtype, device=attn_weights.device)
             attn_weights = torch.where(causal_mask, attn_weights.to(attn_weights.dtype), mask_value)
 
         if attention_mask is not None:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -198,7 +198,7 @@ class GPT2Attention(nn.Module):
             mask_value = torch.finfo(attn_weights.dtype).min
             # Need to be a tensor, otherwise we get error: `RuntimeError: expected scalar type float but found double`.
             # Need to be on the same device, otherwise `RuntimeError: ..., x and y to be on the same device`
-            mask_value = torch.full([], mask_value, dtype=attn_weights.dtype).to(attn_weights.device)
+            mask_value = torch.full([], mask_value, dtype=attn_weights.dtype, device=attn_weights.device)
             attn_weights = torch.where(causal_mask, attn_weights.to(attn_weights.dtype), mask_value)
 
         if attention_mask is not None:


### PR DESCRIPTION
# What does this PR do?

Before this PR, if we create GPT2 on "meta" device and trace it with dynamo or torch.export, the following line would create an error:
```
mask_value = torch.full([], mask_value, dtype=attn_weights.dtype).to(attn_weights.device)
```

```
torch._dynamo.exc.TorchRuntimeError: Failed running call_method to(*(FakeTensor(..., size=()), device(type='meta')), **{}):
Creating a new Tensor subclass FakeTensor but the raw Tensor object is already associated to a python object of type FakeTensor
```

That is, tracing a `.to("meta")` method on a meta tensor is not yet supported by PT2, even though we were just tracing the code.

A quick workaround is to move the device in `.to` method to the tensor constructor, which is what this PR does.

Longer term, it would be best for dynamo/export to not error out when tracing through the `.to` method in this situation.

(I will file an issue again PyTorch.)


## Who can review?

@younesbelkada
@muellerzr @SunMarc 