### PR TITLE
Static Cache: load models with MQA or GQA

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -351,7 +351,9 @@ class StaticCache(Cache):
         self.max_batch_size = max_batch_size
         self.max_cache_len = config.max_position_embeddings if max_cache_len is None else max_cache_len
         self.head_dim = config.hidden_size // config.num_attention_heads
-        self.num_key_value_heads = config.num_attention_heads if config.num_key_value_heads is None else config.num_key_value_heads
+        self.num_key_value_heads = (
+            config.num_attention_heads if config.num_key_value_heads is None else config.num_key_value_heads
+        )
         self.dtype = config.torch_dtype if config.torch_dtype is not None else dtype
 
         cache_shape = (max_batch_size, self.num_key_value_heads, self.max_cache_len, self.head_dim)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -351,10 +351,10 @@ class StaticCache(Cache):
         self.max_batch_size = max_batch_size
         self.max_cache_len = config.max_position_embeddings if max_cache_len is None else max_cache_len
         self.head_dim = config.hidden_size // config.num_attention_heads
-        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_attention_heads if config.num_key_value_heads is None else config.num_key_value_heads
         self.dtype = config.torch_dtype if config.torch_dtype is not None else dtype
 
-        cache_shape = (max_batch_size, self.num_heads, self.max_cache_len, self.head_dim)
+        cache_shape = (max_batch_size, self.num_key_value_heads, self.max_cache_len, self.head_dim)
         self.key_cache: torch.Tensor = torch.zeros(cache_shape, dtype=self.dtype, device=device)
         self.value_cache: torch.Tensor = torch.zeros(cache_shape, dtype=self.dtype, device=device)
         self.seen_tokens = 0
@@ -398,6 +398,12 @@ class StaticCache(Cache):
         """Returns the sequence length of the cached states that were seen by the model. `layer_idx` kept for BC"""
         return self.seen_tokens
 
+<<<<<<< Updated upstream
+=======
+    def get_usable_length(self, new_sequence_length=None, layer_idx: Optional[int] = 0) -> int:
+        return 0
+
+>>>>>>> Stashed changes
     def get_max_length(self) -> Optional[int]:
         """Returns the maximum sequence length of the cached states. DynamicCache does not have a maximum length."""
         return self.max_cache_len

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -398,12 +398,6 @@ class StaticCache(Cache):
         """Returns the sequence length of the cached states that were seen by the model. `layer_idx` kept for BC"""
         return self.seen_tokens
 
-<<<<<<< Updated upstream
-=======
-    def get_usable_length(self, new_sequence_length=None, layer_idx: Optional[int] = 0) -> int:
-        return 0
-
->>>>>>> Stashed changes
     def get_max_length(self) -> Optional[int]:
         """Returns the maximum sequence length of the cached states. DynamicCache does not have a maximum length."""
         return self.max_cache_len

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -629,8 +629,14 @@ class LlamaSdpaAttention(LlamaAttention):
         key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
         value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
+<<<<<<< Updated upstream
         kv_seq_len = key_states.shape[-2]
         past_seen_tokens = 0
+=======
+        cos, sin = self.rotary_emb(value_states, position_ids.unsqueeze(0), seq_len=None)
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, None)
+
+>>>>>>> Stashed changes
         past_key_value = getattr(self, "past_key_value", past_key_value)
         if past_key_value is not None:
             past_seen_tokens = past_key_value.get_usable_length(kv_seq_len, self.layer_idx)  # add what was seen

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -629,14 +629,8 @@ class LlamaSdpaAttention(LlamaAttention):
         key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
         value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
-<<<<<<< Updated upstream
         kv_seq_len = key_states.shape[-2]
         past_seen_tokens = 0
