### PR TITLE
[DOCS] Fix typo for llava next docs

### DIFF
--- a/docs/source/en/model_doc/llava_next.md
+++ b/docs/source/en/model_doc/llava_next.md
@@ -101,7 +101,7 @@ print(processor.decode(output[0], skip_special_tokens=True))
 The model can be loaded in 8 or 4 bits, greatly reducing the memory requirements while maintaining the performance of the original model. First make sure to install bitsandbytes, `pip install bitsandbytes`` and make sure to have access to a CUDA compatible GPU device. Simply change the snippet above with:
 
 ```python
-from transformers import LlavaNextForConditionalGeneration, BitsandBytesConfig
+from transformers import LlavaNextForConditionalGeneration, BitsAndBytesConfig
 
 # specify how to quantize the model
 quantization_config = BitsAndBytesConfig(


### PR DESCRIPTION
fix typo in `BitsandBytesConfig` import in the example code
cc @stevhliu @MKhalusova
