### PR TITLE
Update test reqs to include sentencepiece

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -321,6 +321,7 @@ extras["testing"] = (
         "beautifulsoup4",
         "tensorboard",
         "pydantic",
+        "sentencepiece",
     )
     + extras["retrieval"]
     + extras["modelcreation"]

--- a/tests/trainer/test_trainer_seq2seq.py
+++ b/tests/trainer/test_trainer_seq2seq.py
@@ -22,7 +22,7 @@ from transformers import (
     Seq2SeqTrainingArguments,
     T5Tokenizer,
 )
-from transformers.testing_utils import TestCasePlus, require_torch, slow, require_sentencepiece
+from transformers.testing_utils import TestCasePlus, require_sentencepiece, require_torch, slow
 from transformers.utils import is_datasets_available
 
 

--- a/tests/trainer/test_trainer_seq2seq.py
+++ b/tests/trainer/test_trainer_seq2seq.py
@@ -22,7 +22,7 @@ from transformers import (
     Seq2SeqTrainingArguments,
     T5Tokenizer,
 )
-from transformers.testing_utils import TestCasePlus, require_torch, slow
+from transformers.testing_utils import TestCasePlus, require_torch, slow, require_sentencepiece
 from transformers.utils import is_datasets_available
 
 
@@ -30,6 +30,7 @@ if is_datasets_available():
     import datasets
 
 
+@require_sentencepiece
 class Seq2seqTrainerTester(TestCasePlus):
     @slow
     @require_torch


### PR DESCRIPTION
# What does this PR do?

Hi, noticed our tests on our PR CI for Accelerate have been red for a week, due to https://github.com/huggingface/transformers/pull/29675

Specifically, before most of the tests in `test_trainer_seq2seq` were marked as `slow` so they were being skipped on our normal CI. However now that it's unslow for once, these tests require `sentencepiece`. 

I've added two different options for this:

1. The test suite now has the `require_sentencepiece` decorator, else we get an err: 

```bash
=================================== FAILURES ===================================
__________ Seq2seqTrainerTester.test_bad_generation_config_fail_early __________

self = <tests.trainer.test_trainer_seq2seq.Seq2seqTrainerTester testMethod=test_bad_generation_config_fail_early>

    @require_torch
    def test_bad_generation_config_fail_early(self):
        # Tests that a bad geneartion config causes the trainer to fail early
        model = AutoModelForSeq2SeqLM.from_pretrained("google-t5/t5-small")
>       tokenizer = T5Tokenizer.from_pretrained("google-t5/t5-small")

tests/trainer/test_trainer_seq2seq.py:189: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/transformers/utils/import_utils.py:1412: in __getattribute__
    requires_backends(cls, cls._backends)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = <class 'transformers.utils.dummy_sentencepiece_objects.T5Tokenizer'>
backends = ['sentencepiece']

    def requires_backends(obj, backends):
        if not isinstance(backends, (list, tuple)):
            backends = [backends]
    
        name = obj.__name__ if hasattr(obj, "__name__") else obj.__class__.__name__
    
        # Raise an error for users who might not realize that classes without "TF" are torch-only
        if "torch" in backends and "tf" not in backends and not is_torch_available() and is_tf_available():
            raise ImportError(PYTORCH_IMPORT_ERROR_WITH_TF.format(name))
    
        # Raise the inverse error for PyTorch users trying to load TF classes
        if "tf" in backends and "torch" not in backends and is_torch_available() and not is_tf_available():
            raise ImportError(TF_IMPORT_ERROR_WITH_PYTORCH.format(name))
    
        checks = (BACKENDS_MAPPING[backend] for backend in backends)
        failed = [msg.format(name) for available, msg in checks if not available()]
        if failed:
>           raise ImportError("".join(failed))
E           ImportError: 
E           T5Tokenizer requires the SentencePiece library but it was not found in your environment. Checkout the instructions on the
E           installation page of its repo: https://github.com/google/sentencepiece#installation and follow the ones
E           that match your environment. Please note that you may need to restart your runtime after installation.

/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/transformers/utils/import_utils.py:1400: ImportError
```

2. This PR also adds `sentencepiece` as a test dep, to allow for `pip install -e .[torch,testing]` to work fine and minimize downstream impact


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @amyeroberts 