### PR TITLE
#27237

### DIFF
--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1228,8 +1228,9 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
                 Shift the lags by this amount back.
         """
         sequence_length = sequence.shape[1]
-        indices = [lag - shift for lag in self.config.lags_sequence]
-
+        # (Khalid Oublal) -> addressed the issue regarding the scenario where lag equals 0.
+        # The previous implementation was: indices = [lag - shift for lag in self.config.lags_sequence]
+        indices = [lag - shift if lag > 0 else 0 for lag in self.config.lags_sequence]
         if max(indices) + subsequences_length > sequence_length:
             raise ValueError(
                 f"lags cannot go further than history length, found lag {max(indices)} "

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1228,8 +1228,6 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
                 Shift the lags by this amount back.
         """
         sequence_length = sequence.shape[1]
-        # (Khalid Oublal) -> addressed the issue regarding the scenario where lag equals 0.
-        # The previous implementation was: indices = [lag - shift for lag in self.config.lags_sequence]
         indices = [lag - shift if lag > 0 else 0 for lag in self.config.lags_sequence]
         if max(indices) + subsequences_length > sequence_length:
             raise ValueError(


### PR DESCRIPTION
#27237  Solved ✅

I suggest a resolution for situations where ``sequence_lags=[0]``. In such instances, the length of the context past sequence aligns with the overall sequence length. Let me provide some clarification on this matter

The issue stems from line `1230` in `modeling_time_series_transformer.py.` In cases where the lag parameter is set to 0, the index is assigned a value of -1. This results in only one data point being lagged, creating a discrepancy when using model.generate(). For example, if the size is 48, selecting a lag of [0] produces 49, rendering it unsuitable for model.generate().

```
sequence_length = sequence.shape[1]
indices = [lag - shift for lag in self.config.lags_sequence]
if max(indices) + subsequences_length > sequence_length:
    raise ValueError(
        f"lags cannot go further than history length, found lag {max(indices)} "
        f"while history length is only {sequence_length}"
    )
```
We can modify the code as shown below to rectify index 0 when negative values are encountered ✅:
```
sequence_length = sequence.shape[1]
# (Khalid Oublal) -> addressed the issue regarding the scenario where lag equals 0.
# The previous implementation was: indices = [lag - shift for lag in self.config.lags_sequence]
indices = [lag - shift if lag > 0 else 0 for lag in self.config.lags_sequence]
if max(indices) + subsequences_length > sequence_length:
    raise ValueError(
        f"lags cannot go further than history length, found lag {max(indices)} "
        f"while history length is only {sequence_length}"
    )
```
### Check DataLoader

In the analysis below, it's evident that there are no lags indicated by `sequence_lags=[0]`. The length of the context in this batch matches the provided context length.

![Screenshot 2024-01-29 at 21 58 42](https://github.com/huggingface/transformers/assets/76509145/0079c3a8-eed6-4d82-bb41-fc6dcaf04a5a)

### Confirming Training Status

Below, it's apparent that the training is progressing smoothly. Some additional print statements were added to verify that the lags are 0, implying the indices should be `[0]`.

![Screenshot 2024-01-29 at 21 54 03](https://github.com/huggingface/transformers/assets/76509145/f159c725-ff81-4a11-89e0-5ef59ac0763e)

### Generating with `model.generate()`

Now, with `sequence_lags=[0]`, we observe that predictions can be made without any issues.

![Screenshot 2024-01-29 at 21 55 31](https://github.com/huggingface/transformers/assets/76509145/dfe7915b-8859-41ad-9664-f72f6c4754c7)

Best,
khalid oublal