### PR TITLE
Add a clone method for model configs

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -954,6 +954,12 @@ class PretrainedConfig(PushToHubMixin):
         with open(json_file_path, "w", encoding="utf-8") as writer:
             writer.write(self.to_json_string(use_diff=use_diff))
 
+    def clone(self):
+        """
+        Return a copy of this configuration (using a deep copy)
+        """
+        return self.__class__(**copy.deepcopy(self.__dict__))
+    
     def update(self, config_dict: Dict[str, Any]):
         """
         Updates attributes of this class with attributes from `config_dict`.

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -959,7 +959,7 @@ class PretrainedConfig(PushToHubMixin):
         Return a copy of this configuration (using a deep copy)
         """
         return self.__class__(**copy.deepcopy(self.__dict__))
-    
+
     def update(self, config_dict: Dict[str, Any]):
         """
         Updates attributes of this class with attributes from `config_dict`.


### PR DESCRIPTION
# What does this PR do?

Adding a convenience `clone()` method to `PretrainedConfig` that creates a deep copy of the current configuration. Useful to make changes to it without modifying the original.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger @gante 

This is a draft PR. Before working on tests and documentation, I wanted to make sure the change proposed in this PR was welcome.