### PR TITLE
Add token_type_ids to Esm tokenizer

### DIFF
--- a/src/transformers/models/esm/tokenization_esm.py
+++ b/src/transformers/models/esm/tokenization_esm.py
@@ -146,6 +146,41 @@ class EsmTokenizer(PreTrainedTokenizer):
             mask += [0] * len(token_ids_1) + [1]
         return mask
 
+    def create_token_type_ids_from_sequences(
+        self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None
+    ) -> List[int]:
+        """
+        Create a mask from the two sequences passed to be used in a sequence-pair classification task. A BERT sequence
+        pair mask has the following format:
+
+        ```
+        0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1
+        | first sequence    | second sequence |
+        ```
+
+        If `token_ids_1` is `None`, this method only returns the first portion of the mask (0s).
+
+        Args:
+            token_ids_0 (`List[int]`):
+                List of IDs.
+            token_ids_1 (`List[int]`, *optional*):
+                Optional second list of IDs for sequence pairs.
+
+        Returns:
+            `List[int]`: List of [token type IDs](../glossary#token-type-ids) according to the given sequence(s).
+        """
+        eos = [self.eos_token_id]
+        cls = [self.cls_token_id]
+        if token_ids_1 is None:
+            return len(cls + token_ids_0 + eos) * [0]
+        return len(cls + token_ids_0 + eos) * [0] + len(token_ids_1 + eos) * [1]
+
+    def save_vocabulary(self, save_directory, filename_prefix):
+        vocab_file = os.path.join(save_directory, (filename_prefix + "-" if filename_prefix else "") + "vocab.txt")
+        with open(vocab_file, "w") as f:
+            f.write("\n".join(self.all_tokens))
+        return (vocab_file,)
+
     def save_vocabulary(self, save_directory, filename_prefix):
         vocab_file = os.path.join(save_directory, (filename_prefix + "-" if filename_prefix else "") + "vocab.txt")
         with open(vocab_file, "w") as f:


### PR DESCRIPTION
# What does this PR do?
Enables EsmTokenizer to correctly return token_type_ids. Before, ignored special tokens. create_token_type_ids_from_sequences was adapted from BertTokenizer with eos instead of sep per Esm special tokens.

This
```
tokenizer = EsmTokenizer.from_pretrained('facebook/esm2_t6_8M_UR50D')
seq = 'PROTEIN'
len(seq) # 7

tokens = tokenizer(seq, seq, return_token_type_ids=True)

len(tokens.input_ids), len(tokens.token_type_ids) # 17, 14 
```
To this
`len(tokens.input_ids), len(tokens.token_type_ids) # 17, 17 `

Fixes [#28656](https://github.com/huggingface/transformers/issues/28656)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker 