### PR TITLE
[`generate`] fix breaking change for patch

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3436,11 +3436,9 @@ class GenerationMixin:
         batch_size = len(beam_scorer._beam_hyps)
         num_beams = beam_scorer.num_beams
 
-        batch_beam_size, cur_len = (
-            model_kwargs["attention_mask"].shape
-            if model_kwargs.get("attention_mask", None) is not None
-            else input_ids.shape
-        )
+        batch_beam_size, cur_len = input_ids.shape
+        if "inputs_embeds" in model_kwargs:
+            cur_len = model_kwargs["inputs_embeds"].shape[1]
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         # init attention / hidden states / scores tuples

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3034,6 +3034,8 @@ class GenerationMixin:
         num_beams = beam_scorer.num_beams
 
         batch_beam_size, cur_len = input_ids.shape
+        if "inputs_embeds" in model_kwargs:
+            cur_len = model_kwargs["inputs_embeds"].shape[1]
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         if num_beams * batch_size != batch_beam_size:
@@ -3797,6 +3799,8 @@ class GenerationMixin:
         device = input_ids.device
 
         batch_beam_size, cur_len = input_ids.shape
+        if "inputs_embeds" in model_kwargs:
+            cur_len = model_kwargs["inputs_embeds"].shape[1]
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         if return_dict_in_generate and output_scores:
@@ -4213,6 +4217,8 @@ class GenerationMixin:
         num_beams = constrained_beam_scorer.num_beams
 
         batch_beam_size, cur_len = input_ids.shape
+        if "inputs_embeds" in model_kwargs:
+            cur_len = model_kwargs["inputs_embeds"].shape[1]
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         if num_beams * batch_size != batch_beam_size:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3436,7 +3436,11 @@ class GenerationMixin:
         batch_size = len(beam_scorer._beam_hyps)
         num_beams = beam_scorer.num_beams
 
-        batch_beam_size, cur_len = input_ids.shape
+        batch_beam_size, cur_len = (
+            model_kwargs["attention_mask"].shape
+            if model_kwargs.get("attention_mask", None) is not None
+            else input_ids.shape
+        )
         model_kwargs["cache_position"] = torch.arange(cur_len, device=input_ids.device)
 
         # init attention / hidden states / scores tuples

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -717,7 +717,7 @@ class GenerationTesterMixin:
             )
 
             self.assertTrue(output_generate.shape[-1] == max_length)
