### PR TITLE
Fix docstring checker issues with PIL enums

### DIFF
--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -933,6 +933,10 @@ def replace_default_in_arg_description(description: str, default: Any) -> str:
                 except Exception:
                     # Otherwise there is a math operator so we add a code block.
                     str_default = f"`{current_default}`"
+            elif isinstance(default, enum.Enum) and default.name == current_default.split(".")[-1]:
+                # When the default is an Enum (this is often the case for PIL.Image.Resampling), and the docstring
+                # matches the enum name, keep the existing docstring rather than clobbering it with the enum value.
+                str_default = f"`{current_default}`"
 
         if str_default is None:
             str_default = stringify_default(default)


### PR DESCRIPTION
The docstring checker is called by `make repo-consistency` or `make fix-copies`, but it struggles with enums, and particularly struggles with the `PIL.Resampling` enum, as this moved in PIL 10 and we set some code in `image_utils` to always put it in the same place. This caused issues where, depending on the installed PIL version, the docstring checker would try to replace enum names like `Resampling.BICUBIC` with the enum int value for that entry.

After this fix, people should be able to upgrade to the latest version of `PIL` and run `make fixup` or `make fix-copies` without issues! The issue may persist on older versions of PIL, unfortunately, where the value is sometimes just a raw `int` rather than an `Enum`, but we can just ask users to upgrade if they encounter issues there.