### PR TITLE
Dynamic parallel processing Size Adjustment for Low Mem Beam Search 

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4868,7 +4868,7 @@ def auto_sequential_bs_forward(
         """Returns the largest factor of n that is smaller than m.
         This helps us find the biggest divisible split size for the input batch size.
         """
-        if m<=1:
+        if m <= 1:
             raise ValueError("m should be greater than 1, because no factor can be found strictly less than 1")
         if m is None:
             m = n

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4847,7 +4847,9 @@ def sequential_bs_forward(
 optimal_low_mem_beam_search_bs = None
 
 
-def auto_sequential_bs_forward(model, model_inputs, batch_size: int, output_attentions: bool, output_hidden_states: bool):
+def auto_sequential_bs_forward(
+    model, model_inputs, batch_size: int, output_attentions: bool, output_hidden_states: bool
+):
     """
     Splits the model inputs into sub-batches, processes each sub-batch through the model,
     and stacks the outputs.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2934,7 +2934,7 @@ class GenerationMixin:
                 #
                 # minibatch_size=batch_size
                 # outputs = minibatch_forward(self, model_inputs, minibatch_size, batch_beam_size, output_attentions, output_hidden_states)
-                outputs = auto_minibatch_forward(
+                outputs = auto_sequential_bs_forward(
                     self, model_inputs, batch_beam_size, output_attentions, output_hidden_states
                 )
 
@@ -4807,7 +4807,7 @@ def stack_model_outputs(model_outputs: List[ModelOutput]) -> ModelOutput:
     return model_output_cls(**concatenated_data)
 
 
-def minibatch_forward(
+def sequential_bs_forward(
     model, model_inputs, mini_batch_size: int, batch_size: int, output_attentions: bool, output_hidden_states: bool
 ):
     """
@@ -4847,7 +4847,7 @@ def minibatch_forward(
 optimal_low_mem_beam_search_bs = None
 
 
-def auto_minibatch_forward(model, model_inputs, batch_size: int, output_attentions: bool, output_hidden_states: bool):
+def auto_sequential_bs_forward(model, model_inputs, batch_size: int, output_attentions: bool, output_hidden_states: bool):
     """
     Splits the model inputs into sub-batches, processes each sub-batch through the model,
     and stacks the outputs.
@@ -4867,7 +4867,7 @@ def auto_minibatch_forward(model, model_inputs, batch_size: int, output_attentio
     # try, except while loop
     while try_split_size > 0:
         try:
-            outputs = minibatch_forward(
+            outputs = sequential_bs_forward(
                 model, model_inputs, try_split_size, batch_size, output_attentions, output_hidden_states
             )
             optimal_low_mem_beam_search_bs = try_split_size


### PR DESCRIPTION
# What does this PR do?

TL;DR

This PR addresses feedback from the community, specifically a [suggestion](https://github.com/huggingface/transformers/pull/26304#issuecomment-1900489106) from @gante, to enhance memory management in beam search operations without adding complexity through additional flags. This development strikes a balance between performance and usability, ensuring the model dynamically adjusts to various hardware constraints.

## Details

This Pull Request (PR) introduces  to dynamically adjust the batch size during low memory beam search operations. Our traditional beam search, with a beam width of `k` and a batch size of `n`, operates as though the batch size were `n*k`. The recently introduced [low memory beam search](https://github.com/huggingface/transformers/pull/26304) improves memory efficiency by dividing the `n*k` batch into `k` sub-batches of size `n`. However, this approach has shown limitations, particularly in two scenarios:

1. **Optimizing for Hardware's Maximum Parallel Processing Capacity (`s`)**: In instances where the hardware's maximum parallel processing capacity `s` falls between `n*k` and `n`, our current method might not utilize the available resources efficiently. For example, with `n=10`, `k=10`, and `S=30`, the low memory beam search would execute ten sequential operations with a batch size of 10, whereas it could achieve better throughput with four operations of batch size 25.

2. **Handling Out-Of-Memory (OOM) Errors When `s` < `n`**: In cases where `s` is smaller than `n`, the low memory beam search might encounter OOM errors, even though a further split of the batch could allow the operation to proceed. While one might argue for using smaller batch sizes from the start, this PR provides a solution to optimize processing dynamically.

### Implementation Highlights:

- **Dynamic Batch Size Adjustment**: By adopting a try/except loop, the system starts with the standard beam search parameters and dynamically reduces the batch size in half upon encountering OOM errors, with a minimum threshold set at 1. This mechanism ensures optimal memory usage and performance efficiency.
  
- **Global Batch Size Caching**: The implementation includes caching the most recent successful batch size in a global variable, `optimal_low_mem_beam_search_bs`. This approach allows for rapid adaptation to the most efficient processing conditions without the need for rediscovery. As text inputs lengthen and memory usage increases during generation, `optimal_low_mem_beam_search_bs` is periodically updated to reflect the most current optimal conditions.

### API Impact:

This update will be transparent to end users, involving no changes to the existing API. Users can expect improved efficiency without any alteration to the results produced by previous implementations.

### Testing:

Existing tests confirm that the results from the low memory beam search align with those from the traditional beam search method. Specific tests for dynamic parallel processing sizes are not yet implemented. If you think it's worth adding some, I have a draft below.


### Doc:
Do you think we should mention this is the doc ? Currently we have 
```
            sequential (`bool`, defaults to `False`):
                By default, beam search has `batch_size * num_beams` as effective batch size (see `beam_search()` for
                more details). This flag will avoid parallelizing the beam search and will instead run beam search
                sequentially.
```
in the [doc](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationConfig.low_memory)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@gante 