### PR TITLE
Typo in mlx tensor support

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -242,7 +242,7 @@ def is_jax_tensor(x):
 
 
 def _is_mlx(x):
-    import mx.core as mx
+    import mlx.core as mx
 
     return isinstance(x, mx.array)
 


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/29406 recently added MLX tensor support to `BatchEncoding`. However, I think there's a typo in `_is_mlx` when importing the `mlx.core` module. 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

cc @Y4hL for verification
