### PR TITLE
Remove warning if `DISABLE_TELEMETRY` is used

### DIFF
--- a/src/transformers/file_utils.py
+++ b/src/transformers/file_utils.py
@@ -18,6 +18,7 @@ This module should not be update anymore and is only left for backward compatibi
 """
 
 from huggingface_hub import get_full_repo_name  # for backward compatibility
+from huggingface_hub.constants import HF_HUB_DISABLE_TELEMETRY as DISABLE_TELEMETRY  # for backward compatibility
 
 from . import __version__
 
@@ -25,7 +26,6 @@ from . import __version__
 from .utils import (
     CLOUDFRONT_DISTRIB_PREFIX,
     CONFIG_NAME,
-    DISABLE_TELEMETRY,
     DUMMY_INPUTS,
     DUMMY_MASK,
     ENV_VARS_TRUE_AND_AUTO_VALUES,

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 from huggingface_hub import get_full_repo_name  # for backward compatibility
+from huggingface_hub.constants import HF_HUB_DISABLE_TELEMETRY as DISABLE_TELEMETRY  # for backward compatibility
 from packaging import version
 
 from .. import __version__
@@ -60,7 +61,6 @@ from .generic import (
 )
 from .hub import (
     CLOUDFRONT_DISTRIB_PREFIX,
-    DISABLE_TELEMETRY,
     HF_MODULES_CACHE,
     HUGGINGFACE_CO_PREFIX,
     HUGGINGFACE_CO_RESOLVE_ENDPOINT,

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -115,7 +115,6 @@ if (
 HF_MODULES_CACHE = os.getenv("HF_MODULES_CACHE", os.path.join(constants.HF_HOME, "modules"))
 TRANSFORMERS_DYNAMIC_MODULE_NAME = "transformers_modules"
 SESSION_ID = uuid4().hex
-DISABLE_TELEMETRY = os.getenv("DISABLE_TELEMETRY", constants.HF_HUB_DISABLE_TELEMETRY) in ENV_VARS_TRUE_VALUES
 
 # Add deprecation warning for old environment variables.
 for key in ("PYTORCH_PRETRAINED_BERT_CACHE", "PYTORCH_TRANSFORMERS_CACHE", "TRANSFORMERS_CACHE"):
@@ -124,11 +123,6 @@ for key in ("PYTORCH_PRETRAINED_BERT_CACHE", "PYTORCH_TRANSFORMERS_CACHE", "TRAN
             f"Using `{key}` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.",
             FutureWarning,
         )
-if os.getenv("DISABLE_TELEMETRY") is not None:
-    warnings.warn(
-        "Using `DISABLE_TELEMETRY` is deprecated and will be removed in v5 of Transformers. Use `HF_HUB_DISABLE_TELEMETRY` instead.",
-        FutureWarning,
-    )
 
 
 S3_BUCKET_PREFIX = "https://s3.amazonaws.com/models.huggingface.co/bert"
@@ -229,7 +223,7 @@ def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
         ua += f"; torch/{_torch_version}"
     if is_tf_available():
         ua += f"; tensorflow/{_tf_version}"
-    if DISABLE_TELEMETRY:
+    if constants.HF_HUB_DISABLE_TELEMETRY:
         return ua + "; telemetry/off"
     if is_training_run_on_sagemaker():
         ua += "; " + "; ".join(f"{k}/{v}" for k, v in define_sagemaker_information().items())


### PR DESCRIPTION
In https://github.com/huggingface/transformers/issues/27564 I did some cleaning in the environment variables. I added a warning if `DISABLE_TELEMETRY` was set to encourage using `HF_HUB_DISABLE_TELEMETRY` instead. However this warning is not necessary for at least two reasons:
- `DISABLE_TELEMETRY` is already well understood and parsed by `huggingface_hub`. No need to handle it specifically in `transformers`. If in the future we want to deprecate it and/or handle it differently, everything would have to happen in `huggingface_hub` directly.
- Also, as highlighted in https://github.com/huggingface/huggingface_hub/issues/1917, keeping `DISABLE_TELEMETRY` in addition to our custom `HF_HUB_DISABLED_TELEMETRY` is also beneficial if this variable become a standard with other libraries. In any case, we do not benefit from not handling it.

Therefore this PR removes the deprecation warning + let `huggingface_hub` handle the environment variables by itself. It removes any custom code from `transformers` about this topic.