### PR TITLE
Fix a configuration key error in forward() of MusicgenForConditionalGeneration

### DIFF
--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -1892,7 +1892,7 @@ class MusicgenForConditionalGeneration(PreTrainedModel):
         if labels is not None:
             logits = decoder_outputs.logits if return_dict else decoder_outputs[0]
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.view(-1, self.config.vocab_size), labels.view(-1))
+            loss = loss_fct(logits.view(-1, self.decoder.config.vocab_size), labels.view(-1))
 
         if not return_dict:
             if loss is not None:


### PR DESCRIPTION
Hi everyone,

I think I noticed a bug in the forward function of MusicgenForConditionalGeneration. When calculating the loss with given labels, I get the error "'MusicgenConfig' object has no attribute 'vocab_size'" as only the decoder.config has a vocab_size entry. 

I think this should be the correct way to implement the loss calculation.