### PR TITLE
Allow different classification labels for each input sequence for zero shot classification to enhance batching performance

### DIFF
--- a/docs/source/en/main_classes/pipelines.md
+++ b/docs/source/en/main_classes/pipelines.md
@@ -453,6 +453,12 @@ Pipelines available for natural language processing tasks include the following.
     - __call__
     - all
 
+### BatchedZeroShotClassificationPipeline
+
+[[autodoc]] BatchedZeroShotClassificationPipeline
+    - __call__
+    - all
+
 ## Multimodal
 
 Pipelines available for multimodal tasks include the following.

--- a/docs/source/ja/main_classes/pipelines.md
+++ b/docs/source/ja/main_classes/pipelines.md
@@ -461,6 +461,12 @@ my_pipeline = pipeline(model="xxxx", pipeline_class=MyPipeline)
     - __call__
     - all
 
+### BatchedZeroShotClassificationPipeline
+
+[[autodoc]] BatchedZeroShotClassificationPipeline
+    - __call__
+    - all
+
 ## Multimodal
 
 マルチモーダル タスクに使用できるパイプラインには次のものがあります。

--- a/docs/source/zh/main_classes/pipelines.md
+++ b/docs/source/zh/main_classes/pipelines.md
@@ -435,6 +435,12 @@ See [`TokenClassificationPipeline`] for all details.
     - __call__
     - all
 
