### PR TITLE
FIX: Fix error with `logger.warning` + inline with recent refactor

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4192,7 +4192,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
     @property
     def _is_quantized_training_enabled(self):
-        logger.warning(
+        warnings.warn(
             "`_is_quantized_training_enabled` is going to be deprecated in transformers 4.39.0. Please use `model.hf_quantizer.is_trainable` instead",
             FutureWarning,
         )


### PR DESCRIPTION
# What does this PR do?

In fact current on transformers main some legacy setup that call `model._is_quantized_training_enabled` throw an error:

```bash
Arguments: (<class 'FutureWarning'>,)
--- Logging error ---
Traceback (most recent call last):
  File "/home/younes_huggingface_co/miniconda3/envs/fix-test/lib/python3.9/logging/__init__.py", line 1083, in emit
    msg = self.format(record)
  File "/home/younes_huggingface_co/miniconda3/envs/fix-test/lib/python3.9/logging/__init__.py", line 927, in format
    return fmt.format(record)
  File "/home/younes_huggingface_co/miniconda3/envs/fix-test/lib/python3.9/logging/__init__.py", line 663, in format
    record.message = record.getMessage()
  File "/home/younes_huggingface_co/miniconda3/envs/fix-test/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```

Because `logger.warning` does take a second positional argument

I also realised we should use `warnings.warn` to be in line with deprecation warning guildelines presented here: https://github.com/huggingface/transformers/pull/26527 🤯 

cc @amyeroberts 
