### PR TITLE
Set correct dtypes for ONNX quantization

### DIFF
--- a/src/transformers/convert_graph_to_onnx.py
+++ b/src/transformers/convert_graph_to_onnx.py
@@ -418,7 +418,7 @@ def quantize(onnx_model_path: Path) -> Path:
     import onnx
     import onnxruntime
     from onnx.onnx_pb import ModelProto
-    from onnxruntime.quantization import QuantizationMode
+    from onnxruntime.quantization import QuantizationMode, QuantType
     from onnxruntime.quantization.onnx_quantizer import ONNXQuantizer
     from onnxruntime.quantization.registry import IntegerOpsRegistry
 
@@ -446,8 +446,8 @@ def quantize(onnx_model_path: Path) -> Path:
             reduce_range=False,
             mode=QuantizationMode.IntegerOps,
             static=False,
-            weight_qType=True,
-            input_qType=False,
+            weight_qType=QuantType.QInt8,
+            input_qType=QuantType.QUInt8,
             tensors_range=None,
             nodes_to_quantize=None,
             nodes_to_exclude=None,
@@ -460,8 +460,8 @@ def quantize(onnx_model_path: Path) -> Path:
             reduce_range=False,
             mode=QuantizationMode.IntegerOps,
             static=False,
-            weight_qType=True,
-            activation_qType=False,
+            weight_qType=QuantType.QInt8,
+            activation_qType=QuantType.QUInt8,
             tensors_range=None,
             nodes_to_quantize=None,
             nodes_to_exclude=None,


### PR DESCRIPTION
# What does this PR do?

It's currently not to possible to quantize an ONNX model with `transformers.convert_graph_to_onnx`.

Running the following snippet on `main`:

```python
from pathlib import Path

from transformers import pipeline
from transformers.convert_graph_to_onnx import convert_pytorch, quantize


# load a ner model
nlp = pipeline(task="ner", model="dbmdz/bert-large-cased-finetuned-conll03-english")

# name of the onnx file to be exported
output = Path("model.onnx")

# first transform pytorch to onnx model
convert_pytorch(nlp, output=output, opset=11, use_external_format=False)

# onnx model can now be quantized
quantize(output)
```

will result in:

```
Traceback (most recent call last):
  File "/home/severin/git/transformers/test-quantization.py", line 12, in <module>
    quantized_model = quantize(output)
                      ^^^^^^^^^^^^^^^^
  File "/home/severin/git/transformers/src/transformers/convert_graph_to_onnx.py", line 472, in quantize
    quantizer.quantize_model()
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/onnx_quantizer.py", line 310, in quantize_model
    op_quantizer.quantize()
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/operators/gather.py", line 29, in quantize
    ) = self.quantizer.quantize_activation(node, [0])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/onnx_quantizer.py", line 825, in quantize_activation
    return self.__quantize_inputs(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/onnx_quantizer.py", line 915, in __quantize_inputs
    q_weight_name, zp_name, scale_name = self.quantize_initializer(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/onnx_quantizer.py", line 995, in quantize_initializer
    _, _, zero_point, scale, q_weight_data = quantize_data(
                                             ^^^^^^^^^^^^^^
  File "/home/severin/git/transformers/.venv/lib/python3.11/site-packages/onnxruntime/quantization/quant_utils.py", line 277, in quantize_data
    raise ValueError(f"Unexpected value for qType={qType}.")
ValueError: Unexpected value for qType=False.
```

The values are updated in this PR to be consistent with the default values in `optimum` (see [this](https://github.com/huggingface/optimum/blob/bb7b71a2c1f9c9220845b258afd88a5c1a24c013/optimum/onnxruntime/quantization.py#L367-L368) and also [this](https://github.com/huggingface/optimum/blob/bb7b71a2c1f9c9220845b258afd88a5c1a24c013/optimum/onnxruntime/configuration.py#L275-L277)).

Running the snippet from above in my branch outputs as expected:

```
Quantized model has been written at model-quantized.onnx: ✔
```

Tested with `onnxruntime` 1.16.3 (on Python 3.11.6) and 1.12.1 (on Python 3.10.13).


## Who can review?

@SunMarc and @younesbelkada (neither `bitsandbytes` nor `autogpt`, but quantization though)
