### PR TITLE
Fix skipped gradient update of the last step when using gradient accumulation.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1996,9 +1996,7 @@ class Trainer:
 
                 self.current_flos += float(self.floating_point_ops(inputs))
 
-                is_last_step_and_steps_less_than_grad_acc = (
-                    (step + 1) == steps_in_epoch
-                )
+                is_last_step_and_steps_less_than_grad_acc = (step + 1) == steps_in_epoch
 
                 if (
                     total_batched_samples % args.gradient_accumulation_steps == 0
@@ -2051,7 +2049,14 @@ class Trainer:
                     self.state.global_step += 1
                     self.state.epoch = epoch + (step + 1 + steps_skipped) / steps_in_epoch
                     self.control = self.callback_handler.on_step_end(args, self.state, self.control)
-                    self._maybe_log_save_evaluate(tr_loss * args.gradient_accumulation_steps / accumulation_step, grad_norm, model, trial, epoch, ignore_keys_for_eval)
+                    self._maybe_log_save_evaluate(
+                        tr_loss * args.gradient_accumulation_steps / accumulation_step,
+                        grad_norm,
+                        model,
+                        trial,
+                        epoch,
+                        ignore_keys_for_eval,
+                    )
                     tr_loss -= tr_loss
                     accumulation_step = 0
                     total_batched_samples = 0

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1677,7 +1677,7 @@ class Trainer:
         num_train_tokens = None
         if has_length(train_dataloader):
             len_dataloader = len(train_dataloader)
-            num_update_steps_per_epoch = len_dataloader // args.gradient_accumulation_steps
+            num_update_steps_per_epoch = math.ceil(len_dataloader / args.gradient_accumulation_steps)
             num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
             num_examples = self.num_examples(train_dataloader)
             if args.max_steps > 0:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1985,9 +1985,7 @@ class Trainer:
 
                 self.current_flos += float(self.floating_point_ops(inputs))
 
-                is_last_step_and_steps_less_than_grad_acc = (
-                    steps_in_epoch <= args.gradient_accumulation_steps and (step + 1) == steps_in_epoch
-                )
+                is_last_step_and_steps_less_than_grad_acc = self.accelerator.gradient_state.end_of_dataloader
 
                 if (
                     total_batched_samples % args.gradient_accumulation_steps == 0

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1993,7 +1993,7 @@ class Trainer:
                 self.current_flos += float(self.floating_point_ops(inputs))
 
                 is_last_step_and_steps_less_than_grad_acc = (
-                    self.accelerator.gradient_state.end_of_dataloader and not args.dataloader_drop_last
+                    not args.dataloader_drop_last and (step + 1) == steps_in_epoch
                 )
 
                 if (

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1947,6 +1947,8 @@ class Trainer:
             step = -1
             accumulation_step = 0
             for step, inputs in enumerate(epoch_iterator):
+                if step >= num_update_steps_per_epoch * args.gradient_accumulation_steps:
+                    break
                 total_batched_samples += 1
                 accumulation_step += 1
 
@@ -1995,7 +1997,7 @@ class Trainer:
                 self.current_flos += float(self.floating_point_ops(inputs))
 
                 is_last_step_and_steps_less_than_grad_acc = (
-                    not args.dataloader_drop_last and (step + 1) == steps_in_epoch
+                    (step + 1) == steps_in_epoch
                 )
 
                 if (


### PR DESCRIPTION
# What does this PR do?

This PR fixes skipped gradient update of the last step when using gradient accumulation in trainer.py.

I'm not sure what is the meaning of ['step is always smaller than gradient_accumulation_steps'](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L1995), but [steps_in_epoch <= args.gradient_accumulation_steps](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L1989) looks like always `False`.
Thus, the update of the last iteration is skipped when gradient_accumulation_step > 1.

This also leads to different total iterations (-1 iteration per epoch).

It might be negligible, and the skipped gradients are used in next iteration, but I believe the gradient update behavior should be the same whether or not using gradient accumulation if the total batch size is the same.

I have tested with [example script](https://github.com/huggingface/transformers/blob/main/examples/pytorch/image-classification/run_image_classification.py) and the comparison results are [here](https://wandb.ai/kshtrue95/fix_grad_accumulation/workspace?nw=nwuserkshtrue95).

accelerator.accumulate() context manager now can handle the last step of data loader, so I'm trying to use it.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @pacman100

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
