### PR TITLE
Experimental loading of MLX files

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -505,7 +505,7 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
         # Check format of the archive
         with safe_open(checkpoint_file, framework="pt") as f:
             metadata = f.metadata()
-        if metadata.get("format") not in ["pt", "tf", "flax"]:
+        if metadata.get("format") not in ["pt", "tf", "flax", "mlx"]:
             raise OSError(
                 f"The safetensors archive passed at {checkpoint_file} does not contain the valid metadata. Make sure "
                 "you save your model with the `save_pretrained` method."
@@ -3328,6 +3328,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             elif metadata.get("format") == "flax":
                 from_flax = True
                 logger.info("A Flax safetensors file is being loaded in a PyTorch model.")
+            elif metadata.get("format") == "mlx":
+                # This is a mlx file, we assume weights are compatible with pt
+                pass
             else:
                 raise ValueError(
                     f"Incompatible safetensors file. File metadata is not ['pt', 'tf', 'flax'] but {metadata.get('format')}"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3302,7 +3302,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 pass
             else:
                 raise ValueError(
-                    f"Incompatible safetensors file. File metadata is not ['pt', 'tf', 'flax'] but {metadata.get('format')}"
+                    f"Incompatible safetensors file. File metadata is not ['pt', 'tf', 'flax', 'mlx'] but {metadata.get('format')}"
                 )
 
         from_pt = not (from_tf | from_flax)

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -242,7 +242,7 @@ def is_jax_tensor(x):
 
 
 def _is_mlx(x):
-    import mx.core as mx
+    import mlx.core as mx
 
     return isinstance(x, mx.array)
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1256,6 +1256,26 @@ class ModelUtilsTest(TestCasePlus):
             self.assertEqual(len(logs.output), 1)
             self.assertIn("Your generation config was originally created from the model config", logs.output[0])
 
+    @require_safetensors
+    def test_model_from_pretrained_from_mlx(self):
+        model = AutoModelForCausalLM.from_pretrained("pcuenq/tiny-random-mistral-mlx")
+        self.assertIsNotNone(model)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir, safe_serialization=True)
+            from safetensors import safe_open
+            with safe_open(os.path.join(tmp_dir, "model.safetensors"), framework="pt") as f:
+                metadata = f.metadata()
+                self.assertEqual(metadata.get("format"), "pt")
+            new_model = AutoModelForCausalLM.from_pretrained(tmp_dir)
+
+        input_ids = torch.randint(100, 1000, (1, 10))
+        with torch.no_grad():
+            outputs = model(input_ids)
+            outputs_from_saved = new_model(input_ids)
+            self.assertTrue(torch.allclose(outputs_from_saved["logits"], outputs["logits"])
+)
+
 
 @slow
 @require_torch

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1260,7 +1260,7 @@ class ModelUtilsTest(TestCasePlus):
     def test_model_from_pretrained_from_mlx(self):
         from safetensors import safe_open
 
-        model = AutoModelForCausalLM.from_pretrained("pcuenq/tiny-random-mistral-mlx")
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-mistral-mlx")
         self.assertIsNotNone(model)
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1258,12 +1258,13 @@ class ModelUtilsTest(TestCasePlus):
 
     @require_safetensors
     def test_model_from_pretrained_from_mlx(self):
+        from safetensors import safe_open
+
         model = AutoModelForCausalLM.from_pretrained("pcuenq/tiny-random-mistral-mlx")
         self.assertIsNotNone(model)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(tmp_dir, safe_serialization=True)
-            from safetensors import safe_open
             with safe_open(os.path.join(tmp_dir, "model.safetensors"), framework="pt") as f:
                 metadata = f.metadata()
                 self.assertEqual(metadata.get("format"), "pt")
@@ -1273,8 +1274,7 @@ class ModelUtilsTest(TestCasePlus):
         with torch.no_grad():
             outputs = model(input_ids)
             outputs_from_saved = new_model(input_ids)
-            self.assertTrue(torch.allclose(outputs_from_saved["logits"], outputs["logits"])
-)
+            self.assertTrue(torch.allclose(outputs_from_saved["logits"], outputs["logits"]))
 
 
 @slow


### PR DESCRIPTION
# What does this PR do?

Meant as a working draft to support the discussion in #29333.
Fixes #29333 

This code works for a simple roundtrip conversion in `float16`:
```
python -m mlx_lm.convert --hf-path TinyLlama/TinyLlama-1.1B-Chat-v1.0 --dtype float16 --mlx-path tiny-llama-chat
```

However:
- It requires `mlx` to be installed because it's detected as a distinct framework. We should possibly override with `pt` in this case, as it doesn't make sense to demand `mlx` as a dependency. This may or may not clash with recent work done in #29406.
- Many model weights in MLX adopt the same naming conventions as `transformers`, this was a decision made in the `mlx-examples` project to increase interoperability. However, this is not guaranteed. We should probably error if we find incompatible weights.
- I don't know how (or if) this works with quantized weights. Many MLX repos are about creating 4-bit quantized versions that run efficiently on Apple silicon.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@alexweberk, @ArthurZucker

cc @Vaibhavs10 