### PR TITLE
Add custom loss to Informer

### DIFF
--- a/src/transformers/models/informer/configuration_informer.py
+++ b/src/transformers/models/informer/configuration_informer.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 """Informer model configuration"""
 
-from typing import List, Optional, Union
+from typing import Optional, Union, List, Callable
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
 
+import torch
 
 logger = logging.get_logger(__name__)
 
@@ -29,6 +30,7 @@ INFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
     # See all Informer models at https://huggingface.co/models?filter=informer
 }
 
+InformerCustomLossFunctionTypeSignature = Callable[[torch.distributions.Distribution, torch.Tensor, float], torch.Tensor]
 
 class InformerConfig(PretrainedConfig):
     r"""
@@ -49,9 +51,9 @@ class InformerConfig(PretrainedConfig):
             `prediction_length`.
         distribution_output (`string`, *optional*, defaults to `"student_t"`):
             The distribution emission head for the model. Could be either "student_t", "normal" or "negative_binomial".
-        loss (`string`, *optional*, defaults to `"nll"`):
+        loss (`string` or `InformerCustomLossFunctionTypeSignature`, *optional*, defaults to `"nll"`):
             The loss function for the model corresponding to the `distribution_output` head. For parametric
-            distributions it is the negative log likelihood (nll) - which currently is the only supported one.
+            distributions it is the negative log likelihood (nll) - which currently is the only builtin supported one.
         input_size (`int`, *optional*, defaults to 1):
             The size of the target variable which by default is 1 for univariate targets. Would be > 1 in case of
             multivariate targets.
@@ -146,7 +148,7 @@ class InformerConfig(PretrainedConfig):
         prediction_length: Optional[int] = None,
         context_length: Optional[int] = None,
         distribution_output: str = "student_t",
-        loss: str = "nll",
+        loss: Optional[Union[str, InformerCustomLossFunctionTypeSignature]] = "nll",
         input_size: int = 1,
         lags_sequence: List[int] = None,
         scaling: Optional[Union[str, bool]] = "mean",

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -32,7 +32,7 @@ from ...modeling_outputs import (
 from ...modeling_utils import PreTrainedModel
 from ...time_series_utils import NegativeBinomialOutput, NormalOutput, StudentTOutput
 from ...utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
-from .configuration_informer import InformerConfig
+from .configuration_informer import InformerConfig, InformerCustomLossFunctionTypeSignature
 
 
 logger = logging.get_logger(__name__)
@@ -1722,10 +1722,13 @@ class InformerForPrediction(InformerPreTrainedModel):
         self.parameter_projection = self.distribution_output.get_parameter_projection(self.model.config.d_model)
         self.target_shape = self.distribution_output.event_shape
 
-        if config.loss == "nll":
-            self.loss = nll
+        if isinstance(config.loss, str):
+            if config.loss == "nll":
+                self.loss = nll
+            else:
+                raise ValueError(f"Unknown loss function {config.loss}")
         else:
-            raise ValueError(f"Unknown loss function {config.loss}")
+            self.loss = config.loss
 
         # Initialize weights of distribution_output and apply final processing
         self.post_init()


### PR DESCRIPTION
# What does this PR do?

This PR adds a custom loss capability to the informer configuration and the informer model.
Currently, there is also the ability to specify an `nll` loss, but any loss of type `Callable[[torch.distributions.Distribution, torch.Tensor, float], torch.Tensor]` can be used.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sgugger 
@elisim 
@kashif 

