### PR TITLE
Avoid unnecessary warnings when loading `CLIPConfig`

### DIFF
--- a/src/transformers/models/altclip/configuration_altclip.py
+++ b/src/transformers/models/altclip/configuration_altclip.py
@@ -339,7 +339,7 @@ class AltCLIPConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `AltCLIPTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -371,7 +371,7 @@ class AltCLIPConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize `AltCLIPVisionConfig`. "
                             f'The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)

--- a/src/transformers/models/chinese_clip/configuration_chinese_clip.py
+++ b/src/transformers/models/chinese_clip/configuration_chinese_clip.py
@@ -360,7 +360,7 @@ class ChineseCLIPConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `ChineseCLIPTextConfig`. "
                             f'The value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -392,7 +392,7 @@ class ChineseCLIPConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize "
                             f'`ChineseCLIPVisionConfig`. The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -347,7 +347,7 @@ class CLIPConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `CLIPTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -379,7 +379,7 @@ class CLIPConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize `CLIPVisionConfig`. "
                             f'The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ CLIP model configuration"""
-
+import json
 import os
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
@@ -330,11 +330,24 @@ class CLIPConfig(PretrainedConfig):
                 text_config = {}
 
             # This is the complete result when using `text_config_dict`.
-            _text_config_dict = CLIPTextConfig(**text_config_dict).to_dict()
+            _text_config_dict = json.loads(CLIPTextConfig(**text_config_dict).to_json_string(use_diff=False))
 
             # Give a warning if the values exist in both `_text_config_dict` and `text_config` but being different.
             for key, value in _text_config_dict.items():
                 if key in text_config and value != text_config[key] and key not in ["transformers_version"]:
+                    # `text_config` was saved when CLIP is added to the library, but it was never used for loading
+                    # `CLIPConfig`. In #22035, we give warnings to avoid users being confused.
+                    # In PR #24773, we change the default values for `bos_token_id` and `eos_token_id`, so
+                    # `_text_config_dict` has those values by default which are different from those in `text_config`,
+                    # and we always get warnings.
+                    # Let's avoid the warnings if `bos_token_id` and `eos_token_id` in `text_config` are not modified by
+                    # the users.
+                    # See:
+                    #   - https://github.com/huggingface/transformers/pull/22035
+                    #   - https://github.com/huggingface/transformers/pull/24773
+                    if (key, text_config[key]) in {("bos_token_id", 0), ("eos_token_id", 2)}:
+                        continue
+
                     # If specified in `text_config_dict`
                     if key in text_config_dict:
                         message = (

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -334,6 +334,7 @@ class CLIPConfig(PretrainedConfig):
             # instead of `str`.
             _text_config_dict = json.loads(CLIPTextConfig(**text_config_dict).to_json_string(use_diff=False))
 
+            only_info = False
             # Give a warning if the values exist in both `_text_config_dict` and `text_config` but being different.
             for key, value in _text_config_dict.items():
                 if key in text_config and value != text_config[key] and key not in ["transformers_version"]:
@@ -348,7 +349,7 @@ class CLIPConfig(PretrainedConfig):
                     #   - https://github.com/huggingface/transformers/pull/22035
                     #   - https://github.com/huggingface/transformers/pull/24773
                     if (key, text_config[key]) in {("bos_token_id", 0), ("eos_token_id", 2)}:
-                        continue
+                        only_info = True
 
                     # If specified in `text_config_dict`
                     if key in text_config_dict:
@@ -362,7 +363,10 @@ class CLIPConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `CLIPTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    if only_info:
+                        logger.info(message)
+                    else:
+                        logger.warning(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)

--- a/src/transformers/models/clip/configuration_clip.py
+++ b/src/transformers/models/clip/configuration_clip.py
@@ -330,6 +330,8 @@ class CLIPConfig(PretrainedConfig):
                 text_config = {}
 
             # This is the complete result when using `text_config_dict`.
+            # We can't simply use `to_dict` due to the type of keys in `text_config_dict["id2label"]` being `int`
+            # instead of `str`.
             _text_config_dict = json.loads(CLIPTextConfig(**text_config_dict).to_json_string(use_diff=False))
 
             # Give a warning if the values exist in both `_text_config_dict` and `text_config` but being different.

--- a/src/transformers/models/clipseg/configuration_clipseg.py
+++ b/src/transformers/models/clipseg/configuration_clipseg.py
@@ -360,7 +360,7 @@ class CLIPSegConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `CLIPSegTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -392,7 +392,7 @@ class CLIPSegConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize `CLIPSegVisionConfig`. "
                             f'The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)

--- a/src/transformers/models/flava/configuration_flava.py
+++ b/src/transformers/models/flava/configuration_flava.py
@@ -596,7 +596,7 @@ class FlavaConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `FlavaTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -628,7 +628,7 @@ class FlavaConfig(PretrainedConfig):
                             f"`image_config_dict` is provided which will be used to initialize `FlavaImageConfig`. "
                             f'The value `image_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `image_config` with the ones in `_image_config_dict`.
             image_config.update(_image_config_dict)
@@ -660,7 +660,7 @@ class FlavaConfig(PretrainedConfig):
                             f"`multimodal_config_dict` is provided which will be used to initialize "
                             f'`FlavaMultimodalConfig`. The value `multimodal_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `multimodal_config` with the ones in `_multimodal_config_dict`.
             multimodal_config.update(_multimodal_config_dict)
@@ -693,7 +693,7 @@ class FlavaConfig(PretrainedConfig):
                             f"`image_codebook_config_dict` is provided which will be used to initialize "
                             f'`FlavaImageCodebookConfig`. The value `image_codebook_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `image_codebook_config` with the ones in `_image_codebook_config_dict`.
             image_codebook_config.update(_image_codebook_config_dict)

--- a/src/transformers/models/groupvit/configuration_groupvit.py
+++ b/src/transformers/models/groupvit/configuration_groupvit.py
@@ -339,7 +339,7 @@ class GroupViTConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `GroupViTTextConfig`. "
                             f'The value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -371,7 +371,7 @@ class GroupViTConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize `GroupViTVisionConfig`."
                             f' The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)

--- a/src/transformers/models/x_clip/configuration_x_clip.py
+++ b/src/transformers/models/x_clip/configuration_x_clip.py
@@ -347,7 +347,7 @@ class XCLIPConfig(PretrainedConfig):
                             f"`text_config_dict` is provided which will be used to initialize `XCLIPTextConfig`. The "
                             f'value `text_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `text_config` with the ones in `_text_config_dict`.
             text_config.update(_text_config_dict)
@@ -379,7 +379,7 @@ class XCLIPConfig(PretrainedConfig):
                             f"`vision_config_dict` is provided which will be used to initialize `XCLIPVisionConfig`. "
                             f'The value `vision_config["{key}"]` will be overriden.'
                         )
-                    logger.warning(message)
+                    logger.info(message)
 
             # Update all values in `vision_config` with the ones in `_vision_config_dict`.
             vision_config.update(_vision_config_dict)


### PR DESCRIPTION
# What does this PR do?

Avoid unnecessary warnings when loading `CLIPConfig`: when a user doesn't change something inside `text_config`.

Fix #28042