### PR TITLE
Add distribution params to time series output

### DIFF
--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1713,6 +1713,7 @@ class SampleTSPredictionOutput(ModelOutput):
             Sampled values from the chosen distribution.
         params (`dict[str, torch.FloatTensor]`): Parameters of the forecasted distribution.
         distribution (`str`): Name of the forecasted distribution.
+        scaling_params: (`dict[str, torch.FloatTensor]`): The distribution affine transformation parameters.
     """
 
     sequences: torch.FloatTensor = None

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1718,7 +1718,7 @@ class SampleTSPredictionOutput(ModelOutput):
     sequences: torch.FloatTensor = None
     params: torch.FloatTensor = None
     distribution: str = None
-    scaling_params: torch.FloatTensor = None
+    scaling_params: dict[str, torch.FloatTensor] = None
 
 
 @dataclass

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1717,7 +1717,7 @@ class SampleTSPredictionOutput(ModelOutput):
     """
 
     sequences: torch.FloatTensor = None
-    params: torch.FloatTensor = None
+    params: dict[str, torch.FloatTensor] = None
     distribution: str = None
     scaling_params: dict[str, torch.FloatTensor] = None
 

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1711,6 +1711,8 @@ class SampleTSPredictionOutput(ModelOutput):
     Args:
         sequences (`torch.FloatTensor` of shape `(batch_size, num_samples, prediction_length)` or `(batch_size, num_samples, prediction_length, input_size)`):
             Sampled values from the chosen distribution.
+        params (`dict[str, torch.FloatTensor]`): Parameters of the forecasted distribution.
+        distribution (`str`): Name of the forecasted distribution.
     """
 
     sequences: torch.FloatTensor = None

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1714,6 +1714,8 @@ class SampleTSPredictionOutput(ModelOutput):
     """
 
     sequences: torch.FloatTensor = None
+    params: torch.FloatTensor = None
+    distribution: str = None
 
 
 @dataclass

--- a/src/transformers/modeling_outputs.py
+++ b/src/transformers/modeling_outputs.py
@@ -1718,6 +1718,7 @@ class SampleTSPredictionOutput(ModelOutput):
     sequences: torch.FloatTensor = None
     params: torch.FloatTensor = None
     distribution: str = None
+    scaling_params: torch.FloatTensor = None
 
 
 @dataclass

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -2144,6 +2144,7 @@ class AutoformerForPrediction(AutoformerPreTrainedModel):
         params = self.output_params(decoder_last_hidden + trend)
         distr = self.output_distribution(params, loc=repeated_loc, scale=repeated_scale)
         future_samples = distr.sample()
+        scaling_params = {"loc": loc, "scale": scale}
 
         return SampleTSPredictionOutput(
             sequences=future_samples.reshape(
@@ -2151,4 +2152,5 @@ class AutoformerForPrediction(AutoformerPreTrainedModel):
             ),
             params=dict(zip(self.distribution_output.args_dim, params)),
             distribution=self.config.distribution_output,
+            scaling_params=scaling_params,
         )

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -2149,6 +2149,6 @@ class AutoformerForPrediction(AutoformerPreTrainedModel):
             sequences=future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
             ),
-            params = {key: param for key, param in zip(self.distribution_output.args_dim, params)},
-            distribution = self.config.distribution_output 
+            params=dict(zip(self.distribution_output.args_dim, params)),
+            distribution=self.config.distribution_output,
         )

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -2148,5 +2148,7 @@ class AutoformerForPrediction(AutoformerPreTrainedModel):
         return SampleTSPredictionOutput(
             sequences=future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
-            )
+            ),
+            params = {key: param for key, param in zip(self.distribution_output.args_dim, params)},
+            distribution = self.config.distribution_output 
         )

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -2048,3 +2048,4 @@ class InformerForPrediction(InformerPreTrainedModel):
             params=concat_future_params,
             distribution=self.config.distribution_output,
         )
+    

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -2008,6 +2008,9 @@ class InformerForPrediction(InformerPreTrainedModel):
         repeated_enc_last_hidden = enc_last_hidden.repeat_interleave(repeats=num_parallel_samples, dim=0)
 
         future_samples = []
+        future_params = {
+            name: [] for name in self.parameter_projection.args_dim
+        }
 
         # greedy decoding
         for k in range(self.config.prediction_length):
@@ -2034,10 +2037,16 @@ class InformerForPrediction(InformerPreTrainedModel):
             )
             future_samples.append(next_sample)
 
+            for key, param in zip(self.parameter_projection.args_dim, params):
+                future_params[key].append(param)
+
         concat_future_samples = torch.cat(future_samples, dim=1)
