### PR TITLE
Fix eval thread fork bomb

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -914,7 +914,7 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
-        # accelerator.free_memory() will destroy the references, so 
+        # accelerator.free_memory() will destroy the references, so
         # we need to store the non-prepared version
         eval_dataloader = DataLoader(eval_dataset, **dataloader_params)
         if self.args.dataloader_persistent_workers:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -888,6 +888,11 @@ class Trainer:
         """
         if eval_dataset is None and self.eval_dataset is None:
             raise ValueError("Trainer: evaluation requires an eval_dataset.")
+
+        # If we have persistent workers, don't do a fork bomb especially as eval datasets
+        # don't change during training
+        if hasattr(self, "_eval_dataloader") and self.args.dataloader_persistent_workers:
+            return self._eval_dataloader
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         data_collator = self.data_collator
 
@@ -909,7 +914,11 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
-        return self.accelerator.prepare(DataLoader(eval_dataset, **dataloader_params))
+        eval_dataloader = self.accelerator.prepare(DataLoader(eval_dataset, **dataloader_params))
+        if self.args.dataloader_persistent_workers:
+            self._eval_dataloader = eval_dataloader
+
+        return eval_dataloader
 
     def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
         """
@@ -942,7 +951,6 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
-        # We use the same batch_size as for eval.
         return self.accelerator.prepare(DataLoader(test_dataset, **dataloader_params))
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -892,7 +892,7 @@ class Trainer:
         # If we have persistent workers, don't do a fork bomb especially as eval datasets
         # don't change during training
         if hasattr(self, "_eval_dataloader") and self.args.dataloader_persistent_workers:
-            return self._eval_dataloader
+            return self.accelerator.prepare(self._eval_dataloader)
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         data_collator = self.data_collator
 
@@ -914,11 +914,11 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
-        eval_dataloader = self.accelerator.prepare(DataLoader(eval_dataset, **dataloader_params))
+        eval_dataloader = DataLoader(eval_dataset, **dataloader_params)
         if self.args.dataloader_persistent_workers:
             self._eval_dataloader = eval_dataloader
 
-        return eval_dataloader
+        return self.accelerator.prepare(eval_dataloader)
 
     def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
         """
@@ -951,6 +951,7 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
+        # We use the same batch_size as for eval.
         return self.accelerator.prepare(DataLoader(test_dataset, **dataloader_params))
 
     def create_optimizer_and_scheduler(self, num_training_steps: int):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -914,6 +914,8 @@ class Trainer:
             dataloader_params["drop_last"] = self.args.dataloader_drop_last
             dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
+        # accelerator.free_memory() will destroy the references, so 
+        # we need to store the non-prepared version
         eval_dataloader = DataLoader(eval_dataset, **dataloader_params)
         if self.args.dataloader_persistent_workers:
             self._eval_dataloader = eval_dataloader


### PR DESCRIPTION
# What does this PR do?

Currently we're creating a fork bomb due to recreating the eval dataloader again and again when `persistent_workers` is set to `True`. 

Since the dataloader for training should be recreated, but eval should *not*, this PR fixes this by making the eval dataloader persistent.

Proved it works by fork-bombing myself 😅 

Fixes https://github.com/huggingface/transformers/issues/28469


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts 