### PR TITLE
Fix error in M4T feature extractor

### DIFF
--- a/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
@@ -220,6 +220,10 @@ class SeamlessM4TFeatureExtractor(SequenceFeatureExtractor):
                 "Failing to do so can result in silent errors that might be hard to debug."
             )
 
+        return_attention_mask = (
+            return_attention_mask if return_attention_mask is not None else self.return_attention_mask
+        )
+
         is_batched_numpy = isinstance(raw_speech, np.ndarray) and len(raw_speech.shape) > 1
         if is_batched_numpy and len(raw_speech.shape) > 3:
             raise ValueError(f"Only mono-channel or stereo-channel audio is supported for input to {self}")

--- a/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/feature_extraction_seamless_m4t.py
@@ -271,14 +271,16 @@ class SeamlessM4TFeatureExtractor(SequenceFeatureExtractor):
         remainder = num_frames % self.stride
         if remainder != 0:
             input_features = input_features[:, :num_frames, :]
-            attention_mask = attention_mask[:, :num_frames]
+            if return_attention_mask:
+                attention_mask = attention_mask[:, :num_frames]
 
         input_features = np.reshape(
             input_features, (batch_size, num_frames // self.stride, num_channels * self.stride)
         )
 
-        indices = np.arange(0, num_frames)
-        attention_mask = attention_mask[:, indices % self.stride == 1]
+        if return_attention_mask:
+            indices = np.arange(0, num_frames)
+            attention_mask = attention_mask[:, indices % self.stride == 1]
 
         padded_inputs["input_features"] = input_features
         padded_inputs["attention_mask"] = attention_mask

--- a/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
@@ -171,6 +171,41 @@ class SeamlessM4TFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unitt
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
+    def test_call_attention_mask(self):
+        feature_extractor_args = self.feat_extract_tester.prepare_feat_extract_dict()
+        feature_extractor_args["return_attention_mask"] = True
+
+        feature_extractor = self.feature_extraction_class(**feature_extractor_args)
+        # create three inputs of length 800, 1000, and 1200
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+        np_speech_inputs = [np.asarray(speech_input) for speech_input in speech_inputs]
+
+        # Test attention mask when passing it to forward call
+        output = feature_extractor(np_speech_inputs, padding=True, return_tensors="np", return_attention_mask=True)
+        input_features = output.input_features
+
+        attention_mask = output.attention_mask
+        self.assertTrue(attention_mask.ndim == 2)
+        self.assertTrue(attention_mask.shape[0] == 3)
+        self.assertTrue(attention_mask.shape[-1] == input_features.shape[1])
+
+        # Test attention mask when initializing
+        feature_extractor_args["return_attention_mask"] = True
+        feature_extractor = self.feature_extraction_class(**feature_extractor_args)
+
+        output = feature_extractor(np_speech_inputs, padding=True, return_tensors="np")
+        input_features = output.input_features
+
+        attention_mask = output.attention_mask
+        self.assertTrue(attention_mask.ndim == 2)
+        self.assertTrue(attention_mask.shape[0] == 3)
+        self.assertTrue(attention_mask.shape[-1] == input_features.shape[1])
+
+        # Test attention mask with list of numpy arrays.
+        list_attention_mask = feature_extractor(speech_inputs, return_tensors="np").attention_mask
+        self.assertTrue(list_attention_mask.shape[-1] == attention_mask.shape[-1])
+        self.assertTrue((list_attention_mask == attention_mask).all())
+
     @require_torch
     # Copied from tests.models.whisper.test_feature_extraction_whisper.WhisperFeatureExtractionTest.test_double_precision_pad
     def test_double_precision_pad(self):

--- a/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
@@ -62,7 +62,7 @@ class SeamlessM4TFeatureExtractionTester(unittest.TestCase):
         feature_size=10,
         padding_value=0.0,
         sampling_rate=4_000,
-        return_attention_mask=True,
+        return_attention_mask=False,
         do_normalize=True,
         stride=2,
     ):


### PR DESCRIPTION
# What does this PR do?

Really small PR that fixes an error when calling the SeamlessM4TFeatureExtractor without attention mask. I simply added a check to verify if the attention mask exists before operating on it. I've also modified the test suite to test this in the future.

cc @amyeroberts or @ArthurZucker ! WDYT ?
