### PR TITLE
[SDPA] Make sure attn mask creation is always done on CPU

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -9,9 +9,9 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.1.0'
+ARG PYTORCH='2.1.1'
 # (not always a valid torch version)
-ARG INTEL_TORCH_EXT='2.1.0'
+ARG INTEL_TORCH_EXT='2.1.1'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu118'
 

--- a/docker/transformers-pytorch-gpu/Dockerfile
+++ b/docker/transformers-pytorch-gpu/Dockerfile
@@ -11,7 +11,7 @@ ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 
 # If set to nothing, will install the latest version
-ARG PYTORCH='2.1.0'
+ARG PYTORCH='2.1.1'
 ARG TORCH_VISION=''
 ARG TORCH_AUDIO=''
 # Example: `cu102`, `cu113`, etc.

--- a/src/transformers/modeling_attn_mask_utils.py
+++ b/src/transformers/modeling_attn_mask_utils.py
@@ -234,8 +234,8 @@ class AttentionMaskConverter:
 
         # Get the index of the first non-zero value for every sample in the batch.
         # In the above example, indices = [[2], [0], [1]]]
-        tmp = torch.arange(attention_mask.shape[1], 0, -1, device=attention_mask.device)
-        indices = torch.argmax(attention_mask * tmp, 1, keepdim=True)
+        tmp = torch.arange(attention_mask.shape[1], 0, -1)
+        indices = torch.argmax(attention_mask.cpu() * tmp, 1, keepdim=True)
 
         # Find the batch indexes that have unattended tokens on the leftmost side (e.g. [0, 0, 1, 1, 1]), for which the first rows of the
         # expanded mask will be completely unattended.

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1651,8 +1651,9 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
         model.to(torch_device)
 
-        ds = load_dataset("common_voice", "ja", split="test", streaming=True)
+        ds = load_dataset("mozilla-foundation/common_voice_6_1", "ja", split="test", streaming=True, token=True)
         ds = ds.cast_column("audio", datasets.Audio(sampling_rate=16_000))
+
         input_speech = next(iter(ds))["audio"]["array"]
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="pt").input_features.to(
             torch_device

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1651,9 +1651,8 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
         model.to(torch_device)
 
-        ds = load_dataset("mozilla-foundation/common_voice_6_1", "ja", split="test", streaming=True, token=True)
+        ds = load_dataset("common_voice", "ja", split="test", streaming=True)
         ds = ds.cast_column("audio", datasets.Audio(sampling_rate=16_000))
-
         input_speech = next(iter(ds))["audio"]["array"]
         input_features = processor.feature_extractor(raw_speech=input_speech, return_tensors="pt").input_features.to(
             torch_device


### PR DESCRIPTION
# What does this PR do?

Many SDPA tests currently fail. E.g. when running:
```
CUDA_VISIBLE_DEVICES="1" RUN_SLOW=1 pytest tests/models/whisper/test_modeling_whisper.py::WhisperStandaloneDecoderModelTest::test_eager_matches_sdpa_inference_0_float16 -sv
```

We get the following error message:
```
>       range_tensor[range_tensor >= indices] = 0
E       RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Until now SDPA tests were not run on our Circle CI because we test on PyTorch 2.1.0, but SDPA needs PyTorch 2.1.1 (see [here](https://github.com/huggingface/transformers/blob/3b742ea84cfc32432d60c0b65c886576ef736833/src/transformers/utils/import_utils.py#L275))

This PR:
- 1. Makes sure the sdpa attention_mask is always created on CPU
- 2. That we test on PyTorch 2.1.1
- 3. It fixes a "FileNotFoundError" for a Whisper slow test (see [here](https://github.com/huggingface/transformers/actions/runs/7442488193/job/20246174017#step:9:1734))