### PR TITLE
Terminator strings for generate()

### DIFF
--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -225,8 +225,8 @@ if TYPE_CHECKING:
             MaxTimeCriteria,
             StoppingCriteria,
             StoppingCriteriaList,
-            validate_stopping_criteria,
             StopStringCriteria,
+            validate_stopping_criteria,
         )
         from .utils import (
             BeamSampleDecoderOnlyOutput,

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -86,6 +86,7 @@ else:
         "StoppingCriteria",
         "StoppingCriteriaList",
         "validate_stopping_criteria",
+        "StopStringCriteria",
     ]
     _import_structure["utils"] = [
         "GenerationMixin",
@@ -225,6 +226,7 @@ if TYPE_CHECKING:
             StoppingCriteria,
             StoppingCriteriaList,
             validate_stopping_criteria,
+            StopStringCriteria,
         )
         from .utils import (
             BeamSampleDecoderOnlyOutput,

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -115,6 +115,8 @@ class GenerationConfig(PushToHubMixin):
         max_time(`float`, *optional*):
             The maximum amount of time you allow the computation to run for in seconds. generation will still finish
             the current pass after allocated time has been passed.
+        stop_strings(`str or List[str]`, *optional*):
+            A string or a list of strings that should terminate generation if the model outputs them.
 
         > Parameters that control the generation strategy used
 
@@ -306,6 +308,7 @@ class GenerationConfig(PushToHubMixin):
         self.min_new_tokens = kwargs.pop("min_new_tokens", None)
         self.early_stopping = kwargs.pop("early_stopping", False)
         self.max_time = kwargs.pop("max_time", None)
+        self.stop_strings = kwargs.pop("stop_strings", None)
 
         # Parameters that control the generation strategy used
         self.do_sample = kwargs.pop("do_sample", False)

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -257,6 +257,31 @@ class StopStringCriteria(StoppingCriteria):
         stop_strings (`Union[str, List[str]]`):
             A list of strings that should end generation. If a string is passed, it will be treated like a
             list with a single element.
+
+    Examples:
+
+    ```python
+    >>> from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    >>> tokenizer = AutoTokenizer.from_pretrained("microsoft/phi-2")
+    >>> model = AutoModelForCausalLM.from_pretrained("microsoft/phi-2")
+    >>> inputs = tokenizer("The biggest states in the USA by land area:", return_tensors="pt")
+
+    >>> gen_out = model.generate(**inputs)
+    >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
+    The biggest states in the USA by land area:
+    - Alaska
+    - Texas
+    - California
+
+    >>> # Passing one or more stop strings will halt generation after those strings are emitted
+    >>> # Note that generating with stop strings requires you to pass the tokenizer too
+    >>> gen_out = model.generate(**inputs, stop_strings=["Texas"], tokenizer=tokenizer)
+    >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
+    The biggest states in the USA by land area:
+    - Alaska
+    - Texas
+    ```
     """
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, List[str]]):

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -253,7 +253,9 @@ class StopStringCriteria(StoppingCriteria):
         string_matches = []
         for stop_string in self.stop_strings:
             target_len = len(stop_string)
+            # Maximum number of internal positions a single token can match
             max_valid_positions = self.max_valid_positions[stop_string]
+            # Maximum number of different overlap sizes a single token can have with the end of the string
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
             # The embedding vec contains the valid positions, end_lengths and total lengths for each token
             embedding_vec = self.embedding_vecs[stop_string]
@@ -261,32 +263,35 @@ class StopStringCriteria(StoppingCriteria):
 
             # Starts contains the number of characters from the string, counting from the end, that the token contains
             # It can have multiple values if the same token can overlap different slices of the end of the string
+            # B x 1 x max_valid_end_lens
             starts = embedded[:, :1, max_valid_positions : max_valid_positions + max_valid_end_lens]
             # Lengths is the total length of each token. Unlike starts, it always has a single value
-            lengths = embedded[:, 1:, -1:]
-            lengths = lengths.expand((-1, -1, starts.shape[-1]))
-            lengths_with_starts = torch.cat([starts, lengths], dim=1)
+            lengths = embedded[:, 1:, -1:]  # B x (maximum_token_len - 1) x 1
+            lengths = lengths.expand((-1, -1, starts.shape[-1]))  # B x (maximum_token_len - 1) x max_valid_end_lens
+            lengths_with_starts = torch.cat([starts, lengths], dim=1)  # B x maximum_token_len x max_valid_end_lens
             # We concatenate each possible starting length with the lengths of the remaining tokens in input_ids
             # Then we cumsum() to get the total length of the string after each token
-            cumsum = lengths_with_starts.cumsum(dim=1)
+            cumsum = lengths_with_starts.cumsum(dim=1)  # B x maximum_token_len x max_valid_end_lens
 
             # Valid positions are the positions in the string that the token can validly appear after
+            # B x (maximum_token_len - 1) x max_valid_positions
             valid_positions = embedded[:, 1:, :max_valid_positions]
             # Tokens can match the start of the string if they have any valid value in the starts vector
-            initial_match = torch.any(starts > 0, dim=-1, keepdim=True)
+            initial_match = starts > 0  # B x 1 x max_valid_end_lens
             # Tokens can continue the string if the cumsum() so far is one of the valid positions for that token
             # Note that we're actually tracking one cumsum() for the list for each possible start overhang length
+            # B x (maximum_token_len - 1) x max_valid_end_lens
             later_match = torch.any(cumsum[:, :-1, None] == valid_positions[:, :, :, None], axis=2)
             # The match vector is a boolean vector that indicates which positions have valid tokens
             match = torch.cat([initial_match, later_match], dim=1)
 
             # Once a single position does not match, all positions following that position are masked
             mask = (~match).cumsum(dim=1, dtype=torch.int32)
-            mask = mask == 0
+            mask = mask == 0  # B x maximum_token_len x max_valid_end_lens
 
             # The string is matched if we reached a cumsum equal to or greater than the length of the string
             # before hitting the mask
-            string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze(1) >= target_len)
+            string_matches.append(torch.amax(cumsum * mask, dim=(1, 2)) >= target_len)
 
         # Now we concatenate the match booleans across all strings and check if any are True
         string_matches = torch.cat(string_matches, dim=0)

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -159,7 +159,6 @@ class StopStringCriteria(StoppingCriteria):
             stop_string: max([len(val) for val in self.strings_to_valid_positions[stop_string].values()])
             for stop_string in stop_strings
         }
-        self.global_max_position = max(self.max_valid_positions.values())
         self.max_valid_end_lens = {
             stop_string: max([len(val) for val in self.strings_to_end_lengths[stop_string].values()])
             for stop_string in stop_strings
@@ -248,9 +247,10 @@ class StopStringCriteria(StoppingCriteria):
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
         # TODO Joao - I'm not using the scores at all and just checking the most recent tokens in input_ids
         #      Is this correct? Should I be sampling from scores?
-        # Note that input_ids can also be *shorter* than the global max position, and the code below should be
-        # ready for that
-        input_ids = input_ids[:, -self.global_max_position :]
+        # The maximum length we need to consider is 1 token per character. Note that input_ids can also be
+        # *shorter* than the global max, and the code below should be ready for that
+        maximum_token_len = max([len(stop_string) for stop_string in self.stop_strings])
+        input_ids = input_ids[:, -maximum_token_len:]
         flipped_ids = torch.flip(input_ids, (1,))
         string_matches = []
         for stop_string in self.stop_strings:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -162,7 +162,7 @@ class StopStringCriteria(StoppingCriteria):
         self.target_lens = torch.tensor([len(stop_string) for stop_string in stop_strings], dtype=torch.int32)
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
-    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.Tensor:
         self.embedding_vec = self.embedding_vec.to(input_ids.device)
         self.target_lens = self.target_lens.to(input_ids.device)
         # The maximum length we need to consider is 1 token per character. Note that input_ids can also be
@@ -217,8 +217,7 @@ class StopStringCriteria(StoppingCriteria):
         string_matches = torch.amax(cumsum * mask, dim=(1, -1)) >= self.target_lens[None, :]
 
         # Now we concatenate the match booleans across all strings and check if any are True
-        # TODO After Raushan's PR, return a per-sample vector here
-        return torch.any(string_matches).item()
+        return torch.any(string_matches, dim=-1)
 
 
 class EosTokenCriteria(StoppingCriteria):

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -281,6 +281,8 @@ def _stop_string_get_matching_positions(
     def _cleanup_token(token: str) -> str:
         if token[0] in ["▁", "Ġ"]:
             token = " " + token[1:]
+        elif token[0] == "##":
+            token = token[2:]
         return token
 
     reversed_filtered_tok_list = [_cleanup_token(token)[::-1] for token in tok_list]

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -216,7 +216,7 @@ class StopStringCriteria(StoppingCriteria):
         # before hitting the mask
         string_matches = torch.amax(cumsum * mask, dim=(1, -1)) >= self.target_lens[None, :]
 
-        # Now we concatenate the match booleans across all strings and check if any are True
+        # We return a per-sample vector that is True is any stop string is matched for that sample
         return torch.any(string_matches, dim=-1)
 
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -186,19 +186,18 @@ class StopStringCriteria(StoppingCriteria):
                 matching_positions = []
                 possible_end_lengths = []
                 for i in range(1 - len(token), len(stop_string)):
-                    tok = reversed_filtered_token
-                    stop = reversed_stop_string
                     if i < 0:
-                        tok = tok[-i:]
+                        tok = reversed_filtered_token[-i:]
                         i = 0
-                    stop = stop[i : i + len(tok)]
-                    if len(tok) > len(stop):
-                        tok = tok[: len(stop)]
-                    if tok == stop:
+                    else:
+                        tok = reversed_filtered_token
+                    stop = reversed_stop_string[i : i + len(tok)]
+                    if tok.startswith(stop):
                         if i == 0:
-                            possible_end_lengths.append(len(tok))
+                            possible_end_lengths.append(min(len(tok), len(stop)))
                         else:
                             matching_positions.append(i)
+
                 if matching_positions:
                     token_valid_positions[stop_string][token] = matching_positions
                 if possible_end_lengths:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -175,7 +175,7 @@ class StopStringCriteria(StoppingCriteria):
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the
         end of the stop string."""
         tok_list = list(self.vocab.keys())
-        reversed_filtered_tok_list = [self._cleanup_token(token[::-1]) for token in tok_list]
+        reversed_filtered_tok_list = [self._cleanup_token(token)[::-1] for token in tok_list]
         token_valid_positions = {}
         token_end_overlaps = {}
         for stop_string in self.stop_strings:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -164,6 +164,7 @@ class StopStringCriteria(StoppingCriteria):
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
         embedding_vec = self.embedding_vec.to(input_ids.device)
+        target_lens = self.target_lens.to(input_ids.device)
         # The maximum length we need to consider is 1 token per character. Note that input_ids can also be
         # *shorter* than the global max, and the code below should be ready for that
         input_ids = input_ids[:, -self.maximum_token_len :]
@@ -213,7 +214,7 @@ class StopStringCriteria(StoppingCriteria):
 
         # The string is matched if we reached a cumsum equal to or greater than the length of the string
         # before hitting the mask
-        string_matches = torch.amax(cumsum * mask, dim=(1, -1)) >= self.target_lens[None, :]
+        string_matches = torch.amax(cumsum * mask, dim=(1, -1)) >= target_lens[None, :]
 
         # Now we concatenate the match booleans across all strings and check if any are True
         # TODO After Raushan's PR, return a per-sample vector here

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -149,10 +149,10 @@ class StopStringCriteria(StoppingCriteria):
         if isinstance(stop_strings, str):
             stop_strings = [stop_strings]
 
-        self.tokenizer = tokenizer
+        self.vocab = tokenizer.get_vocab()
         self.stop_strings: List[str] = stop_strings
         self.strings_to_valid_positions, self.strings_to_end_lengths = self.get_matching_positions(
-            tokenizer, stop_strings
+            self.vocab, stop_strings
         )
 
         self.max_valid_positions = {
@@ -166,12 +166,11 @@ class StopStringCriteria(StoppingCriteria):
         self.embedding_vecs = self.create_embedding_vecs()
 
     @staticmethod
-    def get_matching_positions(tokenizer, stop_strings):
+    def get_matching_positions(vocab, stop_strings):
         """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
         validly appear in the stop strings. For each stop string, it returns a dictionary mapping tokens to a list of
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the
         end of the stop string."""
-        vocab = tokenizer.get_vocab()
         tok_list = list(vocab.keys())
         strings_to_valid_positions = {}
         strings_to_end_lengths = {}
@@ -215,7 +214,7 @@ class StopStringCriteria(StoppingCriteria):
         and possible end lengths for each token, and the total length of the token string. When tokens have
         fewer valid positions or end lengths than the maximum, we pad the vectors with -1.
         """
-        vocab = self.tokenizer.get_vocab()
+        vocab = self.vocab
         embedding_vecs = {}
         for stop_string in self.stop_strings:
             positions = self.strings_to_valid_positions[stop_string]
@@ -227,7 +226,7 @@ class StopStringCriteria(StoppingCriteria):
             max_valid_positions = self.max_valid_positions[stop_string]
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
             vec_size = max_valid_positions + max_valid_end_lens + 1
-            gather_vec = np.full((len(self.tokenizer), vec_size), dtype=np.int32, fill_value=-1)
+            gather_vec = np.full((len(self.vocab), vec_size), dtype=np.int32, fill_value=-1)
             for token, valid_positions in positions.items():
                 token_idx = vocab[token]
                 gather_vec[token_idx, : len(valid_positions)] = valid_positions

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -240,42 +240,50 @@ class StopStringCriteria(StoppingCriteria):
         flipped_ids = torch.flip(input_ids, (1,))
         string_matches = []
         for stop_string in self.stop_strings:
+            # We need the length of the stop string to know how many characters our token sequence should have
             target_len = len(stop_string)
-            # Maximum number of internal positions a single token can match
+
+            # Size of the vector of positions a single token can match
             max_valid_positions = self.max_valid_positions[stop_string]
-            # Maximum number of different overlap sizes a single token can have with the end of the string
+
+            # Size of the vector of overlap sizes a single token can have with the end of the string
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
+
             # The embedding vec contains the valid positions, end_lengths and total lengths for each token
             embedding_vec = self.embedding_vecs[stop_string]
             embedded = F.embedding(flipped_ids, embedding_vec)
 
-            # Starts contains the number of characters from the string, counting from the end, that the token contains
-            # It can have multiple values if the same token can overlap different slices of the end of the string
-            # B x 1 x max_valid_end_lens
-            starts = embedded[:, :1, max_valid_positions : max_valid_positions + max_valid_end_lens]
-            # Lengths is the total length of each token. Unlike starts, it always has a single value
-            lengths = embedded[:, 1:, -1:]  # B x (maximum_token_len - 1) x 1
-            lengths = lengths.expand((-1, -1, starts.shape[-1]))  # B x (maximum_token_len - 1) x max_valid_end_lens
-            lengths_with_starts = torch.cat([starts, lengths], dim=1)  # B x maximum_token_len x max_valid_end_lens
-            # We concatenate each possible starting length with the lengths of the remaining tokens in input_ids
-            # Then we cumsum() to get the total length of the string after each token
-            cumsum = lengths_with_starts.cumsum(dim=1)  # B x maximum_token_len x max_valid_end_lens
+            # end_lengths is the number of characters from the string, counting from the end, that the token
+            # contains. It can have multiple values if the same token can overlap different end lengths
+            end_lengths = embedded[:, :1, max_valid_positions : max_valid_positions + max_valid_end_lens]
 
-            # Valid positions are the positions in the string that the token can validly appear after
-            # B x (maximum_token_len - 1) x max_valid_positions
+            # Lengths is the total length of each token. Unlike end_lengths, it always has a single value
+            lengths = embedded[:, 1:, -1:]  # B x (maximum_token_len - 1) x 1
+
+            # Concatenate lengths onto each possible end_lengths value
+            lengths = lengths.expand((-1, -1, end_lengths.shape[-1]))
+            lengths_with_ends = torch.cat([end_lengths, lengths], dim=1)  # B x maximum_token_len x max_valid_end_lens
+
+            # cumsum() to get the number of matched characters in the stop string after each token
+            cumsum = lengths_with_ends.cumsum(dim=1)  # B x maximum_token_len x max_valid_end_lens
+
+            # The code above assumes that all tokens are in valid positions. This code masks the ones that are not.
+            # First we get the vector of positions tokens can validly appear in
             valid_positions = embedded[:, 1:, :max_valid_positions]
-            # Tokens can match the start of the string if they have any valid value in the starts vector
-            initial_match = starts > 0  # B x 1 x max_valid_end_lens
+
+            # Tokens can match the start of the string if they have any valid value in the end_lengths vector
+            initial_match = end_lengths > 0
+
             # Tokens can continue the string if the cumsum() so far is one of the valid positions for that token
-            # Note that we're actually tracking one cumsum() for the list for each possible start overhang length
-            # B x (maximum_token_len - 1) x max_valid_end_lens
+            # Note that we're actually tracking one cumsum() for for each possible end_length
             later_match = torch.any(cumsum[:, :-1, None] == valid_positions[:, :, :, None], axis=2)
+
             # The match vector is a boolean vector that indicates which positions have valid tokens
             match = torch.cat([initial_match, later_match], dim=1)
 
             # Once a single position does not match, all positions following that position are masked
             mask = (~match).cumsum(dim=1, dtype=torch.int32)
-            mask = mask == 0  # B x maximum_token_len x max_valid_end_lens
+            mask = mask == 0
 
             # The string is matched if we reached a cumsum equal to or greater than the length of the string
             # before hitting the mask

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -149,7 +149,7 @@ class StopStringCriteria(StoppingCriteria):
     - ["st", "op"]
     - ["stop"]
     - ["st", "opera"]
-    - ["sto", "opper"]
+    - ["sto", "pper"]
     - ["las", "topper"]
 
     Note that a match will only be triggered if the stop string is at the end of the generated sequence. In other

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -291,7 +291,7 @@ class StopStringCriteria(StoppingCriteria):
                 max_valid_end_lens,
             )
             if len(STOP_STRING_EMBEDDING_CACHE) > 8:
-                STOP_STRING_EMBEDDING_CACHE.popitem(last=False)
+                STOP_STRING_EMBEDDING_CACHE.popitem(last=False)  # Pop from the start, the least recently used item
         return embedding_vec, max_valid_positions, max_valid_end_lens
 
     @staticmethod

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -250,7 +250,7 @@ class StopStringCriteria(StoppingCriteria):
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
 
             # The embedding vec contains the valid positions, end_lengths and total lengths for each token
-            embedding_vec = self.embedding_vecs[stop_string]
+            embedding_vec = self.embedding_vecs[stop_string].to(flipped_ids.device)
             embedded = F.embedding(flipped_ids, embedding_vec)
 
             # end_lengths is the number of characters from the string, counting from the end, that the token

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -131,7 +131,7 @@ class MaxTimeCriteria(StoppingCriteria):
         return torch.full((input_ids.shape[0],), is_done, device=input_ids.device, dtype=torch.bool)
 
 
-class TerminationSequenceCriteria(StoppingCriteria):
+class StopStringCriteria(StoppingCriteria):
     """
     This class can be used to stop generation whenever specific string sequences are encountered. Because the same
     substring can be tokenized in different ways depending on context, this class expands strings up into every possible
@@ -141,39 +141,39 @@ class TerminationSequenceCriteria(StoppingCriteria):
     Args:
         tokenizer (`PreTrainedTokenizer`):
             The model's associated tokenizer (necessary to extract vocab and tokenize the termination sequences)
-        termination_sequences (`Union[str, List[str]]`):
-            The sequences that should end generation. If a string is passed, it will be treated like a
+        stop_strings (`Union[str, List[str]]`):
+            A list of strings that should end generation. If a string is passed, it will be treated like a
             list with a single element.
     """
 
-    def __init__(self, tokenizer: PreTrainedTokenizerBase, termination_sequences: Union[str, List[str]]):
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, List[str]]):
         vocab = tokenizer.get_vocab()
         tok_list = list(vocab.keys())
-        if isinstance(termination_sequences, str):
-            termination_sequences = [termination_sequences]
-        termination_tokens = []
-        for seq in termination_sequences:
-            if seq in tokenizer.special_tokens_map.values():
-                # If it's a special token it won't be split, so we can just use it directly
-                termination_tokens.append(vocab[seq])
-                continue
-            # If it isn't a special token, we need to figure out all sequences of tokens which contain this string.
-            # This is horribly inefficient, but it'll do to start.
-            bridging_seqs = []
-            for prefix_len in range(1, len(seq) + 1):
-                for suffix_len in range(len(seq), len(seq) - prefix_len, -1):
-                    prefix = seq[:prefix_len]
-                    suffix = seq[-suffix_len:]
-                    middle = seq[prefix_len:-suffix_len]
-                    possible_starts = [token for token in tok_list if token.endswith(prefix)]
-                    possible_ends = [token for token in tok_list if token.startswith(suffix)]
-                    if not possible_starts or not possible_ends:
-                        continue
-                    bridging_seqs.extend([start + middle + end for start in possible_starts for end in possible_ends])
-            if not bridging_seqs:
-                raise ValueError("Couldn't find any set of tokens spanning the termination sequence " + seq)
-            bridging_seqs = list(set(bridging_seqs))  # Uniquify just in case
-            termination_tokens.extend(tokenizer(bridging_seqs, add_special_tokens=False)['input_ids'])
+        if isinstance(stop_strings, str):
+            stop_strings = [stop_strings]
+        for stop_string in stop_strings:
+            for token in tok_list:
+                matching_positions = []
+                for i in range(1 - len(token), len(stop_string)):
+                    if i < 0:
+                        token = token[:i]
+                        if not token:
+                            raise ValueError("Token is null - this is a bug!")
+                        i = 0
+                    stop_string = stop_string[i: i + len(token)]
+                    if not stop_string:
+                        raise ValueError("Stop string is null - this is a bug!")
+                    if len(token) > len(stop_string):
+                        token = token[-len(stop_string):]
+                        if not token:
+                            raise ValueError("Token is null after stop string truncation - this is a bug!")
+                    if token == stop_string:
+                        matching_positions.append((i, len(token)))
+
+
+
+
+
 
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -181,7 +181,7 @@ class StopStringCriteria(StoppingCriteria):
                 matching_positions = []
                 possible_end_lengths = []
                 for i in range(1 - len(token), len(stop_string)):
-                    tok = token[::-1].replace("▁", " ")
+                    tok = token[::-1].replace("▁", " ").replace("Ġ", " ")
                     stop = stop_string[::-1]
                     if i < 0:
                         tok = tok[-i:]

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -210,7 +210,7 @@ class StopStringCriteria(StoppingCriteria):
                     strings_to_end_lengths[stop_string][token] = possible_end_lengths
         return strings_to_valid_positions, strings_to_end_lengths
 
-    def create_embedding_vecs(self):
+    def create_embedding_vecs(self) -> Dict[str, torch.tensor]:
         """
         This function builds an embedding matrix for each stop string, consisting of possible valid positions
         and possible end lengths for each token, and the total length of the token string. When tokens have

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -2,7 +2,7 @@ import time
 import warnings
 from abc import ABC
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple, Dict
 
 import numpy as np
 import torch
@@ -172,17 +172,19 @@ class StopStringCriteria(StoppingCriteria):
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the
         end of the stop string."""
         tok_list = list(vocab.keys())
+        reversed_filtered_tok_list = [token[::-1].replace("▁", " ").replace("Ġ", " ") for token in tok_list]
         strings_to_valid_positions = {}
         strings_to_end_lengths = {}
         for stop_string in stop_strings:
+            reversed_stop_string = stop_string[::-1]
             strings_to_valid_positions[stop_string] = {}
             strings_to_end_lengths[stop_string] = {}
-            for token in tok_list:
+            for token, reversed_filtered_token in zip(tok_list, reversed_filtered_tok_list):
                 matching_positions = []
                 possible_end_lengths = []
                 for i in range(1 - len(token), len(stop_string)):
-                    tok = token[::-1].replace("▁", " ").replace("Ġ", " ")
-                    stop = stop_string[::-1]
+                    tok = reversed_filtered_token
+                    stop = reversed_stop_string
                     if i < 0:
                         tok = tok[-i:]
                         if not tok:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -325,8 +325,8 @@ def _stop_string_create_embedding_vec(tok_list, tok_indices, stop_strings) -> Di
         tok_list, tok_indices, stop_strings
     )
 
-    max_valid_positions = max([len(val) for positions in token_valid_positions.values() for val in positions.values()])
-    max_valid_end_lens = max([len(val) for positions in token_end_overlaps.values() for val in positions.values()])
+    max_valid_positions = max(len(val) for positions in token_valid_positions.values() for val in positions.values())
+    max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
     vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
     gather_vec = np.full((len(tok_list), vec_size), dtype=np.int32, fill_value=-1)
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -2,12 +2,13 @@ import time
 import warnings
 from abc import ABC
 from copy import deepcopy
-from typing import Optional, List, Union
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+from torch.nn import functional as F
 
 from ..tokenization_utils_base import PreTrainedTokenizerBase
-
-import torch
-
 from ..utils import add_start_docstrings, logging
 
 
@@ -133,10 +134,8 @@ class MaxTimeCriteria(StoppingCriteria):
 
 class StopStringCriteria(StoppingCriteria):
     """
-    This class can be used to stop generation whenever specific string sequences are encountered. Because the same
-    substring can be tokenized in different ways depending on context, this class expands strings up into every possible
-    token sequence that could contain them in a preprocessing step, then does a vectorized comparison against
-    `input_ids` during generation. This is much faster than doing detokenization inside the generation loop.
+    This class can be used to stop generation whenever specific string sequences are encountered. It preprocesses
+    the strings together with the tokenizer vocab to find positions where tokens can validly complete the stop strings.
 
     Args:
         tokenizer (`PreTrainedTokenizer`):
@@ -147,38 +146,139 @@ class StopStringCriteria(StoppingCriteria):
     """
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, List[str]]):
-        vocab = tokenizer.get_vocab()
-        tok_list = list(vocab.keys())
         if isinstance(stop_strings, str):
             stop_strings = [stop_strings]
+
+        self.tokenizer = tokenizer
+        self.stop_strings: List[str] = stop_strings
+        self.strings_to_valid_positions, self.strings_to_end_lengths = self.get_matching_positions(
+            tokenizer, stop_strings
+        )
+
+        self.max_valid_positions = {
+            stop_string: max([len(val) for val in self.strings_to_valid_positions[stop_string].values()])
+            for stop_string in stop_strings
+        }
+        self.global_max_position = max(self.max_valid_positions.values())
+        self.max_valid_end_lens = {
+            stop_string: max([len(val) for val in self.strings_to_end_lengths[stop_string].values()])
+            for stop_string in stop_strings
+        }
+        self.embedding_vecs = self.create_embedding_vecs()
+
+    @staticmethod
+    def get_matching_positions(tokenizer, stop_strings):
+        """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
+        validly appear in the stop strings. For each stop string, it returns a dictionary mapping tokens to a list of
+        valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the
+        end of the stop string."""
+        vocab = tokenizer.get_vocab()
+        tok_list = list(vocab.keys())
+        strings_to_valid_positions = {}
+        strings_to_end_lengths = {}
         for stop_string in stop_strings:
+            strings_to_valid_positions[stop_string] = {}
+            strings_to_end_lengths[stop_string] = {}
             for token in tok_list:
                 matching_positions = []
+                possible_end_lengths = []
                 for i in range(1 - len(token), len(stop_string)):
+                    tok = token[::-1].replace("▁", " ")
+                    stop = stop_string[::-1]
                     if i < 0:
-                        token = token[:i]
-                        if not token:
-                            raise ValueError("Token is null - this is a bug!")
+                        tok = tok[-i:]
+                        if not tok:
+                            raise ValueError("Tok is null - this is a bug!")
                         i = 0
-                    stop_string = stop_string[i: i + len(token)]
-                    if not stop_string:
-                        raise ValueError("Stop string is null - this is a bug!")
-                    if len(token) > len(stop_string):
-                        token = token[-len(stop_string):]
-                        if not token:
-                            raise ValueError("Token is null after stop string truncation - this is a bug!")
-                    if token == stop_string:
-                        matching_positions.append((i, len(token)))
+                    stop = stop[i : i + len(tok)]
+                    if not stop:
+                        raise ValueError("Stop is null - this is a bug!")
+                    if len(tok) > len(stop):
+                        tok = tok[: len(stop)]
+                        if not tok:
+                            raise ValueError("Tok is null after stop string truncation - this is a bug!")
+                    if len(tok) != len(stop):
+                        raise ValueError("Truncated token and stop string have different lengths - this is a bug!")
+                    if tok == stop:
+                        if i == 0:
+                            possible_end_lengths.append(len(tok))
+                        else:
+                            matching_positions.append(i)
+                if matching_positions:
+                    strings_to_valid_positions[stop_string][token] = matching_positions
+                if possible_end_lengths:
+                    strings_to_end_lengths[stop_string][token] = possible_end_lengths
+        return strings_to_valid_positions, strings_to_end_lengths
 
+    def create_embedding_vecs(self):
+        """
+        This function builds an embedding matrix for each stop string, consisting of possible valid positions
+        and possible end lengths for each token, and the total length of the token string. When tokens have
+        fewer valid positions or end lengths than the maximum, we pad the vectors with -1000.
+        The value of -1000 is chosen to be very negative and thus overwhelm any positive values
+        in the cumsum() calls later.
+        """
+        vocab = self.tokenizer.get_vocab()
+        embedding_vecs = {}
+        for stop_string in self.stop_strings:
+            positions = self.strings_to_valid_positions[stop_string]
+            end_lens = self.strings_to_end_lengths[stop_string]
+            # TODO Matt: Merge the embeddings across all stop strings to save space and reduce gather calls?
 
-
-
-
-
+            # Since this is lots of very small assignments of lists, we build it with numpy rather
+            # than torch for speed + simplicity, then convert to torch at the end
+            max_valid_positions = self.max_valid_positions[stop_string]
+            max_valid_end_lens = self.max_valid_end_lens[stop_string]
+            vec_size = max_valid_positions + max_valid_end_lens + 1
+            gather_vec = np.full((len(self.tokenizer), vec_size), dtype=np.int32, fill_value=-1000)
+            for token, valid_positions in positions.items():
+                token_idx = vocab[token]
+                gather_vec[token_idx, : len(valid_positions)] = valid_positions
+            for token, possible_end_lens in end_lens.items():
+                token_idx = vocab[token]
+                gather_vec[
+                    token_idx, max_valid_positions : max_valid_positions + len(possible_end_lens)
+                ] = possible_end_lens
+            for token, token_idx in vocab.items():
+                gather_vec[token_idx, -1] = len(token)
+            embedding_vecs[stop_string] = torch.tensor(gather_vec, dtype=torch.int32)
+        return embedding_vecs
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-        return time.time() - self.initial_timestamp > self.max_time
+        # TODO Joao - I'm not using the scores at all and just checking the most recent tokens in input_ids
+        #      Is this correct? Should I be sampling from scores?
+        # Note that input_ids can also be *shorter* than the global max position, and the code below should be
+        # ready for that
+        input_ids = input_ids[:, -self.global_max_position :]
+        flipped_ids = torch.flip(input_ids, (1,))
+        string_matches = []
+        for stop_string in self.stop_strings:
+            target_len = len(stop_string)
+            max_valid_positions = self.max_valid_positions[stop_string]
+            max_valid_end_lens = self.max_valid_end_lens[stop_string]
+            embedding_vec = self.embedding_vecs[stop_string]
+            embedded = F.embedding(flipped_ids, embedding_vec)
+
+            starts = embedded[:, :1, max_valid_positions : max_valid_positions + max_valid_end_lens]
+            lengths = embedded[:, 1:, -1:]
+            lengths = lengths.expand((-1, -1, starts.shape[-1]))
+            lengths_with_starts = torch.cat([starts, lengths], dim=1)
+            cumsum = lengths_with_starts.cumsum(dim=1)
+            valid_positions = embedded[:, 1:, :max_valid_positions]
+
+            initial_match = torch.any(starts > 0, dim=-1, keepdim=True)
+            later_match = torch.isin(cumsum[:, :-1], valid_positions)
+            match = torch.cat([initial_match, later_match], dim=1)
+
+            mask = (~match).cumsum(dim=1, dtype=torch.int32)
+            mask = mask == 0
+
+            string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze() >= target_len)
+
+        # Now we concatenate matches across all strings and check if any are True
+        string_matches = torch.cat(string_matches, dim=0)
+        return torch.any(string_matches).item()
 
 
 class EosTokenCriteria(StoppingCriteria):

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -163,13 +163,19 @@ class StopStringCriteria(StoppingCriteria):
         }
         self.embedding_vecs = self._create_embedding_vecs()
 
+    @staticmethod
+    def _cleanup_token(token: str) -> str:
+        if token[0] in ["▁", "Ġ"]:
+            token = " " + token[1:]
+        return token
+
     def _get_matching_positions(self) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
         """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
         validly appear in the stop strings. For each stop string, it returns a dictionary mapping tokens to a list of
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the
         end of the stop string."""
         tok_list = list(self.vocab.keys())
-        reversed_filtered_tok_list = [token[::-1].replace("▁", " ").replace("Ġ", " ") for token in tok_list]
+        reversed_filtered_tok_list = [self._cleanup_token(token[::-1]) for token in tok_list]
         token_valid_positions = {}
         token_end_overlaps = {}
         for stop_string in self.stop_strings:

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -2,7 +2,7 @@ import time
 import warnings
 from abc import ABC
 from copy import deepcopy
-from typing import List, Optional, Union, Tuple, Dict
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -166,7 +166,9 @@ class StopStringCriteria(StoppingCriteria):
         self.embedding_vecs = self.create_embedding_vecs()
 
     @staticmethod
-    def get_matching_positions(vocab: List[str], stop_strings: List[str]) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
+    def get_matching_positions(
+        vocab: List[str], stop_strings: List[str]
+    ) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
         """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
         validly appear in the stop strings. For each stop string, it returns a dictionary mapping tokens to a list of
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -216,7 +216,7 @@ class StopStringCriteria(StoppingCriteria):
         # before hitting the mask
         string_matches = torch.amax(cumsum * mask, dim=(1, -1)) >= self.target_lens[None, :]
 
-        # We return a per-sample vector that is True is any stop string is matched for that sample
+        # We return a per-sample vector that is True if any stop string is matched for that sample
         return torch.any(string_matches, dim=-1)
 
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -303,7 +303,6 @@ class StopStringCriteria(StoppingCriteria):
         space addition/removal. To work around this, we add a static prefix to the start of the token, then remove
         it (and any prefix that may have been introduced with it) after calling convert_tokens_to_string().
         """
-        # TODO Matt this work is done every time the criterion is initialized - can we cache it?
         vocab = tokenizer.get_vocab()
         clean_token_list = []
         clean_token_indices = []

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -344,7 +344,7 @@ def _stop_string_create_embedding_vecs(tok_list, tok_indices, stop_strings) -> D
             ] = possible_end_lens
         for token, token_idx in zip(tok_list, tok_indices):
             gather_vec[token_idx, -1] = len(token)
-        embedding_vecs[stop_string] = torch.tensor(gather_vec, dtype=torch.int32).pin_memory()
+        embedding_vecs[stop_string] = torch.tensor(gather_vec, dtype=torch.int32)
 
     # TODO Remove this block and stop returning these values after the embedding vec is merged
     max_valid_positions = {

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -213,9 +213,7 @@ class StopStringCriteria(StoppingCriteria):
         """
         This function builds an embedding matrix for each stop string, consisting of possible valid positions
         and possible end lengths for each token, and the total length of the token string. When tokens have
-        fewer valid positions or end lengths than the maximum, we pad the vectors with -1000.
-        The value of -1000 is chosen to be very negative and thus overwhelm any positive values
-        in the cumsum() calls later.
+        fewer valid positions or end lengths than the maximum, we pad the vectors with -1.
         """
         vocab = self.tokenizer.get_vocab()
         embedding_vecs = {}
@@ -229,7 +227,7 @@ class StopStringCriteria(StoppingCriteria):
             max_valid_positions = self.max_valid_positions[stop_string]
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
             vec_size = max_valid_positions + max_valid_end_lens + 1
-            gather_vec = np.full((len(self.tokenizer), vec_size), dtype=np.int32, fill_value=-1000)
+            gather_vec = np.full((len(self.tokenizer), vec_size), dtype=np.int32, fill_value=-1)
             for token, valid_positions in positions.items():
                 token_idx = vocab[token]
                 gather_vec[token_idx, : len(valid_positions)] = valid_positions
@@ -251,32 +249,47 @@ class StopStringCriteria(StoppingCriteria):
         # *shorter* than the global max, and the code below should be ready for that
         maximum_token_len = max([len(stop_string) for stop_string in self.stop_strings])
         input_ids = input_ids[:, -maximum_token_len:]
+        # Flip input_ids because we're only matching strings at the end of the generated sequence
         flipped_ids = torch.flip(input_ids, (1,))
         string_matches = []
         for stop_string in self.stop_strings:
             target_len = len(stop_string)
             max_valid_positions = self.max_valid_positions[stop_string]
             max_valid_end_lens = self.max_valid_end_lens[stop_string]
+            # The embedding vec contains the valid positions, end_lengths and total lengths for each token
             embedding_vec = self.embedding_vecs[stop_string]
             embedded = F.embedding(flipped_ids, embedding_vec)
 
+            # Starts contains the number of characters from the string, counting from the end, that the token contains
+            # It can have multiple values if the same token can overlap different slices of the end of the string
             starts = embedded[:, :1, max_valid_positions : max_valid_positions + max_valid_end_lens]
+            # Lengths is the total length of each token. Unlike starts, it always has a single value
             lengths = embedded[:, 1:, -1:]
             lengths = lengths.expand((-1, -1, starts.shape[-1]))
             lengths_with_starts = torch.cat([starts, lengths], dim=1)
+            # We concatenate each possible starting length with the lengths of the remaining tokens in input_ids
+            # Then we cumsum() to get the total length of the string after each token
             cumsum = lengths_with_starts.cumsum(dim=1)
-            valid_positions = embedded[:, 1:, :max_valid_positions]
 
+            # Valid positions are the positions in the string that the token can validly appear after
+            valid_positions = embedded[:, 1:, :max_valid_positions]
+            # Tokens can match the start of the string if they have any valid value in the starts vector
             initial_match = torch.any(starts > 0, dim=-1, keepdim=True)
+            # Tokens can continue the string if the cumsum() so far is one of the valid positions for that token
+            # Note that we're actually tracking one cumsum() for the list for each possible start overhang length
             later_match = torch.isin(cumsum[:, :-1], valid_positions)
+            # The match vector is a boolean vector that indicates which positions have valid tokens
             match = torch.cat([initial_match, later_match], dim=1)
 
+            # Once a single position does not match, all positions following that position are masked
             mask = (~match).cumsum(dim=1, dtype=torch.int32)
             mask = mask == 0
 
+            # The string is matched if we reached a cumsum equal to or greater than the length of the string
+            # before hitting the masked run
             string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze() >= target_len)
 
-        # Now we concatenate matches across all strings and check if any are True
+        # Now we concatenate the match booleans across all strings and check if any are True
         string_matches = torch.cat(string_matches, dim=0)
         return torch.any(string_matches).item()
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -2,7 +2,9 @@ import time
 import warnings
 from abc import ABC
 from copy import deepcopy
-from typing import List, Optional, Union
+from typing import Optional, List, Union
+
+from ..tokenization_utils_base import PreTrainedTokenizerBase
 
 import torch
 
@@ -127,6 +129,56 @@ class MaxTimeCriteria(StoppingCriteria):
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.BoolTensor:
         is_done = time.time() - self.initial_timestamp > self.max_time
         return torch.full((input_ids.shape[0],), is_done, device=input_ids.device, dtype=torch.bool)
+
+
+class TerminationSequenceCriteria(StoppingCriteria):
+    """
+    This class can be used to stop generation whenever specific string sequences are encountered. Because the same
+    substring can be tokenized in different ways depending on context, this class expands strings up into every possible
+    token sequence that could contain them in a preprocessing step, then does a vectorized comparison against
+    `input_ids` during generation. This is much faster than doing detokenization inside the generation loop.
+
+    Args:
+        tokenizer (`PreTrainedTokenizer`):
+            The model's associated tokenizer (necessary to extract vocab and tokenize the termination sequences)
+        termination_sequences (`Union[str, List[str]]`):
+            The sequences that should end generation. If a string is passed, it will be treated like a
+            list with a single element.
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, termination_sequences: Union[str, List[str]]):
+        vocab = tokenizer.get_vocab()
+        tok_list = list(vocab.keys())
+        if isinstance(termination_sequences, str):
+            termination_sequences = [termination_sequences]
+        termination_tokens = []
+        for seq in termination_sequences:
+            if seq in tokenizer.special_tokens_map.values():
+                # If it's a special token it won't be split, so we can just use it directly
+                termination_tokens.append(vocab[seq])
+                continue
+            # If it isn't a special token, we need to figure out all sequences of tokens which contain this string.
+            # This is horribly inefficient, but it'll do to start.
+            bridging_seqs = []
+            for prefix_len in range(1, len(seq) + 1):
+                for suffix_len in range(len(seq), len(seq) - prefix_len, -1):
+                    prefix = seq[:prefix_len]
+                    suffix = seq[-suffix_len:]
+                    middle = seq[prefix_len:-suffix_len]
+                    possible_starts = [token for token in tok_list if token.endswith(prefix)]
+                    possible_ends = [token for token in tok_list if token.startswith(suffix)]
+                    if not possible_starts or not possible_ends:
+                        continue
+                    bridging_seqs.extend([start + middle + end for start in possible_starts for end in possible_ends])
+            if not bridging_seqs:
+                raise ValueError("Couldn't find any set of tokens spanning the termination sequence " + seq)
+            bridging_seqs = list(set(bridging_seqs))  # Uniquify just in case
+            termination_tokens.extend(tokenizer(bridging_seqs, add_special_tokens=False)['input_ids'])
+
+
+    @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        return time.time() - self.initial_timestamp > self.max_time
 
 
 class EosTokenCriteria(StoppingCriteria):

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -276,7 +276,7 @@ class StopStringCriteria(StoppingCriteria):
             initial_match = torch.any(starts > 0, dim=-1, keepdim=True)
             # Tokens can continue the string if the cumsum() so far is one of the valid positions for that token
             # Note that we're actually tracking one cumsum() for the list for each possible start overhang length
-            later_match = torch.isin(cumsum[:, :-1], valid_positions)
+            later_match = torch.any(cumsum[:, :-1, None] == valid_positions[:, :, :, None], axis=2)
             # The match vector is a boolean vector that indicates which positions have valid tokens
             match = torch.cat([initial_match, later_match], dim=1)
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -1,8 +1,8 @@
 import time
 import warnings
 from abc import ABC
+from collections import OrderedDict
 from copy import deepcopy
-from functools import lru_cache
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -14,6 +14,9 @@ from ..utils import add_start_docstrings, logging
 
 
 logger = logging.get_logger(__name__)
+# We maintain a module-level cache of the embedding vectors for the stop string criterion
+# because they are slow to compute
+STOP_STRING_EMBEDDING_CACHE = OrderedDict()
 
 
 STOPPING_CRITERIA_INPUTS_DOCSTRING = r"""
@@ -259,16 +262,37 @@ class StopStringCriteria(StoppingCriteria):
     def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, List[str]]):
         if isinstance(stop_strings, str):
             stop_strings = [stop_strings]
-
-        self.token_list, self.token_indices = self.clean_tokenizer_vocab(tokenizer)
         self.stop_strings: Tuple[str, ...] = tuple(stop_strings)
-
-        self.embedding_vec, self.max_valid_positions, self.max_valid_end_lens = _stop_string_create_embedding_vec(
-            self.token_list, self.token_indices, self.stop_strings
+        vocab = tokenizer.get_vocab()
+        token_list, token_indices = tuple(vocab.keys()), tuple(vocab.values())
+        self.embedding_vec, self.max_valid_positions, self.max_valid_end_lens = self.clean_and_embed_tokens_with_cache(
+            token_list, token_indices, self.stop_strings, tokenizer
         )
+
         self.maximum_token_len = max([len(stop_string) for stop_string in self.stop_strings])
         self.num_stop_strings = len(self.stop_strings)
         self.target_lens = torch.tensor([len(stop_string) for stop_string in stop_strings], dtype=torch.int32)
+
+    def clean_and_embed_tokens_with_cache(self, token_list, token_indices, stop_strings, tokenizer):
+        # We don't use the tokenizer in the cache key, because I don't trust it to have well-behaved equality
+        if (token_list, token_indices, stop_strings) in STOP_STRING_EMBEDDING_CACHE:
+            embedding_vec, max_valid_positions, max_valid_end_lens = STOP_STRING_EMBEDDING_CACHE[
+                (token_list, token_indices, self.stop_strings)
+            ]
+            STOP_STRING_EMBEDDING_CACHE.move_to_end((token_list, token_indices, stop_strings))
+        else:
+            clean_token_list, clean_token_indices = self.clean_tokenizer_vocab(tokenizer)
+            embedding_vec, max_valid_positions, max_valid_end_lens = self._stop_string_create_embedding_vec(
+                clean_token_list, clean_token_indices, stop_strings
+            )
+            STOP_STRING_EMBEDDING_CACHE[(token_list, token_indices, stop_strings)] = (
+                embedding_vec,
+                max_valid_positions,
+                max_valid_end_lens,
+            )
+            if len(STOP_STRING_EMBEDDING_CACHE) > 8:
+                STOP_STRING_EMBEDDING_CACHE.popitem(last=False)
+        return embedding_vec, max_valid_positions, max_valid_end_lens
 
     @staticmethod
     def clean_tokenizer_vocab(tokenizer, static_prefix="abcdef"):
@@ -291,6 +315,88 @@ class StopStringCriteria(StoppingCriteria):
             clean_token_list.append(token_string)
             clean_token_indices.append(token_idx)
         return tuple(clean_token_list), tuple(clean_token_indices)
+
+    @staticmethod
+    def _stop_string_get_matching_positions(
+        token_list, token_indices, stop_strings
+    ) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
+        """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
+        validly appear in the stop strings. For each token, it computes a list of positions in the stop string where the
+        token appears, as well as a list of the possible "end overlaps" for that token - that is, the number of characters
+        from the end of the stop string that overlap with the start of the token, which can have more than one value.
+
+        The reason for computing these may seem a bit cryptic - please see the docstring for StopStringCriteria for a full
+        explanation of what these values are for!"""
+
+        token_valid_positions = {}
+        token_end_overlaps = {}
+        for stop_string in stop_strings:
+            reversed_stop_string = stop_string[::-1]
+            token_valid_positions[stop_string] = {}
+            token_end_overlaps[stop_string] = {}
+            for token, tok_idx in zip(token_list, token_indices):
+                reversed_token = token[::-1]
+                matching_positions = []
+                possible_end_lengths = []
+                for i in range(1 - len(token), len(stop_string)):
+                    if i < 0:
+                        tok = reversed_token[-i:]
+                        i = 0
+                    else:
+                        tok = reversed_token
+                    stop = reversed_stop_string[i : i + len(tok)]
+                    if tok.startswith(stop):
+                        if i == 0:
+                            possible_end_lengths.append(min(len(tok), len(stop)))
+                        else:
+                            matching_positions.append(i)
+
+                if matching_positions:
+                    token_valid_positions[stop_string][tok_idx] = matching_positions
+                if possible_end_lengths:
+                    token_end_overlaps[stop_string][tok_idx] = possible_end_lengths
+        return token_valid_positions, token_end_overlaps
+
+    @staticmethod
+    def _stop_string_create_embedding_vec(token_list, token_indices, stop_strings) -> Dict[str, torch.tensor]:
+        """This function precomputes everything needed for the run-time checks in StopStringCriteria, and packs
+        them into an embedding tensor that can be accessed with pure tensor operations. For the specifics of the values
+        that are precomputed and what they are used for, please refer to the StopStringCriteria docstring!"""
+        token_valid_positions, token_end_overlaps = StopStringCriteria._stop_string_get_matching_positions(
+            token_list, token_indices, stop_strings
+        )
+
+        max_valid_positions = max(
+            len(val) for positions in token_valid_positions.values() for val in positions.values()
+        )
+        max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
+        vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
+        gather_vec = np.full((len(token_list), vec_size), dtype=np.int32, fill_value=-1)
+
+        for i, stop_string in enumerate(stop_strings):
+            positions = token_valid_positions[stop_string]
+            end_lens = token_end_overlaps[stop_string]
+
+            # Since this is lots of very small assignments of lists, we build it with numpy rather
+            # than torch for speed + simplicity, then convert to torch at the end
+            for token_idx, valid_positions in positions.items():
+                gather_vec[
+                    token_idx, max_valid_positions * i : max_valid_positions * i + len(valid_positions)
+                ] = valid_positions
+            for token_idx, possible_end_lens in end_lens.items():
+                gather_vec[
+                    token_idx,
+                    max_valid_positions * len(stop_strings) + max_valid_end_lens * i : max_valid_positions
+                    * len(stop_strings)
+                    + max_valid_end_lens * i
+                    + len(possible_end_lens),
+                ] = possible_end_lens
+            for token, token_idx in zip(token_list, token_indices):
+                gather_vec[token_idx, -1] = len(token)
+
+        gather_vec = torch.tensor(gather_vec, dtype=torch.int32)
+
+        return gather_vec, max_valid_positions, max_valid_end_lens
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.Tensor:
@@ -398,84 +504,3 @@ def validate_stopping_criteria(stopping_criteria: StoppingCriteriaList, max_leng
     elif stopping_max_length is None:
         new_stopping_criteria.append(MaxLengthCriteria(max_length=max_length))
     return new_stopping_criteria
-
-
-def _stop_string_get_matching_positions(
-    token_list, token_indices, stop_strings
-) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
-    """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
-    validly appear in the stop strings. For each token, it computes a list of positions in the stop string where the
-    token appears, as well as a list of the possible "end overlaps" for that token - that is, the number of characters
-    from the end of the stop string that overlap with the start of the token, which can have more than one value.
-
-    The reason for computing these may seem a bit cryptic - please see the docstring for StopStringCriteria for a full
-    explanation of what these values are for!"""
-
-    token_valid_positions = {}
-    token_end_overlaps = {}
-    for stop_string in stop_strings:
-        reversed_stop_string = stop_string[::-1]
-        token_valid_positions[stop_string] = {}
-        token_end_overlaps[stop_string] = {}
-        for token, tok_idx in zip(token_list, token_indices):
-            reversed_token = token[::-1]
-            matching_positions = []
-            possible_end_lengths = []
-            for i in range(1 - len(token), len(stop_string)):
-                if i < 0:
-                    tok = reversed_token[-i:]
-                    i = 0
-                else:
-                    tok = reversed_token
-                stop = reversed_stop_string[i : i + len(tok)]
-                if tok.startswith(stop):
-                    if i == 0:
-                        possible_end_lengths.append(min(len(tok), len(stop)))
-                    else:
-                        matching_positions.append(i)
-
-            if matching_positions:
-                token_valid_positions[stop_string][tok_idx] = matching_positions
-            if possible_end_lengths:
-                token_end_overlaps[stop_string][tok_idx] = possible_end_lengths
-    return token_valid_positions, token_end_overlaps
-
-
-@lru_cache(8)
-def _stop_string_create_embedding_vec(token_list, token_indices, stop_strings) -> Dict[str, torch.tensor]:
-    """This function precomputes everything needed for the run-time checks in StopStringCriteria, and packs
-    them into an embedding tensor that can be accessed with pure tensor operations. For the specifics of the values
-    that are precomputed and what they are used for, please refer to the StopStringCriteria docstring!"""
-    token_valid_positions, token_end_overlaps = _stop_string_get_matching_positions(
-        token_list, token_indices, stop_strings
-    )
-
-    max_valid_positions = max(len(val) for positions in token_valid_positions.values() for val in positions.values())
-    max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
-    vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
-    gather_vec = np.full((len(token_list), vec_size), dtype=np.int32, fill_value=-1)
-
-    for i, stop_string in enumerate(stop_strings):
-        positions = token_valid_positions[stop_string]
-        end_lens = token_end_overlaps[stop_string]
-
-        # Since this is lots of very small assignments of lists, we build it with numpy rather
-        # than torch for speed + simplicity, then convert to torch at the end
-        for token_idx, valid_positions in positions.items():
-            gather_vec[
-                token_idx, max_valid_positions * i : max_valid_positions * i + len(valid_positions)
-            ] = valid_positions
-        for token_idx, possible_end_lens in end_lens.items():
-            gather_vec[
-                token_idx,
-                max_valid_positions * len(stop_strings) + max_valid_end_lens * i : max_valid_positions
-                * len(stop_strings)
-                + max_valid_end_lens * i
-                + len(possible_end_lens),
-            ] = possible_end_lens
-        for token, token_idx in zip(token_list, token_indices):
-            gather_vec[token_idx, -1] = len(token)
-
-    gather_vec = torch.tensor(gather_vec, dtype=torch.int32)
-
-    return gather_vec, max_valid_positions, max_valid_end_lens

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -244,8 +244,6 @@ class StopStringCriteria(StoppingCriteria):
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-        # TODO Joao - I'm not using the scores at all and just checking the most recent tokens in input_ids
-        #      Is this correct? Should I be sampling from scores?
         # The maximum length we need to consider is 1 token per character. Note that input_ids can also be
         # *shorter* than the global max, and the code below should be ready for that
         maximum_token_len = max([len(stop_string) for stop_string in self.stop_strings])

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -166,7 +166,7 @@ class StopStringCriteria(StoppingCriteria):
         self.embedding_vecs = self.create_embedding_vecs()
 
     @staticmethod
-    def get_matching_positions(vocab, stop_strings):
+    def get_matching_positions(vocab: List[str], stop_strings: List[str]) -> Tuple[Dict[str, Dict[str, List[int]]], Dict[str, Dict[str, List[int]]]]:
         """This function preprocesses stop strings and the tokenizer vocabulary to determine where tokens can
         validly appear in the stop strings. For each stop string, it returns a dictionary mapping tokens to a list of
         valid positions, as well as a dictionary mapping tokens to a list of possible overlap lengths at the

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -286,7 +286,7 @@ class StopStringCriteria(StoppingCriteria):
 
             # The string is matched if we reached a cumsum equal to or greater than the length of the string
             # before hitting the mask
-            string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze() >= target_len)
+            string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze(1) >= target_len)
 
         # Now we concatenate the match booleans across all strings and check if any are True
         string_matches = torch.cat(string_matches, dim=0)

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -285,7 +285,7 @@ class StopStringCriteria(StoppingCriteria):
             mask = mask == 0
 
             # The string is matched if we reached a cumsum equal to or greater than the length of the string
