### PR TITLE
[`Mamba`] from pretrained issue with `self.embeddings`

### DIFF
--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -501,7 +501,12 @@ class MambaModel(MambaPreTrainedModel):
         self.gradient_checkpointing = False
         self.norm_f = MambaRMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
         # Initialize weights and apply final processing
+        self._register_load_state_dict_pre_hook(self.load_hook)
         self.post_init()
+
+    def load_hook(self, state_dict, prefix, *args):
+        if "embedding" in state_dict:
+            state_dict["embeddings"] = state_dict.pop("embedding", None)
 
     def get_input_embeddings(self):
         return self.embeddings

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -505,8 +505,8 @@ class MambaModel(MambaPreTrainedModel):
         self.post_init()
 
     def load_hook(self, state_dict, prefix, *args):
-        if "embedding" in state_dict:
-            state_dict["embeddings"] = state_dict.pop("embedding", None)
+        if "backbone.embeddings.weight" in state_dict:
+            state_dict["backbone.embeddings.weight"] = state_dict.pop("backbone.embedding.weight", None)
 
     def get_input_embeddings(self):
         return self.embeddings

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -505,8 +505,10 @@ class MambaModel(MambaPreTrainedModel):
         self.post_init()
 
     def load_hook(self, state_dict, prefix, *args):
-        if "backbone.embeddings.weight" in state_dict:
-            state_dict["backbone.embeddings.weight"] = state_dict.pop("backbone.embedding.weight", None)
+        for k in state_dict:
+            if "embedding" in k:
+                state_dict[k.replace("embedding.", "embeddings.")] = state_dict.pop(k)
+                break
 
     def get_input_embeddings(self):
         return self.embeddings

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -506,7 +506,7 @@ class MambaModel(MambaPreTrainedModel):
 
     def load_hook(self, state_dict, prefix, *args):
         for k in state_dict:
-            if "embedding" in k:
+            if "embedding." in k:
                 state_dict[k.replace("embedding.", "embeddings.")] = state_dict.pop(k)
                 break
 


### PR DESCRIPTION
# What does this PR do?
Fixes #29631. There was a typo when porting the models, `self.embeddings` vs `self.embedding` which was not caught because of a `from_pretrained` issue. 

```python
>>> from transformers import AutoModel
>>> model = AutoModel.from_pretrained("state-spaces/mamba-130m-hf")
```
no longer gives a warning