### PR TITLE
[Trainer] Rename tokenizer to processor, add deprecation

### DIFF
--- a/docs/source/en/tasks/image_classification.md
+++ b/docs/source/en/tasks/image_classification.md
@@ -322,7 +322,7 @@ At this point, only three steps remain:
 ...     data_collator=data_collator,
 ...     train_dataset=food["train"],
 ...     eval_dataset=food["test"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ... )
 
@@ -418,7 +418,7 @@ and use the [PushToHubCallback](../main_classes/keras_callbacks#transformers.Pus
 >>> metric_callback = KerasMetricCallback(metric_fn=compute_metrics, eval_dataset=tf_eval_dataset)
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="food_classifier",
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     save_strategy="no",
 ... )
 >>> callbacks = [metric_callback, push_to_hub_callback]

--- a/docs/source/en/tasks/object_detection.md
+++ b/docs/source/en/tasks/object_detection.md
@@ -384,7 +384,7 @@ Finally, bring everything together, and call [`~transformers.Trainer.train`]:
 ...     args=training_args,
 ...     data_collator=collate_fn,
 ...     train_dataset=cppe5["train"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ... )
 
 >>> trainer.train()

--- a/docs/source/en/tasks/video_classification.md
+++ b/docs/source/en/tasks/video_classification.md
@@ -407,7 +407,7 @@ Then you just pass all of this along with the datasets to `Trainer`:
 ...     args,
 ...     train_dataset=train_dataset,
 ...     eval_dataset=val_dataset,
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ...     data_collator=collate_fn,
 ... )

--- a/docs/source/es/tasks/image_classification.md
+++ b/docs/source/es/tasks/image_classification.md
@@ -160,7 +160,7 @@ Al llegar a este punto, solo quedan tres pasos:
 ...     data_collator=data_collator,
 ...     train_dataset=food["train"],
 ...     eval_dataset=food["test"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ... )
 
 >>> trainer.train()

--- a/docs/source/ja/tasks/image_classification.md
+++ b/docs/source/ja/tasks/image_classification.md
@@ -328,7 +328,7 @@ food["test"].set_transform(preprocess_val)
 ...     data_collator=data_collator,
 ...     train_dataset=food["train"],
 ...     eval_dataset=food["test"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ... )
 
