### PR TITLE
FIX [`bnb` / `tests`]: Fix currently failing bnb tests

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -42,7 +42,7 @@ from transformers.testing_utils import (
 
 
 def get_some_linear_layer(model):
-    if model.config.model_type == "openai-community/gpt2":
+    if model.config.model_type == "gpt2":
         return model.transformer.h[0].mlp.c_fc
     return model.transformer.h[0].mlp.dense_4h_to_h
 


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/29001 changed the logic of handling how to get linear layers from testing models. In fact, the `model_type` should always stay `"gpt2"` and not `"openai-community/gpt2"`

cc @amyeroberts @Titus-von-Koeller 