### PR TITLE
FEAT [`Trainer` / `bnb`]: Add RMSProp from `bitsandbytes` to HF `Trainer`

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1106,7 +1106,7 @@ class Trainer:
                 elif "rmsprop" in args.optim:
                     optimizer_cls = RMSprop
                     # Above we pass all `adam_kwargs` to the optimizer, here
-                    # we only pass `optim_args` which can be passed to the user.
+                    # we only pass `optim_args` which can be passed by the user.
                     additional_optim_kwargs = optim_args
 
                 bnb_kwargs = {"optim_bits": optim_bits}

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4147,6 +4147,11 @@ class Trainer:
             wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
             raise ValueError(f"{wrapper} can't be used with `save_only_model` along with `load_best_model_at_end`.")
 
+        # `auto_find_batch_size` isn't yet supported with DeepSpeed/FSDP
+        if (self.is_deepspeed_enabled or self.is_fsdp_enabled) and self.args.auto_find_batch_size:
+            wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
+            raise NotImplementedError(f"`{wrapper}` doesn't support `auto_find_batch_size`.")
+
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """
         Sets values in the deepspeed plugin based on the Trainer args

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -157,6 +157,9 @@ class OptimizerNames(ExplicitEnum):
     PAGED_LION = "paged_lion_32bit"
     PAGED_LION_8BIT = "paged_lion_8bit"
     RMSPROP = "rmsprop"
+    RMSPROP_BNB = "rmsprop_bnb"
+    RMSPROP_8BIT = "rmsprop_bnb_8bit"
+    RMSPROP_32BIT = "rmsprop_bnb_32bit"
 
 
 # TODO: `TrainingArguments` users rely on it being fully mutable. In the future see if we can narrow this to a few keys: https://github.com/huggingface/transformers/pull/25903


### PR DESCRIPTION
# What does this PR do?

As requested by the community, this PR adds the support for bnb RMSProp optimizers to HF Trainer ! 
`RMSProp` exists in bitsandbytes since its first commit: https://github.com/TimDettmers/bitsandbytes/commit/7439924891496025edf60c9da6a782f362a50c70#diff-8384af03566f84c3055f3fee7b1516696a1546d130d63935714af17781d6202b so this PR is compatible with all versions of bnb. 

I also added nice tests, which all pass on my machine

Fixes: https://github.com/huggingface/trl/issues/1336

cc @amyeroberts and @Titus-von-Koeller FYI !
