### PR TITLE
[tests] make `test_trainer_log_level_replica` to run on accelerators with more than 2 devices

### DIFF
--- a/tests/extended/test_trainer_ext.py
+++ b/tests/extended/test_trainer_ext.py
@@ -62,6 +62,7 @@ class TestTrainerExt(TestCasePlus):
         do_train=True,
         do_eval=True,
         do_predict=True,
+        n_gpus_to_use=None,
     ):
         output_dir = self.run_trainer(
             eval_steps=1,
@@ -74,6 +75,7 @@ class TestTrainerExt(TestCasePlus):
             do_train=do_train,
             do_eval=do_eval,
             do_predict=do_predict,
+            n_gpus_to_use=n_gpus_to_use,
         )
         logs = TrainerState.load_from_json(os.path.join(output_dir, "trainer_state.json")).log_history
 
@@ -138,7 +140,13 @@ class TestTrainerExt(TestCasePlus):
         }
 
         data = experiments[experiment_id]
-        kwargs = {"distributed": True, "predict_with_generate": False, "do_eval": False, "do_predict": False}
+        kwargs = {
+            "distributed": True,
+            "predict_with_generate": False,
+            "do_eval": False,
+            "do_predict": False,
+            "n_gpus_to_use": 2,
+        }
         log_info_string = "Running training"
         with CaptureStderr() as cl:
             self.run_seq2seq_quick(**kwargs, extra_args_str=data["extra_args_str"])


### PR DESCRIPTION
## What does this PR do?
When I run the following test on NV A100 with 7 available cards, 
```bash
RUN_SLOW=1 pytest -rA tests/extended/test_trainer_ext.py::TestTrainerExt
```
I got 2 failing tests:
```bash
================================================= short test summary info =================================================
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_ddp
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_dp
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_0_base
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_3_mixed
SKIPPED [1] tests/extended/test_trainer_ext.py:107: test requires apex
SKIPPED [1] tests/extended/test_trainer_ext.py:174: test requires bitsandbytes and torch
SKIPPED [1] tests/extended/test_trainer_ext.py:93: test requires 0 or 1 accelerator
FAILED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_1_low - AssertionError: 7 != 2
FAILED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_2_high - AssertionError: 6 != 1
```
This is because the variable `n_matches` is hard-coded and assumes that there should be 2 cards available on the device. This PR fixes this issue by setting `n_gpus_to_use` to 2 for this test. 

Below is the tests results after the fix:
```bash
=================================================== short test summary info ====================================================
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_ddp
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_run_seq2seq_dp
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_0_base
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_1_low
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_2_high
PASSED tests/extended/test_trainer_ext.py::TestTrainerExt::test_trainer_log_level_replica_3_mixed
SKIPPED [1] tests/extended/test_trainer_ext.py:109: test requires apex
SKIPPED [1] tests/extended/test_trainer_ext.py:182: test requires bitsandbytes and torch
SKIPPED [1] tests/extended/test_trainer_ext.py:95: test requires 0 or 1 accelerator
==================================== 7 passed, 3 skipped, 21 warnings in 143.86s (0:02:23) ====================================
```

Could you help review this PR? Thanks a lot! 
@amyeroberts