### PR TITLE
Implemented add_pooling_layer arg to TFBertModel

### DIFF
--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -1182,10 +1182,10 @@ BERT_INPUTS_DOCSTRING = r"""
     BERT_START_DOCSTRING,
 )
 class TFBertModel(TFBertPreTrainedModel):
-    def __init__(self, config: BertConfig, *inputs, **kwargs):
+    def __init__(self, config: BertConfig, add_pooling_layer: bool = True, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
 
-        self.bert = TFBertMainLayer(config, name="bert")
+        self.bert = TFBertMainLayer(config, add_pooling_layer, name="bert")
 
     @unpack_inputs
     @add_start_docstrings_to_model_forward(BERT_INPUTS_DOCSTRING.format("batch_size, sequence_length"))


### PR DESCRIPTION
# What does this PR do?
This PR implements support for the `add_pooling_layer` argument in the initialization of transformers.TFBertModel. Rationale behind this is, not only is the exclusion of a pooling layer already supported for the PyTorch counterpart (`transformers.BertModel`), this provides the user access to an uncondensed output of dimension `(batch, seq_length, hidden_dim)` instead of the pooled output of dimension `(batch, 1, hidden_dim)` for more complex downstream use.

Fixes Issue [#29567](https://github.com/huggingface/transformers/issues/29567)


## Who can review?
@amyeroberts @Rocketknight1 
