### PR TITLE
Populate torch_dtype from model to pipeline

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -862,8 +862,6 @@ class Pipeline(_ScikitCompat):
         else:
             self.device = device if device is not None else -1
 
-        self._initial_torch_dtype = torch_dtype
-
         self.binary_output = binary_output
 
         # We shouldn't call `model.to()` for models loaded with accelerate
@@ -957,20 +955,11 @@ class Pipeline(_ScikitCompat):
         return self(X)
 
     @property
-    def torch_dtype(self):
-        if hasattr(self.model, "dtype"):
-            # NB: We extract dtype from the underlying model, but it is possible that the model has dtype
-            # but the pipeline subclass doesn't support it. In such case we should not return anything,
-            # but it is not straightforward to detect it in a generic way. Therefore, we assume that the
-            # pipeline support torch_dtype if (1) the extracted dtype is not default one (float32), or
-            # (2) the torch_dtype argument was set by the user when creating the pipeline.
-            if self._initial_torch_dtype is not None or self.model.dtype not in (
-                torch.float32,
-                "float32",
-                "torch.float32",
-            ):
-                return self.model.dtype
-        return self._initial_torch_dtype
+    def torch_dtype(self) -> Optional["torch.dtype"]:
+        """
+        Torch dtype of the model (if it's Pytorch model), `None` otherwise.
+        """
+        return getattr(self.model, "dtype", None)
 
     @contextmanager
     def device_placement(self):

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -862,6 +862,16 @@ class Pipeline(_ScikitCompat):
         else:
             self.device = device if device is not None else -1
         self.torch_dtype = torch_dtype
+
+        if not self.torch_dtype and is_torch_available():
+            # If pipeline dtype is not specified, populate it from the model
+            # NB: We should only do this when the extracted dtype is not default one (float32),
+            # because not all models/pipelines support torch_dtype. Here we assume that if the
+            # model dtype is not float32 it is set by the user with torch_dtype param, so the
+            # model or pipeline should support it.
+            if hasattr(model, "dtype") and model.dtype not in (torch.float32, "float32", "torch.float32"):
+                self.torch_dtype = model.dtype
+
         self.binary_output = binary_output
 
         # We shouldn't call `model.to()` for models loaded with accelerate

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -964,9 +964,10 @@ class Pipeline(_ScikitCompat):
             # but it is not straightforward to detect it in a generic way. Therefore, we assume that the
             # pipeline support torch_dtype if (1) the extracted dtype is not default one (float32), or
             # (2) the torch_dtype argument was set by the user when creating the pipeline.
-            if (
-                self._initial_torch_dtype is not None
-                or self.model.dtype not in (torch.float32, "float32", "torch.float32")
+            if self._initial_torch_dtype is not None or self.model.dtype not in (
+                torch.float32,
+                "float32",
+                "torch.float32",
             ):
                 return self.model.dtype
         return self._initial_torch_dtype

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -213,23 +213,14 @@ class CommonPipelineTest(unittest.TestCase):
         pipe.model.to(torch.bfloat16)
         self.assertEqual(pipe.torch_dtype, torch.bfloat16)
 
-        # Even if the model dtype is the default one, we can safely assume the pipeline supports torch_dtype
-        # as it is constructed with torch_dtype specified
-        pipe.model.to(torch.float32)
+        # If dtype is NOT specified in the pipeline constructor, the property should just return
+        # the dtype of the underlying model (default)
+        pipe = pipeline(model=model_id)
         self.assertEqual(pipe.torch_dtype, torch.float32)
 
-        # If dtype is NOT specified in the pipeline constructor, the property should NOT return type
-        # as we don't know if the pipeline supports torch_dtype
-        pipe = pipeline(model=model_id)
-        self.assertEqual(pipe.torch_dtype, None)
-
-        # If the model changes to non default dtype, we assume the pipeline supports torch_dtype
-        pipe.model.to(torch.float16)
-        self.assertEqual(pipe.torch_dtype, torch.float16)
-
-        # If the model dtype is the default, we conservatively assume the pipeline doesn't support torch_dtype
-        pipe.model.to(torch.float32)
-        self.assertEqual(pipe.torch_dtype, None)
+        # If underlying model doesn't have dtype property, simply return None
+        pipe.model = None
+        self.assertIsNone(pipe.torch_dtype)
 
 
 @is_pipeline_test

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -202,6 +202,7 @@ class CommonPipelineTest(unittest.TestCase):
     @require_torch
     def test_torch_dtype_property(self):
         import torch
+
         model_id = "hf-internal-testing/tiny-random-distilbert"
 
         # If dtype is specified in the pipeline constructor, the property should return that type


### PR DESCRIPTION
# What does this PR do?

When constructing a pipeline from a model, it doesn't inherit the `torch_dtype` attribute from the model's dtype. This causes asymmetry of pipeline and model, as the model always inherit the `torch_dtype` when the pipeline is created with `torch_dtype` param. Sometimes it's a bit confusing that the pipeline's `torch_dtype` is `None` (which could mislead the dtype is default one), while the underlying model has different dtype.
Therefore, this PR updates the pipeline construction logic to set `torch_dtype` attribute on pipeline based on model's dtype.


Fixes #28817 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @Rocketknight1