@@ -426,7 +426,7 @@ Convert your datasets to the `tf.data.Dataset` format using the [`~datasets.Data
 >>> metric_callback = KerasMetricCallback(metric_fn=compute_metrics, eval_dataset=tf_eval_dataset)
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="food_classifier",
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     save_strategy="no",
 ... )
 >>> callbacks = [metric_callback, push_to_hub_callback]

--- a/docs/source/ja/tasks/object_detection.md
+++ b/docs/source/ja/tasks/object_detection.md
@@ -376,7 +376,7 @@ DETR モデルをトレーニングできる「ラベル」。画像プロセッ
 ...     args=training_args,
 ...     data_collator=collate_fn,
 ...     train_dataset=cppe5["train"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ... )
 
 >>> trainer.train()

--- a/docs/source/ja/tasks/video_classification.md
+++ b/docs/source/ja/tasks/video_classification.md
@@ -414,7 +414,7 @@ def compute_metrics(eval_pred):
 ...     args,
 ...     train_dataset=train_dataset,
 ...     eval_dataset=val_dataset,
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ...     data_collator=collate_fn,
 ... )

--- a/docs/source/ko/tasks/image_classification.md
+++ b/docs/source/ko/tasks/image_classification.md
@@ -321,7 +321,7 @@ food["test"].set_transform(preprocess_val)
 ...     data_collator=data_collator,
 ...     train_dataset=food["train"],
 ...     eval_dataset=food["test"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ... )
 
@@ -417,7 +417,7 @@ TensorFlow에서 모델을 미세 조정하려면 다음 단계를 따르세요:
 >>> metric_callback = KerasMetricCallback(metric_fn=compute_metrics, eval_dataset=tf_eval_dataset)
 >>> push_to_hub_callback = PushToHubCallback(
 ...     output_dir="food_classifier",
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     save_strategy="no",
 ... )
 >>> callbacks = [metric_callback, push_to_hub_callback]

--- a/docs/source/ko/tasks/object_detection.md
+++ b/docs/source/ko/tasks/object_detection.md
@@ -366,7 +366,7 @@ DatasetDict({
 ...     args=training_args,
 ...     data_collator=collate_fn,
 ...     train_dataset=cppe5["train"],
-...     image_processor=image_processor,
+...     processor=image_processor,
 ... )
 
 >>> trainer.train()

--- a/docs/source/ko/tasks/video_classification.md
+++ b/docs/source/ko/tasks/video_classification.md
@@ -411,7 +411,7 @@ def compute_metrics(eval_pred):
 ...     args,
 ...     train_dataset=train_dataset,
 ...     eval_dataset=val_dataset,
-...     image_processor=image_processor,
+...     processor=image_processor,
 ...     compute_metrics=compute_metrics,
 ...     data_collator=collate_fn,
 ... )

--- a/examples/pytorch/image-classification/run_image_classification.py
+++ b/examples/pytorch/image-classification/run_image_classification.py
@@ -411,7 +411,7 @@ def main():
         train_dataset=dataset["train"] if training_args.do_train else None,
         eval_dataset=dataset["validation"] if training_args.do_eval else None,
         compute_metrics=compute_metrics,
-        image_processor=image_processor,
+        processor=image_processor,
         data_collator=collate_fn,
     )
 

--- a/examples/pytorch/image-pretraining/run_mae.py
+++ b/examples/pytorch/image-pretraining/run_mae.py
@@ -369,7 +369,7 @@ def main():
         args=training_args,
         train_dataset=ds["train"] if training_args.do_train else None,
         eval_dataset=ds["validation"] if training_args.do_eval else None,
-        image_processor=image_processor,
+        processor=image_processor,
         data_collator=collate_fn,
     )
 

--- a/examples/pytorch/image-pretraining/run_mim.py
+++ b/examples/pytorch/image-pretraining/run_mim.py
@@ -458,7 +458,7 @@ def main():
         args=training_args,
         train_dataset=ds["train"] if training_args.do_train else None,
         eval_dataset=ds["validation"] if training_args.do_eval else None,
-        image_processor=image_processor,
+        processor=image_processor,
         data_collator=collate_fn,
     )
 

--- a/examples/pytorch/semantic-segmentation/run_semantic_segmentation.py
+++ b/examples/pytorch/semantic-segmentation/run_semantic_segmentation.py
@@ -510,7 +510,7 @@ def main():
         train_dataset=dataset["train"] if training_args.do_train else None,
         eval_dataset=dataset["validation"] if training_args.do_eval else None,
         compute_metrics=compute_metrics,
-        image_processor=image_processor,
+        processor=image_processor,
         data_collator=default_data_collator,
     )
 

--- a/examples/tensorflow/image-classification/run_image_classification.py
+++ b/examples/tensorflow/image-classification/run_image_classification.py
@@ -552,7 +552,7 @@ def main():
                     output_dir=training_args.output_dir,
                     hub_model_id=push_to_hub_model_id,
                     hub_token=training_args.push_to_hub_token,
-                    image_processor=image_processor,
+                    processor=image_processor,
                     **model_card_kwargs,
                 )
             )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -687,7 +687,7 @@ class Trainer:
     @property
     def tokenizer(self):
         warnings.warn(
-            "The 'tokenizer' is deprecated and will be removed in a future version. Use `processor` instead",
+            "The 'tokenizer' attribute is deprecated and will be removed in a future version. Use `processor` instead",
             FutureWarning,
         )
         return self.processor

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -504,7 +504,7 @@ class Trainer:
             self.place_model_on_device = False
 
         default_collator = (
-            DataCollatorWithPadding(tokenizer)
+            DataCollatorWithPadding(processor)
             if processor is not None and isinstance(processor, PreTrainedTokenizerBase)
             else default_data_collator
         )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -684,6 +684,14 @@ class Trainer:
             num_devices = xr.global_runtime_device_count()
             xs.set_global_mesh(xs.Mesh(np.array(range(num_devices)), (num_devices, 1), axis_names=("fsdp", "tensor")))
 
+    @property
+    def tokenizer(self):
+        warnings.warn(
+            "The 'tokenizer' is deprecated and will be removed in a future version. Use `processor` instead",
+            FutureWarning,
+        )
+        return self.processor
+
     def _activate_neftune(self, model):
         r"""
         Activates the neftune as presented in this code: https://github.com/neelsjain/NEFTune and paper:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -303,7 +303,7 @@ class Trainer:
              The dataset to use for evaluation. If it is a [`~datasets.Dataset`], columns not accepted by the
              `model.forward()` method are automatically removed. If it is a dictionary, it will evaluate on each
              dataset prepending the dictionary key to the metric name.
-        processor ([`PreTrainedTokenizerBase` or `BaseImageProcessor`], *optional*):
+        processor ([`PreTrainedTokenizer` or `BaseImageProcessor` or `SequenceFeatureExtractor` or `ProcessorMixin`], *optional*):
             The processor used to preprocess the data. Can be a tokenizer, image processor, feature extractor or multimodal processor.
 
             If a tokenizer is provided, it will be used to automatically pad the inputs to the

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -373,7 +373,7 @@ class Trainer:
         preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
         tokenizer: Optional[PreTrainedTokenizerBase] = None,
     ):
-        if tokenizer is not None and not isinstance(tokenizer, PreTrainedTokenizerBase):
+        if tokenizer is not None:
             warnings.warn(
                 "The `tokenizer` argument is deprecated and will be removed in v5 of Transformers. You can use `processor` "
                 "instead to pass your tokenizer/image processor/feature extractor/multimodal processor object.",
@@ -687,7 +687,7 @@ class Trainer:
     @property
     def tokenizer(self):
         warnings.warn(
-            "The 'tokenizer' attribute is deprecated and will be removed in a future version. Use `processor` instead",
+            "The 'tokenizer' attribute is deprecated and will be removed in v5 of Transformers. Use `processor` instead",
             FutureWarning,
         )
         return self.processor

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -24,7 +24,6 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 from tqdm.auto import tqdm
 
-from .tokenization_utils_base import PreTrainedTokenizerBase
 from .trainer_utils import IntervalStrategy, has_length
 from .training_args import TrainingArguments
 from .utils import logging
@@ -310,7 +309,7 @@ class CallbackHandler(TrainerCallback):
     """Internal class that just calls the list of callbacks in order."""
 
     def __init__(self, callbacks, model, processor, optimizer, lr_scheduler, tokenizer=None):
-        if tokenizer is not None and not isinstance(tokenizer, PreTrainedTokenizerBase):
+        if tokenizer is not None:
             warnings.warn(
                 "The `tokenizer` argument is deprecated and will be removed in v5 of Transformers. You can use `processor` "
                 "instead to pass your tokenizer/image processor/feature extractor/multimodal processor object.",

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -309,7 +309,7 @@ class TrainerCallback:
 class CallbackHandler(TrainerCallback):
     """Internal class that just calls the list of callbacks in order."""
 
-    def __init__(self, callbacks, model, processor, optimizer, lr_scheduler, tokenizer):
+    def __init__(self, callbacks, model, processor, optimizer, lr_scheduler, tokenizer=None):
         if tokenizer is not None and not isinstance(tokenizer, PreTrainedTokenizerBase):
             warnings.warn(
                 "The `tokenizer` argument is deprecated and will be removed in v5 of Transformers. You can use `processor` "


### PR DESCRIPTION
# What does this PR do?

This PR updates the `tokenizer` argument which people can pass to the Trainer and TrainerCallback classes to `processor` instead. This allows for people to pass tokenizers, image processors, feature extractors or multimodal, which it will then automatically save along the model when training.

Follow-up of #29896

To do:

- [ ] perhaps use `preprocessor` instead of `processor` to avoid confusion with multimodal processors like `CLIPProcessor`?
- [x] add deprecation message for tokenizer attribute