### PR TITLE
Tests: tag `test_save_load_fast_init_from_base` as flaky

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -382,7 +382,7 @@ class ModelTesterMixin:
                         m.gradient_checkpointing, f"Module {n} does not have gradient_checkpointing set to False"
                     )
 
-    @is_flaky(description="low likelihood of failure, reason not yet discovered"))
+    @is_flaky(description="low likelihood of failure, reason not yet discovered")
     def test_save_load_fast_init_from_base(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         if config.__class__ not in MODEL_MAPPING:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -382,7 +382,7 @@ class ModelTesterMixin:
                         m.gradient_checkpointing, f"Module {n} does not have gradient_checkpointing set to False"
                     )
 
-    @is_flaky()
+    @is_flaky(description="low likelihood of failure, reason not yet discovered"))
     def test_save_load_fast_init_from_base(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         if config.__class__ not in MODEL_MAPPING:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -64,6 +64,7 @@ from transformers.models.auto.modeling_auto import (
 )
 from transformers.testing_utils import (
     CaptureLogger,
+    is_flaky,
     is_pt_flax_cross_test,
     is_pt_tf_cross_test,
     require_accelerate,
@@ -381,6 +382,7 @@ class ModelTesterMixin:
                         m.gradient_checkpointing, f"Module {n} does not have gradient_checkpointing set to False"
                     )
 
+    @is_flaky()
     def test_save_load_fast_init_from_base(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         if config.__class__ not in MODEL_MAPPING:


### PR DESCRIPTION
# What does this PR do?

As discussed [internally on slack](https://huggingface.slack.com/archives/C01NE71C4F7/p1707407250079089) with @ydshieh -- this test is known to be flaky for a while.