### PR TITLE
[Whisper] Use Attention Cache

### DIFF
--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1484,13 +1484,12 @@ class WhisperDecoder(WhisperPreTrainedModel):
             all_hidden_states += (hidden_states,)
 
         next_cache = None
-        if use_cache:
-            if use_legacy_cache:
-                next_cache = ()
-                for self_attn, cross_attn in zip(
-                    next_decoder_cache[0].to_legacy_cache(), next_decoder_cache[1].to_legacy_cache()
-                ):
-                    next_cache += (self_attn + cross_attn,)
+        if use_cache and use_legacy_cache:
+            next_cache = ()
+            for self_attn, cross_attn in zip(
+                next_decoder_cache[0].to_legacy_cache(), next_decoder_cache[1].to_legacy_cache()
+            ):
+                next_cache += (self_attn + cross_attn,)
         if not return_dict:
             return tuple(
                 v


### PR DESCRIPTION
# What does this PR do?

Refactors the Whisper model to use the attention cache abstraction proposed in #26681. This is required to have consistency with the `StaticCache` attention class proposed in #27931.

The complexity with the current `Cache` abstraction comes from the fact that Whisper is an encoder-decoder model, meaning each decoder attention layer consists of:
1. A self-attention layer (k/v cache over the previous decoder input ids)
2. A cross-attention layer (k/v cache from the encoder hidden-states)

=> the problematic layer for static generation is the dynamic k/v cache in the self-attention layer. In anticipation of using a static cache for this module, the proposed design uses a separate cache for each layer. We can't build the k/v cache into a single `Cache` abstraction, as the shapes for the self and cross-attention key-values are different (which would break compile).

The design is therefore:

```python
past_key_values: Tuple[Cache] = (past_self_attn_key_values, past_cross_attn_key_values)
```

Where `past_self_attn_key_values` and `past_cross_attn_key_values` are each `Cache` abstractions. This is not the most elegant design, but is compatible with the current `Cache` abstraction. Another option would be to do a refactor of the `Cache` / `DynamicCache` / `StaticCache` for better compatibility with encoder-decoder models.

cc @ArthurZucker @tomaarsen @gante 