### PR TITLE
Misc updates to CPU Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/docker/transformers-cpu/Dockerfile
+++ b/docker/transformers-cpu/Dockerfile
@@ -1,26 +1,54 @@
-FROM ubuntu:18.04
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# tests directory-specific settings - this file is run automatically
+# by pytest before any tests are run
+
+ARG IMAGE_NAME=ubuntu
+ARG IMAGE_TAG=22.04
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
+
 LABEL maintainer="Hugging Face"
 LABEL repository="transformers"
 
-RUN apt update && \
-    apt install -y bash \
-                   build-essential \
-                   git \
-                   curl \
-                   ca-certificates \
-                   python3 \
-                   python3-pip && \
+ARG PY_VER=3.10
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --fix-missing -y \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-pip && \
     rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir \
+RUN ln -sf $( which python${PY_VER} ) /usr/bin/python && \
+    ln -sf $( which python${PY_VER} ) /usr/bin/python3
+
+ARG TORCH_CPU_URL=https://download.pytorch.org/whl/cpu/torch_stable.html
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir \
     jupyter \
+    mkl \
     tensorflow-cpu \
-    torch
+    torch -f ${TORCH_CPU_URL}
 
 WORKDIR /workspace
 COPY . transformers/
 RUN cd transformers/ && \
-    python3 -m pip install --no-cache-dir .
+    python -m pip install --no-cache-dir .
 
 CMD ["/bin/bash"]

--- a/docker/transformers-pytorch-cpu/Dockerfile
+++ b/docker/transformers-pytorch-cpu/Dockerfile
@@ -1,21 +1,48 @@
-FROM ubuntu:18.04
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# tests directory-specific settings - this file is run automatically
+# by pytest before any tests are run
+
+ARG IMAGE_NAME=ubuntu
+ARG IMAGE_TAG=22.04
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
+
 LABEL maintainer="Hugging Face"
 LABEL repository="transformers"
 
-RUN apt update && \
-    apt install -y bash \
-                   build-essential \
-                   git \
-                   curl \
-                   ca-certificates \
-                   python3 \
-                   python3-pip && \
+ARG PY_VER=3.10
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --fix-missing -y \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-pip && \
     rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir \
+RUN ln -sf $( which python${PY_VER} ) /usr/bin/python && \
+    ln -sf $( which python${PY_VER} ) /usr/bin/python3
+
+ARG TORCH_CPU_URL=https://download.pytorch.org/whl/cpu/torch_stable.html
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir \
     jupyter \
-    torch
+    torch -f ${TORCH_CPU_URL}
 
 WORKDIR /workspace
 COPY . transformers/

--- a/docker/transformers-pytorch-cpu/Dockerfile
+++ b/docker/transformers-pytorch-cpu/Dockerfile
@@ -47,6 +47,6 @@ RUN python -m pip install --no-cache-dir --upgrade pip && \
 WORKDIR /workspace
 COPY . transformers/
 RUN cd transformers/ && \
-    python3 -m pip install --no-cache-dir .
+    python -m pip install --no-cache-dir .
 
 CMD ["/bin/bash"]

--- a/docker/transformers-tensorflow-cpu/Dockerfile
+++ b/docker/transformers-tensorflow-cpu/Dockerfile
@@ -38,14 +38,14 @@ RUN apt-get update && \
 RUN ln -sf $( which python${PY_VER} ) /usr/bin/python && \
     ln -sf $( which python${PY_VER} ) /usr/bin/python3
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir \
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir \
     mkl \
     tensorflow-cpu
 
 WORKDIR /workspace
 COPY . transformers/
 RUN cd transformers/ && \
-    python3 -m pip install --no-cache-dir .
+    python -m pip install --no-cache-dir .
 
 CMD ["/bin/bash"]

--- a/docker/transformers-tensorflow-cpu/Dockerfile
+++ b/docker/transformers-tensorflow-cpu/Dockerfile
@@ -1,16 +1,42 @@
-FROM ubuntu:18.04
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# tests directory-specific settings - this file is run automatically
+# by pytest before any tests are run
+
+ARG IMAGE_NAME=ubuntu
+ARG IMAGE_TAG=22.04
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
+
 LABEL maintainer="Hugging Face"
 LABEL repository="transformers"
 
-RUN apt update && \
-    apt install -y bash \
-                   build-essential \
-                   git \
-                   curl \
-                   ca-certificates \
-                   python3 \
-                   python3-pip && \
+ARG PY_VER=3.10
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --fix-missing -y \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-pip && \
     rm -rf /var/lib/apt/lists
+
+RUN ln -sf $( which python${PY_VER} ) /usr/bin/python && \
+    ln -sf $( which python${PY_VER} ) /usr/bin/python3
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir \


### PR DESCRIPTION
# What does this PR do?
This PR fixes #28082 

Currently `cpu` containers and possibly GPU ones as well under `docker` folder are out of date.The reason being [ubuntu:18.04](https://hub.docker.com/_/ubuntu/tags?page=1&name=18.04) base image was updated over 6 months ago and most likely there won't be anymore updates for that base and that's causing containers to fail during the build.

I also noticed even after updating to newer base images, Torch CPU containers install `GPU` distribution as well which is not only unnecessary but also leads to large final containers.

```
$ docker images | grep transformers-pytorch-cpu
transformers-pytorch-cpu-pr                                    latest                                                   9e377aa5efd9   20 minutes ago   867MB
transformers-pytorch-cpu-main                                  latest                                                   9a88121eeb33   20 hours ago     1.61GB
```

This PR:
- Sets the default base to [ubuntu:22.04](https://hub.docker.com/_/ubuntu/tags?page=1&name=22.04) which should be supported for a couple of years
- Adds appropriate license headers to the files
- Removes unnecessary `Torch GPU` bits from `CPU` containers