### PR TITLE
Make EncodecModel.decode ONNX exportable

### DIFF
--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -111,15 +111,24 @@ class EncodecConv1d(nn.Module):
         elif self.norm_type == "time_group_norm":
             self.norm = nn.GroupNorm(1, out_channels)
 
-    @staticmethod
+        kernel_size = self.conv.kernel_size[0]
+        stride = torch.tensor(self.conv.stride[0])
+        dilation = self.conv.dilation[0]
+        kernel_size = torch.tensor((kernel_size - 1) * dilation + 1)  # effective kernel size with dilations
+
+        self.register_buffer("stride", stride, persistent=False)
+        self.register_buffer("kernel_size", kernel_size, persistent=False)
+        self.register_buffer("padding_total", torch.tensor(kernel_size - stride), persistent=False)
+
     def _get_extra_padding_for_conv1d(
-        hidden_states: torch.Tensor, kernel_size: int, stride: int, padding_total: int = 0
-    ) -> int:
+        self, hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
         """See `pad_for_conv1d`."""
         length = hidden_states.shape[-1]
-        n_frames = (length - kernel_size + padding_total) / stride + 1
-        ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
-        return ideal_length - length
+        n_frames = (length - self.kernel_size + self.padding_total) / self.stride + 1
+        ideal_length = ((torch.ceil(n_frames) - 1) * self.stride + (self.kernel_size - self.padding_total)) / 1.  # Fixes Cannot input a tensor of type Float as an integral argument
+        return (ideal_length - length).to(torch.int64)
+
 
     @staticmethod
     def _pad1d(hidden_states: torch.Tensor, paddings: Tuple[int, int], mode: str = "zero", value: float = 0.0):
@@ -141,20 +150,15 @@ class EncodecConv1d(nn.Module):
         return padded[..., :end]
 
     def forward(self, hidden_states):
-        kernel_size = self.conv.kernel_size[0]
-        stride = self.conv.stride[0]
-        dilation = self.conv.dilation[0]
-        kernel_size = (kernel_size - 1) * dilation + 1  # effective kernel size with dilations
-        padding_total = kernel_size - stride
-        extra_padding = self._get_extra_padding_for_conv1d(hidden_states, kernel_size, stride, padding_total)
+        extra_padding = self._get_extra_padding_for_conv1d(hidden_states)
 
         if self.causal:
             # Left padding for causal
-            hidden_states = self._pad1d(hidden_states, (padding_total, extra_padding), mode=self.pad_mode)
+            hidden_states = self._pad1d(hidden_states, (self.padding_total, extra_padding), mode=self.pad_mode)
         else:
             # Asymmetric padding required for odd strides
-            padding_right = padding_total // 2
-            padding_left = padding_total - padding_right
+            padding_right = self.padding_total // 2
+            padding_left = self.padding_total - padding_right
             hidden_states = self._pad1d(
                 hidden_states, (padding_left, padding_right + extra_padding), mode=self.pad_mode
             )

--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -112,13 +112,13 @@ class EncodecConv1d(nn.Module):
             self.norm = nn.GroupNorm(1, out_channels)
 
         kernel_size = self.conv.kernel_size[0]
-        stride = torch.tensor(self.conv.stride[0])
+        stride = torch.tensor(self.conv.stride[0], dtype=torch.int64)
         dilation = self.conv.dilation[0]
-        kernel_size = torch.tensor((kernel_size - 1) * dilation + 1)  # effective kernel size with dilations
+        kernel_size = torch.tensor((kernel_size - 1) * dilation + 1, dtype=torch.int64)  # effective kernel size with dilations
 
         self.register_buffer("stride", stride, persistent=False)
         self.register_buffer("kernel_size", kernel_size, persistent=False)
