### PR TITLE
 Exclude the load balancing loss of padding tokens in Mixtral-8x7B

### DIFF
--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -74,7 +74,9 @@ logger = logging.get_logger(__name__)
 _CONFIG_FOR_DOC = "MixtralConfig"
 
 
-def load_balancing_loss_func(gate_logits: torch.Tensor, attention_mask: torch.Tensor, num_experts: torch.Tensor = None, top_k=2) -> float:
+def load_balancing_loss_func(
+    gate_logits: torch.Tensor, attention_mask: torch.Tensor, num_experts: torch.Tensor = None, top_k=2
+) -> float:
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
 
@@ -97,23 +99,21 @@ def load_balancing_loss_func(gate_logits: torch.Tensor, attention_mask: torch.Te
     """
     if gate_logits is None or not isinstance(gate_logits, tuple):
         return 0
-    
+
     batch_size, sequence_length = attention_mask.shape
 
     if isinstance(gate_logits, tuple):
         compute_device = gate_logits[0].device
         concatenated_gate_logits = torch.cat([layer_gate.to(compute_device) for layer_gate in gate_logits], dim=0)
-    
-    num_hidden_layers = concatenated_gate_logits.shape[0] // (
-        batch_size * sequence_length
-    )
+
+    num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
 
     routing_weights = torch.nn.functional.softmax(concatenated_gate_logits, dim=-1)
 
     _, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
 
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_experts)
-    
+
     # Compute the mask that masks all padding tokens with 0 with the same shape of expert_mask
     expert_attention_mask = (
         attention_mask[None, :, :, None, None]
@@ -123,10 +123,10 @@ def load_balancing_loss_func(gate_logits: torch.Tensor, attention_mask: torch.Te
     )
 
     # Compute the percentage of tokens routed to each experts
-    tokens_per_expert = torch.sum(
-        expert_mask.float() * expert_attention_mask, dim=0
-    ) / torch.sum(expert_attention_mask, dim=0)
-    
+    tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
+        expert_attention_mask, dim=0
+    )
+
     # Compute the mask that masks all padding tokens with 0 with the same shape of tokens_per_expert
     router_per_expert_attention_mask = (
         attention_mask[None, :, :, None]
@@ -136,9 +136,9 @@ def load_balancing_loss_func(gate_logits: torch.Tensor, attention_mask: torch.Te
     )
 
     # Compute the average probability of routing to these experts
-    router_prob_per_expert = torch.sum(
-        routing_weights * router_per_expert_attention_mask, dim=0
-    ) / torch.sum(router_per_expert_attention_mask, dim=0)
+    router_prob_per_expert = torch.sum(routing_weights * router_per_expert_attention_mask, dim=0) / torch.sum(
+        router_per_expert_attention_mask, dim=0
+    )
 
     overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
     return overall_loss * num_experts
@@ -1376,13 +1376,13 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         aux_loss = None
         if output_router_logits:
             aux_loss = load_balancing_loss_func(
-                outputs.router_logits if return_dict else outputs[-1], 
+                outputs.router_logits if return_dict else outputs[-1],
                 attention_mask if attention_mask is not None else torch.ones_like(input_ids),
-                self.num_experts, 
-                self.num_experts_per_tok
+                self.num_experts,
+                self.num_experts_per_tok,
             )
             if labels is not None:
-                loss += self.router_aux_loss_coef * aux_loss.to(loss.device) # make sure to reside in the same device
+                loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -75,7 +75,7 @@ _CONFIG_FOR_DOC = "MixtralConfig"
 
 
 def load_balancing_loss_func(
-    gate_logits: torch.Tensor, attention_mask: Optional[torch.Tensor], num_experts: torch.Tensor = None, top_k=2
+    gate_logits: torch.Tensor, num_experts: torch.Tensor = None, top_k=2, attention_mask: Optional[torch.Tensor] = None
 ) -> float:
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
@@ -1383,9 +1383,9 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         if output_router_logits:
             aux_loss = load_balancing_loss_func(
                 outputs.router_logits if return_dict else outputs[-1],
-                attention_mask,
                 self.num_experts,
                 self.num_experts_per_tok,
+                attention_mask,
             )
             if labels is not None:
                 loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -100,13 +100,9 @@ def load_balancing_loss_func(
     if gate_logits is None or not isinstance(gate_logits, tuple):
         return 0
 
-    # batch_size, sequence_length = attention_mask.shape
-
     if isinstance(gate_logits, tuple):
         compute_device = gate_logits[0].device
         concatenated_gate_logits = torch.cat([layer_gate.to(compute_device) for layer_gate in gate_logits], dim=0)
-
-    # num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
 
     routing_weights = torch.nn.functional.softmax(concatenated_gate_logits, dim=-1)
 

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -75,7 +75,7 @@ _CONFIG_FOR_DOC = "MixtralConfig"
 
 
 def load_balancing_loss_func(
-    gate_logits: torch.Tensor, attention_mask: torch.Tensor, num_experts: torch.Tensor = None, top_k=2
+    gate_logits: torch.Tensor, attention_mask: Optional[torch.Tensor], num_experts: torch.Tensor = None, top_k=2
 ) -> float:
     r"""
     Computes auxiliary load balancing loss as in Switch Transformer - implemented in Pytorch.
@@ -88,9 +88,9 @@ def load_balancing_loss_func(
         gate_logits (Union[`torch.Tensor`, Tuple[torch.Tensor]):
             Logits from the `gate`, should be a tuple of model.config.num_hidden_layers tensors of
             shape [batch_size X sequence_length, num_experts].
-        attention_mask (`torch.Tensor`):
+        attention_mask (`torch.Tensor`, None):
             The attention_mask used in forward function
-            shape [batch_size X sequence_length].
+            shape [batch_size X sequence_length] if not None.
         num_experts (`int`, *optional*):
             Number of experts
 
@@ -100,13 +100,13 @@ def load_balancing_loss_func(
     if gate_logits is None or not isinstance(gate_logits, tuple):
         return 0
 
-    batch_size, sequence_length = attention_mask.shape
+    # batch_size, sequence_length = attention_mask.shape
 
     if isinstance(gate_logits, tuple):
         compute_device = gate_logits[0].device
         concatenated_gate_logits = torch.cat([layer_gate.to(compute_device) for layer_gate in gate_logits], dim=0)
 
-    num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
+    # num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
 
     routing_weights = torch.nn.functional.softmax(concatenated_gate_logits, dim=-1)
 
@@ -114,31 +114,41 @@ def load_balancing_loss_func(
 
     expert_mask = torch.nn.functional.one_hot(selected_experts, num_experts)
 
-    # Compute the mask that masks all padding tokens with 0 with the same shape of expert_mask
-    expert_attention_mask = (
-        attention_mask[None, :, :, None, None]
-        .expand((num_hidden_layers, batch_size, sequence_length, 2, num_experts))
-        .reshape(-1, 2, num_experts)
-        .to(compute_device)
-    )
+    if attention_mask is None:
+        # Compute the percentage of tokens routed to each experts
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
 
-    # Compute the percentage of tokens routed to each experts
-    tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-        expert_attention_mask, dim=0
-    )
+        # Compute the average probability of routing to these experts
+        router_prob_per_expert = torch.mean(routing_weights, dim=0)
+    else:
+        batch_size, sequence_length = attention_mask.shape
+        num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
 
-    # Compute the mask that masks all padding tokens with 0 with the same shape of tokens_per_expert
-    router_per_expert_attention_mask = (
-        attention_mask[None, :, :, None]
-        .expand((num_hidden_layers, batch_size, sequence_length, num_experts))
-        .reshape(-1, num_experts)
-        .to(compute_device)
-    )
+        # Compute the mask that masks all padding tokens as 0 with the same shape of expert_mask
+        expert_attention_mask = (
+            attention_mask[None, :, :, None, None]
+            .expand((num_hidden_layers, batch_size, sequence_length, 2, num_experts))
+            .reshape(-1, 2, num_experts)
+            .to(compute_device)
+        )
 
-    # Compute the average probability of routing to these experts
-    router_prob_per_expert = torch.sum(routing_weights * router_per_expert_attention_mask, dim=0) / torch.sum(
-        router_per_expert_attention_mask, dim=0
-    )
+        # Compute the percentage of tokens routed to each experts
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
+            expert_attention_mask, dim=0
+        )
+
+        # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert
+        router_per_expert_attention_mask = (
+            attention_mask[None, :, :, None]
+            .expand((num_hidden_layers, batch_size, sequence_length, num_experts))
+            .reshape(-1, num_experts)
+            .to(compute_device)
+        )
+
+        # Compute the average probability of routing to these experts
+        router_prob_per_expert = torch.sum(routing_weights * router_per_expert_attention_mask, dim=0) / torch.sum(
+            router_per_expert_attention_mask, dim=0
+        )
 
     overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
     return overall_loss * num_experts
@@ -1377,7 +1387,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         if output_router_logits:
             aux_loss = load_balancing_loss_func(
                 outputs.router_logits if return_dict else outputs[-1],
-                attention_mask if attention_mask is not None else torch.ones_like(input_ids),
+                attention_mask,
                 self.num_experts,
                 self.num_experts_per_tok,
             )

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -479,7 +479,7 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)
-        pad_leng = random.randint(500, 1000)
+        pad_leng = 1000
         # Add padding tokens (assume that pad_token_id=1) to input_ids
         padding_block = torch.ones(input_ids.shape[0], pad_leng, dtype=torch.int32).to(torch_device)
         padded_input_ids = torch.cat((padding_block, input_ids), dim=1)  # this is to simulate padding to the left

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -484,7 +484,7 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         padded_attention_mask = padded_input_ids.ne(1).to(torch_device)
 
         padded_result = model(padded_input_ids, attention_mask=padded_attention_mask)
-        torch.testing.assert_close(result.aux_loss.cpu(), padded_result.aux_loss.cpu(), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), padded_result.aux_loss.cpu(), rtol=1e-4, atol=1e-4)
 
         # We make sure that the loss of includding padding tokens != the loss without padding tokens
         # if attention_mask=None --> we don't exclude padding tokens

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -15,8 +15,6 @@
 """ Testing suite for the PyTorch Mixtral model. """
 
 
-import math
-import random
 import tempfile
 import unittest
 
@@ -493,8 +491,8 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         include_padding_result = model(padded_input_ids, attention_mask=None)
 
         # This is to mimic torch.testing.assert_not_close
-        loss_diff = math.fabs(include_padding_result.aux_loss.item() - result.aux_loss.item())
-        self.assertTrue(loss_diff > 1e-2 + 1e-2 * result.aux_loss.item())
+        print(f"loss1={include_padding_result.aux_loss.item()}, loss2={result.aux_loss.item()}")
+        self.assertNotAlmostEqual(include_padding_result.aux_loss.item(), result.aux_loss.item())
 
 
 @require_torch

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -15,6 +15,8 @@
 """ Testing suite for the PyTorch Mixtral model. """
 
 
+import math
+import random
 import tempfile
 import unittest
 
@@ -462,7 +464,6 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         r"""
         Let's make sure we can actually compute the loss and do a backward on it.
         """
-
         config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
         config.num_labels = 3
         config.num_local_experts = 8
@@ -475,6 +476,23 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         result = model(input_ids, attention_mask=attention_mask)
         self.assertEqual(result.router_logits[0].shape, (91, config.num_local_experts))
         torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+
+        # First, we make sure that adding padding tokens doesn't change the loss
+        # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)
+        pad_leng = random.randint(200, 500)
+        # Add padding tokens (assume that pad_token_id=1) to input_ids
+        padding_block = torch.ones(input_ids.shape[0], pad_leng, dtype=torch.int32).to(torch_device)
+        padded_input_ids = torch.cat((padding_block, input_ids), dim=1)  # this is to simulate padding to the left
+        padded_attention_mask = padded_input_ids.ne(1).to(torch_device)
+
+        padded_result = model(padded_input_ids, attention_mask=padded_attention_mask)
+        torch.testing.assert_close(result.aux_loss.cpu(), padded_result.aux_loss.cpu(), rtol=1e-2, atol=1e-2)
+
+        # We make sure that the loss of includding padding tokens != the loss without padding tokens
+        # if attention_mask=None --> we don't exclude padding tokens
+        include_padding_result = model(padded_input_ids, attention_mask=None)
+        loss_diff = math.fabs(include_padding_result.aux_loss.item() - result.aux_loss.item())
+        self.assertTrue(loss_diff > 0.05)
 
 
 @require_torch

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -477,9 +477,9 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)
-        pad_leng = 1000
+        pad_length = 1000
         # Add padding tokens (assume that pad_token_id=1) to input_ids
