### PR TITLE
fix: get mlflow version from mlflow-skinny

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -131,6 +131,13 @@ def is_mlflow_available():
     return importlib.util.find_spec("mlflow") is not None
 
 
+def get_mlflow_version():
+    try:
+        return importlib.metadata.version("mlflow")
+    except importlib.metadata.PackageNotFoundError:
+        return importlib.metadata.version("mlflow-skinny")
+
+
 def is_dagshub_available():
     return None not in [importlib.util.find_spec("dagshub"), importlib.util.find_spec("mlflow")]
 
@@ -1002,7 +1009,7 @@ class MLflowCallback(TrainerCallback):
         # "synchronous" flag is only available with mlflow version >= 2.8.0
         # https://github.com/mlflow/mlflow/pull/9705
         # https://github.com/mlflow/mlflow/releases/tag/v2.8.0
-        if packaging.version.parse(importlib.metadata.version("mlflow")) >= packaging.version.parse("2.8.0"):
+        if packaging.version.parse(get_mlflow_version()) >= packaging.version.parse("2.8.0"):
             self._async_log = True
         logger.debug(
             f"MLflow experiment_name={self._experiment_name}, run_name={args.run_name}, nested={self._nested_run},"


### PR DESCRIPTION
# What does this PR do?

`mlflow` module can be provided by either [mlflow](https://pypi.org/project/mlflow/) or [mlflow-skinny](https://pypi.org/project/mlflow-skinny/) packages. The latter is a more lightweight option.

After a [recent change](https://github.com/huggingface/transformers/pull/29195) the usages of `mlflow-skinny` are broken for `transformers` see [this discussion](https://github.com/huggingface/transformers/pull/29195/files#r1541386713):
```
if packaging.version.parse(importlib.metadata.version("mlflow")) >= packaging.version.parse("2.8.0"):
  File "/opt/conda/lib/python3.9/importlib/metadata.py", line 569, in version
return distribution(distribution_name).version
  File "/opt/conda/lib/python3.9/importlib/metadata.py", line 542, in distribution
return Distribution.from_name(distribution_name)
  File "/opt/conda/lib/python3.9/importlib/metadata.py", line 196, in from_name
raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: mlflow
```

Fun fact: `importlib.util.find_spec("mlflow") is not None` check in `is_mlflow_available` actually passes for `mlflow-skinny`.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #29195


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? `I didn't find any tests for this functionality at all`


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
