### PR TITLE
Fix max length for BLIP generation

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1453,6 +1453,7 @@ class GenerationMixin:
             and not self.config.is_encoder_decoder
         ):
             generation_config.max_length -= inputs_tensor.shape[1]
+            generation_config.max_length = max(generation_config.max_length - inputs_tensor.shape[1], 0)
 
         if generation_config.cache_implementation in NEED_SETUP_CACHE_CLASSES_MAPPING:
             if generation_config.cache_implementation == "static":

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1453,7 +1453,7 @@ class GenerationMixin:
             and not self.config.is_encoder_decoder
         ):
             generation_config.max_length -= inputs_tensor.shape[1]
-            generation_config.max_length = max(generation_config.max_length - inputs_tensor.shape[1], 0)
+            generation_config.min_length = max(generation_config.min_length - inputs_tensor.shape[1], 0)
 
         if generation_config.cache_implementation in NEED_SETUP_CACHE_CLASSES_MAPPING:
             if generation_config.cache_implementation == "static":

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1829,17 +1829,15 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
-            max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
-            min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
         else:
-            max_length = generate_kwargs.get("max_length", 20)
-            min_length = generate_kwargs.get("min_length", 0)
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20)
+            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0)
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
-            max_length=max_length,
-            min_length=min_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1827,6 +1827,7 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
+        # add image_embeds lenth to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1827,15 +1827,18 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
-        if "max_length" in generate_kwargs:
-            max_length = generate_kwargs["max_length"] + language_model_inputs.shape[1]
+        if not self.language_model.config.is_encoder_decoder:
+            max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
         else:
-            max_length = 20 + language_model_inputs.shape[1]
+            max_length = generate_kwargs.get("max_length", 20)
+            min_length = generate_kwargs.get("min_length", 0)
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             max_length=max_length,
+            min_length=min_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1830,7 +1830,7 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
-            generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
+            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1827,7 +1827,7 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
-        # add image_embeds lenth to max_length, so that the final max_length in counted only on token embeds
+        # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1827,9 +1827,15 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
+        if "max_length" in generate_kwargs:
+            max_length = generate_kwargs["max_length"] + language_model_inputs.shape[1]
+        else:
+            max_length = 20 + language_model_inputs.shape[1]
+
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
+            max_length=max_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1831,9 +1831,6 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
-        else:
-            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20)
-            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0)
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1537,15 +1537,18 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
-        if "max_length" in generate_kwargs:
-            max_length = generate_kwargs["max_length"] + language_model_inputs.shape[1]
+        if not self.language_model.config.is_encoder_decoder:
+            max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
         else:
-            max_length = 20 + language_model_inputs.shape[1]
+            max_length = generate_kwargs.get("max_length", 20)
+            min_length = generate_kwargs.get("min_length", 0)
         
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             max_length=max_length,
+            min_length=min_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1537,9 +1537,15 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
+        if "max_length" in generate_kwargs:
+            max_length = generate_kwargs["max_length"] + language_model_inputs.shape[1]
+        else:
+            max_length = 20 + language_model_inputs.shape[1]
+        
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
+            max_length=max_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1544,7 +1544,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         else:
             max_length = generate_kwargs.get("max_length", 20)
             min_length = generate_kwargs.get("min_length", 0)
-        
+
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1537,7 +1537,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
-        # add image_embeds lenth to max_length, so that the final max_length in counted only on token embeds
+        # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1537,6 +1537,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = self.get_input_embeddings()(input_ids)
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
+        # add image_embeds lenth to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1539,17 +1539,15 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
-            max_length = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
-            min_length = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
         else:
-            max_length = generate_kwargs.get("max_length", 20)
-            min_length = generate_kwargs.get("min_length", 0)
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20)
+            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0)
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
-            max_length=max_length,
-            min_length=min_length,
             **generate_kwargs,
         )
 

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1540,7 +1540,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
-            generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
+            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1541,9 +1541,6 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
             generate_kwargs["min_length"] = min(0, generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1])
-        else:
-            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20)
-            generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0)
 
         outputs = self.language_model.generate(
             inputs_embeds=inputs_embeds,


### PR DESCRIPTION
# What does this PR do?

In the previous PR #28994, I did not make changes in multimodal models, which have custom `generate` and pass in `input_embeds`. This PR fixes it. Currently the only model in `transformers`  failing in generation from embeds is BLIP2 and its instruct version. I checked other multimodal generation models, everything is fine there.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@gante 