### PR TITLE
Fix: Fixed the previous tracking URI setting logic to prevent clashes with original MLflow code.

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -961,7 +961,7 @@ class MLflowCallback(TrainerCallback):
             [`TrainingArguments`]'s `output_dir` to the local or remote artifact storage. Using it without a remote
             storage will just copy the files to your artifact location.
         - **MLFLOW_TRACKING_URI** (`str`, *optional*):
-            Whether to store runs at a specific path or remote server. Default to `None` which skips setting the
+            Whether to store runs at a specific path or remote server. Unset by default, which skips setting the
             tracking URI entirely.
         - **MLFLOW_EXPERIMENT_NAME** (`str`, *optional*, defaults to `None`):
             Whether to use an MLflow experiment_name under which to launch the run. Default to `None` which will point

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -960,9 +960,9 @@ class MLflowCallback(TrainerCallback):
             remote server, e.g. s3 or GCS. If set to `True` or *1*, will copy each saved checkpoint on each save in
             [`TrainingArguments`]'s `output_dir` to the local or remote artifact storage. Using it without a remote
             storage will just copy the files to your artifact location.
-        - **MLFLOW_TRACKING_URI** (`str`, *optional*, defaults to `""`):
-            Whether to store runs at a specific path or remote server. Default to an empty string which will store runs
-            at `./mlruns` locally.
+        - **MLFLOW_TRACKING_URI** (`str`, *optional*, defaults to `None`):
+            Whether to store runs at a specific path or remote server. Default to `None` which skips setting the
+            tracking URI entirely.
         - **MLFLOW_EXPERIMENT_NAME** (`str`, *optional*, defaults to `None`):
             Whether to use an MLflow experiment_name under which to launch the run. Default to `None` which will point
             to the `Default` experiment in MLflow. Otherwise, it is a case sensitive name of the experiment to be
@@ -982,7 +982,7 @@ class MLflowCallback(TrainerCallback):
         """
         self._log_artifacts = os.getenv("HF_MLFLOW_LOG_ARTIFACTS", "FALSE").upper() in ENV_VARS_TRUE_VALUES
         self._nested_run = os.getenv("MLFLOW_NESTED_RUN", "FALSE").upper() in ENV_VARS_TRUE_VALUES
-        self._tracking_uri = os.getenv("MLFLOW_TRACKING_URI", "")
+        self._tracking_uri = os.getenv("MLFLOW_TRACKING_URI", None)
         self._experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", None)
         self._flatten_params = os.getenv("MLFLOW_FLATTEN_PARAMS", "FALSE").upper() in ENV_VARS_TRUE_VALUES
         self._run_id = os.getenv("MLFLOW_RUN_ID", None)
@@ -997,12 +997,16 @@ class MLflowCallback(TrainerCallback):
             f" tags={self._nested_run}, tracking_uri={self._tracking_uri}"
         )
         if state.is_world_process_zero:
-            self._ml_flow.set_tracking_uri(self._tracking_uri)
-
-            if self._tracking_uri == "":
-                logger.debug(f"MLflow tracking URI is not set. Runs will be stored at {os.path.realpath('./mlruns')}")
-            else:
+            if self._tracking_uri is not None:
                 logger.debug(f"MLflow tracking URI is set to {self._tracking_uri}")
+                self._ml_flow.set_tracking_uri(self._tracking_uri)
+            else:
+                logger.debug(
+                    (
+                        "Environment variable `MLFLOW_TRACKING_URI` is not provided and"
+                        "therefore will not be explicitly set."
+                    )
+                )
 
             if self._ml_flow.active_run() is None or self._nested_run or self._run_id:
                 if self._experiment_name:

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1003,10 +1003,8 @@ class MLflowCallback(TrainerCallback):
                     logger.debug(f"MLflow tracking URI is set to {self._tracking_uri}")
                 else:
                     logger.debug(
-                        (
-                            "Environment variable `MLFLOW_TRACKING_URI` is not provided and therefore will not be"
-                            " explicitly set."
-                        )
+                        "Environment variable `MLFLOW_TRACKING_URI` is not provided and therefore will not be"
+                        " explicitly set."
                     )
             else:
                 logger.debug(f"MLflow tracking URI is set to {self._ml_flow.get_tracking_uri()}")

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -997,16 +997,19 @@ class MLflowCallback(TrainerCallback):
             f" tags={self._nested_run}, tracking_uri={self._tracking_uri}"
         )
         if state.is_world_process_zero:
-            if self._tracking_uri is not None:
-                logger.debug(f"MLflow tracking URI is set to {self._tracking_uri}")
-                self._ml_flow.set_tracking_uri(self._tracking_uri)
-            else:
-                logger.debug(
-                    (
-                        "Environment variable `MLFLOW_TRACKING_URI` is not provided and"
-                        "therefore will not be explicitly set."
+            if not self._ml_flow.is_tracking_uri_set():
+                if self._tracking_uri:
+                    self._ml_flow.set_tracking_uri(self._tracking_uri)
+                    logger.debug(f"MLflow tracking URI is set to {self._tracking_uri}")
+                else:
+                    logger.debug(
+                        (
+                            "Environment variable `MLFLOW_TRACKING_URI` is not provided and therefore will not be"
+                            " explicitly set."
+                        )
                     )
-                )
+            else:
+                logger.debug(f"MLflow tracking URI is set to {self._ml_flow.get_tracking_uri()}")
 
             if self._ml_flow.active_run() is None or self._nested_run or self._run_id:
                 if self._experiment_name:

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -960,7 +960,7 @@ class MLflowCallback(TrainerCallback):
             remote server, e.g. s3 or GCS. If set to `True` or *1*, will copy each saved checkpoint on each save in
             [`TrainingArguments`]'s `output_dir` to the local or remote artifact storage. Using it without a remote
             storage will just copy the files to your artifact location.
-        - **MLFLOW_TRACKING_URI** (`str`, *optional*, defaults to `None`):
+        - **MLFLOW_TRACKING_URI** (`str`, *optional*):
             Whether to store runs at a specific path or remote server. Default to `None` which skips setting the
             tracking URI entirely.
         - **MLFLOW_EXPERIMENT_NAME** (`str`, *optional*, defaults to `None`):


### PR DESCRIPTION
# What does this PR do?

The previous code was calling the `mlflow.set_tracking_uri` function regardless of whether or not the environment variable `MLFLOW_TRACKING_URI` is even set. This led to clashes with the original MLflow implementation and therefore the logic was changed to only calling the function when the environment variable is explicitly set.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

~~Fixes # (issue)~~ Doesn't fix a specific issue but addresses a problem that was brought up as a comment in the aforementioned PR: https://github.com/huggingface/transformers/pull/29032#issuecomment-1951595909


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/omnious/model-classifier/blob/885efa563cba97e58ed5c5874a2c9d0f32daded2/tests/unit/test_model.py#L1185
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Maintainers: @amyeroberts @muellerzr @pacman100 
Original author of MLflowCallback: @noise-field 
Author of comment and MLflow maintainer: @harupy 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
