### PR TITLE
Fix `filter_models`

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1064,7 +1064,7 @@ def infer_tests_to_run(
     impacted_files = sorted(set(impacted_files))
     print(f"\n### IMPACTED FILES ###\n{_print_list(impacted_files)}")
 
-    model_impacted = sorted(set(["/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")]))
+    model_impacted = sorted(set("/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")))
 
     # Grab the corresponding test files:
     if any(x in modified_files for x in ["setup.py", ".circleci/create_circleci_config.py"]):
@@ -1072,7 +1072,7 @@ def infer_tests_to_run(
         repo_utils_launch = True
     # The number `30` is just a heuristic to determine if we `guess` all models are impacted.
     elif not filter_models and len(model_impacted) > 30:
-        print(f"More than 30 models are impacted and `filter_models=False`. CI is configured to test everything.")
+        print("More than 30 models are impacted and `filter_models=False`. CI is configured to test everything.")
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
     else:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -68,6 +68,10 @@ PATH_TO_EXAMPLES = PATH_TO_REPO / "examples"
 PATH_TO_TRANFORMERS = PATH_TO_REPO / "src/transformers"
 PATH_TO_TESTS = PATH_TO_REPO / "tests"
 
+# The value is just a heuristic to determine if we `guess` all models are impacted.
+# This variable has effect only if `filter_models=False`.
+NUM_MODELS_TO_TRIGGER_FULL_CI = 30
+
 # List here the models to always test.
 IMPORTANT_MODELS = [
     "auto",
@@ -1064,15 +1068,16 @@ def infer_tests_to_run(
     impacted_files = sorted(set(impacted_files))
     print(f"\n### IMPACTED FILES ###\n{_print_list(impacted_files)}")
 
-    model_impacted = sorted({"/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")})
+    model_impacted = {"/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")}
 
     # Grab the corresponding test files:
     if any(x in modified_files for x in ["setup.py", ".circleci/create_circleci_config.py"]):
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
-    # The number `30` is just a heuristic to determine if we `guess` all models are impacted.
-    elif not filter_models and len(model_impacted) > 30:
-        print("More than 30 models are impacted and `filter_models=False`. CI is configured to test everything.")
+    elif not filter_models and len(model_impacted) >= NUM_MODELS_TO_TRIGGER_FULL_CI:
+        print(
+            f"More than {NUM_MODELS_TO_TRIGGER_FULL_CI - 1} models are impacted and `filter_models=False`. CI is configured to test everything."
+        )
         test_files_to_run = ["tests", "examples"]
         repo_utils_launch = True
     else:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1064,7 +1064,7 @@ def infer_tests_to_run(
     impacted_files = sorted(set(impacted_files))
     print(f"\n### IMPACTED FILES ###\n{_print_list(impacted_files)}")
 
-    model_impacted = sorted(set("/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")))
+    model_impacted = sorted({"/".join(x.split("/")[:3]) for x in impacted_files if x.startswith("tests/models/")})
 
     # Grab the corresponding test files:
     if any(x in modified_files for x in ["setup.py", ".circleci/create_circleci_config.py"]):


### PR DESCRIPTION
Fix #29683


# What does this PR do?

#29682 is reverted because, when there are many files impacted and `filter_models=False`, the argument to pytest is too long, and `fetch_tests` job on Circle fails with `/bin/bash: line 25: /usr/bin/jq: Argument list too long`.

This PR avoids this situation by using a heuristic of 30 models. If there are more than 30 models being impacted +`filter_models=False`, we will trigger a full CI by using `tests` as the target.

See the file `tests_fetched_summary.txt` in

https://app.circleci.com/pipelines/github/huggingface/transformers/87349/workflows/3a84543d-d965-416d-81f7-eee0286e30c7/jobs/1134895/artifacts

```bash
More than 30 models are impacted and `filter_models=False`. CI is configured to test everything.

### TEST TO RUN ###
- tests
```

