### PR TITLE
Config: warning when saving generation kwargs in the model config

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -477,7 +477,7 @@ class PretrainedConfig(PushToHubMixin):
         if len(set_generation_parameters) > 0:
             logger.warning(
                 "Some non-default generation parameters are set in the model config. These should go into a "
-                "GenerationConfig file (https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)"
+                "GenerationConfig file (https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model) "
                 "instead. This warning will be raised to an exception in v4.39.\n"
                 f"Set generation parameters: {str(set_generation_parameters)}"
             )

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -470,17 +470,17 @@ class PretrainedConfig(PushToHubMixin):
         if os.path.isfile(save_directory):
             raise AssertionError(f"Provided path ({save_directory}) should be a directory, not a file")
 
+        set_generation_parameters = {}
         for parameter_name, default_value in GENERATION_DEFAULTS.items():
-            set_generation_parameters = {}
-            if getattr(self, parameter_name) != default_value:
+            if hasattr(self, parameter_name) and getattr(self, parameter_name) != default_value:
                 set_generation_parameters.update({parameter_name: getattr(self, parameter_name)})
-            if len(set_generation_parameters) > 0:
-                logger.warning(
-                    "Some non-default generation parameters are set in the model config. These should go into a "
-                    "GenerationConfig file (https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)"
-                    "instead. This warning will be raised to an exception in v4.39.\n"
-                    f"Set generation parameters: {str(set_generation_parameters)}"
-                )
+        if len(set_generation_parameters) > 0:
+            logger.warning(
+                "Some non-default generation parameters are set in the model config. These should go into a "
+                "GenerationConfig file (https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)"
+                "instead. This warning will be raised to an exception in v4.39.\n"
+                f"Set generation parameters: {str(set_generation_parameters)}"
+            )
 
         os.makedirs(save_directory, exist_ok=True)
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1069,6 +1069,15 @@ class PretrainedConfig(PushToHubMixin):
 
         cls._auto_class = auto_class
 