+        concat_future_params = {key: torch.cat(params, dim=1) for key, params in future_params.items()}
 
         return SampleTSPredictionOutput(
             sequences=concat_future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
-            )
+            ),
+            params = concat_future_params,
+            distribution = self.config.distribution_output 
         )

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -2008,9 +2008,7 @@ class InformerForPrediction(InformerPreTrainedModel):
         repeated_enc_last_hidden = enc_last_hidden.repeat_interleave(repeats=num_parallel_samples, dim=0)
 
         future_samples = []
-        future_params = {
-            name: [] for name in self.parameter_projection.args_dim
-        }
+        future_params = {name: [] for name in self.parameter_projection.args_dim}
 
         # greedy decoding
         for k in range(self.config.prediction_length):
@@ -2047,6 +2045,6 @@ class InformerForPrediction(InformerPreTrainedModel):
             sequences=concat_future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
             ),
-            params = concat_future_params,
-            distribution = self.config.distribution_output 
+            params=concat_future_params,
+            distribution=self.config.distribution_output,
         )

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -2048,4 +2048,3 @@ class InformerForPrediction(InformerPreTrainedModel):
             params=concat_future_params,
             distribution=self.config.distribution_output,
         )
-    

--- a/src/transformers/models/informer/modeling_informer.py
+++ b/src/transformers/models/informer/modeling_informer.py
@@ -2040,6 +2040,7 @@ class InformerForPrediction(InformerPreTrainedModel):
 
         concat_future_samples = torch.cat(future_samples, dim=1)
         concat_future_params = {key: torch.cat(params, dim=1) for key, params in future_params.items()}
+        scaling_params = {"loc": loc, "scale": scale}
 
         return SampleTSPredictionOutput(
             sequences=concat_future_samples.reshape(
@@ -2047,4 +2048,5 @@ class InformerForPrediction(InformerPreTrainedModel):
             ),
             params=concat_future_params,
             distribution=self.config.distribution_output,
+            scaling_params=scaling_params,
         )

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1777,6 +1777,7 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
 
         concat_future_samples = torch.cat(future_samples, dim=1)
         concat_future_params = {key: torch.cat(params, dim=1) for key, params in future_params.items()}
+        scaling_params = {"loc": loc, "scale": scale}
 
         return SampleTSPredictionOutput(
             sequences=concat_future_samples.reshape(
@@ -1784,4 +1785,5 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
             ),
             params=concat_future_params,
             distribution=self.config.distribution_output,
+            scaling_params=scaling_params,
         )

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1746,9 +1746,7 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
         repeated_enc_last_hidden = enc_last_hidden.repeat_interleave(repeats=num_parallel_samples, dim=0)
 
         future_samples = []
-        future_params = {
-            name: [] for name in self.parameter_projection.args_dim
-        }
+        future_params = {name: [] for name in self.parameter_projection.args_dim}
 
         # greedy decoding
         for k in range(self.config.prediction_length):
@@ -1784,6 +1782,6 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
             sequences=concat_future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
             ),
-            params = concat_future_params,
-            distribution = self.config.distribution_output 
+            params=concat_future_params,
+            distribution=self.config.distribution_output,
         )

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -1746,6 +1746,9 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
         repeated_enc_last_hidden = enc_last_hidden.repeat_interleave(repeats=num_parallel_samples, dim=0)
 
         future_samples = []
+        future_params = {
+            name: [] for name in self.parameter_projection.args_dim
+        }
 
         # greedy decoding
         for k in range(self.config.prediction_length):
@@ -1771,11 +1774,16 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
                 (repeated_past_values, (next_sample - repeated_loc) / repeated_scale), dim=1
             )
             future_samples.append(next_sample)
+            for key, param in zip(self.parameter_projection.args_dim, params):
+                future_params[key].append(param)
 
         concat_future_samples = torch.cat(future_samples, dim=1)
+        concat_future_params = {key: torch.cat(params, dim=1) for key, params in future_params.items()}
 
         return SampleTSPredictionOutput(
             sequences=concat_future_samples.reshape(
                 (-1, num_parallel_samples, self.config.prediction_length) + self.target_shape,
-            )
+            ),
+            params = concat_future_params,
+            distribution = self.config.distribution_output 
         )

--- a/tests/models/autoformer/test_modeling_autoformer.py
+++ b/tests/models/autoformer/test_modeling_autoformer.py
@@ -468,6 +468,10 @@ class AutoformerModelIntegrationTests(unittest.TestCase):
             )
         expected_shape = torch.Size((64, model.config.num_parallel_samples, model.config.prediction_length))
         self.assertEqual(outputs.sequences.shape, expected_shape)
