### PR TITLE
Skip M4T `test_retain_grad_hidden_states_attentions` 

### DIFF
--- a/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
@@ -610,7 +610,9 @@ class SeamlessM4TModelWithSpeechInputTest(ModelTesterMixin, unittest.TestCase):
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
             )
 
-    @unittest.skip(reason="The speech encoder attentions are sometimes skipped resulting in None.")
+    @unittest.skip(
+        reason="In training model, the first speech encoder layer is sometimes skipped. Training is not supported yet, so the test is ignored."
+    )
     def test_retain_grad_hidden_states_attentions(self):
         pass
 

--- a/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
@@ -20,7 +20,7 @@ import tempfile
 import unittest
 
 from transformers import SeamlessM4TConfig, is_speech_available, is_torch_available
-from transformers.testing_utils import is_flaky, require_torch, slow, torch_device
+from transformers.testing_utils import require_torch, slow, torch_device
 from transformers.trainer_utils import set_seed
 from transformers.utils import cached_property
 
@@ -610,9 +610,9 @@ class SeamlessM4TModelWithSpeechInputTest(ModelTesterMixin, unittest.TestCase):
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
             )
 
-    @is_flaky()
+    @unittest.skip(reason="The speech encoder attentions are sometimes skipped resulting in None.")
     def test_retain_grad_hidden_states_attentions(self):
-        super().test_retain_grad_hidden_states_attentions()
+        pass
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

After investigating the reasons for the `test_retain_grad_hidden_states_attentions` flaky failure, I realized the speech encoder attentions can be `None` with a non-zero probability when `training=True`.  Skipping the test is the fastest fix.

Fixes #28036

cc @gante @amyeroberts @ydshieh 