### PR TITLE
Drop `feature_extractor_type` when loading an image processor file

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -75,6 +75,9 @@ class ImageProcessingMixin(PushToHubMixin):
 
     def __init__(self, **kwargs):
         """Set elements of `kwargs` as attributes."""
+        # This key was saved while we still used `XXXFeatureExtractor` for image processing. Now we use
+        # `XXXImageProcessor`, this attribute and its value are misleading.
+        kwargs.pop("feature_extractor_type", None)
         # Pop "processor_class" as it should be saved as private attribute
         self._processor_class = kwargs.pop("processor_class", None)
         # Additional attributes without default values


### PR DESCRIPTION
# What does this PR do?

`preprocessor_config.json` created in old days like [this](https://huggingface.co/openai/clip-vit-large-patch14/blob/main/preprocessor_config.json) has, for example, `"feature_extractor_type": "CLIPFeatureExtractor",` in it. If that file is for an image processor, during the loading (in `__init__`), it is added as the object's attribute. This is already misleading.

If we save the image processor again, the file will contain `feature_extractor_type` and `image_processor_type`, which is even more confusing. See the example below.

**This PR pop up this attribute during the loading, so it won't be an attribute of the loaded object.**

### To reproduce

```python
from transformers import CLIPImageProcessor
import json


p = CLIPImageProcessor.from_pretrained("openai/clip-vit-large-patch14")
print(getattr(p, "feature_extractor_type", None))
print(getattr(p, "image_processor_type", None))
print("-" * 40)

p.save_pretrained("myclip")
p = CLIPImageProcessor.from_pretrained("myclip")
print(getattr(p, "feature_extractor_type", None))
print(getattr(p, "image_processor_type", None))
```

### Output

**before this PR**
```bash
CLIPFeatureExtractor
None
----------------------------------------
CLIPFeatureExtractor
CLIPImageProcessor
```

**after this PR**
```bash
None
None
----------------------------------------
None
CLIPImageProcessor
```