-            if "inputs_embeds" in inspect.signature(model.prepare_inputs_for_generation):
+            if "inputs_embeds" in set(inspect.signature(model.prepare_inputs_for_generation).parameters):
                 input_embeds = model.get_input_embeddings()(input_ids)
                 beam_kwargs.update({"inputs_embeds": input_embeds})
                 output_generate2 = self._beam_sample_generate(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -720,7 +720,7 @@ class GenerationTesterMixin:
 
             input_embeds = model.get_input_embeddings()(input_ids)
             beam_kwargs.update({"input_embeds": input_embeds})
-            output_generate = self._beam_search_generate(
+            output_generate = self._beam_sample_generate(
                 model=model,
                 input_ids=None,
                 attention_mask=attention_mask,

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -718,6 +718,19 @@ class GenerationTesterMixin:
 
             self.assertTrue(output_generate.shape[-1] == max_length)
 
+            input_embeds = model.get_input_embeddings()(input_ids)
+            output_generate = self._beam_search_generate(
+                model=model,
+                input_ids=None,
+                attention_mask=attention_mask,
+                max_length=max_length,
+                beam_kwargs=beam_kwargs,
+                logits_process_kwargs=logits_process_kwargs,
+                beam_kwargs={"input_embeds":input_embeds}
+            )
+
+            self.assertTrue(output_generate.shape[-1] == max_length)
+            
     def test_beam_sample_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:
             config, input_ids, attention_mask, max_length = self._get_input_ids_and_config()

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -720,7 +720,7 @@ class GenerationTesterMixin:
 
             input_embeds = model.get_input_embeddings()(input_ids)
             beam_kwargs.update({"inputs_embeds": input_embeds})
-            output_generate = self._beam_sample_generate(
+            output_generate2 = self._beam_sample_generate(
                 model=model,
                 input_ids=None,
                 attention_mask=attention_mask,
@@ -729,7 +729,7 @@ class GenerationTesterMixin:
                 logits_warper_kwargs=logits_warper_kwargs,
             )
 
-            self.assertTrue(output_generate.shape[-1] == max_length)
+            torch.testing.assert_close(output_generate[:,input_embeds.shape[1]:], output_generate2)
 
     def test_beam_sample_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -717,19 +717,19 @@ class GenerationTesterMixin:
             )
 
             self.assertTrue(output_generate.shape[-1] == max_length)
+            if "inputs_embeds" in inspect.signature(model.prepare_inputs_for_generation):
+                input_embeds = model.get_input_embeddings()(input_ids)
+                beam_kwargs.update({"inputs_embeds": input_embeds})
+                output_generate2 = self._beam_sample_generate(
+                    model=model,
+                    input_ids=None,
+                    attention_mask=attention_mask,
+                    max_length=max_length,
+                    beam_kwargs=beam_kwargs,
+                    logits_warper_kwargs=logits_warper_kwargs,
+                )
 
-            input_embeds = model.get_input_embeddings()(input_ids)
-            beam_kwargs.update({"inputs_embeds": input_embeds})
-            output_generate2 = self._beam_sample_generate(
-                model=model,
-                input_ids=None,
-                attention_mask=attention_mask,
-                max_length=max_length,
-                beam_kwargs=beam_kwargs,
-                logits_warper_kwargs=logits_warper_kwargs,
-            )
-
-            torch.testing.assert_close(output_generate[:, input_embeds.shape[1] :], output_generate2)
+                torch.testing.assert_close(output_generate[:, input_embeds.shape[1] :], output_generate2)
 
     def test_beam_sample_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -726,6 +726,7 @@ class GenerationTesterMixin:
                 attention_mask=attention_mask,
                 max_length=max_length,
                 beam_kwargs=beam_kwargs,
+                logits_warper_kwargs=logits_warper_kwargs,
             )
 
             self.assertTrue(output_generate.shape[-1] == max_length)

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -729,7 +729,7 @@ class GenerationTesterMixin:
                 logits_warper_kwargs=logits_warper_kwargs,
             )
 
-            torch.testing.assert_close(output_generate[:,input_embeds.shape[1]:], output_generate2)
+            torch.testing.assert_close(output_generate[:, input_embeds.shape[1] :], output_generate2)
 
     def test_beam_sample_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -719,18 +719,17 @@ class GenerationTesterMixin:
             self.assertTrue(output_generate.shape[-1] == max_length)
 
             input_embeds = model.get_input_embeddings()(input_ids)
+            beam_kwargs.update({"input_embeds": input_embeds})
             output_generate = self._beam_search_generate(
                 model=model,
                 input_ids=None,
                 attention_mask=attention_mask,
                 max_length=max_length,
                 beam_kwargs=beam_kwargs,
-                logits_process_kwargs=logits_process_kwargs,
-                beam_kwargs={"input_embeds":input_embeds}
             )
 
             self.assertTrue(output_generate.shape[-1] == max_length)
-            
+
     def test_beam_sample_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:
             config, input_ids, attention_mask, max_length = self._get_input_ids_and_config()

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -719,7 +719,7 @@ class GenerationTesterMixin:
             self.assertTrue(output_generate.shape[-1] == max_length)
 
             input_embeds = model.get_input_embeddings()(input_ids)
-            beam_kwargs.update({"input_embeds": input_embeds})
+            beam_kwargs.update({"inputs_embeds": input_embeds})
             output_generate = self._beam_sample_generate(
                 model=model,
                 input_ids=None,

--- a/tests/models/biogpt/test_modeling_biogpt.py
+++ b/tests/models/biogpt/test_modeling_biogpt.py
@@ -414,6 +414,10 @@ class BioGptModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         result = model(input_ids, attention_mask=attention_mask, labels=sequence_labels)
         self.assertEqual(result.logits.shape, (self.model_tester.batch_size, self.model_tester.num_labels))
 
+    @unittest.skip("The `input_embeds` when fed don't produce the same results.")
+    def test_beam_sample_generate(self):
+        pass
+
 
 @require_torch
 class BioGptModelIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

A bug was introduced by #29467 pretty much unrelated to cache positions.
This fixes #29968

cc @gante and @zucchini-nlp. The testing suite is missing this particular test for all generation strategies
