### PR TITLE
[`Doc`] Fix docbuilder - make `BackboneMixin` and `BackboneConfigMixin` importable from `utils`. 

### DIFF
--- a/docs/source/en/main_classes/backbones.md
+++ b/docs/source/en/main_classes/backbones.md
@@ -18,9 +18,6 @@ rendered properly in your Markdown viewer.
 
 A backbone is a model used for feature extraction for higher level computer vision tasks such as object detection and image classification. Transformers provides an [`AutoBackbone`] class for initializing a Transformers backbone from pretrained model weights, and two utility classes:
 
-* [`~utils.backbone_utils.BackboneMixin`] enables initializing a backbone from Transformers or [timm](https://hf.co/docs/timm/index) and includes functions for returning the output features and indices.
-* [`~utils.backbone_utils.BackboneConfigMixin`] sets the output features and indices of the backbone configuration.
-
 [timm](https://hf.co/docs/timm/index) models are loaded with the [`TimmBackbone`] and [`TimmBackboneConfig`] classes.
 
 Backbones are supported for the following models:

--- a/docs/source/en/main_classes/backbones.md
+++ b/docs/source/en/main_classes/backbones.md
@@ -18,6 +18,9 @@ rendered properly in your Markdown viewer.
 
 A backbone is a model used for feature extraction for higher level computer vision tasks such as object detection and image classification. Transformers provides an [`AutoBackbone`] class for initializing a Transformers backbone from pretrained model weights, and two utility classes:
 
+* [`~utils.BackboneMixin`] enables initializing a backbone from Transformers or [timm](https://hf.co/docs/timm/index) and includes functions for returning the output features and indices.
+* [`~utils.BackboneConfigMixin`] sets the output features and indices of the backbone configuration.
+
 [timm](https://hf.co/docs/timm/index) models are loaded with the [`TimmBackbone`] and [`TimmBackboneConfig`] classes.
 
 Backbones are supported for the following models:
@@ -42,11 +45,11 @@ Backbones are supported for the following models:
 
 ## BackboneMixin
 
-[[autodoc]] utils.backbone_utils.BackboneMixin
+[[autodoc]] utils.BackboneMixin
 
 ## BackboneConfigMixin
 
-[[autodoc]] utils.backbone_utils.BackboneConfigMixin
+[[autodoc]] utils.BackboneConfigMixin
 
 ## TimmBackbone
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -20,6 +20,7 @@ from huggingface_hub.constants import HF_HUB_DISABLE_TELEMETRY as DISABLE_TELEME
 from packaging import version
 
 from .. import __version__
+from .backbone_utils import BackboneConfigMixin, BackboneMixin
 from .constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
 from .doc import (
     add_code_sample_docstrings,


### PR DESCRIPTION
# What does this PR do?

Several CIs have started having the doc builds failing e.g.:
* https://github.com/huggingface/transformers/actions/runs/7881443714/job/21529678872
* https://github.com/huggingface/transformers/actions/runs/7884708184/job/21530274589

On one case rerunning lead to a successful build: 
* Failed: https://github.com/huggingface/transformers/actions/runs/7881054565/attempts/1
* Passed: https://github.com/huggingface/transformers/actions/runs/7881054565/job/21518984718

However, trying this on other runs wasn't successful e.g.: 
* https://github.com/huggingface/transformers/actions/runs/7884708184/attempts/1
* https://github.com/huggingface/transformers/actions/runs/7884708184/attempts/2
* https://github.com/huggingface/transformers/actions/runs/7884708184

I haven't been able to identify why these tests have started failing. Obvious dependencies haven't been affected: 
* `backbones.md` was touched two weeks ago
* Latest update to doc-builder was two weeks ago
* `backbone_utils` was updated three weeks ago

This PR moves the offending backbone classes to be importable from `utils`. This was to match all other `~utils` references in the doc, which have the form `~utils.module.object`. 

Doing this appears to have resolved the issue: 
* Two runs on the same commit on github CI have passed - [run 1](https://github.com/huggingface/transformers/actions/runs/7889497104/attempts/1), [run 2](https://github.com/huggingface/transformers/actions/runs/7889497104)
* Another run on a different, empty commit passed - [here](https://github.com/huggingface/transformers/actions/runs/7890483169/job/21532741409?pr=29002)
