### PR TITLE
Fix weights not properly initialized due to shape mismatch

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -555,7 +555,7 @@ def set_initialized_submodules(model, state_dict_keys, loaded=True):
             not_loaded_keys = [
                 k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
             ]
-            if len(set(module.state_dict().keys()).intersection(not_loaded_keys)) == 0:
+            if len(set(module.state_dict().keys()).intersection(not_loaded_keys)) > 0:
                 module._is_hf_initialized = False
 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4163,7 +4163,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if _fast_init:
             mismatched_model_keys = [
-                checkpoint_key_to_model_key(x[0], remove_prefix_from_model, add_prefix_to_model) for x in mismatched_keys
+                checkpoint_key_to_model_key(x[0], remove_prefix_from_model, add_prefix_to_model)
+                for x in mismatched_keys
             ]
             set_initialized_submodules(model, mismatched_model_keys, loaded=False)
             # This will only initialize submodules that are re-marked as `not loaded` above due to mismatched

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -545,9 +545,18 @@ def set_initialized_submodules(model, state_dict_keys, loaded=True):
     dict.
     """
     for module_name, module in model.named_modules():
-        loaded_keys = [k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")]
-        if len(set(module.state_dict().keys()) - set(loaded_keys)) == 0:
-            module._is_hf_initialized = loaded
+        if loaded:
+            loaded_keys = [
+                k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
+            ]
+            if len(set(module.state_dict().keys()) - set(loaded_keys)) == 0:
+                module._is_hf_initialized = loaded
+        else:
+            not_loaded_keys = [
+                k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
+            ]
+            if len(set(module.state_dict().keys()).intersection(not_loaded_keys)) == 0:
+                module._is_hf_initialized = False
 
 
 def _load_state_dict_into_model(model_to_load, state_dict, start_prefix):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -555,7 +555,7 @@ def set_initialized_submodules(model, state_dict_keys, loaded=True):
             not_loaded_keys = [
                 k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
             ]
-            if len(set(module.state_dict().keys()).intersection(not_loaded_keys)) > 0:
+            if set(module.state_dict().keys()) == set(not_loaded_keys):
                 module._is_hf_initialized = False
 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4163,7 +4163,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if _fast_init:
             mismatched_model_keys = [
-                checkpoint_key_to_model_key(k, remove_prefix_from_model, add_prefix_to_model) for k in mismatched_keys
+                checkpoint_key_to_model_key(x[0], remove_prefix_from_model, add_prefix_to_model) for x in mismatched_keys
             ]
             set_initialized_submodules(model, mismatched_model_keys, loaded=False)
             # This will only initialize submodules that are re-marked as `not loaded` above due to mismatched

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2910,12 +2910,14 @@ class ModelTesterMixin:
                     logger = logging.get_logger("transformers.modeling_utils")
 
                     with CaptureLogger(logger) as cl:
+                        torch.manual_seed(0)
                         new_model = AutoModelForSequenceClassification.from_pretrained(
                             tmp_dir, num_labels=42, ignore_mismatched_sizes=True
                         )
                     self.assertIn("the shapes did not match", cl.out)
 
                     with CaptureLogger(logger) as cl:
+                        torch.manual_seed(0)
                         new_model_2 = AutoModelForSequenceClassification.from_pretrained(
                             tmp_dir,
                             num_labels=42,

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2889,6 +2889,48 @@ class ModelTesterMixin:
                     else:
                         new_model_without_prefix(input_ids)
 
+    def test_mismatched_shapes_have_properly_initialized_weights(self):
+        if not self.test_mismatched_shapes:
+            return
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            if model_class.__name__ not in get_values(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES):
+                continue
+
+            with self.subTest(msg=f"Testing {model_class}"):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    model = model_class(config)
+                    model.save_pretrained(tmp_dir)
+
+                    # Fails when we don't set ignore_mismatched_sizes=True
+                    with self.assertRaises(RuntimeError):
+                        new_model = AutoModelForSequenceClassification.from_pretrained(tmp_dir, num_labels=42)
+
+                    logger = logging.get_logger("transformers.modeling_utils")
+
+                    with CaptureLogger(logger) as cl:
+                        new_model = AutoModelForSequenceClassification.from_pretrained(
+                            tmp_dir, num_labels=42, ignore_mismatched_sizes=True
+                        )
+                    self.assertIn("the shapes did not match", cl.out)
+
+                    with CaptureLogger(logger) as cl:
+                        new_model_2 = AutoModelForSequenceClassification.from_pretrained(
+                            tmp_dir,
+                            num_labels=42,
+                            ignore_mismatched_sizes=True,
+                        )
+                    self.assertIn("the shapes did not match", cl.out)
+
+                    # The classifier heads of `new_model` and `new_model_2` should contain different weight values.
+                    diff_found = False
+                    for key in new_model.state_dict():
+                        if not torch.allclose(new_model.state_dict()[key], new_model_2.state_dict()[key], atol=1e-9):
+                            diff_found = True
+                            break
+                    self.assertTrue(diff_found)
+
     def test_model_is_small(self):
         # Just a consistency check to make sure we are not running tests on 80M parameter models.
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2930,8 +2930,7 @@ class ModelTesterMixin:
                     for key in new_model.state_dict():
                         if not torch.allclose(new_model.state_dict()[key], new_model_2.state_dict()[key], atol=1e-9):
                             diff_found = True
-                            break
-                    self.assertTrue(diff_found)
+                    self.assertFalse(diff_found)
 
     def test_model_is_small(self):
         # Just a consistency check to make sure we are not running tests on 80M parameter models.

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2894,13 +2894,15 @@ class ModelTesterMixin:
             return
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
+        configs_no_init = _config_zero_init(config)
+
         for model_class in self.all_model_classes:
             if model_class.__name__ not in get_values(MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES):
                 continue
 
             with self.subTest(msg=f"Testing {model_class}"):
                 with tempfile.TemporaryDirectory() as tmp_dir:
-                    model = model_class(config)
+                    model = model_class(configs_no_init)
                     model.save_pretrained(tmp_dir)
 
                     # Fails when we don't set ignore_mismatched_sizes=True
@@ -2910,27 +2912,18 @@ class ModelTesterMixin:
                     logger = logging.get_logger("transformers.modeling_utils")
 
                     with CaptureLogger(logger) as cl:
-                        torch.manual_seed(0)
                         new_model = AutoModelForSequenceClassification.from_pretrained(
                             tmp_dir, num_labels=42, ignore_mismatched_sizes=True
                         )
                     self.assertIn("the shapes did not match", cl.out)
 
-                    with CaptureLogger(logger) as cl:
-                        torch.manual_seed(0)
-                        new_model_2 = AutoModelForSequenceClassification.from_pretrained(
-                            tmp_dir,
-                            num_labels=42,
-                            ignore_mismatched_sizes=True,
-                        )
-                    self.assertIn("the shapes did not match", cl.out)
-
-                    # The classifier heads of `new_model` and `new_model_2` should contain different weight values.
-                    diff_found = False
-                    for key in new_model.state_dict():
-                        if not torch.allclose(new_model.state_dict()[key], new_model_2.state_dict()[key], atol=1e-9):
-                            diff_found = True
-                    self.assertFalse(diff_found)
+                    for name, param in new_model.named_parameters():
+                        if param.requires_grad:
+                            self.assertIn(
+                                ((param.data.mean() * 1e9).round() / 1e9).item(),
+                                [0.0, 1.0],
+                                msg=f"Parameter {name} of model {model_class} seems not properly initialized",
+                            )
 
     def test_model_is_small(self):
         # Just a consistency check to make sure we are not running tests on 80M parameter models.


### PR DESCRIPTION
Currently, if there is some weight shape mismatched between the model and the checkpoint, and if `ignore_mismatched_sizes=True`, that/those weight(s) won't get initialized by the model's `_init_weights` method, and could get crazy values like `1e37`.

This could make the training gets nan loss value from the beginning and won't have any progress.

One example is by running `src/transformers/modeling_utils.py` (add `ignore_mismatched_sizes=True`).

We usually set `ignore_mismatched_sizes=True` when we want to perform classification tasks using an existing model but to another task having different number of targets.

This PR aims to fix this issue.