### PR TITLE
[Trainer] Fix default data collator

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -58,6 +58,7 @@ from . import __version__
 from .configuration_utils import PretrainedConfig
 from .data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
 from .debug_utils import DebugOption, DebugUnderflowOverflow
+from .feature_extraction_sequence_utils import SequenceFeatureExtractor
 from .hyperparameter_search import ALL_HYPERPARAMETER_SEARCH_BACKENDS, default_hp_search_backend
 from .image_processing_utils import BaseImageProcessor
 from .integrations.deepspeed import deepspeed_init, deepspeed_load_checkpoint, is_deepspeed_available
@@ -494,7 +495,7 @@ class Trainer:
 
         default_collator = (
             DataCollatorWithPadding(tokenizer)
-            if tokenizer is not None and isinstance(tokenizer, PreTrainedTokenizerBase)
+            if tokenizer is not None and isinstance(tokenizer, (PreTrainedTokenizerBase, SequenceFeatureExtractor))
             else default_data_collator
         )
         self.data_collator = data_collator if data_collator is not None else default_collator

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -492,7 +492,11 @@ class Trainer:
         ):
             self.place_model_on_device = False
 
-        default_collator = DataCollatorWithPadding(tokenizer) if tokenizer is not None else default_data_collator
+        default_collator = (
+            DataCollatorWithPadding(tokenizer)
+            if tokenizer is not None and isinstance(tokenizer, PreTrainedTokenizerBase)
+            else default_data_collator
+        )
         self.data_collator = data_collator if data_collator is not None else default_collator
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset


### PR DESCRIPTION
# What does this PR do?

This PR isolates a fix proposed in #30129, namely the DataCollatorWithPadding only needs to be used in case a tokenizer is being passed and is effectively a tokenizer or feature extractor, not another object like an image processor.