### PR TITLE
Add support to the MPS device on the Pipeline class

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -41,6 +41,7 @@ from ..utils import (
     is_tf_available,
     is_torch_available,
     is_torch_cuda_available,
+    is_torch_mps_available,
     is_torch_mlu_available,
     is_torch_npu_available,
     is_torch_xpu_available,
@@ -856,6 +857,8 @@ class Pipeline(_ScikitCompat):
                 self.device = torch.device(f"mlu:{device}")
             elif is_torch_cuda_available():
                 self.device = torch.device(f"cuda:{device}")
+            elif is_torch_mps_available():
+                self.device = torch.device(f"mps:{device}")
             elif is_torch_npu_available():
                 self.device = torch.device(f"npu:{device}")
             elif is_torch_xpu_available(check_device=True):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -182,6 +182,7 @@ from .import_utils import (
     is_torch_bf16_gpu_available,
     is_torch_compile_available,
     is_torch_cuda_available,
+    is_torch_mps_available,
     is_torch_fp16_available_on_device,
     is_torch_fx_available,
     is_torch_fx_proxy,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -340,6 +340,15 @@ def is_torch_cuda_available():
         return False
 
 
+def is_torch_mps_available():
+    if is_torch_available():
+        import torch
+
+        return torch.backends.mps.is_available()
+    else:
+        return False
+
+
 def is_mamba_ssm_available():
     if is_torch_available():
         import torch


### PR DESCRIPTION
# What does this PR do?

Implements automatic MPS device detection for the Pipeline class.

This PR extends the current functionality of the Pipeline class to automatically detect and leverage MPS devices for inference. This aligns with the behavior of existing accelerator support, streamlining the experience for users running on Apple devices.
