### PR TITLE
fix bug:divide by zero in _maybe_log_save_evaluate()

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2238,7 +2238,7 @@ class Trainer:
             )
 
     def _maybe_log_save_evaluate(self, tr_loss, model, trial, epoch, ignore_keys_for_eval):
-        if self.control.should_log:
+        if self.control.should_log and self.state.global_step > self._globalstep_last_logged:
             if is_torch_tpu_available():
                 xm.mark_step()
 


### PR DESCRIPTION
Hi, everyone.
**This is a new clean PR for previous PR #28102.**
set logging_strategy="steps" and logging_steps=10,
when that one epoch have 100 steps, the should_log will be set to True in last step.
And self._globalstep_last_logged will be assign to self.state.global_step in _maybe_log_save_evaluate() method by line 1917 in trainer.py.
the line 1933 in trainer.py , self.callback_handler.on_epoch_end() will keep the should_log=True, then in line 1934 run _maybe_log_save_evaluate() method (self.state.global_step - self._globalstep_last_logged) will be zero in line 2247.

@muellerzr @pacman100
