### PR TITLE
Use `-v` for `pytest` on CircleCI 

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -32,7 +32,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PT_FLAX_CROSS_TESTS": False,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
-COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile"}
+COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile", "v": None}
 DEFAULT_DOCKER_IMAGE = [{"image": "cimg/python:3.8.12"}]
 
 
@@ -227,7 +227,7 @@ class CircleCIJob:
             # failure.
             test_command = f"({test_command}) || true"
         else:
-            test_command += " || true"
+            test_command = f"({test_command} | tee tests_output.txt) || true"
         steps.append({"run": {"name": "Run tests", "command": test_command}})
 
         # Deal with errors


### PR DESCRIPTION
# What does this PR do?

So we get info about which process run which tests

> [gw4] [ 99%] PASSED tests/models/kosmos2/test_processor_kosmos2.py::Kosmos2ProcessorTest::test_model_input_names 
tests/models/kosmos2/test_processor_kosmos2.py::Kosmos2ProcessorTest::test_processor 
[gw3] [ 99%] PASSED tests/models/pix2struct/test_processor_pix2struct.py::Pix2StructProcessorTest::test_model_input_names 
tests/models/pix2struct/test_processor_pix2struct.py::Pix2StructProcessorTest::test_processor 
[gw0] [ 99%] PASSED tests/models/bloom/test_tokenization_bloom.py::BloomTokenizationTest::test_training_new_tokenizer 

Full CI will produce ~100K lines. The output is also saved and uploaded as artifact.