### PR TITLE
Fix building alibi tensor when num_heads is not a power of 2

### DIFF
--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -74,7 +74,6 @@ def build_mpt_alibi_tensor(num_heads, sequence_length, alibi_bias_max=8, device=
 
     if num_heads_power_of_2 != num_heads:
         slopes = torch.concat([slopes[:, 1::2, ...], slopes[:, ::2, ...]], dim=1)[:, :num_heads, ...]
-        print(slopes.shape)
 
     alibi = alibi * slopes
     return alibi.squeeze(0)

--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -70,10 +70,11 @@ def build_mpt_alibi_tensor(num_heads, sequence_length, alibi_bias_max=8, device=
     base = base * (alibi_bias_max / num_heads_power_of_2)
 
     slopes = 1.0 / torch.pow(2, base)
-    slopes = slopes.view(1, num_heads, 1, 1)
+    slopes = slopes.view(1, num_heads_power_of_2, 1, 1)
 
     if num_heads_power_of_2 != num_heads:
-        slopes = torch.concat([slopes[1::2], slopes[::2]])[:num_heads]
+        slopes = torch.concat([slopes[:, 1::2, ...], slopes[:, ::2, ...]], dim=1)[:, :num_heads, ...]
+        print(slopes.shape)
 
     alibi = alibi * slopes
     return alibi.squeeze(0)

--- a/tests/models/mpt/test_modeling_mpt.py
+++ b/tests/models/mpt/test_modeling_mpt.py
@@ -53,7 +53,7 @@ class MptModelTester:
         use_labels=True,
         use_mc_token_ids=True,
         vocab_size=99,
-        hidden_size=32,
+        hidden_size=48,
         num_hidden_layers=2,
         num_attention_heads=4,
         intermediate_size=37,
@@ -383,6 +383,12 @@ class MptModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
     def test_mpt_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_mpt_model(*config_and_inputs)
+
+    def test_mpt_model_alibi_tensor(self):
+        # test creation of alibi tensor when num heads is not a power of two
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        config_and_inputs[0].n_heads = 6
         self.model_tester.create_and_check_mpt_model(*config_and_inputs)
 
     def test_mpt_model_past(self):


### PR DESCRIPTION
# Fix building alibi tensor when `n_heads` is not a power of 2

when the `n_heads` of MPT model is not a power of 2 number (ex: 6), the function that build the alibi tensor will return with an error, you can check that by running the extra test case that I have added. This PR fixes that issue. 

## Before submitting
- [x] Did you write any new necessary tests?


@ArthurZucker and @younesbelkada

