### PR TITLE
Further pin pytest version (in a temporary way)

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -513,7 +513,7 @@ doc_test_job = CircleCIJob(
         "pip install --upgrade --upgrade-strategy eager pip",
         "pip install -U --upgrade-strategy eager -e .[dev]",
         "pip install -U --upgrade-strategy eager -e git+https://github.com/huggingface/accelerate@main#egg=accelerate",
-        "pip install --upgrade --upgrade-strategy eager pytest pytest-sugar",
+        "pip install --upgrade --upgrade-strategy eager 'pytest<8.0.0' pytest-sugar",
         "pip install -U --upgrade-strategy eager 'natten<0.15.0'",
         "pip install -U --upgrade-strategy eager g2p-en",
         "find -name __pycache__ -delete",


### PR DESCRIPTION
# What does this PR do?

#28758 tried to pin `pytest<8.0.0` version, however, in `doc_test_job` job, there is a command 

> pip install --upgrade --upgrade-strategy eager pytest pytest-sugar

which bring it back to `8.0.0` again after the desired version being installed with `pip install -e .[dev]`.

This PR changes it to 

> pip install --upgrade --upgrade-strategy eager 'pytest<8.0.0' pytest-sugar

this is not a very ideal solution, but let's fix it quickly and I will see if I can have a better solution for the long term.