### PR TITLE
pass kwargs in stopping criteria list

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -1,4 +1,5 @@
 import time
+import inspect
 import warnings
 from abc import ABC
 from copy import deepcopy
@@ -129,7 +130,7 @@ class MaxTimeCriteria(StoppingCriteria):
 class StoppingCriteriaList(list):
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-        return any(criteria(input_ids, scores) for criteria in self)
+        return any(criteria(input_ids, scores, **kwargs) for criteria in self)
 
     @property
     def max_length(self) -> Optional[int]:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -1,5 +1,4 @@
 import time
-import inspect
 import warnings
 from abc import ABC
 from copy import deepcopy


### PR DESCRIPTION
# What does this PR do?

This PR passes kwargs to each criteria when calling `StoppingCriteriaList`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@gante 
