### PR TITLE
Doctests: fetch all files in the diff that contain doctests

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1617,6 +1617,7 @@ class LogitNormalization(LogitsProcessor, LogitsWarper):
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
         scores = scores.log_softmax(dim=-1)
+        scores = scores + 1  # this should trigger the doctests (and fail them here!)
         return scores
 
 

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1617,7 +1617,6 @@ class LogitNormalization(LogitsProcessor, LogitsWarper):
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
         scores = scores.log_softmax(dim=-1)
-        scores = scores + 1  # this should trigger the doctests (and fail them here!)
         return scores
 
 

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -446,7 +446,7 @@ def get_modified_python_files(diff_with_last_commit: bool = False) -> List[str]:
 
 def get_diff_for_doctesting(repo: Repo, base_commit: str, commits: List[str]) -> List[str]:
     """
-    Get the diff in doc examples between a base commit and one or several commits.
+    Get the diff containing doc examples between a base commit and one or several commits.
 
     Args:
         repo (`git.Repo`):


### PR DESCRIPTION
# What does this PR do?

The first commit in this PR (incorrectly) changes a logits processor with a doctest. With the change, the doctests are incorrect and should fail. However, that doesn't happen (check its CI status -- no `ci/circleci: tests_pr_documentation_tests`) 😭 

👉 The current doctest fetcher only consider files where the doctest itself was changed. For instance, in some `generate`-related doctests, I noticed that things got stale without any red CI (especially now, that we don't have the daily doctest runner)

This PR changes the doctest fetcher to add the files in the diff to the doctest CI if they have any doctest, to ensure the doctest stays consistent with the code. We can see in the 2nd commit that the doctest CI is now triggered, and it fails because of the change in the first commit 🙌 

The 3rd commit removes the change in the first commit.

🚨 Merging this change may cause future commits to fail, if the corresponding doctests are stale!