### PR TITLE
Fix labels encoding in RobertaForSequenceClassification when problem_type="multi_label_classification" 

### DIFF
--- a/src/transformers/models/roberta/modeling_roberta.py
+++ b/src/transformers/models/roberta/modeling_roberta.py
@@ -1232,7 +1232,8 @@ class RobertaForSequenceClassification(RobertaPreTrainedModel):
                 loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
-                loss = loss_fct(logits, labels)
+                one_hot_labels = torch.functional.F.one_hot(labels, num_classes=self.config.num_labels).double()
+                loss = loss_fct(logits, one_hot_labels)
 
         if not return_dict:
             output = (logits,) + outputs[2:]


### PR DESCRIPTION

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->
Here is a simple script that illustrates the problem
```python
import this
from transformers import (AutoConfig,
                          RobertaForSequenceClassification,
                          RobertaTokenizerFast, Trainer, TrainingArguments)
from itertools import cycle
from datasets import Dataset


def main():
    # dataset
    print("dataset")
    text = this.s.split("\n")
    num_labels = 4
    labels = [int(cycle("1234").__next__()) for _ in range(len(text))]
    ds = Dataset.from_dict({"text": text, "label": labels})
    ds = ds.train_test_split(test_size=0.3)
    output_folder_path = "/tmp/roberta"

    # model and parameters
    print("model and parameters")

    model_id = "distilroberta-base"
    config = AutoConfig.from_pretrained(model_id)
    config.problem_type = "multi_label_classification"
    config.num_labels = num_labels

    model = RobertaForSequenceClassification.from_pretrained(
        model_id, config=config
    )

    args = {
        "batch_size": 100,
        "tokenizer_max_length": 512,
        "training_args": {
            "num_train_epochs": 2,
            "learning_rate": 1e-5,
            "warmup_steps": 500,
            "report_to": "none",
        },
    }
    # tokenizer
    print("tokenizer")
    tokenizer = RobertaTokenizerFast.from_pretrained(model_id)

    def tokenize(batch):
        return tokenizer(batch["text"], padding=True, truncation=True, max_length=args["tokenizer_max_length"])

    ds = ds.map(tokenize, batched=True, batch_size=args["batch_size"])
    ds.set_format("torch", columns=["input_ids", "attention_mask", "label"])

    # Training
    print("training")
    training_args = TrainingArguments(
        output_dir=output_folder_path,
        **args["training_args"]
    )

    trainer = Trainer(
        model=model,
        args=training_args,
        train_dataset=ds["train"],
        eval_dataset=ds["test"],
    )
    trainer.train(resume_from_checkpoint=False)


if __name__ == "__main__":
    main()
```

Output error is
```
ValueError: Target size (torch.Size([2])) must be the same as input size (torch.Size([2, 4]))
```
Because transformers/models/roberta/modeling_roberta.py L1236 expects labels to be one hot encoded.
The code in this PR solves this issus.
<!-- Remove if not applicable -->
Fixes # (issue)


## Before submitting
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada


 -->
