### PR TITLE
fix a hidden bug of `GenerationConfig`, now the `generation_config.json` can be loaded successfully

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -908,7 +908,14 @@ class GenerationConfig(PushToHubMixin):
             for metadata_field in METADATA_FIELDS:
                 config_dict.pop(metadata_field, None)
 
-        return json.dumps(config_dict, indent=2, sort_keys=False) + "\n"
+        def convert_keys_to_string(dictionary):
+            if not isinstance(dictionary, dict):
+                return dictionary
+            return {str(key): convert_keys_to_string(value) for key, value in dictionary.items()}
+
+        config_dict = convert_keys_to_string(config_dict)
+
+        return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
 
     def to_json_file(self, json_file_path: Union[str, os.PathLike], use_diff: bool = True):
         """

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -908,7 +908,7 @@ class GenerationConfig(PushToHubMixin):
             for metadata_field in METADATA_FIELDS:
                 config_dict.pop(metadata_field, None)
 
-        return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
+        return json.dumps(config_dict, indent=2, sort_keys=False) + "\n"
 
     def to_json_file(self, json_file_path: Union[str, os.PathLike], use_diff: bool = True):
         """

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -908,10 +908,10 @@ class GenerationConfig(PushToHubMixin):
             for metadata_field in METADATA_FIELDS:
                 config_dict.pop(metadata_field, None)
 
-        def convert_keys_to_string(dictionary):
-            if not isinstance(dictionary, dict):
-                return dictionary
-            return {str(key): convert_keys_to_string(value) for key, value in dictionary.items()}
+        def convert_keys_to_string(obj):
+            if not isinstance(obj, dict):
+                return obj
+            return {str(key): convert_keys_to_string(value) for key, value in obj.items()}
 
         config_dict = convert_keys_to_string(config_dict)
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -909,9 +909,12 @@ class GenerationConfig(PushToHubMixin):
                 config_dict.pop(metadata_field, None)
 
         def convert_keys_to_string(obj):
-            if not isinstance(obj, dict):
+            if isinstance(obj, dict):
+                return {str(key): convert_keys_to_string(value) for key, value in obj.items()}
+            elif isinstance(obj, list):
+                return [convert_keys_to_string(item) for item in obj]
+            else:
                 return obj
-            return {str(key): convert_keys_to_string(value) for key, value in obj.items()}
 
         config_dict = convert_keys_to_string(config_dict)
 


### PR DESCRIPTION
# What does this PR do?

I was developing an open-source LLM project, and I found that the `generation_config.json` file cannot be successfully loaded to controll model's generation process, though I've written some attributes in this file, such as `eos_token_id` (a newly initialized model object from `from_pretrained` api did not get correct `eos_token_id`).

I am aware of that there're many walkarounds to control the generation process instead of using `generation_config.json`. But I still want to use `generation_config.json` and no more other code, as it should be a standard way. So I dived into the source code of class `GenerationConfig` and spend hours to do debugging stuff.

The initialization process would be called several times during the initialization of a pretrained model. But I found the last time is somehow very strange. Using following code:

```Python
print('before')
logger.info(f"Configuration saved in {output_config_file}") # original L594 of `transformers/generation/configuration_utils.py`
print('after')
```

`before` was printed but `after` was not, as if the function is suddenly returned at here or broken. It gave me clue that there's some problem in the `__repr__` method of `GenerationConfig`. Continue to dive in, I finally located the bug:

```Python
try:
    return json.dumps(config_dict, indent=2, sort_keys=True) + "\n" # original L991 of `transformers/generation/configuration_utils.py`
except Exception:
    print(e)
    raise
```

It gave me the error info of `not supported between instances of 'str' and 'int'`. So it seems that there is some dirty code like `try:... except: pass` outside of the `GenerationConfig` class. Nevertheless, I can finally solve the problem by

```Python
return json.dumps(config_dict, indent=2, sort_keys=False) + "\n"
```

Although only one line of code need to be changed, I believe it's a very hidden bug that one may spend a entire afternoon to find it. Now we can successfully load `generation_config.json` and correctly configure model's generation behavior.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- generate: @gante
- Big Model Inference: @SunMarc