### PR TITLE
Patch fix - don't use safetensors for TF models

### DIFF
--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -111,7 +111,7 @@ class GenerationIntegrationTestsMixin:
         article = """Justin Timberlake."""
         gpt2_tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
-        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
         input_ids = gpt2_tokenizer(article, return_tensors=return_tensors).input_ids
         if is_pt:
             gpt2_model = gpt2_model.to(torch_device)

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -582,7 +582,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -611,7 +611,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -638,7 +638,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -194,7 +194,7 @@ class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTests
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors="tf")
-        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=False)
 
         eos_token_id = 638
         # forces the generation to happen on CPU, to avoid GPU-related quirks

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -268,6 +268,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
         text_generator = TextGenerationPipeline(model=model, tokenizer=tokenizer)
         return text_generator, ["This is a test", "Another test"]
 
+    @require_torch  # See https://github.com/huggingface/transformers/issues/30117
     def test_stop_sequence_stopping_criteria(self):
         prompt = """Hello I believe in"""
         text_generator = pipeline("text-generation", model="hf-internal-testing/tiny-random-gpt2")


### PR DESCRIPTION
# What does this PR do?

There was an upstream change to the model weights used for testing: https://huggingface.co/hf-internal-testing/tiny-random-gpt2/tree/main

This resulted in TF generation tests using this checkpoint to fail. 

This resolves test which are currently failing on main and open PRs e.g. [here](https://app.circleci.com/pipelines/github/huggingface/transformers/88901/workflows/0cad538f-e551-478f-873c-1e9e0df45b5b/jobs/1158132)

```
FAILED tests/generation/test_tf_utils.py::TFGenerationIntegrationTests::test_eos_token_id_int_and_list_beam_search - AssertionError: False is not true
FAILED tests/generation/test_tf_utils.py::TFGenerationIntegrationTests::test_eos_token_id_int_and_list_contrastive_search - AssertionError: False is not true
FAILED tests/generation/test_tf_utils.py::TFGenerationIntegrationTests::test_eos_token_id_int_and_list_greedy_search - AssertionError: False is not true
FAILED tests/generation/test_tf_utils.py::TFGenerationIntegrationTests::test_eos_token_id_int_and_list_top_k_top_sampling - AssertionError: False is not true
```

The tests did not start failing for the PT models, indicating there is an mis-match between safetensors loading behaviour for PT and TF. 

An issue has been opened here: #30117
