### PR TITLE
Add missing None check for hf_quantizer

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3727,12 +3727,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 if param.device == torch.device("meta"):
                     value = torch.empty(*param.size(), dtype=target_dtype)
-                    if hf_quantizer is not None and (
+                    if (hf_quantizer is None or
                         getattr(hf_quantizer, "requires_parameters_quantization", False)
                         or not hf_quantizer.check_quantized_param(
                             model, param_value=value, param_name=key, state_dict={}
-                        )
-                    ):
+                        )):
                         set_module_tensor_to_device(model, key, "cpu", value)
                     else:
                         hf_quantizer.create_quantized_param(model, value, key, "cpu", state_dict)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3727,11 +3727,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 if param.device == torch.device("meta"):
                     value = torch.empty(*param.size(), dtype=target_dtype)
-                    if (hf_quantizer is None or
-                        getattr(hf_quantizer, "requires_parameters_quantization", False)
+                    if (
+                        hf_quantizer is None
+                        or getattr(hf_quantizer, "requires_parameters_quantization", False)
                         or not hf_quantizer.check_quantized_param(
                             model, param_value=value, param_name=key, state_dict={}
-                        )):
+                        )
+                    ):
                         set_module_tensor_to_device(model, key, "cpu", value)
                     else:
                         hf_quantizer.create_quantized_param(model, value, key, "cpu", state_dict)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3727,10 +3727,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
                 if param.device == torch.device("meta"):
                     value = torch.empty(*param.size(), dtype=target_dtype)
-                    if getattr(
-                        hf_quantizer, "requires_parameters_quantization", False
-                    ) or not hf_quantizer.check_quantized_param(
-                        model, param_value=value, param_name=key, state_dict={}
+                    if hf_quantizer is not None and (
+                        getattr(hf_quantizer, "requires_parameters_quantization", False)
+                        or not hf_quantizer.check_quantized_param(
+                            model, param_value=value, param_name=key, state_dict={}
+                        )
                     ):
                         set_module_tensor_to_device(model, key, "cpu", value)
                     else:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -304,7 +304,6 @@ class ModelUtilsTest(TestCasePlus):
 
     @require_accelerate
     def test_model_from_pretrained_with_none_quantization_config(self):
-        model = None
         # Needs a device_map for to enter the low_cpu_mem branch. We also load AutoModelForSequenceClassification
         # deliberately to enter the missing keys branch.
         model = AutoModelForSequenceClassification.from_pretrained(

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -305,7 +305,8 @@ class ModelUtilsTest(TestCasePlus):
     @require_accelerate
     def test_model_from_pretrained_with_none_quantization_config(self):
         model = None
-        # Needs device_map for low_cpu_mem trigger & missing keys in base model load to trigger.
+        # Needs a device_map for to enter the low_cpu_mem branch. We also load AutoModelForSequenceClassification
+        # deliberately to enter the missing keys branch.
         model = AutoModelForSequenceClassification.from_pretrained(
             TINY_MISTRAL, device_map="auto", quantization_config=None
         )

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -35,9 +35,9 @@ from transformers import (
     AutoConfig,
     AutoModel,
     AutoModelForSequenceClassification,
+    LlamaConfig,
     OwlViTForObjectDetection,
     PretrainedConfig,
-    LlamaConfig,
     is_torch_available,
     logging,
 )

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -35,7 +35,6 @@ from transformers import (
     AutoConfig,
     AutoModel,
     AutoModelForSequenceClassification,
-    LlamaConfig,
     OwlViTForObjectDetection,
     PretrainedConfig,
     is_torch_available,
@@ -203,7 +202,7 @@ if is_tf_available():
 
 TINY_T5 = "patrickvonplaten/t5-tiny-random"
 TINY_BERT_FOR_TOKEN_CLASSIFICATION = "hf-internal-testing/tiny-bert-for-token-classification"
-TINY_LLAMA = "seanmor5/tiny-llama-test"
+TINY_MISTRAL = "hf-internal-testing/tiny-random-MistralForCausalLM"
 
 
 def check_models_equal(model1, model2):
@@ -308,7 +307,7 @@ class ModelUtilsTest(TestCasePlus):
         model = None
         # Needs device_map for low_cpu_mem trigger & missing keys in base model load to trigger.
         model = AutoModelForSequenceClassification.from_pretrained(
-            TINY_LLAMA, config=LlamaConfig.from_pretrained(TINY_LLAMA), device_map="auto", quantization_config=None
+            TINY_MISTRAL, device_map="auto", quantization_config=None
         )
         self.assertIsNotNone(model)
 


### PR DESCRIPTION
Adds None check for hf_quantizer that otherwise can blow up when `from_pretrained` is called with `quanitization_config=None`.
