### PR TITLE
Resolve DeepSpeed cannot resume training with PeftModel

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -458,7 +458,7 @@ def deepspeed_load_checkpoint(
         # this magically updates self.optimizer and self.lr_scheduler
         load_path, _ = deepspeed_engine.load_checkpoint(
             checkpoint_path,
-            load_module_strict=load_module_strict,
+            load_module_strict=False,
             load_optimizer_states=True,
             load_lr_scheduler_states=True,
         )

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -458,7 +458,7 @@ def deepspeed_load_checkpoint(
         # this magically updates self.optimizer and self.lr_scheduler
         load_path, _ = deepspeed_engine.load_checkpoint(
             checkpoint_path,
-            load_module_strict=False,
+            load_module_strict=load_module_strict,
             load_optimizer_states=True,
             load_lr_scheduler_states=True,
         )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1719,7 +1719,9 @@ class Trainer:
         # ckpt loading
         if resume_from_checkpoint is not None:
             if self.is_deepspeed_enabled:
-                deepspeed_load_checkpoint(self.model_wrapped, resume_from_checkpoint)
+                deepspeed_load_checkpoint(
+                    self.model_wrapped, resume_from_checkpoint, load_module_strict=not _is_peft_model(model)
+                )
             elif is_sagemaker_mp_enabled() or self.is_fsdp_enabled:
                 self._load_from_checkpoint(resume_from_checkpoint, self.model_wrapped)
 
@@ -2179,7 +2181,9 @@ class Trainer:
 
         model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
         if self.is_deepspeed_enabled:
-            deepspeed_load_checkpoint(self.model_wrapped, self.state.best_model_checkpoint)
+            deepspeed_load_checkpoint(
+                self.model_wrapped, self.state.best_model_checkpoint, load_module_strict=not _is_peft_model(model),
+            )
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(
                 self.accelerator.state.fsdp_plugin, self.accelerator, model, self.state.best_model_checkpoint

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1720,7 +1720,7 @@ class Trainer:
         if resume_from_checkpoint is not None:
             if self.is_deepspeed_enabled:
                 deepspeed_load_checkpoint(
-                    self.model_wrapped, resume_from_checkpoint, load_module_strict=not _is_peft_model(model)
+                    self.model_wrapped, resume_from_checkpoint, load_module_strict=not _is_peft_model(self.model)
                 )
             elif is_sagemaker_mp_enabled() or self.is_fsdp_enabled:
                 self._load_from_checkpoint(resume_from_checkpoint, self.model_wrapped)
@@ -2182,7 +2182,7 @@ class Trainer:
         model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
         if self.is_deepspeed_enabled:
             deepspeed_load_checkpoint(
-                self.model_wrapped, self.state.best_model_checkpoint, load_module_strict=not _is_peft_model(model),
+                self.model_wrapped, self.state.best_model_checkpoint, load_module_strict=not _is_peft_model(self.model),
             )
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2182,7 +2182,9 @@ class Trainer:
         model = self.model_wrapped if is_sagemaker_mp_enabled() else self.model
         if self.is_deepspeed_enabled:
             deepspeed_load_checkpoint(
-                self.model_wrapped, self.state.best_model_checkpoint, load_module_strict=not _is_peft_model(self.model),
+                self.model_wrapped,
+                self.state.best_model_checkpoint,
+                load_module_strict=not _is_peft_model(self.model),
             )
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(


### PR DESCRIPTION
Hi all,

I found an issue about resume ft **PeftModel** with **DeepSpeed** while I using `accelerate launch` to follow [zephyr-7b-beta recipes](https://github.com/huggingface/alignment-handbook/tree/c74ed111710d57f563cfbf1806cfb8f07dd3dc67/recipes/zephyr-7b-beta) with **qlora**. 
In details, the process will be crashing on load resume checkpoint with **DeepSpeed** with **PeftModel**. I referred to https://github.com/ymcui/Chinese-LLaMA-Alpaca/issues/559#issuecomment-1585948697 and created a PR to resolve this issue. I was updated and it works accurately on my fork.

Thanks for review @pacman100 @muellerzr 
