### PR TITLE
Correctly resolve trust_remote_code=None for AutoTokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -769,14 +769,13 @@ class AutoTokenizer:
                 tokenizer_auto_map = config.auto_map["AutoTokenizer"]
 
         has_remote_code = tokenizer_auto_map is not None
-        has_local_code = False
-        if type(config) in TOKENIZER_MAPPING:
-            has_local_code = True
-        elif config_tokenizer_class is not None:
-            for module_name, tokenizers in TOKENIZER_MAPPING_NAMES.items():
-                if config_tokenizer_class in tokenizers:
-                    has_local_code = True
-                    break
+        has_local_code = type(config) in TOKENIZER_MAPPING or (
+            config_tokenizer_class is not None
+            and (
+                tokenizer_class_from_name(config_tokenizer_class) is not None
+                or tokenizer_class_from_name(config_tokenizer_class + "Fast") is not None
+            )
+        )
         trust_remote_code = resolve_trust_remote_code(
             trust_remote_code, pretrained_model_name_or_path, has_local_code, has_remote_code
         )

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -769,7 +769,14 @@ class AutoTokenizer:
                 tokenizer_auto_map = config.auto_map["AutoTokenizer"]
 
         has_remote_code = tokenizer_auto_map is not None
-        has_local_code = config_tokenizer_class is not None or type(config) in TOKENIZER_MAPPING
+        has_local_code = False
+        if type(config) in TOKENIZER_MAPPING:
+            has_local_code = True
+        elif config_tokenizer_class is not None:
+            for module_name, tokenizers in TOKENIZER_MAPPING_NAMES.items():
+                if config_tokenizer_class in tokenizers:
+                    has_local_code = True
+                    break
         trust_remote_code = resolve_trust_remote_code(
             trust_remote_code, pretrained_model_name_or_path, has_local_code, has_remote_code
         )


### PR DESCRIPTION
If `trust_remote_code` is left at the default `None` in `AutoTokenizer.from_pretrained()`, an error is thrown if you try to load a repo that requires remote code, rather than the correct dialog box being displayed. This PR fixes that issue.