### PR TITLE
Explicitly check if token ID's are None in TFBertTokenizer constructor

### DIFF
--- a/src/transformers/models/bert/tokenization_bert_tf.py
+++ b/src/transformers/models/bert/tokenization_bert_tf.py
@@ -91,9 +91,9 @@ class TFBertTokenizer(keras.layers.Layer):
 
         self.vocab_list = vocab_list
         self.do_lower_case = do_lower_case
-        self.cls_token_id = cls_token_id or vocab_list.index("[CLS]")
-        self.sep_token_id = sep_token_id or vocab_list.index("[SEP]")
-        self.pad_token_id = pad_token_id or vocab_list.index("[PAD]")
+        self.cls_token_id = vocab_list.index("[CLS]") if cls_token_id is None else cls_token_id
+        self.sep_token_id = vocab_list.index("[SEP]") if sep_token_id is None else sep_token_id
+        self.pad_token_id = vocab_list.index("[PAD]") if pad_token_id is None else pad_token_id
         self.paired_trimmer = ShrinkLongestTrimmer(max_length - 3, axis=1)  # Allow room for special tokens
         self.max_length = max_length
         self.padding = padding


### PR DESCRIPTION
# What does this PR do?

Since the token ID's are ints, the `if token_id` check will fail if `token_id == 0`, when it should only fail when `token_id == None`. This PR adds an explicit None check.

@ArthurZucker
