### PR TITLE
Fix @require_read_token in tests

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -38,7 +38,6 @@ from typing import Callable, Dict, Iterable, Iterator, List, Optional, Union
 from unittest import mock
 from unittest.mock import patch
 
-import huggingface_hub
 import urllib3
 
 from transformers import logging as transformers_logging
@@ -466,11 +465,11 @@ def require_read_token(fn):
     """
     A decorator that loads the HF token for tests that require to load gated models.
     """
-    token = os.getenv("HF_HUB_READ_TOKEN", None)
+    token = os.getenv("HF_HUB_READ_TOKEN")
 
     @wraps(fn)
     def _inner(*args, **kwargs):
-        with patch.object(huggingface_hub.utils._headers, "get_token", return_value=token):
+        with patch("huggingface_hub.utils._headers.get_token", return_value=token):
             return fn(*args, **kwargs)
 
     return _inner


### PR DESCRIPTION
Related to https://github.com/huggingface/transformers/pull/29242. This PR fixes the `@require_read_token` decorator to correctly patch `get_token`.
 
(currently tests are failing: https://github.com/huggingface/transformers/actions/runs/8091976401/job/22111912351)

cc @younesbelkada @ArthurZucker 