### PR TITLE
Larger runner on CircleCI

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -57,9 +57,9 @@ class CircleCIJob:
     install_steps: List[str] = None
     marker: Optional[str] = None
     parallelism: Optional[int] = 1
-    pytest_num_workers: int = 8
+    pytest_num_workers: int = 12
     pytest_options: Dict[str, Any] = None
-    resource_class: Optional[str] = "xlarge"
+    resource_class: Optional[str] = "2xlarge"
     tests_to_run: Optional[List[str]] = None
     working_directory: str = "~/transformers"
     # This should be only used for doctest job!
@@ -317,7 +317,7 @@ torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager -e git+https://github.com/huggingface/accelerate@main#egg=accelerate",
     ],
     parallelism=1,
-    pytest_num_workers=6,
+    pytest_num_workers=12,
 )
 
 
@@ -353,7 +353,7 @@ pipelines_torch_job = CircleCIJob(
         "pip install -U --upgrade-strategy eager .[sklearn,torch,testing,sentencepiece,torch-speech,vision,timm,video]",
     ],
     marker="is_pipeline_test",
-    pytest_num_workers=6,
+    pytest_num_workers=12,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

To avoid OOM on some job (torch/tf/flax jobs). With `-n 12`, we have ~83% RAM usage (of 32GB)

<img width="1001" alt="Screenshot 2024-03-20 094333" src="https://github.com/huggingface/transformers/assets/2521628/c26e82f8-da51-4456-ad80-6ffcb66b8efe">

