### PR TITLE
[tests] use the correct `n_gpu` in `TrainerIntegrationTest::test_train_and_eval_dataloaders` for XPU

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1030,7 +1030,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertFalse(is_any_loss_nan_or_inf(log_history_filter))
 
     def test_train_and_eval_dataloaders(self):
-        n_gpu = max(1, backend_device_count(torch_device))
+        if torch_device == 'cuda':
+            n_gpu = max(1, backend_device_count(torch_device))
+        else:
+            n_gpu = 1
         trainer = get_regression_trainer(learning_rate=0.1, per_device_train_batch_size=16)
         self.assertEqual(trainer.get_train_dataloader().total_batch_size, 16 * n_gpu)
         trainer = get_regression_trainer(learning_rate=0.1, per_device_eval_batch_size=16)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1030,7 +1030,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertFalse(is_any_loss_nan_or_inf(log_history_filter))
 
     def test_train_and_eval_dataloaders(self):
-        if torch_device == 'cuda':
+        if torch_device == "cuda":
             n_gpu = max(1, backend_device_count(torch_device))
         else:
             n_gpu = 1


### PR DESCRIPTION
## What does this PR do?
The below test fails on intel GPU with 8 cards:
```bash
___________________________________ TrainerIntegrationTest.test_train_and_eval_dataloaders ___________________________________

self = <tests.trainer.test_trainer.TrainerIntegrationTest testMethod=test_train_and_eval_dataloaders>

    def test_train_and_eval_dataloaders(self):
        n_gpu = max(1, backend_device_count(torch_device))
        trainer = get_regression_trainer(learning_rate=0.1, per_device_train_batch_size=16)
>       self.assertEqual(trainer.get_train_dataloader().total_batch_size, 16 * n_gpu)
E       AssertionError: 16 != 128

tests/trainer/test_trainer.py:1035: AssertionError
```
This is because the `n_gpu` is 8, but the default `_n_gpus` in `TrainingArguments` is 1 as can be seen [here](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L1969), leading to a total_batch_size of 16. This test works on CUDA, because CUDA supports DataParallel and would set `_n_gpus` to a value larger than 1 as can be seen [here](https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L1984). But on all other devices except CUDA and CPU, this test will fail. 

To fix this issue, we need to add a conditional check to the test to make this test work on other devices except GPU. Pls have a review: @muellerzr and @pacman100