### PR TITLE
Static Cache: no mandatory `cache_positions` input

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -4,6 +4,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 
 from .configuration_utils import PretrainedConfig
+from .utils import logging
+
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -57,6 +61,17 @@ class Cache:
             return max_length - new_seq_length
         return previous_seq_length
 
+    @property
+    def seen_tokens(self):
+        logger.warning_once(
+            "The `seen_tokens` attribute is deprecated and will be removed in v4.40. Use the `cache_position` "
+            "variable instead."
+        )
+        if hasattr(self, "_seen_tokens"):
+            return self._seen_tokens
+        else:
+            return None
+
 
 class DynamicCache(Cache):
     """
@@ -69,7 +84,7 @@ class DynamicCache(Cache):
     def __init__(self) -> None:
         self.key_cache: List[torch.Tensor] = []
         self.value_cache: List[torch.Tensor] = []
-        self.seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
+        self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
 
     def __getitem__(self, layer_idx: int) -> List[Tuple[torch.Tensor]]:
         """
@@ -121,7 +136,7 @@ class DynamicCache(Cache):
         """
         # Update the number of seen tokens
         if layer_idx == 0:
-            self.seen_tokens += key_states.shape[-2]
+            self._seen_tokens += key_states.shape[-2]
 
         # Update the cache
         if len(self.key_cache) <= layer_idx:
@@ -191,7 +206,7 @@ class SinkCache(Cache):
         self.window_length = window_length
         self.num_sink_tokens = num_sink_tokens
         self.cos_sin_cache = {}
-        self.seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
+        self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
 
     @staticmethod
     def _rotate_half(x):
@@ -272,7 +287,7 @@ class SinkCache(Cache):
 
         # Update the number of seen tokens
         if layer_idx == 0:
-            self.seen_tokens += key_states.shape[-2]
+            self._seen_tokens += key_states.shape[-2]
 
         # [bsz, num_heads, seq_len, head_dim]
         if len(self.key_cache) <= layer_idx:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -399,8 +399,8 @@ class StaticCache(Cache):
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
         """Returns the sequence length of the cached states that were seen by the model. `layer_idx` kept for BC"""
         # Occupied cache == any slot in the 3rd dim (sequence length) holds a non-zero value. To save on compute, let's
-        # check the first batch member and the first head only.
-        return (self.key_cache[0, 0].sum(dim=-1) != 0).sum()
+        # limit the check to the first batch member and head dimension.
+        return (self.key_cache[0, 0].any(dim=-1)).sum()
 
     def get_max_length(self) -> Optional[int]:
         """Returns the maximum sequence length of the cached states. DynamicCache does not have a maximum length."""

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -398,16 +398,9 @@ class StaticCache(Cache):
 
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
         """Returns the sequence length of the cached states that were seen by the model. `layer_idx` kept for BC"""
-        # TODO: Fix once the stateful `int` bug in PyTorch is fixed.
-        raise ValueError(
-            "get_seq_length is not implemented for StaticCache. Please refer to https://github.com/huggingface/transformers/pull/29114."
-        )
-
-    def get_usable_length(self, new_sequence_length=None, layer_idx: Optional[int] = 0) -> int:
-        # TODO: Fix once the stateful `int` bug in PyTorch is fixed.
-        raise ValueError(
-            "get_seq_length is not implemented for StaticCache. Please refer to https://github.com/huggingface/transformers/pull/29114."
-        )
+        # Occupied cache == any slot in the 3rd dim (sequence length) holds a non-zero value. To save on compute, let's
+        # check the first batch member and the first head only.
+        return (self.key_cache[0, 0].sum(dim=-1) != 0).sum()
 
     def get_max_length(self) -> Optional[int]:
         """Returns the maximum sequence length of the cached states. DynamicCache does not have a maximum length."""

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -400,6 +400,8 @@ class StaticCache(Cache):
         """Returns the sequence length of the cached states that were seen by the model. `layer_idx` kept for BC"""
         # Occupied cache == any slot in the 3rd dim (sequence length) holds a non-zero value. To save on compute, let's
         # limit the check to the first batch member and head dimension.
+        # TODO: This is error prone, a filled cache may be `0.0`. Let's use a stateless integer instead, after
+        # https://github.com/pytorch/pytorch/issues/120248 is fixed
         return (self.key_cache[0, 0].any(dim=-1)).sum()
 
     def get_max_length(self) -> Optional[int]:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -678,6 +678,8 @@ class GenerationMixin:
                     dim=-1,
                 )
 
+        model_kwargs["cache_position"] = model_inputs.get("cache_position", None)
+
         return model_kwargs
 
     def _reorder_cache(self, past_key_values, beam_idx):
@@ -4929,8 +4931,9 @@ def _split_model_inputs(
     # Here we can have four types of values: tensors, tuples of tensors and booleans, and encoder_outputs which is a
     # ModelOutput object.
     # bool should not be split but replicated for each split
-    bool_keys = [k for k in keys if isinstance(model_input[k], bool)]
-    non_bool_keys = [k for k in keys if not isinstance(model_input[k], bool) and k != "encoder_outputs"]
+    bool_keys = [k for k in keys if isinstance(model_input[k], bool) or k == "cache_position"]
+    keys_to_ignore = ["cache_position", "encoder_outputs"]
+    non_bool_keys = [k for k in keys if not isinstance(model_input[k], bool) and k not in keys_to_ignore]
 
     # we split the tensors and tuples of tensors
     data_split_list = [

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -678,8 +678,6 @@ class GenerationMixin:
                     dim=-1,
                 )
 
-        model_kwargs["cache_position"] = model_inputs.get("cache_position", None)
-
         return model_kwargs
 
     def _reorder_cache(self, past_key_values, beam_idx):
@@ -4931,9 +4929,8 @@ def _split_model_inputs(
     # Here we can have four types of values: tensors, tuples of tensors and booleans, and encoder_outputs which is a
     # ModelOutput object.
     # bool should not be split but replicated for each split
-    bool_keys = [k for k in keys if isinstance(model_input[k], bool) or k == "cache_position"]
-    keys_to_ignore = ["cache_position", "encoder_outputs"]
-    non_bool_keys = [k for k in keys if not isinstance(model_input[k], bool) and k not in keys_to_ignore]
+    bool_keys = [k for k in keys if isinstance(model_input[k], bool)]
+    non_bool_keys = [k for k in keys if not isinstance(model_input[k], bool) and k != "encoder_outputs"]
 
     # we split the tensors and tuples of tensors
     data_split_list = [

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1145,7 +1145,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 0)
+            position_ids.masked_fill_(attention_mask == 0, 1)
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -782,6 +782,10 @@ GEMMA_INPUTS_DOCSTRING = r"""
             more detail.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence. Contrarily to `position_ids`,
