### PR TITLE
Set custom_container in build docs workflows

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,6 +16,7 @@ jobs:
       package: transformers
       notebook_folder: transformers_doc
       languages: de en es fr hi it ko pt tr zh ja te
+      custom_container: huggingface/transformers-doc-builder
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,3 +15,4 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: de en es fr hi it ko pt tr zh ja te
+      custom_container: huggingface/transformers-doc-builder


### PR DESCRIPTION
**TL;DR:** this PR doesn't change anything but prevents future break.

Related to https://github.com/huggingface/doc-builder/pull/487. There is now a `custom_container` option when building docs in CI. When set to `""` (instead of `"huggingface/transformers-doc-builder"` by default), we don't run the CI inside a container, therefore saving ~2min of download time. The plan is to test disabling the transformers container on a few "big" repo and if everything works correctly, we will stop making it the default container. More details on https://github.com/huggingface/doc-builder/pull/487. This PR explicitly set the custom_container to transformers's one to avoid any breaks.

cc @mishig25 