### PR TITLE
Stop confusing the TF compiler with ModelOutput objects

### DIFF
--- a/src/transformers/models/blip/modeling_tf_blip.py
+++ b/src/transformers/models/blip/modeling_tf_blip.py
@@ -1171,7 +1171,7 @@ class TFBlipForConditionalGeneration(TFBlipPreTrainedModel):
             attention_mask=attention_mask,
             encoder_hidden_states=image_embeds,
             labels=labels,
-            return_dict=return_dict,
+            return_dict=None,
             training=training,
         )
 
@@ -1179,12 +1179,19 @@ class TFBlipForConditionalGeneration(TFBlipPreTrainedModel):
             outputs = (outputs[0], outputs[1], image_embeds, vision_outputs[0]) + vision_outputs[2:]
             return tuple(output for output in outputs if output is not None)
 
-        if outputs.loss is not None and outputs.loss.shape.rank == 0:
-            outputs.loss = tf.reshape(outputs.loss, (1,))
+        if labels is not None:
+            loss = outputs[0]
+            logits = outputs[1]
+        else:
+            loss = None
+            logits = outputs[0]
+
+        if loss is not None and loss.shape.rank == 0:
+            loss = tf.reshape(loss, (1,))
 
         return TFBlipForConditionalGenerationModelOutput(
-            loss=outputs.loss,
-            logits=outputs.logits,
+            loss=loss,
+            logits=logits,
             image_embeds=image_embeds,
             last_hidden_state=vision_outputs.last_hidden_state,
             hidden_states=vision_outputs.hidden_states,

--- a/src/transformers/models/blip/modeling_tf_blip.py
+++ b/src/transformers/models/blip/modeling_tf_blip.py
@@ -1171,7 +1171,7 @@ class TFBlipForConditionalGeneration(TFBlipPreTrainedModel):
             attention_mask=attention_mask,
             encoder_hidden_states=image_embeds,
             labels=labels,
-            return_dict=None,
+            return_dict=False,
             training=training,
         )
 

--- a/src/transformers/models/blip/modeling_tf_blip_text.py
+++ b/src/transformers/models/blip/modeling_tf_blip_text.py
@@ -1060,7 +1060,8 @@ class TFBlipTextLMHeadModel(TFBlipTextPreTrainedModel):
             labels = labels[:, 1:]
             labels = tf.reshape(labels, (-1,))
             # Keras won't give us label smoothing for sparse CE, so we de-sparsify things here
-            one_hot_labels = tf.one_hot(labels, depth=self.config.vocab_size, dtype=tf.float32)
+            # Use relu to clamp masked labels at 0 to avoid NaN (we will be zeroing those out later anyway)
+            one_hot_labels = tf.one_hot(tf.nn.relu(labels), depth=self.config.vocab_size, dtype=tf.float32)
             loss_fct = tf.keras.losses.CategoricalCrossentropy(from_logits=True, label_smoothing=0.1, reduction="none")
             masked_positions = tf.cast(tf.not_equal(labels, -100), dtype=tf.float32)
             lm_loss = loss_fct(one_hot_labels, shifted_prediction_scores)


### PR DESCRIPTION
The `test_saved_model_creation` test was failing for BLIP with the rather unusual symptom that the `loss` key of one of the intermediate outputs had transformed into a strange generator object. I still don't know **why** this happened, but it requires the following:

1) TF compilation (doesn't happen in eager mode)
2) `ModelOutput` dicts with `loss` as the first, optional key
3) The `ModelOutput` dicts have to be returned internally and then used in a subsequent step, rather than returned as the last step of the outermost model

Since this is a nightmare zone, I'm going to work around the issue by just setting `return_dict` to `False` when calling the sub-model and get the tensors we need from the output tuple instead. This should be invisible for our users!

I also slipped a quick fix into the loss calculation to avoid potential NaNs from passing negative labels to one of the built-in TF loss functions. Even though all the negative-label positions should be masked, NaNs tend to persist (because `nan * 0 == nan`).