### PR TITLE
Gemma: update activation warning

### DIFF
--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -173,17 +173,14 @@ class GemmaMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         if config.hidden_activation is None:
-            if config.hidden_act != "gelu_pytorch_tanh":
-                logger.warning_once(
-                    "Gemma's activation function should be approximate GeLU and not exact GeLU.\n"
-                    "Changing the activation function to `gelu_pytorch_tanh`."
-                    f"if you want to use the legacy `{config.hidden_act}`, "
-                    f"edit the `model.config` to set `hidden_activation={config.hidden_act}` "
-                    "  instead of `hidden_act`. See https://github.com/huggingface/transformers/pull/29402 for more details."
-                )
-            hidden_activation = "gelu_pytorch_tanh"
-        else:
-            hidden_activation = config.hidden_activation
+            logger.warning_once(
+                "`config.hidden_act` is ignored, you should use `config.hidden_activation` instead.\n"
+                "Gemma's activation function will be set to `gelu_pytorch_tanh`. Please, use\n"
+                "`config.hidden_activation` if you want to override this behaviour.\n"
+                "See https://github.com/huggingface/transformers/pull/29402 for more details."
+            )
+            config.hidden_activation = "gelu_pytorch_tanh"
+        hidden_activation = config.hidden_activation
         self.act_fn = ACT2FN[hidden_activation]
 
     def forward(self, x):

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -173,13 +173,14 @@ class GemmaMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         if config.hidden_activation is None:
-            logger.warning_once(
-                "Gemma's activation function should be approximate GeLU and not exact GeLU.\n"
-                "Changing the activation function to `gelu_pytorch_tanh`."
-                f"if you want to use the legacy `{config.hidden_act}`, "
-                f"edit the `model.config` to set `hidden_activation={config.hidden_act}` "
-                "  instead of `hidden_act`. See https://github.com/huggingface/transformers/pull/29402 for more details."
-            )
+            if config.hidden_act != "gelu_pytorch_tanh":
+                logger.warning_once(
+                    "Gemma's activation function should be approximate GeLU and not exact GeLU.\n"
+                    "Changing the activation function to `gelu_pytorch_tanh`."
+                    f"if you want to use the legacy `{config.hidden_act}`, "
+                    f"edit the `model.config` to set `hidden_activation={config.hidden_act}` "
+                    "  instead of `hidden_act`. See https://github.com/huggingface/transformers/pull/29402 for more details."
+                )
             hidden_activation = "gelu_pytorch_tanh"
         else:
             hidden_activation = config.hidden_activation


### PR DESCRIPTION
# What does this PR do?

This is a nit PR, but I was confused. I got the warning even after I had changed `hidden_act` to `gelu_pytorch_tanh`, telling me that I was using the "legacy" `gelu_pytorch_tanh`.

Another option is to keep the warning but change the message to say something like "`hidden_act` is ignored, please use `hidden_activation` instead. Setting Gemma's activation function to `gelu_pytorch_tanh`".

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
