### PR TITLE
improve dev setup comments and hints

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,7 @@ from transformers.testing_utils import HfDoctestModule, HfDocTestParser
 
 
 # allow having multiple repository checkouts and not needing to remember to rerun
-# 'pip install -e .[dev]' when switching between checkouts and running tests.
+# `pip install -e '.[dev]'` when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(__file__), "src"))
 sys.path.insert(1, git_repo_path)
 

--- a/examples/flax/conftest.py
+++ b/examples/flax/conftest.py
@@ -21,7 +21,7 @@ from os.path import abspath, dirname, join
 
 
 # allow having multiple repository checkouts and not needing to remember to rerun
-# 'pip install -e .[dev]' when switching between checkouts and running tests.
+# `pip install -e '.[dev]'` when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(dirname(dirname(__file__))), "src"))
 sys.path.insert(1, git_repo_path)
 

--- a/examples/pytorch/conftest.py
+++ b/examples/pytorch/conftest.py
@@ -21,7 +21,7 @@ from os.path import abspath, dirname, join
 
 
 # allow having multiple repository checkouts and not needing to remember to rerun
-# 'pip install -e .[dev]' when switching between checkouts and running tests.
+# `pip install -e '.[dev]'` when switching between checkouts and running tests.
 git_repo_path = abspath(join(dirname(dirname(dirname(__file__))), "src"))
 sys.path.insert(1, git_repo_path)
 

--- a/src/transformers/utils/versions.py
+++ b/src/transformers/utils/versions.py
@@ -113,5 +113,5 @@ def require_version(requirement: str, hint: Optional[str] = None) -> None:
 
 def require_version_core(requirement):
     """require_version wrapper which emits a core-specific hint on failure"""
-    hint = "Try: pip install transformers -U or pip install -e '.[dev]' if you're working with git main"
+    hint = "Try: `pip install transformers -U` or `pip install -e '.[dev]'` if you're working with git main"
     return require_version(requirement, hint)

--- a/tests/utils/test_versions_utils.py
+++ b/tests/utils/test_versions_utils.py
@@ -68,7 +68,7 @@ class DependencyVersionCheckTest(TestCasePlus):
                 require_version_core(req)
             except importlib.metadata.PackageNotFoundError as e:
                 self.assertIn(f"The '{req}' distribution was not found and is required by this application", str(e))
-                self.assertIn("Try: pip install transformers -U", str(e))
+                self.assertIn("Try: `pip install transformers -U`", str(e))
 
         # bogus requirements formats:
         # 1. whole thing

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -358,12 +358,12 @@ def check_missing_backends():
         missing = ", ".join(missing_backends)
         if os.getenv("TRANSFORMERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
             raise Exception(
-                "Full repo consistency checks require all backends to be installed (with `pip install -e .[dev]` in the "
+                "Full repo consistency checks require all backends to be installed (with `pip install -e '.[dev]'` in the "
                 f"Transformers repo, the following are missing: {missing}."
             )
         else:
             warnings.warn(
-                "Full repo consistency checks require all backends to be installed (with `pip install -e .[dev]` in the "
+                "Full repo consistency checks require all backends to be installed (with `pip install -e '.[dev]'` in the "
                 f"Transformers repo, the following are missing: {missing}. While it's probably fine as long as you "
                 "didn't make any change in one of those backends modeling files, you should probably execute the "
                 "command above to be on the safe side."


### PR DESCRIPTION
# What does this PR do?

Changes 'pip install -e .[dev]' -> \`pip install -e '.[dev]'\` in multiple comments and hints. 

New command runs on both *zsh* and *bash*, previously it did not work on *zsh*.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Documentation: @stevhliu and @MKhalusova