### PR TITLE
Use DS_DISABLE_NINJA=1

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -265,7 +265,7 @@ jobs:
         working-directory: /workspace
         run: |
           python3 -m pip uninstall -y deepspeed
-          DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 python3 -m pip install deepspeed --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check
+          DS_DISABLE_NINJA=1 DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 python3 -m pip install deepspeed --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check
 
       - name: NVIDIA-SMI
         run: |


### PR DESCRIPTION
# What does this PR do?

Deepspeed ` 0.13.3` was released on Feb. 24 but causes the prebuild failed in our CI workflow.

@pacman100 found it's likely due to  https://github.com/microsoft/DeepSpeed/pull/5088

and suggested using 

> DS_DISABLE_NINJA=1

I tried it and the prebuild is fine now.