### PR TITLE
bug-fix: avoid 'Expected all tensors to be on the same device' error when doing multi-GPU training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1968,11 +1968,7 @@ class Trainer:
                     # if loss is nan or inf simply add the average of previous logged losses
                     tr_loss += tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
                 else:
-                    tr_loss += (
-                        torch.as_tensor(tr_loss_step, device=tr_loss.device)
-                        if tr_loss_step.device != tr_loss.device
-                        else tr_loss_step
-                    )
+                    tr_loss += tr_loss_step
 
                 self.current_flos += float(self.floating_point_ops(inputs))
 
@@ -2914,7 +2910,7 @@ class Trainer:
         else:
             self.accelerator.backward(loss)
 
-        return loss.detach() / self.args.gradient_accumulation_steps
+        return loss.detach().to(self.args.device) / self.args.gradient_accumulation_steps
 
     def compute_loss(self, model, inputs, return_outputs=False):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1968,7 +1968,11 @@ class Trainer:
                     # if loss is nan or inf simply add the average of previous logged losses
                     tr_loss += tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
                 else:
-                    tr_loss += tr_loss_step
+                    tr_loss += (
+                        torch.as_tensor(tr_loss_step, device=tr_loss.device)
+                        if tr_loss_step.device != tr_loss.device
+                        else tr_loss_step
+                    )
 
                 self.current_flos += float(self.floating_point_ops(inputs))
 


### PR DESCRIPTION
When doing DPO training, if the model has been split over multiple GPUs, the `tr_loss` and the `tr_loss_step` end up on different devices at some point, resulting in a 

```
Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1
```
error. ~This patch makes an explicit copy of the `tr_loss_step` value on the same device as the `tr_loss` value, when necessary.~

Update: This patch now explicitly moves the loss value to `self.args.device` to match `tr_loss` in the training step function. This is already done in the `is_sagemaker_mp_enabled()` case.

Ping @patrickvonplaten (git blame last touched), @younesbelkada
