### PR TITLE
disable query_length diff on graph model

### DIFF
--- a/src/transformers/modeling_attn_mask_utils.py
+++ b/src/transformers/modeling_attn_mask_utils.py
@@ -405,7 +405,7 @@ def _prepare_4d_causal_attention_mask_for_sdpa(
 
         # From PyTorch 2.1 onwards, F.scaled_dot_product_attention with the memory-efficient attention backend
         # produces nans if sequences are completely unattended in the attention mask. Details: https://github.com/pytorch/pytorch/issues/110213
-        if query_length > 1:
+        if query_length > 1 and not is_tracing:
             expanded_4d_mask = AttentionMaskConverter._unmask_unattended(
                 expanded_4d_mask, attention_mask, unmasked_value=0.0
             )


### PR DESCRIPTION
Hi @fxmarty 

In generation tasks, the model will not use `AttentionMaskConverter._unmask_unattended` on the 1st token because no `past_key_values`, but will use it from the 2nd token. It will cause a different implementation while tracing, so we need to disable check `query_length` when using `jit.trace`.

cc @younesbelkada @ArthurZucker 