### PR TITLE
SiLU activation wrapper for safe importing

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import warnings
 from collections import OrderedDict
 
 import torch
@@ -135,6 +136,14 @@ class AccurateGELUActivation(nn.Module):
 
     def forward(self, input: Tensor) -> Tensor:
         return 0.5 * input * (1 + torch.tanh(self.precomputed_constant * (input + 0.044715 * torch.pow(input, 3))))
+
+
+class SiLUActivation(nn.SiLU):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The SiLUActivation class has been deprecated and will be removed in v4.39. Please use nn.SiLU instead.",
+        )
+        super().__init__(*args, **kwargs)
 
 
 class MishActivation(nn.Module):


### PR DESCRIPTION
# What does this PR do?

The custom implementation of `SiLUActivation` was removed in #27136. This causes two issues: 

1. Users unable to unpickle objects - c.f. #28177 
2. Users unable to import the class - c.f. #28496 

For 1. - the unpickling of modified transformers models through torch.load isn't something we officially support. However, this will (temporarily) provide an equivalent class. 

For 2 - provides a class with deprecation warning that can be imported 

Fixes #28177 #28496 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?