### PR TITLE
Adding FlaxNoRepeatNGramLogitsProcessor

### DIFF
--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -161,6 +161,7 @@ else:
         "FlaxTopKLogitsWarper",
         "FlaxTopPLogitsWarper",
         "FlaxWhisperTimeStampLogitsProcessor",
+        "FlaxNoRepeatNGramLogitsProcessor",
     ]
     _import_structure["flax_utils"] = [
         "FlaxGenerationMixin",
@@ -298,6 +299,7 @@ if TYPE_CHECKING:
             FlaxTopKLogitsWarper,
             FlaxTopPLogitsWarper,
             FlaxWhisperTimeStampLogitsProcessor,
+            FlaxNoRepeatNGramLogitsProcessor,
         )
         from .flax_utils import FlaxBeamSearchOutput, FlaxGenerationMixin, FlaxGreedySearchOutput, FlaxSampleOutput
 else:

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -293,13 +293,13 @@ if TYPE_CHECKING:
             FlaxLogitsProcessorList,
             FlaxLogitsWarper,
             FlaxMinLengthLogitsProcessor,
+            FlaxNoRepeatNGramLogitsProcessor,
             FlaxSuppressTokensAtBeginLogitsProcessor,
             FlaxSuppressTokensLogitsProcessor,
             FlaxTemperatureLogitsWarper,
             FlaxTopKLogitsWarper,
             FlaxTopPLogitsWarper,
             FlaxWhisperTimeStampLogitsProcessor,
-            FlaxNoRepeatNGramLogitsProcessor,
         )
         from .flax_utils import FlaxBeamSearchOutput, FlaxGenerationMixin, FlaxGreedySearchOutput, FlaxSampleOutput
 else:

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -493,7 +493,9 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
         )
 
         data = jnp.ones((all_update_indices.shape[0],), dtype=jnp.uint16)
