### PR TITLE
[Flax] Update no init test for Flax v0.7.1

### DIFF
--- a/tests/test_modeling_flax_common.py
+++ b/tests/test_modeling_flax_common.py
@@ -984,7 +984,7 @@ class FlaxModelTesterMixin:
 
             # Check if we params can be properly initialized when calling init_weights
             params = model.init_weights(model.key, model.input_shape)
-            self.assertIsInstance(params, FrozenDict)
+            assert isinstance(params, (dict, FrozenDict)), f"params are not an instance of {FrozenDict}"
             # Check if all required parmas are initialized
             keys = set(flatten_dict(unfreeze(params)).keys())
             self.assertTrue(all(k in keys for k in model.required_params))


### PR DESCRIPTION
# What does this PR do?

PR to unblock new model additions in Flax. As of version 0.7.1, Flax defaults to returning regular dictionaries with the methods .init and .apply, not frozen dictionaries as was the case before: https://github.com/google/flax/discussions/3191.

This means our "no automatic init" method returns regular dicts, instead of frozen dicts. Until we merge a bigger change to bring ourselves in-line with Flax (_c.f._ https://github.com/huggingface/transformers/issues/28368#issue-2068557686), we need to update our "no automatic init" test to account for both possible dicts, otherwise we'll have a red CI.
