### PR TITLE
Stop passing None to compile() in TF examples

### DIFF
--- a/examples/tensorflow/image-classification/run_image_classification.py
+++ b/examples/tensorflow/image-classification/run_image_classification.py
@@ -509,7 +509,7 @@ def main():
                 collate_fn=collate_fn,
             ).with_options(dataset_options)
         else:
-            optimizer = None
+            optimizer = "sgd"  # Just write anything because we won't be using it
 
         if training_args.do_eval:
             eval_dataset = model.prepare_tf_dataset(

--- a/examples/tensorflow/multiple-choice/run_swag.py
+++ b/examples/tensorflow/multiple-choice/run_swag.py
@@ -482,7 +482,7 @@ def main():
                 adam_global_clipnorm=training_args.max_grad_norm,
             )
         else:
-            optimizer = None
+            optimizer = "sgd"  # Just write anything because we won't be using it
         # Transformers models compute the right loss for their task by default when labels are passed, and will
         # use this for training unless you specify your own loss function in compile().
         model.compile(optimizer=optimizer, metrics=["accuracy"], jit_compile=training_args.xla)

--- a/examples/tensorflow/question-answering/run_qa.py
+++ b/examples/tensorflow/question-answering/run_qa.py
@@ -706,7 +706,7 @@ def main():
             model.compile(optimizer=optimizer, jit_compile=training_args.xla, metrics=["accuracy"])
 
         else:
-            model.compile(optimizer=None, jit_compile=training_args.xla, metrics=["accuracy"])
+            model.compile(optimizer="sgd", jit_compile=training_args.xla, metrics=["accuracy"])
             training_dataset = None
 
         if training_args.do_eval:

--- a/examples/tensorflow/question-answering/run_qa.py
+++ b/examples/tensorflow/question-answering/run_qa.py
@@ -706,6 +706,7 @@ def main():
             model.compile(optimizer=optimizer, jit_compile=training_args.xla, metrics=["accuracy"])
 
         else:
+            # Optimizer doesn't matter as it won't be used anyway
             model.compile(optimizer="sgd", jit_compile=training_args.xla, metrics=["accuracy"])
             training_dataset = None
 

--- a/examples/tensorflow/summarization/run_summarization.py
+++ b/examples/tensorflow/summarization/run_summarization.py
@@ -621,7 +621,7 @@ def main():
                 adam_global_clipnorm=training_args.max_grad_norm,
             )
         else:
-            optimizer = None
+            optimizer = "sgd"  # Just write anything because we won't be using it
 
         # endregion
 

--- a/examples/tensorflow/text-classification/README.md
+++ b/examples/tensorflow/text-classification/README.md
@@ -75,7 +75,10 @@ python run_text_classification.py \
 --train_file training_data.json \
 --validation_file validation_data.json \
 --output_dir output/ \
---test_file data_to_predict.json
+--test_file data_to_predict.json \
+--do_train \
+--do_eval \
+--do_predict
 ```
 
 ## run_glue.py

--- a/examples/tensorflow/text-classification/run_glue.py
+++ b/examples/tensorflow/text-classification/run_glue.py
@@ -477,7 +477,7 @@ def main():
                 adam_global_clipnorm=training_args.max_grad_norm,
             )
         else:
-            optimizer = "adam"  # Just write anything because we won't be using it
+            optimizer = "sgd"  # Just write anything because we won't be using it
         if is_regression:
             metrics = []
         else:

--- a/examples/tensorflow/text-classification/run_text_classification.py
+++ b/examples/tensorflow/text-classification/run_text_classification.py
@@ -526,7 +526,7 @@ def main():
                 adam_global_clipnorm=training_args.max_grad_norm,
             )
         else:
-            optimizer = None
+            optimizer = "sgd"  # Just use any default
         if is_regression:
             metrics = []
         else:

--- a/examples/tensorflow/translation/run_translation.py
+++ b/examples/tensorflow/translation/run_translation.py
@@ -584,7 +584,7 @@ def main():
                 adam_global_clipnorm=training_args.max_grad_norm,
             )
         else:
-            optimizer = None
+            optimizer = "sgd"  # Just write anything because we won't be using it
         # endregion
 
         # region Metric and postprocessing


### PR DESCRIPTION
TensorFlow used to accept a value of `None` for the optimizer argument in `compile()`, as long as you didn't actually try to `fit()` the resulting model, but now it doesn't. This PR passes a dummy `sgd` optimizer instead to avoid that issue.

It also reworks the sample invocation given for `run_text_classification.py` to avoid confusion.

Fixes #29584
