### PR TITLE
Fix `FastSpeech2ConformerModelTest` and skip it on CPU

### DIFF
--- a/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
+++ b/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
@@ -1256,7 +1256,7 @@ class FastSpeech2ConformerModel(FastSpeech2ConformerPreTrainedModel):
         )
 
         if attention_mask is None:
-            attention_mask = torch.ones(input_ids.shape)
+            attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
 
         has_missing_labels = (
             spectrogram_labels is None or duration_labels is None or pitch_labels is None or energy_labels is None

--- a/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
+++ b/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
@@ -1256,7 +1256,7 @@ class FastSpeech2ConformerModel(FastSpeech2ConformerPreTrainedModel):
         )
 
         if attention_mask is None:
-            attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
+            attention_mask = torch.ones(input_ids.shape, device=input_ids.device)
 
         has_missing_labels = (
             spectrogram_labels is None or duration_labels is None or pitch_labels is None or energy_labels is None

--- a/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
+++ b/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
@@ -25,7 +25,7 @@ from transformers import (
     FastSpeech2ConformerWithHifiGanConfig,
     is_torch_available,
 )
-from transformers.testing_utils import require_g2p_en, require_torch, slow, torch_device
+from transformers.testing_utils import require_g2p_en, require_torch, require_torch_accelerator, slow, torch_device
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, _config_zero_init, ids_tensor
@@ -117,6 +117,7 @@ class FastSpeech2ConformerModelTester:
         return config, inputs_dict
 
 
+@require_torch_accelerator
 @require_torch
 class FastSpeech2ConformerModelTest(ModelTesterMixin, unittest.TestCase):
     all_model_classes = (FastSpeech2ConformerModel,) if is_torch_available() else ()


### PR DESCRIPTION
# What does this PR do?

- There is device issue on GPU.
- There is low level (C++) issue with torch 2.2 (we have to report to torch team)
  - Skip this  `FastSpeech2ConformerModelTest` on CPU. 
  - (It is still tested on GPU, and it pass)
