### PR TITLE
4D mask documentation updates

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -874,7 +874,8 @@ LLAMA_INPUTS_DOCSTRING = r"""
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
-        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+        attention_mask (`torch.Tensor` of 2D shape `(batch_size, sequence_length)`
+            or 4D shape `(heads, batch_size, sequence_length, total_sequence_length)`, *optional*):
             Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
 
             - 1 for tokens that are **not masked**,
@@ -884,6 +885,9 @@ LLAMA_INPUTS_DOCSTRING = r"""
 
             Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
             [`PreTrainedTokenizer.__call__`] for details.
+
+            Attention mask may be supplied in 4D shape for finer control of attention patterns within sequences.
+            In such case, the `position_ids` parameters must be customised accordingly.
 
             If `past_key_values` is used, optionally only the last `input_ids` have to be input (see
             `past_key_values`).

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1029,7 +1029,7 @@ class LlamaModel(LlamaPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if self._use_flash_attention_2:
-            # 2d mask is passed through the layers
+            # the original 2d or 4d mask is passed through the layers
             attention_mask = attention_mask if (attention_mask is not None and 0 in attention_mask) else None
         elif self._use_sdpa and not output_attentions:
             # output_attentions=True can not be supported when using SDPA, and we fall back on
@@ -1041,7 +1041,7 @@ class LlamaModel(LlamaPreTrainedModel):
                 past_key_values_length,
             )
         else:
-            # 4d mask is passed through the layers
+            # a modified 4d mask is passed through the layers
             attention_mask = _prepare_4d_causal_attention_mask(
                 attention_mask, (batch_size, seq_length), inputs_embeds, past_key_values_length
             )

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -68,13 +68,17 @@ XGLM_INPUTS_DOCSTRING = r"""
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
-        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+        attention_mask (`torch.Tensor` of 2D shape `(batch_size, sequence_length)`
+            or 4D shape `(heads, batch_size, sequence_length, total_sequence_length)`, *optional*):
             Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
 
             - 1 for tokens that are **not masked**,
             - 0 for tokens that are **masked**.
 
             [What are attention masks?](../glossary#attention-mask)
+
+            Attention mask may be supplied in 4D shape for finer control of attention patterns within sequences.
+            In such case, the `position_ids` parameters must be customised accordingly.
         position_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
             config.max_position_embeddings - 1]`.


### PR DESCRIPTION
following https://github.com/huggingface/transformers/pull/27539 this PR adds updates to transformers documentation to reflect possibility of utilizing 4D masks.

Plan:
- add updates for Llama model docstring(s)
- identify other models that can use 4D masks in present form (which requires ability to accept custom `position_ids` argument) and updating their docstrings. Classes that need updates:
    -  Falcon Model
    - [TODO identify more]
- update code comments that may need corrections, like cases where the mask may be either 2D or 4D now. one example is based on [this comment](https://github.com/huggingface/transformers/pull/27539#issuecomment-1863285474) by @shentianxiao

Update 20.12.2023:
to find out which models require docstring changes, I scanned all model classes in transformers insing inspect.
- excluded tf and jax classes
- excluded models without `position_ids` argument in `.forward()` - can't use 4D mask effectively
- excluded models that do not use `_prepare_4d_attention_mask` method - need different code change to use 4D mask
- excluded multi-modal models (clip, clvp, vit, bark, git)

what is left is LlamaModel, FalconModel and XGLMModel.

cc @ArthurZucker 