### PR TITLE
Fix: handle logging of scalars in Weights & Biases summary

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -802,13 +802,25 @@ class WandbCallback(TrainerCallback):
                 self._wandb.run.log_artifact(artifact)
 
     def on_log(self, args, state, control, model=None, logs=None, **kwargs):
+        single_value_scalars = [
+            "train_runtime",
+            "train_samples_per_second",
+            "train_steps_per_second",
+            "train_loss",
+            "total_flos",
+        ]
+
         if self._wandb is None:
             return
         if not self._initialized:
             self.setup(args, state, model)
         if state.is_world_process_zero:
-            logs = rewrite_logs(logs)
-            self._wandb.log({**logs, "train/global_step": state.global_step})
+            for k, v in logs.items():
+                if k in single_value_scalars:
+                    self._wandb.run.summary[k] = v
+            non_scalar_logs = {k: v for k, v in logs.items() if k not in single_value_scalars}
+            non_scalar_logs = rewrite_logs(non_scalar_logs)
+            self._wandb.log({**non_scalar_logs, "train/global_step": state.global_step})
 
     def on_save(self, args, state, control, **kwargs):
         if self._log_model == "checkpoint" and self._initialized and state.is_world_process_zero:


### PR DESCRIPTION
# What does this PR do?

This PR handles logging scalars to wandb correctly by adding the scalars to the wandb summary rather than the workspace run logs.

Here's an example workspace [run](https://wandb.ai/parambharat/test-transformers/runs/9p7kwbfl) with the fix

### Example workspace before fix:
![image](https://github.com/huggingface/transformers/assets/12809212/73159045-dd9e-4aad-a357-8148ddd50a5e)


### Example workspace after fix:

![image](https://github.com/huggingface/transformers/assets/12809212/6bb204f9-a8b3-42d8-90ec-166c7de4cb1a)

### Example Summary after fix:

![image](https://github.com/huggingface/transformers/assets/12809212/971e6120-dc27-471d-bad4-f37da9fb8f7b)


Fixes #29430


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.

## Who can review?

@muellerzr
@nmd2k
@ArthurZucker 

