### PR TITLE
[WIP] Change LlavaProcessor to include more (any) tokenizer and image processor.

### DIFF
--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -41,8 +41,8 @@ class LlavaProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = ("AutoImageProcessor")
-    tokenizer_class = ("AutoTokenizer")
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
 
     def __init__(self, image_processor=None, tokenizer=None):
         super().__init__(image_processor, tokenizer)
@@ -59,9 +59,9 @@ class LlavaProcessor(ProcessorMixin):
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
-        and `kwargs` arguments to LlamaTokenizerFast's [`~LlamaTokenizerFast.__call__`] if `text` is not `None` to encode
+        and `kwargs` arguments to AutoTokenizerFast's [`~AutoTokenizerFast.__call__`] if `text` is not `None` to encode
         the text. To prepare the image(s), this method forwards the `images` and `kwrags` arguments to
-        CLIPImageProcessor's [`~CLIPImageProcessor.__call__`] if `images` is not `None`. Please refer to the doctsring
+        AutoImageProcessor's [`~AutoImageProcessor.__call__`] if `images` is not `None`. Please refer to the doctsring
         of the above two methods for more information.
 
         Args:
@@ -93,6 +93,8 @@ class LlavaProcessor(ProcessorMixin):
                 - `'pt'`: Return PyTorch `torch.Tensor` objects.
                 - `'np'`: Return NumPy `np.ndarray` objects.
                 - `'jax'`: Return JAX `jnp.ndarray` objects.
+            add_special_tokens (`bool`, *optional*, defaults to `True`):
+                Passes `add_special_tokens` argument to tokenizer. You may want to set to `False` if you are separately using the `PreTrainedTokenizerBase.apply_chat_template` functionality.
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:
@@ -108,7 +110,12 @@ class LlavaProcessor(ProcessorMixin):
         else:
             pixel_values = None
         text_inputs = self.tokenizer(
-            text, return_tensors=return_tensors, padding=padding, truncation=truncation, max_length=max_length, add_special_tokens=add_special_tokens
+            text,
+            return_tensors=return_tensors,
+            padding=padding,
+            truncation=truncation,
+            max_length=max_length,
+            add_special_tokens=add_special_tokens,
         )
 
         return BatchFeature(data={**text_inputs, "pixel_values": pixel_values})

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -30,20 +30,19 @@ class LlavaProcessor(ProcessorMixin):
     r"""
     Constructs a Llava processor which wraps a Llava image processor and a Llava tokenizer into a single processor.
 
-    [`LlavaProcessor`] offers all the functionalities of [`CLIPImageProcessor`] and [`LlamaTokenizerFast`]. See the
+    [`LlavaProcessor`] offers all the functionalities of [`AutoImageProcessor`] and [`AutoTokenizer`]. See the
     [`~LlavaProcessor.__call__`] and [`~LlavaProcessor.decode`] for more information.
 
     Args:
-        image_processor ([`CLIPImageProcessor`], *optional*):
+        image_processor ([`AutoImageProcessor`], *optional*):
             The image processor is a required input.
-        tokenizer ([`LlamaTokenizerFast`], *optional*):
+        tokenizer ([`AutoTokenizer`], *optional*):
             The tokenizer is a required input.
     """
 
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = ("CLIPImageProcessor", "BitImageProcessor")
-    tokenizer_class = ("LlamaTokenizer", "LlamaTokenizerFast",
-                       "GemmaTokenizer", "GemmaTokenizerFast")
+    image_processor_class = ("AutoImageProcessor")
+    tokenizer_class = ("AutoTokenizer")
 
     def __init__(self, image_processor=None, tokenizer=None):
         super().__init__(image_processor, tokenizer)
@@ -56,6 +55,7 @@ class LlavaProcessor(ProcessorMixin):
         truncation: Union[bool, str, TruncationStrategy] = None,
         max_length=None,
         return_tensors: Optional[Union[str, TensorType]] = TensorType.PYTORCH,
+        add_special_tokens: bool = True,
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
@@ -108,7 +108,7 @@ class LlavaProcessor(ProcessorMixin):
         else:
             pixel_values = None
         text_inputs = self.tokenizer(
-            text, return_tensors=return_tensors, padding=padding, truncation=truncation, max_length=max_length
+            text, return_tensors=return_tensors, padding=padding, truncation=truncation, max_length=max_length, add_special_tokens=add_special_tokens
         )
 
         return BatchFeature(data={**text_inputs, "pixel_values": pixel_values})

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -55,7 +55,7 @@ class LlavaProcessor(ProcessorMixin):
         truncation: Union[bool, str, TruncationStrategy] = None,
         max_length=None,
         return_tensors: Optional[Union[str, TensorType]] = TensorType.PYTORCH,
-        add_special_tokens: bool = True,
+        add_special_tokens: bool = None,
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -41,8 +41,9 @@ class LlavaProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = "CLIPImageProcessor"
-    tokenizer_class = ("LlamaTokenizer", "LlamaTokenizerFast")
+    image_processor_class = ("CLIPImageProcessor", "BitImageProcessor")
+    tokenizer_class = ("LlamaTokenizer", "LlamaTokenizerFast",
+                       "GemmaTokenizer", "GemmaTokenizerFast")
 
     def __init__(self, image_processor=None, tokenizer=None):
         super().__init__(image_processor, tokenizer)


### PR DESCRIPTION
# What does this PR do?

This PR changes `processing_llava.py` to permit users to use language and vision backbones with tokenizers and image processors other than `LlamaTokenizer` and `CLIPImageProcessor`.

We are adding to permit out-of-the-box functionality for the [recently uploaded Gemma-based LLaVA model](https://huggingface.co/Intel/llava-gemma-2b) (see #29887).

Fixes #29887.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

### Regarding documentation:

I made relevant changes to the docstring in the LlavaProcessor class, but decided against modifying the source docs for the LLaVA models because nothing in those suggests that you cannot use alternate tokenizers/processors.

I am happy to change the source docs to give alternate examples, if helpful.

### Regarding tests:

I do not think any new tests are necessary. I ran the existing ones for tokenizers and processors.

## Who can review?

@ArthurZucker
