### PR TITLE
Fix slow backbone tests - out_indices must match stage name ordering

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -244,8 +244,8 @@ class AutoModelTest(unittest.TestCase):
         self.assertIsInstance(model, TimmBackbone)
 
         # Check kwargs are correctly passed to the backbone
-        model = AutoBackbone.from_pretrained("resnet18", use_timm_backbone=True, out_indices=(-1, -2))
-        self.assertEqual(model.out_indices, (-1, -2))
+        model = AutoBackbone.from_pretrained("resnet18", use_timm_backbone=True, out_indices=(-2, -1))
+        self.assertEqual(model.out_indices, (-2, -1))
 
         # Check out_features cannot be passed to Timm backbones
         with self.assertRaises(ValueError):
@@ -259,9 +259,9 @@ class AutoModelTest(unittest.TestCase):
         self.assertIsInstance(model, ResNetBackbone)
 
         # Check kwargs are correctly passed to the backbone
-        model = AutoBackbone.from_pretrained("microsoft/resnet-18", out_indices=[-1, -2])
-        self.assertEqual(model.out_indices, [-1, -2])
-        self.assertEqual(model.out_features, ["stage4", "stage3"])
+        model = AutoBackbone.from_pretrained("microsoft/resnet-18", out_indices=[-2, -1])
+        self.assertEqual(model.out_indices, [-2, -1])
+        self.assertEqual(model.out_features, ["stage3", "stage4"])
 
         model = AutoBackbone.from_pretrained("microsoft/resnet-18", out_features=["stage2", "stage4"])
         self.assertEqual(model.out_indices, [2, 4])


### PR DESCRIPTION
# What does this PR do?

Fixes slow autobackbone tests failing on nightly after #27606 

#27606 enforces the out_indices and out_features to be in the same order as the stage names. This ensures backbone selects the correct features in its forward pass. 