### PR TITLE
Prepend `bos token` to Blip generations

### DIFF
--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1828,8 +1828,9 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
+        # -1 is a temp hack until `generate` is refactored to work better with VLMs
         if not self.language_model.config.is_encoder_decoder:
-            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1] - 1
             generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]
 
         outputs = self.language_model.generate(

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1838,4 +1838,16 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
             **generate_kwargs,
         )
 
+        # this is a temporary workaround to be consistent with other generation models and
+        # have BOS as the first token, even though under the hood we are calling LM with embeds
+        if not self.language_model.config.is_encoder_decoder:
+            bos_tokens = (
+                torch.LongTensor([[self.config.text_config.bos_token_id]])
+                .repeat(batch_size, 1)
+                .to(image_embeds.device)
+            )
+            if not isinstance(outputs, torch.Tensor):
+                outputs.sequences = torch.cat([bos_tokens, outputs.sequences], dim=-1)
+            else:
+                outputs = torch.cat([bos_tokens, outputs], dim=-1)
         return outputs

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -1828,7 +1828,8 @@ class Blip2ForConditionalGeneration(Blip2PreTrainedModel):
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
-        # -1 is a temp hack until `generate` is refactored to work better with VLMs
+        # -1 is to account for the prepended BOS after `generate.`
+        # TODO (joao, raushan): refactor `generate` to avoid these operations with VLMs
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1] - 1
             generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1538,8 +1538,9 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
+        # -1 is a temp hack until `generate` is refactored to work better with VLMs
         if not self.language_model.config.is_encoder_decoder:
-            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1]
+            generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1] - 1
             generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]
 
         outputs = self.language_model.generate(

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -1538,7 +1538,7 @@ class InstructBlipForConditionalGeneration(InstructBlipPreTrainedModel):
         inputs_embeds = torch.cat([language_model_inputs, inputs_embeds.to(language_model_inputs.device)], dim=1)
 
         # add image_embeds length to max_length, so that the final max_length in counted only on token embeds
-        # -1 is a temp hack until `generate` is refactored to work better with VLMs
+        # -1 is to account for the prepended BOS after `generate.`
         if not self.language_model.config.is_encoder_decoder:
             generate_kwargs["max_length"] = generate_kwargs.get("max_length", 20) + language_model_inputs.shape[1] - 1
             generate_kwargs["min_length"] = generate_kwargs.get("min_length", 0) + language_model_inputs.shape[1]

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -32,6 +32,7 @@ from transformers.testing_utils import (
 )
 from transformers.utils import is_torch_available, is_vision_available
 
+from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import (
     ModelTesterMixin,
@@ -434,7 +435,7 @@ class Blip2ForConditionalGenerationDecoderOnlyModelTester:
 
 
 @require_torch
-class Blip2ForConditionalGenerationDecoderOnlyTest(ModelTesterMixin, unittest.TestCase):
+class Blip2ForConditionalGenerationDecoderOnlyTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     all_model_classes = (Blip2ForConditionalGeneration,) if is_torch_available() else ()
     fx_compatible = False
     test_head_masking = False
@@ -683,7 +684,7 @@ class Blip2ModelTester:
 
 
 @require_torch
-class Blip2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
+class Blip2ModelTest(ModelTesterMixin, PipelineTesterMixin, GenerationTesterMixin, unittest.TestCase):
     all_model_classes = (Blip2ForConditionalGeneration, Blip2Model) if is_torch_available() else ()
     pipeline_model_mapping = (
         {

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -869,7 +869,8 @@ class Blip2ModelIntegrationTest(unittest.TestCase):
         prompt = "Question: which city is this? Answer:"
         inputs = processor(images=image, text=prompt, return_tensors="pt").to(torch_device, dtype=torch.float16)
 
-        predictions = model.generate(**inputs)
+        # max_length for BLIP includes prompt length, so we need more than 20 to reach EOS here
+        predictions = model.generate(**inputs, max_length=25)
         generated_text = processor.batch_decode(predictions, skip_special_tokens=True)[0].strip()
 
         # Test output

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -869,8 +869,8 @@ class Blip2ModelIntegrationTest(unittest.TestCase):
         prompt = "Question: which city is this? Answer:"
         inputs = processor(images=image, text=prompt, return_tensors="pt").to(torch_device, dtype=torch.float16)
 
-        # max_length for BLIP includes prompt length, so we need more than 20 to reach EOS here
-        predictions = model.generate(**inputs, max_length=25)
+        # max_length for BLIP includes prompt length from now on, use max_new_tokens
+        predictions = model.generate(**inputs, max_new_tokens=11)
         generated_text = processor.batch_decode(predictions, skip_special_tokens=True)[0].strip()
 
         # Test output

--- a/tests/models/instructblip/test_modeling_instructblip.py
+++ b/tests/models/instructblip/test_modeling_instructblip.py
@@ -39,6 +39,7 @@ from transformers.testing_utils import (
 )
 from transformers.utils import is_torch_available, is_vision_available
 
+from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import (
     ModelTesterMixin,
@@ -452,7 +453,7 @@ class InstructBlipForConditionalGenerationDecoderOnlyModelTester:
 
 
 @require_torch
-class InstructBlipForConditionalGenerationDecoderOnlyTest(ModelTesterMixin, unittest.TestCase):
+class InstructBlipForConditionalGenerationDecoderOnlyTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     all_model_classes = (InstructBlipForConditionalGeneration,) if is_torch_available() else ()
     fx_compatible = False
     test_head_masking = False


### PR DESCRIPTION
# What does this PR do?

Fixes a failing test reported in our [internal slack](https://huggingface.slack.com/archives/C01NE71C4F7/p1710237799604759?thread_ts=1709544527.619019&cid=C01NE71C4F7). In the prev PR #28994 , we removed `bos` initialization when embeds are passed as input to `generate`, and instead initialized with empty placeholder. As a temporary workaround I suggest to artificially prepend "bos" token after generation. 


For long term, I suggest to reconsider how we work with multimodal LLMs for generation, I guess we'll have more of these models in the future. I analyzed the models we have in more detail, and what I want to do is use the current Llava-style workflow for generation, but with one change. We will need a method similar to "prepare_inputs_for_generation", which will be responsible to taking inputs in all modalities and concatenating them in correct way. The method will be called in generate, while preparing model inputs. I think calling "concat_modalities" from within generate would make it easier for us:

- not to worry about attention and other input lengths mismatch or losing padded attentions, since "concat" will already give us the correct multimodal length. All we do later is simply add one more id for new token
- easy to do assisted decoding with these workflow, which I have been trying to make work for a while 
- we will always have the prompt as part of generated text, which is intuitive for decoder-only models. I guess all VLMs can be thought of as decoder only

I made a board for visual explanation [here](https://miro.com/app/board/uXjVNhBRraU=/?share_link_id=582477932131) and a proof-of-concept that it works [here](https://github.com/zucchini-nlp/transformers/tree/multimodal_generation).

@gante I want your thoughts on this

