### PR TITLE
Add FSDP config for CPU RAM efficient loading through accelerate

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -514,8 +514,8 @@ class TrainingArguments:
                     If `"True"`, each individually wrapped FSDP unit will broadcast module parameters from rank 0 to
                     ensure they are the same across all ranks after initialization
                 - cpu_ram_efficient_loading (`bool`, *optional*, defaults to `False`)
-                    If `"True"`, only the first process loads the pretrained model checkpoint while all other processes
-                    have empty weights.  When this setting is True, `sync_module_states` also must to be True,
+                    If `True`, only the first process loads the pretrained model checkpoint while all other processes
+                    have empty weights.  When this setting is `True`, `sync_module_states` also must to be `True`,
                     otherwise all the processes except the main process would have random weights leading to unexpected
                     behaviour during training.
                 - activation_checkpointing (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -513,6 +513,11 @@ class TrainingArguments:
                 - sync_module_states (`bool`, *optional*, defaults to `True`)
                     If `"True"`, each individually wrapped FSDP unit will broadcast module parameters from rank 0 to
                     ensure they are the same across all ranks after initialization
+                - cpu_ram_efficient_loading (`bool`, *optional*, defaults to `False`)
+                    If `"True"`, only the first process loads the pretrained model checkpoint while all other processes
+                    have empty weights.  When this setting is True, `sync_module_states` also must to be True,
+                    otherwise all the processes except the main process would have random weights leading to unexpected
+                    behaviour during training.
                 - activation_checkpointing (`bool`, *optional*, defaults to `False`):
                     If `"True"`, activation checkpointing is a technique to reduce memory usage by clearing activations of
                     certain layers and recomputing them during a backward pass. Effectively, this trades extra
@@ -1827,6 +1832,7 @@ class TrainingArguments:
             os.environ[f"{prefix}BACKWARD_PREFETCH"] = prefetch_policy.upper()
             os.environ[f"{prefix}FORWARD_PREFETCH"] = self.fsdp_config.get("forward_prefetch", "false")
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
+            os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"] = self.fsdp_config.get("cpu_ram_efficient_loading", "false")
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "true")
 
         if is_accelerate_available():

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1838,7 +1838,7 @@ class TrainingArguments:
             if str(sync_module_states).lower() == "false" and str(cpu_ram_efficient_loading).lower() == "true":
                 # In this case, all the processes except the main process would have random weights leading
                 # to unexpected behaviour during training, thus throwing error here to prevent it.
-                raise ValueError("`sync_module_states` must be `\"True\"` if `cpu_ram_efficient_loading` is `\"True\"`")
+                raise ValueError('`sync_module_states` must be `"True"` if `cpu_ram_efficient_loading` is `"True"`')
 
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = sync_module_states
             os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"] = cpu_ram_efficient_loading

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1838,7 +1838,7 @@ class TrainingArguments:
             if str(sync_module_states).lower() == "false" and str(cpu_ram_efficient_loading).lower() == "true":
                 # In this case, all the processes except the main process would have random weights leading
                 # to unexpected behaviour during training, thus throwing error here to prevent it.
-                raise ValueError("`sync_module_states` must be \"True\" if `cpu_ram_efficient_loading` is `\"True\"`")
+                raise ValueError("`sync_module_states` must be `\"True\"` if `cpu_ram_efficient_loading` is `\"True\"`")
 
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = sync_module_states
             os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"] = cpu_ram_efficient_loading

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1832,7 +1832,9 @@ class TrainingArguments:
             os.environ[f"{prefix}BACKWARD_PREFETCH"] = prefetch_policy.upper()
             os.environ[f"{prefix}FORWARD_PREFETCH"] = self.fsdp_config.get("forward_prefetch", "false")
             os.environ[f"{prefix}SYNC_MODULE_STATES"] = self.fsdp_config.get("sync_module_states", "true")
-            os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"] = self.fsdp_config.get("cpu_ram_efficient_loading", "false")
+            os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"] = self.fsdp_config.get(
+                "cpu_ram_efficient_loading", "false"
+            )
             os.environ[f"{prefix}USE_ORIG_PARAMS"] = self.fsdp_config.get("use_orig_params", "true")
 
         if is_accelerate_available():

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -515,7 +515,7 @@ class TrainingArguments:
                     ensure they are the same across all ranks after initialization
                 - cpu_ram_efficient_loading (`bool`, *optional*, defaults to `False`)
                     If `True`, only the first process loads the pretrained model checkpoint while all other processes
-                    have empty weights.  When this setting is `True`, `sync_module_states` also must to be `True`,
+                    have empty weights.  When this setting as `True`, `sync_module_states` also must to be `True`,
                     otherwise all the processes except the main process would have random weights leading to unexpected
                     behaviour during training.
                 - activation_checkpointing (`bool`, *optional*, defaults to `False`):

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -209,7 +209,9 @@ class TrainerIntegrationFSDP(TestCasePlus, TrainerIntegrationCommon):
             self.assertEqual(os.environ[f"{prefix}FORWARD_PREFETCH"], fsdp_config["forward_prefetch"])
             self.assertEqual(os.environ[f"{prefix}USE_ORIG_PARAMS"], fsdp_config["use_orig_params"])
             self.assertEqual(os.environ[f"{prefix}SYNC_MODULE_STATES"], fsdp_config["sync_module_states"])
-            self.assertEqual(os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"], fsdp_config["cpu_ram_efficient_loading"])
+            self.assertEqual(
+                os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"], fsdp_config["cpu_ram_efficient_loading"]
+            )
             self.assertEqual(os.environ.get("ACCELERATE_USE_FSDP", "false"), "true")
 
     @parameterized.expand(params, name_func=_parameterized_custom_name_func)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -144,6 +144,7 @@ class TrainerIntegrationFSDP(TestCasePlus, TrainerIntegrationCommon):
             "limit_all_gathers": "False",
             "use_orig_params": "True",
             "sync_module_states": "True",
+            "cpu_ram_efficient_loading": "True",
             "activation_checkpointing": "False",
             "min_num_params": 1,
         }
@@ -208,6 +209,7 @@ class TrainerIntegrationFSDP(TestCasePlus, TrainerIntegrationCommon):
             self.assertEqual(os.environ[f"{prefix}FORWARD_PREFETCH"], fsdp_config["forward_prefetch"])
             self.assertEqual(os.environ[f"{prefix}USE_ORIG_PARAMS"], fsdp_config["use_orig_params"])
             self.assertEqual(os.environ[f"{prefix}SYNC_MODULE_STATES"], fsdp_config["sync_module_states"])
+            self.assertEqual(os.environ[f"{prefix}CPU_RAM_EFFICIENT_LOADING"], fsdp_config["cpu_ram_efficient_loading"])
             self.assertEqual(os.environ.get("ACCELERATE_USE_FSDP", "false"), "true")
 
     @parameterized.expand(params, name_func=_parameterized_custom_name_func)


### PR DESCRIPTION
# What does this PR do?
Currently the environment variable `FSDP_CPU_RAM_EFFICIENT_LOADING` is being read [here](https://github.com/huggingface/transformers/blob/5080ab12c818d3875858ad37b667c00c6f09f094/src/transformers/modeling_utils.py#L137) but are set in `transformers` codebase. This change added option to set `FSDP_CPU_RAM_EFFICIENT_LOADING` through `cpu_ram_efficient_loading` FSDP option so jobs launched from `torchrun` or other means can take advantage of `FSDP_CPU_RAM_EFFICIENT_LOADING` through configs.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@pacman100 
@muellerzr 
@ArthurZucker 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
