### PR TITLE
test_generation_config_is_loaded_with_model  - fall back to pytorch model for now

### DIFF
--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1188,7 +1188,9 @@ class ModelUtilsTest(TestCasePlus):
         # `transformers_version` field set to `foo`. If loading the file fails, this test also fails.
 
         # 1. Load without further parameters
-        model = AutoModelForCausalLM.from_pretrained("joaogante/tiny-random-gpt2-with-generation-config", use_safetensors=False)
+        model = AutoModelForCausalLM.from_pretrained(
+            "joaogante/tiny-random-gpt2-with-generation-config", use_safetensors=False
+        )
         self.assertEqual(model.generation_config.transformers_version, "foo")
 
         # 2. Load with `device_map`

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1188,12 +1188,12 @@ class ModelUtilsTest(TestCasePlus):
         # `transformers_version` field set to `foo`. If loading the file fails, this test also fails.
 
         # 1. Load without further parameters
-        model = AutoModelForCausalLM.from_pretrained("joaogante/tiny-random-gpt2-with-generation-config")
+        model = AutoModelForCausalLM.from_pretrained("joaogante/tiny-random-gpt2-with-generation-config", use_safetensors=False)
         self.assertEqual(model.generation_config.transformers_version, "foo")
 
         # 2. Load with `device_map`
         model = AutoModelForCausalLM.from_pretrained(
-            "joaogante/tiny-random-gpt2-with-generation-config", device_map="auto"
+            "joaogante/tiny-random-gpt2-with-generation-config", device_map="auto", use_safetensors=False
         )
         self.assertEqual(model.generation_config.transformers_version, "foo")
 


### PR DESCRIPTION
# What does this PR do?

Tests started failing because the new safetensors weights added for a test model on https://hf.co/joaogante/tiny-random-gpt2-with-generation-config

Failure message:
```
FAILED tests/test_modeling_utils.py::ModelUtilsTest::test_generation_config_is_loaded_with_model - ValueError: weight is on the meta device, we need a value to put in on 0.
```

Example circleci run: 
https://app.circleci.com/pipelines/github/huggingface/transformers/86552


This PR forces the test to used to old, pytorch weights whilst a fix is found. 

cc @gante 