### PR TITLE
TrainingArguments no longer sets `ACCELERATE_MIXED_PRECISION` environment variable

### DIFF
--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1212,7 +1212,7 @@ class AcceleratorConfig:
 
     mixed_precision: str = field(
         default="no",
-        metadata={"help": "Whether or not use mixed precision. Generally already set by TrainerArguments."},
+        metadata={"help": "Whether or not use mixed precision and what type. Generally already set by TrainerArguments or during `accelerate launch`"},
     )
 
     @classmethod

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1210,6 +1210,13 @@ class AcceleratorConfig:
         },
     )
 
+    mixed_precision: str = field(
+        default="no",
+        metadata={
+            "help": "Whether or not use mixed precision. Generally already set by TrainerArguments."
+        },
+    )
+
     @classmethod
     def from_json_file(cls, json_file):
         # Check if exists

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1212,9 +1212,7 @@ class AcceleratorConfig:
 
     mixed_precision: str = field(
         default="no",
-        metadata={
-            "help": "Whether or not use mixed precision. Generally already set by TrainerArguments."
-        },
+        metadata={"help": "Whether or not use mixed precision. Generally already set by TrainerArguments."},
     )
 
     @classmethod

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1769,7 +1769,16 @@ class TrainingArguments:
                 else:
                     self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
 
-            self.accelerator_config.mixed_precision = mixed_precision_dtype
+            if self.accelerator_config.mixed_precision == "no":
+                self.accelerator_config.mixed_precision = mixed_precision_dtype
+            elif mixed_precision_dtype != "no" and self.accelerator_config.mixed_precision != mixed_precision_dtype:
+                raise ValueError(
+                    "Mismatch on specified mixed precision dtype: "
+                    f"The specified mixed precision dtype ({mixed_precision_dtype}) does not match "
+                    f"the accelerator's configuration ({self.accelerator_config.mixed_precision}). "
+                    "Please ensure consistency or set the mixed precision dtype through only one configuration."
+                )
+            mixed_precision_dtype = self.accelerator_config.mixed_precision
 
             if self.dispatch_batches is not None:
                 warnings.warn(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1622,13 +1622,11 @@ class TrainingArguments:
                 # no need to assert on else
 
         # if training args is specified, it will override the one specified in the accelerate config
-        if self.half_precision_backend != "apex":
-            mixed_precision_dtype = os.environ.get("ACCELERATE_MIXED_PRECISION", "no")
-            if self.fp16:
-                mixed_precision_dtype = "fp16"
-            elif self.bf16:
-                mixed_precision_dtype = "bf16"
-            os.environ["ACCELERATE_MIXED_PRECISION"] = mixed_precision_dtype
+        mixed_precision_dtype = os.environ.get("ACCELERATE_MIXED_PRECISION", "no")
+        if self.fp16:
+            mixed_precision_dtype = "fp16"
+        elif self.bf16:
+            mixed_precision_dtype = "bf16"
 
         if self.report_to is None:
             logger.info(
@@ -1770,6 +1768,9 @@ class TrainingArguments:
                     self.accelerator_config = AcceleratorConfig(**self.accelerator_config)
                 else:
                     self.accelerator_config = AcceleratorConfig.from_json_file(self.accelerator_config)
+
+            self.accelerator_config.mixed_precision = mixed_precision_dtype
+
             if self.dispatch_batches is not None:
                 warnings.warn(
                     "Using `--dispatch_batches` is deprecated and will be removed in version 4.41 of 🤗 Transformers. Use"
@@ -1826,8 +1827,7 @@ class TrainingArguments:
             from accelerate.utils import DeepSpeedPlugin
 
             self.deepspeed_plugin = DeepSpeedPlugin()
-            mixed_precision = os.environ.get("ACCELERATE_MIXED_PRECISION", "no")
-            self.deepspeed_plugin.set_mixed_precision(mixed_precision)
+            self.deepspeed_plugin.set_mixed_precision(mixed_precision_dtype)
             self.deepspeed_plugin.set_deepspeed_weakref()
 
         if self.use_cpu:


### PR DESCRIPTION
# What does this PR do?

TrainingArguments no longer sets `ACCELERATE_MIXED_PRECISION` environment variable and instead relies on newly added `AcceleratorConfig.mixed_precision` attribute. This prevents cases where mixed precision was activated even when Training arguments wasn't provided to `Trainer`.

* AcceleratorConfig now contains a new attribute named `mixed_precision`

* TrainerArguments no longer sets `ACCELERATE_MIXED_PRECISION` environment variable

* TrainerArguments sets AcceleratorConfig.mixed_precision attribute according to received arguments

* TrainerArguments sets deep_speed mixed precision even when activated through ACCELERATE_USE_DEEPSPEED env variable

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #29510

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr & @amyeroberts

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
