### PR TITLE
`intial_prompt` support for automatic-speech-recognition (whisper) pipeline

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -574,18 +574,18 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
 
             if self.type == "seq2seq_whisper" and inputs.shape[-1] > self.feature_extractor.nb_max_frames:
                 generate_kwargs["input_features"] = inputs
-                if self.processor:
-                    # Added initial prompt for whisper
-                    if "initial_prompt" in generate_kwargs:
-                        initial_prompt = generate_kwargs.pop("initial_prompt")
-                        generate_kwargs["prompt_ids"] = self.processor.get_prompt_ids(initial_prompt)
-                else:
-                    if "initial_prompt" in generate_kwargs:
-                        initial_prompt = generate_kwargs.pop("initial_prompt")
-                    RuntimeWarning("No defined processor for Whisper Prompting. `initial_ptompt` will be ignored.")
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
+            if self.processor:
+                # Added initial prompt for whisper
+                if "initial_prompt" in generate_kwargs:
+                    initial_prompt = generate_kwargs.pop("initial_prompt")
+                    generate_kwargs["prompt_ids"] = self.processor.get_prompt_ids(initial_prompt)
+            else:
+                if "initial_prompt" in generate_kwargs:
+                    initial_prompt = generate_kwargs.pop("initial_prompt")
+                RuntimeWarning("No defined processor for Whisper Prompting. `initial_ptompt` will be ignored.")
             print(generate_kwargs)
             tokens = self.model.generate(
                 attention_mask=attention_mask,

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -586,6 +586,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
+            print(generate_kwargs)
             tokens = self.model.generate(
                 attention_mask=attention_mask,
                 **generate_kwargs,

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -577,7 +577,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 if self.processor:
                     # Added initial prompt for whisper
                     if "initial_prompt" in generate_kwargs:
-                        generate_kwargs["prompt_ids"] = self.processor.get_prompt_ids(generate_kwargs["initial_prompt"])
+                        initial_prompt = generate_kwargs.pop("initial_prompt")
+                        generate_kwargs["prompt_ids"] = self.processor.get_prompt_ids(initial_prompt)
                 else:
                     RuntimeWarning("No defined processor for Whisper Prompting. `initial_ptompt` will be ignored.")
             else:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -580,6 +580,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                         initial_prompt = generate_kwargs.pop("initial_prompt")
                         generate_kwargs["prompt_ids"] = self.processor.get_prompt_ids(initial_prompt)
                 else:
+                    if "initial_prompt" in generate_kwargs:
+                        initial_prompt = generate_kwargs.pop("initial_prompt")
                     RuntimeWarning("No defined processor for Whisper Prompting. `initial_ptompt` will be ignored.")
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -594,7 +594,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 out = {"tokens": tokens["sequences"], "token_timestamps": tokens["token_timestamps"]}
             else:
                 out = {"tokens": tokens}
-                
+
             if "prompt_ids" in generate_kwargs:
                 if isinstance(out["tokens"], torch.Tensor):
                     prompt_tensor = torch.tensor(generate_kwargs["prompt_ids"], dtype=out["tokens"].dtype)
@@ -602,7 +602,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                     tmp_tokens = out["tokens"][0]
                     if (tmp_tokens[0:nprompt_token] == prompt_tensor).sum() == nprompt_token:
                         out["tokens"][0, 0:nprompt_token] = torch.tensor([self.tokenizer.unk_token_id]*nprompt_token, dtype = out["tokens"].dtype)
-                    
+
             if self.type == "seq2seq_whisper":
                 if stride is not None:
                     out["stride"] = stride


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (feature)
- `initial_prompt` support for whisper Pipeline (automatic-speech-recognition) 

## Before submitting
- [ ] Added initial_prompt as an option for whisper model
- [ ] To handle initial prompt `processor` considered as optional parameter
- [ ] Current implementation supports only Torch version of decoding.
- [ ] how to use initial prompt; 

``` python
from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
from datasets import load_dataset

model_id = "openai/whisper-small"
model = AutoModelForSpeechSeq2Seq.from_pretrained(
    model_id, torch_dtype=torch_dtype, low_cpu_mem_usage=True, use_safetensors=True
)
model.to(device)

processor = AutoProcessor.from_pretrained(model_id)

pipe = pipeline(
    "automatic-speech-recognition",
    model=model,
    tokenizer=processor.tokenizer,
    feature_extractor=processor.feature_extractor,
    max_new_tokens=128,
    chunk_length_s=15,
    batch_size=16,
    torch_dtype=torch_dtype,
    device=device,
    processor=processor
)

dataset = load_dataset("distil-whisper/librispeech_long", "clean", split="validation")
sample = dataset[0]["audio"]

# including timestamp
print(pipe(audio, initial_prompt = "Biswajit, Whisper", return_timestamps=True))

# without timestamp
print(pipe(audio, initial_prompt = "Biswajit, Whisper"))
```

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. @sanchit-gandhi , @Narsil, Can anyone help to take this PR forward please. Let me know, if anything is needed.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
