### PR TITLE
Log a warning when best model is not loaded

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1968,8 +1968,12 @@ class Trainer:
                 dist.barrier()
             elif is_sagemaker_mp_enabled():
                 smp.barrier()
-
             self._load_best_model()
+        elif args.load_best_model_at_end and self.state.best_model_checkpoint is None:
+            logger.warning(
+                'Best model cannot be loaded because "trainer.state.best_model_checkpoint" is None. '
+                'Have you set the "save_strategy" Training Argument?'
+            )
 
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1617,13 +1617,13 @@ class Trainer:
         self.max_steps = max_steps
         if self.args.save_strategy == "steps" and max_steps < self.args.save_steps:
             logger.warning(
-                'Model(s) will not be saved because max_steps is less than args.save_steps: '
+                "Model(s) will not be saved because max_steps is less than args.save_steps: "
                 'Set args.save_strategy to "no" or "epoch", or increase duration of training.'
             )
             if self.args.load_best_model_at_end:
                 raise ValueError(
                     'Max steps is less than args.save_steps: Set args.save_strategy to "no" or "epoch", '
-                    'set args.load_best_model_at_end to False, or increase duration of training.'
+                    "set args.load_best_model_at_end to False, or increase duration of training."
                 )
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
@@ -1983,9 +1983,7 @@ class Trainer:
                 smp.barrier()
             self._load_best_model()
         elif args.load_best_model_at_end and self.state.best_model_checkpoint is None:
-            logger.warning(
-                'Best model cannot be loaded because "trainer.state.best_model_checkpoint" is None.'
-            )
+            logger.warning('Best model cannot be loaded because "trainer.state.best_model_checkpoint" is None.')
 
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1613,6 +1613,14 @@ class Trainer:
                 f" {args.max_steps}"
             )
 
+        # Ensure save_steps < max_steps
+        if self.args.save_strategy == "steps":
+            if max_steps < self.args.save_steps:
+                raise ValueError(
+                    'args.save_steps must be less than max_steps. Either set args.save_strategy to "no" or "epoch", '
+                    'or increase number of training steps.'
+                )
+
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:
                 # nn.DataParallel(model) replicates the model, creating new variables and module

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1984,8 +1984,7 @@ class Trainer:
             self._load_best_model()
         elif args.load_best_model_at_end and self.state.best_model_checkpoint is None:
             logger.warning(
-                'Best model cannot be loaded because "trainer.state.best_model_checkpoint" is None. '
-                'Have you set the "save_strategy" Training Argument?'
+                'Best model cannot be loaded because "trainer.state.best_model_checkpoint" is None.'
             )
 
         # add remaining tr_loss

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1614,11 +1614,17 @@ class Trainer:
             )
 
         # Ensure save_steps < max_steps
+        self.max_steps = max_steps
         if self.args.save_strategy == "steps" and max_steps < self.args.save_steps:
-            raise ValueError(
-                'args.save_steps must be less than max_steps. Either set args.save_strategy to "no" or "epoch", '
-                'or increase number of training steps.'
+            logger.warning(
+                'Model(s) will not be saved because max_steps is less than args.save_steps: '
+                'Set args.save_strategy to "no" or "epoch", or increase duration of training.'
             )
+            if self.args.load_best_model_at_end:
+                raise ValueError(
+                    'Max steps is less than args.save_steps: Set args.save_strategy to "no" or "epoch", '
+                    'set args.load_best_model_at_end to False, or increase duration of training.'
+                )
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1614,12 +1614,11 @@ class Trainer:
             )
 
         # Ensure save_steps < max_steps
-        if self.args.save_strategy == "steps":
-            if max_steps < self.args.save_steps:
-                raise ValueError(
-                    'args.save_steps must be less than max_steps. Either set args.save_strategy to "no" or "epoch", '
-                    'or increase number of training steps.'
-                )
+        if self.args.save_strategy == "steps" and max_steps < self.args.save_steps:
+            raise ValueError(
+                'args.save_steps must be less than max_steps. Either set args.save_strategy to "no" or "epoch", '
+                'or increase number of training steps.'
+            )
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:


### PR DESCRIPTION
Specifying "load_best_model_at_end=True" in TrainingArguments should ensure that the best model is always loaded at end of training. However, this is not always the case: When best_model_checkpoint is None, the best model is not loaded, and the user may be unaware of this behavior.

Add a warning to the log to let the user know when the best model is not loaded at the end of training. Suggest that the user check the "save_strategy" TrainingArguments, as failing to to do so is one possible reason why the best model failed to load.

@muellerzr 
@pacman100 