### PR TITLE
Silence deprecations and use the DataLoaderConfig

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -221,6 +221,9 @@ if is_accelerate_available():
     if is_deepspeed_available():
         from accelerate.utils import DeepSpeedSchedulerWrapper
 
+if is_accelerate_available("0.28.0"):
+    from accelerate.utils import DataLoaderConfiguration
+
 
 def _is_peft_model(model):
     if is_peft_available():
@@ -4248,12 +4251,27 @@ class Trainer:
         grad_acc_kwargs["sync_with_dataloader"] = False
         gradient_accumulation_plugin = GradientAccumulationPlugin(**grad_acc_kwargs)
 
+        accelerator_config = self.args.accelerator_config.to_dict()
+
+        if is_accelerate_available("0.28.0"):
+            dataloader_config = DataLoaderConfiguration(
+                split_batches=accelerator_config.pop("split_batches"),
+                dispatch_batches=accelerator_config.pop("dispatch_batches"),
+                even_batches=accelerator_config.pop("even_batches"),
+                use_seedable_sampler=accelerator_config.pop("use_seedable_sampler"),
+            )
+        args = {
+            "deepspeed_plugin":self.args.deepspeed_plugin, 
+            "gradient_accumulation_plugin":gradient_accumulation_plugin
+        }
+        if is_accelerate_available("0.28.0"):
+            args["dataloader_config"] = dataloader_config
+        else:
+            args.update(accelerator_config)
+
+
         # create accelerator object
-        self.accelerator = Accelerator(
-            deepspeed_plugin=self.args.deepspeed_plugin,
-            gradient_accumulation_plugin=gradient_accumulation_plugin,
-            **self.args.accelerator_config.to_dict(),
-        )
+        self.accelerator = Accelerator(**args)
         # some Trainer classes need to use `gather` instead of `gather_for_metrics`, thus we store a flag
         self.gather_function = self.accelerator.gather_for_metrics
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4261,14 +4261,13 @@ class Trainer:
                 use_seedable_sampler=accelerator_config.pop("use_seedable_sampler"),
             )
         args = {
-            "deepspeed_plugin":self.args.deepspeed_plugin, 
-            "gradient_accumulation_plugin":gradient_accumulation_plugin
+            "deepspeed_plugin": self.args.deepspeed_plugin,
+            "gradient_accumulation_plugin": gradient_accumulation_plugin,
         }
         if is_accelerate_available("0.28.0"):
             args["dataloader_config"] = dataloader_config
         else:
             args.update(accelerator_config)
-
 
         # create accelerator object
         self.accelerator = Accelerator(**args)


### PR DESCRIPTION
# What does this PR do?

Now that accelerate v0.28.0 is out, removes the super annoying future warnings and opts to use the `DataLoaderConfig` 

![image](https://github.com/huggingface/transformers/assets/7831895/72985ebb-dc82-4922-9fe3-7086efd703af)

Follow up to https://github.com/huggingface/transformers/pull/28664


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@pacman100 @amyeroberts 