### PR TITLE
Make `is_torch_bf16_available_on_device` more strict

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -359,6 +359,14 @@ def is_torch_fp16_available_on_device(device):
     try:
         x = torch.zeros(2, 2, dtype=torch.float16).to(device)
         _ = x @ x
+
+        # At this moment, let's be strict of the check: check if `LayerNorm` is also supported on device, because many
+        # models use this layer.
+        batch, sentence_length, embedding_dim = 3, 4, 5
+        embedding = torch.randn(batch, sentence_length, embedding_dim, dtype=torch.float16, device=device)
+        layer_norm = torch.nn.LayerNorm(embedding_dim, dtype=torch.float16, device=device)
+        _ = layer_norm(embedding)
+
     except:  # noqa: E722
         # TODO: more precise exception matching, if possible.
         # most backends should return `RuntimeError` however this is not guaranteed.


### PR DESCRIPTION
# What does this PR do?

The layernorm op is required to be supported in order for this function to return `True`.


### detail
Previously, the function `is_torch_bf16_available_on_device` check
```python
        x = torch.zeros(2, 2, dtype=torch.float16).to(device)
        _ = x @ x
```
With torch < 2.2 on CPU, this will give

> RuntimeError: "addmm_impl_cpu_" not implemented for 'Half'

and `is_torch_bf16_available_on_device` returns `False`.

With torch 2.2, this doesn't fail and the function return `True`. However, many models use `LayerNorm` and this is still not supported by torch 2.2 on CPU. We then get many failures for fp16 tests on CircleCI (cpu only)

