### PR TITLE
Fix weights not properly initialized due to shape mismatch

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3956,7 +3956,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         )
 
         # retrieve unintialized modules and initialize before maybe overriding that with the pretrained weights.
-        if _fast_init:
+        if _fast_init and not ignore_mismatched_sizes:
             if remove_prefix_from_model:
                 _loaded_keys = [f"{prefix}.{k}" for k in loaded_keys]
             elif add_prefix_to_model:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3956,14 +3956,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         )
 
         # retrieve unintialized modules and initialize before maybe overriding that with the pretrained weights.
-        if _fast_init and not ignore_mismatched_sizes:
-            if remove_prefix_from_model:
-                _loaded_keys = [f"{prefix}.{k}" for k in loaded_keys]
-            elif add_prefix_to_model:
-                _loaded_keys = [k[len(prefix) + 1 :] for k in loaded_keys]
-            else:
-                _loaded_keys = loaded_keys
-            set_initialized_submodules(model, _loaded_keys)
+        if _fast_init:
+            if not ignore_mismatched_sizes:
+                if remove_prefix_from_model:
+                    _loaded_keys = [f"{prefix}.{k}" for k in loaded_keys]
+                elif add_prefix_to_model:
+                    _loaded_keys = [k[len(prefix) + 1 :] for k in loaded_keys]
+                else:
+                    _loaded_keys = loaded_keys
+                set_initialized_submodules(model, _loaded_keys)
             # This will only initialize submodules that are not marked as initialized by the line above.
             model.apply(model._initialize_weights)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2975,7 +2975,7 @@ class ModelTesterMixin:
                     max_diff = torch.max(torch.abs(model.state_dict()[key] - new_model.state_dict()[key]))
                     self.assertLessEqual(
                         max_diff.item(),
-                        1e-3,
+                        1e-6,
                         msg=f"the weight values for `{key}` in `new_model` and `model` are  not identical",
                     )
                 else:
@@ -2988,7 +2988,7 @@ class ModelTesterMixin:
                     max_diff = torch.max(torch.abs(new_model.state_dict()[key] - target_model.state_dict()[key]))
                     self.assertLessEqual(
                         max_diff.item(),
-                        1e-5,
+                        1e-6,
                         msg=f"the weight values for `{key}` in `new_model` and `target_model` are not identical",
                     )
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2954,7 +2954,7 @@ class ModelTesterMixin:
         # not to init. the weights during the creation: to match the logic in `from_pretrained`, so we can keep the
         # same sequence of random ops in the execution path to allow us to compare `target_model` and `new_model` below
         # for `linear` part.
-        with ContextManagers([no_init_weights(False)]):
+        with ContextManagers([no_init_weights(True)]):
             target_model = MyClass(config=config)
         target_model.apply(target_model._initialize_weights)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2969,7 +2969,7 @@ class ModelTesterMixin:
             new_model = MyClass.from_pretrained(tmpdirname, num_labels=4, ignore_mismatched_sizes=True)
 
             for key in new_model.state_dict().keys():
-                # Make sure that weight values for weights with matched shapes are identical
+                # check weight values for weights with matched shapes are identical
                 # (i.e. correctly loaded from the checkpoint)
                 if key not in ["linear.weight", "linear.bias"]:
                     max_diff = torch.max(torch.abs(model.state_dict()[key] - new_model.state_dict()[key]))
@@ -2979,12 +2979,13 @@ class ModelTesterMixin:
                         msg=f"the weight values for `{key}` in `new_model` and `model` are  not identical",
                     )
                 else:
-                    # make sure we do have some mismatched shapes
+                    # check we have some mismatched shapes
                     self.assertNotEqual(
                         model.state_dict()[key].shape,
                         new_model.state_dict()[key].shape,
                         msg=f"the weight shapes for {key} in `model` and `new_model` should differ",
                     )
+                    # check the weights with mismatched shape are properly initialized
                     max_diff = torch.max(torch.abs(new_model.state_dict()[key] - target_model.state_dict()[key]))
                     self.assertLessEqual(
                         max_diff.item(),


### PR DESCRIPTION
# What does this PR do?

Currently, if there is some weight shape mismatched between the model and the checkpoint, and if ignore_mismatched_sizes=True, that/those weight(s) won't get initialized by the model's `_init_weights` method, and could get crazy values like 1e37.

This could make the training gets `nan loss value` from the beginning, (then `Trainer` will change this to `0.0`) and the training won't have any progress (loss always 0.0).

One example is by running `src/transformers/modeling_utils.py` (add `ignore_mismatched_sizes=True`).

We usually set `ignore_mismatched_sizes=True` when we want to perform classification tasks using an existing model but to another task having different number of targets.

This PR aims to fix this issue.
