### PR TITLE
Explicit server error on gated model

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -414,9 +414,8 @@ def cached_file(
         if resolved_file is not None or not _raise_exceptions_for_gated_repo:
             return resolved_file
         raise EnvironmentError(
-            "You are trying to access a gated repo.\nMake sure to request access at "
-            f"https://huggingface.co/{path_or_repo_id} and pass a token having permission to this repo either "
-            "by logging in with `huggingface-cli login` or by passing `token=<your_token>`."
+            "You are trying to access a gated repo.\nMake sure to have access to it at "
+            f"https://huggingface.co/{path_or_repo_id}.\n{str(e)}"
         ) from e
     except RepositoryNotFoundError as e:
         raise EnvironmentError(


### PR DESCRIPTION
When a `GatedRepoError` error is raised while accessing a file, `transformers` catches the error to set a custom message inside a `EnvironmentError` (i.e. OSError) exception. This can be confusing since the underlying error (the `GatedRepoError`) contains more information on why the model cannot be accessed. Even though the `GatedRepoError` is thrown in the stacktrace, the message that could help the user is too hidden which can be misleading. This PR fixes that by forwarding the server message inside the `EnvironmentError`.

cc @coyotte508 who suggested this PR [in slack](https://huggingface.slack.com/archives/C02EMARJ65P/p1706866127367819?thread_ts=1706783851.655979&cid=C02EMARJ65P) (private) cc @meganriley as well

Error on gated repo if no auth:
```
Cannot access gated repo for url https://huggingface.co/nvidia/nemotron-3-8b-base-4k/resolve/main/.gitattributes.
Repo model nvidia/nemotron-3-8b-base-4k is gated. You must be authenticated to access it.
```

Error on gated repo if auth but not requested yet
```
Cannot access gated repo for url https://huggingface.co/baseten/docs-example-gated-model/resolve/main/.gitattributes.
Access to model baseten/docs-example-gated-model is restricted and you are not in the authorized list. Visit https://huggingface.co/baseten/docs-example-gated-model to ask for access.
```

Error on gated repo if auth but pending request:
```
Cannot access gated repo for url https://huggingface.co/nvidia/nemotron-3-8b-base-4k/resolve/main/.gitattributes.
Your request to access model nvidia/nemotron-3-8b-base-4k is awaiting a review from the repo authors.
```