### PR TITLE
Verify if output has logits or prediction logits in fill-mask pipeline

### DIFF
--- a/src/transformers/pipelines/fill_mask.py
+++ b/src/transformers/pipelines/fill_mask.py
@@ -133,7 +133,10 @@ class FillMaskPipeline(Pipeline):
         if target_ids is not None and target_ids.shape[0] < top_k:
             top_k = target_ids.shape[0]
         input_ids = model_outputs["input_ids"][0]
-        outputs = model_outputs["logits"]
+        if model_outputs.get("logits") is not None:
+            outputs = model_outputs["logits"]
+        elif model_outputs.get("prediction_logits") is not None:
+            outputs = model_outputs["prediction_logits"]
 
         if self.framework == "tf":
             masked_index = tf.where(input_ids == self.tokenizer.mask_token_id).numpy()[:, 0]


### PR DESCRIPTION
# What does this PR do?

It checks if the output has the key "logits" or "prediction_logits" to avoid breaking the fill-mask pipeline for some models like BertForPreTraining that returns:

```
return BertForPreTrainingOutput(
            loss=total_loss,
            prediction_logits=prediction_scores,
            seq_relationship_logits=seq_relationship_score,
            hidden_states=outputs.hidden_states,
            attentions=outputs.attentions,
        )
```

Error without this change:

<img width="1122" alt="image" src="https://github.com/huggingface/transformers/assets/27240528/a7491281-db09-4b23-a795-5f102ec9d911">

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@ArthurZucker @younesbelkada