### PR TITLE
Revert workaround for TF safetensors loading

### DIFF
--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -111,7 +111,7 @@ class GenerationIntegrationTestsMixin:
         article = """Justin Timberlake."""
         gpt2_tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
-        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         input_ids = gpt2_tokenizer(article, return_tensors=return_tensors).input_ids
         if is_pt:
             gpt2_model = gpt2_model.to(torch_device)
@@ -582,7 +582,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -611,7 +611,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -638,7 +638,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)

--- a/tests/generation/test_framework_agnostic.py
+++ b/tests/generation/test_framework_agnostic.py
@@ -111,7 +111,7 @@ class GenerationIntegrationTestsMixin:
         article = """Justin Timberlake."""
         gpt2_tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
-        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
+        gpt2_model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
         input_ids = gpt2_tokenizer(article, return_tensors=return_tensors).input_ids
         if is_pt:
             gpt2_model = gpt2_model.to(torch_device)
@@ -582,7 +582,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -611,7 +611,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
@@ -638,7 +638,7 @@ class GenerationIntegrationTestsMixin:
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors=return_tensors)
-        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=is_pt)
+        model = model_cls.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
         if is_pt:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -194,7 +194,7 @@ class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTests
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors="tf")
-        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", use_safetensors=False)
+        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
 
         eos_token_id = 638
         # forces the generation to happen on CPU, to avoid GPU-related quirks

--- a/tests/generation/test_tf_utils.py
+++ b/tests/generation/test_tf_utils.py
@@ -194,7 +194,7 @@ class TFGenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTests
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
         tokens = tokenizer(text, return_tensors="tf")
-        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        model = TFAutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
 
         eos_token_id = 638
         # forces the generation to happen on CPU, to avoid GPU-related quirks

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -270,7 +270,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
 
     def test_stop_sequence_stopping_criteria(self):
         prompt = """Hello I believe in"""
-        text_generator = pipeline("text-generation", model="hf-internal-testing/tiny-random-gpt2", revision="pr/4")
+        text_generator = pipeline("text-generation", model="hf-internal-testing/tiny-random-gpt2")
         output = text_generator(prompt)
         self.assertEqual(
             output,

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -268,10 +268,9 @@ class TextGenerationPipelineTests(unittest.TestCase):
         text_generator = TextGenerationPipeline(model=model, tokenizer=tokenizer)
         return text_generator, ["This is a test", "Another test"]
 
-    @require_torch  # See https://github.com/huggingface/transformers/issues/30117
     def test_stop_sequence_stopping_criteria(self):
         prompt = """Hello I believe in"""
-        text_generator = pipeline("text-generation", model="hf-internal-testing/tiny-random-gpt2")
+        text_generator = pipeline("text-generation", model="hf-internal-testing/tiny-random-gpt2", revision="pr/4")
         output = text_generator(prompt)
         self.assertEqual(
             output,


### PR DESCRIPTION
In #30118 @amyeroberts skipped safetensors loading on TF models. I believe I've worked out the cause, and it was that the safetensors weights in that repo were a bit malformed. I tried fixing them by loading and saving them again with a torch `AutoModelForCausalLM`, so hopefully we can use the fixed weights and revert the changes.