### PR TITLE
Update pipeline torch_dtype property not to return dtype when it is not Pytorch model.

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -969,7 +969,8 @@ class Pipeline(_ScikitCompat):
         """
         Torch dtype of the model (if it's Pytorch model), `None` otherwise.
         """
-        return getattr(self.model, "dtype", None)
+        model_dtype = getattr(self.model, "dtype", None)
+        return model_dtype if is_torch_available and isinstance(model_dtype, torch.dtype) else None
 
     @contextmanager
     def device_placement(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -222,6 +222,11 @@ class CommonPipelineTest(unittest.TestCase):
         pipe.model = None
         self.assertIsNone(pipe.torch_dtype)
 
+    @require_tf
+    def test_torch_dtype_property_returns_none_for_tf_model(self):
+        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert", framework="tf")
+        self.assertIsNone(pipe.torch_dtype)
+
 
 @is_pipeline_test
 class PipelineScikitCompatTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?
Follow-up for #28940. The previous PR added `torch_dtype` property, but it also returns dtype string for Tensorflow model, which is not accurate behavior for the property name. This PR fixes the property only returns `torch.dtype` object of Pytorch models.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? Yes, also tested the property for Pytorch/Tensorflow models locally.


## Who can review?

@ArthurZucker (as the reviewer of the previous PR)