### PR TITLE
[`Refactor Attention mask handling`] Moves attention mask processing to the Attention class

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -284,8 +284,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 class LlamaAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
+
     _attention_mask = None
-    
+
     def __init__(self, config: LlamaConfig, layer_idx: Optional[int] = None):
         super().__init__()
         self.config = config
@@ -318,7 +319,6 @@ class LlamaAttention(nn.Module):
         self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=config.attention_bias)
         self._init_rope()
-
 
     def _init_rope(self):
         if self.config.rope_scaling is None:
@@ -400,8 +400,6 @@ class LlamaAttention(nn.Module):
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
-
-
         if past_key_value is not None:
             cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
@@ -417,14 +415,14 @@ class LlamaAttention(nn.Module):
                 f" {attn_weights.size()}"
             )
         if attention_mask is not None:
-            if self._attention_mask is None or self._attention_mask.shape[-1] != attention_mask.shape[-1] :
+            if self._attention_mask is None or self._attention_mask.shape[-1] != attention_mask.shape[-1]:
                 # create the 4d mask and cache it
                 attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask(
                     attention_mask, (bsz, q_len), hidden_states, kv_seq_len - q_len
                 )
-            elif self._attention_mask is not None: # use the cached value
+            elif self._attention_mask is not None:  # use the cached value
                 attention_mask = self._attention_mask
-            
+
             if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
                 raise ValueError(
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
@@ -550,9 +548,7 @@ class LlamaFlashAttention2(LlamaAttention):
             key_states = key_states.to(target_dtype)
             value_states = value_states.to(target_dtype)
 
-        if attention_mask is not None and 0 in attention_mask:
-            attn_weights = attn_weights + attention_mask
-        else:
+        if 0 not in attention_mask:
             attention_mask = None
 
         attn_output = self._flash_attention_forward(
@@ -729,7 +725,7 @@ class LlamaSdpaAttention(LlamaAttention):
                 )
             elif self._attention_mask is not None:
                 attention_mask = self._attention_mask
-            
+
             if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
                 raise ValueError(
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -406,7 +406,7 @@ class LlamaAttention(nn.Module):
             attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask(
                 attention_mask, (bsz, q_len), hidden_states, kv_seq_len - q_len
             )
-        elif self._attention_mask is not None:
+        elif self._attention_mask is not None: # use the cached value
             attention_mask = self._attention_mask
 
         if past_key_value is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -415,7 +415,7 @@ class LlamaAttention(nn.Module):
                 f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
                 f" {attn_weights.size()}"
             )
-        
+
         if LlamaAttention.cached_mask is None or self.layer_idx == 0 or attention_mask is None:
             # create the 4d mask and cache it
             attention_mask = LlamaAttention.cached_mask = _prepare_4d_causal_attention_mask(

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -289,7 +289,6 @@ class LlamaAttention(nn.Module):
 
     def __init__(self, config: LlamaConfig, layer_idx: Optional[int] = None):
         super().__init__()
-        self.cached_mask = None
         self.config = config
         self.layer_idx = layer_idx
         if layer_idx is None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -717,6 +717,7 @@ class LlamaSdpaAttention(LlamaAttention):
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
 
+
         if attention_mask is not None:
             if self._attention_mask is None or self._attention_mask.shape[-1] != attention_mask.shape[-1]:
                 # create the 4d mask and cache it
@@ -726,10 +727,10 @@ class LlamaSdpaAttention(LlamaAttention):
             elif self._attention_mask is not None:
                 attention_mask = self._attention_mask
 
-            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
-                raise ValueError(
-                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
-                )
+                if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                    raise ValueError(
+                        f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                    )
 
             # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
             # Reference: https://github.com/pytorch/pytorch/issues/112577.

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -413,7 +413,7 @@ class LlamaAttention(nn.Module):
                 f" {attn_weights.size()}"
             )
 
-        if attention_mask is not None:
+        if attention_mask is not None and attention_mask.dim() > 2:
             if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
                 raise ValueError(
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
@@ -718,7 +718,7 @@ class LlamaSdpaAttention(LlamaAttention):
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
 
-        if attention_mask is not None:
+        if attention_mask is not None and attention_mask.dim() > 2:
             if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
                 raise ValueError(
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -359,7 +359,7 @@ class LlamaAttention(nn.Module):
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         bsz, q_len, _ = hidden_states.size()
-        
+
         if self.config.pretraining_tp > 1:
             key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.config.pretraining_tp
             query_slices = self.q_proj.weight.split(
@@ -420,7 +420,9 @@ class LlamaAttention(nn.Module):
                 )
         elif attention_mask is None and self._attention_mask is None:
             # 4d mask is passed through the layers
-            attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask(attention_mask, (bsz, q_len), hidden_states, kv_seq_len)
+            attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask(
+                attention_mask, (bsz, q_len), hidden_states, kv_seq_len
+            )
         else:
             attention_mask = self._attention_mask
 
@@ -545,11 +547,11 @@ class LlamaFlashAttention2(LlamaAttention):
             key_states = key_states.to(target_dtype)
             value_states = value_states.to(target_dtype)
 
-        if (attention_mask is not None and 0 in attention_mask):
+        if attention_mask is not None and 0 in attention_mask:
             attn_weights = attn_weights + attention_mask
         else:
             attention_mask = None
-        
+
         attn_output = self._flash_attention_forward(
             query_states, key_states, value_states, attention_mask, q_len, dropout=dropout_rate
         )
@@ -722,7 +724,9 @@ class LlamaSdpaAttention(LlamaAttention):
                     f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
                 )
         elif attention_mask is None and self._attention_mask is None:
-            attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(attention_mask, (bsz, q_len), hidden_states, kv_seq_len)
+            attention_mask = self._attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
+                attention_mask, (bsz, q_len), hidden_states, kv_seq_len
+            )
         else:
             attention_mask = self._attention_mask
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -416,7 +416,7 @@ class LlamaAttention(nn.Module):
                 f" {attn_weights.size()}"
             )
 
