### PR TITLE
Generate: replace breaks by a loop condition

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1792,9 +1792,8 @@ class GenerationMixin:
             # did all peers finish? the reduced sum will be 0.0 then
             if this_peer_finished_flag.item() == 0.0:
                 return False
-        else:
-            if this_peer_finished:
-                return False
+        elif this_peer_finished:
+            return False
         return True
 
     def contrastive_search(self, *args, **kwargs):


### PR DESCRIPTION
# What does this PR do?

Pulled from the `torch.compile(..., fullgraph=True)` draft PR: https://github.com/huggingface/transformers/pull/29374

It replaces the `breaks` that exit the endless generation loop with an equivalent function that returns `False` when it should stop generating, while preserving ZeRO stage 3 support. It is not only an improvement in terms of code reuse, but also a hard requirement to enable  `torch.compile(..., fullgraph=True)`: `break` and data-dependent control flow is not supported.