+        self.assertEqual(outputs.distribution, "student_t")
+        self.assertEqual(outputs.params["df"].snape, expected_shape)
+        self.assertEqual(outputs.params["loc"].snape, expected_shape)
+        self.assertEqual(outputs.params["scale"].snape, expected_shape)
 
         expected_slice = torch.tensor([3130.6763, 4056.5293, 7053.0786], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)

--- a/tests/models/autoformer/test_modeling_autoformer.py
+++ b/tests/models/autoformer/test_modeling_autoformer.py
@@ -472,6 +472,7 @@ class AutoformerModelIntegrationTests(unittest.TestCase):
         self.assertEqual(outputs.params["df"].snape, expected_shape)
         self.assertEqual(outputs.params["loc"].snape, expected_shape)
         self.assertEqual(outputs.params["scale"].snape, expected_shape)
+        self.assertEqual(len(outputs.scaling_params), 2)
 
         expected_slice = torch.tensor([3130.6763, 4056.5293, 7053.0786], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)

--- a/tests/models/informer/test_modeling_informer.py
+++ b/tests/models/informer/test_modeling_informer.py
@@ -543,6 +543,7 @@ class InformerModelIntegrationTests(unittest.TestCase):
         self.assertEqual(outputs.params["df"].snape, expected_shape)
         self.assertEqual(outputs.params["loc"].snape, expected_shape)
         self.assertEqual(outputs.params["scale"].snape, expected_shape)
+        self.assertEqual(len(outputs.scaling_params), 2)
 
         expected_slice = torch.tensor([3400.8005, 4289.2637, 7101.9209], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)

--- a/tests/models/informer/test_modeling_informer.py
+++ b/tests/models/informer/test_modeling_informer.py
@@ -539,7 +539,11 @@ class InformerModelIntegrationTests(unittest.TestCase):
             )
         expected_shape = torch.Size((64, model.config.num_parallel_samples, model.config.prediction_length))
         self.assertEqual(outputs.sequences.shape, expected_shape)
-
+        self.assertEqual(outputs.distribution, "student_t")
+        self.assertEqual(outputs.params["df"].snape, expected_shape)
+        self.assertEqual(outputs.params["loc"].snape, expected_shape)
+        self.assertEqual(outputs.params["scale"].snape, expected_shape)
+        
         expected_slice = torch.tensor([3400.8005, 4289.2637, 7101.9209], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)
         self.assertTrue(torch.allclose(mean_prediction[0, -3:], expected_slice, rtol=1e-1))

--- a/tests/models/informer/test_modeling_informer.py
+++ b/tests/models/informer/test_modeling_informer.py
@@ -543,7 +543,7 @@ class InformerModelIntegrationTests(unittest.TestCase):
         self.assertEqual(outputs.params["df"].snape, expected_shape)
         self.assertEqual(outputs.params["loc"].snape, expected_shape)
         self.assertEqual(outputs.params["scale"].snape, expected_shape)
-        
+
         expected_slice = torch.tensor([3400.8005, 4289.2637, 7101.9209], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)
         self.assertTrue(torch.allclose(mean_prediction[0, -3:], expected_slice, rtol=1e-1))

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -549,6 +549,10 @@ class TimeSeriesTransformerModelIntegrationTests(unittest.TestCase):
             )
         expected_shape = torch.Size((64, model.config.num_parallel_samples, model.config.prediction_length))
         self.assertEqual(outputs.sequences.shape, expected_shape)
+        self.assertEqual(outputs.distribution, "student_t")
+        self.assertEqual(outputs.params["df"].snape, expected_shape)
+        self.assertEqual(outputs.params["loc"].snape, expected_shape)
+        self.assertEqual(outputs.params["scale"].snape, expected_shape)
 
         expected_slice = torch.tensor([2825.2749, 3584.9207, 6763.9951], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -553,6 +553,7 @@ class TimeSeriesTransformerModelIntegrationTests(unittest.TestCase):
         self.assertEqual(outputs.params["df"].snape, expected_shape)
         self.assertEqual(outputs.params["loc"].snape, expected_shape)
         self.assertEqual(outputs.params["scale"].snape, expected_shape)
+        self.assertEqual(len(outputs.scaling_params), 2)
 
         expected_slice = torch.tensor([2825.2749, 3584.9207, 6763.9951], device=torch_device)
         mean_prediction = outputs.sequences.mean(dim=1)


### PR DESCRIPTION
# What does this PR do?

This PR is adding the distribution params and the name of the distribution to the `SampleTSPredictionOutput`. Additionally, it enables the distribution outputs in the autoformer, informer, and time series transformer. 
<!-- Remove if not applicable -->

Fixes #29556 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

I extended existing tests

## Who can review?

@kashif 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
