### PR TITLE
[bnb] Fix bug in `_replace_with_bnb_linear`

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -156,7 +156,10 @@ def _replace_with_bnb_linear(
 
         if (isinstance(module, nn.Linear) or isinstance(module, Conv1D)) and name not in modules_to_not_convert:
             # Check if the current key is not in the `modules_to_not_convert`
-            if not any(key in ".".join(current_key_name) for key in modules_to_not_convert):
+            current_key_name_str = ".".join(current_key_name)
+            if not any(
+                (key + "." in current_key_name_str) or (key == current_key_name_str) for key in modules_to_not_convert
+            ):
                 with init_empty_weights():
                     if isinstance(module, Conv1D):
                         in_features, out_features = module.weight.shape


### PR DESCRIPTION
# What does this PR do 

This PR fixes a bug in `_replace_with_bnb_linear` when we use `modules_to_not_convert`. Before this PR, we were skipping the conversion of some modules if their name starts with "model.layers.1" (e.g. "model.layers.10.self_attn.q_proj") in the case where `modules_to_not_convert = ['model.layers.1']`. 

Fixes https://github.com/huggingface/transformers/issues/29691