### PR TITLE
Fix BatchEncoding not prepending batch axis when tensor_type is None

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -691,6 +691,8 @@ class BatchEncoding(UserDict):
                 Whether or not to add the batch dimension during the conversion.
         """
         if tensor_type is None:
+            if prepend_batch_axis:
+                self.data = {k: [v] for k, v in self.data.items()}
             return self
 
         # Convert to TensorType


### PR DESCRIPTION
# Fix BatchEncoding not prepending batch axis to python list when tensor_type is None

Fixes #28882

## Who can review?
@ArthurZucker
