### PR TITLE
[`pipeline`] Add pool option to image feature extraction pipeline

### DIFF
--- a/src/transformers/pipelines/image_feature_extraction.py
+++ b/src/transformers/pipelines/image_feature_extraction.py
@@ -14,6 +14,8 @@ if is_vision_available():
         image_processor_kwargs (`dict`, *optional*):
                 Additional dictionary of keyword arguments passed along to the image processor e.g.
                 {"size": {"height": 100, "width": 100}}
+        pool (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the pooled output. If `False`, the model will return the raw hidden states.
     """,
 )
 class ImageFeatureExtractionPipeline(Pipeline):
@@ -41,9 +43,14 @@ class ImageFeatureExtractionPipeline(Pipeline):
     [huggingface.co/models](https://huggingface.co/models).
     """
 
-    def _sanitize_parameters(self, image_processor_kwargs=None, return_tensors=None, **kwargs):
+    def _sanitize_parameters(self, image_processor_kwargs=None, return_tensors=None, pool=None, **kwargs):
         preprocess_params = {} if image_processor_kwargs is None else image_processor_kwargs
-        postprocess_params = {"return_tensors": return_tensors} if return_tensors is not None else {}
+
+        postprocess_params = {}
+        if pool is not None:
+            postprocess_params["pool"] = pool
+        if return_tensors is not None:
+            postprocess_params["return_tensors"] = return_tensors
 
         if "timeout" in kwargs:
             preprocess_params["timeout"] = kwargs["timeout"]
@@ -59,14 +66,23 @@ class ImageFeatureExtractionPipeline(Pipeline):
         model_outputs = self.model(**model_inputs)
         return model_outputs
 
-    def postprocess(self, model_outputs, return_tensors=False):
-        # [0] is the first available tensor, logits or last_hidden_state.
+    def postprocess(self, model_outputs, pool=None, return_tensors=False):
+        pool = pool if pool is not None else False
+
+        if pool:
+            if "pooler_output" not in model_outputs:
+                raise ValueError("The model needs to have a `pooler` layer to use the `pool` option.")
+            outputs = model_outputs["pooler_output"]
+        else:
+            # [0] is the first available tensor, logits or last_hidden_state.
+            outputs = model_outputs[0]
+
         if return_tensors:
-            return model_outputs[0]
+            return outputs
         if self.framework == "pt":
-            return model_outputs[0].tolist()
+            return outputs.tolist()
         elif self.framework == "tf":
-            return model_outputs[0].numpy().tolist()
+            return outputs.numpy().tolist()
 
     def __call__(self, *args, **kwargs):
         """

--- a/src/transformers/pipelines/image_feature_extraction.py
+++ b/src/transformers/pipelines/image_feature_extraction.py
@@ -71,7 +71,9 @@ class ImageFeatureExtractionPipeline(Pipeline):
 
         if pool:
             if "pooler_output" not in model_outputs:
-                raise ValueError("The model needs to have a `pooler` layer to use the `pool` option.")
+                raise ValueError(
+                    "No pooled output was returned. Make sure the model has a `pooler` layer when using the `pool` option."
+                )
             outputs = model_outputs["pooler_output"]
         else:
             # [0] is the first available tensor, logits or last_hidden_state.

--- a/tests/pipelines/test_pipelines_image_feature_extraction.py
+++ b/tests/pipelines/test_pipelines_image_feature_extraction.py
@@ -62,16 +62,38 @@ class ImageFeatureExtractionPipelineTests(unittest.TestCase):
             nested_simplify(outputs[0][0]),
             [-1.417, -0.392, -1.264, -1.196, 1.648, 0.885, 0.56, -0.606, -1.175, 0.823, 1.912, 0.081, -0.053, 1.119, -0.062, -1.757, -0.571, 0.075, 0.959, 0.118, 1.201, -0.672, -0.498, 0.364, 0.937, -1.623, 0.228, 0.19, 1.697, -1.115, 0.583, -0.981])  # fmt: skip
 
+    @require_torch
+    def test_small_model_w_pooler_pt(self):
+        feature_extractor = pipeline(
+            task="image-feature-extraction", model="hf-internal-testing/tiny-random-vit-w-pooler", framework="pt"
+        )
+        img = prepare_img()
+        outputs = feature_extractor(img, pool=True)
+        self.assertEqual(
+            nested_simplify(outputs[0]),
+            [-0.056,  0.083,  0.021,  0.038,  0.242, -0.279, -0.033, -0.003, 0.200, -0.192,  0.045, -0.095, -0.077,  0.017, -0.058, -0.063, -0.029, -0.204,  0.014,  0.042,  0.305, -0.205, -0.099,  0.146, -0.287,  0.020,  0.168, -0.052,  0.046,  0.048, -0.156,  0.093])  # fmt: skip
+
     @require_tf
     def test_small_model_tf(self):
         feature_extractor = pipeline(
-            task="image-feature-extraction", model="hf-internal-testing/tiny-random-vit", framework="tf"
+            task="image-feature-extraction", model="hf-internal-testing/tiny-random-vit-w-pooler", framework="tf"
         )
         img = prepare_img()
         outputs = feature_extractor(img)
         self.assertEqual(
             nested_simplify(outputs[0][0]),
             [-1.417, -0.392, -1.264, -1.196, 1.648, 0.885, 0.56, -0.606, -1.175, 0.823, 1.912, 0.081, -0.053, 1.119, -0.062, -1.757, -0.571, 0.075, 0.959, 0.118, 1.201, -0.672, -0.498, 0.364, 0.937, -1.623, 0.228, 0.19, 1.697, -1.115, 0.583, -0.981])  # fmt: skip
+
+    @require_tf
+    def test_small_model_w_pooler_tf(self):
+        feature_extractor = pipeline(
+            task="image-feature-extraction", model="hf-internal-testing/tiny-random-vit-w-pooler", framework="tf"
+        )
+        img = prepare_img()
+        outputs = feature_extractor(img, pool=True)
+        self.assertEqual(
+            nested_simplify(outputs[0]),
+            [-0.056,  0.083,  0.021,  0.038,  0.242, -0.279, -0.033, -0.003, 0.200, -0.192,  0.045, -0.095, -0.077,  0.017, -0.058, -0.063, -0.029, -0.204,  0.014,  0.042,  0.305, -0.205, -0.099,  0.146, -0.287,  0.020,  0.168, -0.052,  0.046,  0.048, -0.156,  0.093])  # fmt: skip
 
     @require_torch
     def test_image_processing_small_model_pt(self):

--- a/tests/pipelines/test_pipelines_image_feature_extraction.py
+++ b/tests/pipelines/test_pipelines_image_feature_extraction.py
@@ -91,6 +91,10 @@ class ImageFeatureExtractionPipelineTests(unittest.TestCase):
         outputs = feature_extractor(img, image_processor_kwargs=image_processor_kwargs)
         self.assertEqual(np.squeeze(outputs).shape, (226, 32))
 
+        # Test pooling option
+        outputs = feature_extractor(img, pool=True)
+        self.assertEqual(np.squeeze(outputs).shape, (32,))
+
     @require_tf
     def test_image_processing_small_model_tf(self):
         feature_extractor = pipeline(
@@ -108,6 +112,10 @@ class ImageFeatureExtractionPipelineTests(unittest.TestCase):
         img = prepare_img()
         outputs = feature_extractor(img, image_processor_kwargs=image_processor_kwargs)
         self.assertEqual(np.squeeze(outputs).shape, (226, 32))
+
+        # Test pooling option
+        outputs = feature_extractor(img, pool=True)
+        self.assertEqual(np.squeeze(outputs).shape, (32,))
 
     @require_torch
     def test_return_tensors_pt(self):


### PR DESCRIPTION
# What does this PR do?

Adds the flag `pool` which will return the pooled output, rather than the raw hidden states. 

Doesn't work for data2vecvision as the model doesn't [add the pooling layer by default](https://github.com/huggingface/transformers/blob/78ba9f4617370a41c436126bbbb6f8d75924837c/src/transformers/models/data2vec/modeling_data2vec_vision.py#L637). At  the moment, [model kwargs aren't passed to the model constructor](https://github.com/huggingface/transformers/blob/78ba9f4617370a41c436126bbbb6f8d75924837c/src/transformers/pipelines/base.py#L817), so it's not simple to add passing `add_pooling_layer` here. 

I chose to raise an error when getting the outputs of the model. Although this means we fail quite late, it avoids any complex inspection needed on the model.

From the list of models in #28944: 

Models which work with the `pool` option:
- beit
- bit
- convnext
- convnextv2
- deit
- dinov2
- dpt
- efficientnet
- focalnet
- levit
- mobilenet_v1
- mobilenet_v2
- mobilevit
- mobilevitv2
- nat
- regnet
- resnet
- swin
- swinv2
- van
- vit
- vit_hybrid
- vivit
- yolos

Models that don't have a pooling layer: 
- conditional_detr
- deformable_detr
- deta
- detr
- dinat
- efficientformer
- glpn
- imagegpt
- poolformer
- pvt
- segformer
- siglip_vision_model
- swiftformer
- swin2sr
- table
- timesformer
- timm_backbone
- videomae
- vit_msn
- vitdet
- vit_mae

Not working
- data2vec-vision. 
 



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
