### PR TITLE
Fix the `bert-base-cased` tokenizer configuration test

### DIFF
--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -222,7 +222,7 @@ class AutoTokenizerTest(unittest.TestCase):
         config = get_tokenizer_config("google-bert/bert-base-cased")
         _ = config.pop("_commit_hash", None)
         # If we ever update google-bert/bert-base-cased tokenizer config, this dict here will need to be updated.
-        self.assertEqual(config, {"do_lower_case": False})
+        self.assertEqual(config, {"do_lower_case": False, "model_max_length": 512})
 
         # This model does not have a tokenizer_config so we get back an empty dict.
         config = get_tokenizer_config(SMALL_MODEL_IDENTIFIER)


### PR DESCRIPTION
In the process of updating the tokenizer configurations on the Hub, this test needs to be updated to reflect the new value of the configuration.