+            this tensor is not affected by padding. It is used to update the cache in the correct position and to infer
+            the complete sequence length.
 """
 
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -876,9 +876,9 @@ class GemmaModel(GemmaPreTrainedModel):
         if attention_mask is None:
             padded_offset = 0
         else:
-            padded_offset = (1 - torch.sum(attention_mask, dim=0).clamp(max=1)).cumsum(-1)
+            padded_offset = (1 - torch.sum(attention_mask.to(torch.int64), dim=0).clamp(max=1)).cumsum(-1)
             padded_offset = torch.cat(
-                (torch.zeros((1,), dtype=padded_offset.dtype, device=padded_offset.device), padded_offset)
+                (torch.zeros((1,), dtype=torch.int64, device=padded_offset.device), padded_offset)
             )[-cache_position.shape[0] - 1 : -1]
         cache_position = cache_position + padded_offset
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1254,7 +1254,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 0)
+            position_ids.masked_fill_(attention_mask == 0, 1)
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -982,10 +982,13 @@ class LlamaModel(LlamaPreTrainedModel):
         # applied on all batch members. Left-padding on all batch members can be detected from the `attention_mask`.
         cache_position = torch.max(position_ids, dim=0).values
         if attention_mask is None:
-            padded_positions = 0
+            padded_offset = 0
         else:
-            padded_positions = torch.sum(attention_mask == 0, dim=1).min()
-        cache_position = cache_position + padded_positions
+            padded_offset = (1 - torch.sum(attention_mask, dim=0).clamp(max=1)).cumsum(-1)
+            padded_offset = torch.cat(
+                (torch.zeros((1,), dtype=padded_offset.dtype, device=padded_offset.device), padded_offset)
+            )[-cache_position.shape[0] - 1 : -1]
+        cache_position = cache_position + padded_offset
 
         causal_mask = self._update_causal_mask(attention_mask, inputs_embeds)
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -943,6 +943,7 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -975,8 +976,11 @@ class LlamaModel(LlamaPreTrainedModel):
                     past_key_values = DynamicCache.from_legacy_cache(past_key_values)
                 past_seen_tokens = past_key_values.get_seq_length()
 
-        # `torch.compile`-friendly `torch.arange` from a shape
-        cache_position = torch.ones_like(inputs_embeds[0, :, 0], dtype=torch.int64).cumsum(0) + past_seen_tokens - 1
+        if cache_position is None:
+            # `torch.compile`-friendly `torch.arange` from a shape
+            cache_position = (
+                torch.ones_like(inputs_embeds[0, :, 0], dtype=torch.int64).cumsum(0) + past_seen_tokens - 1
+            )
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
@@ -1128,6 +1132,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1171,6 +1176,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            cache_position=cache_position,
         )
 
         hidden_states = outputs[0]
@@ -1258,6 +1264,12 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 
+        # TODO @gante we should only keep a `cache_position` in generate, and do +=1.
+        # same goes for position ids. Could also help with continued generation.
+        input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
+        cache_position = torch.arange(past_length, past_length + input_length, device=input_ids.device)
+        position_ids = position_ids.contiguous() if position_ids is not None else None
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}
@@ -1273,6 +1285,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         model_inputs.update(
             {
                 "position_ids": position_ids.contiguous(),
+                "cache_position": cache_position,
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -984,9 +984,9 @@ class LlamaModel(LlamaPreTrainedModel):
         if attention_mask is None:
             padded_offset = 0
         else:
-            padded_offset = (1 - torch.sum(attention_mask, dim=0).clamp(max=1)).cumsum(-1)
+            padded_offset = (1 - torch.sum(attention_mask.to(torch.int64), dim=0).clamp(max=1)).cumsum(-1)
             padded_offset = torch.cat(
-                (torch.zeros((1,), dtype=padded_offset.dtype, device=padded_offset.device), padded_offset)
+                (torch.zeros((1,), dtype=torch.int64, device=padded_offset.device), padded_offset)
             )[-cache_position.shape[0] - 1 : -1]
         cache_position = cache_position + padded_offset
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -985,6 +985,7 @@ class LlamaModel(LlamaPreTrainedModel):
             cache_position = (
                 torch.ones_like(inputs_embeds[0, :, 0], dtype=torch.int64).cumsum(0) + past_seen_tokens - 1
             )
+
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
@@ -1218,24 +1219,24 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         )
 
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, cache_position=None, **kwargs
     ):
         # With static cache, the `past_key_values` is None
+        # TODO joao: standardize interface for the different Cache classes and remove of this if
         has_static_cache = False
         if past_key_values is None:
-            has_static_cache = True
             past_key_values = getattr(self.model.layers[0].self_attn, "past_key_value", None)
+            has_static_cache = past_key_values is not None
 
         past_length = 0
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
-                cache_length = past_key_values.get_seq_length()
+                past_length = (
+                    cache_position[-1] + 1 if cache_position is not None else past_key_values.get_seq_length()
+                )
                 max_cache_length = past_key_values.get_max_length()
-                # TODO joao: find a better way to track the total number of tokens seen in the static cache
-                if max_cache_length is not None:
-                    past_length = cache_length
-                else:
-                    past_length = past_key_values.seen_tokens
+                cache_length = past_length if max_cache_length is None else min(max_cache_length, int(past_length))
+            # TODO joao: remove this `else` after `generate` prioritizes `Cache` objects
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
                 max_cache_length = None

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -966,29 +966,22 @@ class LlamaModel(LlamaPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         past_seen_tokens = 0
-        if use_cache:  # kept for BC (cache positions)
-            if not isinstance(past_key_values, StaticCache):
+        if use_cache:
+            if past_key_values is not None and not isinstance(past_key_values, Cache):
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            # non-static cache
+            if past_key_values is not None:
                 past_seen_tokens = past_key_values.get_seq_length()
+            # static cache
+            elif past_key_values is None:
+                static_cache = getattr(self.layers[0].self_attn, "past_key_value", None)
+                if static_cache is not None:
+                    past_seen_tokens = static_cache.get_seq_length()
 
+        # `torch.compile`-friendly `torch.arange` from a shape
+        cache_position = torch.ones_like(inputs_embeds[0, :, 0], dtype=torch.int64).cumsum(0) + past_seen_tokens - 1
         if position_ids is None:
-            if isinstance(past_key_values, StaticCache):
-                raise ValueError("position_ids is a required argument when using StaticCache.")
-            position_ids = torch.arange(
-                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
-            ).unsqueeze(0)
-
-        # One of the rows in `position_ids` contains the highest sequence of cache indexes, excluding left-padding
-        # applied on all batch members. Left-padding on all batch members can be detected from the `attention_mask`.
-        cache_position = torch.max(position_ids, dim=0).values
-        if attention_mask is None:
-            padded_offset = 0
-        else:
-            padded_offset = (1 - torch.sum(attention_mask.to(torch.int64), dim=0).clamp(max=1)).cumsum(-1)
-            padded_offset = torch.cat(
-                (torch.zeros((1,), dtype=torch.int64, device=padded_offset.device), padded_offset)
-            )[-cache_position.shape[0] - 1 : -1]
-        cache_position = cache_position + padded_offset
+            position_ids = cache_position.unsqueeze(0)
 
         causal_mask = self._update_causal_mask(attention_mask, inputs_embeds)
 
@@ -1220,12 +1213,22 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
     def prepare_inputs_for_generation(
         self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
+        # With static cache, the `past_key_values` is None
+        has_static_cache = False
+        if past_key_values is None:
+            has_static_cache = True
+            past_key_values = getattr(self.model.layers[0].self_attn, "past_key_value", None)
+
         past_length = 0
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
                 cache_length = past_key_values.get_seq_length()
-                past_length = past_key_values.seen_tokens
                 max_cache_length = past_key_values.get_max_length()
+                # TODO joao: find a better way to track the total number of tokens seen in the static cache
+                if max_cache_length is not None:
+                    past_length = cache_length
+                else:
+                    past_length = past_key_values.seen_tokens
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
                 max_cache_length = None
@@ -1266,6 +1269,9 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             # recompiles graphs as the stride of the inputs is a guard. Ref: https://github.com/huggingface/transformers/pull/29114
             # TODO: use `next_tokens` directly instead.
             model_inputs = {"input_ids": input_ids.contiguous()}
+
+        if has_static_cache:
+            past_key_values = None
 
         model_inputs.update(
             {

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -357,7 +357,7 @@ class LlamaAttention(nn.Module):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
         if past_key_value is not None:
-            # sin and cos are specific to RoPE models; position_ids needed for the static cache
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
@@ -446,7 +446,7 @@ class LlamaFlashAttention2(LlamaAttention):
         past_key_value = getattr(self, "past_key_value", past_key_value)
 
         if past_key_value is not None:
-            # sin and cos are specific to RoPE models; position_ids needed for the static cache
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
@@ -625,7 +625,6 @@ class LlamaSdpaAttention(LlamaAttention):
                 past_key_value=past_key_value,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
-                cache_position=cache_position,
             )
 
         bsz, q_len, _ = hidden_states.size()
@@ -645,7 +644,7 @@ class LlamaSdpaAttention(LlamaAttention):
         past_key_value = getattr(self, "past_key_value", past_key_value)
 
         if past_key_value is not None:
-            # sin and cos are specific to RoPE models; position_ids needed for the static cache
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
@@ -943,7 +942,6 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -972,15 +970,21 @@ class LlamaModel(LlamaPreTrainedModel):
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
                 past_seen_tokens = past_key_values.get_seq_length()
 
-        if cache_position is None:
-            if isinstance(past_key_values, StaticCache):
-                raise ValueError("cache_position is a required argument when using StaticCache.")
-            cache_position = torch.arange(
-                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
-            )
-
         if position_ids is None:
-            position_ids = cache_position.unsqueeze(0)
+            if isinstance(past_key_values, StaticCache):
+                raise ValueError("position_ids is a required argument when using StaticCache.")
+            position_ids = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            ).unsqueeze(0)
+
+        # One of the rows in `position_ids` contains the highest sequence of cache indexes, excluding left-padding
+        # applied on all batch members. Left-padding on all batch members can be detected from the `attention_mask`.
+        cache_position = torch.max(position_ids, dim=0).values
+        if attention_mask is None:
+            padded_positions = 0
+        else:
+            padded_positions = torch.sum(attention_mask == 0, dim=1).min()
+        cache_position = cache_position + padded_positions
 
         causal_mask = self._update_causal_mask(attention_mask, inputs_embeds)
 
@@ -1130,7 +1134,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1174,7 +1177,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            cache_position=cache_position,
         )
 
         hidden_states = outputs[0]
@@ -1248,23 +1250,9 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 1)
+            position_ids.masked_fill_(attention_mask == 0, 0)
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
-
-        if getattr(self.model.layers[0].self_attn, "past_key_value", None) is not None:
-            # generation with static cache
-            cache_position = kwargs.get("cache_position", None)
-            if cache_position is None:
-                past_length = 0
-            else:
-                past_length = cache_position[-1] + 1
-            input_ids = input_ids[:, past_length:]
-            position_ids = position_ids[:, past_length:]
-
-        # TODO @gante we should only keep a `cache_position` in generate, and do +=1.
-        # same goes for position ids. Could also help with continued generation.
-        cache_position = torch.arange(past_length, past_length + position_ids.shape[-1], device=position_ids.device)
 
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
@@ -1278,7 +1266,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         model_inputs.update(
             {
                 "position_ids": position_ids.contiguous(),
-                "cache_position": cache_position,
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -892,6 +892,10 @@ LLAMA_INPUTS_DOCSTRING = r"""
             more detail.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence. Contrarily to `position_ids`,
