### PR TITLE
Update config class check in auto factory

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -579,7 +579,7 @@ class _BaseAutoModelClass:
             model_class ([`PreTrainedModel`]):
                 The model to register.
         """
-        if hasattr(model_class, "config_class") and model_class.config_class != config_class:
+        if hasattr(model_class, "config_class") and str(model_class.config_class) != str(config_class):
             raise ValueError(
                 "The model class you are passing has a `config_class` attribute that is not consistent with the "
                 f"config class you passed (model has {model_class.config_class} and you passed {config_class}. Fix "


### PR DESCRIPTION
Our code for custom classes checks that `model_class.config_class` matches `config_class`, but this test is behaving oddly - it's returning a failure even though the two classes look identical to me. I changed the test to a string comparison test instead - it's possible that we're just initializing the two classes in slightly different ways, and that's creating two different objects that still represent the same class.

Update: The underlying cause is not my original PR, but PR #29262. The check is failing because we now use `importlib.machinery.SourceFileLoader()` rather than `importlib.import_module`, and this causes the two classes to not be equal (even though all their attributes are the same). I think the string comparison test should work fine as a solution for now!

Fixes #29828

(Probably) fixes #30149