-=======
-        cos, sin = self.rotary_emb(value_states, position_ids.unsqueeze(0), seq_len=None)
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, None)
-
->>>>>>> Stashed changes
         past_key_value = getattr(self, "past_key_value", past_key_value)
         if past_key_value is not None:
             past_seen_tokens = past_key_value.get_usable_length(kv_seq_len, self.layer_idx)  # add what was seen

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -128,7 +128,7 @@ class CacheTest(unittest.TestCase):
         attention (MQA)
         """
 
-        def _random_key_values(config):
+        def _random_kvs(config):
             # shape for key and values: (batch_size, num_heads, seq_len, head_dim)
             random_keys = torch.rand(
                 (1, config.num_key_value_heads, 1, config.hidden_size // config.num_attention_heads),
@@ -143,7 +143,7 @@ class CacheTest(unittest.TestCase):
         mha_config = LlamaConfig(num_attention_heads=32)
         mha_static_cache = StaticCache(config=mha_config, max_batch_size=1, max_cache_len=10, device=torch_device)
         cached_keys, cached_values = mha_static_cache.update(
-            *_random_key_values(mha_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+            *_random_kvs(mha_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
         )
         self.assertTrue(cached_keys.shape == (1, 32, 10, 128))
         self.assertTrue(cached_values.shape == (1, 32, 10, 128))
@@ -151,7 +151,7 @@ class CacheTest(unittest.TestCase):
         gqa_config = LlamaConfig(num_attention_heads=32, num_key_value_heads=4)
         gqa_static_cache = StaticCache(config=gqa_config, max_batch_size=1, max_cache_len=10, device=torch_device)
         cached_keys, cached_values = gqa_static_cache.update(
-            *_random_key_values(gqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+            *_random_kvs(gqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
         )
         self.assertTrue(cached_keys.shape == (1, 4, 10, 128))
         self.assertTrue(cached_values.shape == (1, 4, 10, 128))
@@ -159,7 +159,7 @@ class CacheTest(unittest.TestCase):
         mqa_config = LlamaConfig(num_attention_heads=32, num_key_value_heads=1)
         mqa_static_cache = StaticCache(config=mqa_config, max_batch_size=1, max_cache_len=10, device=torch_device)
         cached_keys, cached_values = mqa_static_cache.update(
-            *_random_key_values(mqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+            *_random_kvs(mqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
         )
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -35,14 +35,16 @@ if is_torch_available():
         AutoModelForCausalLM,
         AutoTokenizer,
         DynamicCache,
+        LlamaConfig,
         LlamaForCausalLM,
         SinkCache,
+        StaticCache,
     )
 
 
 @require_torch
 class CacheTest(unittest.TestCase):
-    def test_cache_equivalence(self):
+    def test_dynamic_cache_retrocompatibility(self):
         """Tests that we can convert back and forth between the legacy cache format and DynamicCache"""
         legacy_cache = ()
         new_cache = DynamicCache()
@@ -119,6 +121,48 @@ class CacheTest(unittest.TestCase):
                         new_cache[layer_idx][key_value_idx], legacy_cache_reordered[layer_idx][key_value_idx]
                     )
                 )
+
+    def test_static_cache_mha_mqa_gqa(self):
+        """
+        Tests that static cache works with multi-head attention (MHA), grouped query attention (GQA), and multi-query
+        attention (MQA)
+        """
+
+        def _random_key_values(config):
+            # shape for key and values: (batch_size, num_heads, seq_len, head_dim)
+            random_keys = torch.rand(
+                (1, config.num_key_value_heads, 1, config.hidden_size // config.num_attention_heads),
+                device=torch_device,
+            )
+            random_values = torch.rand(
+                (1, config.num_key_value_heads, 1, config.hidden_size // config.num_attention_heads),
+                device=torch_device,
+            )
+            return random_keys, random_values
+
+        mha_config = LlamaConfig(num_attention_heads=32)
+        mha_static_cache = StaticCache(config=mha_config, max_batch_size=1, max_cache_len=10, device=torch_device)
+        cached_keys, cached_values = mha_static_cache.update(
+            *_random_key_values(mha_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+        )
+        self.assertTrue(cached_keys.shape == (1, 32, 10, 128))
+        self.assertTrue(cached_values.shape == (1, 32, 10, 128))
+
+        gqa_config = LlamaConfig(num_attention_heads=32, num_key_value_heads=4)
+        gqa_static_cache = StaticCache(config=gqa_config, max_batch_size=1, max_cache_len=10, device=torch_device)
+        cached_keys, cached_values = gqa_static_cache.update(
+            *_random_key_values(gqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+        )
+        self.assertTrue(cached_keys.shape == (1, 4, 10, 128))
+        self.assertTrue(cached_values.shape == (1, 4, 10, 128))
+
+        mqa_config = LlamaConfig(num_attention_heads=32, num_key_value_heads=1)
+        mqa_static_cache = StaticCache(config=mqa_config, max_batch_size=1, max_cache_len=10, device=torch_device)
+        cached_keys, cached_values = mqa_static_cache.update(
+            *_random_key_values(mqa_config), 0, cache_kwargs={"position_ids": torch.arange(1)}
+        )
+        self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
+        self.assertTrue(cached_values.shape == (1, 1, 10, 128))
 
 
 @require_torch_gpu


### PR DESCRIPTION
# What does this PR do?

Adds support to loading MQA or GQA models to the static cache (such as [this one](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0))