### PR TITLE
[generate] deprecate forced ids processor

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -15,6 +15,7 @@
 
 import inspect
 import math
+import warnings
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -1745,8 +1746,13 @@ class ForceTokensLogitsProcessor(LogitsProcessor):
     ```
     """
 
-    def __init__(self, force_token_map: List[List[int]]):
+    def __init__(self, force_token_map: List[List[int]], _has_warned: Optional[bool] = False):
         self.force_token_map = dict(force_token_map)
+        if not _has_warned:
+            warnings.warn(
+                "This `ForceTokensLogitsProcessor` has been deprecated and will be removed in v4.40. Please pass `input_ids` or `decoder_input_ids` to the generate method directly.",
+                FutureWarning,
+            )
 
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1749,6 +1749,7 @@ class ForceTokensLogitsProcessor(LogitsProcessor):
     def __init__(self, force_token_map: List[List[int]], _has_warned: Optional[bool] = False):
         self.force_token_map = dict(force_token_map)
         if not _has_warned:
+            # TODO(Sanchit): remove this processor entirely in v4.40
             warnings.warn(
                 "This `ForceTokensLogitsProcessor` has been deprecated and will be removed in v4.40. Please pass `input_ids` or `decoder_input_ids` to the generate method directly.",
                 FutureWarning,

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1751,7 +1751,7 @@ class ForceTokensLogitsProcessor(LogitsProcessor):
         if not _has_warned:
             # TODO(Sanchit): remove this processor entirely in v4.40
             warnings.warn(
-                "This `ForceTokensLogitsProcessor` has been deprecated and will be removed in v4.40. Please pass `input_ids` or `decoder_input_ids` to the generate method directly.",
+                "This `ForceTokensLogitsProcessor` has been deprecated and will be removed in v4.40. Should you need to provide prompt ids for generation, specify `input_ids` to the generate method for decoder-only models, or `decoder_input_ids` for encoder-decoder models.",
                 FutureWarning,
             )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -865,7 +865,12 @@ class GenerationMixin:
                 SuppressTokensAtBeginLogitsProcessor(generation_config.begin_suppress_tokens, begin_index)
             )
         if generation_config.forced_decoder_ids is not None:
-            processors.append(ForceTokensLogitsProcessor(generation_config.forced_decoder_ids))
+            # TODO(Sanchit): deprecate in v4.40 by removing this logic
+            warnings.warn(
+                "You have explicitly specified`forced_decoder_ids`. This functionality has been deprecated and will throw an error in v4.40. Please use `input_ids` or `decoder_input_ids` respectively.",
+                FutureWarning,
+            )
+            processors.append(ForceTokensLogitsProcessor(generation_config.forced_decoder_ids, _has_warned=True))
         processors = self._merge_criteria_processor_list(processors, logits_processor)
         # `LogitNormalization` should always be the last logit processor, when present
         if generation_config.renormalize_logits is True:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -867,7 +867,7 @@ class GenerationMixin:
         if generation_config.forced_decoder_ids is not None:
             # TODO(Sanchit): deprecate in v4.40 by removing this logic
             warnings.warn(
-                "You have explicitly specified`forced_decoder_ids`. This functionality has been deprecated and will throw an error in v4.40. Please use `input_ids` or `decoder_input_ids` respectively.",
+                "You have explicitly specified `forced_decoder_ids`. This functionality has been deprecated and will throw an error in v4.40. Please remove the `forced_decoder_ids` argument in favour of `input_ids` or `decoder_input_ids` respectively.",
                 FutureWarning,
             )
             processors.append(ForceTokensLogitsProcessor(generation_config.forced_decoder_ids, _has_warned=True))


### PR DESCRIPTION
# What does this PR do?

First stage of deprecation for the `ForceTokensLogitsProcessor`. This logits processor was exclusively used for Whisper. However, the PR #29485 removed the last calls to this processor from Whisper, in favour of `decoder_input_ids` set internally by generate, meaning this processor can now be removed.