+            this tensor is not affected by padding. It is used to update the cache in the correct position and to infer
+            the complete sequence length.
 """
 
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -625,6 +625,7 @@ class LlamaSdpaAttention(LlamaAttention):
                 past_key_value=past_key_value,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
+                cache_position=cache_position,
             )
 
         bsz, q_len, _ = hidden_states.size()

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -436,9 +436,9 @@ class CacheIntegrationTest(unittest.TestCase):
 
         model.generation_config.cache_implementation = "static"
 
-        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-        self.assertListEqual(decoded, EXPECTED_GENERATION)
+        # gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+        # decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+        # self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         # Now with extra left-padding
         inputs_expanded = tokenizer(

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -436,9 +436,9 @@ class CacheIntegrationTest(unittest.TestCase):
 
         model.generation_config.cache_implementation = "static"
 
-        # gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-        # decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-        # self.assertListEqual(decoded, EXPECTED_GENERATION)
+        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+        self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         # Now with extra left-padding
         inputs_expanded = tokenizer(


### PR DESCRIPTION
# What does this PR do?

Removes the hard requirement of `cache_position` from the public model classes (e.g. classes that can be loaded with `AutoModel`). Its contents can be derived from the cache's `get_seq_length()`.

________________________________________________________
### Performance and Quality checks

Slow tests run, getting the same outcome as in `main`:
- [x] `RUN_SLOW=1 py.test tests/models/llama/test_modeling_llama.py -vv`
- [x] `RUN_SLOW=1 py.test tests/models/gemma/test_modeling_gemma.py -vv`
- [x] `RUN_SLOW=1 py.test tests/test_cache_utils.py -vv` [Note: two new tests were added here]

👉 Note that these tests ensure that `torch.compile` works, with and without `attention_mask` being passed.

Local benchmark (RTX3090, tiny llama) -- no changes
(main)
![Screenshot 2024-02-22 at 11 54 26](https://github.com/huggingface/transformers/assets/12240844/ec452847-4a4d-4aec-8063-2a6017a62857)

(this pr)
![Screenshot 2024-02-22 at 17 57 13](https://github.com/huggingface/transformers/assets/12240844/199edee2-1909-4045-9414-5c9975788493)
