### PR TITLE
[PyTorch/XLA] Fix extra TPU compilations introduced by recent changes

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1364,7 +1364,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 hard_check_only=False,
                 check_device_map=check_device_map,
             )
-        elif requested_attn_implementation in [None, "sdpa"]:
+        elif requested_attn_implementation in [None, "sdpa"] and not is_torch_tpu_available():
             # use_flash_attention_2 takes priority over SDPA, hence SDPA treated in this elif.
             config = cls._check_and_enable_sdpa(
                 config,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1364,7 +1364,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 hard_check_only=False,
                 check_device_map=check_device_map,
             )
-        elif requested_attn_implementation in [None, "sdpa"] and not is_torch_tpu_available():
+        elif requested_attn_implementation in [None, "sdpa"] and not is_torch_xla_available():
             # use_flash_attention_2 takes priority over SDPA, hence SDPA treated in this elif.
             config = cls._check_and_enable_sdpa(
                 config,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1938,19 +1938,7 @@ class Trainer:
                 rng_to_sync = True
 
             step = -1
-            profile_step = int(os.environ.get('PROFILE_STEP', -1))
-            profile_epoch = int(os.environ.get('PROFILE_EPOCH', -1))
-            profile_duration = int(os.environ.get('PROFILE_DURATION_MS', 20000))
-            profile_logdir = os.environ.get('PROFILE_LOGDIR', None)
-
-            import torch_xla.debug.profiler as xp
-            server = xp.start_server(9012)
-            logger.info(f'Profiling server started: {str(server)}')
-
             for step, inputs in enumerate(epoch_iterator):
-                # if step > 5:
-                #     break
-
                 total_batched_samples += 1
 
                 if self.args.include_num_input_tokens_seen:
@@ -2065,14 +2053,6 @@ class Trainer:
                     if is_torch_xla_available():
                         xm.mark_step()
                     break
-
-                if step == profile_step and epoch == profile_epoch:
-                    # Wait until device execution catches up to tracing before triggering the profile. This will
-                    # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
-                    # for the step, the interruption will be minimal.
-                    xm.wait_device_ops()
-                    import tempfile
-                    xp.trace_detached('127.0.0.1:9012', profile_logdir or tempfile.mkdtemp(), profile_duration or 20000)
 
             if step < 0:
                 logger.warning(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1938,7 +1938,19 @@ class Trainer:
                 rng_to_sync = True
 
             step = -1
+            profile_step = int(os.environ.get('PROFILE_STEP', -1))
+            profile_epoch = int(os.environ.get('PROFILE_EPOCH', -1))
+            profile_duration = int(os.environ.get('PROFILE_DURATION_MS', 20000))
+            profile_logdir = os.environ.get('PROFILE_LOGDIR', None)
+
+            import torch_xla.debug.profiler as xp
+            server = xp.start_server(9012)
+            logger.info(f'Profiling server started: {str(server)}')
+
             for step, inputs in enumerate(epoch_iterator):
+                # if step > 5:
+                #     break
+
                 total_batched_samples += 1
 
                 if self.args.include_num_input_tokens_seen:
@@ -2053,6 +2065,15 @@ class Trainer:
                     if is_torch_xla_available():
                         xm.mark_step()
                     break
+
+                if step == profile_step and epoch == profile_epoch:
+                    # Wait until device execution catches up to tracing before triggering the profile. This will
+                    # interrupt training slightly on the hosts which are capturing, but by waiting after tracing
+                    # for the step, the interruption will be minimal.
+                    xm.wait_device_ops()
+                    import tempfile
+                    xp.trace_detached('127.0.0.1:9012', profile_logdir or tempfile.mkdtemp(), profile_duration or 20000)
+
             if step < 0:
                 logger.warning(
                     "There seems to be not a single sample in your epoch_iterator, stopping training at step"

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2053,7 +2053,6 @@ class Trainer:
                     if is_torch_xla_available():
                         xm.mark_step()
                     break
-
             if step < 0:
                 logger.warning(
                     "There seems to be not a single sample in your epoch_iterator, stopping training at step"


### PR DESCRIPTION
# What does this PR do?

This PR tries to fix some extra TPU compilations caused by recent HF changes.
1. PyTorch/XLA doesn't support sdpa yet. So we need to set the default attention implementation to eager.
2. tensor.item() will trigger tpu graph synchronization. We should avoid using it in the training loop.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @younesbelkada 