### PR TITLE
Wrap Keras methods to support BatchEncoding

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -46,6 +46,7 @@ from .tf_utils import (
     save_attributes_to_hdf5_group,
     shape_list,
 )
+from .tokenization_utils_base import BatchEncoding
 from .utils import (
     SAFE_WEIGHTS_INDEX_NAME,
     SAFE_WEIGHTS_NAME,
@@ -1154,6 +1155,68 @@ class TFPreTrainedModel(keras.Model, TFModelUtilsMixin, TFGenerationMixin, PushT
 
     def get_config(self):
         return self.config.to_dict()
+
+    # TODO Matt: Rebase and replace all tf.keras with keras after merging the tf_keras PR.
+    #            Do not merge this before that PR is in!
+    @functools.wraps(tf.keras.Model.fit)
+    def fit(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().fit(*args, **kwargs)
+
+    @functools.wraps(tf.keras.Model.train_on_batch)
+    def train_on_batch(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().train_on_batch(*args, **kwargs)
+
+    @functools.wraps(tf.keras.Model.test_on_batch)
+    def test_on_batch(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().test_on_batch(*args, **kwargs)
+
+    @functools.wraps(tf.keras.Model.predict_on_batch)
+    def predict_on_batch(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().predict_on_batch(*args, **kwargs)
+
+    @functools.wraps(tf.keras.Model.predict)
+    def predict(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().predict(*args, **kwargs)
+
+    @functools.wraps(tf.keras.Model.evaluate)
+    def evaluate(self, *args, **kwargs):
+        # Convert HF BatchEncoding objects to dicts that Keras understands
+        if args and isinstance(args[0], BatchEncoding):
+            args = list(args)
+            args[0] = dict(args[0])
+        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+            kwargs["x"] = dict(kwargs["x"])
+        return super().evaluate(*args, **kwargs)
 
     @classmethod
     def from_config(cls, config, **kwargs):

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -41,12 +41,12 @@ from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
 from .generation import GenerationConfig, TFGenerationMixin
 from .tf_utils import (
+    convert_batch_encoding,
     expand_1d,
     load_attributes_from_hdf5_group,
     save_attributes_to_hdf5_group,
     shape_list,
 )
-from .tokenization_utils_base import BatchEncoding
 from .utils import (
     SAFE_WEIGHTS_INDEX_NAME,
     SAFE_WEIGHTS_NAME,
@@ -1160,62 +1160,32 @@ class TFPreTrainedModel(keras.Model, TFModelUtilsMixin, TFGenerationMixin, PushT
     #            Do not merge this before that PR is in!
     @functools.wraps(tf.keras.Model.fit)
     def fit(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().fit(*args, **kwargs)
 
     @functools.wraps(tf.keras.Model.train_on_batch)
     def train_on_batch(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().train_on_batch(*args, **kwargs)
 
     @functools.wraps(tf.keras.Model.test_on_batch)
     def test_on_batch(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().test_on_batch(*args, **kwargs)
 
     @functools.wraps(tf.keras.Model.predict_on_batch)
     def predict_on_batch(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().predict_on_batch(*args, **kwargs)
 
     @functools.wraps(tf.keras.Model.predict)
     def predict(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().predict(*args, **kwargs)
 
     @functools.wraps(tf.keras.Model.evaluate)
     def evaluate(self, *args, **kwargs):
-        # Convert HF BatchEncoding objects to dicts that Keras understands
-        if args and isinstance(args[0], BatchEncoding):
-            args = list(args)
-            args[0] = dict(args[0])
-        elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
-            kwargs["x"] = dict(kwargs["x"])
+        args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().evaluate(*args, **kwargs)
 
     @classmethod

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -1156,34 +1156,32 @@ class TFPreTrainedModel(keras.Model, TFModelUtilsMixin, TFGenerationMixin, PushT
     def get_config(self):
         return self.config.to_dict()
 
-    # TODO Matt: Rebase and replace all tf.keras with keras after merging the tf_keras PR.
-    #            Do not merge this before that PR is in!
-    @functools.wraps(tf.keras.Model.fit)
+    @functools.wraps(keras.Model.fit)
     def fit(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().fit(*args, **kwargs)
 
-    @functools.wraps(tf.keras.Model.train_on_batch)
+    @functools.wraps(keras.Model.train_on_batch)
     def train_on_batch(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().train_on_batch(*args, **kwargs)
 
-    @functools.wraps(tf.keras.Model.test_on_batch)
+    @functools.wraps(keras.Model.test_on_batch)
     def test_on_batch(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().test_on_batch(*args, **kwargs)
 
-    @functools.wraps(tf.keras.Model.predict_on_batch)
+    @functools.wraps(keras.Model.predict_on_batch)
     def predict_on_batch(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().predict_on_batch(*args, **kwargs)
 
-    @functools.wraps(tf.keras.Model.predict)
+    @functools.wraps(keras.Model.predict)
     def predict(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().predict(*args, **kwargs)
 
-    @functools.wraps(tf.keras.Model.evaluate)
+    @functools.wraps(keras.Model.evaluate)
     def evaluate(self, *args, **kwargs):
         args, kwargs = convert_batch_encoding(*args, **kwargs)
         return super().evaluate(*args, **kwargs)

--- a/src/transformers/tf_utils.py
+++ b/src/transformers/tf_utils.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Union
 import numpy as np
 import tensorflow as tf
 
+from .tokenization_utils_base import BatchEncoding
 from .utils import logging
 
 
@@ -253,3 +254,13 @@ def expand_1d(data):
         return t
 
     return tf.nest.map_structure(_expand_single_1d_tensor, data)
+
+
+def convert_batch_encoding(*args, **kwargs):
+    # Convert HF BatchEncoding objects in the inputs to dicts that Keras understands
+    if args and isinstance(args[0], BatchEncoding):
+        args = list(args)
+        args[0] = dict(args[0])
+    elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+        kwargs["x"] = dict(kwargs["x"])
+    return args, kwargs

--- a/src/transformers/tf_utils.py
+++ b/src/transformers/tf_utils.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Union
 import numpy as np
 import tensorflow as tf
 
+from .feature_extraction_utils import BatchFeature
 from .tokenization_utils_base import BatchEncoding
 from .utils import logging
 
@@ -257,10 +258,10 @@ def expand_1d(data):
 
 
 def convert_batch_encoding(*args, **kwargs):
-    # Convert HF BatchEncoding objects in the inputs to dicts that Keras understands
-    if args and isinstance(args[0], BatchEncoding):
+    # Convert HF BatchEncoding/BatchFeature objects in the inputs to dicts that Keras understands
+    if args and isinstance(args[0], (BatchEncoding, BatchFeature)):
         args = list(args)
         args[0] = dict(args[0])
-    elif "x" in kwargs and isinstance(kwargs["x"], BatchEncoding):
+    elif "x" in kwargs and isinstance(kwargs["x"], (BatchEncoding, BatchFeature)):
         kwargs["x"] = dict(kwargs["x"])
     return args, kwargs


### PR DESCRIPTION
One last Keras PR before I go back to chat templates - a recurring annoyance that I (and the forum users) have always had with our Keras models is that our tokenizers output `BatchEncoding` by default, which behaves like a mixed dict/list. Keras doesn't understand this at all and fails to handle it when passed to `fit()` or `predict()`. The result is that you have to manually remember to convert tokenizer outputs to a dict or you get a confusing error.

The right time to do this was about two and a half years ago, but late is better than never! This PR wraps the Keras methods to do that transparently, without changing other behaviour. Note that because we're changing the exact Keras we're importing, this PR shouldn't be merged before the `tf_keras` PR is in.