### PR TITLE
Add compatibility with skip_memory_metrics for mps device

### DIFF
--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -591,7 +591,7 @@ class TrainerMemoryTracker:
                 self.gpu_mem_used_now = self.torch.mps.current_allocated_memory()
                 # self.torch.mps.max_memory_allocated() does not exist yet
                 self.gpu_mem_used_peak = None
-                
+
             else:
                 raise ValueError("No available GPU device found!")
 
@@ -603,7 +603,7 @@ class TrainerMemoryTracker:
             if self.gpu_mem_used_peak is not None:
                 self.gpu[self.cur_stage]["peaked"] = max(0, self.gpu_mem_used_peak - self.gpu_mem_used_now)
             else:
-                self.gpu[self.cur_stage]["peaked"] = "Not availble"
+                self.gpu[self.cur_stage]["peaked"] = "Not available"
 
         # cpu
         self.cpu_mem_used_now = self.cpu_mem_used()

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -535,6 +535,8 @@ class TrainerMemoryTracker:
                 self.gpu_mem_used_at_start = self.torch.xpu.memory_allocated()
             elif is_torch_npu_available():
                 self.gpu_mem_used_at_start = self.torch.npu.memory_allocated()
+            elif is_torch_mps_available():
+                self.gpu_mem_used_at_start = self.torch.mps.current_allocated_memory()
 
         # cpu
         self.cpu_mem_used_at_start = self.cpu_mem_used()
@@ -564,6 +566,8 @@ class TrainerMemoryTracker:
                 self.torch.xpu.empty_cache()
             elif is_torch_npu_available():
                 self.torch.npu.empty_cache()
+            elif is_torch_mps_available():
+                self.torch.mps.empty_cache()
 
         # concepts:
         # - alloc_delta:  the difference of allocated memory between the end and the start
@@ -581,6 +585,10 @@ class TrainerMemoryTracker:
             elif is_torch_npu_available():
                 self.gpu_mem_used_now = self.torch.npu.memory_allocated()
                 self.gpu_mem_used_peak = self.torch.npu.max_memory_allocated()
+            elif is_torch_mps_available():
+                self.gpu_mem_used_now = self.torch.mps.current_allocated_memory()
+                self.gpu_mem_used_peak = self.torch.mps.driver_allocated_memory()
+                
             else:
                 raise ValueError("No available GPU device found!")
 


### PR DESCRIPTION
# What does this PR do 
This PR makes mps device compatible with memory profiling integrated in Trainer (`skip_memory_metrics`=False). However, we can't get the information on the peak memory since` torch.mps.max_memory_allocated()` doesn't exist yet. 
Fixes #27181
Tested on mac and I get the following output for a simple Trainer [example](https://gist.github.com/SunMarc/ccd7704cb5d5668aa5d15f5d02c712bf):

`{'train_runtime': 7.8136, 'train_samples_per_second': 24.572, 'train_steps_per_second': 3.072, 'train_loss': 5.870065689086914, 'init_mem_cpu_alloc_delta': 950272, 'init_mem_gpu_alloc_delta': 512, 'init_mem_cpu_peaked_delta': 16384, 'init_mem_gpu_peaked_delta': 'Not available', 'train_mem_cpu_alloc_delta': 38354944, 'train_mem_gpu_alloc_delta': 2304, 'train_mem_cpu_peaked_delta': 16384, 'train_mem_gpu_peaked_delta': 'Not available', 'before_init_mem_cpu': 351813632, 'before_init_mem_gpu': 0, 'epoch': 3.0}`