### PR TITLE
Fix - don't return pixel mask for yolos

### DIFF
--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -1297,7 +1297,7 @@ class YolosImageProcessor(BaseImageProcessor):
             encoded_inputs = self.pad(
                 images,
                 annotations=annotations,
-                return_pixel_mask=True,
+                return_pixel_mask=False,
                 data_format=data_format,
                 input_data_format=input_data_format,
                 update_bboxes=do_convert_annotations,


### PR DESCRIPTION
# What does this PR do?

#28363 introduced a bug where the pixel mask was now being returned for YOLOS. `pixel_mask` isn't a valid YOLOS input, and so this breaks this. 

The PR fixes that. 

Weirdly, this wasn't caught on the original PR, but was triggered in #28312 

cc @ydshieh for reference - we can try and debug together why we're not catching all the necessary tests when you're back :) 
