### PR TITLE
Enforce saving at end of training if saving option chosen

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -544,7 +544,7 @@ class DefaultFlowCallback(TrainerCallback):
         # End training
         if state.global_step >= state.max_steps:
             control.should_training_stop = True
-            # Save the best model at the end if we have a save strategy
+            # Save the model at the end if we have a save strategy
             if args.save_strategy != IntervalStrategy.NO:
                 control.should_save = True
 

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -544,6 +544,9 @@ class DefaultFlowCallback(TrainerCallback):
         # End training
         if state.global_step >= state.max_steps:
             control.should_training_stop = True
+            # Save the best model at the end if we have a save strategy
+            if args.save_strategy != IntervalStrategy.NO:
+                control.should_save = True
 
         return control
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -333,6 +333,9 @@ class TrainingArguments:
                 - `"no"`: No save is done during training.
                 - `"epoch"`: Save is done at the end of each epoch.
                 - `"steps"`: Save is done every `save_steps`.
+
+                If `"epoch"` or `"steps"` is chosen, saving will also be performed at the
+                very end of training, always.
         save_steps (`int` or `float`, *optional*, defaults to 500):
             Number of updates steps before two checkpoint saves if `save_strategy="steps"`. Should be an integer or a
             float in range `[0,1)`. If smaller than 1, will be interpreted as ratio of total training steps.

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -127,7 +127,7 @@ if is_torch_available():
 
     if is_safetensors_available():
         import safetensors.torch
-        
+
 
 # for version specific tests in TrainerIntegrationTest
 require_accelerate_version_min_0_28 = partial(require_accelerate, min_version="0.28")
@@ -2013,7 +2013,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             # this goes by the last `eval` step check to do so, so it won't be
             # the last model *saved*
             model_state = trainer.model.state_dict()
-            final_model_weights = safetensors.torch.load_file(os.path.join(tmpdir, "checkpoint-10", "model.safetensors"))
+            final_model_weights = safetensors.torch.load_file(
+                os.path.join(tmpdir, "checkpoint-10", "model.safetensors")
+            )
             for k, v in model_state.items():
                 assert torch.allclose(v, final_model_weights[k]), f"{k} is not the same"
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -34,7 +34,6 @@ import numpy as np
 from huggingface_hub import HfFolder, ModelCard, delete_repo, list_repo_commits, list_repo_files
 from parameterized import parameterized
 from requests.exceptions import HTTPError
-from safetensors.torch import load_file
 
 from transformers import (
     AutoTokenizer,
@@ -128,6 +127,7 @@ if is_torch_available():
 
     if is_safetensors_available():
         import safetensors.torch
+        
 
 # for version specific tests in TrainerIntegrationTest
 require_accelerate_version_min_0_28 = partial(require_accelerate, min_version="0.28")
@@ -2013,7 +2013,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             # this goes by the last `eval` step check to do so, so it won't be
             # the last model *saved*
             model_state = trainer.model.state_dict()
-            final_model_weights = load_file(os.path.join(tmpdir, "checkpoint-10", "model.safetensors"))
+            final_model_weights = safetensors.torch.load_file(os.path.join(tmpdir, "checkpoint-10", "model.safetensors"))
             for k, v in model_state.items():
                 assert torch.allclose(v, final_model_weights[k]), f"{k} is not the same"
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -153,7 +153,7 @@ class TrainerCallbackTest(unittest.TestCase):
                     expected_events.append("on_log")
                 if trainer.args.eval_strategy == IntervalStrategy.STEPS and step % trainer.args.eval_steps == 0:
                     expected_events += evaluation_events.copy()
-                if step % trainer.args.save_steps == 0:
+                if step % trainer.args.save_steps == 0 or step == trainer.state.max_steps:
                     expected_events.append("on_save")
             expected_events.append("on_epoch_end")
             if trainer.args.eval_strategy == IntervalStrategy.EPOCH:


### PR DESCRIPTION
# What does this PR do?

Currently we save at the end of training if an `epoch` strategy is chosen, but not if a `steps` strategy is chosen. This can be undesireable because the end of a users training might not be saved at all, sometimes upwards of 10% as seen here: https://github.com/huggingface/transformers/issues/28539

This PR mimics the behavior of `epoch`, by choosing to save the model at the end of training as well if `steps` is chosen.

I do not believe it makes sense to make this configurable, because a user should *always* have access to the end-resulting model when training!


Fixes https://github.com/huggingface/transformers/issues/28539


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @pacman100 