### PR TITLE
Improve torch version check

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -180,8 +180,8 @@ if USE_TORCH in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TF not in ENV_VARS_TRUE_VA
         import torch
 
         _torch_version = torch.__version__
-        if '+' in _torch_version:
-            torch_version = _torch_version.split('+')[0]
+        if "+" in _torch_version:
+            torch_version = _torch_version.split("+")[0]
 else:
     logger.info("Disabling PyTorch because USE_TF is set")
     _torch_available = False


### PR DESCRIPTION
`import_utils.py` has a lot of functions for checking when packages are available, and also what their version is. However, some problems can occur because `_is_package_available` uses `importlib.metadata` to check versions, but this checks the version of the [distribution package, not the import package](https://packaging.python.org/en/latest/discussions/distribution-package-vs-import-package/). Therefore, it fails when the distribution package cannot be correctly located, even if `torch` is available.

I reworked the test in the following ways:

1) Stop reporting any package as unavailable just because we can't find its version, unless the version was specifically requested
2) Modify the `torch` check specifically to import torch and check its version directly, in the case when `torch` is importable but the distribution package version cannot be determined.

Fixes #29861