### PR TITLE
Fix `VisionEncoderDecoder` Positional Arg

### DIFF
--- a/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
@@ -573,7 +573,7 @@ class VisionEncoderDecoderModel(PreTrainedModel):
                 raise ValueError("You have to specify pixel_values")
 
             encoder_outputs = self.encoder(
-                pixel_values,
+                pixel_values=pixel_values,
                 output_attentions=output_attentions,
                 output_hidden_states=output_hidden_states,
                 return_dict=return_dict,


### PR DESCRIPTION
# What does this PR do?

When using certain models as the encoder for `VisionEncoderDecoder` (e.g. `LayoutLMv3`), `pixel_values` could incorrectly be the model's first positional argument (`input_ids` for `LayoutLMv3`).

This PR fixes the issue by specifying `pixel_values` as a keyword argument and adds the appropriate tests to validate going forward.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

@amyeroberts