### PR TITLE
Revert "Fix wrong condition used in `filter_models`"

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1244,7 +1244,7 @@ if __name__ == "__main__":
                     args.output_file,
                     diff_with_last_commit=diff_with_last_commit,
                     json_output_file=args.json_output_file,
-                    filter_models=(not (commit_flags["no_filter"] or is_main_branch)),
+                    filter_models=(not commit_flags["no_filter"] or is_main_branch),
                 )
                 filter_tests(args.output_file, ["repo_utils"])
             except Exception as e:


### PR DESCRIPTION
Reverts huggingface/transformers#29673

Sorry, I am not aware we have issue with 

> /bin/bash: line 25: /usr/bin/jq: Argument list too long

because we have too many models now!

See the file [test_preparation/generated_config.txt](https://app.circleci.com/pipelines/github/huggingface/transformers/87251/workflows/d1af48ac-13ee-425d-b1ab-f7e4f4d00003/jobs/1133645/artifacts)

We have to rethink how we can do, but let's revert the PR asap so future merge events won't face such issues.

