### PR TITLE
Fix test failure on DeepSpeed

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2011,7 +2011,10 @@ class Trainer:
                             is_accelerate_available()
                             and self.accelerator.distributed_type == DistributedType.DEEPSPEED
                         ):
-                            grad_norm = model.get_global_grad_norm().item()
+                            grad_norm = model.get_global_grad_norm()
+                            # In some cases the grad norm may not return a float
+                            if isinstance(grad_norm, torch.Tensor):
+                                grad_norm = grad_norm.item()
                         else:
                             grad_norm = _grad_norm.item() if _grad_norm is not None else None
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2013,7 +2013,7 @@ class Trainer:
                         ):
                             grad_norm = model.get_global_grad_norm()
                             # In some cases the grad norm may not return a float
-                            if isinstance(grad_norm, torch.Tensor):
+                            if hasattr(grad_norm, "item"):
                                 grad_norm = grad_norm.item()
                         else:
                             grad_norm = _grad_norm.item() if _grad_norm is not None else None


### PR DESCRIPTION
# What does this PR do?

It looks like `grad_norm` might not always be a `torch.Tensor`, as that merged PR breaks all of our deepspeed trainer tests. In such cases, we can check for `item` before calling it. Follow-up to https://github.com/huggingface/transformers/pull/29212, linked to https://github.com/huggingface/transformers/pull/27326

Fixes failing DeepSpeed tests


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @pacman100 