### PR TITLE
Support gated Linear Layers for SwitchTransformers

### DIFF
--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -176,7 +176,7 @@ class SwitchTransformersConfig(PretrainedConfig):
         self.router_z_loss_coef = router_z_loss_coef
         self.router_aux_loss_coef = router_aux_loss_coef
         
-        act_info = self.dense_act_fn.split("-")
+        act_info = dense_act_fn.split("-")
         self.dense_act_fn = act_info[-1]
         self.is_gated_act = act_info[0] == "gated"
 

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -173,13 +173,12 @@ class SwitchTransformersConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.add_router_probs = add_router_probs
 
+        self.router_z_loss_coef = router_z_loss_coef
+        self.router_aux_loss_coef = router_aux_loss_coef
+        
         act_info = self.feed_forward_proj.split("-")
         self.dense_act_fn = act_info[-1]
         self.is_gated_act = act_info[0] == "gated"
-
-        self.router_z_loss_coef = router_z_loss_coef
-        self.router_aux_loss_coef = router_aux_loss_coef
-        self.dense_act_fn = dense_act_fn
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -173,6 +173,10 @@ class SwitchTransformersConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.add_router_probs = add_router_probs
 
+        act_info = self.feed_forward_proj.split("-")
+        self.dense_act_fn = act_info[-1]
+        self.is_gated_act = act_info[0] == "gated"
+
         self.router_z_loss_coef = router_z_loss_coef
         self.router_aux_loss_coef = router_aux_loss_coef
         self.dense_act_fn = dense_act_fn

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -175,7 +175,7 @@ class SwitchTransformersConfig(PretrainedConfig):
 
         self.router_z_loss_coef = router_z_loss_coef
         self.router_aux_loss_coef = router_aux_loss_coef
-        
+
         act_info = dense_act_fn.split("-")
         self.dense_act_fn = act_info[-1]
         self.is_gated_act = act_info[0] == "gated"

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -176,7 +176,7 @@ class SwitchTransformersConfig(PretrainedConfig):
         self.router_z_loss_coef = router_z_loss_coef
         self.router_aux_loss_coef = router_aux_loss_coef
         
-        act_info = self.feed_forward_proj.split("-")
+        act_info = self.dense_act_fn.split("-")
         self.dense_act_fn = act_info[-1]
         self.is_gated_act = act_info[0] == "gated"
 

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -84,7 +84,7 @@ class SwitchTransformersConfig(PretrainedConfig):
         initializer_factor (`float`, *optional*, defaults to 1.0):
             A factor for initializing all weight matrices (should be kept to 1, used internally for initialization
             testing).
-        dense_act_fn (`string`, *optional*, defaults to `"relu"`):
+        feed_forward_proj (`string`, *optional*, defaults to `"relu"`):
             Type of feed forward layer to be used. Should be one of `"relu"` or `"gated-gelu"`. SwitchTransformersv1.1
             uses the `"gated-gelu"` feed forward projection. Original SwitchTransformers uses `"relu"`.
         add_router_probs (`bool`, *optional*, defaults to `False`):
@@ -121,7 +121,7 @@ class SwitchTransformersConfig(PretrainedConfig):
         router_z_loss_coef=0.001,
         router_aux_loss_coef=0.001,
         initializer_factor=1.0,
-        dense_act_fn="relu",
+        feed_forward_proj="relu",
         is_encoder_decoder=True,
         add_router_probs=False,
         use_cache=True,
@@ -176,7 +176,8 @@ class SwitchTransformersConfig(PretrainedConfig):
         self.router_z_loss_coef = router_z_loss_coef
         self.router_aux_loss_coef = router_aux_loss_coef
 
-        act_info = dense_act_fn.split("-")
+        self.feed_forward_proj = feed_forward_proj
+        act_info = self.feed_forward_proj.split("-")
         self.dense_act_fn = act_info[-1]
         self.is_gated_act = act_info[0] == "gated"
 

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -371,7 +371,7 @@ class SwitchTransformersLayerFF(nn.Module):
             if config.is_gated_act:
                 self.mlp = SwitchTransformersSparseMLP(config, SwitchTransformersDenseGatedActDense)
             else:
-                self.mlp = SwitchTransformersDenseActDense(config, SwitchTransformersDenseGatedActDense)
+                self.mlp = SwitchTransformersSparseMLP(config, SwitchTransformersDenseActDense)
 
         self.layer_norm = SwitchTransformersLayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -366,10 +366,8 @@ class SwitchTransformersLayerFF(nn.Module):
             mlp_cls = SwitchTransformersDenseGatedActDense if config.is_gated_act else SwitchTransformersDenseActDense
             self.mlp = mlp_cls(config)
         else:
