### PR TITLE
Bug: `training_args.py` fix missing import with accelerate with version `accelerate==0.20.1`

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -36,6 +36,7 @@ from .trainer_utils import (
     SchedulerType,
 )
 from .utils import (
+    ACCELERATE_MIN_VERSION,
     ExplicitEnum,
     cached_property,
     is_accelerate_available,
@@ -1839,7 +1840,8 @@ class TrainingArguments:
         if not is_sagemaker_mp_enabled():
             if not is_accelerate_available():
                 raise ImportError(
-                    "Using the `Trainer` with `PyTorch` requires `accelerate>=0.21.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
+                    f"Using the `Trainer` with `PyTorch` requires `accelerate>={ACCELERATE_MIN_VERSION}`:
+                    Please run `pip install transformers[torch]` or `pip install accelerate -U`"
                 )
             AcceleratorState._reset_state(reset_partial_state=True)
         self.distributed_state = None

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1840,8 +1840,8 @@ class TrainingArguments:
         if not is_sagemaker_mp_enabled():
             if not is_accelerate_available():
                 raise ImportError(
-                    f"Using the `Trainer` with `PyTorch` requires `accelerate>={ACCELERATE_MIN_VERSION}`:
-                    Please run `pip install transformers[torch]` or `pip install accelerate -U`"
+                    f"Using the `Trainer` with `PyTorch` requires `accelerate>={ACCELERATE_MIN_VERSION}`: "
+                    "Please run `pip install transformers[torch]` or `pip install accelerate -U`"
                 )
             AcceleratorState._reset_state(reset_partial_state=True)
         self.distributed_state = None

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1837,9 +1837,9 @@ class TrainingArguments:
         requires_backends(self, ["torch"])
         logger.info("PyTorch: setting up devices")
         if not is_sagemaker_mp_enabled():
-            if not is_accelerate_available(min_version="0.20.1"):
+            if not is_accelerate_available():
                 raise ImportError(
-                    "Using the `Trainer` with `PyTorch` requires `accelerate>=0.20.1`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
+                    "Using the `Trainer` with `PyTorch` requires `accelerate>=0.21.0`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
                 )
             AcceleratorState._reset_state(reset_partial_state=True)
         self.distributed_state = None

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -90,6 +90,7 @@ from .hub import (
     try_to_load_from_cache,
 )
 from .import_utils import (
+    ACCELERATE_MIN_VERSION,
     ENV_VARS_TRUE_AND_AUTO_VALUES,
     ENV_VARS_TRUE_VALUES,
     TORCH_FX_REQUIRED_VERSION,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

I have accelerate and transformers using `poetry` pinned to 

```
accelerate="^0.20.1"
transformers="4.36.2"
```

This leads to the weird error, that 

```python
is_accelerate_available(min_version="0.20.1") # True
is_accelerate_available() # False, leading no import at top of file
```

```python
Step #1 - "build-image": #99 59.93     @cached_property
Step #1 - "build-image": #99 59.93     def _setup_devices(self) -> "torch.device":
Step #1 - "build-image": #99 59.93         requires_backends(self, ["torch"])
Step #1 - "build-image": #99 59.93         logger.info("PyTorch: setting up devices")
Step #1 - "build-image": #99 59.93         if not is_sagemaker_mp_enabled():
Step #1 - "build-image": #99 59.93             if not is_accelerate_available(min_version="0.20.1"):
Step #1 - "build-image": #99 59.93                 raise ImportError(
Step #1 - "build-image": #99 59.93                     "Using the `Trainer` with `PyTorch` requires `accelerate>=0.20.1`: Please run `pip install transformers[torch]` or `pip install accelerate -U`"
Step #1 - "build-image": #99 59.93                 )
Step #1 - "build-image": #99 59.93 >           AcceleratorState._reset_state(reset_partial_state=True)
Step #1 - "build-image": #99 59.93 E           NameError: name 'AcceleratorState' is not defined
```


## Before submitting
- [NA  ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ NA ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [NA ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
