### PR TITLE
Ability to override clean_code_for_run

### DIFF
--- a/src/transformers/tools/agents.py
+++ b/src/transformers/tools/agents.py
@@ -315,6 +315,13 @@ class Agent:
         self.chat_state = {}
         self.cached_tools = None
 
+    def clean_code_for_run(self, result):
+        """
+        Override this method if you want to change the way the code is
+        cleaned for the `run` method.
+        """
+        return clean_code_for_run(result)
+
     def run(self, task, *, return_code=False, remote=False, **kwargs):
         """
         Sends a request to the agent.
@@ -339,7 +346,7 @@ class Agent:
         """
         prompt = self.format_prompt(task)
         result = self.generate_one(prompt, stop=["Task:"])
-        explanation, code = clean_code_for_run(result)
+        explanation, code = self.clean_code_for_run(result)
 
         self.log(f"==Explanation from the agent==\n{explanation}")
 

--- a/src/transformers/tools/evaluate_agent.py
+++ b/src/transformers/tools/evaluate_agent.py
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .agents import BASE_PYTHON_TOOLS, clean_code_for_chat, clean_code_for_run
+from .agents import BASE_PYTHON_TOOLS, clean_code_for_chat
 from .python_interpreter import InterpretorError, evaluate
 
 
@@ -554,7 +554,7 @@ def evaluate_agent(agent, batch_size=8, verbose=False, return_errors=False):
             problem = EVALUATION_TASKS[eval_idx[start_idx + idx]]
             if verbose:
                 print(f"====Task {start_idx + idx}====\n{batch_tasks[idx]}\n")
-            explanation, code = clean_code_for_run(result)
+            explanation, code = agent.clean_code_for_run(result)
 
             # Evaluate agent answer and code answer
             agent_answer = evaluate_code(code, problem.inputs, verbose=verbose)


### PR DESCRIPTION
# What does this PR do?

Adds an interface function called `clean_code_for_run` to the `Agent` class.
This function simply returns the results of `clean_code_for_run()`, which was happening on line 349.

The reason for this change is to allow developers to override the results of the `clean_code_for_run` function in an easy way.

Prior to this change, when I use `Agent` with the Mistral Instruct model, the following results are returned:

```
==Code generated by the agent==
result = add_tool(a=5, b=7)
print(f"The result is {result}")
```</s>
```

This would result in an eval error when executing the function. In order to work around this, I did the following:

```
from transformers import LocalAgent as LocalAgentBase


class LocalAgent(LocalAgentBase):
    def format_prompt(self, task, chat_mode=False):
        task = task.replace("```", "").replace("</s>", "")
        return task

    def run(self, task, *, return_code=False, remote=False, **kwargs):
        prompt = self.format_prompt(task)
        result = self.generate_one(prompt, stop=["Task:"])
        explanation, code = clean_code_for_run(result)

        self.log(f"==Explanation from the agent==\n{explanation}")

        """
        This entire class exists as a work around in order
        to run the following line of code. Without this, the evaluation
        will fail with Mistral Instruct (possibly with other models as well) 
        """
        code = code.replace("```", "").replace("</s>", "")

        self.log(f"\n\n==Code generated by the agent==\n{code}")
        if not return_code:
            self.log("\n\n==Result==")
            self.cached_tools = resolve_tools(code, self.toolbox, remote=remote, cached_tools=self.cached_tools)
            return evaluate(code, self.cached_tools, state=kwargs.copy())
        else:
            tool_code = get_tool_creation_code(code, self.toolbox, remote=remote)
            return f"{tool_code}\n{code}"
```

As you can see from the comments, this line:

`code = code.replace("```", "").replace("</s>", "")`

Is required in order to strip the undesired EOS characters. This may be an issue with Mistral Instruct specifically.

Rather than overriding the entire run method as shown above, this new update would allow me to do this instead:

```
from transformers import LocalAgent as LocalAgentBase


class LocalAgent(LocalAgentBase):
    def format_prompt(self, task, chat_mode=False):
        task = super().format_prompt(task, chat_mode=chat_mode)
        return task.replace("```", "").replace("</s>", "")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
