### PR TITLE
More TF fixes

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1149,7 +1149,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
         self._set_save_spec(self.input_signature)
 
-
     def get_config(self):
         return self.config.to_dict()
 

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1147,6 +1147,8 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
         self.config = config
         self.name_or_path = config.name_or_path
         self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
+        self._set_save_spec(self.input_signature)
+
 
     def get_config(self):
         return self.config.to_dict()

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -211,7 +211,7 @@ class TFAutoModelTest(unittest.TestCase):
         config = copy.deepcopy(model.config)
         config.architectures = ["FunnelBaseModel"]
         model = TFAutoModel.from_config(config)
-        model.build()
+        model.build_in_name_scope()
 
         self.assertIsInstance(model, TFFunnelBaseModel)
 
@@ -249,7 +249,7 @@ class TFAutoModelTest(unittest.TestCase):
                     config = NewModelConfig(**tiny_config.to_dict())
 
                     model = auto_class.from_config(config)
-                    model.build()
+                    model.build_in_name_scope()
 
                     self.assertIsInstance(model, TFNewModel)
 

--- a/tests/models/gpt2/test_modeling_tf_gpt2.py
+++ b/tests/models/gpt2/test_modeling_tf_gpt2.py
@@ -445,7 +445,7 @@ class TFGPT2ModelTest(TFModelTesterMixin, TFCoreModelTesterMixin, PipelineTester
                 continue
 
             model = model_class(config)
-            model.build()
+            model.build_in_name_scope()
 
             onnx_model_proto, _ = tf2onnx.convert.from_keras(model, opset=self.onnx_min_opset)
 

--- a/tests/models/whisper/test_modeling_tf_whisper.py
+++ b/tests/models/whisper/test_modeling_tf_whisper.py
@@ -312,7 +312,7 @@ class TFWhisperModelTest(TFModelTesterMixin, PipelineTesterMixin, unittest.TestC
         config = self.model_tester.get_config()
         for model_class in self.all_model_classes:
             model = model_class(config)
-            model.build()
+            model.build_in_name_scope()
 
             embeds = model.get_encoder().embed_positions.get_weights()[0]
             sinusoids = sinusoidal_embedding_init(embeds.shape).numpy()

--- a/tests/utils/test_modeling_tf_core.py
+++ b/tests/utils/test_modeling_tf_core.py
@@ -217,7 +217,7 @@ class TFCoreModelTesterMixin:
         for model_class in self.all_model_classes[:2]:
             class_inputs_dict = self._prepare_for_class(inputs_dict, model_class)
             model = model_class(config)
-            model.build()
+            model.build_in_name_scope()
             num_out = len(model(class_inputs_dict))
 
             for key in list(class_inputs_dict.keys()):


### PR DESCRIPTION
The TF `build()` PR brought back an old issue where TF would latch onto the first concrete shape it saw, which would then become the model's save signature. We avoid it by hitting `self._set_save_spec()` with flexible shapes ASAP when models are created.

This PR also replaces a few more instances of `build()` with `build_in_name_scope()` in our tests. This should hopefully fix the CI issues (cc @ydshieh)