### PR TITLE
[TPU] Support PyTorch/XLA FSDP via SPMD

### DIFF
--- a/src/transformers/integrations/tpu.py
+++ b/src/transformers/integrations/tpu.py
@@ -1,0 +1,30 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..utils import is_torch_tpu_available
+from torch.utils.data import DataLoader
+
+def tpu_spmd_dataloader(dataloader: DataLoader):
+    if is_torch_tpu_available():
+        import torch_xla.distributed.parallel_loader as pl
+        assert isinstance(dataloader, pl.MpDeviceLoader), "The dataloader must be a `torch_xla.distributed.parallel_loader.MpDeviceLoader`."
+
+        # This is to support PyTorch/XLA FSDP via SPMD.
+        # Here we shard the input data's 0th dim across the fsdp axis.
+        import torch_xla.distributed.spmd as xs
+        sharding_spec = xs.ShardingSpec(xs.get_global_mesh(), ('fsdp', None))
+        dataloader._parallel_loader_kwargs['input_sharding'] = sharding_spec
+        return dataloader
+    else:
+        return dataloader

--- a/src/transformers/integrations/tpu.py
+++ b/src/transformers/integrations/tpu.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils import is_torch_tpu_available
 from torch.utils.data import DataLoader
+
+from ..utils import is_torch_tpu_available
+
 
 def tpu_spmd_dataloader(dataloader: DataLoader):
     if is_torch_tpu_available():
         import torch_xla.distributed.parallel_loader as pl
-        assert isinstance(dataloader, pl.MpDeviceLoader), "The dataloader must be a `torch_xla.distributed.parallel_loader.MpDeviceLoader`."
+
+        assert isinstance(
+            dataloader, pl.MpDeviceLoader
+        ), "The dataloader must be a `torch_xla.distributed.parallel_loader.MpDeviceLoader`."
 
         # This is to support PyTorch/XLA FSDP via SPMD.
         # Here we shard the input data's 0th dim across the fsdp axis.
         import torch_xla.distributed.spmd as xs
-        sharding_spec = xs.ShardingSpec(xs.get_global_mesh(), ('fsdp', None))
-        dataloader._parallel_loader_kwargs['input_sharding'] = sharding_spec
+
+        sharding_spec = xs.ShardingSpec(xs.get_global_mesh(), ("fsdp", None))
+        dataloader._parallel_loader_kwargs["input_sharding"] = sharding_spec
         return dataloader
     else:
         return dataloader

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1436,9 +1436,6 @@ class Trainer:
 
             # Wrap the base model with an outer FSDP wrapper
             if self.is_fsdp_xla_v2_enabled:
-                # Should we have this logic into the FSDPv2 wrapper?
-                model = model.to(xm.xla_device())
-
                 def shard_output(output, mesh):
                     from .modeling_outputs import CausalLMOutputWithPast
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1456,7 +1456,7 @@ class Trainer:
 
                 self.model = model = FSDPv2(
                     model,
-                    shard_output,
+                    shard_output = shard_output,
                     auto_wrap_policy=auto_wrap_policy,
                     auto_wrapper_callable=auto_wrapper_callable,
                 )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1436,6 +1436,7 @@ class Trainer:
 
             # Wrap the base model with an outer FSDP wrapper
             if self.is_fsdp_xla_v2_enabled:
+
                 def shard_output(output, mesh):
                     from .modeling_outputs import CausalLMOutputWithPast
 
@@ -1453,7 +1454,7 @@ class Trainer:
 
                 self.model = model = FSDPv2(
                     model,
-                    shard_output = shard_output,
+                    shard_output=shard_output,
                     auto_wrap_policy=auto_wrap_policy,
                     auto_wrapper_callable=auto_wrapper_callable,
                 )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1684,6 +1684,7 @@ class TrainingArguments:
         ):
             raise ValueError("`min_num_params` and `transformer_layer_cls_to_wrap` are mutually exclusive.")
         self.fsdp_config["xla"] = self.fsdp_config.get("xla", False)
+        self.fsdp_config["xla_fsdp_v2"] = self.fsdp_config.get("xla_fsdp_v2", False)
         self.fsdp_config["xla_fsdp_grad_ckpt"] = self.fsdp_config.get("xla_fsdp_grad_ckpt", False)
         if self.fsdp_config["xla"]:
             if len(self.fsdp) > 0:


### PR DESCRIPTION
# What does this PR do?

Summary:
This is the first attempt to enable FSDP via SPMD (FSDPv2) on PyTorch/XLA model.

More information about FSDPv2 can be found here:
1. A user guide: https://github.com/pytorch/xla/blob/master/docs/fsdpv2.md
2. A RFC: https://github.com/pytorch/xla/issues/6379

Besides the initial implementation of FSDPv2 in r2.2, this change will also requires the following changes in PyTorch/XLA:
1. https://github.com/pytorch/xla/pull/6499
2. https://github.com/pytorch/xla/pull/6500
3. https://github.com/pytorch/xla/pull/6498
4. https://github.com/pytorch/xla/pull/6525
Therefore, it will only be compatible with the nightly builds.

Example use cases:
1. Prepare a FSDPv2 config:
```json
{
    "fsdp_transformer_layer_cls_to_wrap": [
        "LlamaDecoderLayer"
    ],
    "xla": true,
    "xla_fsdp_v2": true,
    "xla_fsdp_grad_ckpt": true
}
```
2. Invoke the trainer using the following command:
```
XLA_USE_SPMD=1 XLA_USE_BF16=1 python3 examples/pytorch/language-modeling/run_clm.py     --num_train_epochs 1     --dataset_name wikitext     --dataset_config_name wikitext-2-raw-v1 --per_device_train_batch_size 128     --do_train     --output_dir /tmp/test-clm     --overwrite_output_dir     --config_name ../transformers_pt/2B.config     --cache_dir /tmp     --tokenizer_name hf-internal-testing/llama-tokenizer      --block_size 1024     --optim adafactor     --save_strategy no     --logging_strategy no --fsdp "full_shard" --fsdp_config fsdp_config.json --torch_dtype bfloat16 --dataloader_drop_last yes
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @younesbelkada 