### PR TITLE
[`bnb`] Fix bnb slow tests

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -342,6 +342,8 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
         """
         output = copy.deepcopy(self.__dict__)
         output["bnb_4bit_compute_dtype"] = str(output["bnb_4bit_compute_dtype"]).split(".")[1]
+        output["load_in_4bit"] = self.load_in_4bit
+        output["load_in_8bit"] = self.load_in_8bit
 
         return output
 


### PR DESCRIPTION
# What does this PR do?

Fixes the current failing BNB slow tests on main: https://github.com/huggingface/transformers/actions/runs/7705429360/job/21003940543 

https://github.com/huggingface/transformers/pull/28266 broke the tests which has been merged right before the quantizer refactoring PR. 

Since the attributes `load_in_4bit` and `load_in_8bit` have been removed in favor of a property method, the fix is simply to explicitly pass them in the `to_dict` method.

cc @ArthurZucker 
