### PR TITLE
Set `inputs` as kwarg in `TextClassificationPipeline`

### DIFF
--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -152,12 +152,7 @@ class TextClassificationPipeline(Pipeline):
 
             If `top_k` is used, one such dictionary is returned per label.
         """
-        if isinstance(inputs, str) or isinstance(inputs, dict):
-            inputs = (inputs,)
-        else:
-            inputs = tuple(
-                [inputs],
-            )  # noqa: C409
+        inputs = (inputs,)
         result = super().__call__(*inputs, **kwargs)
         # TODO try and retrieve it in a nicer way from _sanitize_parameters.
         _legacy = "top_k" not in kwargs

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -155,7 +155,7 @@ class TextClassificationPipeline(Pipeline):
         if isinstance(inputs, str) or isinstance(inputs, dict):
             inputs = (inputs,)
         else:
-            inputs = tuple([inputs],)
+            inputs = tuple([inputs],)  # noqa: C409
         result = super().__call__(*inputs, **kwargs)
         # TODO try and retrieve it in a nicer way from _sanitize_parameters.
         _legacy = "top_k" not in kwargs

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -155,7 +155,9 @@ class TextClassificationPipeline(Pipeline):
         if isinstance(inputs, str) or isinstance(inputs, dict):
             inputs = (inputs,)
         else:
-            inputs = tuple([inputs],)  # noqa: C409
+            inputs = tuple(
+                [inputs],
+            )  # noqa: C409
         result = super().__call__(*inputs, **kwargs)
         # TODO try and retrieve it in a nicer way from _sanitize_parameters.
         _legacy = "top_k" not in kwargs

--- a/src/transformers/pipelines/text_classification.py
+++ b/src/transformers/pipelines/text_classification.py
@@ -118,12 +118,12 @@ class TextClassificationPipeline(Pipeline):
             postprocess_params["function_to_apply"] = function_to_apply
         return preprocess_params, {}, postprocess_params
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, inputs, **kwargs):
         """
         Classify the text(s) given as inputs.
 
         Args:
-            args (`str` or `List[str]` or `Dict[str]`, or `List[Dict[str]]`):
+            inputs (`str` or `List[str]` or `Dict[str]`, or `List[Dict[str]]`):
                 One or several texts to classify. In order to use text pairs for your classification, you can send a
                 dictionary containing `{"text", "text_pair"}` keys, or a list of those.
             top_k (`int`, *optional*, defaults to `1`):
@@ -152,10 +152,14 @@ class TextClassificationPipeline(Pipeline):
 
             If `top_k` is used, one such dictionary is returned per label.
         """
-        result = super().__call__(*args, **kwargs)
+        if isinstance(inputs, str) or isinstance(inputs, dict):
+            inputs = (inputs,)
+        else:
+            inputs = tuple([inputs],)
+        result = super().__call__(*inputs, **kwargs)
         # TODO try and retrieve it in a nicer way from _sanitize_parameters.
         _legacy = "top_k" not in kwargs
-        if isinstance(args[0], str) and _legacy:
+        if isinstance(inputs[0], str) and _legacy:
             # This pipeline is odd, and return a list when single item is run
             return [result]
         else:


### PR DESCRIPTION
# What does this PR do?

This PR replaces the current `*args` arg within `TextClassificationPipeline` with a kwarg named `inputs` to be able to use it as a keyword arg when e.g. trying to unpack a Python dict as `pipeline(**{"inputs": "text"})` which is not possible with the current approach since the `*args` were being used instead.

Additionally, the usage of a kwarg aligns the `TextClassificationPipeline` implementation with the rest of the `Pipeline` subclasses, and not being a breaking change, since before no keyword arg could be specified.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? -> There was no need to write any test, since the unpacking of `*inputs` works the same way as `*args` did, only adding the possibility to use it as a kwarg too.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Library:

- pipelines: @Rocketknight1 