### PR TITLE
ENH: Do not pass warning message in case `quantization_config` is in config but not passed as an arg

### DIFF
--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -151,4 +151,3 @@ class AutoHfQuantizer:
             warnings.warn(warning_msg)
 
         return quantization_config
-        return quantization_config

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -129,10 +129,13 @@ class AutoHfQuantizer:
         """
         handles situations where both quantization_config from args and quantization_config from model config are present.
         """
-        warning_msg = (
-            "You passed `quantization_config` or equivalent parameters to `from_pretrained` but the model you're loading"
-            " already has a `quantization_config` attribute. The `quantization_config` from the model will be prevail."
-        )
+        if quantization_config_from_args is not None:
+            warning_msg = (
+                "You passed `quantization_config` or equivalent parameters to `from_pretrained` but the model you're loading"
+                " already has a `quantization_config` attribute. The `quantization_config` from the model will be prevail."
+            )
+        else:
+            warning_msg = ""
 
         if isinstance(quantization_config, dict):
             quantization_config = AutoQuantizationConfig.from_dict(quantization_config)

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -132,7 +132,7 @@ class AutoHfQuantizer:
         if quantization_config_from_args is not None:
             warning_msg = (
                 "You passed `quantization_config` or equivalent parameters to `from_pretrained` but the model you're loading"
-                " already has a `quantization_config` attribute. The `quantization_config` from the model will be prevail."
+                " already has a `quantization_config` attribute. The `quantization_config` from the model will be used."
             )
         else:
             warning_msg = ""

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -147,5 +147,8 @@ class AutoHfQuantizer:
                 setattr(quantization_config, attr, val)
             warning_msg += f"However, loading attributes (e.g. {list(loading_attr_dict.keys())}) will be overwritten with the one you passed to `from_pretrained`. The rest will be ignored."
 
-        warnings.warn(warning_msg)
+        if warning_msg != "":
+            warnings.warn(warning_msg)
+
+        return quantization_config
         return quantization_config


### PR DESCRIPTION
# What does this PR do?

Currently, transformers always warns users with a wrong message when loading a model that has a quantization_config without even passing quantization_config to from_pretrained. Indeed we should warn users only when `quantization_config_from_args` instead of all the time 

cc @amyeroberts 

```bash
/usr/local/lib/python3.10/dist-packages/transformers/quantizers/auto.py:151: UserWarning: You passed `quantization_config` or equivalent parameters to `from_pretrained` but the model you're loading already has a `quantization_config` attribute. The `quantization_config` from the model will be prevail.
  warnings.warn(warning_msg)
```