### PR TITLE
Skip now failing test in the Trainer tests

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -77,6 +77,7 @@ from transformers.testing_utils import (
     require_torch_up_to_2_accelerators,
     require_torchdynamo,
     require_wandb,
+    skip,
     slow,
     torch_device,
 )
@@ -1458,6 +1459,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.train(resume_from_checkpoint=True)
         self.assertTrue("No valid checkpoint found in output directory" in str(context.exception))
 
+    @skip("@muellerzr: Fix once Trainer can take an accelerate configuration. Need to set `seedable_sampler=True`.")
     def test_resume_training_with_randomness(self):
         # For more than 1 GPUs, since the randomness is introduced in the model and with DataParallel (which is used
         # in this test for more than 2 GPUs), the calls to the torch RNG will happen in a random order (sometimes

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -77,7 +77,6 @@ from transformers.testing_utils import (
     require_torch_up_to_2_accelerators,
     require_torchdynamo,
     require_wandb,
-    skip,
     slow,
     torch_device,
 )
@@ -1459,7 +1458,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.train(resume_from_checkpoint=True)
         self.assertTrue("No valid checkpoint found in output directory" in str(context.exception))
 
-    @skip("@muellerzr: Fix once Trainer can take an accelerate configuration. Need to set `seedable_sampler=True`.")
+    @unittest.skip(
+        reason="@muellerzr: Fix once Trainer can take an accelerate configuration. Need to set `seedable_sampler=True`."
+    )
     def test_resume_training_with_randomness(self):
         # For more than 1 GPUs, since the randomness is introduced in the model and with DataParallel (which is used
         # in this test for more than 2 GPUs), the calls to the torch RNG will happen in a random order (sometimes


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/accelerate/pull/2319 introduced a revert on the DataLoader sampling logic to *not* use a SeedableRandomSampler by default as users were taken aback by the performance differences, so we've set it to `False` by default. This test is now back to its old way, where it was failing for ages. 

As noted in the `skip`, one of my next items to hit is a configuration for Accelerator that can be passed to the `TrainingArguments` that can customize this, but for now it's not the case. 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker 
