### PR TITLE
Examples: check `max_position_embeddings` in the translation example

### DIFF
--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -469,6 +469,19 @@ def main():
     source_lang = data_args.source_lang.split("_")[0]
     target_lang = data_args.target_lang.split("_")[0]
 
+    # Check the whether the source target length fits in the model, if it has absolute positional embeddings
+    if (
+        hasattr(model.config, "max_position_embeddings")
+        and not hasattr(model.config, "relative_attention_max_distance")
+        and model.config.max_position_embeddings < data_args.max_source_length
+    ):
+        raise ValueError(
+            f"`--max_source_length` is set to {data_args.max_source_length}, but the model only has"
+            f" {model.config.max_position_embeddings} position encodings. Consider either reducing"
+            f" `--max_source_length` to {model.config.max_position_embeddings} or using a model with larger position "
+            "embeddings"
+        )
+
     # Temporarily set max_target_length for training.
     max_target_length = data_args.max_target_length
     padding = "max_length" if data_args.pad_to_max_length else False


### PR DESCRIPTION
# What does this PR do?

Fixes #28104 

When a model with absolute position embeddings (such as Marian) is used in the translation training example, we must confirm that the input sequence length argument is smaller than its maximum sequence length. Otherwise, the data gets prepared with a larger sequence length, resulting in indexing errors.

This PR adds an informative exception, explaining what can be fixed when that happens :)

[Note: models with relative position embeddings, like T5, don't need this check. They can handle arbitrary sequence lengths.]