-            # before hitting the masked run
+            # before hitting the mask
             string_matches.append(torch.max(cumsum * mask, dim=1).values.squeeze() >= target_len)
 
         # Now we concatenate the match booleans across all strings and check if any are True

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -80,6 +80,7 @@ from .stopping_criteria import (
     MaxTimeCriteria,
     StoppingCriteria,
     StoppingCriteriaList,
+    StopStringCriteria,
     validate_stopping_criteria,
 )
 
@@ -881,7 +882,7 @@ class GenerationMixin:
         return processors
 
     def _get_stopping_criteria(
-        self, generation_config: GenerationConfig, stopping_criteria: Optional[StoppingCriteriaList]
+        self, generation_config: GenerationConfig, stopping_criteria: Optional[StoppingCriteriaList], **kwargs
     ) -> StoppingCriteriaList:
         criteria = StoppingCriteriaList()
         if generation_config.max_length is not None:
@@ -894,6 +895,14 @@ class GenerationMixin:
             )
         if generation_config.max_time is not None:
             criteria.append(MaxTimeCriteria(max_time=generation_config.max_time))
+        if generation_config.stop_strings is not None:
+            if "tokenizer" not in kwargs:
+                raise ValueError(
+                    "To generate with stop strings, you need to pass the model's tokenizer to the `generate` method."
+                )
+            criteria.append(
+                StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=kwargs["tokenizer"])
+            )
         if generation_config.eos_token_id is not None:
             criteria.append(EosTokenCriteria(eos_token_id=generation_config.eos_token_id))
         criteria = self._merge_criteria_processor_list(criteria, stopping_criteria)
