### PR TITLE
fix image-to-text batch incorrect output issue

### DIFF
--- a/src/transformers/pipelines/pt_utils.py
+++ b/src/transformers/pipelines/pt_utils.py
@@ -73,7 +73,7 @@ class PipelineIterator(IterableDataset):
         """
         if isinstance(self._loader_batch_data, torch.Tensor):
             # Batch data is simple tensor, just fetch the slice
-            result = self._loader_batch_data[self._loader_batch_index]
+            result = self._loader_batch_data[self._loader_batch_index].unsqueeze(0)
         else:
             # Batch data is assumed to be BaseModelOutput (or dict)
             loader_batched = {}

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -141,6 +141,25 @@ class ImageToTextPipelineTests(unittest.TestCase):
 
         outputs = pipe(image, prompt=prompt)
         self.assertTrue(outputs[0]["generated_text"].startswith(prompt))
+        for batch_size in (1, 2):
+            outputs = pipe([image, image], prompt=prompt, batch_size=batch_size)
+            self.assertTrue(outputs[0][0]["generated_text"].startswith(prompt))
+            self.assertTrue(outputs[1][0]["generated_text"].startswith(prompt))
+
+        from torch.utils.data import Dataset
+
+        class MyDataset(Dataset):
+            def __len__(self):
+                return 5
+
+            def __getitem__(self, i):
+                return "./tests/fixtures/tests_samples/COCO/000000039769.png"
+
+        dataset = MyDataset()
+        for batch_size in (1, 2):
+            outputs = pipe(dataset, prompt=prompt, batch_size=batch_size)
+            self.assertTrue(list(outputs)[0][0]["generated_text"].startswith(prompt))
+            self.assertTrue(list(outputs)[1][0]["generated_text"].startswith(prompt))
 
     @slow
     @require_torch


### PR DESCRIPTION
fix image to text multi-batch input , but output incorrect issue

- pipelines: @Narsil
