### PR TITLE
Update `docs/source/en/perf_infer_gpu_one.md`

### DIFF
--- a/docs/source/en/perf_infer_gpu_one.md
+++ b/docs/source/en/perf_infer_gpu_one.md
@@ -172,6 +172,8 @@ For now, Transformers supports SDPA inference and training for the following arc
 * [Llama](https://huggingface.co/docs/transformers/model_doc/llama#transformers.LlamaModel)
 * [Idefics](https://huggingface.co/docs/transformers/model_doc/idefics#transformers.IdeficsModel)
 * [Whisper](https://huggingface.co/docs/transformers/model_doc/whisper#transformers.WhisperModel)
+* [Mistral](https://huggingface.co/docs/transformers/model_doc/mistral#transformers.MistralModel)
+* [Mixtral](https://huggingface.co/docs/transformers/model_doc/mixtral#transformers.MixtralModel)
 
 <Tip>
 


### PR DESCRIPTION
# What does this PR do?

Update `docs/source/en/perf_infer_gpu_one.md` to fix 

> FAILED tests/utils/test_doc_samples.py::TestDocLists::test_sdpa_support_list - ValueError: mixtral should be in listed in the SDPA documentation but is not. Please update the documentation.