### PR TITLE
Support saving only PEFT adapter in checkpoints when using PEFT + FSDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2114,7 +2114,13 @@ class Trainer:
                     # release memory
                     del state_dict
             elif self.is_fsdp_enabled:
-                load_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, model, resume_from_checkpoint, adapter_only=True)
+                load_fsdp_model(
+                    self.accelerator.state.fsdp_plugin,
+                    self.accelerator,
+                    model,
+                    resume_from_checkpoint,
+                    adapter_only=True,
+                )
             else:
                 # We load the model state dict on the CPU to avoid an OOM error.
                 if self.args.save_safetensors and os.path.isfile(safe_weights_file):
@@ -2167,7 +2173,11 @@ class Trainer:
             deepspeed_load_checkpoint(self.model_wrapped, self.state.best_model_checkpoint)
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(
-                self.accelerator.state.fsdp_plugin, self.accelerator, model, self.state.best_model_checkpoint, adapter_only=True
+                self.accelerator.state.fsdp_plugin,
+                self.accelerator,
+                model,
+                self.state.best_model_checkpoint,
+                adapter_only=True,
             )
         elif (
             os.path.exists(best_model_path)
@@ -2486,7 +2496,9 @@ class Trainer:
                 self.model_wrapped.save_checkpoint(output_dir)
         elif self.is_fsdp_enabled:
             # save fsdp specific ckpt for resuming from ckpt
-            save_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir, adapter_only=True)
+            save_fsdp_model(
+                self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir, adapter_only=True
+            )
             save_fsdp_optimizer(
                 self.accelerator.state.fsdp_plugin, self.accelerator, self.optimizer, self.model, output_dir
             )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2167,7 +2167,7 @@ class Trainer:
             deepspeed_load_checkpoint(self.model_wrapped, self.state.best_model_checkpoint)
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(
-                self.accelerator.state.fsdp_plugin, self.accelerator, model, self.state.best_model_checkpoint
+                self.accelerator.state.fsdp_plugin, self.accelerator, model, self.state.best_model_checkpoint, adapter_only=True
             )
         elif (
             os.path.exists(best_model_path)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2114,7 +2114,7 @@ class Trainer:
                     # release memory
                     del state_dict
             elif self.is_fsdp_enabled:
-                load_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, model, resume_from_checkpoint)
+                load_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, model, resume_from_checkpoint, adapter_only=True)
             else:
                 # We load the model state dict on the CPU to avoid an OOM error.
                 if self.args.save_safetensors and os.path.isfile(safe_weights_file):
@@ -2486,7 +2486,7 @@ class Trainer:
                 self.model_wrapped.save_checkpoint(output_dir)
         elif self.is_fsdp_enabled:
             # save fsdp specific ckpt for resuming from ckpt
-            save_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir)
+            save_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir, adapter_only=True)
             save_fsdp_optimizer(
                 self.accelerator.state.fsdp_plugin, self.accelerator, self.optimizer, self.model, output_dir
             )
@@ -2580,6 +2580,7 @@ class Trainer:
                             self.optimizer,
                             self.model,
                             checkpoint,
+                            adapter_only=True,
                         )
                     else:
                         self.optimizer.load_state_dict(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2165,7 +2165,7 @@ class Trainer:
         model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
         if self.is_deepspeed_enabled:
             deepspeed_load_checkpoint(self.model_wrapped, self.state.best_model_checkpoint)
-        elif self.is_fsdp_enabled and not _is_peft_model(unwrap_model(model)):
+        elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(
                 self.accelerator.state.fsdp_plugin, self.accelerator, model, self.state.best_model_checkpoint
             )
@@ -2201,7 +2201,7 @@ class Trainer:
                     state_dict["_smp_is_partial"] = False
                     load_result = model.load_state_dict(state_dict, strict=True)
             else:
-                if _is_peft_model(unwrap_model(model)):
+                if _is_peft_model(model):
                     # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
                     if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
                         if os.path.exists(best_adapter_model_path) or os.path.exists(best_safe_adapter_model_path):
@@ -2486,8 +2486,7 @@ class Trainer:
                 self.model_wrapped.save_checkpoint(output_dir)
         elif self.is_fsdp_enabled:
             # save fsdp specific ckpt for resuming from ckpt
-            if not _is_peft_model(unwrap_model(self.model)):
-                save_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir)
+            save_fsdp_model(self.accelerator.state.fsdp_plugin, self.accelerator, self.model, output_dir)
             save_fsdp_optimizer(
                 self.accelerator.state.fsdp_plugin, self.accelerator, self.optimizer, self.model, output_dir
             )


### PR DESCRIPTION
# What does this PR do?

Currently, both the full model weights (`pytorch_model_fsdp.bin`) and the PEFT adapter weights (`adapter_model.safetensors`) are saved when saving checkpoints when PEFT + FSDP is used (leading to unnecessary excessive disk usage and slower training due to saving large files). 

**These changes ensure only the PEFT adapters are saved/loaded by:**

-  Using the newly added `adapter_only` parameter on `save_fsdp_model` and `load_fsdp_model`. This will ensure `pytorch_model_fsdp.bin` only contains the PEFT adapter weights v.s. the full model weights.
- See the related PR in `accelerate`:  https://github.com/huggingface/accelerate/pull/2321


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@pacman100 @ArthurZucker @amyeroberts 