### PR TITLE
Allow setting dtype in rescaling in image_processing_donut.py

### DIFF
--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -440,7 +440,7 @@ class DonutImageProcessor(BaseImageProcessor):
 
         if do_rescale:
             images = [
-                self.rescale(image=image, scale=rescale_factor, input_data_format=input_data_format)
+                self.rescale(image=image, scale=rescale_factor, input_data_format=input_data_format, **kwargs)
                 for image in images
             ]
 


### PR DESCRIPTION
Fixes #28969 
With this fix, dtype can be changed by passing as a kwargs argument

if do_rescale:
    images = [
        self.rescale(image=image, scale=rescale_factor, input_data_format=input_data_format, **kwargs)
        for image in images
    ]