### PR TITLE
Correct model_type in PretrainedConfig's to_dict

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -898,8 +898,12 @@ class PretrainedConfig(PushToHubMixin):
             `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
         """
         output = copy.deepcopy(self.__dict__)
-        if hasattr(self.__class__, "model_type"):
+
+        if hasattr(self, "model_type"):
+            output["model_type"] = self.model_type
+        elif hasattr(self.__class__, "model_type"):
             output["model_type"] = self.__class__.model_type
+
         if "_auto_class" in output:
             del output["_auto_class"]
         if "_commit_hash" in output:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -901,9 +901,6 @@ class PretrainedConfig(PushToHubMixin):
 
         if hasattr(self, "model_type"):
             output["model_type"] = self.model_type
-        elif hasattr(self.__class__, "model_type"):
-            output["model_type"] = self.__class__.model_type
-
         if "_auto_class" in output:
             del output["_auto_class"]
         if "_commit_hash" in output:


### PR DESCRIPTION
As per title, now

```python
from transformers import AutoConfig, PretrainedConfig

cfg = AutoConfig.from_pretrained("bert-base-uncased")
config = PretrainedConfig.from_dict(cfg.to_dict())
config.model_type = "my-model"

print(config.to_dict()["model_type"])
```

rightfully yields `my-model`, while it use to give `""` (the class attribute value of PretrainedConfig).

I think instance attributes (if any) should take precedence over class attributes.

Related to https://github.com/huggingface/optimum/pull/1645