### PR TITLE
[`TorchFp8Quantizer`] Attempt to integrate `pytorch-labs/float8_experimental` in HF transformers

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1085,7 +1085,7 @@ _import_structure = {
         "is_vision_available",
         "logging",
     ],
-    "utils.quantization_config": ["AwqConfig", "BitsAndBytesConfig", "GPTQConfig"],
+    "utils.quantization_config": ["AwqConfig", "BitsAndBytesConfig", "GPTQConfig", "TorchFp8Config"],
 }
 
 # sentencepiece-backed objects

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -21,11 +21,13 @@ from ..utils.quantization_config import (
     GPTQConfig,
     QuantizationConfigMixin,
     QuantizationMethod,
+    TorchFp8Config,
 )
 from .quantizer_awq import AwqQuantizer
 from .quantizer_bnb_4bit import Bnb4BitHfQuantizer
 from .quantizer_bnb_8bit import Bnb8BitHfQuantizer
 from .quantizer_gptq import GptqHfQuantizer
+from .quantizer_torch_fp8 import TorchFp8Quantizer
 
 
 AUTO_QUANTIZER_MAPPING = {
@@ -33,6 +35,7 @@ AUTO_QUANTIZER_MAPPING = {
     "bitsandbytes_4bit": Bnb4BitHfQuantizer,
     "bitsandbytes_8bit": Bnb8BitHfQuantizer,
     "gptq": GptqHfQuantizer,
+    "torch_fp8": TorchFp8Quantizer,
 }
 
 AUTO_QUANTIZATION_CONFIG_MAPPING = {
@@ -40,6 +43,7 @@ AUTO_QUANTIZATION_CONFIG_MAPPING = {
     "bitsandbytes_4bit": BitsAndBytesConfig,
     "bitsandbytes_8bit": BitsAndBytesConfig,
     "gptq": GPTQConfig,
+    "torch_fp8": TorchFp8Config,
 }
 
 

--- a/src/transformers/quantizers/quantizer_awq.py
+++ b/src/transformers/quantizers/quantizer_awq.py
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import importlib.metadata
 from typing import TYPE_CHECKING
-
-from packaging import version
 
 from .base import HfQuantizer
 
@@ -92,8 +89,6 @@ class AwqQuantizer(HfQuantizer):
             )
 
     def _process_model_after_weight_loading(self, model):
-        model._is_quantized_training_enabled = self.is_trainable
-
         if self.quantization_config.do_fuse:
             from ..integrations import fuse_awq_modules
 
@@ -110,5 +105,6 @@ class AwqQuantizer(HfQuantizer):
 
     @property
     def is_trainable(self):
-        MIN_AWQ_VERSION = "0.1.7"
-        return version.parse(importlib.metadata.version("autoawq")) >= version.parse(MIN_AWQ_VERSION)
+        # AWQ does not support neither QAT (Quantization Aware Training or PEFT yet.)
+        # TODO: if this is supported in the future, do a version check here.
+        return False

--- a/src/transformers/quantizers/quantizer_awq.py
+++ b/src/transformers/quantizers/quantizer_awq.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib.metadata
 from typing import TYPE_CHECKING
+
+from packaging import version
 
 from .base import HfQuantizer
 
@@ -89,6 +92,8 @@ class AwqQuantizer(HfQuantizer):
             )
 
     def _process_model_after_weight_loading(self, model):
+        model._is_quantized_training_enabled = self.is_trainable
+
         if self.quantization_config.do_fuse:
             from ..integrations import fuse_awq_modules
 
@@ -105,6 +110,5 @@ class AwqQuantizer(HfQuantizer):
 
     @property
     def is_trainable(self):
-        # AWQ does not support neither QAT (Quantization Aware Training or PEFT yet.)
-        # TODO: if this is supported in the future, do a version check here.
-        return False
+        MIN_AWQ_VERSION = "0.1.7"
+        return version.parse(importlib.metadata.version("autoawq")) >= version.parse(MIN_AWQ_VERSION)

