### PR TITLE
Fix typo at ImportError

### DIFF
--- a/src/transformers/quantizers/quantizer_quanto.py
+++ b/src/transformers/quantizers/quantizer_quanto.py
@@ -60,7 +60,9 @@ class QuantoHfQuantizer(HfQuantizer):
         if not is_quanto_available():
             raise ImportError("Loading a quanto quantized model requires quanto library (`pip install quanto`)")
         if not is_accelerate_available():
-            raise ImportError("Loading a quanto quantized model requires accelerate library (`pip install quanto`)")
+            raise ImportError(
+                "Loading a quanto quantized model requires accelerate library (`pip install accelerate`)"
+            )
 
     def update_device_map(self, device_map):
         if device_map is None:


### PR DESCRIPTION
# What does this PR do?

When instantiating a `QuantoHfQuantizer`, the `ImportError` message that is risen for `accelerate` has a typo in it.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 

