### PR TITLE
[ `TokenizationUtils`] Fix `add_special_tokens` when the token is already there

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -943,13 +943,14 @@ class SpecialTokensMixin:
                     isinstance(t, (str, AddedToken)) for t in value
                 ), f"Tokens {value} for key {key} should all be str or AddedToken instances"
 
-                to_add = set()
+                to_add = []
                 for token in value:
                     if isinstance(token, str):
                         # for legacy purpose we default to stripping. `test_add_tokens_tokenizer` depends on this
                         token = AddedToken(token, rstrip=False, lstrip=False, normalized=False, special=True)
-                    if str(token) not in self.additional_special_tokens:
-                        to_add.add(token)
+                    if not replace_additional_special_tokens and str(token) in self.additional_special_tokens:
+                        continue
+                    to_add.append(token)
                 if replace_additional_special_tokens and len(to_add) > 0:
                     setattr(self, key, list(to_add))
                 else:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -950,7 +950,7 @@ class SpecialTokensMixin:
                         token = AddedToken(token, rstrip=False, lstrip=False, normalized=False, special=True)
                     if str(token) not in self.additional_special_tokens:
                         to_add.add(token)
-                if replace_additional_special_tokens:
+                if replace_additional_special_tokens and len(to_add) > 0:
                     setattr(self, key, list(to_add))
                 else:
                     self._additional_special_tokens.extend(to_add)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4139,3 +4139,17 @@ class TokenizerTesterMixin:
                                 _test_added_vocab_and_eos(
                                     EXPECTED_ADDED_TOKENS_DECODER, self.tokenizer_class, new_eos, tmp_dir_4
                                 )
+
+    def test_special_token_addition(self):
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                # Create tokenizer and add an additional special token
+                tokenizer_1 = tokenizer.from_pretrained(pretrained_name)
+                tokenizer_1.add_special_tokens({"additional_special_tokens": ["<tok>"]})
+                self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>"])
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    tokenizer_1.save_pretrained(tmp_dir)
+                    # Load the above tokenizer and add the same special token a second time
+                    tokenizer_2 = tokenizer.from_pretrained(pretrained_name)
+                    tokenizer_2.add_special_tokens({"additional_special_tokens": ["<tok>"]})
+                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>"])

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4153,3 +4153,12 @@ class TokenizerTesterMixin:
                     tokenizer_2 = tokenizer.from_pretrained(pretrained_name)
                     tokenizer_2.add_special_tokens({"additional_special_tokens": ["<tok>"]})
                     self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>"])
+
+                    tokenizer_2.add_special_tokens({"additional_special_tokens": ["<tok>", "<other>"]})
+                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>", "<other>"])
+
+                    tokenizer_2.add_special_tokens(
+                        {"additional_special_tokens": ["<another>", "<other>"]},
+                        replace_additional_special_tokens=False,
+                    )
+                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>", "<other>", "<another>"])

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4146,7 +4146,7 @@ class TokenizerTesterMixin:
                 # Create tokenizer and add an additional special token
                 tokenizer_1 = tokenizer.from_pretrained(pretrained_name)
                 tokenizer_1.add_special_tokens({"additional_special_tokens": ["<tok>"]})
-                self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>"])
+                self.assertEqual(tokenizer_1.additional_special_tokens, ["<tok>"])
                 with tempfile.TemporaryDirectory() as tmp_dir:
                     tokenizer_1.save_pretrained(tmp_dir)
                     # Load the above tokenizer and add the same special token a second time

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4156,9 +4156,11 @@ class TokenizerTesterMixin:
 
                     tokenizer_2.add_special_tokens({"additional_special_tokens": ["<tok>", "<other>"]})
                     self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>", "<other>"])
+                    tokenizer_2.add_special_tokens({"additional_special_tokens": ["<other>", "<another>"]})
+                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<other>", "<another>"])
 
                     tokenizer_2.add_special_tokens(
-                        {"additional_special_tokens": ["<another>", "<other>"]},
+                        {"additional_special_tokens": ["<tok>"]},
                         replace_additional_special_tokens=False,
                     )
-                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<tok>", "<other>", "<another>"])
+                    self.assertEqual(tokenizer_2.additional_special_tokens, ["<other>", "<another>", "<tok>"])


### PR DESCRIPTION
# What does this PR do?
Fixes #27888 : the method was missing a check that was overwriting the special token list. 