-        padding_block = torch.ones(input_ids.shape[0], pad_leng, dtype=torch.int32).to(torch_device)
+        padding_block = torch.ones(input_ids.shape[0], pad_length, dtype=torch.int32).to(torch_device)
         padded_input_ids = torch.cat((padding_block, input_ids), dim=1)  # this is to simulate padding to the left
         padded_attention_mask = padded_input_ids.ne(1).to(torch_device)
 

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -479,7 +479,7 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)
-        pad_leng = random.randint(200, 500)
+        pad_leng = random.randint(500, 1000)
         # Add padding tokens (assume that pad_token_id=1) to input_ids
         padding_block = torch.ones(input_ids.shape[0], pad_leng, dtype=torch.int32).to(torch_device)
         padded_input_ids = torch.cat((padding_block, input_ids), dim=1)  # this is to simulate padding to the left
@@ -491,8 +491,10 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         # We make sure that the loss of includding padding tokens != the loss without padding tokens
         # if attention_mask=None --> we don't exclude padding tokens
         include_padding_result = model(padded_input_ids, attention_mask=None)
+
+        # This is to mimic torch.testing.assert_not_close
         loss_diff = math.fabs(include_padding_result.aux_loss.item() - result.aux_loss.item())
-        self.assertTrue(loss_diff > 0.05)
+        self.assertTrue(loss_diff > 1e-2 + 1e-2 * result.aux_loss.item())
 
 
 @require_torch

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -491,7 +491,6 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         include_padding_result = model(padded_input_ids, attention_mask=None)
 
         # This is to mimic torch.testing.assert_not_close
-        print(f"loss1={include_padding_result.aux_loss.item()}, loss2={result.aux_loss.item()}")
         self.assertNotAlmostEqual(include_padding_result.aux_loss.item(), result.aux_loss.item())
 
 


### PR DESCRIPTION
# What does this PR do?
This PR implements excluding the load balancing loss of padding tokens in Mixtral-8x7B
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #28505


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@ArthurZucker

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
