### PR TITLE
fix failing trainer ds tests

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -786,9 +786,6 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
             with self.assertRaises(Exception) as context:
                 checkpoint = os.path.join(output_dir, "checkpoint-5")
                 trainer.train(resume_from_checkpoint=f"{checkpoint}-bogus")
-            self.assertTrue(
-                "Can't find a valid checkpoint at" in str(context.exception), f"got exception: {context.exception}"
-            )
 
     @parameterized.expand(params_with_optims_and_schedulers, name_func=parameterized_custom_name_func)
     def test_can_resume_training_normal(self, stage, dtype, optim, scheduler):


### PR DESCRIPTION
# What does this PR do?
1. After PR https://github.com/huggingface/transformers/pull/27568, when resuming from ckpt, it first loads the `trainer_state.json` file. As such, when bogus ckpt folder is passed it will throw file not found error. Earlier, the code would throw different invalid ckpt error in the function call `deepspeed_load_checkpoint`. As such, `test_can_resume_training_errors` tests were failing. This PR fixes the tests by removing the exact check on the error message when resuming from bogus ckpt.   