@@ -1527,7 +1536,7 @@ class GenerationMixin:
 
         # 9. prepare stopping criteria
         prepared_stopping_criteria = self._get_stopping_criteria(
-            generation_config=generation_config, stopping_criteria=stopping_criteria
+            generation_config=generation_config, stopping_criteria=stopping_criteria, **kwargs
         )
         # 10. go into different generation modes
         if generation_mode == GenerationMode.ASSISTED_GENERATION:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -88,6 +88,7 @@ from .stopping_criteria import (
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
     from .streamers import BaseStreamer
+    from ..tokenization_utils_base import PreTrainedTokenizerBase
 
 logger = logging.get_logger(__name__)
 
@@ -882,7 +883,7 @@ class GenerationMixin:
         return processors
 
     def _get_stopping_criteria(
-        self, generation_config: GenerationConfig, stopping_criteria: Optional[StoppingCriteriaList], **kwargs
+        self, generation_config: GenerationConfig, stopping_criteria: Optional[StoppingCriteriaList], tokenizer: Optional["PreTrainedTokenizerBase"] = None, **kwargs
     ) -> StoppingCriteriaList:
         criteria = StoppingCriteriaList()
         if generation_config.max_length is not None:
@@ -1396,6 +1397,7 @@ class GenerationMixin:
                 synced_gpus = True
             else:
                 synced_gpus = False
+        tokenizer = kwargs.pop("tokenizer", None)
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
 
@@ -1538,7 +1540,7 @@ class GenerationMixin:
 
         # 9. prepare stopping criteria
         prepared_stopping_criteria = self._get_stopping_criteria(
-            generation_config=generation_config, stopping_criteria=stopping_criteria, **kwargs
+            generation_config=generation_config, stopping_criteria=stopping_criteria, tokenizer=tokenizer, **kwargs
         )
         # 10. go into different generation modes
         if generation_mode == GenerationMode.ASSISTED_GENERATION:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -898,7 +898,9 @@ class GenerationMixin:
         if generation_config.stop_strings is not None:
             if "tokenizer" not in kwargs:
                 raise ValueError(
-                    "To generate with stop strings, you need to pass the model's tokenizer to the `generate` method."
+                    "There are one or more stop strings, either in the arguments to `generate` or in the "
+                    "model's generation config, but we could not locate a tokenizer. When generating with "
+                    "stop strings, you must pass the model's tokenizer to the `tokenizer` argument of `generate`."
                 )
             criteria.append(
                 StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=kwargs["tokenizer"])

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -87,8 +87,8 @@ from .stopping_criteria import (
 
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
-    from .streamers import BaseStreamer
     from ..tokenization_utils_base import PreTrainedTokenizerBase
+    from .streamers import BaseStreamer
 
 logger = logging.get_logger(__name__)
 
@@ -883,7 +883,11 @@ class GenerationMixin:
         return processors
 
     def _get_stopping_criteria(
-        self, generation_config: GenerationConfig, stopping_criteria: Optional[StoppingCriteriaList], tokenizer: Optional["PreTrainedTokenizerBase"] = None, **kwargs
+        self,
+        generation_config: GenerationConfig,
+        stopping_criteria: Optional[StoppingCriteriaList],
+        tokenizer: Optional["PreTrainedTokenizerBase"] = None,
+        **kwargs,
     ) -> StoppingCriteriaList:
         criteria = StoppingCriteriaList()
         if generation_config.max_length is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -907,9 +907,7 @@ class GenerationMixin:
                     "model's generation config, but we could not locate a tokenizer. When generating with "
                     "stop strings, you must pass the model's tokenizer to the `tokenizer` argument of `generate`."
                 )
-            criteria.append(
-                StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=tokenizer)
-            )
+            criteria.append(StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=tokenizer))
         if generation_config.eos_token_id is not None:
             criteria.append(EosTokenCriteria(eos_token_id=generation_config.eos_token_id))
         criteria = self._merge_criteria_processor_list(criteria, stopping_criteria)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -901,14 +901,14 @@ class GenerationMixin:
         if generation_config.max_time is not None:
             criteria.append(MaxTimeCriteria(max_time=generation_config.max_time))
         if generation_config.stop_strings is not None:
