### PR TITLE
[tests] enable test_pipeline_accelerate_top_p on XPU   

### DIFF
--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -450,7 +450,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
     def test_pipeline_accelerate_top_p(self):
         import torch
 
-        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device_map="auto", torch_dtype=torch.float16)
+        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device=torch_device, torch_dtype=torch.float16)
         pipe("This is a test", do_sample=True, top_p=0.5)
 
     def test_pipeline_length_setting_warning(self):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -450,7 +450,9 @@ class TextGenerationPipelineTests(unittest.TestCase):
     def test_pipeline_accelerate_top_p(self):
         import torch
 
-        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device_map=torch_device, torch_dtype=torch.float16)
+        pipe = pipeline(
+            model="hf-internal-testing/tiny-random-bloom", device_map=torch_device, torch_dtype=torch.float16
+        )
         pipe("This is a test", do_sample=True, top_p=0.5)
 
     def test_pipeline_length_setting_warning(self):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -450,7 +450,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
     def test_pipeline_accelerate_top_p(self):
         import torch
 
-        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device=torch_device, torch_dtype=torch.float16)
+        pipe = pipeline(model="hf-internal-testing/tiny-random-bloom", device_map=torch_device, torch_dtype=torch.float16)
         pipe("This is a test", do_sample=True, top_p=0.5)
 
     def test_pipeline_length_setting_warning(self):


### PR DESCRIPTION
## What does this PR do?
Is there any particular reason why we use `device_map="auto"` in this test `test_pipeline_accelerate_top_p`? If not, I would suggest using the device-agnostic variable `torch_device` instead of `device_map="auto"` just like in all other tests e.g. `test_small_model_fp16`. 

Another reason is that the `device_map="auto"` mechanism is still not mature on XPU, causing the model to be loaded on the CPU, rather than on XPU. With this fix, `test_pipeline_accelerate_top_p` will definitively work on all devices. Below is an evidence for XPU:

BEFORE
```bash
================================================== short test summary info ===================================================
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:221: test requires TensorFlow
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:378: test requires CUDA
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:180: test requires TensorFlow
FAILED tests/pipelines/test_pipelines_text_generation.py::TextGenerationPipelineTests::test_small_model_fp16 - RuntimeError: could not execute a primitive
===================================== 1 failed, 5 passed, 3 skipped, 8 warnings in 7.18s =====================================
```

AFTER

```bash
================================================== short test summary info ===================================================
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:221: test requires TensorFlow
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:378: test requires CUDA
SKIPPED [1] tests/pipelines/test_pipelines_text_generation.py:180: test requires TensorFlow
========================================== 6 passed, 3 skipped, 8 warnings in 7.52s ==========================================
```

Pls have a review, thx! @Narsil @ArthurZucker 