### PR TITLE
Fix OneFormer `post_process_instance_segmentation` for panoptic tasks

### DIFF
--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -1244,8 +1244,8 @@ class OneFormerImageProcessor(BaseImageProcessor):
             # if this is panoptic segmentation, we only keep the "thing" classes
             if task_type == "panoptic":
                 keep = torch.zeros_like(scores_per_image).bool()
-                for i, lab in enumerate(labels_per_image):
-                    keep[i] = lab in self.metadata["thing_ids"]
+                for j, lab in enumerate(labels_per_image):
+                    keep[j] = lab in self.metadata["thing_ids"]
 
                 scores_per_image = scores_per_image[keep]
                 labels_per_image = labels_per_image[keep]
@@ -1258,8 +1258,8 @@ class OneFormerImageProcessor(BaseImageProcessor):
                 continue
 
             if "ade20k" in self.class_info_file and not is_demo and "instance" in task_type:
-                for i in range(labels_per_image.shape[0]):
-                    labels_per_image[i] = self.metadata["thing_ids"].index(labels_per_image[i].item())
+                for j in range(labels_per_image.shape[0]):
+                    labels_per_image[j] = self.metadata["thing_ids"].index(labels_per_image[j].item())
 
             # Get segmentation map and segment information of batch item
             target_size = target_sizes[i] if target_sizes is not None else None

--- a/tests/models/oneformer/test_image_processing_oneformer.py
+++ b/tests/models/oneformer/test_image_processing_oneformer.py
@@ -295,6 +295,19 @@ class OneFormerImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
                 el["segmentation"].shape, (self.image_processor_tester.height, self.image_processor_tester.width)
             )
 
+        segmentation_with_opts = image_processor.post_process_instance_segmentation(
+            outputs,
+            threshold=0,
+            target_sizes=[(1, 4) for _ in range(self.image_processor_tester.batch_size)],
+            task_type="panoptic",
+        )
+        self.assertTrue(len(segmentation_with_opts) == self.image_processor_tester.batch_size)
+        for el in segmentation_with_opts:
+            self.assertTrue("segmentation" in el)
+            self.assertTrue("segments_info" in el)
+            self.assertEqual(type(el["segments_info"]), list)
+            self.assertEqual(el["segmentation"].shape, (1, 4))
+
     def test_post_process_panoptic_segmentation(self):
         image_processor = self.image_processing_class(
             num_labels=self.image_processor_tester.num_classes,


### PR DESCRIPTION
# What does this PR do?

Fixes the `post_process_instance_segmentation` method of OneFormer. 

When specifying both `task_type="panoptic"` and `target_size` in `post_process_instance_segmentation`, the `i` variable would be overloaded by an enumeration. This would cause line 1265 (specifying `target_size`) to blow up and throw `IndexError: list index out of range`. This PR fixes the variable overloading in the two places it could occur.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?

## Who can review?

@patrickvonplaten @NielsRogge

> ☝️  Based on the original reviewers for OneFormer.