### PR TITLE
Hotfix - make `torchaudio` get the correct version in `torch_and_flax_job`

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -299,6 +299,8 @@ torch_and_flax_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager --upgrade pip",
         "pip install -U --upgrade-strategy eager .[sklearn,flax,torch,testing,sentencepiece,torch-speech,vision]",
         "pip install -U --upgrade-strategy eager -e git+https://github.com/huggingface/accelerate@main#egg=accelerate",
+        # TODO: remove this one after fixing the dependency issue(s) above
+        "pip install -U --upgrade-strategy eager torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
     ],
     marker="is_pt_flax_cross_test",
     pytest_options={"rA": None, "durations": 0},

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -314,6 +314,8 @@ torch_job = CircleCIJob(
         "pip install --upgrade --upgrade-strategy eager pip",
         "pip install -U --upgrade-strategy eager .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm]",
         "pip install -U --upgrade-strategy eager -e git+https://github.com/huggingface/accelerate@main#egg=accelerate",
+        # TODO: remove this one after fixing the dependency issue(s) above
+        "pip install -U --upgrade-strategy eager torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
     ],
     parallelism=1,
     pytest_num_workers=6,

--- a/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
+++ b/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
@@ -533,6 +533,8 @@ class FastSpeech2ConformerWithHifiGanTester:
         return config, inputs_dict
 
 
+@require_torch_accelerator
+@require_torch
 class FastSpeech2ConformerWithHifiGanTest(ModelTesterMixin, unittest.TestCase):
     all_model_classes = (FastSpeech2ConformerWithHifiGan,) if is_torch_available() else ()
     test_pruning = False


### PR DESCRIPTION
# What does this PR do?

Apply one more hot fix to make the torchaudio get's the correct version .

(failing job run [here](https://app.circleci.com/pipelines/github/huggingface/transformers/83910/workflows/023ecc92-20eb-44b5-8f09-98f3d9459f53/jobs/1083262))

(not identified on the previous PR, because of the cache restoring mechanism on CircleCI)