### PR TITLE
Raise error when using `save_only_model` with `load_best_model_at_end` for DeepSpeed/FSDP

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4052,6 +4052,16 @@ class Trainer:
         if self.is_deepspeed_enabled and getattr(self.args, "hf_deepspeed_config", None) is None:
             self.propagate_args_to_deepspeed()
 
+        # `save_only_model` can't be used with DeepSpeed/FSDP along with `load_best_model_at_end`
+        if (
+            self.args.save_only_model
+            and (self.is_deepspeed_enabled or self.is_fsdp_enabled)
+            and self.args.load_best_model_at_end
+        ):
+            raise ValueError(
+                "DeepSpeed/FSDP can't be used with `save_only_model` along with `load_best_model_at_end`."
+            )
+
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """
         Sets values in the deepspeed plugin based on the Trainer args

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4058,9 +4058,8 @@ class Trainer:
             and (self.is_deepspeed_enabled or self.is_fsdp_enabled)
             and self.args.load_best_model_at_end
         ):
-            raise ValueError(
-                "DeepSpeed/FSDP can't be used with `save_only_model` along with `load_best_model_at_end`."
-            )
+            wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
+            raise ValueError(f"{wrapper} can't be used with `save_only_model` along with `load_best_model_at_end`.")
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """


### PR DESCRIPTION
### What does this PR do?
1. `save_only_model` can't be used with DeepSpeed/FSDP along with `load_best_model_at_end`. This is because the models are wrapped in DeepSpeed Engine or FSDP units and require the ckpts in their respective formats which isn't the case when saving only the model as it is in transformers format. 
2. Fixes #https://github.com/huggingface/transformers/issues/27751 by explicitly raising an error when such config params are passed.
