### PR TITLE
added support for llama v2 and codellama in weight conversion for issue #28241

### DIFF
--- a/src/transformers/models/llama/convert_llama_weights_to_hf.py
+++ b/src/transformers/models/llama/convert_llama_weights_to_hf.py
@@ -103,7 +103,7 @@ def write_model(model_path, input_base_path, model_size, llama_version, tokenize
         max_position_embeddings = 16384
     elif llama_version == "v2":
         max_position_embeddings = 4096
-    else: # defaults to v1 LLaMa
+    else:  # defaults to v1 LLaMa
         max_position_embeddings = 2048
 
     tokenizer_class = LlamaTokenizer if LlamaTokenizerFast is None else LlamaTokenizerFast

--- a/src/transformers/models/llama/convert_llama_weights_to_hf.py
+++ b/src/transformers/models/llama/convert_llama_weights_to_hf.py
@@ -302,7 +302,7 @@ def main():
         "--llama_version",
         choices=["v1", "v2", "code"],
         help="Specifies which LLaMa version to use, as each version has a different maximum context length. LLaMa v1 has a maximum context length of 2048, LLaMa v2 has a maximum context length of 4096, and CodeLLaMa has a maximum context length of 16384. Defaults to v1.",
-    )    
+    )
     parser.add_argument(
         "--output_dir",
         help="Location to write HF model and tokenizer",


### PR DESCRIPTION
# What does this PR do?

This PR adds support for LLaMa V2 and CodeLLaMa while maintaining backwards compatibility for LLaMa V1 in the LLaMa-HuggingFace weight conversion script `src/transformers/models/llama/convert_llama_weights_to_hf.py`. This PR changes the max_position_embeddings for LLaMa V2 to 4096, and for CodeLLaMa to 16384, while maintaining a default max_position_embeddings of 2048 for LLaMa V1.



Fixes #28241 


## Who can review?

@ArthurZucker @amyeroberts 
