### PR TITLE
[pipeline] allow fp16/bf16 inputs on cpu

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1009,8 +1009,6 @@ class Pipeline(_ScikitCompat):
         elif isinstance(inputs, tuple):
             return tuple([self._ensure_tensor_on_device(item, device) for item in inputs])
         elif isinstance(inputs, torch.Tensor):
-            if device == torch.device("cpu") and inputs.dtype != self.torch_dtype:
-                return inputs.to(device, dtype=self.torch_dtype)
             return inputs.to(device)
         else:
             return inputs

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1009,8 +1009,8 @@ class Pipeline(_ScikitCompat):
         elif isinstance(inputs, tuple):
             return tuple([self._ensure_tensor_on_device(item, device) for item in inputs])
         elif isinstance(inputs, torch.Tensor):
-            if device == torch.device("cpu") and inputs.dtype in {torch.float16, torch.bfloat16}:
-                inputs = inputs.float()
+            if device == torch.device("cpu") and inputs.dtype != self.torch_dtype:
+                return inputs.to(device, dtype=self.torch_dtype)
             return inputs.to(device)
         else:
             return inputs


### PR DESCRIPTION
# What does this PR do?

Fixes #29475: rather than forcing the inputs to float32 when on cpu, we leave them in their respective dtypes.