### PR TITLE
Fix `multi_gpu_data_parallel_forward` for `MusicgenTest`

### DIFF
--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -103,7 +103,7 @@ class MusicgenDecoderTester:
     def __init__(
         self,
         parent,
-        batch_size=3,  # need batch_size != num_hidden_layers
+        batch_size=4,  # need batch_size != num_hidden_layers
         seq_length=7,
         is_training=False,
         use_labels=False,
@@ -441,7 +441,7 @@ class MusicgenTester:
     def __init__(
         self,
         parent,
-        batch_size=3,  # need batch_size != num_hidden_layers
+        batch_size=4,  # need batch_size != num_hidden_layers
         seq_length=7,
         is_training=False,
         use_labels=False,


### PR DESCRIPTION
# What does this PR do?

Fix 

```
tests/models/musicgen/test_modeling_musicgen.py::MusicgenDecoderTest::test_multi_gpu_data_parallel_forward

tests/models/musicgen/test_modeling_musicgen.py::MusicgenTest::test_multi_gpu_data_parallel_forward
```
introduced in #29297

we need batch size to be even number