### PR TITLE
Prevent MLflow exception from disrupting training

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1036,7 +1036,7 @@ class MLflowCallback(TrainerCallback):
                         f'Trainer is attempting to log a value of "{v}" of type {type(v)} for key "{k}" as a metric. '
                         "MLflow's log_metric() only accepts float and int types so we dropped this attribute."
                     )
-            self._ml_flow.log_metrics(metrics=metrics, step=state.global_step)
+            self._ml_flow.log_metrics(metrics=metrics, step=state.global_step, synchronous=False)
 
     def on_train_end(self, args, state, control, **kwargs):
         if self._initialized and state.is_world_process_zero:


### PR DESCRIPTION
This PR prevents a training in progress from **being interrupted** due to a problem with the MLflow server (e.g., lack of connectivity) and will make the code more **faul-tolerant**, as also discussed in [this](https://github.com/mlflow/mlflow/issues/1550) MLflow issue.

This can be achieved by simply changing the `synchronous` parameter of `mlflow.log_metrics` to `False` (previously the default value was left, which is `True`)

In this way, as described in the [MLflow documentation](https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.log_metrics), the function logs the metrics asynchronously and return a future representing the logging operation, instead of blocking until the log is successful.