### PR TITLE
`erfinv_` and `clamp_` ops do not exist in float16+cpu

### DIFF
--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -77,7 +77,7 @@ def _trunc_normal_(tensor, mean, std, a, b):
     # Use inverse cdf transform for normal distribution to get truncated
     # standard normal
     if tensor.dtype == torch.float16:
-        # The `erfinv_` op is not (yet?) defined in float16
+        # The `erfinv_` op is not (yet?) defined in float16+cpu
         tensor = tensor.to(torch.float32)
         tensor.erfinv_()
         tensor = tensor.to(torch.float16)
@@ -90,7 +90,7 @@ def _trunc_normal_(tensor, mean, std, a, b):
 
     # Clamp to ensure it's in the proper range
     if tensor.dtype == torch.float16:
-        # The `clamp_` op is not (yet?) defined in float16
+        # The `clamp_` op is not (yet?) defined in float16+cpu
         tensor = tensor.to(torch.float32)
         tensor.clamp_(min=a, max=b)
         tensor = tensor.to(torch.float16)

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -76,7 +76,13 @@ def _trunc_normal_(tensor, mean, std, a, b):
 
     # Use inverse cdf transform for normal distribution to get truncated
     # standard normal
-    tensor.erfinv_()
+    if tensor.dtype in [torch.bfloat16, torch.float16]:
+        og_dtype = tensor.dtype
+        tensor = tensor.to(torch.float32)
+        tensor.erfinv_()
+        tensor = tensor.to(og_dtype)
+    else:
+        tensor.erfinv_()
 
     # Transform to proper mean, std
     tensor.mul_(std * math.sqrt(2.0))


### PR DESCRIPTION
On cpu, some ops are not defined. This messes up a lot of init weights operations for siglip.
I know fp16 + CPU is weird and probably never happening in practise. As such, feel free to ignore this PR.

Reproduction case:
```python
from transformers import AutoModel, AutoConfig
import torch
config = AutoConfig.from_pretrained("google/siglip-so400m-patch14-384")
model = AutoModel.from_config(config, torch_dtype=torch.float16)
print(sum([m.sum().item() for m in model.parameters()])) # sanity check
```

I am using torch==2.0.1 (+ cu118).