### PR TITLE
Fix PVT v2 tests

### DIFF
--- a/tests/models/pvt_v2/test_modeling_pvt_v2.py
+++ b/tests/models/pvt_v2/test_modeling_pvt_v2.py
@@ -19,7 +19,6 @@ import tempfile
 import unittest
 
 from transformers import PvtV2Backbone, PvtV2Config, is_torch_available, is_vision_available
-from transformers.models.auto import get_values
 from transformers.testing_utils import (
     require_accelerate,
     require_torch,
@@ -39,6 +38,7 @@ if is_torch_available():
     import torch
 
     from transformers import MODEL_MAPPING, AutoImageProcessor, PvtV2ForImageClassification, PvtV2Model
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
     from transformers.models.pvt_v2.modeling_pvt_v2 import PVT_V2_PRETRAINED_MODEL_ARCHIVE_LIST
 
 
@@ -289,7 +289,7 @@ class PvtV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config.return_dict = True
 
         for model_class in self.all_model_classes:
-            if model_class in get_values(MODEL_MAPPING):
+            if model_class.__name__ in MODEL_MAPPING_NAMES.values():
                 continue
             model = model_class(config)
             model.to(torch_device)

--- a/tests/models/pvt_v2/test_modeling_pvt_v2.py
+++ b/tests/models/pvt_v2/test_modeling_pvt_v2.py
@@ -37,7 +37,7 @@ from ...test_pipeline_mixin import PipelineTesterMixin
 if is_torch_available():
     import torch
 
-    from transformers import MODEL_MAPPING, AutoImageProcessor, PvtV2ForImageClassification, PvtV2Model
+    from transformers import AutoImageProcessor, PvtV2ForImageClassification, PvtV2Model
     from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
     from transformers.models.pvt_v2.modeling_pvt_v2 import PVT_V2_PRETRAINED_MODEL_ARCHIVE_LIST
 


### PR DESCRIPTION
# What does this PR do?

Same #29362 but for the newly added model pvt v2

failing test is

```
tests/models/pvt_v2/test_modeling_pvt_v2.py::PvtV2ModelTest::test_training

(line 1448)  RuntimeError: Failed to import transformers.models.dinat.modeling_dinat because of the following error (look up to see its traceback):
```