### PR TITLE
Fix transformers.utils.fx compatibility with torch<2.0

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -53,6 +53,7 @@ from ..models.auto.modeling_auto import (
     MODEL_FOR_ZERO_SHOT_IMAGE_CLASSIFICATION_MAPPING_NAMES,
     MODEL_MAPPING_NAMES,
 )
+from ..pytorch_utils import is_torch_greater_or_equal_than_2_0
 from ..utils import (
     ENV_VARS_TRUE_VALUES,
     TORCH_FX_REQUIRED_VERSION,
@@ -608,12 +609,16 @@ _MANUAL_META_OVERRIDES: Dict[Callable, Callable] = {
     torch.Tensor.unsqueeze: torch_tensor_unsqueeze,
     torch.unique_consecutive: torch_unique_consecutive,
     torch.nn.functional.one_hot: torch_nn_functional_one_hot,
-    torch.nn.functional.scaled_dot_product_attention: torch_nn_functional_scaled_dot_product_attention,
     torch.nn.MSELoss: torch_nn_mseloss,
     torch.nn.CrossEntropyLoss: torch_nn_crossentropyloss,
     torch.nn.BCEWithLogitsLoss: torch_nn_bcewithlogitsloss,
     operator.getitem: operator_getitem,
 }
+
+if is_torch_greater_or_equal_than_2_0:
+    _MANUAL_META_OVERRIDES[
+        torch.nn.functional.scaled_dot_product_attention
+    ] = torch_nn_functional_scaled_dot_product_attention
 
 
 class HFProxy(Proxy):


### PR DESCRIPTION
Fixes https://github.com/huggingface/transformers/issues/28690

Tested on 1.13 that `pytest tests/models/opt/ -k "test_torch_fx" -s -vvvvv` passes, while it is currently failing with torch<2.0 following https://github.com/huggingface/transformers/pull/28447 (`AttributeError: module 'torch.nn.functional' has no attribute 'scaled_dot_product_attention'`).