### PR TITLE
Fix load correct tokenizer in Mixtral model documentation

### DIFF
--- a/docs/source/en/model_doc/mixtral.md
+++ b/docs/source/en/model_doc/mixtral.md
@@ -66,7 +66,7 @@ These ready-to-use checkpoints can be downloaded and used via the HuggingFace Hu
 >>> device = "cuda" # the device to load the model onto
 
 >>> model = AutoModelForCausalLM.from_pretrained("mistralai/Mixtral-8x7B-v0.1")
->>> tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-8x7B")
+>>> tokenizer = AutoTokenizer.from_pretrained("mistralai/Mixtral-8x7B-v0.1")
 
 >>> prompt = "My favourite condiment is"
 


### PR DESCRIPTION
# What does this PR do?

There is an incorrect non existent tokenizer linked in the Mixtral documentation. https://huggingface.co/docs/transformers/main/en/model_doc/mixtral#usage-tips

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Models:

- text models: @ArthurZucker and @younesbelkada

Documentation: @stevhliu and @MKhalusova