+### BatchedZeroShotClassificationPipeline
+
+[[autodoc]] BatchedZeroShotClassificationPipeline
+    - __call__
+    - all
+
 ## 多模态
 
 可用于多模态任务的pipeline包括以下几种。

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -990,6 +990,7 @@ _import_structure = {
     "pipelines": [
         "AudioClassificationPipeline",
         "AutomaticSpeechRecognitionPipeline",
+        "BatchedZeroShotClassificationPipeline",
         "Conversation",
         "ConversationalPipeline",
         "CsvPipelineDataFormat",
@@ -5852,6 +5853,7 @@ if TYPE_CHECKING:
     from .pipelines import (
         AudioClassificationPipeline,
         AutomaticSpeechRecognitionPipeline,
+        BatchedZeroShotClassificationPipeline,
         Conversation,
         ConversationalPipeline,
         CsvPipelineDataFormat,

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -58,6 +58,7 @@ from .base import (
     get_default_model_and_revision,
     infer_framework_load_model,
 )
+from .batched_zero_shot_classification_pipeline import BatchedZeroShotClassificationPipeline
 from .conversational import Conversation, ConversationalPipeline
 from .depth_estimation import DepthEstimationPipeline
 from .document_question_answering import DocumentQuestionAnsweringPipeline
@@ -303,6 +304,22 @@ SUPPORTED_TASKS = {
     },
     "zero-shot-classification": {
         "impl": ZeroShotClassificationPipeline,
+        "tf": (TFAutoModelForSequenceClassification,) if is_tf_available() else (),
+        "pt": (AutoModelForSequenceClassification,) if is_torch_available() else (),
+        "default": {
+            "model": {
+                "pt": ("facebook/bart-large-mnli", "c626438"),
+                "tf": ("FacebookAI/roberta-large-mnli", "130fb28"),
+            },
+            "config": {
+                "pt": ("facebook/bart-large-mnli", "c626438"),
+                "tf": ("FacebookAI/roberta-large-mnli", "130fb28"),
+            },
+        },
+        "type": "text",
+    },
+    "batched-zero-shot-classification": {
+        "impl": BatchedZeroShotClassificationPipeline,
         "tf": (TFAutoModelForSequenceClassification,) if is_tf_available() else (),
         "pt": (AutoModelForSequenceClassification,) if is_torch_available() else (),
         "default": {
@@ -619,6 +636,7 @@ def pipeline(
             - `"video-classification"`: will return a [`VideoClassificationPipeline`].
             - `"visual-question-answering"`: will return a [`VisualQuestionAnsweringPipeline`].
             - `"zero-shot-classification"`: will return a [`ZeroShotClassificationPipeline`].
+            - `"batched-zero-shot-classification"`: will return a [`BatchedZeroShotClassificationPipeline`].
             - `"zero-shot-image-classification"`: will return a [`ZeroShotImageClassificationPipeline`].
             - `"zero-shot-audio-classification"`: will return a [`ZeroShotAudioClassificationPipeline`].
             - `"zero-shot-object-detection"`: will return a [`ZeroShotObjectDetectionPipeline`].

--- a/src/transformers/pipelines/batched_zero_shot_classification_pipeline.py
+++ b/src/transformers/pipelines/batched_zero_shot_classification_pipeline.py
@@ -1,0 +1,287 @@
+import inspect
+from typing import List, NamedTuple, Tuple, Union
+
+import numpy as np
+
+from ..tokenization_utils import TruncationStrategy
+from ..utils import add_end_docstrings, logging
+from .base import ArgumentHandler, ChunkPipeline, build_pipeline_init_args
+
+
+logger = logging.get_logger(__name__)
+
+
+class _BatchedZeroShotSample(NamedTuple):
+    """
+    Named Tuple implementation for batched zero shot input entity to make the code more readable.
+    """
+
+    sequence: str
+    labels: List[str]
+
+
+class BatchedZeroShotClassificationArgumentHandler(ArgumentHandler):
+    """
+    Handles arguments for batched zero-shot for text classification by turning each possible label into an NLI
+    premise/hypothesis pair.
+    """
+
+    def _parse_labels(self, labels):
+        if isinstance(labels, str):
+            labels = [label.strip() for label in labels.split(",") if label.strip()]
+        return labels
+
+    def __call__(self, inputs, hypothesis_template):
+        if not isinstance(inputs, List):
+            inputs = [inputs]
+        if len(inputs) == 0 or any(len(sample.labels) == 0 for sample in inputs):
+            raise ValueError("You must include at least one label and at least one sequence.")
+        if hypothesis_template.format(inputs[0].labels[0]) == hypothesis_template:
+            raise ValueError(
+                (
+                    'The provided hypothesis_template "{}" was not able to be formatted with the target labels. '
+                    "Make sure the passed template includes formatting syntax such as {{}} where the label should go."
+                ).format(hypothesis_template)
+            )
+        sequence_pairs = []
+        cleaned_input = []
+        for sample in inputs:
+            cleaned_input.extend(
+                [
+                    {"sequence": sample.sequence, "label": label, "is_last": i == len(sample.labels) - 1}
+                    for i, label in enumerate(sample.labels)
+                ]
+            )
+            sequence_pairs.extend([[sample.sequence, hypothesis_template.format(label)] for label in sample.labels])
+
+        return sequence_pairs, cleaned_input
+
+
+@add_end_docstrings(build_pipeline_init_args(has_tokenizer=True))
+class BatchedZeroShotClassificationPipeline(ChunkPipeline):
+    """
+    Clone of the zero shot classification pipeline but accept different labels for each sample
+    Example:
+
+    ```python
+    >>> from transformers import pipeline
+
+    >>> oracle = pipeline('batched-zero-shot-classification' ,model="facebook/bart-large-mnli")
+    >>> oracle(
+    ...      [("I have a problem with my iphone that needs to be resolved asap!!",
+    ...      ["urgent", "not urgent"]),
+    ...      ("I have a problem with my iphone that needs to be resolved asap!!",
+    ...      ["phone", "tablet", "computer"]),
+    ...      ("I have a problem with my iphone that needs to be resolved asap!!",
+    ...      ["english", "german"])]
+    ...  )
+    [{'labels': ['urgent', 'not urgent'],
+      'scores': [0.994754433631897, 0.00524557288736105],
+      'sequence': 'I have a problem with my iphone that needs to be resolved '
+                  'asap!!'},
+     {'labels': ['phone', 'computer', 'tablet'],
+      'scores': [0.9698024988174438, 0.025521162897348404, 0.004676352720707655],
+      'sequence': 'I have a problem with my iphone that needs to be resolved '
+                  'asap!!'},
+     {'labels': ['english', 'german'],
+      'scores': [0.8135161995887756, 0.18648380041122437],
+      'sequence': 'I have a problem with my iphone that needs to be resolved '
+                  'asap!!'}]
+    Learn more about the basics of using a pipeline in the [pipeline tutorial](../pipeline_tutorial)
+
+    This NLI pipeline can currently be loaded from [`pipeline`] using the following task identifier:
+    `"batched-zero-shot-classification"`.
+
+    The models that this pipeline can use are models that have been fine-tuned on an NLI task. See the up-to-date list
+    of available models on [huggingface.co/models](https://huggingface.co/models?search=nli).
+    """
+
+    def __init__(self, args_parser=BatchedZeroShotClassificationArgumentHandler(), *args, **kwargs):
+        self._args_parser = args_parser
+        super().__init__(*args, **kwargs)
+        if self.entailment_id == -1:
+            logger.warning(
+                "Failed to determine 'entailment' label id from the label2id mapping in the model config. Setting to "
+                "-1. Define a descriptive label2id mapping in the model config to ensure correct outputs."
+            )
+
+    @property
+    def entailment_id(self):
+        for label, ind in self.model.config.label2id.items():
+            if label.lower().startswith("entail"):
+                return ind
+        return -1
+
+    def _parse_and_tokenize(
+        self, sequence_pairs, padding=True, add_special_tokens=True, truncation=TruncationStrategy.ONLY_FIRST, **kwargs
+    ):
+        """
+        Parse arguments and tokenize only_first so that hypothesis (label) is not truncated
+        """
+        return_tensors = self.framework
+        if self.tokenizer.pad_token is None:
+            # Override for tokenizers not supporting padding
+            logger.error(
+                "Tokenizer was not supporting padding necessary for zero-shot, attempting to use "
+                " `pad_token=eos_token`"
+            )
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        try:
+            inputs = self.tokenizer(
+                sequence_pairs,
+                add_special_tokens=add_special_tokens,
+                return_tensors=return_tensors,
+                padding=padding,
+                truncation=truncation,
+            )
+        except Exception as e:
+            if "too short" in str(e):
+                # tokenizers might yell that we want to truncate
+                # to a value that is not even reached by the input.
+                # In that case we don't want to truncate.
+                # It seems there's not a really better way to catch that
+                # exception.
+
+                inputs = self.tokenizer(
+                    sequence_pairs,
+                    add_special_tokens=add_special_tokens,
+                    return_tensors=return_tensors,
+                    padding=padding,
+                    truncation=TruncationStrategy.DO_NOT_TRUNCATE,
+                )
+            else:
+                raise e
+
+        return inputs
+
+    def _sanitize_parameters(self, **kwargs):
+        if kwargs.get("multi_class", None) is not None:
+            kwargs["multi_label"] = kwargs["multi_class"]
+            logger.warning(
+                "The `multi_class` argument has been deprecated and renamed to `multi_label`. "
+                "`multi_class` will be removed in a future version of Transformers."
+            )
+        preprocess_params = {}
+        if "hypothesis_template" in kwargs:
+            preprocess_params["hypothesis_template"] = kwargs["hypothesis_template"]
+
+        postprocess_params = {}
+        if "multi_label" in kwargs:
+            postprocess_params["multi_label"] = kwargs["multi_label"]
+        return preprocess_params, {}, postprocess_params
+
+    def _validate_sample(self, sample):
+        return (
+            isinstance(sample, Tuple)
+            and len(sample) == 2
+            and isinstance(sample[0], str)
+            and (
+                isinstance(sample[1], str)
+                or (isinstance(sample[1], list) and all((isinstance(label, str) for label in sample[1])))
+            )
+        )
+
+    def __call__(
+        self,
+        inputs: Union[Tuple[str, List[str]], List[Tuple[str, List[str]]]],
+        **kwargs,
+    ):
+        """
+        Classify the sequence(s) given as inputs. See the [`ZeroShotClassificationPipeline`] documentation for more
+        information.
+
+        Args:
+            sequences (Tuple(`str`, List[str] or str) or `List` of the same Tuple):
+                The sequence(s) to classify with there respective labels, will be truncated if the model input is too large.
+            hypothesis_template (`str`, *optional*, defaults to `"This example is {}."`):
+                The template used to turn each label into an NLI-style hypothesis. This template must include a {} or
+                similar syntax for the candidate label to be inserted into the template. For example, the default
+                template is `"This example is {}."` With the candidate label `"sports"`, this would be fed into the
+                model like `"<cls> sequence to classify <sep> This example is sports . <sep>"`. The default template
+                works well in many cases, but it may be worthwhile to experiment with different templates depending on
+                the task setting.
+            multi_label (`bool`, *optional*, defaults to `False`):
+                Whether or not multiple candidate labels can be true. If `False`, the scores are normalized such that
+                the sum of the label likelihoods for each sequence is 1. If `True`, the labels are considered
+                independent and probabilities are normalized for each candidate by doing a softmax of the entailment
+                score vs. the contradiction score.
+
+        Return:
+            A `dict` or a list of `dict`: Each result comes as a dictionary with the following keys:
+
+            - **sequence** (`str`) -- The sequence for which this is the output.
+            - **labels** (`List[str]`) -- The labels sorted by order of likelihood.
+            - **scores** (`List[float]`) -- The probabilities for each of the labels.
+        """
+        if not isinstance(inputs, List):
+            inputs = [inputs]
+
+        if not all((self._validate_sample(sample) for sample in inputs)):
+            raise ValueError(
+                "Inputs to must be of type Tuple of (str, list[str]) or Tuple of (str, str) or list of those tuples"
+            )
+        inputs = [
+            sample
+            if isinstance(sample, _BatchedZeroShotSample)
+            else _BatchedZeroShotSample(sample[0], self._args_parser._parse_labels(sample[1]))
+            for sample in inputs
+        ]
+        return super().__call__(inputs, **kwargs)
+
+    def preprocess(self, inputs, hypothesis_template="This example is {}."):
+        sequence_pairs, cleaned_inputs = self._args_parser(inputs, hypothesis_template)
+
+        for sequence_pair, cleaned_input in zip(sequence_pairs, cleaned_inputs):
+            model_input = self._parse_and_tokenize([sequence_pair])
+            yield {
+                "candidate_label": cleaned_input["label"],
+                "sequence": cleaned_input["sequence"],
+                "is_last": cleaned_input["is_last"],
+                **model_input,
+            }
+
+    def _forward(self, inputs):
+        candidate_label = inputs["candidate_label"]
+        sequence = inputs["sequence"]
+        model_inputs = {k: inputs[k] for k in self.tokenizer.model_input_names}
+        # `XXXForSequenceClassification` models should not use `use_cache=True` even if it's supported
+        model_forward = self.model.forward if self.framework == "pt" else self.model.call
+        if "use_cache" in inspect.signature(model_forward).parameters.keys():
+            model_inputs["use_cache"] = False
+        outputs = self.model(**model_inputs)
+
+        model_outputs = {
+            "candidate_label": candidate_label,
+            "sequence": sequence,
+            "is_last": inputs["is_last"],
+            **outputs,
+        }
+        return model_outputs
+
+    def postprocess(self, model_outputs, multi_label=False):
+        candidate_labels = [outputs["candidate_label"] for outputs in model_outputs]
+        sequences = [outputs["sequence"] for outputs in model_outputs]
+        logits = np.concatenate([output["logits"].numpy() for output in model_outputs])
+        N = logits.shape[0]
+        n = len(candidate_labels)
+        num_sequences = N // n
+        reshaped_outputs = logits.reshape((num_sequences, n, -1))
+
+        if multi_label or len(candidate_labels) == 1:
+            # softmax over the entailment vs. contradiction dim for each label independently
+            entailment_id = self.entailment_id
+            contradiction_id = -1 if entailment_id == 0 else 0
+            entail_contr_logits = reshaped_outputs[..., [contradiction_id, entailment_id]]
+            scores = np.exp(entail_contr_logits) / np.exp(entail_contr_logits).sum(-1, keepdims=True)
+            scores = scores[..., 1]
+        else:
+            # softmax the "entailment" logits over all candidate labels
+            entail_logits = reshaped_outputs[..., self.entailment_id]
+            scores = np.exp(entail_logits) / np.exp(entail_logits).sum(-1, keepdims=True)
+
+        top_inds = list(reversed(scores[0].argsort()))
+        return {
+            "sequence": sequences[0],
+            "labels": [candidate_labels[i] for i in top_inds],
+            "scores": scores[0, top_inds].tolist(),
+        }

--- a/tests/pipelines/test_pipelines_batched_zero_shot.py
+++ b/tests/pipelines/test_pipelines_batched_zero_shot.py
@@ -1,0 +1,311 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import (
+    MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
+    TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING,
+    BatchedZeroShotClassificationPipeline,
+    Pipeline,
+    pipeline,
+)
+from transformers.testing_utils import is_pipeline_test, nested_simplify, require_tf, require_torch, slow
+
+from .test_pipelines_common import ANY
+
+
+# These 2 model types require different inputs than those of the usual text models.
+_TO_SKIP = {"LayoutLMv2Config", "LayoutLMv3Config"}
+
+
+@is_pipeline_test
+class BatchedZeroShotClassificationPipelineTests(unittest.TestCase):
+    model_mapping = MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+    tf_model_mapping = TF_MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING
+
+    if model_mapping is not None:
+        model_mapping = {config: model for config, model in model_mapping.items() if config.__name__ not in _TO_SKIP}
+    if tf_model_mapping is not None:
+        tf_model_mapping = {
+            config: model for config, model in tf_model_mapping.items() if config.__name__ not in _TO_SKIP
+        }
+
+    def get_test_pipeline(self, model, tokenizer, processor):
+        classifier = BatchedZeroShotClassificationPipeline(
+            model=model, tokenizer=tokenizer, candidate_labels=["polics", "health"]
+        )
+        return classifier, ["Who are you voting for in 2020?", "My stomach hurts."]
+
+    def run_pipeline_test(self, classifier, _):
+        outputs = classifier(("Who are you voting for in 2020?", "politics"))
+        self.assertEqual(outputs, {"sequence": ANY(str), "labels": [ANY(str)], "scores": [ANY(float)]})
+
+        outputs = classifier(("Who are you voting for in 2020?", ["politics"]))
+        self.assertEqual(outputs, {"sequence": ANY(str), "labels": [ANY(str)], "scores": [ANY(float)]})
+
+        outputs = classifier(("Who are you voting for in 2020?", "politics, public health"))
+        self.assertEqual(
+            outputs, {"sequence": ANY(str), "labels": [ANY(str), ANY(str)], "scores": [ANY(float), ANY(float)]}
+        )
+        self.assertAlmostEqual(sum(nested_simplify(outputs["scores"])), 1.0)
+
+        outputs = classifier(("Who are you voting for in 2020?", ["politics", "public health"]))
+        self.assertEqual(
+            outputs, {"sequence": ANY(str), "labels": [ANY(str), ANY(str)], "scores": [ANY(float), ANY(float)]}
+        )
+        self.assertAlmostEqual(sum(nested_simplify(outputs["scores"])), 1.0)
+
+        outputs = classifier(
+            ("Who are you voting for in 2020?", "politics"), hypothesis_template="This text is about {}"
+        )
+        self.assertEqual(outputs, {"sequence": ANY(str), "labels": [ANY(str)], "scores": [ANY(float)]})
+
+        # https://github.com/huggingface/transformers/issues/13846
+        outputs = classifier([("I am happy", ["positive", "negative"])])
+        self.assertEqual(
+            outputs,
+            [
+                {"sequence": ANY(str), "labels": [ANY(str), ANY(str)], "scores": [ANY(float), ANY(float)]}
+                for i in range(1)
+            ],
+        )
+        outputs = classifier([("I am happy", "I am sad", ["positive", "negative"])])
+        self.assertEqual(
+            outputs,
+            [
+                {"sequence": ANY(str), "labels": [ANY(str), ANY(str)], "scores": [ANY(float), ANY(float)]}
+                for i in range(2)
+            ],
+        )
+
+        with self.assertRaises(ValueError):
+            classifier(("", "politics"))
+
+        with self.assertRaises(TypeError):
+            classifier((None, "politics"))
+
+        with self.assertRaises(ValueError):
+            classifier(("Who are you voting for in 2020?"))
+
+        with self.assertRaises(TypeError):
+            classifier(("Who are you voting for in 2020?", None))
+
+        with self.assertRaises(ValueError):
+            classifier(
+                ("Who are you voting for in 2020?", "politics"),
+                hypothesis_template="Not formatting template",
+            )
+
+        with self.assertRaises(AttributeError):
+            classifier(
+                ("Who are you voting for in 2020?", "politics"),
+                hypothesis_template=None,
+            )
+
+        self.run_entailment_id(classifier)
+
+    def run_entailment_id(self, zero_shot_classifier: Pipeline):
+        config = zero_shot_classifier.model.config
+        original_label2id = config.label2id
+        original_entailment = zero_shot_classifier.entailment_id
+
+        config.label2id = {"LABEL_0": 0, "LABEL_1": 1, "LABEL_2": 2}
+        self.assertEqual(zero_shot_classifier.entailment_id, -1)
+
+        config.label2id = {"entailment": 0, "neutral": 1, "contradiction": 2}
+        self.assertEqual(zero_shot_classifier.entailment_id, 0)
+
+        config.label2id = {"ENTAIL": 0, "NON-ENTAIL": 1}
+        self.assertEqual(zero_shot_classifier.entailment_id, 0)
+
+        config.label2id = {"ENTAIL": 2, "NEUTRAL": 1, "CONTR": 0}
+        self.assertEqual(zero_shot_classifier.entailment_id, 2)
+
+        zero_shot_classifier.model.config.label2id = original_label2id
+        self.assertEqual(original_entailment, zero_shot_classifier.entailment_id)
+
+    @require_torch
+    def test_truncation(self):
+        zero_shot_classifier = pipeline(
+            "batched-zero-shot-classification",
+            model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
+            framework="pt",
+        )
+        # There was a regression in 4.10 for this
+        # Adding a test so we don't make the mistake again.
+        # https://github.com/huggingface/transformers/issues/13381#issuecomment-912343499
+        zero_shot_classifier(("Who are you voting for in 2020?" * 100, ["politics", "public health", "science"]))
+
+    @require_torch
+    def test_small_model_pt(self):
+        zero_shot_classifier = pipeline(
+            "batched-zero-shot-classification",
+            model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
+            framework="pt",
+        )
+        outputs = zero_shot_classifier(("Who are you voting for in 2020?", ["politics", "public health", "science"]))
+
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": "Who are you voting for in 2020?",
+                    "labels": ["science", "public health", "politics"],
+                    "scores": [0.333, 0.333, 0.333],
+                }
+            ],
+        )
+
+    @require_tf
+    def test_small_model_tf(self):
+        zero_shot_classifier = pipeline(
+            "batched-zero-shot-classification",
+            model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
+            framework="tf",
+        )
+        outputs = zero_shot_classifier(("Who are you voting for in 2020?", ["politics", "public health", "science"]))
+
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": "Who are you voting for in 2020?",
+                    "labels": ["science", "public health", "politics"],
+                    "scores": [0.333, 0.333, 0.333],
+                }
+            ],
+        )
+
+    @slow
+    @require_torch
+    def test_large_model_pt(self):
+        zero_shot_classifier = pipeline(
+            "batched-zero-shot-classification", model="FacebookAI/roberta-large-mnli", framework="pt"
+        )
+        outputs = zero_shot_classifier(("Who are you voting for in 2020?", ["politics", "public health", "science"]))
+
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": "Who are you voting for in 2020?",
+                    "labels": ["politics", "public health", "science"],
+                    "scores": [0.976, 0.015, 0.009],
+                }
+            ],
+        )
+        outputs = zero_shot_classifier(
+            (
+                "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks"
+                " in an encoder-decoder configuration. The best performing models also connect the encoder and decoder"
+                " through an attention mechanism. We propose a new simple network architecture, the Transformer, based"
+                " solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two"
+                " machine translation tasks show these models to be superior in quality while being more parallelizable"
+                " and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014"
+                " English-to-German translation task, improving over the existing best results, including ensembles by"
+                " over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new"
+                " single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small"
+                " fraction of the training costs of the best models from the literature. We show that the Transformer"
+                " generalizes well to other tasks by applying it successfully to English constituency parsing both with"
+                " large and limited training data.",
+                ["machine learning", "statistics", "translation", "vision"],
+            ),
+            multi_label=True,
+        )
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": (
+                        "The dominant sequence transduction models are based on complex recurrent or convolutional neural"
+                        " networks in an encoder-decoder configuration. The best performing models also connect the"
+                        " encoder and decoder through an attention mechanism. We propose a new simple network"
+                        " architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence"
+                        " and convolutions entirely. Experiments on two machine translation tasks show these models to be"
+                        " superior in quality while being more parallelizable and requiring significantly less time to"
+                        " train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task,"
+                        " improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014"
+                        " English-to-French translation task, our model establishes a new single-model state-of-the-art"
+                        " BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training"
+                        " costs of the best models from the literature. We show that the Transformer generalizes well to"
+                        " other tasks by applying it successfully to English constituency parsing both with large and"
+                        " limited training data."
+                    ),
+                    "labels": ["translation", "machine learning", "vision", "statistics"],
+                    "scores": [0.817, 0.713, 0.018, 0.018],
+                }
+            ],
+        )
+
+    @slow
+    @require_tf
+    def test_large_model_tf(self):
+        zero_shot_classifier = pipeline(
+            "batched-zero-shot-classification", model="FacebookAI/roberta-large-mnli", framework="tf"
+        )
+        outputs = zero_shot_classifier(("Who are you voting for in 2020?", ["politics", "public health", "science"]))
+
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": "Who are you voting for in 2020?",
+                    "labels": ["politics", "public health", "science"],
+                    "scores": [0.976, 0.015, 0.009],
+                }
+            ],
+        )
+        outputs = zero_shot_classifier(
+            (
+                "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks"
+                " in an encoder-decoder configuration. The best performing models also connect the encoder and decoder"
+                " through an attention mechanism. We propose a new simple network architecture, the Transformer, based"
+                " solely on attention mechanisms, dispensing with recurrence and convolutions entirely. Experiments on two"
+                " machine translation tasks show these models to be superior in quality while being more parallelizable"
+                " and requiring significantly less time to train. Our model achieves 28.4 BLEU on the WMT 2014"
+                " English-to-German translation task, improving over the existing best results, including ensembles by"
+                " over 2 BLEU. On the WMT 2014 English-to-French translation task, our model establishes a new"
+                " single-model state-of-the-art BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small"
+                " fraction of the training costs of the best models from the literature. We show that the Transformer"
+                " generalizes well to other tasks by applying it successfully to English constituency parsing both with"
+                " large and limited training data.",
+                ["machine learning", "statistics", "translation", "vision"],
+            ),
+            multi_label=True,
+        )
+        self.assertEqual(
+            nested_simplify(outputs),
+            [
+                {
+                    "sequence": (
+                        "The dominant sequence transduction models are based on complex recurrent or convolutional neural"
+                        " networks in an encoder-decoder configuration. The best performing models also connect the"
+                        " encoder and decoder through an attention mechanism. We propose a new simple network"
+                        " architecture, the Transformer, based solely on attention mechanisms, dispensing with recurrence"
+                        " and convolutions entirely. Experiments on two machine translation tasks show these models to be"
+                        " superior in quality while being more parallelizable and requiring significantly less time to"
+                        " train. Our model achieves 28.4 BLEU on the WMT 2014 English-to-German translation task,"
+                        " improving over the existing best results, including ensembles by over 2 BLEU. On the WMT 2014"
+                        " English-to-French translation task, our model establishes a new single-model state-of-the-art"
+                        " BLEU score of 41.8 after training for 3.5 days on eight GPUs, a small fraction of the training"
+                        " costs of the best models from the literature. We show that the Transformer generalizes well to"
+                        " other tasks by applying it successfully to English constituency parsing both with large and"
+                        " limited training data."
+                    ),
+                    "labels": ["translation", "machine learning", "vision", "statistics"],
+                    "scores": [0.817, 0.713, 0.018, 0.018],
+                }
+            ],
+        )

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -801,6 +801,7 @@ OBJECTS_TO_IGNORE = [
     "YosoConfig",
     "ZeroShotAudioClassificationPipeline",
     "ZeroShotClassificationPipeline",
+    "BatchedZeroShotClassificationPipeline",
     "ZeroShotImageClassificationPipeline",
     "ZeroShotObjectDetectionPipeline",
 ]


### PR DESCRIPTION
# What does this PR do?
Following on this feature request [https://github.com/huggingface/transformers/issues/29793](https://github.com/huggingface/transformers/issues/29793)

This PR create a new pipeline for zero shot text classification that accept different type of input. This input type group the labels there respective sequence. With that you can do one call with multiple different labels and batch the prediction. This will make prediction more efficient in the case of multiple type of labels classification. 


## Before submitting


- [] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline] (https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/transformers/issues/29793
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@younesbelkada @ArthurZucker @Narsil

