### PR TITLE
Automatic safetensors conversion when lacking these files

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3210,34 +3210,35 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             is_sharded = True
 
                     if resolved_archive_file is not None:
-                        # If the PyTorch file was found, check if there is a safetensors file on the repository
-                        # If there is no safetensors file on the repositories, start an auto conversion
-                        safe_weights_name = SAFE_WEIGHTS_INDEX_NAME if is_sharded else SAFE_WEIGHTS_NAME
-                        has_file_kwargs = {
-                            "revision": revision,
-                            "proxies": proxies,
-                            "token": token,
-                        }
-                        cached_file_kwargs = {
-                            "cache_dir": cache_dir,
-                            "force_download": force_download,
-                            "resume_download": resume_download,
-                            "local_files_only": local_files_only,
-                            "user_agent": user_agent,
-                            "subfolder": subfolder,
-                            "_raise_exceptions_for_gated_repo": False,
-                            "_raise_exceptions_for_missing_entries": False,
-                            "_commit_hash": commit_hash,
-                            **has_file_kwargs,
-                        }
-                        if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
-                            logging.set_verbosity_debug()
-                            Thread(
-                                target=auto_conversion,
-                                args=(pretrained_model_name_or_path,),
-                                kwargs=cached_file_kwargs,
-                                name="Thread-autoconversion",
-                            ).start()
+                        if filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]:
+                            # If the PyTorch file was found, check if there is a safetensors file on the repository
+                            # If there is no safetensors file on the repositories, start an auto conversion
+                            safe_weights_name = SAFE_WEIGHTS_INDEX_NAME if is_sharded else SAFE_WEIGHTS_NAME
+                            has_file_kwargs = {
+                                "revision": revision,
+                                "proxies": proxies,
+                                "token": token,
+                            }
+                            cached_file_kwargs = {
+                                "cache_dir": cache_dir,
+                                "force_download": force_download,
+                                "resume_download": resume_download,
+                                "local_files_only": local_files_only,
+                                "user_agent": user_agent,
+                                "subfolder": subfolder,
+                                "_raise_exceptions_for_gated_repo": False,
+                                "_raise_exceptions_for_missing_entries": False,
+                                "_commit_hash": commit_hash,
+                                **has_file_kwargs,
+                            }
+                            if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
+                                logging.set_verbosity_debug()
+                                Thread(
+                                    target=auto_conversion,
+                                    args=(pretrained_model_name_or_path,),
+                                    kwargs=cached_file_kwargs,
+                                    name="Thread-autoconversion",
+                                ).start()
                     else:
                         # Otherwise, no PyTorch file was found, maybe there is a TF or Flax model file.
                         # We try those to give a helpful error message.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3232,7 +3232,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                                 **has_file_kwargs,
                             }
                             if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
-                                logging.set_verbosity_debug()
                                 Thread(
                                     target=auto_conversion,
                                     args=(pretrained_model_name_or_path,),

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3231,12 +3231,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             **has_file_kwargs,
                         }
                         if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
-                            cls._auto_conversion = Thread(
+                            logging.set_verbosity_debug()
+                            Thread(
                                 target=auto_conversion,
                                 args=(pretrained_model_name_or_path,),
                                 kwargs=cached_file_kwargs,
-                            )
-                            cls._auto_conversion.start()
+                                name="Thread-autoconversion",
+                            ).start()
                     else:
                         # Otherwise, no PyTorch file was found, maybe there is a TF or Flax model file.
                         # We try those to give a helpful error message.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3231,7 +3231,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             **has_file_kwargs,
                         }
                         if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
-                            logging.set_verbosity_debug()
                             cls._auto_conversion = Thread(
                                 target=auto_conversion,
                                 args=(pretrained_model_name_or_path,),

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -29,6 +29,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial, wraps
+from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from zipfile import is_zipfile
 
@@ -3207,9 +3208,39 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         )
                         if resolved_archive_file is not None:
                             is_sharded = True
-                    if resolved_archive_file is None:
-                        # Otherwise, maybe there is a TF or Flax model file.  We try those to give a helpful error
-                        # message.
+
+                    if resolved_archive_file is not None:
+                        # If the PyTorch file was found, check if there is a safetensors file on the repository
+                        # If there is no safetensors file on the repositories, start an auto conversion
+                        safe_weights_name = SAFE_WEIGHTS_INDEX_NAME if is_sharded else SAFE_WEIGHTS_NAME
+                        has_file_kwargs = {
+                            "revision": revision,
+                            "proxies": proxies,
+                            "token": token,
+                        }
+                        cached_file_kwargs = {
+                            "cache_dir": cache_dir,
+                            "force_download": force_download,
+                            "resume_download": resume_download,
+                            "local_files_only": local_files_only,
+                            "user_agent": user_agent,
+                            "subfolder": subfolder,
+                            "_raise_exceptions_for_gated_repo": False,
+                            "_raise_exceptions_for_missing_entries": False,
+                            "_commit_hash": commit_hash,
+                            **has_file_kwargs,
+                        }
+                        if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
+                            logging.set_verbosity_debug()
+                            cls._auto_conversion = Thread(
+                                target=auto_conversion,
+                                args=(pretrained_model_name_or_path,),
+                                kwargs=cached_file_kwargs,
+                            )
+                            cls._auto_conversion.start()
+                    else:
+                        # Otherwise, no PyTorch file was found, maybe there is a TF or Flax model file.
+                        # We try those to give a helpful error message.
                         has_file_kwargs = {
                             "revision": revision,
                             "proxies": proxies,

--- a/src/transformers/safetensors_conversion.py
+++ b/src/transformers/safetensors_conversion.py
@@ -80,6 +80,7 @@ def get_conversion_pr_reference(api: HfApi, model_id: str, **kwargs):
         logger.info("Safetensors PR exists")
 
     sha = f"refs/pr/{pr.num}"
+    logger.info(sha)
 
     return sha
 

--- a/src/transformers/safetensors_conversion.py
+++ b/src/transformers/safetensors_conversion.py
@@ -80,7 +80,6 @@ def get_conversion_pr_reference(api: HfApi, model_id: str, **kwargs):
         logger.info("Safetensors PR exists")
 
     sha = f"refs/pr/{pr.num}"
-    logger.info(sha)
 
     return sha
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -20,6 +20,7 @@ import os
 import os.path
 import sys
 import tempfile
+import threading
 import unittest
 import unittest.mock as mock
 import uuid
@@ -1461,7 +1462,9 @@ class ModelOnTheFlyConversionTester(unittest.TestCase):
         initial_model.push_to_hub(self.repo_name, token=self.token, safe_serialization=False)
 
         initial_model = BertModel.from_pretrained(self.repo_name, token=self.token)
-        BertModel._auto_conversion.join()
+        for thread in threading.enumerate():
+            if thread.name == "Thread-autoconversion":
+                thread.join(timeout=10)
 
         with self.subTest("PR was open with the safetensors account"):
             discussions = self.api.get_repo_discussions(self.repo_name)


### PR DESCRIPTION
When a user calls the PyTorch `from_pretrained` on a repository that only contains PyTorch/Flax/TF files, start an auto conversion in the background so that it has a PR opened with `safetensors` files.