### PR TITLE
[Whisper Tok] Move token ids to CPU when computing offsets

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -553,7 +553,8 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 The time ratio to convert from token to time.
         """
         offsets = []
-        if hasattr(token_ids, "cpu") and callable(token_ids.cpu):
+        # ensure torch tensor of token ids is placed on cpu
+        if "torch" in str(type(token_ids)) and (hasattr(token_ids, "cpu") and callable(token_ids.cpu)):
             token_ids = token_ids.cpu()
         token_ids = np.array(token_ids)
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -553,6 +553,8 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 The time ratio to convert from token to time.
         """
         offsets = []
+        if hasattr(token_ids, "cpu") and callable(token_ids.cpu):
+            token_ids = token_ids.cpu()
         token_ids = np.array(token_ids)
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -248,6 +248,9 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 The time ratio to convert from token to time.
         """
         offsets = []
+        # ensure torch tensor of token ids is placed on cpu
+        if "torch" in str(type(token_ids)) and (hasattr(token_ids, "cpu") and callable(token_ids.cpu)):
+            token_ids = token_ids.cpu()
         token_ids = np.array(token_ids)
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")


### PR DESCRIPTION
# What does this PR do?

Fixes #28097 by moving token ids in pytorch on GPU to the CPU before converting to numpy.
