### PR TITLE
Set env var to hold Keras at Keras 2

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -81,8 +81,9 @@ if TYPE_CHECKING:
 if "TF_USE_LEGACY_KERAS" not in os.environ:
     os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
 elif os.environ["TF_USE_LEGACY_KERAS"] != "1":
-    raise RuntimeError("Transformers is only compatible with Keras 2, but you have explicitly set "
-                       "`TF_USE_LEGACY_KERAS` to `0`.")
+    raise RuntimeError(
+        "Transformers is only compatible with Keras 2, but you have explicitly set " "`TF_USE_LEGACY_KERAS` to `0`."
+    )
 
 try:
     import tf_keras as keras

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -78,6 +78,8 @@ if is_safetensors_available():
 if TYPE_CHECKING:
     from . import PreTrainedTokenizerBase
 
+os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
+
 try:
     import tf_keras as keras
     from tf_keras import backend as K

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -78,7 +78,11 @@ if is_safetensors_available():
 if TYPE_CHECKING:
     from . import PreTrainedTokenizerBase
 
-os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
+if "TF_USE_LEGACY_KERAS" not in os.environ:
+    os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
+elif os.environ["TF_USE_LEGACY_KERAS"] != "1":
+    raise RuntimeError("Transformers is only compatible with Keras 2, but you have explicitly set "
+                       "`TF_USE_LEGACY_KERAS` to `0`.")
 
 try:
     import tf_keras as keras

--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -78,11 +78,14 @@ if is_safetensors_available():
 if TYPE_CHECKING:
     from . import PreTrainedTokenizerBase
 
+logger = logging.get_logger(__name__)
+
 if "TF_USE_LEGACY_KERAS" not in os.environ:
     os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
 elif os.environ["TF_USE_LEGACY_KERAS"] != "1":
-    raise RuntimeError(
-        "Transformers is only compatible with Keras 2, but you have explicitly set " "`TF_USE_LEGACY_KERAS` to `0`."
+    logger.warning(
+        "Transformers is only compatible with Keras 2, but you have explicitly set `TF_USE_LEGACY_KERAS` to `0`. "
+        "This may result in unexpected behaviour or errors if Keras 3 objects are passed to Transformers models."
     )
 
 try:
@@ -100,7 +103,6 @@ except (ModuleNotFoundError, ImportError):
         )
 
 
-logger = logging.get_logger(__name__)
 tf_logger = tf.get_logger()
 
 TFModelInputType = Union[


### PR DESCRIPTION
Newer versions of TF use the environment variable `TF_USE_LEGACY_KERAS` to decide whether to use Keras 2 or Keras 3. We set this immediately in `modeling_tf_utils` to make sure that no Keras 3 objects sneak in - this should hopefully fix a lot of user scripts that are using `tf.keras` instead of `keras` or `tf-keras` as well.

Fixes #29470