### PR TITLE
fix ffmpeg_microphone under WSL2 (use pulseaudio)

### DIFF
--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -64,9 +64,14 @@ def ffmpeg_microphone(
         raise ValueError(f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`")
 
     system = platform.system()
+    release = platform.release()
     if system == "Linux":
-        format_ = "alsa"
-        input_ = "default"
+        if release.endswith("WSL2"):
+            format_ = "pulse"
+            input_ = "RDPSource"
+        else:
+            format_ = "alsa"
+            input_ = "default"
     elif system == "Darwin":
         format_ = "avfoundation"
         input_ = ":0"


### PR DESCRIPTION
# Fix ffmpeg_microphone under WSL2
This attempts to detect if it is running under WSL2 and defaults to using pulseaudio with an input of "RDPSource" in order to work with WSL2.

@Narsil - tagging you since you contributed most of this file.  I'm also happy to update this to just accept the format and input as parameters if you prefer (and either keep or roll back the defaults for WSL2).