### PR TITLE
[`CI` / `core`] Fix CI with GC + pytorch 2.2

### DIFF
--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -679,8 +679,8 @@ class MistralSdpaAttention(MistralAttention):
             attention_mask is not None and not torch.all(attention_mask[..., 0] == 1) and q_len != 1
         ):  # user defined causal mask
             causal_mask = attention_mask[:, :, past_seen_tokens : past_seen_tokens + q_len, : key_states.shape[-2]]
-            # this one liner is equivalent to the pad_unpad function
-            causal_mask.mul_(~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
+            # this one liner is equivalent to the pad_unpad function   
+            causal_mask = causal_mask * (~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
         else:
             causal_mask = None
 

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -679,7 +679,7 @@ class MistralSdpaAttention(MistralAttention):
             attention_mask is not None and not torch.all(attention_mask[..., 0] == 1) and q_len != 1
         ):  # user defined causal mask
             causal_mask = attention_mask[:, :, past_seen_tokens : past_seen_tokens + q_len, : key_states.shape[-2]]
-            # this one liner is equivalent to the pad_unpad function   
+            # this one liner is equivalent to the pad_unpad function
             causal_mask = causal_mask * (~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
         else:
             causal_mask = None

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -757,7 +757,7 @@ class MixtralSdpaAttention(MixtralAttention):
         ):  # user defined causal mask
             causal_mask = attention_mask[:, :, past_seen_tokens : past_seen_tokens + q_len, : key_states.shape[-2]]
             # this one liner is equivalent to the pad_unpad function
-            causal_mask.mul_(~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
+            causal_mask = causal_mask * (~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
         else:
             causal_mask = None
 

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -690,7 +690,7 @@ class Qwen2SdpaAttention(Qwen2Attention):
         ):  # user defined causal mask
             causal_mask = attention_mask[:, :, past_seen_tokens : past_seen_tokens + q_len, : key_states.shape[-2]]
             # this one liner is equivalent to the pad_unpad function
-            causal_mask.mul_(~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
+            causal_mask = causal_mask * (~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])
         else:
             causal_mask = None
 


### PR DESCRIPTION
# What does this PR do?

Fixes the current failing CI for Mistral, Mixtral and Qwen2 for gradient checkpointing. For some reason, since pytorch 2.2, gradient checkpointing raises an error when going through in-place operations such as `tensor.mul_(xxx)` which was not the case in earlier versions. 

Simply replacing `causal_mask.mul_(~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])` by `causal_mask = causal_mask * (~torch.eq(causal_mask, causal_mask.min()).all(dim=-1)[..., None])`

This makes me think we should maybe have a job that runs the CI on torch nightly to catch these early bugs, do we have that already? If not, happy to have a look

cc @ArthurZucker @amyeroberts 