### PR TITLE
Fix causal mask in llama for long seq_length

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1061,9 +1061,10 @@ class LlamaModel(LlamaPreTrainedModel):
         device = input_tensor.device
 
         # support going beyond cached `max_position_embedding`
-        if seq_length > self.causal_mask.shape[-1]:
-            causal_mask = torch.full((2 * self.causal_mask.shape[-1], 2 * self.causal_mask.shape[-1]), fill_value=1)
-            self.register_buffer("causal_mask", torch.triu(causal_mask, diagonal=1), persistent=False)
+        causal_mask = self.causal_mask
+        while seq_length > causal_mask.shape[-1]:
+            causal_mask = torch.full((2 * causal_mask.shape[-1], 2 * causal_mask.shape[-1]), fill_value=1)
+        self.register_buffer("causal_mask", torch.triu(causal_mask, diagonal=1), persistent=False)
 
         # We use the current dtype to avoid any overflows
         min_dtype = torch.finfo(dtype).min


### PR DESCRIPTION
# What does this PR do?

Fix a bug in Llama causal mask creation for when input length > causal_mask.shape (which comes from max_position_embeddings). 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @younesbelkada 

