### PR TITLE
Generate: fix generation with `inputs_embeds` when `input_ids=None` for llama and gemma

### DIFF
--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1194,9 +1194,15 @@ class CohereForCausalLM(CoherePreTrainedModel):
             # TODO: use `next_tokens` directly instead.
             model_inputs = {"input_ids": input_ids.contiguous()}
 
-        input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
+        if position_ids is not None:
+            input_length = position_ids.shape[-1]
+        elif input_ids is not None:
+            input_length = input_ids.shape[-1]
+        else:
+            input_length = inputs_embeds.shape[-2]
         if cache_position is None:
-            cache_position = torch.arange(past_length, past_length + input_length, device=input_ids.device)
+            input_tensor = inputs_embeds if input_ids is None else input_ids
+            cache_position = torch.arange(past_length, past_length + input_length, device=input_tensor.device)
         else:
             cache_position = cache_position[-input_length:]
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1198,9 +1198,15 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
             # TODO: use `next_tokens` directly instead.
             model_inputs = {"input_ids": input_ids.contiguous()}
 
-        input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
+        if position_ids is not None:
+            input_length = position_ids.shape[-1]
+        elif input_ids is not None:
+            input_length = input_ids.shape[-1]
+        else:
+            input_length = inputs_embeds.shape[-2]
         if cache_position is None:
-            cache_position = torch.arange(past_length, past_length + input_length, device=input_ids.device)
+            input_tensor = inputs_embeds if input_ids is None else input_ids
+            cache_position = torch.arange(past_length, past_length + input_length, device=input_tensor.device)
         else:
             cache_position = cache_position[-input_length:]
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1295,9 +1295,15 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             # TODO: use `next_tokens` directly instead.
             model_inputs = {"input_ids": input_ids.contiguous()}
 
-        input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
+        if position_ids is not None:
+            input_length = position_ids.shape[-1]
+        elif input_ids is not None:
+            input_length = input_ids.shape[-1]
+        else:
+            input_length = inputs_embeds.shape[-2]
         if cache_position is None:
-            cache_position = torch.arange(past_length, past_length + input_length, device=input_ids.device)
+            input_tensor = inputs_embeds if input_ids is None else input_ids
+            cache_position = torch.arange(past_length, past_length + input_length, device=input_tensor.device)
         else:
             cache_position = cache_position[-input_length:]
 


### PR DESCRIPTION
The changes in https://github.com/huggingface/transformers/pull/29467 break generation with `inputs_embeds` when `input_ids` is `None` since they expect `input_ids` to be non-`None` even for the prefill forward without `past_key_values`.

@gante 