### PR TITLE
Fix `remove_columns` in `text-classification` example

### DIFF
--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -422,7 +422,7 @@ def main():
         for split in raw_datasets.keys():
             for column in data_args.remove_columns.split(","):
                 logger.info(f"removing column {column} from split {split}")
-                raw_datasets[split].remove_columns(column)
+                raw_datasets[split] = raw_datasets[split].remove_columns(column)
 
     if data_args.label_column_name is not None and data_args.label_column_name != "label":
         for key in raw_datasets.keys():


### PR DESCRIPTION
`Dataset.remove_columns` returns a new `Dataset` object instead of modifying the input dataset in-place.

Fixes https://github.com/huggingface/datasets/issues/6700