### PR TITLE
Fix: avoid re-instantiating past_key_values(Cache Class)

### DIFF
--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -876,9 +876,11 @@ class GemmaModel(GemmaPreTrainedModel):
 
         past_seen_tokens = 0
         if use_cache:  # kept for BC (cache positions)
-            if not isinstance(past_key_values, StaticCache):
+            use_legacy_cache = not isinstance(past_key_values, Cache)
+            if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-            past_seen_tokens = past_key_values.get_seq_length()
+            if not isinstance(past_key_values, StaticCache):
+                past_seen_tokens = past_key_values.get_seq_length()
 
         if cache_position is None:
             cache_position = torch.arange(

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -973,8 +973,10 @@ class LlamaModel(LlamaPreTrainedModel):
 
         past_seen_tokens = 0
         if use_cache:  # kept for BC (cache positions)
-            if not isinstance(past_key_values, StaticCache):
+            use_legacy_cache = not isinstance(past_key_values, Cache)
+            if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            if not isinstance(past_key_values, StaticCache):
                 past_seen_tokens = past_key_values.get_seq_length()
 
         if cache_position is None:


### PR DESCRIPTION
# What does this PR do?

Fix a bug when set `use_cache=True` and pass a `DynamicCache` class as the `past_key_values` 
## Bug Description

There is an issue when the `use_cache` option is enabled and `DynamicCache()` is passed as the `past_key_values` parameter. Example code is shown below. Specifically, the `past_key_values` are being utilized to reinstantiate a new `DynamicCache()` instance. This behavior is unexpected and results in incorrect outcomes.

```python
kv_cache = DynamicCache()
gen_length  = 0
max_gen_len = 30
while gen_length < max_gen_len:
    output = model(input_ids=prompt, past_key_values=kv_cache, use_cache=True)
    pred_token_idx = output.logits[:, -1, :].argmax(dim=-1)
    prompt = pred_token_idx
    gen_length +=1
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@gante 
@ArthurZucker 
@younesbelkada 