+    def has_set_generation_parameters(self) -> bool:
+        """
+        Whether or not this instance holds non-default generation parameters.
+        """
+        for parameter_name, default_value in GENERATION_DEFAULTS.items():
+            if hasattr(self, parameter_name) and getattr(self, parameter_name) != default_value:
+                return True
+        return False
+
 
 def get_configuration_file(configuration_files: List[str]) -> str:
     """

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -449,7 +449,7 @@ class PretrainedConfig(PushToHubMixin):
             logger.warning(
                 "Some non-default generation parameters are set in the model config. These should go into a "
                 "GenerationConfig file (https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model) "
-                "instead. This warning will be raised to an exception in v4.39.\n"
+                "instead. This warning will be raised to an exception in v4.41.\n"
                 f"Non-default generation parameters: {str(non_default_generation_parameters)}"
             )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1274,11 +1274,14 @@ class GenerationMixin:
         # priority: `generation_config` argument > `model.generation_config` (the default generation config)
         if generation_config is None:
             # legacy: users may modify the model configuration to control generation. To trigger this legacy behavior,
-            # two conditions must be met
+            # three conditions must be met
             # 1) the generation config must have been created from the model config (`_from_model_config` field);
-            # 2) the generation config must have seen no modification since its creation (the hash is the same).
-            if self.generation_config._from_model_config and self.generation_config._original_object_hash == hash(
-                self.generation_config
+            # 2) the generation config must have seen no modification since its creation (the hash is the same);
+            # 3) the user must have set generation parameters in the model config.
+            if (
+                self.generation_config._from_model_config
+                and self.generation_config._original_object_hash == hash(self.generation_config)
+                and self.config.has_set_generation_parameters()
             ):
                 new_generation_config = GenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1281,7 +1281,7 @@ class GenerationMixin:
             if (
                 self.generation_config._from_model_config
                 and self.generation_config._original_object_hash == hash(self.generation_config)
-                and self.config.has_set_generation_parameters()
+                and self.config._has_non_default_generation_parameters()
             ):
                 new_generation_config = GenerationConfig.from_model_config(self.config)
                 if new_generation_config != self.generation_config:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2334,12 +2334,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     if new_generation_config != model_to_save.generation_config:
                         logger.warning(
                             "Your generation config was originally created from the model config, but the model "
-                            "config has changed since then. Unless you parameterize this model's `generate` calls, "
-                            "they will revert to a legacy behavior, loading the parameterization from the model "
-                            "config. To avoid this behavior and this warning, make sure you correctly update OR "
-                            "redefine your generation config before saving it, preferably also removing the "
-                            "generation kwargs from the model config. This warning will be raised to an exception in "
-                            "v4.39."
+                            "config has changed since then. Unless you pass the `generation_config` argument to this "
+                            "model's `generate` calls, they will revert to the legacy behavior where the base "
+                            "`generate` parameterization is loaded from the model config instead. "
+                            "To avoid this behavior and this warning, we recommend you to overwrite the generation "
+                            "config model attribute before calling the model's `save_pretrained`, preferably also "
+                            "removing any generation kwargs from the model config. This warning will be raised to an "
+                            "exception in v4.39."
                         )
                 model_to_save.generation_config.save_pretrained(save_directory)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2329,6 +2329,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if not _hf_peft_config_loaded:
                 model_to_save.config.save_pretrained(save_directory)
             if self.can_generate():
+                if model_to_save.generation_config._from_model_config:
+                    new_generation_config = GenerationConfig.from_model_config(model_to_save.config)
+                    if new_generation_config != model_to_save.generation_config:
+                        logger.warning(
+                            "Your generation config was originally created from the model config, but the model "
+                            "config has changed since then. Unless you parameterize this model's `generate` calls, "
+                            "they will revert to a legacy behavior, loading the parameterization from the model "
+                            "config. To avoid this behavior and this warning, make sure you correctly update OR "
+                            "redefine your generation config before saving it, preferably also removing the "
+                            "generation kwargs from the model config. This warning will be raised to an exception in "
+                            "v4.39."
+                        )
                 model_to_save.generation_config.save_pretrained(save_directory)
 
             if _hf_peft_config_loaded:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2333,7 +2333,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 # may revert to legacy behavior if the two don't match
                 if (
                     model_to_save.generation_config._from_model_config
-                    and model_to_save.config.has_set_generation_parameters()
+                    and model_to_save.config._has_non_default_generation_parameters()
                 ):
                     new_generation_config = GenerationConfig.from_model_config(model_to_save.config)
                     if new_generation_config != model_to_save.generation_config:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2329,8 +2329,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if not _hf_peft_config_loaded:
                 model_to_save.config.save_pretrained(save_directory)
             if self.can_generate():
-                # generation config build from the model config + the model config holds generation kwargs -> generate
-                # may revert to legacy behavior
+                # generation config built from the model config + the model config holds generation kwargs -> generate
+                # may revert to legacy behavior if the two don't match
                 if (
                     model_to_save.generation_config._from_model_config
                     and model_to_save.config.has_set_generation_parameters()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2345,7 +2345,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             "To avoid this behavior and this warning, we recommend you to overwrite the generation "
                             "config model attribute before calling the model's `save_pretrained`, preferably also "
                             "removing any generation kwargs from the model config. This warning will be raised to an "
-                            "exception in v4.39."
+                            "exception in v4.41."
                         )
                 model_to_save.generation_config.save_pretrained(save_directory)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2331,7 +2331,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if self.can_generate():
                 # generation config build from the model config + the model config holds generation kwargs -> generate
                 # may revert to legacy behavior
-                if model_to_save.generation_config._from_model_config and model_to_save.config.has_set_generation_parameters():
+                if (
+                    model_to_save.generation_config._from_model_config
+                    and model_to_save.config.has_set_generation_parameters()
+                ):
                     new_generation_config = GenerationConfig.from_model_config(model_to_save.config)
                     if new_generation_config != model_to_save.generation_config:
                         logger.warning(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2329,7 +2329,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if not _hf_peft_config_loaded:
                 model_to_save.config.save_pretrained(save_directory)
             if self.can_generate():
-                if model_to_save.generation_config._from_model_config:
+                # generation config build from the model config + the model config holds generation kwargs -> generate
+                # may revert to legacy behavior
+                if model_to_save.generation_config._from_model_config and model_to_save.config.has_set_generation_parameters():
                     new_generation_config = GenerationConfig.from_model_config(model_to_save.config)
                     if new_generation_config != model_to_save.generation_config:
                         logger.warning(

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -529,7 +529,7 @@ class GenerationIntegrationTestsMixin:
 
         pixel_values = floats_tensor((2, 3, 30, 30))
         model = model_cls.from_pretrained("hf-internal-testing/tiny-random-VisionEncoderDecoderModel-vit-gpt2")
-        model.config.decoder.eos_token_id = None
+        model.generation_config.eos_token_id = None
         if is_pt:
             pixel_values = pixel_values.to(torch_device)
             model = model.to(torch_device)

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -296,3 +296,11 @@ class ConfigTestUtils(unittest.TestCase):
         old_transformers.configuration_utils.__version__ = "v3.0.0"
         old_configuration = old_transformers.models.auto.AutoConfig.from_pretrained(repo)
         self.assertEqual(old_configuration.hidden_size, 768)
+
+    def test_saving_config_with_custom_generation_kwargs_raises_warning(self):
+        config = BertConfig(min_length=3)  # `min_length = 3` is a non-default generation kwarg
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertLogs("transformers.configuration_utils", level="WARNING") as logs:
+                config.save_pretrained(tmp_dir, generation_kwargs=config_common_kwargs)
+            self.assertEqual(len(logs.output), 1)
+            self.assertIn("min_length", logs.output[0])

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -301,6 +301,6 @@ class ConfigTestUtils(unittest.TestCase):
         config = BertConfig(min_length=3)  # `min_length = 3` is a non-default generation kwarg
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertLogs("transformers.configuration_utils", level="WARNING") as logs:
-                config.save_pretrained(tmp_dir, generation_kwargs=config_common_kwargs)
+                config.save_pretrained(tmp_dir)
             self.assertEqual(len(logs.output), 1)
             self.assertIn("min_length", logs.output[0])

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -304,3 +304,11 @@ class ConfigTestUtils(unittest.TestCase):
                 config.save_pretrained(tmp_dir)
             self.assertEqual(len(logs.output), 1)
             self.assertIn("min_length", logs.output[0])
+
+    def test_has_set_generation_parameters(self):
+        config = BertConfig()
+        self.assertFalse(config.has_set_generation_parameters())
+        config = BertConfig(min_length=3)
+        self.assertTrue(config.has_set_generation_parameters())
+        config = BertConfig(min_length=0)  # `min_length = 0` is a default generation kwarg
+        self.assertFalse(config.has_set_generation_parameters())

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -305,10 +305,10 @@ class ConfigTestUtils(unittest.TestCase):
             self.assertEqual(len(logs.output), 1)
             self.assertIn("min_length", logs.output[0])
 
-    def test_has_set_generation_parameters(self):
+    def test_has_non_default_generation_parameters(self):
         config = BertConfig()
-        self.assertFalse(config.has_set_generation_parameters())
+        self.assertFalse(config._has_non_default_generation_parameters())
         config = BertConfig(min_length=3)
-        self.assertTrue(config.has_set_generation_parameters())
+        self.assertTrue(config._has_non_default_generation_parameters())
         config = BertConfig(min_length=0)  # `min_length = 0` is a default generation kwarg
-        self.assertFalse(config.has_set_generation_parameters())
+        self.assertFalse(config._has_non_default_generation_parameters())

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1212,6 +1212,15 @@ class ModelUtilsTest(TestCasePlus):
         for p1, p2 in zip(model.parameters(), new_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
+    def test_modifying_model_config_causes_warning_saving_generation_config(self):
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        model.config.top_k = 1
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertLogs("transformers.modeling_utils", level="WARNING") as logs:
+                model.save_pretrained(tmp_dir)
+            self.assertEqual(len(logs.output), 1)
+            self.assertIn("Your generation config was originally created from the model config", logs.output[0])
+
 
 @slow
 @require_torch


### PR DESCRIPTION
# What does this PR do?

## Context

`generate` is ideally controlled by a `GenerationConfig`. However, to remain retrocompatible, a `PretrainedConfig` may control `generate` in the following conditions:
1. `generate` does not receive a `generation_config` argument; AND
2. `model.generation_config._from_model_config is True`, which means the user never manually created a `GenerationConfig`; AND
3. the user has not modified `model.generation_config` since it was created, which (together with 2.) means that `model.generation_config` holds a copy of the generation parameterization in `model.config` at init time; AND 
4. [added in this PR] the model config holds non-default generation kwargs, which means there is some intent to control generation through the model config

Having the legacy behavior active essentially means there are two places to control generation, which has been causing some GH issues. We can't get rid of it (we would have to submit PRs to thousands of models), but we can be more persuasive in slowly shifting new models entirely towards the `GenerationConfig`. This should help with documentation, ease of use across tasks such as fine-tuning modern models, as well as reducing the number of occurrences of the legacy behavior warning (see [1:03 in this video](https://twitter.com/reach_vb/status/1736471172970086792) -- many @TheBloke models suffer from it, as `max_length` is set in the model config and not in the generation config).

## This PR

This PR adds:
1. Clause 4. in the context list above, to avoid showing the warning when there was no intent of controlling `generate` through `model.config`
2. Two future deprecation warnings in the following legacy-triggering situations:
  a. When saving a `PretrainedConfig` with non-default generation attributes, which demonstrates an intent to control `generate` through it. Users are nudged towards using `GenerationConfig` instead;
  b. When saving a model where `model.generation_config` is built from `model.config`, but `model.config`'s generation attributes have been modified since the creation of `model.generation_config` (i.e. the two hold different `generate` parameterization). Users are nudged towards creating a brand new `GenerationConfig` instead.