### PR TITLE
Generate: deprecate old public functions

### DIFF
--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -3105,6 +3105,12 @@ def tf_top_k_top_p_filtering(logits, top_k=0, top_p=1.0, filter_value=-float("In
 
     From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
     """
+
+    warnings.warn(
+        "`tf_top_k_top_p_filtering` is scheduled for deletion in v4.39. Use `TFTopKLogitsWarper` and "
+        "`TFTopPLogitsWarper` instead.", DeprecationWarning,
+    )
+
     logits_shape = shape_list(logits)
 
     if top_k > 0:

--- a/src/transformers/generation/tf_utils.py
+++ b/src/transformers/generation/tf_utils.py
@@ -3108,7 +3108,8 @@ def tf_top_k_top_p_filtering(logits, top_k=0, top_p=1.0, filter_value=-float("In
 
     warnings.warn(
         "`tf_top_k_top_p_filtering` is scheduled for deletion in v4.39. Use `TFTopKLogitsWarper` and "
-        "`TFTopPLogitsWarper` instead.", DeprecationWarning,
+        "`TFTopPLogitsWarper` instead.",
+        DeprecationWarning,
     )
 
     logits_shape = shape_list(logits)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4876,6 +4876,11 @@ def top_k_top_p_filtering(
 
     From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
     """
+    warnings.warn(
+        "`top_k_top_p_filtering` is scheduled for deletion in v4.39. Use `TopKLogitsWarper` and `TopPLogitsWarper` "
+        "instead.", DeprecationWarning,
+    )
+
     if top_k > 0:
         logits = TopKLogitsWarper(top_k=top_k, filter_value=filter_value, min_tokens_to_keep=min_tokens_to_keep)(
             None, logits

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4878,7 +4878,8 @@ def top_k_top_p_filtering(
     """
     warnings.warn(
         "`top_k_top_p_filtering` is scheduled for deletion in v4.39. Use `TopKLogitsWarper` and `TopPLogitsWarper` "
-        "instead.", DeprecationWarning,
+        "instead.",
+        DeprecationWarning,
     )
 
     if top_k > 0:


### PR DESCRIPTION
# What does this PR do?

Schedules for deprecation old public functions -- these functions are not used anywhere in the code base, and haven't been since I've been in charge of `generate`.