### PR TITLE
Respect `add_prefix_space` option in `LlamaTokenizerFast`

### DIFF
--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -129,6 +129,9 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
                 "You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers"
             )
             kwargs["from_slow"] = True
+        else:
+            # Set default value for `add_prefix_space` if not provided (to pass typechecks)
+            add_prefix_space = False
 
         super().__init__(
             vocab_file=vocab_file,

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -131,7 +131,7 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
             kwargs["from_slow"] = True
         else:
             # Set default value for `add_prefix_space` if not provided (to pass typechecks)
-            add_prefix_space = False
+            add_prefix_space = True
 
         super().__init__(
             vocab_file=vocab_file,

--- a/src/transformers/models/llama/tokenization_llama_fast.py
+++ b/src/transformers/models/llama/tokenization_llama_fast.py
@@ -140,6 +140,7 @@ class LlamaTokenizerFast(PreTrainedTokenizerFast):
             add_bos_token=add_bos_token,
             add_eos_token=add_eos_token,
             use_default_system_prompt=use_default_system_prompt,
+            add_prefix_space=add_prefix_space,
             **kwargs,
         )
         self._add_bos_token = add_bos_token

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -737,6 +737,7 @@ class BatchEncoding(UserDict):
 
             def is_tensor(obj):
                 return isinstance(obj, mx.array)
+
         else:
 
             def as_tensor(value, dtype=None):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -737,7 +737,6 @@ class BatchEncoding(UserDict):
 
             def is_tensor(obj):
                 return isinstance(obj, mx.array)
-
         else:
 
             def as_tensor(value, dtype=None):


### PR DESCRIPTION
# What does this PR do?
Respect `add_prefix_space` option in Llama tokenizer (Fixes #29625)

The `add_prefix_space` option in Llama tokenizer was set but not passed to the `super().__init__()` method to `PretrainedTokenizersFast`. This resulted in SPIECE_UNDERLINE token being added even when `add_prefix_space=False`. 

## Minimal example
When `add_prefix_space` is `False`
```python
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf", add_prefix_space=False)
>>> tokenizer.tokenize('overheard')
['over', 'he', 'ard']
```

`add_prefix_space` is `True` 
```python
>>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf", add_prefix_space=True)
>>> tokenizer.tokenize('overheard')
>>> ['\u2581over', 'he', 'ard']
```

Fixes #29625 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @scruel 