### PR TITLE
GenerationConfig validate both constraints and force_words_ids

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -482,11 +482,11 @@ class GenerationConfig(PushToHubMixin):
         # 3. detect incorrect paramaterization specific to advanced beam modes
         else:
             # constrained beam search
-            if self.constraints is not None:
+            if self.constraints is not None or self.force_words_ids is not None:
                 constrained_wrong_parameter_msg = (
-                    "`constraints` is not `None`, triggering constrained beam search. However, `{flag_name}` is set "
-                    "to `{flag_value}`, which is incompatible with this generation mode. Set `constraints=None` or "
-                    "unset `{flag_name}` to continue." + fix_location
+                    "one of `constraints`, `force_words_ids` is not `None`, triggering constrained beam search. However, "
+                    "`{flag_name}` is set to `{flag_value}`, which is incompatible with this generation mode. Set "
+                    "`constraints` and `force_words_ids` to `None` or unset `{flag_name}` to continue." + fix_location
                 )
                 if self.do_sample is True:
                     raise ValueError(

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -156,6 +156,11 @@ class GenerationConfigTest(unittest.TestCase):
         # Impossible sets of contraints/parameters will raise an exception
         with self.assertRaises(ValueError):
             GenerationConfig(do_sample=False, num_beams=1, num_return_sequences=2)
+        with self.assertRaises(ValueError):
+            # dummy constraint
+            GenerationConfig(do_sample=True, num_beams=2, constraints=["dummy"])
+        with self.assertRaises(ValueError):
+            GenerationConfig(do_sample=True, num_beams=2, force_words_ids=[[[1, 2, 3]]])
 
         # Passing `generate()`-only flags to `validate` will raise an exception
         with self.assertRaises(ValueError):


### PR DESCRIPTION

# What does this PR do?

There is currently two ways to pass constraints to constrained beam search, either `constraints` or `force_words_ids`. They get merged [here](https://github.com/gante/transformers/blob/17c5cb66f91a10e900017da9200693c929798ac8/src/transformers/generation/utils.py#L1689) which is after the GenerationConfig initialization. I was following the [blog](https://huggingface.co/blog/constrained-beam-search) on constrained decoding (using `force_words_ids` and was checking for myself which other options constrained beam search can be combined with (Ex: can I sample and constrained beam search? [no])

This snippet raised a `ValueError`:

```python
    generated_tokens = self.model.generate(
        **encoded_source,
        forced_bos_token_id=forced_bos_token_id,
        num_beams=5,
        num_return_sequences=1,
        constraints=constraints,
        do_sample=True
    )
```

while this snipped __didn't__:
```python
    generated_tokens = self.model.generate(
        **encoded_source,
        forced_bos_token_id=forced_bos_token_id,
        num_beams=5,
        num_return_sequences=1,
        force_words_ids=force_words_ids,
        do_sample=True
    )
```

I've added the additional check to `GenerationConfig.validate()` to include `force_words_ids` and I've added two new tests:

```python
        with self.assertRaises(ValueError):
            # dummy constraint
            GenerationConfig(do_sample=True, num_beams=2, constraints=["dummy"])
        with self.assertRaises(ValueError):
            GenerationConfig(do_sample=True, num_beams=2, force_words_ids=[[[1, 2, 3]]])
```

Without the change only the first test passes, with the change both tests pass as they now both raise `ValueErrors` (Expected behavior).

This is my first time opening a PR here, so let me know what I can improve. I've followed the docs on contribution for this PR, though after running all tests after installation there were 5 tests that failed before I changed anything.

Cheers! :)

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

maybe @gante 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
