### PR TITLE
Allow remote code repo names to contain "."

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -185,7 +185,7 @@ def check_imports(filename: Union[str, os.PathLike]) -> List[str]:
     return get_relative_imports(filename)
 
 
-def get_class_in_module(class_name: str, module_path: Union[str, os.PathLike]) -> typing.Type:
+def get_class_in_module(repo_id: str, class_name: str, module_path: Union[str, os.PathLike]) -> typing.Type:
     """
     Import a module on the cache directory for modules and extract a class from it.
 
@@ -197,7 +197,19 @@ def get_class_in_module(class_name: str, module_path: Union[str, os.PathLike]) -
         `typing.Type`: The class looked for.
     """
     module_path = module_path.replace(os.path.sep, ".")
-    module = importlib.import_module(module_path)
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as e:
+        if not ('.' in repo_id and module_path.startswith("transformers_modules") and repo_id.replace('/', '.') in module_path):
+            raise e  # We can't figure this one out, just reraise the original error
+        # TODO The fundamental problem here is that we know one part of the path shouldn't be split on .
+        #      We can hack that but we should really override a Loader with a specific method
+        modules_dir = [dir for dir in ]
+        breakpoint()
+        print()
+    module = importlib.machinery.SourceFileLoader(module_path, os.path.join(sys.path[0], 'program_1.4.py')).exec_module()
+    breakpoint()
+
     return getattr(module, class_name)
 
 
@@ -497,7 +509,7 @@ def get_class_from_dynamic_module(
         local_files_only=local_files_only,
         repo_type=repo_type,
     )
-    return get_class_in_module(class_name, final_module.replace(".py", ""))
+    return get_class_in_module(repo_id, class_name, final_module.replace(".py", ""))
 
 
 def custom_object_save(obj: Any, folder: Union[str, os.PathLike], config: Optional[Dict] = None) -> List[str]:

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -185,16 +185,13 @@ def check_imports(filename: Union[str, os.PathLike]) -> List[str]:
     return get_relative_imports(filename)
 
 
-def get_class_in_module(
-    repo_id: str, class_name: str, module_path: Union[str, os.PathLike], cache_dir: Optional[Union[str, os.PathLike]]
-) -> typing.Type:
+def get_class_in_module(repo_id: str, class_name: str, module_path: Union[str, os.PathLike]) -> typing.Type:
     """
     Import a module on the cache directory for modules and extract a class from it.
 
     Args:
         class_name (`str`): The name of the class to import.
         module_path (`str` or `os.PathLike`): The path to the module to import.
-        cache_dir (`str` or `os.PathLike`, *optional*): Path to the directory containing the module cache.
 
 
     Returns:
@@ -212,9 +209,7 @@ def get_class_in_module(
             and repo_id.replace("/", ".") in module_path
         ):
             raise e  # We can't figure this one out, just reraise the original error
-        if cache_dir is None:
-            cache_dir = HF_MODULES_CACHE
-        corrected_path = os.path.join(cache_dir, module_path.replace(".", "/")) + ".py"
+        corrected_path = os.path.join(HF_MODULES_CACHE, module_path.replace(".", "/")) + ".py"
         corrected_path = corrected_path.replace(repo_id.replace(".", "/"), repo_id)
         module = importlib.machinery.SourceFileLoader(module_path, corrected_path).load_module()
 
@@ -517,7 +512,7 @@ def get_class_from_dynamic_module(
         local_files_only=local_files_only,
         repo_type=repo_type,
     )
-    return get_class_in_module(repo_id, class_name, final_module.replace(".py", ""), cache_dir)
+    return get_class_in_module(repo_id, class_name, final_module.replace(".py", ""))
 
 
 def custom_object_save(obj: Any, folder: Union[str, os.PathLike], config: Optional[Dict] = None) -> List[str]:

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -190,6 +190,7 @@ def get_class_in_module(repo_id: str, class_name: str, module_path: Union[str, o
     Import a module on the cache directory for modules and extract a class from it.
 
     Args:
+        repo_id (`str`): The repo containing the module. Used for path manipulation.
         class_name (`str`): The name of the class to import.
         module_path (`str` or `os.PathLike`): The path to the module to import.
 

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -423,7 +423,6 @@ class _BaseAutoModelClass:
                 repo_id, class_ref = class_ref.split("--")
             else:
                 repo_id = config.name_or_path
-
             model_class = get_class_from_dynamic_module(class_ref, repo_id, **kwargs)
             if os.path.isdir(config._name_or_path):
                 model_class.register_for_auto_class(cls.__name__)

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -423,6 +423,7 @@ class _BaseAutoModelClass:
                 repo_id, class_ref = class_ref.split("--")
             else:
                 repo_id = config.name_or_path
+
             model_class = get_class_from_dynamic_module(class_ref, repo_id, **kwargs)
             if os.path.isdir(config._name_or_path):
                 model_class.register_for_auto_class(cls.__name__)

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -376,6 +376,20 @@ class AutoModelTest(unittest.TestCase):
         for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
+    def test_from_pretrained_dynamic_model_with_period(self):
+        # We used to have issues where repos with "." in the name would cause issues because the Python
+        # import machinery would treat that as a directory separator, so we test that case
+
+        # If remote code is not set, we will time out when asking whether to load the model.
+        with self.assertRaises(ValueError):
+            model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0")
+        # If remote code is disabled, we can't load this config.
+        with self.assertRaises(ValueError):
+            model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=False)
+
+        model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=True)
+        self.assertEqual(model.__class__.__name__, "NewModel")
+
     def test_new_model_registration(self):
         AutoConfig.register("custom", CustomConfig)
 

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -390,6 +390,12 @@ class AutoModelTest(unittest.TestCase):
         model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=True)
         self.assertEqual(model.__class__.__name__, "NewModel")
 
+        # Test that it works with a custom cache dir too
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModel.from_pretrained(
+                "Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=True, cache_dir=tmp_dir
+            )
+
     def test_new_model_registration(self):
         AutoConfig.register("custom", CustomConfig)
 

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -382,19 +382,20 @@ class AutoModelTest(unittest.TestCase):
 
         # If remote code is not set, we will time out when asking whether to load the model.
         with self.assertRaises(ValueError):
-            model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0")
+            model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model_v1.0")
         # If remote code is disabled, we can't load this config.
         with self.assertRaises(ValueError):
-            model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=False)
+            model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model_v1.0", trust_remote_code=False)
 
-        model = AutoModel.from_pretrained("Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=True)
+        model = AutoModel.from_pretrained("hf-internal-testing/test_dynamic_model_v1.0", trust_remote_code=True)
         self.assertEqual(model.__class__.__name__, "NewModel")
 
         # Test that it works with a custom cache dir too
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModel.from_pretrained(
-                "Rocketknight1/test_dynamic_model_v1.0", trust_remote_code=True, cache_dir=tmp_dir
+                "hf-internal-testing/test_dynamic_model_v1.0", trust_remote_code=True, cache_dir=tmp_dir
             )
+            self.assertEqual(model.__class__.__name__, "NewModel")
 
     def test_new_model_registration(self):
         AutoConfig.register("custom", CustomConfig)


### PR DESCRIPTION
Thanks to @not-lain for spotting this one! When the repo path for a remote code model contains `.`, our code fails to import it correctly because `.` is interpreted by the Python import machinery as a module separator.

For now, we monkey-patch this in `get_class_in_module`, but we can consider a more thorough overhaul of the import machinery if problems crop up elsewhere.

TODO:
- [x] Test this with custom cache dirs
- [x] Add a test for this somewhere?

Fixes #28919