### PR TITLE
[`make fix-copies`] update and help

### DIFF
--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -313,7 +313,7 @@ def split_code_into_blocks(
         target_block_name = re.search(
             rf"^{' ' * (indent - 4)}((class|def)\s+\S+)(\(|\:)", lines[start_index]
         ).groups()[0]
-    except:
+    except ValueError:
         raise ValueError(
             f"Tried to split a class or function. It did not work. Error comes from line {start_index}: ```\n"
             + "".join(lines[start_index:end_index])

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -309,7 +309,16 @@ def split_code_into_blocks(
     """
     splits = []
     # `indent - 4` is the indent level of the target class/func header
-    target_block_name = re.search(rf"^{' ' * (indent - 4)}((class|def)\s+\S+)(\(|\:)", lines[start_index]).groups()[0]
+    try:
+        target_block_name = re.search(
+            rf"^{' ' * (indent - 4)}((class|def)\s+\S+)(\(|\:)", lines[start_index]
+        ).groups()[0]
+    except:
+        raise ValueError(
+            f"Tried to split a class or function. It did not work. Error comes from line {start_index}: ```\n"
+            + "".join(lines[start_index:end_index])
+            + "```\n"
+        )
 
     # from now on, the `block` means inner blocks unless explicitly specified
     indent_str = " " * indent


### PR DESCRIPTION
# What does this PR do?
```python
(py310) ➜  transformers git:(add-rwkv5) ✗ make fixup 
Checking/fixing src/transformers/__init__.py src/transformers/models/__init__.py src/transformers/models/auto/configuration_auto.py src/transformers/models/auto/modeling_auto.py src/transformers/models/auto/tokenization_auto.py src/transformers/models/rwkv5/__init__.py src/transformers/models/rwkv5/configuration_rwkv5.py src/transformers/models/rwkv5/convert_rwkv5_checkpoint_to_hf.py src/transformers/models/rwkv5/modeling_rwkv5.py src/transformers/models/rwkv5/tokenization_rwkv5.py src/transformers/tokenization_utils.py src/transformers/utils/dummy_pt_objects.py tests/models/rwkv5/__init__.py tests/models/rwkv5/test_modeling_rwkv5.py tests/models/rwkv5/test_tokenization_rwkv5.py
Found 3 errors (3 fixed, 0 remaining).
2 files reformatted, 13 files left unchanged
python utils/custom_init_isort.py
python utils/sort_auto_mappings.py
python utils/check_doc_toc.py --fix_and_overwrite
running deps_table_update
updating src/transformers/dependency_versions_table.py
python utils/check_copies.py
Traceback (most recent call last):
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 1192, in <module>
    check_copies(args.fix_and_overwrite, args.file)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 826, in check_copies
    new_diffs = is_copy_consistent(filename, overwrite, buffer)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 688, in is_copy_consistent
    observed_code_splits = split_code_into_blocks(lines, start_index, line_index, len(indent), backtrace=True)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 312, in split_code_into_blocks
    target_block_name = re.search(rf"^{' ' * (indent - 4)}((class|def)\s+\S+)(\(|\:)", lines[start_index]).groups()[0]
AttributeError: 'NoneType' object has no attribute 'groups'
make: *** [repo-consistency] Error 1
```
after: 
```python
(py310) ➜  transformers git:(add-rwkv5) ✗ make fixup
Checking/fixing src/transformers/__init__.py src/transformers/models/__init__.py src/transformers/models/auto/configuration_auto.py src/transformers/models/auto/modeling_auto.py src/transformers/models/auto/tokenization_auto.py src/transformers/models/rwkv5/__init__.py src/transformers/models/rwkv5/configuration_rwkv5.py src/transformers/models/rwkv5/convert_rwkv5_checkpoint_to_hf.py src/transformers/models/rwkv5/modeling_rwkv5.py src/transformers/models/rwkv5/tokenization_rwkv5.py src/transformers/tokenization_utils.py src/transformers/utils/dummy_pt_objects.py tests/models/rwkv5/__init__.py tests/models/rwkv5/test_modeling_rwkv5.py tests/models/rwkv5/test_tokenization_rwkv5.py utils/check_copies.py
utils/check_copies.py:316:5: E722 Do not use bare `except`
Found 1 error.
16 files left unchanged
python utils/custom_init_isort.py
python utils/sort_auto_mappings.py
python utils/check_doc_toc.py --fix_and_overwrite
running deps_table_update
updating src/transformers/dependency_versions_table.py
python utils/check_copies.py
Traceback (most recent call last):
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 315, in split_code_into_blocks
    ).groups()[0]
AttributeError: 'NoneType' object has no attribute 'groups'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 1201, in <module>
    check_copies(args.fix_and_overwrite, args.file)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 835, in check_copies
    new_diffs = is_copy_consistent(filename, overwrite, buffer)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 697, in is_copy_consistent
    observed_code_splits = split_code_into_blocks(lines, start_index, line_index, len(indent), backtrace=True)
  File "/Users/arthurzucker/Work/transformers/utils/check_copies.py", line 317, in split_code_into_blocks
    raise ValueError(
ValueError: Tried to split a class or function. It did not work. Error comes from line 465: ```
@dataclass
class Rwkv5Output(ModelOutput):
    """
    Class for the RWKV5 model outputs.

    Args:
        last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
            Sequence of hidden-states at the output of the last layer of the model.
        state (list of five `torch.FloatTensor` of shape `(batch_size, hidden_size, num_hidden_layers)`):
            The state of the model at the last time step. Can be used in a forward method with the next `input_ids` to
            avoid providing the old `input_ids`.
        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
            Tuple of `torch.FloatTensor` (one for the output of the embeddings, if the model has an embedding layer, +
            one for the output of each layer) of shape `(batch_size, sequence_length, hidden_size)`. Hidden-states of
            the model at the output of each layer plus the optional initial embedding outputs.
        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
            sequence_length)`. Attentions weights after the attention softmax, used to compute the weighted average in
            the self-attention heads.
    """

    last_hidden_state: torch.FloatTensor = None
    state: Optional[List[torch.FloatTensor]] = None
    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
    attentions: Optional[Tuple[torch.FloatTensor]] = None
```

make: *** [repo-consistency] Error 1
```