### PR TITLE
Mixtral: Reduce and Increase Expert Models

### DIFF
--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1182,6 +1182,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         self.post_init()
 
     def remove_expert(self, *idxs):
+        self.num_experts -= 1
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -710,7 +710,13 @@ class MixtralSparseMoeBlock(nn.Module):
         self.experts = nn.ModuleList([MixtralBLockSparseTop2MLP(config) for _ in range(self.num_experts)])
 
     def _remove_expert_by_idx(self, idx: int):
-        new_gate = nn.Linear(self.hidden_dim, self.num_experts - 1, bias=False).to(self.gate.weight.device)
+        new_gate = nn.Linear(
+            self.hidden_dim, 
+            self.num_experts - 1, 
+            bias=False,
+            device=self.gate.weight.device,
+            dtype=self.gate.weight.dtype
+            )
         new_gate.weight.data[:idx] = self.gate.weight.data[:idx]
         new_gate.weight.data[idx:] = self.gate.weight.data[idx + 1 :]
         self.gate = new_gate

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1183,7 +1183,6 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
 
     def remove_expert(self, *idxs):
         self.num_experts -= 1
-        self.config.num_local_experts -= 1
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):
@@ -1406,7 +1405,6 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
         self.post_init()
 
     def remove_expert(self, *idxs):
-        self.config.num_local_experts -= 1
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -724,10 +724,12 @@ class MixtralSparseMoeBlock(nn.Module):
                 f"Removing {len(idxs)} experts would result in less than {self.top_k} experts. This is not allowed as it would"
                 f" result in a loss of capacity."
             )
+        if len(idxs) != len(set(idxs)):
+            raise ValueError("The same expert cannot be removed twice.")
         
-        for idx in idxs:
-            self._remove_expert_by_idx(idx)
-
+        for count, idx in enumerate(sorted(idxs)):
+            self._remove_expert_by_idx(idx - count)
+        
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """ """
         batch_size, sequence_length, hidden_dim = hidden_states.shape

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1003,7 +1003,7 @@ class MixtralModel(MixtralPreTrainedModel):
         self.post_init()
 
     def remove_expert(self, *idxs):
-        self.config.num_local_experts -= 1
+        self.config.num_local_experts -= len(idxs)
         for layer in self.layers:
             layer.remove_expert(*idxs)
 
@@ -1182,7 +1182,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         # Initialize weights and apply final processing
 
     def remove_expert(self, *idxs):
-        self.num_experts -= 1
+        self.num_experts -= len(idxs)
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1003,6 +1003,7 @@ class MixtralModel(MixtralPreTrainedModel):
         self.post_init()
 
     def remove_expert(self, *idxs):
+        self.config.num_local_experts -= 1
         for layer in self.layers:
             layer.remove_expert(*idxs)
 
@@ -1179,10 +1180,10 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         self.num_experts = config.num_local_experts
         self.num_experts_per_tok = config.num_experts_per_tok
         # Initialize weights and apply final processing
-        self.post_init()
 
     def remove_expert(self, *idxs):
         self.num_experts -= 1
+        self.config.num_local_experts -= 1
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):
@@ -1405,6 +1406,7 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
         self.post_init()
 
     def remove_expert(self, *idxs):
+        self.config.num_local_experts -= 1
         self.model.remove_expert(*idxs)
 
     def get_input_embeddings(self):


### PR DESCRIPTION
This pr adds a method to MixtralSparseMoeBlock, MixtralDecoderLayer and MixtralModel that removes one or more experts from MixtralModel.