--- a/src/transformers/quantizers/quantizer_torch_fp8.py
+++ b/src/transformers/quantizers/quantizer_torch_fp8.py
@@ -1,0 +1,92 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import TYPE_CHECKING
+
+from .base import HfQuantizer
+
+
+if TYPE_CHECKING:
+    from ..modeling_utils import PreTrainedModel
+
+from ..utils import is_torch_available, logging, is_torch_fp8_available
+
+
+if is_torch_available():
+    import torch
+
+logger = logging.get_logger(__name__)
+
+
+class TorchFp8Quantizer(HfQuantizer):
+    """
+    FP8 Quantization using torch-fp8 library: https://github.com/pytorch-labs/float8_experimental
+    """
+    requires_calibration = False
+
+    required_packages = ["float8_experimental"]
+
+    def __init__(self, quantization_config, **kwargs):
+        super().__init__(quantization_config, **kwargs)
+
+    def validate_environment(self, device_map, **kwargs):
+        if not torch.cuda.is_available():
+            raise RuntimeError("GPU is required to run AWQ quantized model.")
+
+        if not is_torch_fp8_available():
+            raise ImportError("Loading a FP8 quantized model requires float8_experimental library (`pip install float8_experimental`)")
+
+
+        if device_map is None:
+            logger.warning_once(
+                "You have loaded an FP8 model on CPU and have a CUDA device available, make sure to set "
+                "your model on a GPU device in order to run your model."
+            )
+        elif device_map is not None:
+            if isinstance(device_map, dict) and ("cpu" in device_map.values() or "disk" in device_map.values()):
+                raise ValueError(
+                    "You are attempting to load a FP8 model with a device_map that contains a CPU or disk device."
+                    " This is not supported. Please remove the CPU or disk device from the device_map."
+                )
+
+    def update_torch_dtype(self, torch_dtype):
+        return torch_dtype
+
+    def adjust_target_dtype(self, target_dtype: "torch.dtype") -> "torch.dtype":
+        # FP8 has the same memory footprint as int8
+        return torch.int8
+
+    def _process_model_before_weight_loading(self, model: "PreTrainedModel", **kwargs):
+        from float8_experimental.float8_linear_utils import (
+            swap_linear_with_float8_linear,
+        )
+        from float8_experimental.float8_linear import Float8Linear
+        from float8_experimental.float8_dynamic_linear import Float8DynamicLinear
+
+        if self.quantization_config.modules_to_not_convert is not None:
+            self.modules_to_not_convert.extend(self.quantization_config.modules_to_not_convert)
+
+        target_cls = Float8DynamicLinear if self.quantization_config.linear_type == "dynamic" else Float8Linear
+
+        swap_linear_with_float8_linear(model, target_cls, skip_fqn_list=self.modules_to_not_convert)
+
+    def _process_model_after_weight_loading(self, model):
+        return
+
+    @property
+    def is_serializable(self):
+        return True
+
+    @property
+    def is_trainable(self):
+        return True

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -176,6 +176,7 @@ from .import_utils import (
     is_torch_bf16_gpu_available,
     is_torch_compile_available,
     is_torch_cuda_available,
+    is_torch_fp8_available,
     is_torch_fp16_available_on_device,
     is_torch_fx_available,
     is_torch_fx_proxy,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -144,6 +144,7 @@ _tokenizers_available = _is_package_available("tokenizers")
 _torchaudio_available = _is_package_available("torchaudio")
 _torchdistx_available = _is_package_available("torchdistx")
 _torchvision_available = _is_package_available("torchvision")
+_torch_fp8_available = _is_package_available("float8_experimental")
 
 
 _torch_version = "N/A"
@@ -249,6 +250,10 @@ if _torch_available:
 
 def is_kenlm_available():
     return _kenlm_available
+
+
+def is_torch_fp8_available():
+    return _torch_fp8_available
 
 
 def is_cv2_available():

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -38,6 +38,7 @@ class QuantizationMethod(str, Enum):
     BITS_AND_BYTES = "bitsandbytes"
     GPTQ = "gptq"
     AWQ = "awq"
+    TORCH_FP8 = "torch_fp8"
 
 
 class AWQLinearVersion(str, Enum):
@@ -731,3 +732,34 @@ class AwqConfig(QuantizationConfigMixin):
         loading_attibutes = ["do_fuse", "modules_to_fuse", "fuse_max_seq_len"]
         loading_attibutes_dict = {i: j for i, j in attibutes_dict.items() if i in loading_attibutes}
         return loading_attibutes_dict
+
+
+@dataclass
+class TorchFp8Config(QuantizationConfigMixin):
+    """
+    This is a wrapper class about all possible attributes and features that you can play with a model that has been
+    loaded using `torch_float8` library.
+
+    Args:
+        linear_type (`str`, *optional*, defaults to `"dynamic"`):
+            The type of linear layer to use.
+    """
+
+    def __init__(
+        self,
+        linear_type="dynamic",
+        modules_to_not_convert=None,
+        **kwargs,
+    ):
+        self.quant_method = QuantizationMethod.TORCH_FP8
+        self.modules_to_not_convert = modules_to_not_convert
+        self.linear_type = linear_type
+
+        self.post_init()
+
+    def post_init(self):
+        r"""
+        Safety checker that arguments are correct
+        """
+        if not torch.cuda.is_available():
+            raise ValueError("torch-float8 is only available on GPU")


### PR DESCRIPTION
# What does this PR do?

As per title, this PR attempts to integrate https://github.com/pytorch-labs/float8_experimental in transformers for efficient FP8 inference. To potentially combine it with https://github.com/huggingface/transformers/pull/27931 for faster text generation on newer hardwares (compute capability >= 9.0)

I need to address these points before 

- [ ] are fp8 layers serializable?
- [ ] make sure the code runs
- [ ] end-to-end training script
- [ ] Docs
- [ ] add tests

Currently the target API is: 

```python
import torch
from transformers import AutoModelForCausalLM, TorchFp8Config, AutoTokenizer

quantization_config = TorchFp8Config(
    linear_type="dynamic",
    modules_to_not_convert=["lm_head"]
)

model_id = "facebook/opt-125m"

model = AutoModelForCausalLM.from_pretrained(
    model_id, 
    quantization_config=quantization_config, 
    device_map="auto",
    torch_dtype=torch.float16,
)

tokenizer = AutoTokenizer.from_pretrained(model_id)
text = "Hello my name is"

inputs = tokenizer(text, return_tensors='pt').to(0)
out = model.generate(**inputs, max_new_tokens=50)

print(tokenizer.decode(out[0]))
```

cc @ArthurZucker @drisspg @vkuzo @pacman100 @SunMarc @Titus-von-Koeller 