-        data = data * (jnp.arange(data.shape[0]) < batch_size * (cur_len - (self.ngram_size - 1)))  # ignore the n-grams not yet generated
+        data = data * (
+            jnp.arange(data.shape[0]) < batch_size * (cur_len - (self.ngram_size - 1))
+        )  # ignore the n-grams not yet generated
 
         return sparse.BCOO((data, all_update_indices), shape=(batch_size,) + (vocab_size,) * self.ngram_size)
 

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -480,10 +480,10 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
         The BCOO representation allow to store only the few non-zero entries, instead of the full (huge) matrix
         """
         batch_size, seq_len = input_ids.shape
-        #number of n-grams in the whole sequence
-        seq_ngrams = (seq_len - (self.ngram_size - 1))
-        #number of n-grams in the currently generated sequence
-        cur_ngrams = (cur_len - (self.ngram_size - 1))
+        # number of n-grams in the whole sequence
+        seq_ngrams = seq_len - (self.ngram_size - 1)
+        # number of n-grams in the currently generated sequence
+        cur_ngrams = cur_len - (self.ngram_size - 1)
 
         def body_fun(i, val):
             b = i % batch_size
@@ -503,9 +503,7 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
         )
 
         # ignore the n-grams not yet generated
-        data = (
-            jnp.arange(batch_size * seq_ngrams) < batch_size * cur_ngrams
-        ).astype("float32")
+        data = (jnp.arange(batch_size * seq_ngrams) < batch_size * cur_ngrams).astype("float32")
 
         return sparse.BCOO((data, all_update_indices), shape=(batch_size,) + (vocab_size,) * self.ngram_size)
 

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -493,7 +493,7 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
         )
 
         data = jnp.ones((all_update_indices.shape[0],), dtype=jnp.uint16)
-        data = data.at[batch_size * (cur_len - (self.ngram_size - 1)) :].set(0)  # ignore the n-grams not yet generated
+        data = data * (jnp.arange(data.shape[0]) < batch_size * (cur_len - (self.ngram_size - 1)))  # ignore the n-grams not yet generated
 
         return sparse.BCOO((data, all_update_indices), shape=(batch_size,) + (vocab_size,) * self.ngram_size)
 

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -18,6 +18,7 @@ import inspect
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
+from jax.experimental import sparse
 
 from ..utils import add_start_docstrings
 from ..utils.logging import get_logger
@@ -455,3 +456,64 @@ class FlaxWhisperTimeStampLogitsProcessor(FlaxLogitsProcessor):
         scores = jax.vmap(handle_cumulative_probs)(logprobs, scores)
 
         return scores
+
+
+class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
+    r"""
+    [`FlaxLogitsProcessor`] that enforces no repetition of n-grams. See
+    [Fairseq](https://github.com/pytorch/fairseq/blob/a07cb6f40480928c9e0548b737aadd36ee66ac76/fairseq/sequence_generator.py#L345).
+
+    Args:
+        ngram_size (`int`):
+            All ngrams of size `ngram_size` can only occur once.
+    """
+
+    def __init__(self, ngram_size: int):
+        if not isinstance(ngram_size, int) or ngram_size <= 0:
+            raise ValueError(f"`ngram_size` has to be a strictly positive integer, but is {ngram_size}")
+        self.ngram_size = ngram_size
+
+    def get_previous_ngrams(self, input_ids: jnp.ndarray, vocab_size: int, cur_len: int):
+        """
+        get a matrix of size [batch_size, vocab_size, vocab_size, vocab_size] (for 3-grams) that
+        represent the 3-grams that occured previously.
+        The BCOO representation allow to store only the few non-zero entries, instead of the full (huge) matrix
+        """
+        batch_size, seq_len = input_ids.shape
+        
+        all_update_indices = jnp.array([[b,] + [input_ids[b, i + j] for j in range(self.ngram_size)]for i in range(seq_len - (self.ngram_size - 1)) for b in range(batch_size) ])
+
+        data=jnp.ones((all_update_indices.shape[0],) , dtype=jnp.uint16)
+        data=data.at[batch_size * (cur_len - (self.ngram_size - 1)):].set(0) #ignore the n-grams not yet generated
+
+        return sparse.BCOO((data, all_update_indices), shape=(batch_size,) + (vocab_size,) * self.ngram_size )
+
+    def get_banned_tokens_mask(self, latest_tokens: jnp.ndarray, previous_ngrams) -> jnp.ndarray:
+        """
+        Determines which tokens must be banned given latest tokens and the previously seen
+        ngrams.
+        """
+        @sparse.sparsify
+        @jax.vmap
+        def inner_fn(latest_tokens, previous_ngrams):
+          vocab_size = previous_ngrams.shape[-1]
+          mask = jnp.ones((vocab_size,))
+          mask *= previous_ngrams[tuple(latest_tokens)]
+          return mask
+        return sparse.bcoo_todense(inner_fn(latest_tokens, previous_ngrams))
+
+    def __call__(self, input_ids: jnp.ndarray, scores: jnp.ndarray, cur_len: int) -> jnp.ndarray:
+        def true_fn():
+            _, vocab_size = scores.shape
+            #store the previously seen n-grams
+            previous_ngrams = self.get_previous_ngrams(input_ids, vocab_size, cur_len)
+
+            #get the n-1 last tokens that prefix the n-gram being generated
+            latest_tokens = jnp.zeros((input_ids.shape[0], self.ngram_size - 1), dtype=input_ids.dtype)
+            latest_tokens = jax.lax.dynamic_update_slice(latest_tokens, jax.lax.dynamic_slice(input_ids, (0, cur_len - (self.ngram_size - 1)), (input_ids.shape[0], (self.ngram_size - 1))), (0, 0))
+
+            #compute the banned tokens, ie all the tokens that when added to the latest tokens lead to a n-gram that was previously generated
+            banned_tokens_indices_mask = jnp.isclose(self.get_banned_tokens_mask(latest_tokens, previous_ngrams), 1)
+            return jnp.where(banned_tokens_indices_mask, -float("inf"), scores)
+        output = jax.lax.cond((cur_len >= self.ngram_size - 1), true_fn, lambda: scores)
+        return output

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -530,7 +530,7 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
             )
 
             # compute the banned tokens, ie all the tokens that when added to the latest tokens lead to a n-gram that was previously generated
-            banned_tokens_indices_mask = jnp.invert(jnp.isclose(self.get_banned_tokens_mask(latest_tokens, previous_ngrams), 0))
+            banned_tokens_indices_mask = self.get_banned_tokens_mask(latest_tokens, previous_ngrams).astype("bool")
             return jnp.where(banned_tokens_indices_mask, -float("inf"), scores)
 
         output = jax.lax.cond((cur_len >= self.ngram_size - 1), true_fn, lambda: scores)

--- a/src/transformers/generation/flax_logits_process.py
+++ b/src/transformers/generation/flax_logits_process.py
@@ -495,7 +495,7 @@ class FlaxNoRepeatNGramLogitsProcessor(FlaxLogitsProcessor):
 
         shape = (batch_size * (seq_len - (self.ngram_size - 1)), self.ngram_size + 1)
         all_update_indices = jax.lax.fori_loop(
-            0, batch_size * (seq_len - (self.ngram_size - 1)), body_fun, jnp.zeros(shape, dtype=input_ids.dtype)
+            0, batch_size * (cur_len - (self.ngram_size - 1)), body_fun, jnp.zeros(shape, dtype=input_ids.dtype)
         )
 
         # ignore the n-grams not yet generated

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -45,6 +45,7 @@ from .flax_logits_process import (
     FlaxTemperatureLogitsWarper,
     FlaxTopKLogitsWarper,
     FlaxTopPLogitsWarper,
+    FlaxNoRepeatNGramLogitsProcessor,
 )
 
 
@@ -534,6 +535,8 @@ class FlaxGenerationMixin:
                 [input_ids_seq_length + i[0] - 1, i[1]] for i in generation_config.forced_decoder_ids
             ]
             processors.append(FlaxForceTokensLogitsProcessor(forced_decoder_ids))
+        if generation_config.no_repeat_ngram_size is not None and generation_config.no_repeat_ngram_size > 0:
+            processors.append(FlaxNoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
         processors = self._merge_criteria_processor_list(processors, logits_processor)
 
         return processors

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -911,7 +911,7 @@ class FlaxGenerationMixin:
             # add new logprobs to existing running logprobs scores.
             log_probs = jax.nn.log_softmax(logits)
             log_probs = logits_processor(
-                flatten_beam_dim(state.running_sequences), flatten_beam_dim(log_probs), state.cur_len
+                flatten_beam_dim(running_sequences), flatten_beam_dim(log_probs), state.cur_len
             )
             log_probs = unflatten_beam_dim(log_probs, batch_size, num_beams)
             log_probs = log_probs + jnp.expand_dims(state.running_scores, axis=2)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -911,7 +911,7 @@ class FlaxGenerationMixin:
             # add new logprobs to existing running logprobs scores.
             log_probs = jax.nn.log_softmax(logits)
             log_probs = logits_processor(
-                flatten_beam_dim(running_sequences), flatten_beam_dim(log_probs), state.cur_len
+                flatten_beam_dim(state.running_sequences), flatten_beam_dim(log_probs), state.cur_len
             )
             log_probs = unflatten_beam_dim(log_probs, batch_size, num_beams)
             log_probs = log_probs + jnp.expand_dims(state.running_scores, axis=2)

--- a/src/transformers/generation/flax_utils.py
+++ b/src/transformers/generation/flax_utils.py
@@ -40,12 +40,12 @@ from .flax_logits_process import (
     FlaxForceTokensLogitsProcessor,
     FlaxLogitsProcessorList,
     FlaxMinLengthLogitsProcessor,
+    FlaxNoRepeatNGramLogitsProcessor,
     FlaxSuppressTokensAtBeginLogitsProcessor,
     FlaxSuppressTokensLogitsProcessor,
     FlaxTemperatureLogitsWarper,
     FlaxTopKLogitsWarper,
     FlaxTopPLogitsWarper,
-    FlaxNoRepeatNGramLogitsProcessor,
 )
 
 

--- a/tests/generation/test_flax_logits_process.py
+++ b/tests/generation/test_flax_logits_process.py
@@ -237,6 +237,7 @@ class LogitsProcessorTest(unittest.TestCase):
         temp_dist_warp = FlaxTemperatureLogitsWarper(temperature=0.5)
         top_k_warp = FlaxTopKLogitsWarper(3)
         top_p_warp = FlaxTopPLogitsWarper(0.8)
+        no_repeat_proc = FlaxNoRepeatNGramLogitsProcessor(2)
 
         # instantiate all logits processors
         min_dist_proc = FlaxMinLengthLogitsProcessor(min_length=10, eos_token_id=eos_token_id)
@@ -252,10 +253,19 @@ class LogitsProcessorTest(unittest.TestCase):
         scores = min_dist_proc(input_ids, scores, cur_len=cur_len)
         scores = bos_dist_proc(input_ids, scores, cur_len=cur_len)
         scores = eos_dist_proc(input_ids, scores, cur_len=cur_len)
+        scores = no_repeat_proc(input_ids, scores, cur_len=cur_len)
 
         # with processor list
         processor = FlaxLogitsProcessorList(
-            [temp_dist_warp, top_k_warp, top_p_warp, min_dist_proc, bos_dist_proc, eos_dist_proc]
+            [
+                temp_dist_warp,
+                top_k_warp,
+                top_p_warp,
+                min_dist_proc,
+                bos_dist_proc,
+                eos_dist_proc,
+                no_repeat_proc,
+            ]
         )
         scores_comp = processor(input_ids, scores_comp, cur_len=cur_len)
 
@@ -284,6 +294,7 @@ class LogitsProcessorTest(unittest.TestCase):
         temp_dist_warp = FlaxTemperatureLogitsWarper(temperature=0.5)
         top_k_warp = FlaxTopKLogitsWarper(3)
         top_p_warp = FlaxTopPLogitsWarper(0.8)
+        no_repeat_proc = FlaxNoRepeatNGramLogitsProcessor(2)
 
         # instantiate all logits processors
         min_dist_proc = FlaxMinLengthLogitsProcessor(min_length=10, eos_token_id=eos_token_id)
@@ -300,12 +311,21 @@ class LogitsProcessorTest(unittest.TestCase):
             scores = min_dist_proc(input_ids, scores, cur_len=cur_len)
             scores = bos_dist_proc(input_ids, scores, cur_len=cur_len)
             scores = eos_dist_proc(input_ids, scores, cur_len=cur_len)
+            scores = no_repeat_proc(input_ids, scores, cur_len=cur_len)
             return scores
 
         # with processor list
         def run_processor_list(input_ids, scores, cur_len):
             processor = FlaxLogitsProcessorList(
-                [temp_dist_warp, top_k_warp, top_p_warp, min_dist_proc, bos_dist_proc, eos_dist_proc]
+                [
+                    temp_dist_warp,
+                    top_k_warp,
+                    top_p_warp,
+                    min_dist_proc,
+                    bos_dist_proc,
+                    eos_dist_proc,
+                    no_repeat_proc,
+                ]
             )
             scores = processor(input_ids, scores, cur_len=cur_len)
             return scores

--- a/tests/generation/test_flax_logits_process.py
+++ b/tests/generation/test_flax_logits_process.py
@@ -33,10 +33,10 @@ if is_flax_available():
         FlaxForcedEOSTokenLogitsProcessor,
         FlaxLogitsProcessorList,
         FlaxMinLengthLogitsProcessor,
+        FlaxNoRepeatNGramLogitsProcessor,
         FlaxTemperatureLogitsWarper,
         FlaxTopKLogitsWarper,
         FlaxTopPLogitsWarper,
-        FlaxNoRepeatNGramLogitsProcessor,
     )
 
 
@@ -216,9 +216,7 @@ class LogitsProcessorTest(unittest.TestCase):
         self.assertListEqual(jnp.isinf(filtered_scores_2_gram).tolist(), [[False, True, True], [True, False, False]])
 
         # 3-gram would forbid no token at 1st batch and 1st token (0) at 2nd batch
-        self.assertListEqual(
-            jnp.isinf(filtered_scores_3_gram).tolist(), [[False, False, False], [True, False, False]]
-        )
+        self.assertListEqual(jnp.isinf(filtered_scores_3_gram).tolist(), [[False, False, False], [True, False, False]])
 
     def test_processor_list(self):
         batch_size = 4


### PR DESCRIPTION
# What does this PR do?

Adding the no repeat n-gram logits processor to Flax, compatible with jitting.
I also added the test `test_no_repeat_ngram_dist_processor`, adapted from the torch one, and added the `FlaxNoRepeatNGramLogitsProcessor` to the `test_processor_list` and `test_processor_list_jitted`.

All the tests are passing, as `RUN_SLOW=1 pytest -sv tests/generation/test_flax_logits_process.py` prints:

```python
======================================= test session starts ========================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.4.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /content/transformers
configfile: pyproject.toml
plugins: anyio-3.7.1
collected 9 items                                                                                  

tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_forced_bos_token_logits_processor PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_forced_eos_token_logits_processor PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_min_length_dist_processor PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_no_repeat_ngram_dist_processor PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_processor_list PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_processor_list_jitted PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_temperature_dist_warper PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_top_k_dist_warper PASSED
tests/generation/test_flax_logits_process.py::LogitsProcessorTest::test_top_p_dist_warper PASSED

========================================= warnings summary =========================================
../../usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1373
  /usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: doctest_glob
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================== 9 passed, 1 warning in 14.73s ===================================
```

Note: in order to work properly within beam search, this processor needs the fix proposed in PR #29636 for the bug discussed in #29635 

Let me know if you have any comments or questions regarding this feature.

## Who can review?

@gante
@sanchit-gandhi
