### PR TITLE
Fix TPU checkpointing inside Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3011,6 +3011,7 @@ class Trainer:
 
         logger.info(f"Saving model checkpoint to {output_dir}")
         model = self.model
+        xm.mark_step()
         model.to("cpu")
 
         if xm.is_master_ordinal():


### PR DESCRIPTION
# What does this PR do?

This PR fixes the following issue:

Whenever `save_steps` is a multiple of `logging_steps` this [step](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L2406) ` if self.control.should_log and self.state.global_step > self._globalstep_last_logged` is invoked which calls the `xm.mark_step` and the checkpointing defined inside `save_tpu` [here](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L3009) works fine. 
 
```python
 def _maybe_log_save_evaluate(self, tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval):
        if self.control.should_log and self.state.global_step > self._globalstep_last_logged:
            if is_torch_xla_available():
                xm.mark_step()
```

but the execution halts when `save_steps` is not a multiple of `logging_steps` as the `xm.mark_step` is never called. 
   

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @pacman100 