### PR TITLE
[tests] enable automatic speech recognition pipeline tests on XPU 

### DIFF
--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -39,6 +39,7 @@ from transformers.testing_utils import (
     require_pyctcdecode,
     require_tf,
     require_torch,
+    require_torch_gpu,
     require_torch_accelerator,
     require_torchaudio,
     slow,
@@ -1148,7 +1149,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(output, [{"text": ANY(str)}])
         self.assertEqual(output[0]["text"][:6], "<s> <s")
 
-    @require_torch
+    @require_torch_gpu
     @slow
     def test_whisper_longform(self):
         # fmt: off
@@ -1176,7 +1177,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
         assert result == EXPECTED_RESULT
 
-    @require_torch
+    @require_torch_gpu
     @slow
     def test_seamless_v2(self):
         pipe = pipeline(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -39,7 +39,6 @@ from transformers.testing_utils import (
     require_pyctcdecode,
     require_tf,
     require_torch,
-    require_torch_gpu,
     require_torch_accelerator,
     require_torchaudio,
     slow,
@@ -1149,7 +1148,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(output, [{"text": ANY(str)}])
         self.assertEqual(output[0]["text"][:6], "<s> <s")
 
-    @require_torch_gpu
+    @require_torch
     @slow
     def test_whisper_longform(self):
         # fmt: off
@@ -1158,7 +1157,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
         processor = AutoProcessor.from_pretrained("openai/whisper-tiny.en")
         model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny.en")
-        model = model.to("cuda")
+        model = model.to(torch_device)
 
         pipe = pipeline(
             "automatic-speech-recognition",
@@ -1166,7 +1165,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             tokenizer=processor.tokenizer,
             feature_extractor=processor.feature_extractor,
             max_new_tokens=128,
-            device="cuda:0",
+            device=torch_device,
         )
 
         ds = load_dataset("distil-whisper/meanwhile", "default")["test"]
@@ -1177,13 +1176,13 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
         assert result == EXPECTED_RESULT
 
-    @require_torch_gpu
+    @require_torch
     @slow
     def test_seamless_v2(self):
         pipe = pipeline(
             "automatic-speech-recognition",
             model="facebook/seamless-m4t-v2-large",
-            device="cuda:0",
+            device=torch_device,
         )
 
         dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")


### PR DESCRIPTION
## What does this PR do?
"cuda" and "cuda:0" are hard-coded in `test_whisper_longform` and `test_seamless_v2` of `test_pipelines_automatic_speech_recognition.py`. So when running the unit tests on XPU, I get 2 failing tests:
```bash
================================================= short test summary info ==================================================
SKIPPED [1] tests/pipelines/test_pipelines_automatic_speech_recognition.py:269: test requires TensorFlow
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_seamless_v2 - AssertionError: Torch not compiled with CUDA enabled
FAILED tests/pipelines/test_pipelines_automatic_speech_recognition.py::AutomaticSpeechRecognitionPipelineTests::test_whisper_longform - AssertionError: Torch not compiled with CUDA enabled
============================= 2 failed, 40 passed, 1 skipped, 31 warnings in 203.95s (0:03:23) =============================
```

This PR proposes to use the device-agnostic variable `torch_device` instead of the hard-coded "cuda" device. After the fix, 
all unit tests in `test_pipelines_automatic_speech_recognition.py` run through on XPU as shown below: 
```bash
================================================= short test summary info ==================================================
SKIPPED [1] tests/pipelines/test_pipelines_automatic_speech_recognition.py:269: test requires TensorFlow
================================== 42 passed, 1 skipped, 32 warnings in 219.40s (0:03:39) ==================================
```

## Who can review?
@Narsil @ArthurZucker 