### PR TITLE
Calculate position ids on the fly in `forward`

### DIFF
--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -415,8 +415,13 @@ class CTRLModel(CTRLPreTrainedModel):
         else:
             past_length = past_key_values[0][0].size(-2)
         if position_ids is None:
-            position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0)
+            if attention_mask is not None:
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+                position_ids = position_ids[..., -input_shape[-1]:].view(-1, input_shape[-1])
+            else:
+                position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
+                position_ids = position_ids.unsqueeze(0)
 
         # Attention mask.
         if attention_mask is not None:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -793,8 +793,13 @@ class GPT2Model(GPT2PreTrainedModel):
         else:
             past_length = past_key_values[0][0].size(-2)
         if position_ids is None:
-            position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
-            position_ids = position_ids.unsqueeze(0)
+            if attention_mask is not None:
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+                position_ids = position_ids[..., -input_shape[-1]:].view(-1, input_shape[-1])
+            else:
+                position_ids = torch.arange(past_length, input_shape[-1] + past_length, dtype=torch.long, device=device)
+                position_ids = position_ids.unsqueeze(0)
 
         # GPT2Attention mask.
         if attention_mask is not None:


### PR DESCRIPTION
# What does this PR do?

I noticed that for some models the position ids are calculated correctly on the fly only in `prepare_ids_for_generation`. However, if calling the `forward` of the model with left padding, position ids do not take into account any attention mask. So they return incorrect logits, since these models use absolute position embeddings.

Given that models like GptBigCode already have correct way to get position ids in `forward`, I decided to add it for other GPT models with absolute position embeddings.

The script I used is:
```python
model = AutoModelForCausalLM.from_pretrained("gpt2-medium")
tokenizer = AutoTokenizer.from_pretrained("gpt2-medium")
tokenizer.pad_token_id = tokenizer.eos_token_id
tokenizer.padding_side = "left"
inputs_padded = tokenizer("Alice and Bob", padding="max_length", max_length=14, return_tensors="pt")
inputs = tokenizer("Alice and Bob", return_tensors="pt")

#make sure that `generate` is working for padded and unpadded inputs
gen_out_padded = tokenizer.batch_decode(model.generate(**inputs_padded, max_new_tokens=10), skip_special_tokens=True)
gen_out = tokenizer.batch_decode(model.generate(**inputs, max_new_tokens=10), skip_special_tokens=True)
#assert(gen_out_padded == gen_out), f"{gen_out_padded} is not equal to {gen_out}"

# if generate is working, then the logits for next token should be nearly-equal
outputs_padded = model(**inputs_padded)
outputs = model(**inputs)
print(torch.max(torch.abs(outputs_padded.logits[:, -1] - outputs.logits[:, -1]))) 
#>>> tensor(172.8631, grad_fn=<MaxBackward1>)
print(outputs_padded.logits[:, -1].argmax(), outputs.logits[:, -1].argmax()) 
#>>> tensor(290) tensor(338)


# Right padding (same result with or w/o fixes in this PR)
tokenizer.padding_side = "right"
inputs_padded = tokenizer("Alice and Bob", padding="max_length", max_length=14, return_tensors="pt")
inputs = tokenizer("Alice and Bob", return_tensors="pt")

#`generate` does not work for right padding apparently
# but the logits for next token are nearly-equal
outputs_padded = model(**inputs_padded)
outputs = model(**inputs)
print(torch.max(torch.abs(outputs_padded.logits[:, 2] - outputs.logits[:, 2]))) 
#>>> tensor(8.3923e-05, grad_fn=<MaxBackward1>)
print(outputs_padded.logits[:, 2].argmax(), outputs.logits[:, 2].argmax()) 
#>>> tensor(338) tensor(338)

```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@gante 