### PR TITLE
ENH [`AutoQuantizer`]: enhance trainer + not supported quant methods

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4193,7 +4193,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     @property
     def _is_quantized_training_enabled(self):
         logger.warning(
-            "`_is_quantized_training_enabled` is going to be deprecated in a future version. Please use `model.hf_quantizer.is_trainable` instead",
+            "`_is_quantized_training_enabled` is going to be deprecated in transformers 4.39.0. Please use `model.hf_quantizer.is_trainable` instead",
             FutureWarning,
         )
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4190,6 +4190,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             logger.warning_once(warn_string)
 
+    @property
+    def _is_quantized_training_enabled(self):
+        logger.warning(
+            "`_is_quantized_training_enabled` is going to be deprecated in a future version. Please use `model.hf_quantizer.is_trainable` instead",
+            FutureWarning,
+        )
+
+        if not hasattr(self, "hf_quantizer"):
+            return False
+
+        return self.hf_quantizer.is_trainable
+
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)
 if PreTrainedModel.push_to_hub.__doc__ is not None:

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -176,7 +176,6 @@ class HfQuantizer(ABC):
             kwargs (`dict`, *optional*):
                 The keyword arguments that are passed along `_process_model_after_weight_loading`.
         """
-        model._is_quantized_training_enabled = self.is_trainable
         return self._process_model_after_weight_loading(model, **kwargs)
 
     @abstractmethod

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -289,7 +289,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
 
     # Copied from transformers.quantizers.quantizer_bnb_8bit.Bnb8BitHfQuantizer._process_model_after_weight_loading with 8bit->4bit
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
-        model._is_quantized_training_enabled = self.is_trainable
         model.is_loaded_in_4bit = True
         model.is_4bit_serializable = self.is_serializable
         return model

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -205,7 +205,6 @@ class Bnb8BitHfQuantizer(HfQuantizer):
             unexpected_keys.remove(fp16_statistics_key)
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
-        model._is_quantized_training_enabled = self.is_trainable
         model.is_loaded_in_8bit = True
         model.is_8bit_serializable = self.is_serializable
         return model


### PR DESCRIPTION
# What does this PR do?

Currently, if a quantization method do not support PEFT fine-tuning an old error with bistandbytes is raised:
```bash
 The model you want to train is loaded in 8-bit precision.  if you want to fine-tune an 8-bit
 model, please make sure that you have installed `bitsandbytes>=0.37.0`. 
```
Regardless of the quantization method. In fact, for example if one uses AWQ + Trainer (which is not supported yet, but soon with https://github.com/huggingface/transformers/pull/28987 / https://github.com/huggingface/peft/pull/1399), they'll get the old error which is very confusing.

Moreover, we should rely on the variable `hf_quantizer.is_trainable` instead of `_is_quantized_training_enabled`

We should instead be more precise and throw an error that states why this is not supported and how to request a fix.

cc @amyeroberts 