### PR TITLE
[test fetcher] Always include the directly related test files

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -957,10 +957,23 @@ def create_module_to_test_map(
         model_tests = {Path(t).parts[2] for t in tests if t.startswith("tests/models/")}
         return len(model_tests) > num_model_tests // 2
 
-    def filter_tests(tests):
-        return [t for t in tests if not t.startswith("tests/models/") or Path(t).parts[2] in IMPORTANT_MODELS]
+    # for each module (if specified in the argument `module`) of the form `models/my_model` (i.e. starting with it),
+    # we always keep the tests (those are already in the argument `tests`) which are in `tests/models/my_model`.
+    # This is to avoid them being excluded when a module has many impacted tests: the directly related test files should
+    # always be included!
+    def filter_tests(tests, module=""):
+        return [
+            t
+            for t in tests
+            if not t.startswith("tests/models/")
+            or Path(t).parts[2] in IMPORTANT_MODELS
+            or "/".join(Path(t).parts[1:3]) in module
+        ]
 
-    return {module: (filter_tests(tests) if has_many_models(tests) else tests) for module, tests in test_map.items()}
+    return {
+        module: (filter_tests(tests, module=module) if has_many_models(tests) else tests)
+        for module, tests in test_map.items()
+    }
 
 
 def check_imports_all_exist():

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -967,6 +967,8 @@ def create_module_to_test_map(
             for t in tests
             if not t.startswith("tests/models/")
             or Path(t).parts[2] in IMPORTANT_MODELS
+            # at this point, `t` is of the form `tests/models/my_model`, and we check if `models/my_model`
+            # (i.e. `parts[1:3]`) is in `module`.
             or "/".join(Path(t).parts[1:3]) in module
         ]
 


### PR DESCRIPTION
# What does this PR do?

Currently, if a module has many impacted test files, those test files are filtered by `IMPORTANT_MODELS`.
The file `models/whisper/modeling_whisper.py` is in this case, but `whisper` is not in `IMPORTANT_MODELS`.
So if `modeling_whisper.py` is modified, `test_modeling_whisper.py` is not included in the testing.

Such situations makes the CI miss the tests that we 100% need to test.

This PR changes the logic to always include the directly related test files.