### PR TITLE
Allow add_tokens for ESM

### DIFF
--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 """Tokenization classes for ESM."""
 import os
-from typing import List, Optional, Union
-
-from transformers import AddedToken
+from typing import List, Optional
 
 from ...tokenization_utils import PreTrainedTokenizer
 from ...utils import logging
@@ -92,11 +90,10 @@ class EsmTokenizer(PreTrainedTokenizer):
     def _tokenize(self, text, **kwargs):
         return text.split()
 
-    def get_vocab_size(self, with_added_tokens=False):
-        return len(self._id_to_token)
-
     def get_vocab(self):
-        return {token: i for i, token in enumerate(self.all_tokens)}
+        base_vocab = {token: i for i, token in enumerate(self.all_tokens)}
+        base_vocab.update(self.added_tokens_encoder)
+        return base_vocab
 
     def token_to_id(self, token: str) -> int:
         return self._token_to_id.get(token, self._token_to_id.get(self.unk_token))
@@ -157,11 +154,4 @@ class EsmTokenizer(PreTrainedTokenizer):
 
     @property
     def vocab_size(self) -> int:
-        return self.get_vocab_size(with_added_tokens=False)
-
-    def _add_tokens(self, new_tokens: Union[List[str], List[AddedToken]], special_tokens: bool = False) -> int:
-        result = super()._add_tokens(new_tokens, special_tokens=special_tokens)
-        for token in new_tokens:
-            if token and token not in self.all_tokens:
-                self.all_tokens.append(token)
-        return result
+        return len(self.all_tokens)

--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -91,7 +91,7 @@ class EsmTokenizer(PreTrainedTokenizer):
         return text.split()
 
     def get_vocab(self):
-        base_vocab = {token: i for i, token in enumerate(self.all_tokens)}
+        base_vocab = self._token_to_id.copy()
         base_vocab.update(self.added_tokens_encoder)
         return base_vocab
 

--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -66,6 +66,8 @@ class EsmTokenizer(PreTrainedTokenizer):
         **kwargs,
     ):
         self.all_tokens = load_vocab_file(vocab_file)
+        self._id_to_token = dict(enumerate(self.all_tokens))
+        self._token_to_id = {tok: ind for ind, tok in enumerate(self.all_tokens)}
         super().__init__(
             unk_token=unk_token,
             cls_token=cls_token,
@@ -80,14 +82,6 @@ class EsmTokenizer(PreTrainedTokenizer):
 
         self.unique_no_split_tokens = self.all_tokens
         self._update_trie(self.unique_no_split_tokens)
-
-    @property
-    def _id_to_token(self):
-        return dict(enumerate(self.all_tokens))
-
-    @property
-    def _token_to_id(self):
-        return {token: i for i, token in enumerate(self.all_tokens)}
 
     def _convert_id_to_token(self, index: int) -> str:
         return self._id_to_token.get(index, self.unk_token)

--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -14,10 +14,9 @@
 # limitations under the License.
 """Tokenization classes for ESM."""
 import os
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from ...tokenization_utils import PreTrainedTokenizer
-from ...tokenization_utils_base import AddedToken
 from ...utils import logging
 
 
@@ -157,6 +156,3 @@ class EsmTokenizer(PreTrainedTokenizer):
     @property
     def vocab_size(self) -> int:
         return self.get_vocab_size(with_added_tokens=False)
-
-    def _add_tokens(self, new_tokens: Union[List[str], List[AddedToken]], special_tokens: bool = False) -> int:
-        return super()._add_tokens(new_tokens, special_tokens=True)

--- a/tests/models/esm/test_tokenization_esm.py
+++ b/tests/models/esm/test_tokenization_esm.py
@@ -87,3 +87,25 @@ class ESMTokenizationTest(unittest.TestCase):
                 self.assertEqual(len(token_2), 1)
                 self.assertEqual(token_1[0], SPECIAL_TOKEN_1)
                 self.assertEqual(token_2[0], SPECIAL_TOKEN_2)
+
+    def test_add_tokens(self):
+        tokenizer = self.tokenizer_class(self.vocab_file)
+
+        vocab_size = len(tokenizer)
+        self.assertEqual(tokenizer.add_tokens(""), 0)
+        self.assertEqual(tokenizer.add_tokens("testoken"), 1)
+        self.assertEqual(tokenizer.add_tokens(["testoken1", "testtoken2"]), 2)
+        self.assertEqual(len(tokenizer), vocab_size + 3)
+
+        self.assertEqual(tokenizer.add_special_tokens({}), 0)
+        self.assertEqual(tokenizer.add_special_tokens({"bos_token": "[BOS]", "eos_token": "[EOS]"}), 2)
+        self.assertRaises(AssertionError, tokenizer.add_special_tokens, {"additional_special_tokens": "<testtoken1>"})
+        self.assertEqual(tokenizer.add_special_tokens({"additional_special_tokens": ["<testtoken2>"]}), 1)
+        self.assertEqual(
+            tokenizer.add_special_tokens({"additional_special_tokens": ["<testtoken3>", "<testtoken4>"]}), 2
+        )
+        self.assertIn("<testtoken3>", tokenizer.special_tokens_map["additional_special_tokens"])
+        self.assertIsInstance(tokenizer.special_tokens_map["additional_special_tokens"], list)
+        self.assertGreaterEqual(len(tokenizer.special_tokens_map["additional_special_tokens"]), 2)
+
+        self.assertEqual(len(tokenizer), vocab_size + 8)


### PR DESCRIPTION
The tokenizer code for ESM forces all added tokens to be special tokens, presumably because the authors felt that the list of amino acids in proteins was constant and therefore that there wouldn't be a need to actually expand the core vocabulary. However, there are definitely use-cases for expanding the vocabulary - see #28387.

This PR makes `add_tokens()` for ESM tokenizers behave like it does for other tokenizers, and doesn't force the added tokens to be special tokens.

Fixes #28387 