### PR TITLE
[`Mask2Former`] Move normalization for numerical stability

### DIFF
--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -374,13 +374,13 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     height_and_width = inputs.shape[1]
 
     criterion = nn.BCEWithLogitsLoss(reduction="none")
-    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs))
-    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs))
+    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs)) / height_and_width
+    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs)) / height_and_width
 
     loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
     loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
     loss = loss_pos + loss_neg
-    loss = loss / height_and_width
+    loss = loss
     return loss
 
 

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -374,11 +374,11 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     height_and_width = inputs.shape[1]
 
     criterion = nn.BCEWithLogitsLoss(reduction="none")
-    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs)) / height_and_width
-    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs)) / height_and_width
+    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs))
+    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs))
 
-    loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
-    loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
+    loss_pos = torch.matmul(cross_entropy_loss_pos / height_and_width, labels.T)
+    loss_neg = torch.matmul(cross_entropy_loss_neg / height_and_width, (1 - labels).T)
     loss = loss_pos + loss_neg
     return loss
 

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -380,7 +380,6 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
     loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
     loss = loss_pos + loss_neg
-    loss = loss
     return loss
 
 

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -204,7 +204,6 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
     loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
     loss = loss_pos + loss_neg
-    loss = loss
     return loss
 
 

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -198,13 +198,13 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     height_and_width = inputs.shape[1]
 
     criterion = nn.BCEWithLogitsLoss(reduction="none")
-    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs))
-    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs))
+    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs)) / height_and_width
+    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs)) / height_and_width
 
     loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
     loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
     loss = loss_pos + loss_neg
-    loss = loss / height_and_width
+    loss = loss
     return loss
 
 

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -198,11 +198,11 @@ def pair_wise_sigmoid_cross_entropy_loss(inputs: torch.Tensor, labels: torch.Ten
     height_and_width = inputs.shape[1]
 
     criterion = nn.BCEWithLogitsLoss(reduction="none")
-    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs)) / height_and_width
-    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs)) / height_and_width
+    cross_entropy_loss_pos = criterion(inputs, torch.ones_like(inputs))
+    cross_entropy_loss_neg = criterion(inputs, torch.zeros_like(inputs))
 
-    loss_pos = torch.matmul(cross_entropy_loss_pos, labels.T)
-    loss_neg = torch.matmul(cross_entropy_loss_neg, (1 - labels).T)
+    loss_pos = torch.matmul(cross_entropy_loss_pos / height_and_width, labels.T)
+    loss_neg = torch.matmul(cross_entropy_loss_neg / height_and_width, (1 - labels).T)
     loss = loss_pos + loss_neg
     return loss
 


### PR DESCRIPTION
# What does this PR do?

Moving the normalization before the matmul operation makes the calculation more stable and less likely to overflow. 

Same differences introduce in #26086 which was closed after becoming stale. 
