### PR TITLE
[`GptNeox`] don't gather on pkv when using the trainer

### DIFF
--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -103,6 +103,7 @@ class GPTNeoXConfig(PretrainedConfig):
     ```"""
 
     model_type = "gpt_neox"
+    keys_to_ignore_at_inference = ["past_key_values"]
 
     def __init__(
         self,


### PR DESCRIPTION
# What does this PR do?
Fixes #29376 by adding `"keys_to_ignore_at_inference"` to the config