### PR TITLE
Warn about tool use

### DIFF
--- a/docs/source/en/custom_tools.md
+++ b/docs/source/en/custom_tools.md
@@ -427,6 +427,15 @@ To upload your custom prompt on a repo on the Hub and share it with the communit
 
 ## Using custom tools
 
+<Tip warning={true}>
+
+Using custom tools in your local runtime means that you'll download code to run on your mahcine.
+
+ALWAYS inspect the tool you're downloading before loading it within your runtime, as you would do when
+installing a package using pip/npm/apt.
+
+</Tip>
+
 In this section, we'll be leveraging two existing custom tools that are specific to image generation:
 
 - We replace [huggingface-tools/image-transformation](https://huggingface.co/spaces/huggingface-tools/image-transformation),

--- a/docs/source/en/custom_tools.md
+++ b/docs/source/en/custom_tools.md
@@ -429,7 +429,7 @@ To upload your custom prompt on a repo on the Hub and share it with the communit
 
 <Tip warning={true}>
 
-Using custom tools in your local runtime means that you'll download code to run on your mahcine.
+Using custom tools in your local runtime means that you'll download code to run on your machine.
 
 ALWAYS inspect the tool you're downloading before loading it within your runtime, as you would do when
 installing a package using pip/npm/apt.

--- a/src/transformers/tools/base.py
+++ b/src/transformers/tools/base.py
@@ -693,7 +693,7 @@ def load_tool(task_or_repo_id, model_repo_id=None, remote=False, token=None, **k
         else:
             return tool_class(model_repo_id, token=token, **kwargs)
     else:
-        logging.warning_once(
+        logger.warning_once(
             f"You're loading a tool from the Hub from {model_repo_id}. Please make sure this is a source that you "
             f"trust as the code within that tool will be executed on your machine. Always verify the code of "
             f"the tools that you load. We recommend specifying a `revision` to ensure you're loading the "

--- a/src/transformers/tools/base.py
+++ b/src/transformers/tools/base.py
@@ -186,6 +186,14 @@ class Tool:
         """
         Loads a tool defined on the Hub.
 
+        <Tip warning={true}>
+
+        Loading a tool from the Hub means that you'll download the tool and execute it locally.
+        ALWAYS inspect the tool you're downloading before loading it within your runtime, as you would do when
+        installing a package using pip/npm/apt.
+
+        </Tip>
+
         Args:
             repo_id (`str`):
                 The name of the repo on the Hub where your tool is defined.
@@ -630,6 +638,14 @@ def load_tool(task_or_repo_id, model_repo_id=None, remote=False, token=None, **k
     """
     Main function to quickly load a tool, be it on the Hub or in the Transformers library.
 
+    <Tip warning={true}>
+
+    Loading a tool means that you'll download the tool and execute it locally.
+    ALWAYS inspect the tool you're downloading before loading it within your runtime, as you would do when
+    installing a package using pip/npm/apt.
+
+    </Tip>
+
     Args:
         task_or_repo_id (`str`):
             The task for which to load the tool or a repo ID of a tool on the Hub. Tasks implemented in Transformers
@@ -677,6 +693,12 @@ def load_tool(task_or_repo_id, model_repo_id=None, remote=False, token=None, **k
         else:
             return tool_class(model_repo_id, token=token, **kwargs)
     else:
+        logging.warning_once(
+            f"You're loading a tool from the Hub from {model_repo_id}. Please make sure this is a source that you "
+            f"trust as the code within that tool will be executed on your machine. Always verify the code of "
+            f"the tools that you load. We recommend specifying a `revision` to ensure you're loading the "
+            f"code that you have checked."
+        )
         return Tool.from_hub(task_or_repo_id, model_repo_id=model_repo_id, token=token, remote=remote, **kwargs)
 
 


### PR DESCRIPTION
This PR adds additional warnings when using tools through the `from_hub` and `load_tool` methods to explicitly mention that this loads tools defined remotely.

This is done in addition to:
- the existing disclaimers within the runtime mentioning that you're downloading new files that you really should inspect
- the python method and class names which are already indicative of remote downloads