### PR TITLE
Bnb test fix for different hardwares

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -847,6 +847,7 @@ class MixedInt8GPT2Test(MixedInt8Test):
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I'm a big fan of")
     EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I'm a fan of the")
+    EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I am a member of the")
 
     def test_int8_from_pretrained(self):
         r"""

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -97,6 +97,7 @@ class BaseMixedInt8Test(unittest.TestCase):
     input_text = "Hello my name is"
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John.\nI am a friend of the family.\n")
+    EXPECTED_OUTPUTS.add("Hello my name is John.\nI am a friend of your father.\n")
     MAX_NEW_TOKENS = 10
 
     def setUp(self):

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -97,6 +97,7 @@ class BaseMixedInt8Test(unittest.TestCase):
     input_text = "Hello my name is"
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John.\nI am a friend of the family.\n")
+    # Expected values on a A10
     EXPECTED_OUTPUTS.add("Hello my name is John.\nI am a friend of your father.\n")
     MAX_NEW_TOKENS = 10
 
@@ -848,6 +849,7 @@ class MixedInt8GPT2Test(MixedInt8Test):
     EXPECTED_OUTPUTS = set()
     EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I'm a big fan of")
     EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I'm a fan of the")
+    # Expected values on a A10
     EXPECTED_OUTPUTS.add("Hello my name is John Doe, and I am a member of the")
 
     def test_int8_from_pretrained(self):


### PR DESCRIPTION
Just updating the acceptable generated text, as this is slightly different based on hardware from what I can tell. The first commit is based on what I observed on my dev VM with A10G and the second commit is based on what I saw [in the failing BNB integration pipeline](https://github.com/huggingface/peft/actions/runs/7925057159/job/21637597387#step:9:83).

In my eyes, both text strings seem similar enough. I already spoke about this with @younesbelkada regarding the first commit. The second seems a similar case.