-            if config.is_gated_act:
-                self.mlp = SwitchTransformersSparseMLP(config, SwitchTransformersDenseGatedActDense)
-            else:
-                self.mlp = SwitchTransformersSparseMLP(config, SwitchTransformersDenseActDense)
+            mlp_cls = SwitchTransformersSparseMLP if config.is_gated_act else SwitchTransformersSparseMLP
+            self.mlp = mlp_cls(config)
 
         self.layer_norm = SwitchTransformersLayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -363,10 +363,8 @@ class SwitchTransformersLayerFF(nn.Module):
 
         # Check if it is a sparse layer, if not then it is a dense layer
         if not self.is_sparse:
-            if config.is_gated_act:
-                self.mlp = SwitchTransformersDenseGatedActDense(config)
-            else:
-                self.mlp = SwitchTransformersDenseActDense(config)
+            mlp_cls = SwitchTransformersDenseGatedActDense if config.is_gated_act else SwitchTransformersDenseActDense
+            self.mlp = mlp_cls(config)
         else:
             if config.is_gated_act:
                 self.mlp = SwitchTransformersSparseMLP(config, SwitchTransformersDenseGatedActDense)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -367,7 +367,7 @@ class SwitchTransformersLayerFF(nn.Module):
             self.mlp = mlp_cls(config)
         else:
             mlp_cls = SwitchTransformersSparseMLP if config.is_gated_act else SwitchTransformersSparseMLP
-            self.mlp = mlp_cls(config)
+            self.mlp = SwitchTransformersSparseMLP(config, mlp_cls)
 
         self.layer_norm = SwitchTransformersLayerNorm(config.d_model, eps=config.layer_norm_epsilon)
         self.dropout = nn.Dropout(config.dropout_rate)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -888,7 +888,7 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
             n_heads = self.config.num_heads
             module.router.classifier.weight.data.normal_(mean=0.0, std=factor * 1)
             for idx in range(self.config.num_experts):
-                if self.config.is_gated_act == True:
+                if self.config.is_gated_act:
                     module.experts[f"expert_{idx}"].wi_0.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
                     module.experts[f"expert_{idx}"].wi_1.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
                 else:

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -366,7 +366,7 @@ class SwitchTransformersLayerFF(nn.Module):
             mlp_cls = SwitchTransformersDenseGatedActDense if config.is_gated_act else SwitchTransformersDenseActDense
             self.mlp = mlp_cls(config)
         else:
-            mlp_cls = SwitchTransformersSparseMLP if config.is_gated_act else SwitchTransformersSparseMLP
+            mlp_cls = SwitchTransformersDenseGatedActDense if config.is_gated_act else SwitchTransformersDenseActDense
             self.mlp = SwitchTransformersSparseMLP(config, mlp_cls)
 
         self.layer_norm = SwitchTransformersLayerNorm(config.d_model, eps=config.layer_norm_epsilon)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -272,7 +272,7 @@ class SwitchTransformersDenseActDense(nn.Module):
         return hidden_states
 
 
-# Copied from transformers.models.t5.modeling_t5.T5DenseActDense with T5->SwitchTransformers
+# Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5->SwitchTransformers
 class SwitchTransformersDenseGatedActDense(nn.Module):
     def __init__(self, config: SwitchTransformersConfig):
         super().__init__()

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -888,7 +888,11 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
             n_heads = self.config.num_heads
             module.router.classifier.weight.data.normal_(mean=0.0, std=factor * 1)
             for idx in range(self.config.num_experts):
-                module.experts[f"expert_{idx}"].wi.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
+                if self.config.is_gated_act == True:
+                    module.experts[f"expert_{idx}"].wi_0.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
+                    module.experts[f"expert_{idx}"].wi_1.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
+                else:
+                    module.experts[f"expert_{idx}"].wi.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
                 module.experts[f"expert_{idx}"].wo.weight.data.normal_(mean=0.0, std=factor * (d_model**-0.5))
 
     def _shift_right(self, input_ids):


### PR DESCRIPTION
# What does this PR do?

The new version of SwitchTransformers uses a gated linear layer.

This pull request adds gated Linear Layers support for SwitchTransformers.

This is very similar to T5 and T5 v1.1 models.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts , @ArthurZucker , @younesbelkada , @younesbelkada , @sgugger