### PR TITLE
[`TokenizationRoformerFast`]  Fix the save and loading

### DIFF
--- a/src/transformers/models/roformer/tokenization_roformer_fast.py
+++ b/src/transformers/models/roformer/tokenization_roformer_fast.py
@@ -138,6 +138,16 @@ class RoFormerTokenizerFast(PreTrainedTokenizerFast):
 
         self.do_lower_case = do_lower_case
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_tokenizer"].pre_tokenizer = BertPreTokenizer()
+        return state
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        vocab = self.__dict__["_tokenizer"].get_vocab()
+        self.__dict__["_tokenizer"].pre_tokenizer = PreTokenizer.custom(JiebaPreTokenizer(vocab))
+
     def build_inputs_with_special_tokens(self, token_ids_0, token_ids_1=None):
         """
         Build model inputs from a sequence or a pair of sequence for sequence classification tasks by concatenating and

--- a/tests/models/roformer/test_tokenization_roformer.py
+++ b/tests/models/roformer/test_tokenization_roformer.py
@@ -71,7 +71,6 @@ class RoFormerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_training_new_tokenizer_with_special_tokens_change(self):
         pass
 
-    # # can't serialise custom PreTokenizer
     def test_save_slow_from_fast_and_reload_fast(self):
         for cls in [RoFormerTokenizer, RoFormerTokenizerFast]:
             original = cls.from_pretrained('alchemab/antiberta2')

--- a/tests/models/roformer/test_tokenization_roformer.py
+++ b/tests/models/roformer/test_tokenization_roformer.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import unittest
-
+import tempfile
 from transformers import RoFormerTokenizer, RoFormerTokenizerFast
 from transformers.testing_utils import require_rjieba, require_tokenizers
 
@@ -71,6 +71,13 @@ class RoFormerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def test_training_new_tokenizer_with_special_tokens_change(self):
         pass
 
-    # can't serialise custom PreTokenizer
+    # # can't serialise custom PreTokenizer
     def test_save_slow_from_fast_and_reload_fast(self):
-        pass
+        for cls in [RoFormerTokenizer, RoFormerTokenizerFast]:
+            original = cls.from_pretrained('alchemab/antiberta2')
+            self.assertEqual(original.encode("生活的真谛是") , [1, 4, 4, 4, 4, 4, 4, 2])
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                original.save_pretrained(tmp_dir)
+                new = cls.from_pretrained(tmp_dir)
+            self.assertEqual(new.encode("生活的真谛是") , [1, 4, 4, 4, 4, 4, 4, 2])

--- a/tests/models/roformer/test_tokenization_roformer.py
+++ b/tests/models/roformer/test_tokenization_roformer.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import tempfile
+import unittest
+
 from transformers import RoFormerTokenizer, RoFormerTokenizerFast
 from transformers.testing_utils import require_rjieba, require_tokenizers
 
@@ -73,10 +74,10 @@ class RoFormerTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_save_slow_from_fast_and_reload_fast(self):
         for cls in [RoFormerTokenizer, RoFormerTokenizerFast]:
-            original = cls.from_pretrained('alchemab/antiberta2')
-            self.assertEqual(original.encode("生活的真谛是") , [1, 4, 4, 4, 4, 4, 4, 2])
+            original = cls.from_pretrained("alchemab/antiberta2")
+            self.assertEqual(original.encode("生活的真谛是"), [1, 4, 4, 4, 4, 4, 4, 2])
 
             with tempfile.TemporaryDirectory() as tmp_dir:
                 original.save_pretrained(tmp_dir)
                 new = cls.from_pretrained(tmp_dir)
-            self.assertEqual(new.encode("生活的真谛是") , [1, 4, 4, 4, 4, 4, 4, 2])
+            self.assertEqual(new.encode("生活的真谛是"), [1, 4, 4, 4, 4, 4, 4, 2])


### PR DESCRIPTION
# What does this PR do?
Fixes #28164, the pre tokenizer state was not correctly set after saving a fast tokenizer only. 