### PR TITLE
[WIP] Word level timestamp for long-form generation

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -882,11 +882,14 @@ class WhisperGenerationMixin:
         seek_outputs["sequences"] = seek_outputs["sequences"][:, decoder_input_ids.shape[-1] :]
 
         def split_by_batch_index(values, key, batch_idx):
-            if key == "scores":
-                return [v[batch_idx].cpu() for v in values]
             if key == "past_key_values":
                 # we don't save `past_key_values` as this is too costly
                 return None
+            elif isinstance(values[batch_idx], list) and torch.is_tensor(values[batch_idx][0]):
+                return [v[batch_idx].cpu() for v in values[batch_idx]]
+            elif isinstance(values[batch_idx], tuple) and torch.is_tensor(values[batch_idx][0]):
+                return (v[batch_idx].cpu() for v in values[batch_idx])
+
             return values[batch_idx].cpu()
 
         sequence_tokens = seek_outputs["sequences"]


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/28977

We haven't added word level timestamp for long-form generation yet. It's definitely possible, but it'll require some more changes in `generate`. Happy to take a closer look here the next days.

With the PR in its current state, one can retrieve word level timestamps, but they are not correct because the`_postprocess_outputs` is not correct. Test it with:

```py
#!/usr/bin/env python3
from transformers import WhisperForConditionalGeneration, WhisperProcessor
import torch
import librosa

DEVICE = "cuda"

model_id = "openai/whisper-tiny"

processor = WhisperProcessor.from_pretrained(model_id)
model = WhisperForConditionalGeneration.from_pretrained(model_id, torch_dtype=torch.float16)
model.to(DEVICE)

audio, _ = librosa.load("./common_voice_fr_17299386.mp3", sr=16_000)

inputs = processor(audio,
                           sampling_rate=16_000,
                           return_tensors="pt",
                           truncation=False, # False so the audio isn't truncated and whole audio is sent to the model
                           return_attention_mask=True,
                           padding="longest")

input_features = inputs.to(DEVICE, dtype=torch.float16)
inputs["input_features"] = inputs.input_features.repeat(1, 1, 8)
print(inputs.input_features.shape)

outputs = model.generate(**input_features, return_token_timestamps=True, return_segments=True)

# decode token ids to text
transcription = processor.batch_decode(outputs["sequences"], skip_special_tokens=False)

print(transcription[0])
per_segment_word_timestamps = [segment["result"]["token_timestamps"] for segment in outputs["segments"][0]]
all_word_timestamps = [x + y["start"] for x, y in zip(per_segment_word_timestamps, outputs["segments"][0])]

print("Word level timestamps", all_word_timestamps)
```