### PR TITLE
fix fuyu device_map compatibility

### DIFF
--- a/src/transformers/models/fuyu/modeling_fuyu.py
+++ b/src/transformers/models/fuyu/modeling_fuyu.py
@@ -290,7 +290,9 @@ class FuyuForCausalLM(FuyuPreTrainedModel):
             inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
             if image_patches is not None and past_key_values is None:
                 patch_embeddings = [
-                    self.vision_embed_tokens(patch.to(self.vision_embed_tokens.weight.dtype)).squeeze(0)
+                    self.vision_embed_tokens(patch.to(self.vision_embed_tokens.weight.dtype))
+                    .squeeze(0)
+                    .to(inputs_embeds.device)
                     for patch in image_patches
                 ]
                 inputs_embeds = self.gather_continuous_embeddings(


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes the multi-gpu issue that users were experiencing here https://github.com/huggingface/transformers/issues/29848. This happened because this [PR](https://github.com/huggingface/transformers/pull/27007) kinda reverted the changes I made to make it compatible with `device_map` [here](https://github.com/huggingface/transformers/pull/26949). 
This is not very elegant since we need to modify the forward a bit, but this is an exception since we are dealing with the output of the vision model and the input of the language model. 