### PR TITLE
Remove deprecated eager_serving fn

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1214,8 +1214,7 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
     def input_signature(self) -> Dict[str, tf.TensorSpec]:
         """
         This property should return a dict mapping input names to tf.TensorSpec objects, representing the expected
-        shape and dtype for model inputs. It is used for both serving and for generating the dummy inputs used to build
-        the model.
+        shape and dtype for model inputs. It is used for both serving and for generating dummy inputs.
         """
         model_inputs = list(inspect.signature(self.call).parameters)
         sig = {}

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1210,22 +1210,6 @@ class TFPreTrainedModel(tf.keras.Model, TFModelUtilsMixin, TFGenerationMixin, Pu
 
         return self.serving_output(output)
 
-    def eager_serving(self, inputs):
-        """
-        Method used for serving the model. This method is deprecated, and will be removed.
-
-        Args:
-            inputs (`Dict[str, tf.Tensor]`):
-                The input of the saved model as a dictionary of tensors.
-        """
-        warnings.warn(
-            "The function `eager_serving` is deprecated and will be removed in version 4.32.0 of Transformers",
-            FutureWarning,
-        )
-        output = self.call(inputs)
-
-        return self.serving_output(output)
-
     @property
     def input_signature(self) -> Dict[str, tf.TensorSpec]:
         """


### PR DESCRIPTION
The `eager_serving` method on our TF models was deprecated some time ago, and can now be removed - it was never part of the public API anyway!

EDIT: Throwing in a quick fix to the nearby `input_signature` docstring while I'm here