### PR TITLE
[`Docs`] Add 4-bit serialization docs

### DIFF
--- a/docs/source/en/quantization.md
+++ b/docs/source/en/quantization.md
@@ -345,7 +345,7 @@ model_4bit = AutoModelForCausalLM.from_pretrained("facebook/opt-350m", load_in_4
 model_4bit.model.decoder.layers[-1].final_layer_norm.weight.dtype
 ```
 
-Once a model is quantized to 4-bit, you can't push the quantized weights to the Hub.
+If you have `bitsandbytes>=0.41.3`, you can serialize 4-bit models and push them on Hugging Face Hub. Simply call `model.push_to_hub()` after loading it in 4-bit precision. You can also save the serialized 4-bit models locally with `model.save_pretrained()` command.  
 
 </hfoption>
 </hfoptions>

--- a/docs/source/en/quantization.md
+++ b/docs/source/en/quantization.md
@@ -468,9 +468,6 @@ Try 4-bit quantization in this [notebook](https://colab.research.google.com/driv
 
 This section explores some of the specific features of 4-bit models, such as changing the compute data type, using the Normal Float 4 (NF4) data type, and using nested quantization.
 
-#### Push 4-bit models on the Hub
-
-If you have `bitsandbytes>=0.41.3`, you can serialize 4-bit models and push them on Hugging Face Hub. Simply call `model.push_to_hub()` after loading it in 4-bit precision.
 
 #### Compute data type
 

--- a/docs/source/en/quantization.md
+++ b/docs/source/en/quantization.md
@@ -468,6 +468,10 @@ Try 4-bit quantization in this [notebook](https://colab.research.google.com/driv
 
 This section explores some of the specific features of 4-bit models, such as changing the compute data type, using the Normal Float 4 (NF4) data type, and using nested quantization.
 
+#### Push 4-bit models on the Hub
+
+If you have `bitsandbytes>=0.41.3`, you can serialize 4-bit models and push them on Hugging Face Hub. Simply call `model.push_to_hub()` after loading it in 4-bit precision.
+
 #### Compute data type
 
 To speedup computation, you can change the data type from float32 (the default value) to bf16 using the `bnb_4bit_compute_dtype` parameter in [`BitsAndBytesConfig`]:


### PR DESCRIPTION
# What does this PR do?

Follow up work from: https://github.com/huggingface/transformers/pull/26037 
Adds few lines in the documentation about serializing 4-bit models on the Hub 

cc @amyeroberts @stevhliu 
