### PR TITLE
Fix for checkpoint rename race condition

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2385,9 +2385,9 @@ class Trainer:
         # Then go through the rewriting process, only renaming from main process(es)
         if staging_output_dir != output_dir:
             if (
-                self.args.distributed_state.is_local_main_process
+                self.is_local_process_zero
                 if self.args.save_on_each_node
-                else self.args.distributed_state.is_main_process
+                else self.is_world_process_zero
             ):
                 if os.path.exists(staging_output_dir):
                     os.rename(staging_output_dir, output_dir)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2390,9 +2390,9 @@ class Trainer:
                     os.rename(staging_output_dir, output_dir)
 
                     # Ensure rename completed in cases where os.rename is not atomic
-                    with open(output_dir, "r") as f:
-                        f.flush()
-                        os.fsync(f.fileno())
+                    fd = os.open(output_dir, os.O_RDONLY)
+                    os.fsync(fd)
+                    os.close(fd)
 
             # Maybe delete some older checkpoints.
             if self.args.should_save:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2382,25 +2382,23 @@ class Trainer:
         # Place checkpoint in final location after all saving is finished.
         # First wait for everyone to finish writing
         self.args.distributed_state.wait_for_everyone()
-        # Then go through the rewriting process, only renaming from main process(es)
-        if staging_output_dir != output_dir:
-            if (
-                self.is_local_process_zero
-                if self.args.save_on_each_node
-                else self.is_world_process_zero
-            ):
+
+        # Then go through the rewriting process, only renaming and rotating from main process(es)
+        if self.is_local_process_zero() if self.args.save_on_each_node else self.is_world_process_zero():
+            if staging_output_dir != output_dir:
                 if os.path.exists(staging_output_dir):
                     os.rename(staging_output_dir, output_dir)
 
                     # Ensure rename completed in cases where os.rename is not atomic
-                    fd = os.open(output_dir, os.O_RDONLY)
-                    os.fsync(fd)
+                    with open(output_dir, "r") as f:
+                        f.flush()
+                        os.fsync(f.fileno())
 
-            self.args.distributed_state.wait_for_everyone()
+            # Maybe delete some older checkpoints.
+            if self.args.should_save:
+                self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)
 
-        # Maybe delete some older checkpoints.
-        if self.args.should_save:
-            self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)
+        self.args.distributed_state.wait_for_everyone()
 
     def _save_rng_state(self, output_dir):
         # Save RNG state in non-distributed training

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2384,7 +2384,11 @@ class Trainer:
         self.args.distributed_state.wait_for_everyone()
         # Then go through the rewriting process, only renaming from main process(es)
         if staging_output_dir != output_dir:
-            if self.args.distributed_state.is_local_main_process if self.args.save_on_each_node else self.args.distributed_state.is_main_process:
+            if (
+                self.args.distributed_state.is_local_main_process
+                if self.args.save_on_each_node
+                else self.args.distributed_state.is_main_process
+            ):
                 if os.path.exists(staging_output_dir):
                     os.rename(staging_output_dir, output_dir)
 


### PR DESCRIPTION
# What does this PR do?
When running distributed training with deepspeed, I was encountered a race condition due to os.rename not being atomic on network filesystems. This rework, changes the logic for renaming to only run on the main processes, or a single main process depending on the save_on_each_node flag. Also added is the use of fsync to try to flush buffers, hopefully ensuring the rename is completed. fsync may have no effect in some filesystems, so a better mechanism may be required to ensure that the rename completed.

Fixes #27925


## Before submitting
- [No] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [Yes] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [Discussed on Github issue] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [Yes] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [No] Did you write any new necessary tests?


## Who can review?
@muellerzr 
@pacman100
