### PR TITLE
Pin pytest version <8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ _deps = [
     "psutil",
     "pyyaml>=5.1",
     "pydantic",
-    "pytest>=7.2.0<8.0.0",
+    "pytest>=7.2.0,<8.0.0",
     "pytest-timeout",
     "pytest-xdist",
     "python>=3.8.0",

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ _deps = [
     "psutil",
     "pyyaml>=5.1",
     "pydantic",
-    "pytest>=7.2.0",
+    "pytest>=7.2.0<8.0.0",
     "pytest-timeout",
     "pytest-xdist",
     "python>=3.8.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -51,7 +51,7 @@ deps = {
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic",
-    "pytest": "pytest>=7.2.0",
+    "pytest": "pytest>=7.2.0,<8.0.0",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",
     "python": "python>=3.8.0",


### PR DESCRIPTION
# What does this PR do?

pytest released a new major version, 8 two days ago: https://pypi.org/project/pytest/8.0.0/

This breaks doctest runs on CI e.g. https://app.circleci.com/pipelines/github/huggingface/transformers/83241/workflows/7ca5119f-b434-4c93-89fb-28378e63c449/jobs/1073188

Pinning until we make our doctests compatible. 