### PR TITLE
Fix wrong condition used in `filter_models`

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1244,7 +1244,7 @@ if __name__ == "__main__":
                     args.output_file,
                     diff_with_last_commit=diff_with_last_commit,
                     json_output_file=args.json_output_file,
-                    filter_models=(not commit_flags["no_filter"] or is_main_branch),
+                    filter_models=(not (commit_flags["no_filter"] or is_main_branch)),
                 )
                 filter_tests(args.output_file, ["repo_utils"])
             except Exception as e:


### PR DESCRIPTION
# What does this PR do?

My previous #28816 used a stupid wrong condition.

The correct one should be : we don't want to filter when we are on `main` branch.

I am so bad at boolean op, sorry

cc @gante 
