### PR TITLE
Mark test_constrained_beam_search_generate as flaky

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1293,6 +1293,7 @@ class GenerationTesterMixin:
                     output, input_ids, model.config, num_return_sequences=num_return_sequences * beam_scorer.num_beams
                 )
 
+    @is_flaky()
     def test_constrained_beam_search_generate(self):
         for model_class in self.all_generative_model_classes:
             config, input_ids, attention_mask, max_length = self._get_input_ids_and_config()

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1293,6 +1293,7 @@ class GenerationTesterMixin:
                     output, input_ids, model.config, num_return_sequences=num_return_sequences * beam_scorer.num_beams
                 )
 
+    # TODO: @gante
     @is_flaky()
     def test_constrained_beam_search_generate(self):
         for model_class in self.all_generative_model_classes:


### PR DESCRIPTION
# What does this PR do?

Test occasionally fails on CI runs e.g. https://app.circleci.com/pipelines/github/huggingface/transformers/83241/workflows/6cb424b9-229b-412f-abfd-71cc6cfc7392/jobs/1073186/tests#failed-test-0

Marking as flaky to trigger retries to help prevent failing CI runs on unrelated PRs.