### PR TITLE
[`HfQuantizer`] Move it to "Developper guides"

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -130,15 +130,15 @@
   - local: custom_tools
     title: Custom Tools and Prompts
   - local: troubleshooting
-    title: Troubleshoot
+    title: Troubleshoot  
+  - local: hf_quantizer
+    title: Contribute new quantization method
   title: Developer guides
 - sections:
   - local: performance
     title: Overview
   - local: quantization
     title: Quantization
-  - local: hf_quantizer
-    title: Contribute new quantization method
   - sections:
     - local: perf_train_gpu_one
       title: Methods and tools for efficient training on a single GPU


### PR DESCRIPTION
# What does this PR do?

Move the "How to add a new quantization method" tutorial into "Developper Guide" which seems to be a better appropriate place for that tutorial rather than in "Performance and scalability"

cc @stevhliu   @ArthurZucker @amyeroberts 