-        if LlamaAttention.cached_mask is None or self.layer_idx == 0 or attention_mask is None:
+        if (attention_mask is None and LlamaAttention.cached_mask is None) or self.layer_idx == 0:
             # create the 4d mask and cache it
             attention_mask = LlamaAttention.cached_mask = _prepare_4d_causal_attention_mask(
                 attention_mask, (bsz, q_len), hidden_states, kv_seq_len - q_len

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -965,8 +965,6 @@ class LlamaModel(LlamaPreTrainedModel):
         self.layers = nn.ModuleList(
             [LlamaDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        self._use_sdpa = config._attn_implementation == "sdpa"
-        self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
         self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         self.gradient_checkpointing = False
@@ -1033,25 +1031,6 @@ class LlamaModel(LlamaPreTrainedModel):
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
-
-        # if self._use_flash_attention_2:
-        #     # 2d mask is passed through the layers
-        #     attention_mask = attention_mask if (attention_mask is not None and 0 in attention_mask) else None
-        # elif self._use_sdpa and not output_attentions:
-        #     # output_attentions=True can not be supported when using SDPA, and we fall back on
-        #     # the manual implementation that requires a 4D causal mask in all cases.
-        #     attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
-        #         attention_mask,
-        #         (batch_size, seq_length),
-        #         inputs_embeds,
-        #         past_key_values_length,
-        #     )
-        # else:
-                    # 4d mask is passed through the layers
-            # attention_mask = _prepare_4d_causal_attention_mask(
-            #     attention_mask, (batch_size, seq_length), inputs_embeds, past_key_values_length
-            # )
-
 
         # embed positions
         hidden_states = inputs_embeds

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3201,7 +3201,7 @@ class ModelTesterMixin:
 
     @parameterized.expand([("float16",), ("bfloat16",), ("float32",)])
     @require_torch_sdpa
-    @slow
+    # @slow
     def test_eager_matches_sdpa_inference(self, torch_dtype: str):
         if not self.all_model_classes[0]._supports_sdpa:
             self.skipTest(f"{self.all_model_classes[0].__name__} does not support SDPA")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3201,7 +3201,7 @@ class ModelTesterMixin:
 
     @parameterized.expand([("float16",), ("bfloat16",), ("float32",)])
     @require_torch_sdpa
-    # @slow
+    @slow
     def test_eager_matches_sdpa_inference(self, torch_dtype: str):
         if not self.all_model_classes[0]._supports_sdpa:
             self.skipTest(f"{self.all_model_classes[0].__name__} does not support SDPA")


### PR DESCRIPTION
# What does this PR do?
This is more aligned with our philosophy, but also simplifies and will simplify things.
Will help a lot with the static cache.

The only way to share the mask is to call `LlamaAttention` but if you have a better way I'll update it! 
This makes the attention class self contained, which is also pretty convenient for testing. 
Ran the slow test without fa2 will run them again on dgx once approved. 

cc @patrickvonplaten for visibility 