### PR TITLE
Allow apply_chat_template to pass kwargs to the template and support a dict of templates

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1746,7 +1746,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             conversation = conversation.messages
 
         if tokenizer_kwargs is None:
-            tokenizer_kwargs = dict()
+            tokenizer_kwargs = {}
 
         # priority: `chat_template` argument > `tokenizer.chat_template` > `tokenizer.default_chat_template`
         if chat_template is None:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1697,7 +1697,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         max_length: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_dict: bool = False,
-        tokenizer_kwargs: Dict[str, Any] = None,
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Union[str, List[int]]:
         """
@@ -1733,7 +1733,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 - `'jax'`: Return JAX `jnp.ndarray` objects.
             return_dict (`bool`, *optional*, defaults to `False`):
                 Whether to return a dictionary with named outputs. Has no effect if tokenize is `False`.
-            **tokenizer_kwargs: Additional kwargs to pass to the tokenizer.
+            tokenizer_kwargs (`Dict[str: Any]`, *optional*): Additional kwargs to pass to the tokenizer.
+            **kwargs: Additional kwargs to pass to the template renderer. Will be accessible by the chat template.
 
         Returns:
             `List[int]`: A list of token ids representing the tokenized chat so far, including control tokens. This

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1760,9 +1760,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 chat_template = template_dict["default"]
             elif chat_template is None:
                 raise ValueError(
-                    "This model has multiple chat templates with no default specified! Please pass "
-                    "the name of the template you wish to use to the `chat_template` argument. Available "
-                    f"templates are {list(template_dict.keys())}."
+                    "This model has multiple chat templates with no default specified! Please either pass a chat "
+                    "template or the name of the template you wish to use to the `chat_template` argument. Available "
+                    f"template names are {sorted(template_dict.keys())}."
                 )
         elif chat_template is None:
             # These are the cases when the model has a single template

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1697,7 +1697,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         max_length: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
         return_dict: bool = False,
-        **tokenizer_kwargs,
+        **kwargs,
     ) -> Union[str, List[int]]:
         """
         Converts a Conversation object or a list of dictionaries with `"role"` and `"content"` keys to a list of token
@@ -1754,7 +1754,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         compiled_template = self._compile_jinja_template(chat_template)
 
         rendered = compiled_template.render(
-            messages=conversation, add_generation_prompt=add_generation_prompt, **self.special_tokens_map
+            messages=conversation, add_generation_prompt=add_generation_prompt, **self.special_tokens_map, **kwargs
         )
 
         if padding is True:
@@ -1768,7 +1768,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     max_length=max_length,
                     add_special_tokens=False,
                     return_tensors=return_tensors,
-                    **tokenizer_kwargs,
+                    **kwargs,
                 )
             else:
                 return self.encode(
@@ -1778,7 +1778,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     max_length=max_length,
                     add_special_tokens=False,
                     return_tensors=return_tensors,
-                    **tokenizer_kwargs,
+                    **kwargs,
                 )
         else:
             return rendered

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1144,6 +1144,25 @@ class TokenizerTesterMixin:
                 )
                 self.assertEqual(output2, output2_via_dict)
 
+    def test_chat_template_dict_saving(self):
+        dummy_template_1 = "{{'a'}}"
+        dummy_template_2 = "{{'b'}}"
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tokenizer.save_pretrained(tmp_dir_name)
+                    config_dict = json.load(open(os.path.join(tmp_dir_name, "tokenizer_config.json")))
+                    # Assert that chat templates are correctly serialized as lists of dictionaries
+                    self.assertEqual(
+                        config_dict["chat_template"],
+                        [{"name": "template1", "template": "{{'a'}}"}, {"name": "template2", "template": "{{'b'}}"}],
+                    )
+                    new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
+                # Assert that the serialized list is correctly reconstructed as a single dict
+                self.assertEqual(new_tokenizer.chat_template, tokenizer.chat_template)
+
     def test_number_of_added_tokens(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)
         for tokenizer in tokenizers:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1123,18 +1123,26 @@ class TokenizerTesterMixin:
         dummy_template_1 = "{{'a'}}"
         dummy_template_2 = "{{'b'}}"
         dummy_conversation = [
-            {"role": "system", "content": "system message"},
             {"role": "user", "content": "user message"},
-            {"role": "assistant", "content": "assistant message"},
         ]
-        tokenizer = self.get_tokenizers()[0]
-        tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
-        output1 = tokenizer.apply_chat_template(dummy_conversation, chat_template=dummy_template_1, tokenize=False)
-        output1_via_dict = tokenizer.apply_chat_template(dummy_conversation, chat_template="template1", tokenize=False)
-        self.assertEqual(output1, output1_via_dict)
-        output2 = tokenizer.apply_chat_template(dummy_conversation, chat_template=dummy_template_2, tokenize=False)
-        output2_via_dict = tokenizer.apply_chat_template(dummy_conversation, chat_template="template2", tokenize=False)
-        self.assertEqual(output2, output2_via_dict)
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
+                output1 = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template=dummy_template_1, tokenize=False
+                )
+                output1_via_dict = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template="template1", tokenize=False
+                )
+                self.assertEqual(output1, output1_via_dict)
+                output2 = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template=dummy_template_2, tokenize=False
+                )
+                output2_via_dict = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template="template2", tokenize=False
+                )
+                self.assertEqual(output2, output2_via_dict)
 
     def test_number_of_added_tokens(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1144,6 +1144,7 @@ class TokenizerTesterMixin:
                 )
                 self.assertEqual(output2, output2_via_dict)
 
+    @require_jinja
     def test_chat_template_dict_saving(self):
         dummy_template_1 = "{{'a'}}"
         dummy_template_2 = "{{'b'}}"

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1118,6 +1118,24 @@ class TokenizerTesterMixin:
                 self.assertEqual(output, expected_output)  # Test output is the same after reloading
                 tokenizer.apply_chat_template(dummy_conversation, tokenize=True)  # Check that no error raised
 
+    @require_jinja
+    def test_chat_template_dict(self):
+        dummy_template_1 = "{{'a'}}"
+        dummy_template_2 = "{{'b'}}"
+        dummy_conversation = [
+            {"role": "system", "content": "system message"},
+            {"role": "user", "content": "user message"},
+            {"role": "assistant", "content": "assistant message"},
+        ]
+        tokenizer = self.get_tokenizers()[0]
+        tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
+        output1 = tokenizer.apply_chat_template(dummy_conversation, chat_template=dummy_template_1, tokenize=False)
+        output1_via_dict = tokenizer.apply_chat_template(dummy_conversation, chat_template="template1", tokenize=False)
+        self.assertEqual(output1, output1_via_dict)
+        output2 = tokenizer.apply_chat_template(dummy_conversation, chat_template=dummy_template_2, tokenize=False)
+        output2_via_dict = tokenizer.apply_chat_template(dummy_conversation, chat_template="template2", tokenize=False)
+        self.assertEqual(output2, output2_via_dict)
+
     def test_number_of_added_tokens(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)
         for tokenizer in tokenizers:


### PR DESCRIPTION
As the title suggests, this is a simple PR that allows two new features:

- `kwargs` can be passed through `apply_chat_template` to the template renderer.
- Models can have a dict of multiple chat templates, which can be accessed by passing their name to `apply_chat_template` (this is used by the new Command-R model)

This PR is very slightly breaking (we used to pass kwargs to the tokenizer), but I don't think this was commonly used, and I think the new usage is more intuitive. Users can still pass kwargs through the method to the tokenizer with the `tokenizer_kwargs` argument.

Other than that, it should have no effect on existing users/templates!