### PR TITLE
[tests] add `require_bitsandbytes` marker

### DIFF
--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -464,9 +464,9 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
 
 
 @require_torch
-@require_bitsandbytes
 class PersimmonIntegrationTest(unittest.TestCase):
     @slow
+    @require_bitsandbytes
     def test_model_8b_chat_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
         model = PersimmonForCausalLM.from_pretrained(

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -466,6 +466,7 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
 @require_torch
 class PersimmonIntegrationTest(unittest.TestCase):
     @slow
+    @require_torch_accelerator
     @require_bitsandbytes
     def test_model_8b_chat_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 from transformers import PersimmonConfig, is_torch_available, set_seed
 from transformers.testing_utils import (
     backend_empty_cache,
+    require_bitsandbytes,
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
@@ -463,6 +464,7 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
 
 
 @require_torch
+@require_bitsandbytes
 class PersimmonIntegrationTest(unittest.TestCase):
     @slow
     def test_model_8b_chat_logits(self):
@@ -492,6 +494,7 @@ class PersimmonIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_torch_fp16
+    @require_bitsandbytes
     def test_model_8b_chat_greedy_generation(self):
         EXPECTED_TEXT_COMPLETION = """human: Simply put, the theory of relativity states that?\n\nadept: The theory of relativity states that the laws of physics are the same for all observers, regardless of their relative motion."""
         prompt = "human: Simply put, the theory of relativity states that?\n\nadept:"


### PR DESCRIPTION
# What does this PR do?
The below 2 tests fails because I haven't installed bitsandbytes in my environment: 
```bash
FAILED tests/models/persimmon/test_modeling_persimmon.py::PersimmonIntegrationTest::test_model_8b_chat_greedy_generation - ImportError: Using `bitsandbytes` 8-bit quantization requires Accelerate: `pip install accelerate` and the latest version of bitsandbytes: `pip install -i https://pypi.org/simple/ bitsandbytes`
FAILED tests/models/persimmon/test_modeling_persimmon.py::PersimmonIntegrationTest::test_model_8b_chat_logits - ImportError: Using `bitsandbytes` 8-bit quantization requires Accelerate: `pip install accelerate` and the latest version of bitsandbytes: `pip install -i https://pypi.org/simple/ bitsandbytes`
```
But these 2 tests should be skipped instead of failed. This PR fixes this issue by adding the `require_bitsandbytes` marker.

## Who can review?
@ArthurZucker 