### PR TITLE
Update VITS modeling to enable ONNX export

### DIFF
--- a/src/transformers/models/vits/modeling_vits.py
+++ b/src/transformers/models/vits/modeling_vits.py
@@ -1022,7 +1022,7 @@ class VitsAttention(nn.Module):
 
         # Pad along column
         x = nn.functional.pad(x, [0, length - 1, 0, 0, 0, 0])
-        x_flat = x.view([batch_heads, length**2 + length * (length - 1)])
+        x_flat = x.view([batch_heads, length*length + length * (length - 1)])
 
         # Add 0's in the beginning that will skew the elements after reshape
         x_flat = nn.functional.pad(x_flat, [length, 0, 0, 0])

--- a/src/transformers/models/vits/modeling_vits.py
+++ b/src/transformers/models/vits/modeling_vits.py
@@ -1022,7 +1022,7 @@ class VitsAttention(nn.Module):
 
         # Pad along column
         x = nn.functional.pad(x, [0, length - 1, 0, 0, 0, 0])
-        x_flat = x.view([batch_heads, length * length + length * (length - 1)])
+        x_flat = x.view([batch_heads, length * (2 * length - 1)])
 
         # Add 0's in the beginning that will skew the elements after reshape
         x_flat = nn.functional.pad(x_flat, [length, 0, 0, 0])

--- a/src/transformers/models/vits/modeling_vits.py
+++ b/src/transformers/models/vits/modeling_vits.py
@@ -1022,7 +1022,7 @@ class VitsAttention(nn.Module):
 
         # Pad along column
         x = nn.functional.pad(x, [0, length - 1, 0, 0, 0, 0])
-        x_flat = x.view([batch_heads, length*length + length * (length - 1)])
+        x_flat = x.view([batch_heads, length * length + length * (length - 1)])
 
         # Add 0's in the beginning that will skew the elements after reshape
         x_flat = nn.functional.pad(x_flat, [length, 0, 0, 0])


### PR DESCRIPTION
This PR enables the ONNX export of VITS models in Optimum (https://github.com/huggingface/optimum/pull/1607), currently the export is failing due to [a cast operator added before the pow operator](https://github.com/pytorch/pytorch/blob/v2.1.2/torch/onnx/symbolic_opset9.py#L3382) in the model graph, resulting in an issue during the concatenation of two values of different data type


cc @xenova 





