### PR TITLE
Introduce AcceleratorConfig dataclass

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4040,8 +4040,6 @@ class Trainer:
                 # Some values may need to go through non-accelerate aligned defaults
                 # and we need to run the `__post_init__` to set them
                 accelerator_kwargs = AcceleratorConfig(**accelerator_kwargs).to_dict()
-            else:
-                accelerator_kwargs = AcceleratorConfig.from_json_file(accelerator_kwargs).to_dict()
 
         self.accelerator = Accelerator(
             deepspeed_plugin=self.args.deepspeed_plugin,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4036,7 +4036,11 @@ class Trainer:
             # dict and AcceleratorConfigs are parseable, json files are not
             if isinstance(accelerator_kwargs, AcceleratorConfig):
                 accelerator_kwargs = accelerator_kwargs.to_dict()
-            elif not isinstance(accelerator_kwargs, dict):
+            elif isinstance(accelerator_kwargs, dict):
+                # Some values may need to go through non-accelerate aligned defaults
+                # and we need to run the `__post_init__` to set them
+                accelerator_kwargs = AcceleratorConfig(**accelerator_kwargs).to_dict()
+            else:
                 accelerator_kwargs = AcceleratorConfig.from_json_file(accelerator_kwargs).to_dict()
 
         self.accelerator = Accelerator(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4035,9 +4035,9 @@ class Trainer:
             accelerator_kwargs = self.args.accelerator_config
             # dict and AcceleratorConfigs are parseable, json files are not
             if isinstance(accelerator_kwargs, AcceleratorConfig):
-                accelerator_kwargs = accelerator_kwargs.to_kwargs()
+                accelerator_kwargs = accelerator_kwargs.to_dict()
             elif not isinstance(accelerator_kwargs, dict):
-                accelerator_kwargs = AcceleratorConfig.from_json_file(accelerator_kwargs).to_kwargs()
+                accelerator_kwargs = AcceleratorConfig.from_json_file(accelerator_kwargs).to_dict()
 
         self.accelerator = Accelerator(
             deepspeed_plugin=self.args.deepspeed_plugin,

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1216,15 +1216,7 @@ class AcceleratorConfig:
         with open_file(json_file, "r", encoding="utf-8") as f:
             config_dict = json.load(f)
         # Check for keys and load sensible defaults
-        if "split_batches" not in config_dict:
-            config_dict["split_batches"] = False
-        if "dispatch_batches" not in config_dict:
-            config_dict["dispatch_batches"] = None
-        if "even_batches" not in config_dict:
-            config_dict["even_batches"] = True
-        if "use_seedable_sampler" not in config_dict:
-            config_dict["use_seedable_sampler"] = True
-        extra_keys = sorted(set(config_dict.keys()) - set(cls.__dataclass_fields__.keys()))
+        extra_keys = sorted(key for key in config_dict.keys() if key not in cls.__dataclass_fields__.keys())
         if len(extra_keys) > 0:
             raise ValueError(
                 f"The config file at {json_file} had unknown keys ({extra_keys}), please try upgrading your `transformers`"

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -16,7 +16,9 @@
 Torch utilities for the Trainer class.
 """
 
+import copy
 import datetime
+import io
 import json
 import math
 import os
@@ -24,7 +26,7 @@ import sys
 import warnings
 from collections.abc import Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from logging import StreamHandler
 from typing import Any, Dict, Iterator, List, Optional, Union
 
@@ -1140,3 +1142,103 @@ if is_sagemaker_mp_enabled():
         # It doesn't seem possible to check here if `tensor` is a StepOutput because StepOutput lives in `smp.step`
         # which is also the name of the decorator so Python is confused.
         return tensor.concat().detach().cpu()
+
+
+@dataclass
+class AcceleratorConfig:
+    """
+    A subset of arguments relating to the underlying [`accelerate.Accelerator`]
+    implementation utilized in the `Trainer` that can be customized.
+    Mostly relating to data.
+
+    Parameters:
+        split_batches (`bool`, *optional*, defaults to `False`):
+            Whether or not the accelerator should split the batches yielded by the dataloaders across the devices. If
+            `True` the actual batch size used will be the same on any kind of distributed processes, but it must be a
+            round multiple of the `num_processes` you are using. If `False`, actual batch size used will be the one set
+            in your script multiplied by the number of processes.
+        dispatch_batches (`bool`, *optional*):
+            If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process
+            and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose
+            underlying dataset is an `IterableDataset`, `False` otherwise.
+        even_batches (`bool`, *optional*, defaults to `True`):
+            If set to `True`, in cases where the total batch size across all processes does not exactly divide the
+            dataset, samples at the start of the dataset will be duplicated so the batch can be divided equally among
+            all workers.
+        use_seedable_sampler (`bool`, *optional*, defaults to `True`):
+            Whether or not use a fully seedable random sampler ([`accelerate.data_loader.SeedableRandomSampler`]). Ensures
+            training results are fully reproducable using a different sampling technique. While seed-to-seed results
+            may differ, on average the differences are neglible when using multiple different seeds to compare. Should
+            also be ran with [`~utils.set_seed`] for the best results.
+
+    """
+
+    # Data related arguments
+    split_batches: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether or not the accelerator should split the batches yielded by the dataloaders across the devices. If"
+            " `True` the actual batch size used will be the same on any kind of distributed processes, but it must be a"
+            " round multiple of the `num_processes` you are using. If `False`, actual batch size used will be the one set"
+            " in your script multiplied by the number of processes."
+        },
+    )
+    dispatch_batches: bool = field(
+        default=None,
+        metadata={
+            "help": "If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process"
+            " and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose"
+            " underlying dataset is an `IterableDataslet`, `False` otherwise."
+        },
+    )
+    even_batches: bool = field(
+        default=True,
+        metadata={
+            "help": "If set to `True`, in cases where the total batch size across all processes does not exactly divide the"
+            " dataset, samples at the start of the dataset will be duplicated so the batch can be divided equally among"
+            " all workers."
+        },
+    )
+    use_seedable_sampler: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether or not use a fully seedable random sampler ([`accelerate.data_loader.SeedableRandomSampler`])."
+            "Ensures training results are fully reproducable using a different sampling technique. "
+            "While seed-to-seed results may differ, on average the differences are neglible when using"
+            "multiple different seeds to compare. Should also be ran with [`~utils.set_seed`] for the best results."
+        },
+    )
+
+    @classmethod
+    def from_json_file(cls, json_file):
+        # Check if exists
+        open_file = io.open if os.path.exists(json_file) else open
+        with open_file(json_file, "r", encoding="utf-8") as f:
+            config_dict = json.load(f)
+        # Check for keys and load sensible defaults
+        if "split_batches" not in config_dict:
+            config_dict["split_batches"] = False
+        if "dispatch_batches" not in config_dict:
+            config_dict["dispatch_batches"] = None
+        if "even_batches" not in config_dict:
+            config_dict["even_batches"] = True
+        if "use_seedable_sampler" not in config_dict:
+            config_dict["use_seedable_sampler"] = True
+        extra_keys = sorted(set(config_dict.keys()) - set(cls.__dataclass_fields__.keys()))
+        if len(extra_keys) > 0:
+            raise ValueError(
+                f"The config file at {json_file} had unknown keys ({extra_keys}), please try upgrading your `transformers`"
+                " version or fix (and potentially remove these keys) from your config file."
+            )
+        return cls(**config_dict)
+
+    def to_dict(self):
+        return copy.deepcopy(self.__dict__)
+
+    def to_kwargs(self):
+        """
+        Returns a dictionary containing the attributes with values different from the default of this class.
+        """
+        default_dict = self.__class__().to_dict()
+        this_dict = self.to_dict()
+        return {k: v for k, v in this_dict.items() if default_dict[k] != v}

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1200,7 +1200,7 @@ class AcceleratorConfig:
         },
     )
     use_seedable_sampler: bool = field(
-        default=True,
+        default=None,
         metadata={
             "help": "Whether or not use a fully seedable random sampler ([`accelerate.data_loader.SeedableRandomSampler`])."
             "Ensures training results are fully reproducable using a different sampling technique. "
@@ -1208,6 +1208,10 @@ class AcceleratorConfig:
             "multiple different seeds to compare. Should also be ran with [`~utils.set_seed`] for the best results."
         },
     )
+
+    def __post_init__(self):
+        if self.use_seedable_sampler is None:
+            self.use_seedable_sampler = True
 
     @classmethod
     def from_json_file(cls, json_file):

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1200,7 +1200,7 @@ class AcceleratorConfig:
         },
     )
     use_seedable_sampler: bool = field(
-        default=None,
+        default=True,
         metadata={
             "help": "Whether or not use a fully seedable random sampler ([`accelerate.data_loader.SeedableRandomSampler`])."
             "Ensures training results are fully reproducable using a different sampling technique. "
@@ -1208,10 +1208,6 @@ class AcceleratorConfig:
             "multiple different seeds to compare. Should also be ran with [`~utils.set_seed`] for the best results."
         },
     )
-
-    def __post_init__(self):
-        if self.use_seedable_sampler is None:
-            self.use_seedable_sampler = True
 
     @classmethod
     def from_json_file(cls, json_file):

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1226,11 +1226,3 @@ class AcceleratorConfig:
 
     def to_dict(self):
         return copy.deepcopy(self.__dict__)
-
-    def to_kwargs(self):
-        """
-        Returns a dictionary containing the attributes with values different from the default of this class.
-        """
-        default_dict = self.__class__().to_dict()
-        this_dict = self.to_dict()
-        return {k: v for k, v in this_dict.items() if default_dict[k] != v}

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1734,7 +1734,7 @@ class TrainingArguments:
 
         if isinstance(self.accelerator_config, str):
             self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
-        if self.dispatch_batches:
+        if self.dispatch_batches is not None:
             warnings.warn(
                 "Using `--dispatch_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
                 " `--accelerator_config {'dispatch_batches':VALUE} instead",
@@ -1742,7 +1742,7 @@ class TrainingArguments:
             )
             self.accelerator_config["dispatch_batches"] = self.dispatch_batches
 
-        if self.split_batches:
+        if self.split_batches is not None:
             warnings.warn(
                 "Using `--split_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
                 " `--accelerator_config {'split_batches':VALUE} instead",

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1836,12 +1836,6 @@ class TrainingArguments:
                 f"{self.hub_model_id}).",
                 FutureWarning,
             )
-        if self.split_batches is not None:
-            warnings.warn(
-                "using `split_batches` is deprecated and will be removed in version 5"
-                " of 🤗 Transformers. Use the `accelerator_config` argument instead.",
-                FutureWarning,
-            )
 
     def __str__(self):
         self_as_dict = asdict(self)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -28,7 +28,6 @@ from huggingface_hub import get_full_repo_name
 from packaging import version
 
 from .debug_utils import DebugOption
-from .trainer_pt_utils import AcceleratorConfig
 from .trainer_utils import (
     EvaluationStrategy,
     FSDPOption,
@@ -70,6 +69,7 @@ if is_torch_available():
 if is_accelerate_available():
     from accelerate.state import AcceleratorState, PartialState
     from accelerate.utils import DistributedType
+    from .trainer_pt_utils import AcceleratorConfig
 
 if is_torch_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2208,6 +2208,9 @@ class TrainingArguments:
                 d[k] = [x.value for x in v]
             if k.endswith("_token"):
                 d[k] = f"<{k.upper()}>"
+            # Handle the accelerator_config if passed
+            if is_accelerate_available() and isinstance(v, AcceleratorConfig):
+                d[k] = v.to_dict()
         return d
 
     def to_json_string(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1732,11 +1732,12 @@ class TrainingArguments:
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "true")
 
-        if not isinstance(self.accelerator_config, (AcceleratorConfig, dict)):
-            if self.accelerator_config is None:
-                self.accelerator_config = AcceleratorConfig()
-            else:
-                self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
+        if is_accelerate_available():
+            if not isinstance(self.accelerator_config, (AcceleratorConfig, dict)):
+                if self.accelerator_config is None:
+                    self.accelerator_config = AcceleratorConfig()
+                else:
+                    self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
         if self.dispatch_batches is not None:
             warnings.warn(
                 "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1732,10 +1732,11 @@ class TrainingArguments:
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "true")
 
-        if isinstance(self.accelerator_config, str):
-            self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
-        elif self.accelerator_config is None:
-            self.accelerator_config = AcceleratorConfig()
+        if not isinstance(self.accelerator_config, (AcceleratorConfig, dict)):
+            if self.accelerator_config is None:
+                self.accelerator_config = AcceleratorConfig()
+            else:
+                self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
         if self.dispatch_batches is not None:
             warnings.warn(
                 "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -28,6 +28,7 @@ from huggingface_hub import get_full_repo_name
 from packaging import version
 
 from .debug_utils import DebugOption
+from .trainer_pt_utils import AcceleratorConfig
 from .trainer_utils import (
     EvaluationStrategy,
     FSDPOption,
@@ -487,6 +488,32 @@ class TrainingArguments:
             Use [Deepspeed](https://github.com/microsoft/deepspeed). This is an experimental feature and its API may
             evolve in the future. The value is either the location of DeepSpeed json config file (e.g.,
             `ds_config.json`) or an already loaded json file as a `dict`"
+
+        accelerator_config (`str`, `dict`, or `AcceleratorConfig`, *optional*):
+            Config to be used with the internal `Accelerator` implementation. The value is either a location of
+            accelerator json config file (e.g., `accelerator_config.json`), an already loaded json file as `dict`,
+            or an instance of [`~trainer_pt_utils.AcceleratorConfig`].
+
+            A list of config and its options:
+                - split_batches (`bool`, *optional*, defaults to `False`):
+                    Whether or not the accelerator should split the batches yielded by the dataloaders across the devices. If
+                    `True` the actual batch size used will be the same on any kind of distributed processes, but it must be a
+                    round multiple of the `num_processes` you are using. If `False`, actual batch size used will be the one set
+                    in your script multiplied by the number of processes.
+                - dispatch_batches (`bool`, *optional*):
+                    If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process
+                    and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose
+                    underlying dataset is an `IterableDataset`, `False` otherwise.
+                - even_batches (`bool`, *optional*, defaults to `True`):
+                    If set to `True`, in cases where the total batch size across all processes does not exactly divide the
+                    dataset, samples at the start of the dataset will be duplicated so the batch can be divided equally among
+                    all workers.
+                - use_seedable_sampler (`bool`, *optional*, defaults to `True`):
+                    Whether or not use a fully seedable random sampler ([`accelerate.data_loader.SeedableRandomSampler`]). Ensures
+                    training results are fully reproducable using a different sampling technique. While seed-to-seed results
+                    may differ, on average the differences are neglible when using multiple different seeds to compare. Should
+                    also be ran with [`~utils.set_seed`] for the best results.
+
         label_smoothing_factor (`float`, *optional*, defaults to 0.0):
             The label smoothing factor to use. Zero means no label smoothing, otherwise the underlying onehot-encoded
             labels are changed from 0s and 1s to `label_smoothing_factor/num_labels` and `1 - label_smoothing_factor +
@@ -1085,6 +1112,16 @@ class TrainingArguments:
         },
     )
     # Do not touch this type annotation or it will stop working in CLI
+    accelerator_config: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Config to be used with the internal Accelerator object initializtion. The value is either a "
+                "accelerator json config file (e.g., `accelerator_config.json`) or an already loaded json file as `dict`."
+            )
+        },
+    )
+    # Do not touch this type annotation or it will stop working in CLI
     deepspeed: Optional[str] = field(
         default=None,
         metadata={
@@ -1282,20 +1319,12 @@ class TrainingArguments:
 
     dispatch_batches: Optional[bool] = field(
         default=None,
-        metadata={
-            "help": "Whether to dispatch batches across devices in distributed training. If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process "
-            "and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose"
-            "underlying dataset is an `IterableDataset`, `False` otherwise."
-        },
+        metadata={"help": "Deprecated. Pass {'dispatch_batches':VALUE} to `accelerator_config`."},
     )
 
     split_batches: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Whether or not the accelerator should split the batches yielded by the dataloaders across the devices during distributed training. If"
-            "set to `True`, the actual batch size used will be the same on any kind of distributed processes, but it must be a"
-            "round multiple of the number of processes you are using (such as GPUs)."
-        },
+        default=None,
+        metadata={"help": "Deprecated. Pass {'split_batches':True} to `accelerator_config`."},
     )
 
     include_tokens_per_second: Optional[bool] = field(
@@ -1702,6 +1731,24 @@ class TrainingArguments:
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "true")
 
+        if isinstance(self.accelerator_config, str):
+            self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
+        if self.dispatch_batches:
+            warnings.warn(
+                "Using `--dispatch_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
+                " `--accelerator_config {'dispatch_batches':VALUE} instead",
+                FutureWarning,
+            )
+            self.accelerator_config["dispatch_batches"] = self.dispatch_batches
+
+        if self.split_batches:
+            warnings.warn(
+                "Using `--split_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
+                " `--accelerator_config {'split_batches':VALUE} instead",
+                FutureWarning,
+            )
+            self.accelerator_config["split_batches"] = self.split_batches
+
         if self.tpu_metrics_debug:
             warnings.warn(
                 "using `--tpu_metrics_debug` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
@@ -1787,6 +1834,12 @@ class TrainingArguments:
                 "`--push_to_hub_organization` is deprecated and will be removed in version 5 of 🤗 Transformers. Use "
                 "`--hub_model_id` instead and pass the full repo name to this argument (in this case "
                 f"{self.hub_model_id}).",
+                FutureWarning,
+            )
+        if self.split_batches is not None:
+            warnings.warn(
+                "using `split_batches` is deprecated and will be removed in version 5"
+                " of 🤗 Transformers. Use the `accelerator_config` argument instead.",
                 FutureWarning,
             )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1734,6 +1734,8 @@ class TrainingArguments:
 
         if isinstance(self.accelerator_config, str):
             self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
+        elif self.accelerator_config is None:
+            self.accelerator_config = AcceleratorConfig()
         if self.dispatch_batches is not None:
             warnings.warn(
                 "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1738,21 +1738,21 @@ class TrainingArguments:
                     self.accelerator_config = AcceleratorConfig()
                 else:
                     self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
-        if self.dispatch_batches is not None:
-            warnings.warn(
-                "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
-                " `--accelerator_config {'dispatch_batches':VALUE} instead",
-                FutureWarning,
-            )
-            self.accelerator_config["dispatch_batches"] = self.dispatch_batches
+            if self.dispatch_batches is not None:
+                warnings.warn(
+                    "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
+                    " `--accelerator_config {'dispatch_batches':VALUE} instead",
+                    FutureWarning,
+                )
+                self.accelerator_config["dispatch_batches"] = self.dispatch_batches
 
-        if self.split_batches is not None:
-            warnings.warn(
-                "Using `--split_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
-                " `--accelerator_config {'split_batches':VALUE} instead",
-                FutureWarning,
-            )
-            self.accelerator_config["split_batches"] = self.split_batches
+            if self.split_batches is not None:
+                warnings.warn(
+                    "Using `--split_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
+                    " `--accelerator_config {'split_batches':VALUE} instead",
+                    FutureWarning,
+                )
+                self.accelerator_config["split_batches"] = self.split_batches
 
         if self.tpu_metrics_debug:
             warnings.warn(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -69,6 +69,7 @@ if is_torch_available():
 if is_accelerate_available():
     from accelerate.state import AcceleratorState, PartialState
     from accelerate.utils import DistributedType
+
     from .trainer_pt_utils import AcceleratorConfig
 
 if is_torch_tpu_available(check_device=False):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1736,7 +1736,7 @@ class TrainingArguments:
             self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
         if self.dispatch_batches is not None:
             warnings.warn(
-                "Using `--dispatch_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
+                "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
                 " `--accelerator_config {'dispatch_batches':VALUE} instead",
                 FutureWarning,
             )
@@ -1744,7 +1744,7 @@ class TrainingArguments:
 
         if self.split_batches is not None:
             warnings.warn(
-                "Using `--split_batches` is deprecated and will be removed in version 5 of 🤗 Transformers. Use"
+                "Using `--split_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
                 " `--accelerator_config {'split_batches':VALUE} instead",
                 FutureWarning,
             )

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2479,6 +2479,27 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertEqual(trainer.accelerator.even_batches, False)
             self.assertEqual(trainer.accelerator.use_seedable_sampler, False)
 
+    def test_accelerator_config_from_partial(self):
+        # Checks that accelerator kwargs can be passed through
+        # and the accelerator is initialized respectively
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = RegressionModelConfig(a=1.5, b=2.5)
+            model = RegressionPreTrainedModel(config)
+            eval_dataset = SampleIterableDataset()
+
+            # Leaves one option as something *not* basic
+            args = RegressionTrainingArguments(
+                output_dir=tmp_dir,
+                accelerator_config={
+                    "split_batches": True,
+                },
+            )
+            trainer = Trainer(model=model, args=args, eval_dataset=eval_dataset)
+            self.assertEqual(trainer.accelerator.split_batches, True)
+            self.assertEqual(trainer.accelerator.dispatch_batches, None)
+            self.assertEqual(trainer.accelerator.even_batches, True)
+            self.assertEqual(trainer.accelerator.use_seedable_sampler, True)
+
     def test_accelerator_config_from_dict_with_deprecated_args(self):
         # Checks that accelerator kwargs can be passed through
         # and the accelerator is initialized respectively

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2413,6 +2413,23 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             execute_subprocess_async(command)
             # successful return here == success - any errors would have caused an error or a timeout in the sub-call
 
+    def test_accelerator_config_empty(self):
+        # Checks that a config can be made with the defaults if not passed
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = RegressionModelConfig(a=1.5, b=2.5)
+            model = RegressionPreTrainedModel(config)
+            eval_dataset = SampleIterableDataset()
+
+            # Leaves one option as something *not* basic
+            args = RegressionTrainingArguments(
+                output_dir=tmp_dir,
+            )
+            trainer = Trainer(model=model, args=args, eval_dataset=eval_dataset)
+            self.assertEqual(trainer.accelerator.split_batches, False)
+            self.assertEqual(trainer.accelerator.dispatch_batches, None)
+            self.assertEqual(trainer.accelerator.even_batches, True)
+            self.assertEqual(trainer.accelerator.use_seedable_sampler, True)
+
     def test_accelerator_config_from_dict(self):
         # Checks that accelerator kwargs can be passed through
         # and the accelerator is initialized respectively

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -83,7 +83,6 @@ from transformers.testing_utils import (
     torch_device,
 )
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-from transformers.trainer_pt_utils import AcceleratorConfig
 from transformers.trainer_utils import PREFIX_CHECKPOINT_DIR, HPSearchBackend, get_last_checkpoint
 from transformers.training_args import OptimizerNames
 from transformers.utils import (
@@ -119,6 +118,7 @@ if is_torch_available():
         TrainerState,
     )
     from transformers.modeling_utils import unwrap_model
+    from transformers.trainer_pt_utils import AcceleratorConfig
 
     if is_safetensors_available():
         import safetensors.torch

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2534,6 +2534,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             trainer = Trainer(model=model, args=args, eval_dataset=eval_dataset)
             self.assertEqual(trainer.accelerator.split_batches, True)
             self.assertEqual(trainer.accelerator.even_batches, False)
+            self.assertEqual(trainer.accelerator.dispatch_batches, None)
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

This PR centralizes all arguments for the `Accelerator` not covered by `fsdp_config` and `deepspeed_config` into a singular dataclass that users can pass in as a json file or through raw CLI param args.

I *think* I have the CLI args configured right? But I'm not 100% sure. Advice on how to check that would be appreciated!

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @LysandreJik 