-            if "tokenizer" not in kwargs:
+            if tokenizer is None:
                 raise ValueError(
                     "There are one or more stop strings, either in the arguments to `generate` or in the "
                     "model's generation config, but we could not locate a tokenizer. When generating with "
                     "stop strings, you must pass the model's tokenizer to the `tokenizer` argument of `generate`."
                 )
             criteria.append(
-                StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=kwargs["tokenizer"])
+                StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=tokenizer)
             )
         if generation_config.eos_token_id is not None:
             criteria.append(EosTokenCriteria(eos_token_id=generation_config.eos_token_id))
@@ -1392,6 +1392,7 @@ class GenerationMixin:
         """
         # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
         self._validate_model_class()
+        tokenizer = kwargs.pop("tokenizer", None)  # Pull this out first, we only use it for stopping criteria
         generation_config, model_kwargs = self._prepare_generation_config(generation_config, **kwargs)
         self._validate_model_kwargs(model_kwargs.copy())
 
@@ -1401,7 +1402,7 @@ class GenerationMixin:
                 synced_gpus = True
             else:
                 synced_gpus = False
-        tokenizer = kwargs.pop("tokenizer", None)
+
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
 

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -127,14 +127,24 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         self.assertEqual(len(stopping_criteria), 1)
 
     def test_stop_string_criteria(self):
-        true_strings = ["<|im_start|><|im_end|>", "<|im_start|><|im_end|<|im_end|>", ">><|im_start|>>stop", "stop"]
+        true_strings = [
+            "<|im_start|><|im_end|>",
+            "<|im_start|><|im_end|<|im_end|>",
+            ">><|im_start|>>stop",
+            "stop",
+            "end",
+        ]
         false_strings = [
             "<|im_start|><|im_end|",
             "<|im_start|><|im_end|<|im_end|",
             "<|im_end|><|im_start|>",
             "<|im_end|<>stop<|im_end|",
         ]
-        too_short_strings = ["<|im_end|", "|im_end|>", "s", "end"]
+        too_short_strings = [
+            "<|im_end|",
+            "|im_end|>",
+            "s",
+        ]
 
         # Use a tokenizer that won't actually have special tokens for these
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
@@ -146,7 +156,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
         )
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop"])
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop", "end"])
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
@@ -162,7 +172,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         too_short_input_ids = tokenizer(
             too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
         )
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop"])
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop", "end"])
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -139,7 +139,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "<|im_end|><|im_start|>",
             "<|im_end|<>stop<|im_end|",
         ]
-        too_short_strings = ["<|im_end|", "|im_end|>", "s"]
+        too_short_strings = ["<|im_end|", "|im_end|>", "s", "end"]
 
         # Use a tokenizer that won't actually have special tokens for these
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -184,7 +184,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
         idx_to_token = {v: k for k, v in tokenizer.get_vocab().items()}
         all_token_valid_positions, all_token_end_overlaps = _stop_string_get_matching_positions(
-            tok_list=criteria.tok_list, tok_indices=criteria.tok_indices, stop_strings=criteria.stop_strings
+            token_list=criteria.token_list, token_indices=criteria.token_indices, stop_strings=criteria.stop_strings
         )
         for stop_string in stop_strings:
             token_valid_positions = all_token_valid_positions[stop_string]
@@ -215,7 +215,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         stop_strings = ["aaaaaaa", "assdfiugsdf", "stop"]
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
         embedding_vec, max_valid_positions, max_valid_end_lens = _stop_string_create_embedding_vec(
-            tok_list=criteria.tok_list, tok_indices=criteria.tok_indices, stop_strings=criteria.stop_strings
+            token_list=criteria.token_list, token_indices=criteria.token_indices, stop_strings=criteria.stop_strings
         )
         valid_positions_vec = embedding_vec[:, : max_valid_positions * len(stop_strings)].unflatten(
             -1, (len(stop_strings), -1)
@@ -226,7 +226,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         token_lengths = embedding_vec[:, -1]
 
         for i, stop_string in enumerate(stop_strings):
-            for token, token_idx in zip(criteria.tok_list, criteria.tok_indices):
+            for token, token_idx in zip(criteria.token_list, criteria.token_indices):
                 # The embedding contains packed valid positions, end overlap lengths, and the total token length
                 token = token.replace("▁", " ").replace("Ġ", " ")
 

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -152,11 +152,11 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         for i in range(len(true_strings)):
-            self.assertTrue(criteria(true_input_ids["input_ids"][i: i+1], scores))
+            self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
-            self.assertFalse(criteria(false_input_ids["input_ids"][i: i+1], scores))
+            self.assertFalse(criteria(false_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(too_short_strings)):
-            self.assertFalse(criteria(too_short_input_ids["input_ids"][i: i+1], scores))
+            self.assertFalse(criteria(too_short_input_ids["input_ids"][i : i + 1], scores))
 
         # Now try it with a tokenizer where those are actually special tokens
         tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
@@ -166,8 +166,8 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         for i in range(len(true_strings)):
-            self.assertTrue(criteria(true_input_ids["input_ids"][i: i+1], scores))
+            self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
-            self.assertFalse(criteria(false_input_ids["input_ids"][i: i+1], scores))
+            self.assertFalse(criteria(false_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(too_short_strings)):
-            self.assertFalse(criteria(too_short_input_ids["input_ids"][i: i+1], scores))
+            self.assertFalse(criteria(too_short_input_ids["input_ids"][i : i + 1], scores))

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -127,9 +127,6 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         self.assertEqual(len(stopping_criteria), 1)
 
     def test_stop_string_criteria(self):
-        # Use a tokenizer that won't actually have special tokens for these
-        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
-
         true_strings = [
             "<|im_start|><|im_end|>",
             "<|im_start|><|im_end|<|im_end|>",
@@ -142,6 +139,9 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "<|im_end|<><|im_end|",
         ]
         too_short_strings = ["<|im_end|", "|im_end|>"]
+
+        # Use a tokenizer that won't actually have special tokens for these
+        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
         tokenizer.pad_token_id = tokenizer.eos_token_id
         tokenizer.padding_side = "left"
         true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -190,7 +190,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
                         # This token runs off the start of the string
                         self.assertTrue(stop_string.startswith(token[trim_length:]))
                     else:
-                        self.assertTrue(stop_string[-position - len(token) : -position] == token)
+                        self.assertTrue(stop_string[-position - len(token):].startswith(token))
             for token, end_overlaps in token_end_overlaps.items():
                 token = token.replace("▁", " ").replace("Ġ", " ")
                 for overlap in end_overlaps:

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -16,7 +16,7 @@
 import time
 import unittest
 
-from transformers import is_torch_available, AutoTokenizer
+from transformers import AutoTokenizer, is_torch_available
 from transformers.testing_utils import require_torch, torch_device
 
 from ..test_modeling_common import ids_tensor
@@ -30,8 +30,8 @@ if is_torch_available():
         MaxLengthCriteria,
         MaxNewTokensCriteria,
         MaxTimeCriteria,
-        StopStringCriteria,
         StoppingCriteriaList,
+        StopStringCriteria,
         validate_stopping_criteria,
     )
 
@@ -140,22 +140,28 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "<|im_start|><|im_end|<|im_end|",
             "<|im_end|><|im_start|>",
             "<|im_end|<><|im_end|",
-            ]
+        ]
+        too_short_strings = ["<|im_end|", "|im_end|>"]
         tokenizer.pad_token_id = tokenizer.eos_token_id
         tokenizer.padding_side = "left"
-        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest")
-        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest")
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
+        too_short_input_ids = tokenizer(
+            too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
+        )
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         self.assertTrue(criteria(true_input_ids["input_ids"], scores))
         self.assertFalse(criteria(false_input_ids["input_ids"], scores))
+        self.assertFalse(criteria(too_short_input_ids["input_ids"], scores))
 
         # Now try it with a tokenizer where those are actually special tokens
         tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
         tokenizer.pad_token_id = tokenizer.eos_token_id
         tokenizer.padding_side = "left"
-        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest")
-        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest")
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         self.assertTrue(criteria(true_input_ids["input_ids"], scores))
         self.assertFalse(criteria(false_input_ids["input_ids"], scores))
+        self.assertFalse(criteria(too_short_input_ids["input_ids"], scores))

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -127,12 +127,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         self.assertEqual(len(stopping_criteria), 1)
 
     def test_stop_string_criteria(self):
-        true_strings = [
-            "<|im_start|><|im_end|>",
-            "<|im_start|><|im_end|<|im_end|>",
-            ">><|im_start|>>stop",
-            "stop"
-        ]
+        true_strings = ["<|im_start|><|im_end|>", "<|im_start|><|im_end|<|im_end|>", ">><|im_start|>>stop", "stop"]
         false_strings = [
             "<|im_start|><|im_end|",
             "<|im_start|><|im_end|<|im_end|",

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -34,11 +34,10 @@ if is_torch_available():
         StopStringCriteria,
         validate_stopping_criteria,
     )
-
-from transformers.generation.stopping_criteria import (
-    _stop_string_create_embedding_vec,
-    _stop_string_get_matching_positions,
-)
+    from transformers.generation.stopping_criteria import (
+        _stop_string_create_embedding_vec,
+        _stop_string_get_matching_positions,
+    )
 
 
 @require_torch

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -36,7 +36,6 @@ if is_torch_available():
     )
 
 from transformers.generation.stopping_criteria import (
-    _stop_string_create_embedding_vecs,
     _stop_string_get_matching_positions,
 )
 
@@ -211,45 +210,45 @@ class StoppingCriteriaTestCase(unittest.TestCase):
                         )
                     )
 
-    def test_stop_string_embedding_vecs(self):
-        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
-        stop_strings = ["aaaaaaa", "assdfiugsdf", "stop"]
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
-        all_embedding_vecs, *_ = _stop_string_create_embedding_vecs(
-            tok_list=criteria.tok_list, tok_indices=criteria.tok_indices, stop_strings=criteria.stop_strings
-        )
-        for stop_string in stop_strings:
-            embedding_vecs = all_embedding_vecs[stop_string]
-            max_valid_positions = criteria.max_valid_positions[stop_string]
-            max_valid_end_lens = criteria.max_valid_end_lens[stop_string]
-            for token, token_idx in zip(criteria.tok_list, criteria.tok_indices):
-                vec = embedding_vecs[token_idx].tolist()
-                # The embedding contains packed valid positions, end overlap lengths, and the total token length
-                token = token.replace("▁", " ").replace("Ġ", " ")
-
-                token_valid_positions = vec[:max_valid_positions]
-                for position in token_valid_positions:
-                    if position == -1:
-                        continue  # Padding value
-                    trim_length = position + len(token) - len(stop_string)
-                    if trim_length > 0:
-                        # This token runs off the start of the string
-                        self.assertTrue(stop_string.startswith(token[trim_length:]))
-                    else:
-                        self.assertTrue(stop_string[-position - len(token) : -position] == token)
-
-                token_end_overlaps = vec[max_valid_positions : max_valid_positions + max_valid_end_lens]
-                for overlap in token_end_overlaps:
-                    if overlap == -1:
-                        continue  # Padding value
-                    # Either this token runs off the end of the string,
-                    # or the entire stop string is a substring of the token
-                    self.assertTrue(
-                        (
-                            stop_string.endswith(token[:overlap])
-                            or (stop_string in token and overlap == len(stop_string))
-                        )
-                    )
-
-                token_length = vec[-1]
-                self.assertTrue(len(token) == token_length)
+    # def test_stop_string_embedding_vecs(self):
+    #     tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+    #     stop_strings = ["aaaaaaa", "assdfiugsdf", "stop"]
+    #     criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
+    #     all_embedding_vecs, *_ = _stop_string_create_embedding_vec(
+    #         tok_list=criteria.tok_list, tok_indices=criteria.tok_indices, stop_strings=criteria.stop_strings
+    #     )
+    #     for stop_string in stop_strings:
+    #         embedding_vecs = all_embedding_vecs[stop_string]
+    #         max_valid_positions = criteria.max_valid_positions[stop_string]
+    #         max_valid_end_lens = criteria.max_valid_end_lens[stop_string]
+    #         for token, token_idx in zip(criteria.tok_list, criteria.tok_indices):
+    #             vec = embedding_vecs[token_idx].tolist()
+    #             # The embedding contains packed valid positions, end overlap lengths, and the total token length
+    #             token = token.replace("▁", " ").replace("Ġ", " ")
+    #
+    #             token_valid_positions = vec[:max_valid_positions]
+    #             for position in token_valid_positions:
+    #                 if position == -1:
+    #                     continue  # Padding value
+    #                 trim_length = position + len(token) - len(stop_string)
+    #                 if trim_length > 0:
+    #                     # This token runs off the start of the string
+    #                     self.assertTrue(stop_string.startswith(token[trim_length:]))
+    #                 else:
+    #                     self.assertTrue(stop_string[-position - len(token) : -position] == token)
+    #
+    #             token_end_overlaps = vec[max_valid_positions : max_valid_positions + max_valid_end_lens]
+    #             for overlap in token_end_overlaps:
+    #                 if overlap == -1:
+    #                     continue  # Padding value
+    #                 # Either this token runs off the end of the string,
+    #                 # or the entire stop string is a substring of the token
+    #                 self.assertTrue(
+    #                     (
+    #                         stop_string.endswith(token[:overlap])
+    #                         or (stop_string in token and overlap == len(stop_string))
+    #                     )
+    #                 )
+    #
+    #             token_length = vec[-1]
+    #             self.assertTrue(len(token) == token_length)

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -190,7 +190,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
                         # This token runs off the start of the string
                         self.assertTrue(stop_string.startswith(token[trim_length:]))
                     else:
-                        self.assertTrue(stop_string[-position - len(token):].startswith(token))
+                        self.assertTrue(stop_string[-position - len(token) :].startswith(token))
             for token, end_overlaps in token_end_overlaps.items():
                 token = token.replace("▁", " ").replace("Ġ", " ")
                 for overlap in end_overlaps:

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -139,11 +139,12 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "<|im_start|><|im_end|",
             "<|im_start|><|im_end|<|im_end|",
             "<|im_end|><|im_start|>",
-            "<|im_end|><|im_start|",
+            "<|im_end|<><|im_end|",
             ]
         tokenizer.pad_token_id = tokenizer.eos_token_id
-        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", padding_side="left")
-        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", padding_side="left")
+        tokenizer.padding_side = "left"
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest")
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest")
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         self.assertTrue(criteria(true_input_ids["input_ids"], scores))
@@ -151,8 +152,10 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         # Now try it with a tokenizer where those are actually special tokens
         tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
-        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", padding_side="left")
-        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", padding_side="left")
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        tokenizer.padding_side = "left"
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest")
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest")
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
         self.assertTrue(criteria(true_input_ids["input_ids"], scores))
         self.assertFalse(criteria(false_input_ids["input_ids"], scores))

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -16,7 +16,7 @@
 import time
 import unittest
 
-from transformers import is_torch_available
+from transformers import is_torch_available, AutoTokenizer
 from transformers.testing_utils import require_torch, torch_device
 
 from ..test_modeling_common import ids_tensor
@@ -30,6 +30,7 @@ if is_torch_available():
         MaxLengthCriteria,
         MaxNewTokensCriteria,
         MaxTimeCriteria,
+        StopStringCriteria,
         StoppingCriteriaList,
         validate_stopping_criteria,
     )
@@ -124,3 +125,34 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         stopping_criteria = validate_stopping_criteria(StoppingCriteriaList(), 11)
 
         self.assertEqual(len(stopping_criteria), 1)
+
+    def test_stop_string_criteria(self):
+        # Use a tokenizer that won't actually have special tokens for these
+        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+
+        true_strings = [
+            "<|im_start|><|im_end|>",
+            "<|im_start|><|im_end|<|im_end|>",
+            ">><|im_start|>><|im_end|>",
+        ]
+        false_strings = [
+            "<|im_start|><|im_end|",
+            "<|im_start|><|im_end|<|im_end|",
+            "<|im_end|><|im_start|>",
+            "<|im_end|><|im_start|",
+            ]
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", padding_side="left")
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", padding_side="left")
+        scores = None
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
+        self.assertTrue(criteria(true_input_ids["input_ids"], scores))
+        self.assertFalse(criteria(false_input_ids["input_ids"], scores))
+
+        # Now try it with a tokenizer where those are actually special tokens
+        tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", padding_side="left")
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", padding_side="left")
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
+        self.assertTrue(criteria(true_input_ids["input_ids"], scores))
+        self.assertFalse(criteria(false_input_ids["input_ids"], scores))

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -147,6 +147,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "|im_end|>",
             "s",
         ]
+        stop_strings = ["<|im_end|>", "stop", "end"]
 
         # Use a tokenizer that won't actually have special tokens for these
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
@@ -158,7 +159,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
         )
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop", "end"])
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
@@ -174,7 +175,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         too_short_input_ids = tokenizer(
             too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
         )
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop", "end"])
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -151,9 +151,12 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         )
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
-        self.assertTrue(criteria(true_input_ids["input_ids"], scores))
-        self.assertFalse(criteria(false_input_ids["input_ids"], scores))
-        self.assertFalse(criteria(too_short_input_ids["input_ids"], scores))
+        for i in range(len(true_strings)):
+            self.assertTrue(criteria(true_input_ids["input_ids"][i: i+1], scores))
+        for i in range(len(false_strings)):
+            self.assertFalse(criteria(false_input_ids["input_ids"][i: i+1], scores))
+        for i in range(len(too_short_strings)):
+            self.assertFalse(criteria(too_short_input_ids["input_ids"][i: i+1], scores))
 
         # Now try it with a tokenizer where those are actually special tokens
         tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
@@ -162,6 +165,9 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
-        self.assertTrue(criteria(true_input_ids["input_ids"], scores))
-        self.assertFalse(criteria(false_input_ids["input_ids"], scores))
-        self.assertFalse(criteria(too_short_input_ids["input_ids"], scores))
+        for i in range(len(true_strings)):
+            self.assertTrue(criteria(true_input_ids["input_ids"][i: i+1], scores))
+        for i in range(len(false_strings)):
+            self.assertFalse(criteria(false_input_ids["input_ids"][i: i+1], scores))
+        for i in range(len(too_short_strings)):
+            self.assertFalse(criteria(too_short_input_ids["input_ids"][i: i+1], scores))

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -130,15 +130,16 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         true_strings = [
             "<|im_start|><|im_end|>",
             "<|im_start|><|im_end|<|im_end|>",
-            ">><|im_start|>><|im_end|>",
+            ">><|im_start|>>stop",
+            "stop"
         ]
         false_strings = [
             "<|im_start|><|im_end|",
             "<|im_start|><|im_end|<|im_end|",
             "<|im_end|><|im_start|>",
-            "<|im_end|<><|im_end|",
+            "<|im_end|<>stop<|im_end|",
         ]
-        too_short_strings = ["<|im_end|", "|im_end|>"]
+        too_short_strings = ["<|im_end|", "|im_end|>", "s"]
 
         # Use a tokenizer that won't actually have special tokens for these
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
@@ -150,7 +151,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
         )
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop"])
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
@@ -160,11 +161,13 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         # Now try it with a tokenizer where those are actually special tokens
         tokenizer = AutoTokenizer.from_pretrained("cognitivecomputations/dolphin-2.5-mixtral-8x7b")
-        tokenizer.pad_token_id = tokenizer.eos_token_id
         tokenizer.padding_side = "left"
         true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings="<|im_end|>")
+        too_short_input_ids = tokenizer(
+            too_short_strings, return_tensors="pt", padding="longest", add_special_tokens=False
+        )
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["<|im_end|>", "stop"])
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -139,6 +139,8 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "<|im_start|><|im_end|<|im_end|",
             "<|im_end|><|im_start|>",
             "<|im_end|<>stop<|im_end|",
+            "en d",
+            "eNd",
         ]
         too_short_strings = [
             "<|im_end|",


### PR DESCRIPTION
`generate()` stops when it encounters `eos_token_id`, but there are various circumstances when we want it to stop for other tokens too. The ideal situation would be to allow a set of strings that halts generation, and then include this information with the model, so model authors can set e.g. custom tokens like `<|im_end|>` as halting strings, even when those strings don't have a special token.

The problem with stopping for specific strings rather than tokens is that a string can be tokenized in many different ways, and the tokens that contain a string may also have overhangs on either end: `["?><", "|", "im_", "end", "|", ">>"]`. Since we have to check after each token generated by the model, we want to avoid detokenization and string comparisons, as this will cause a lot of slowdown and prevent us from compiling the generation loop.

This PR adds a `StoppingCriteria` for stop strings. It takes some time to preprocess the stop strings and the tokenizer vocabulary together and builds an embedding matrix containing the information it needs about which tokens can construct each stop string, but once that's done the entire generation-time check can be performed with only tensor operations and static, known shapes.

fixes #28801