### PR TITLE
feat: enable multi-device for ResNet

### DIFF
--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -274,6 +274,7 @@ class ResNetPreTrainedModel(PreTrainedModel):
     config_class = ResNetConfig
     base_model_prefix = "resnet"
     main_input_name = "pixel_values"
+    _no_split_modules = []
 
     def _init_weights(self, module):
         if isinstance(module, nn.Conv2d):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

for #29786, [Resnet](https://github.com/huggingface/transformers/blob/main/src/transformers/models/resnet/modeling_resnet.py)

Tested on a dual RTX 3060 system

```
$ pytest tests/models/llama/test_modeling_llama.py -vv -k "offload or parallelism"
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.10.13, pytest-7.4.4, pluggy-1.4.0 -- /opt/conda/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/root/transformers/.hypothesis/examples'))
rootdir: /root/transformers
configfile: pyproject.toml
plugins: hypothesis-6.98.10, xdist-3.5.0, timeout-2.3.1, anyio-4.3.0
collected 150 items / 146 deselected / 4 selected                                                                                                                                 

tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_cpu_offload <- tests/test_modeling_common.py PASSED                                                         [ 25%]
tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_disk_offload_bin <- tests/test_modeling_common.py PASSED                                                    [ 50%]
tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_disk_offload_safetensors <- tests/test_modeling_common.py PASSED                                            [ 75%]
tests/models/llama/test_modeling_llama.py::LlamaModelTest::test_model_parallelism <- tests/test_modeling_common.py PASSED                                                   [100%]

<warnings redacted>
================================================================== 4 passed, 146 deselected, 8 warnings in 4.75s ==================================================================
```

## Who can review?

@amyeroberts 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
