### PR TITLE
[Whisper] Fix errors with MPS backend introduced by new code on word-level timestamps computation

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -43,7 +43,6 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
-    is_torch_mps_available,
     logging,
     replace_return_docstrings,
 )

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -2599,7 +2599,11 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
 
         if num_frames is None or isinstance(num_frames, int):
             # Normalize and smoothen the weights.
-            std, mean = torch.std_mean(weights, dim=-2, keepdim=True, unbiased=False)
+            try:
+                std, mean = torch.std_mean(weights, dim=-2, keepdim=True, unbiased=False)
+            except NotImplementedError:
+                std = torch.std(weights, dim=-2, keepdim=True, unbiased=False)
+                mean = torch.mean(weights, dim=-2, keepdim=True)                
             weights = (weights - mean) / std
             weights = _median_filter(weights, self.config.median_filter_width)
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -2600,12 +2600,8 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
 
         if num_frames is None or isinstance(num_frames, int):
             # Normalize and smoothen the weights.
-            if is_torch_mps_available():
-                # In the MPS backend torch.std_mean is not implemented yet
-                std = torch.std(weights, dim=-2, keepdim=True, unbiased=False)
-                mean = torch.mean(weights, dim=-2, keepdim=True)
-            else:
-                std, mean = torch.std_mean(weights, dim=-2, keepdim=True, unbiased=False)
+            std = torch.std(weights, dim=-2, keepdim=True, unbiased=False)
+            mean = torch.mean(weights, dim=-2, keepdim=True)
             weights = (weights - mean) / std
             weights = _median_filter(weights, self.config.median_filter_width)
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -2603,7 +2603,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
                 std, mean = torch.std_mean(weights, dim=-2, keepdim=True, unbiased=False)
             except NotImplementedError:
                 std = torch.std(weights, dim=-2, keepdim=True, unbiased=False)
-                mean = torch.mean(weights, dim=-2, keepdim=True)                
+                mean = torch.mean(weights, dim=-2, keepdim=True)
             weights = (weights - mean) / std
             weights = _median_filter(weights, self.config.median_filter_width)
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -2608,11 +2608,16 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
 
         # Perform dynamic time warping on each element of the batch.
         for batch_idx in range(batch_size):
-            if num_frames is not None and isinstance(num_frames, (tuple, list)):
+            if num_frames is not None and isinstance(num_frames, (tuple, list, np.ndarray)):
                 matrix = weights[batch_idx, ..., : num_frames[batch_idx] // 2]
 
                 # Normalize and smoothen the weights.
-                std, mean = torch.std_mean(matrix, dim=-2, keepdim=True, unbiased=False)
+                try:
+                    std, mean = torch.std_mean(matrix, dim=-2, keepdim=True, unbiased=False)
+                except NotImplementedError:
+                    # With MPS backend torch.std_mean is not implemented yet, nor is scheduled for implementation
+                    std = torch.std(matrix, dim=-2, keepdim=True, unbiased=False)
+                    mean = torch.mean(matrix, dim=-2, keepdim=True)
                 matrix = (matrix - mean) / std
                 matrix = _median_filter(matrix, self.config.median_filter_width)
 
@@ -2621,7 +2626,7 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
             else:
                 matrix = weights[batch_idx]
 
-            text_indices, time_indices = _dynamic_time_warping(-matrix.double().cpu().numpy())
+            text_indices, time_indices = _dynamic_time_warping(-matrix.cpu().double().numpy())
             jumps = np.pad(np.diff(text_indices), (1, 0), constant_values=1).astype(bool)
             jump_times = time_indices[jumps] * time_precision
             timestamps[batch_idx, 1:] = torch.tensor(jump_times)

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -43,9 +43,9 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torch_mps_available,
     logging,
     replace_return_docstrings,
-    is_torch_mps_available,
 )
 from .configuration_whisper import WhisperConfig
 from .tokenization_whisper import TASK_IDS, TO_LANGUAGE_CODE

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -2613,12 +2613,8 @@ class WhisperForConditionalGeneration(WhisperPreTrainedModel):
                 matrix = weights[batch_idx, ..., : num_frames[batch_idx] // 2]
 
                 # Normalize and smoothen the weights.
-                if is_torch_mps_available():
-                    # In the MPS backend torch.std_mean is not implemented yet
-                    std = torch.std(matrix, dim=-2, keepdim=True, unbiased=False)
-                    mean = torch.mean(matrix, dim=-2, keepdim=True)
-                else:
-                    std, mean = torch.std_mean(matrix, dim=-2, keepdim=True, unbiased=False)
+                std = torch.std(matrix, dim=-2, keepdim=True, unbiased=False)
+                mean = torch.mean(matrix, dim=-2, keepdim=True)
                 matrix = (matrix - mean) / std
                 matrix = _median_filter(matrix, self.config.median_filter_width)
 


### PR DESCRIPTION
Fixed some issue with MPS backend raised from the recent changes from the great 
 updates from https://github.com/huggingface/transformers/pull/28114

First, the torch.std_mean is not implemented and is not scheduled for implementation, while the single torch.std and torch.mean are. 

Second, MPS backend does not support float64, so it can not cast from float32 to float64. Inverting the double() when the matrix tensor is loaded in the the cpu fixes the issue while it does not change the logic.

Finally, the first changed line is adding to the `isinstance` check tuple the `np.ndarray` type. This is a bug that has also been found here: https://github.com/huggingface/transformers/pull/28226

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->

I think @ylacombe can review this as a continuation of https://github.com/huggingface/transformers/pull/28114
In addition, as per suggestions in the PR: @sanchit-gandhi

Looking forward to your feedback.