### PR TITLE
Don't save `processor_config.json` if a processor has no extra attribute 

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -188,11 +188,6 @@ class ProcessorMixin(PushToHubMixin):
             kwargs (`Dict[str, Any]`, *optional*):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
-        # For now, let's not save to `processor_config.json` if the processor doesn't have extra attributes and
-        # `auto_map` is not specified.
-        if set(self.to_dict().keys()) == {"processor_class"}:
-            return []
-
         use_auth_token = kwargs.pop("use_auth_token", None)
 
         if use_auth_token is not None:
@@ -239,8 +234,11 @@ class ProcessorMixin(PushToHubMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
 
-        self.to_json_file(output_processor_file)
-        logger.info(f"processor saved in {output_processor_file}")
+        # For now, let's not save to `processor_config.json` if the processor doesn't have extra attributes and
+        # `auto_map` is not specified.
+        if set(self.to_dict().keys()) != {"processor_class"}:
+            self.to_json_file(output_processor_file)
+            logger.info(f"processor saved in {output_processor_file}")
 
         if push_to_hub:
             self._upload_modified_files(
@@ -251,6 +249,8 @@ class ProcessorMixin(PushToHubMixin):
                 token=kwargs.get("token"),
             )
 
+        if set(self.to_dict().keys()) == {"processor_class"}:
+            return []
         return [output_processor_file]
 
     @classmethod

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -188,6 +188,11 @@ class ProcessorMixin(PushToHubMixin):
             kwargs (`Dict[str, Any]`, *optional*):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
+        # For now, let's not save to `processor_config.json` if the processor doesn't have extra attributes and
+        # `auto_map` is not specified.
+        if set(self.to_dict().keys()) == {"processor_class"}:
+            return []
+
         use_auth_token = kwargs.pop("use_auth_token", None)
 
         if use_auth_token is not None:

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -123,13 +123,14 @@ class AutoFeatureExtractorTest(unittest.TestCase):
             # save in new folder
             processor.save_pretrained(tmpdirname)
 
-            # drop `processor_class` in processor
-            with open(os.path.join(tmpdirname, PROCESSOR_NAME), "r") as f:
-                config_dict = json.load(f)
-                config_dict.pop("processor_class")
+            if os.path.isfile(os.path.join(tmpdirname, PROCESSOR_NAME)):
+                # drop `processor_class` in processor
+                with open(os.path.join(tmpdirname, PROCESSOR_NAME), "r") as f:
+                    config_dict = json.load(f)
+                    config_dict.pop("processor_class")
 
-            with open(os.path.join(tmpdirname, PROCESSOR_NAME), "w") as f:
-                f.write(json.dumps(config_dict))
+                with open(os.path.join(tmpdirname, PROCESSOR_NAME), "w") as f:
+                    f.write(json.dumps(config_dict))
 
             # drop `processor_class` in tokenizer
             with open(os.path.join(tmpdirname, TOKENIZER_CONFIG_FILE), "r") as f:
@@ -153,13 +154,14 @@ class AutoFeatureExtractorTest(unittest.TestCase):
             # save in new folder
             processor.save_pretrained(tmpdirname)
 
-            # drop `processor_class` in processor
-            with open(os.path.join(tmpdirname, PROCESSOR_NAME), "r") as f:
-                config_dict = json.load(f)
-                config_dict.pop("processor_class")
+            if os.path.isfile(os.path.join(tmpdirname, PROCESSOR_NAME)):
+                # drop `processor_class` in processor
+                with open(os.path.join(tmpdirname, PROCESSOR_NAME), "r") as f:
+                    config_dict = json.load(f)
+                    config_dict.pop("processor_class")
 
-            with open(os.path.join(tmpdirname, PROCESSOR_NAME), "w") as f:
-                f.write(json.dumps(config_dict))
+                with open(os.path.join(tmpdirname, PROCESSOR_NAME), "w") as f:
+                    f.write(json.dumps(config_dict))
 
             # drop `processor_class` in feature extractor
             with open(os.path.join(tmpdirname, FEATURE_EXTRACTOR_NAME), "r") as f:

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -101,6 +101,12 @@ class AutoFeatureExtractorTest(unittest.TestCase):
             # save in new folder
             processor.save_pretrained(tmpdirname)
 
+            if not os.path.isfile(os.path.join(tmpdirname, PROCESSOR_NAME)):
+                # create one manually in order to perform this test's objective
+                config_dict = {"processor_class": "Wav2Vec2Processor"}
+                with open(os.path.join(tmpdirname, PROCESSOR_NAME), "w") as fp:
+                    json.dump(config_dict, fp)
+
             # drop `processor_class` in tokenizer config
             with open(os.path.join(tmpdirname, TOKENIZER_CONFIG_FILE), "r") as f:
                 config_dict = json.load(f)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -80,7 +80,7 @@ class ProcessorTesterMixin:
                 check_json_file_has_correct_format(saved_files[0])
                 processor_second = self.processor_class.from_pretrained(tmpdirname)
 
-        self.assertEqual(processor_second.to_dict(), processor_first.to_dict())
+                self.assertEqual(processor_second.to_dict(), processor_first.to_dict())
 
 
 class MyProcessor(ProcessorMixin):

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -75,9 +75,10 @@ class ProcessorTesterMixin:
         processor_first = self.get_processor()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            saved_file = processor_first.save_pretrained(tmpdirname)[0]
-            check_json_file_has_correct_format(saved_file)
-            processor_second = self.processor_class.from_pretrained(tmpdirname)
+            saved_files = processor_first.save_pretrained(tmpdirname)
+            if len(saved_files) > 0:
+                check_json_file_has_correct_format(saved_files[0])
+                processor_second = self.processor_class.from_pretrained(tmpdirname)
 
         self.assertEqual(processor_second.to_dict(), processor_first.to_dict())
 


### PR DESCRIPTION
# What does this PR do?

Don't save `processor_config.json` if a processor has no extra attribute 