### PR TITLE
Generate: deprecate old src imports

### DIFF
--- a/src/transformers/generation_flax_utils.py
+++ b/src/transformers/generation_flax_utils.py
@@ -23,6 +23,6 @@ class FlaxGenerationMixin(FlaxGenerationMixin):
     # warning at import time
     warnings.warn(
         "Importing `FlaxGenerationMixin` from `src/transformers/generation_flax_utils.py` is deprecated and will "
-        "be removed in Transformers v5. Import as `from transformers import FlaxGenerationMixin` instead.",
+        "be removed in Transformers v4.40. Import as `from transformers import FlaxGenerationMixin` instead.",
         FutureWarning,
     )

--- a/src/transformers/generation_tf_utils.py
+++ b/src/transformers/generation_tf_utils.py
@@ -23,6 +23,6 @@ class TFGenerationMixin(TFGenerationMixin):
     # warning at import time
     warnings.warn(
         "Importing `TFGenerationMixin` from `src/transformers/generation_tf_utils.py` is deprecated and will "
-        "be removed in Transformers v5. Import as `from transformers import TFGenerationMixin` instead.",
+        "be removed in Transformers v4.40. Import as `from transformers import TFGenerationMixin` instead.",
         FutureWarning,
     )

--- a/src/transformers/generation_utils.py
+++ b/src/transformers/generation_utils.py
@@ -23,6 +23,6 @@ class GenerationMixin(GenerationMixin):
     # warning at import time
     warnings.warn(
         "Importing `GenerationMixin` from `src/transformers/generation_utils.py` is deprecated and will "
-        "be removed in Transformers v5. Import as `from transformers import GenerationMixin` instead.",
+        "be removed in Transformers v4.40. Import as `from transformers import GenerationMixin` instead.",
         FutureWarning,
     )


### PR DESCRIPTION
# What does this PR do?

We have 3 thin wrappers for `generate`, one for each framework, whose sole purpose is to import the mixin from `src/transformers/generation(_flax/_tf)_utils.py`. In other words, to import from `src` according to the codebase before [this PR](https://github.com/huggingface/transformers/pull/20096).

Since this is a `src` import (and not a `from transformers import X`), I believe this can be safely removed before v5.