### PR TITLE
filter out callable attributes from tokenizer_config in save_pretrained

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2381,7 +2381,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         target_keys.update(["model_max_length", "clean_up_tokenization_spaces"])
 
         for k in target_keys:
-            if hasattr(self, k):
+            if hasattr(self, k) and not callable(getattr(self, k)):
                 tokenizer_config[k] = getattr(self, k)
 
         # Let's make sure we properly save the special tokens.

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -283,3 +283,16 @@ class TokenizerUtilsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             bert_tokenizer.save(os.path.join(tmpdirname, "tokenizer.json"))
             PreTrainedTokenizerFast(tokenizer_file=os.path.join(tmpdirname, "tokenizer.json"))
+
+    @require_tokenizers
+    def test_save_pretrained(self):
+        def save_tokenizer(tokenizer: PreTrainedTokenizer):
+            with tempfile.TemporaryDirectory() as dir:
+                tokenizer.save_pretrained(dir)
+
+        with self.subTest("No extra args"):
+            tokenizer = BertTokenizer.from_pretrained("bert-base-cased")
+            save_tokenizer(tokenizer)
+        with self.subTest("With add_special_token args"):
+            tokenizer = BertTokenizer.from_pretrained("bert-base-cased", add_special_tokens=True)
+            save_tokenizer(tokenizer)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/28472

As discussed in the upstream bug report, `add_special_token` can be both kwargs parameter passed to the `from_pretrained` and a method in `SpecialTokensMixin.add_special_tokens`. Not sure that it's the best way for doing this, but this PR:
* ensures that no methods are passed into the tokenizer config
* so it can be safely serialized to json with `json.dumps`


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker 


