### PR TITLE
Fixed error in GPT-SW3 tokenizer

### DIFF
--- a/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
+++ b/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
@@ -135,7 +135,8 @@ class GPTSw3Tokenizer(PreTrainedTokenizer):
         # Default definitions for our 2 tokenizer versions, with None-checks to enable proper testing
         eos_token = "<|endoftext|>" if eos_token is None else eos_token
         unk_token = "<unk>" if unk_token is None else unk_token
-        if ("gpt-sw3-7b" in name_or_path) or ("gpt-sw3-6.7b" in name_or_path):
+        if ("gpt-sw3-6.7b" in name_or_path) and ("6.7b-v" not in name_or_path):
+            # this branch only applies to the original 6.7b
             pad_token = unk_token if pad_token is None else pad_token
             bos_token = eos_token if bos_token is None else bos_token
         else:

--- a/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
+++ b/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
@@ -127,7 +127,7 @@ class GPTSw3Tokenizer(PreTrainedTokenizer):
         name_or_path = kwargs.get("name_or_path")
         if name_or_path is None:
             logger.warning(
-                "name_or_path not provided, will work for all GPTSw3 models except gpt-sw3-7b,"
+                "name_or_path not provided, will work for all GPTSw3 models except gpt-sw3-6.7b,"
                 " you are testing the model, this can safely be ignored"
             )
             name_or_path = "None"
@@ -135,7 +135,7 @@ class GPTSw3Tokenizer(PreTrainedTokenizer):
         # Default definitions for our 2 tokenizer versions, with None-checks to enable proper testing
         eos_token = "<|endoftext|>" if eos_token is None else eos_token
         unk_token = "<unk>" if unk_token is None else unk_token
-        if "gpt-sw3-7b" in name_or_path:
+        if ("gpt-sw3-7b" in name_or_path) or ("gpt-sw3-6.7b" in name_or_path):
             pad_token = unk_token if pad_token is None else pad_token
             bos_token = eos_token if bos_token is None else bos_token
         else:


### PR DESCRIPTION
This pull request fixes an error in the  GPT-SW3 tokenizer in `transformers/models/gpt_sw3/tokenization_gpt_sw3.py`.
There is a string comparison which checks for a specific model size. The string is incorrect so for some model sizes this improperly results in additional tokens being added to the vocabulary which did not exist at training time and don't match the size of the embedding matrix of that particular model (6.7b).

It can be reproduced with:
```
from transformers import AutoTokenizer, AutoModelForCausalLM
model_name = "/data/models/gpt-sw3/AI-Sweden-Models/gpt-sw3-6.7b"
tokenizer = AutoTokenizer.from_pretrained(model_name)
model = AutoModelForCausalLM.from_pretrained(model_name)

# this raises an IndexError
model(torch.tensor([[tokenizer.bos_token_id]]))
```