### PR TITLE
[fix] Optimize deletion speed while truncate_sequences (#3563)

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -3560,16 +3560,16 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             for _ in range(num_tokens_to_remove):
                 if pair_ids is None or len(ids) > len(pair_ids):
                     if self.truncation_side == "right":
-                        ids = ids[:-1]
+                        del ids[-1]
                     elif self.truncation_side == "left":
-                        ids = ids[1:]
+                        del ids[0]
                     else:
                         raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
                 else:
                     if self.truncation_side == "right":
-                        pair_ids = pair_ids[:-1]
+                        del pair_ids[-1]
                     elif self.truncation_side == "left":
-                        pair_ids = pair_ids[1:]
+                        del pair_ids[0]
                     else:
                         raise ValueError("invalid truncation strategy:" + str(self.truncation_side))
         elif truncation_strategy == TruncationStrategy.ONLY_SECOND and pair_ids is not None:


### PR DESCRIPTION
# What does this PR do?
The process remains unchanged, but the writing method is changed to improve the speed of truncate_sequences().
"del ids[-1]" is an in-place operation, while the original "ids = ids[:-1]"  make an additional copy of ids[0:-1]. Therefore, the original writting method is slower, especially when sentences are long.



## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker and @younesbelkada