### PR TITLE
update path to hub files in the error message

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -368,7 +368,7 @@ def cached_file(
             if _raise_exceptions_for_missing_entries:
                 raise EnvironmentError(
                     f"{path_or_repo_id} does not appear to have a file named {full_filename}. Checkout "
-                    f"'https://huggingface.co/{path_or_repo_id}/{revision}' for available files."
+                    f"'https://huggingface.co/{path_or_repo_id}/tree/{revision}' for available files."
                 )
             else:
                 return None


### PR DESCRIPTION
need to add `tree/` to path to files at HF hub.
see example path:
`https://huggingface.co/meta-llama/Llama-2-7b-hf/tree/main`

Just makes the warning message point to the correct location.

cc @younesbelkada @ArthurZucker 