### PR TITLE
Add missing key to TFLayoutLM signature

### DIFF
--- a/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
+++ b/src/transformers/models/layoutlm/modeling_tf_layoutlm.py
@@ -944,6 +944,12 @@ class TFLayoutLMPreTrainedModel(TFPreTrainedModel):
     config_class = LayoutLMConfig
     base_model_prefix = "layoutlm"
 
+    @property
+    def input_signature(self):
+        signature = super().input_signature
+        signature["bbox"] = tf.TensorSpec(shape=(None, None, 4), dtype=tf.int32, name="bbox")
+        return signature
+
 
 LAYOUTLM_START_DOCSTRING = r"""
 


### PR DESCRIPTION
LayoutLM is missing the `bbox` key in its signature, which affects exporting to TFLite/TF Serving. LayoutLMv3 already has the correct signature and doesn't need to be fixed.