### PR TITLE
Refactor TFP call to just sigmoid()

### DIFF
--- a/src/transformers/pipelines/table_question_answering.py
+++ b/src/transformers/pipelines/table_question_answering.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ..utils import (
     add_end_docstrings,
-    is_tensorflow_probability_available,
     is_tf_available,
     is_torch_available,
     requires_backends,
@@ -21,9 +20,8 @@ if is_torch_available():
         MODEL_FOR_TABLE_QUESTION_ANSWERING_MAPPING_NAMES,
     )
 
-if is_tf_available() and is_tensorflow_probability_available():
+if is_tf_available():
     import tensorflow as tf
-    import tensorflow_probability as tfp
 
     from ..models.auto.modeling_tf_auto import (
         TF_MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES,
@@ -249,8 +247,7 @@ class TableQuestionAnsweringPipeline(Pipeline):
 
                 all_logits.append(logits)
 
-                dist_per_token = tfp.distributions.Bernoulli(logits=logits)
-                probabilities = dist_per_token.probs_parameter() * tf.cast(attention_mask_example, tf.float32)
+                probabilities = tf.math.sigmoid(logits) * tf.cast(attention_mask_example, tf.float32)
 
                 coords_to_probs = collections.defaultdict(list)
                 token_type_ids_example = token_type_ids_example

--- a/src/transformers/pipelines/table_question_answering.py
+++ b/src/transformers/pipelines/table_question_answering.py
@@ -247,7 +247,9 @@ class TableQuestionAnsweringPipeline(Pipeline):
 
                 all_logits.append(logits)
 
-                probabilities = tf.math.sigmoid(logits) * tf.cast(attention_mask_example, tf.float32)
+                probabilities = tf.math.sigmoid(tf.cast(logits, tf.float32)) * tf.cast(
+                    attention_mask_example, tf.float32
+                )
 
                 coords_to_probs = collections.defaultdict(list)
                 token_type_ids_example = token_type_ids_example


### PR DESCRIPTION
We're seeing [issues](https://huggingface.co/google/gemma-7b-it/discussions/71) caused by Tensorflow Probability + Keras 3 incompatibilities. Annoyingly, these are being thrown even when people are trying to use unrelated Torch models, as long as they have TF / TFP installed!

The underlying cause is that we import TFP in one of our pipeline files if it's present, and this file is run when `pipeline` is imported, even if the user is using an entirely different pipeline/framework. I removed the import entirely - it was only used to get the probabilities of a Bernoulli distribution given input logits, but this is just the sigmoid function, so I replaced the whole thing with a single call to `sigmoid()` instead.