-        self.register_buffer("padding_total", torch.tensor(kernel_size - stride), persistent=False)
+        self.register_buffer("padding_total", torch.tensor(kernel_size - stride, dtype=torch.int64), persistent=False)
 
     def _get_extra_padding_for_conv1d(
         self, hidden_states: torch.Tensor,
@@ -126,8 +126,8 @@ class EncodecConv1d(nn.Module):
         """See `pad_for_conv1d`."""
         length = hidden_states.shape[-1]
         n_frames = (length - self.kernel_size + self.padding_total) / self.stride + 1
-        ideal_length = ((torch.ceil(n_frames) - 1) * self.stride + (self.kernel_size - self.padding_total)) / 1.  # Fixes Cannot input a tensor of type Float as an integral argument
-        return (ideal_length - length).to(torch.int64)
+        ideal_length = ((torch.ceil(n_frames).to(torch.int64) - 1) * self.stride + (self.kernel_size - self.padding_total))
+        return ideal_length - length
 
 
     @staticmethod

--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -114,21 +114,25 @@ class EncodecConv1d(nn.Module):
         kernel_size = self.conv.kernel_size[0]
         stride = torch.tensor(self.conv.stride[0], dtype=torch.int64)
         dilation = self.conv.dilation[0]
-        kernel_size = torch.tensor((kernel_size - 1) * dilation + 1, dtype=torch.int64)  # effective kernel size with dilations
+        kernel_size = torch.tensor(
+            (kernel_size - 1) * dilation + 1, dtype=torch.int64
+        )  # effective kernel size with dilations
 
         self.register_buffer("stride", stride, persistent=False)
         self.register_buffer("kernel_size", kernel_size, persistent=False)
         self.register_buffer("padding_total", torch.tensor(kernel_size - stride, dtype=torch.int64), persistent=False)
 
     def _get_extra_padding_for_conv1d(
-        self, hidden_states: torch.Tensor,
+        self,
+        hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         """See `pad_for_conv1d`."""
         length = hidden_states.shape[-1]
         n_frames = (length - self.kernel_size + self.padding_total) / self.stride + 1
-        ideal_length = ((torch.ceil(n_frames).to(torch.int64) - 1) * self.stride + (self.kernel_size - self.padding_total))
+        ideal_length = (torch.ceil(n_frames).to(torch.int64) - 1) * self.stride + (
+            self.kernel_size - self.padding_total
+        )
         return ideal_length - length
-
 
     @staticmethod
     def _pad1d(hidden_states: torch.Tensor, paddings: Tuple[int, int], mode: str = "zero", value: float = 0.0):

--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -114,9 +114,9 @@ class EncodecConv1d(nn.Module):
         kernel_size = self.conv.kernel_size[0]
         stride = torch.tensor(self.conv.stride[0], dtype=torch.int64)
         dilation = self.conv.dilation[0]
-        kernel_size = torch.tensor(
-            (kernel_size - 1) * dilation + 1, dtype=torch.int64
-        )  # effective kernel size with dilations
+
+        # Effective kernel size with dilations.
+        kernel_size = torch.tensor((kernel_size - 1) * dilation + 1, dtype=torch.int64)
 
         self.register_buffer("stride", stride, persistent=False)
         self.register_buffer("kernel_size", kernel_size, persistent=False)
@@ -129,9 +129,9 @@ class EncodecConv1d(nn.Module):
         """See `pad_for_conv1d`."""
         length = hidden_states.shape[-1]
         n_frames = (length - self.kernel_size + self.padding_total) / self.stride + 1
-        ideal_length = (torch.ceil(n_frames).to(torch.int64) - 1) * self.stride + (
-            self.kernel_size - self.padding_total
-        )
+        n_frames = torch.ceil(n_frames).to(torch.int64) - 1
+        ideal_length = n_frames * self.stride + self.kernel_size - self.padding_total
+
         return ideal_length - length
 
     @staticmethod


### PR DESCRIPTION
As per title. This is needed for the ONNX export of Musicgen e.g. for transformers.js

This removes an important warning:
```
/home/fxmarty/hf_internship/transformers/src/transformers/models/encodec/modeling_encodec.py:121: TracerWarning: Converting a tensor to a Python float might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
```
where a padding length was previously hard-coded and applied here https://github.com/huggingface/transformers/blob/f01e1609bf4dba146d1347c1368c8c49df8636f6/src/transformers/models/encodec/modeling_encodec.py#L149-L160