### PR TITLE
Fix a typo in `examples/pytorch/text-classification/run_classification.py`

### DIFF
--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -404,7 +404,7 @@ def main():
             raw_datasets.pop(split)
 
     if data_args.train_split_name is not None:
-        logger.info(f"using {data_args.validation_split_name} as validation set")
+        logger.info(f"using {data_args.train_split_name} as train set")
         raw_datasets["train"] = raw_datasets[data_args.train_split_name]
         raw_datasets.pop(data_args.train_split_name)
 


### PR DESCRIPTION
Hi there, this commit fixes a tiny typo in the provided pytorch text classification pipeline.