### PR TITLE
Don't allow passing `load_in_8bit` and `load_in_4bit` at the same time

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -216,8 +216,8 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
         if load_in_4bit and load_in_8bit:
             raise ValueError("load_in_4bit and load_in_8bit are both True, but only one can be used at the same time")
 
-        self.load_in_8bit = load_in_8bit
-        self.load_in_4bit = load_in_4bit
+        self._load_in_8bit = load_in_8bit
+        self._load_in_4bit = load_in_4bit
         self.llm_int8_threshold = llm_int8_threshold
         self.llm_int8_skip_modules = llm_int8_skip_modules
         self.llm_int8_enable_fp32_cpu_offload = llm_int8_enable_fp32_cpu_offload
@@ -235,6 +235,26 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
             raise ValueError("bnb_4bit_compute_dtype must be a string or a torch.dtype")
 
         self.post_init()
+
+    @property
+    def load_in_4bit(self):
+        return self._load_in_4bit
+
+    @load_in_4bit.setter
+    def load_in_4bit(self, value: bool):
+        if self.load_in_8bit and value:
+            raise ValueError("load_in_8bit and load_in_4bit are both True, but only one can be used at the same time")
+        self._load_in_4bit = value
+
+    @property
+    def load_in_8bit(self):
+        return self._load_in_8bit
+
+    @load_in_8bit.setter
+    def load_in_8bit(self, value: bool):
+        if self.load_in_4bit and value:
+            raise ValueError("load_in_8bit and load_in_4bit are both True, but only one can be used at the same time")
+        self._load_in_8bit = value
 
     def post_init(self):
         r"""

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -215,7 +215,7 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
 
         if load_in_4bit and load_in_8bit:
             raise ValueError("load_in_4bit and load_in_8bit are both True, but only one can be used at the same time")
-        
+
         self.load_in_8bit = load_in_8bit
         self.load_in_4bit = load_in_4bit
         self.llm_int8_threshold = llm_int8_threshold
@@ -233,7 +233,6 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
             self.bnb_4bit_compute_dtype = bnb_4bit_compute_dtype
         else:
             raise ValueError("bnb_4bit_compute_dtype must be a string or a torch.dtype")
-
 
         self.post_init()
 

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -243,7 +243,7 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
     @load_in_4bit.setter
     def load_in_4bit(self, value: bool):
         if self.load_in_8bit and value:
-            raise ValueError("load_in_8bit and load_in_4bit are both True, but only one can be used at the same time")
+            raise ValueError("load_in_4bit and load_in_8bit are both True, but only one can be used at the same time")
         self._load_in_4bit = value
 
     @property
@@ -253,7 +253,7 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
     @load_in_8bit.setter
     def load_in_8bit(self, value: bool):
         if self.load_in_4bit and value:
-            raise ValueError("load_in_8bit and load_in_4bit are both True, but only one can be used at the same time")
+            raise ValueError("load_in_4bit and load_in_8bit are both True, but only one can be used at the same time")
         self._load_in_8bit = value
 
     def post_init(self):

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -212,6 +212,10 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
         **kwargs,
     ):
         self.quant_method = QuantizationMethod.BITS_AND_BYTES
+
+        if load_in_4bit and load_in_8bit:
+            raise ValueError("load_in_4bit and load_in_8bit are both True, but only one can be used at the same time")
+        
         self.load_in_8bit = load_in_8bit
         self.load_in_4bit = load_in_4bit
         self.llm_int8_threshold = llm_int8_threshold
@@ -229,6 +233,7 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
             self.bnb_4bit_compute_dtype = bnb_4bit_compute_dtype
         else:
             raise ValueError("bnb_4bit_compute_dtype must be a string or a torch.dtype")
+
 
         self.post_init()
 

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -648,3 +648,19 @@ class GPTSerializationTest(BaseSerializationTest):
     """
 
     model_name = "gpt2-xl"
+
+
+@require_bitsandbytes
+@require_accelerate
+@require_torch
+@require_torch_gpu
+@slow
+class Bnb4BitTestBasicConfigTest(unittest.TestCase):
+    def test_load_in_4_and_8_bit_fails(self):
+        with self.assertRaisesRegex(ValueError, "load_in_4bit and load_in_8bit are both True"):
+            AutoModelForCausalLM.from_pretrained("facebook/opt-125m", load_in_4bit=True, load_in_8bit=True)
+
+    def test_set_load_in_8_bit(self):
+        quantization_config = BitsAndBytesConfig(load_in_4bit=True)
+        with self.assertRaisesRegex(ValueError, "load_in_4bit and load_in_8bit are both True"):
+            quantization_config.load_in_8bit = True

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -652,7 +652,6 @@ class GPTSerializationTest(BaseSerializationTest):
 
 @require_bitsandbytes
 @require_accelerate
-@require_torch
 @require_torch_gpu
 @slow
 class Bnb4BitTestBasicConfigTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

This PR disallows having both `load_in_8bit` and `load_in_4bit` set simultaneously. This would help avoid unexpected behaviors or broken configurations.

## Example

**Without the PR**

```
from transformers import BitsAndBytesConfig

BitsAndBytesConfig(load_in_8bit=True, load_in_4bit=True)
ValueError: load_in_4bit and load_in_8bit are both True, but only one can be used at the same time
```

works fine

**With the PR**

```
from transformers import BitsAndBytesConfig

BitsAndBytesConfig(load_in_8bit=True, load_in_4bit=True)
ValueError: load_in_4bit and load_in_8bit are both True, but only one can be used at the same time
```

errors as I would expect