### PR TITLE
Streamlining bnb quantizer interfaces [bnb]

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -171,11 +171,6 @@ def _replace_with_bnb_linear(
                             has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
                             threshold=quantization_config.llm_int8_threshold,
                         )
-                        model._modules[name].register_buffer(
-                            "SCB",                            
-                            torch.empty(model._modules[name].weight.shape[0], dtype=torch.float32, device=torch.device"meta"),
-                            persistent=True,
-                        )
                         has_been_replaced = True
                     else:
                         if (

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -171,6 +171,11 @@ def _replace_with_bnb_linear(
                             has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
                             threshold=quantization_config.llm_int8_threshold,
                         )
+                        model._modules[name].register_buffer(
+                            "SCB",                            
+                            torch.empty(model._modules[name].weight.shape[0], dtype=torch.float32, device=torch.device"meta"),
+                            persistent=True,
+                        )
                         has_been_replaced = True
                     else:
                         if (

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -796,16 +796,17 @@ def _load_state_dict_into_meta_model(
                 offload_index = offload_weight(param, param_name, offload_folder, offload_index)
         elif param_device == "cpu" and state_dict_index is not None:
             state_dict_index = offload_weight(param, param_name, model, state_dict_folder, state_dict_index)
-        elif (
-            hf_quantizer is None
-            or (not hf_quantizer.requires_parameters_quantization)
-            or (not hf_quantizer.check_quantized_param(model, param, param_name, state_dict))
-        ):
+        # elif (
+        #     hf_quantizer is None
+        #     or (not hf_quantizer.requires_parameters_quantization)
+        #     or (not hf_quantizer.check_quantized_param(model, param, param_name, state_dict))
+        # ):
+        else:
             # For backward compatibility with older versions of `accelerate` and for non-quantized params
             set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)
-        else:
-            hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict, unexpected_keys)
-            # TODO: consider removing used param_parts from state_dict before return
+        # else:
+        # hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict, unexpected_keys)
+        # TODO: consider removing used param_parts from state_dict before return
 
     return error_msgs, offload_index, state_dict_index
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -796,17 +796,9 @@ def _load_state_dict_into_meta_model(
                 offload_index = offload_weight(param, param_name, offload_folder, offload_index)
         elif param_device == "cpu" and state_dict_index is not None:
             state_dict_index = offload_weight(param, param_name, model, state_dict_folder, state_dict_index)
-        # elif (
-        #     hf_quantizer is None
-        #     or (not hf_quantizer.requires_parameters_quantization)
-        #     or (not hf_quantizer.check_quantized_param(model, param, param_name, state_dict))
-        # ):
         else:
             # For backward compatibility with older versions of `accelerate` and for non-quantized params
             set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)
-        # else:
-        # hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict, unexpected_keys)
-        # TODO: consider removing used param_parts from state_dict before return
 
     return error_msgs, offload_index, state_dict_index
 

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -163,18 +163,6 @@ class Bnb8BitHfQuantizer(HfQuantizer):
             if fp16_statistics is not None:
                 setattr(module.weight, "SCB", fp16_statistics.to(target_device))
 
-    def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
-        import bitsandbytes as bnb
-
-        for name, module in model.named_modules():
-            if isinstance(module, bnb.nn.modules.Linear8bitLt):
-                self.activate_module(module)
-
-        model._is_quantized_training_enabled = self.is_trainable
-        model.is_loaded_in_8bit = True
-        model.is_8bit_serializable = self.is_serializable
-        return model
-
     def _process_model_before_weight_loading(
         self,
         model: "PreTrainedModel",
@@ -229,6 +217,18 @@ class Bnb8BitHfQuantizer(HfQuantizer):
         # TODO: consider bringing replace_with_bnb_linear() code from ..integrations/bitsandbyter.py to here
 
         model.config.quantization_config = self.quantization_config
+
+    def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
+        import bitsandbytes as bnb
+
+        for name, module in model.named_modules():
+            if isinstance(module, bnb.nn.modules.Linear8bitLt):
+                self.activate_module(module)
+
+        model._is_quantized_training_enabled = self.is_trainable
+        model.is_loaded_in_8bit = True
+        model.is_8bit_serializable = self.is_serializable
+        return model
 
     @property
     def is_serializable(self):

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Union
 
 from packaging import version
 
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
 from ..utils import is_accelerate_available, is_bitsandbytes_available, is_torch_available, logging
-from .quantizers_utils import get_module_from_name
 
 
 if is_torch_available():
@@ -133,31 +132,9 @@ class Bnb8BitHfQuantizer(HfQuantizer):
             logger.info("target_dtype {target_dtype} is replaced by `torch.int8` for 8-bit BnB quantization")
         return torch.int8
 
-    def check_quantized_param(
-        self, model: "PreTrainedModel", param_value: "torch.Tensor", param_name: str, state_dict: Dict[str, Any]
-    ):
-        import bitsandbytes as bnb
-
-        module, tensor_name = get_module_from_name(model, param_name)
-        if isinstance(module._parameters[tensor_name], bnb.nn.Int8Params):
-            if self.pre_quantized:
-                if param_name.replace("weight", "SCB") not in state_dict.keys():
-                    raise ValueError("Missing quantization component `SCB`")
-                if param_value.dtype != torch.int8:
-                    raise ValueError(
-                        f"Incompatible dtype `{param_value.dtype}` when loading 8-bit prequantized weight. Expected `torch.int8`."
-                    )
-            return True
-        return False
-
-    def create_quantized_param(
+    def activate_module(
         self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        target_device: "torch.device",
-        state_dict: Dict[str, Any],
-        unexpected_keys: List[str],
+        module,
     ):
         """
         combines logic from _load_state_dict_into_meta_model and .integrations.bitsandbytes.py::set_module_quantized_tensor_to_device()
@@ -165,25 +142,8 @@ class Bnb8BitHfQuantizer(HfQuantizer):
         """
         import bitsandbytes as bnb
 
-        fp16_statistics_key = param_name.replace("weight", "SCB")
-        fp16_statistics = state_dict.get(fp16_statistics_key, None)
+        target_device = module.weight.device
 
-        module, tensor_name = get_module_from_name(model, param_name)
-        if tensor_name not in module._parameters:
-            raise ValueError(f"{module} does not have a parameter or a buffer named {tensor_name}.")
-
-        old_value = getattr(module, tensor_name)
-
-        if not isinstance(module._parameters[tensor_name], bnb.nn.Int8Params):
-            raise ValueError(f"Parameter `{tensor_name}` should only be a `bnb.nn.Int8Params` instance.")
-        if (
-            old_value.device == torch.device("meta")
-            and target_device not in ["meta", torch.device("meta")]
-            and param_value is None
-        ):
-            raise ValueError(f"{tensor_name} is on the meta device, we need a `value` to put in on {target_device}.")
-
-        new_value = param_value.to("cpu")
         if self.pre_quantized and not self.is_serializable:
             raise ValueError(
                 "Detected int8 weights but the version of bitsandbytes is not compatible with int8 serialization. "
@@ -192,19 +152,26 @@ class Bnb8BitHfQuantizer(HfQuantizer):
 
         # Support models using `Conv1D` in place of `nn.Linear` (e.g. gpt2) by transposing the weight matrix prior to quantization.
         # Since weights are saved in the correct "orientation", we skip transposing when loading.
-        if issubclass(module.source_cls, Conv1D):
-            if fp16_statistics is None:
-                new_value = new_value.T
+        if issubclass(module.source_cls, Conv1D) and not self.pre_quantized:
+            new_value = module.weight.data
+            new_value = new_value.T
 
-        kwargs = old_value.__dict__
-        new_value = bnb.nn.Int8Params(new_value, requires_grad=False, **kwargs).to(target_device)
+            kwargs = module.weight.__dict__
+            new_value = bnb.nn.Int8Params(new_value, requires_grad=False, **kwargs).to(target_device)
 
-        module._parameters[tensor_name] = new_value
+            module._parameters["weight"] = new_value
+
+        fp16_statistics = module._buffers.get("SCB", None)
         if fp16_statistics is not None:
             setattr(module.weight, "SCB", fp16_statistics.to(target_device))
-            unexpected_keys.remove(fp16_statistics_key)
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
+        import bitsandbytes as bnb
+
+        for name, module in model.named_modules():
+            if isinstance(module, bnb.nn.modules.Linear8bitLt):
+                self.activate_module(module)
+
         model._is_quantized_training_enabled = self.is_trainable
         model.is_loaded_in_8bit = True
         model.is_8bit_serializable = self.is_serializable


### PR DESCRIPTION
This is a follow-up to #26610 .

The Bnb classes require few additional calls in the middle of `_load_state_dict_into_meta_model()`. This PR makes the class interface comparable to that of GPTQ and AWQ:
- creating buffers to load quantization params in `_process_model_before_weight_loading()`
- load weights from state dict normally
- use `_process_model_after_weight_loading()` to combine weights with the buffer values into the quantized weights.

Benefits:
- more uniform class interfaces
- fewer calls from `from_pretrained()` to the quantizer.

So far I did this for `bnb.8bit`.
4bit is doable but is a bit more tricky.

@younesbelkada @SunMarc , what do you think of this idea?