### PR TITLE
Reduce GPU memory usage when using FSDP+PEFT

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1697,6 +1697,8 @@ class Trainer:
         use_accelerator_prepare = True if model is self.model else False
 
         if delay_optimizer_creation:
+            if use_accelerator_prepare:
+                self.model = self.accelerator.prepare(self.model)
             self.create_optimizer_and_scheduler(num_training_steps=max_steps)
 
         # prepare using `accelerator` prepare


### PR DESCRIPTION
# What does this PR do?
1. For FSDP+PEFT, When using `use_orig_params=True` which is now the default in Accelerate, there is no memory savings when compared to FSDP full fine-tuning. We have to set `use_orig_params=False` to realize the memory savings which makes it difficult to be in line with Accelerate’s minimal API. However, this means that the model needs to be wrapped in FSDP unit before the creation of the optimizer. This PR wraps the model in FSDP before the creation of optimizer so that GPU memory savings are realized when using FSDP+PEFT.

![Screenshot 2023-12-27 at 8 48 12 PM (2)](https://github.com/huggingface/transformers/assets/13534540/4156e0b1-b84a-4a32-87ad-6d111fb2f81d)
