### PR TITLE
[tests] make 2 tests device-agnostic 

### DIFF
--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -992,7 +992,7 @@ class Blip2ModelIntegrationTest(unittest.TestCase):
 
         # prepare image
         image = prepare_img()
-        inputs = processor(images=image, return_tensors="pt").to(0, dtype=torch.float16)
+        inputs = processor(images=image, return_tensors="pt").to(f"{torch_device}:0", dtype=torch.float16)
 
         predictions = model.generate(**inputs)
         generated_text = processor.batch_decode(predictions, skip_special_tokens=True)[0].strip()
@@ -1003,7 +1003,7 @@ class Blip2ModelIntegrationTest(unittest.TestCase):
 
         # image and context
         prompt = "Question: which city is this? Answer:"
-        inputs = processor(images=image, text=prompt, return_tensors="pt").to(0, dtype=torch.float16)
+        inputs = processor(images=image, text=prompt, return_tensors="pt").to(f"{torch_device}:0", dtype=torch.float16)
 
         predictions = model.generate(**inputs)
         generated_text = processor.batch_decode(predictions, skip_special_tokens=True)[0].strip()

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -756,7 +756,7 @@ class ModelUtilsTest(TestCasePlus):
 
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
         inputs = tokenizer("Hello, my name is", return_tensors="pt")
-        output = model.generate(inputs["input_ids"].to(0))
+        output = model.generate(inputs["input_ids"].to(f"{torch_device}:0"))
 
         text_output = tokenizer.decode(output[0].tolist())
         self.assertEqual(text_output, "Hello, my name is John. I'm a writer, and I'm a writer. I'm")


### PR DESCRIPTION
# What does this PR do?
After Fix:
```bash
$ RUN_SLOW=1 TRANSFORMERS_TEST_DEVICE=xpu TRANSFORMERS_TEST_DEVICE_SPEC=spec.py pytest tests/test_modeling_utils.py::ModelUtilsTest::test_model_parallelism_gpt2 tests/models/blip_2/test_modeling_blip_2.py::Blip2ModelIntegrationTest::test_inference_t5_multi_accelerator
==================================================== test session starts =====================================================
platform linux -- Python 3.9.19, pytest-7.4.4, pluggy-1.4.0
rootdir: /soft/fanli/transformers
configfile: pyproject.toml
plugins: xdist-3.5.0, metadata-3.1.1, reportlog-0.4.0, anyio-4.2.0, excel-1.6.0, hypothesis-6.98.0, html-4.1.1, timeout-2.3.1, env-1.1.3
collected 2 items                                                                                                            

tests/test_modeling_utils.py .                                                                                         [ 50%]
tests/models/blip_2/test_modeling_blip_2.py .                                                                          [100%]
=============================================== 2 passed, 5 warnings in 11.19s ===============================================
```

## Who can review?
@ArthurZucker
