### PR TITLE
Allow repo_id--module.classname config definition even if loading from path

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -510,7 +510,7 @@ def get_class_from_dynamic_module(
 
     # And lastly we get the class inside our newly created module
     final_module = get_cached_module_file(
-        pretrained_model_name_or_path,
+        module_path_or_repo_id,
         module_filename,
         cache_dir=cache_dir,
         force_download=force_download,

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -500,10 +500,18 @@ def get_class_from_dynamic_module(
 
     if code_revision is None and pretrained_model_name_or_path == repo_id:
         code_revision = revision
+    # if we are loading from a path but we're using a class reference with a repo_id--module.classname format
+    # use the path instead of the repo_id because likely module.classname is a peer of the config.json
+    module_path_or_repo_id = repo_id
+    module_filename = module_file + ".py"
+    module_file_path = os.path.join(pretrained_model_name_or_path, module_filename)
+    if os.path.isfile(module_file_path):
+        module_path_or_repo_id = pretrained_model_name_or_path
+
     # And lastly we get the class inside our newly created module
     final_module = get_cached_module_file(
-        repo_id,
-        module_file + ".py",
+        pretrained_model_name_or_path,
+        module_filename,
         cache_dir=cache_dir,
         force_download=force_download,
         resume_download=resume_download,

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -485,18 +485,11 @@ class NopConfig(PretrainedConfig):
             with open(tokenizer_config_file, "w") as wfp:
                 json.dump(tokenizer_config, wfp, indent=2)
 
-            prev_dir = os.getcwd()
+            # this should work because we trust the code
+            _ = AutoTokenizer.from_pretrained(fake_repo, local_files_only=True, trust_remote_code=True)
             try:
-                # it looks like subdir= is broken in the from_pretrained also, so this is necessary
-                os.chdir(tmp_dir)
-
-                # this should work because we trust the code
-                _ = AutoTokenizer.from_pretrained(fake_model_id, local_files_only=True, trust_remote_code=True)
-                try:
-                    # this should fail because we don't trust and we're not at a terminal for interactive response
-                    _ = AutoTokenizer.from_pretrained(fake_model_id, local_files_only=True, trust_remote_code=False)
-                    self.fail("AutoTokenizer.from_pretrained with trust_remote_code=False should raise ValueException")
-                except ValueError:
-                    pass
-            finally:
-                os.chdir(prev_dir)
+                # this should fail because we don't trust and we're not at a terminal for interactive response
+                _ = AutoTokenizer.from_pretrained(fake_repo, local_files_only=True, trust_remote_code=False)
+                self.fail("AutoTokenizer.from_pretrained with trust_remote_code=False should raise ValueException")
+            except ValueError:
+                pass


### PR DESCRIPTION
When you have a model that's in a path that's not exactly the repo_id relative to the current directory and the config has AutoConfig of the form model_id--module.classname in it, you can't load the model using the path to the model because resolving module.classname ends up being relative to repo_id as defined in the config. 

Let me lay this out. 

```
path/to/large/storage/
    models/
        model_a/
            config.json
            tokenizer_config.json
            model_config.py
            model_impl.py
        model_b/
             ...
path/to/sourcecode/
        my_module/
            __init__.py
            __main__.py
```

What i want to do is, from my `__main__.py` load my model from `AutoModel.from_pretrained()` so I pass `path/to/large/storage/models/model_a` as model_id_or_path with `local_files_only=True` because i only want to use the specific model that i have on my filesystem. 

When you try to do this, you end up with an exception that looks like this:

```Could not locate the model_config.py inside rl337/cicero-ffn.
Traceback (most recent call last):
  File "/Users/rlee/dev/singularity/.venv/lib/python3.9/site-packages/transformers/utils/hub.py", line 398, in cached_file
    resolved_file = hf_hub_download(
  File "/Users/rlee/dev/singularity/.venv/lib/python3.9/site-packages/huggingface_hub/utils/_validators.py", line 118, in _inner_fn
    return fn(*args, **kwargs)
  File "/Users/rlee/dev/singularity/.venv/lib/python3.9/site-packages/huggingface_hub/file_download.py", line 1363, in hf_hub_download
    raise LocalEntryNotFoundError(
huggingface_hub.utils._errors.LocalEntryNotFoundError: Cannot find the requested files in the disk cache and outgoing traffic has been disabled. To enable hf.co look-ups and downloads online, set 'local_files_only' to False.
```

Here, even though I'm trying to load the model from a  path it's trying to resolve the code relative to the repo_id.  This is problematic because if i made changes to the model code and i'm not restricting downloads, i may download and use out of date code from the hub.  If i don't notice that it's downloaded code, it'd be super confusing to debug. 

The workaround is to edit the config.json to remove the repo_id-- part of the definition which is kind of annoying because if you want to push changes to the hub after, you need to remember to add the repo_id-- back in. 

I think the root problem here is when the model_id_or_path is specified as a path, really what it's doing is its acting like a path to the config.json and then it doesn't treat the directory it loads the config.json from to be a self contained model.  It instead tries to resolve things defined in the config.json relative to the current directory or relative to the model hub/cache.   Concretely it requires a directory structure that looks more like this:

```
path/to/sourcecode/
    my_module/
        __init__.py
        __main__.py
    username/model_id/
        config.json
        tokenizer_config.json
        model_config.py
        model_impl.py
```

When i run my `__main__.py` from the directory designated by `path/to/sourcecode`, everything seems to work okay because resolution of the model_id `username/model_id` happens relative to the current directory. 

# What does this PR do?

This PR adds a check to see if the repo_or_path is  a path containing the module file to download.  If it is, load from that path instead of referencing the repo_id.   It then tries to load the model.classname from the path rather than the repo_id when dynamically loading classes. 

At this point, the config.json was already loaded from the path so likely the path is okay to load code from especially if trust_remote_code is true.. which it must be at this point. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
