### PR TITLE
Update split string in doctest to reflect #28087

### DIFF
--- a/tests/utils/test_doc_samples.py
+++ b/tests/utils/test_doc_samples.py
@@ -60,7 +60,7 @@ class TestDocLists(unittest.TestCase):
             doctext = f.read()
 
             doctext = doctext.split(
-                "For now, Transformers supports inference and training through SDPA for the following architectures:"
+                "For now, Transformers supports SDPA inference and training for the following architectures:"
             )[1]
             doctext = doctext.split("Note that FlashAttention can only be used for models using the")[0]
 


### PR DESCRIPTION
# What does this PR do?

Resolves current failing test `tests/utils/test_doc_samples.py::TestDocLists::test_sdpa_support_list`  on main because the string used to split the doc string wasn't updated in line with #28087 

cc @stevhliu 