### PR TITLE
Disable AMD memory benchmarks

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -34,3 +34,6 @@ RUN python3 -m pip uninstall -y tensorflow flax
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop
+
+# Remove py3nvml as it is not compatible with ROCm
+RUN pip uninstall py3nvml

--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -35,5 +35,5 @@ RUN python3 -m pip uninstall -y tensorflow flax
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop
 
-# Remove py3nvml as it is not compatible with ROCm
-RUN pip uninstall py3nvml
+# Remove nvml as it is not compatible with ROCm
+RUN python3 -m pip uninstall py3nvml pynvml -y

--- a/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
@@ -43,3 +43,6 @@ RUN python3 -m pip install --no-cache-dir ./transformers[accelerate,testing,sent
 RUN cd transformers && python3 setup.py develop
 
 RUN python3 -c "from deepspeed.launcher.runner import main"
+
+# Remove py3nvml as it is not compatible with ROCm
+RUN pip uninstall py3nvml

--- a/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
@@ -44,5 +44,5 @@ RUN cd transformers && python3 setup.py develop
 
 RUN python3 -c "from deepspeed.launcher.runner import main"
 
-# Remove py3nvml as it is not compatible with ROCm
-RUN pip uninstall py3nvml
+# Remove nvml as it is not compatible with ROCm
+RUN python3 -m pip uninstall py3nvml pynvml -y


### PR DESCRIPTION
# What does this PR do?

This PR disables the memory measurements using `pynvml`/`py3nvml` on AMD GPUs as `nvml` is not compatible with ROCm.

Benchmark tests passing: https://github.com/huggingface/transformers/actions/runs/8431639514/job/23095964749