### PR TITLE
Fix Marian model conversion

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3840,7 +3840,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model_buffers = {".".join([prefix, key]) for key in model_buffers}
         unexpected_keys = sorted(unexpected_keys - model_buffers)
 
-        model.tie_weights()
         if device_map is None and not is_fsdp_enabled() and not is_deepspeed_zero3_enabled():
             ptrs = collections.defaultdict(list)
             for name, tensor in model.state_dict().items():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3840,6 +3840,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model_buffers = {".".join([prefix, key]) for key in model_buffers}
         unexpected_keys = sorted(unexpected_keys - model_buffers)
 
+        model.tie_weights()
         if device_map is None and not is_fsdp_enabled() and not is_deepspeed_zero3_enabled():
             ptrs = collections.defaultdict(list)
             for name, tensor in model.state_dict().items():

--- a/src/transformers/models/marian/convert_marian_tatoeba_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_tatoeba_to_pytorch.py
@@ -87,7 +87,7 @@ class TatoebaConverter:
             opus_language_groups_to_hf = convert_opus_name_to_hf_name
             pair_name = opus_language_groups_to_hf(model["_name"])
             convert(save_dir / model["_name"], dest_dir / f"opus-mt-{pair_name}")
-            # self.write_model_card(model, dry_run=dry_run)
+            self.write_model_card(model, dry_run=dry_run)
 
     def expand_group_to_two_letter_codes(self, grp_name):
         return [self.alpha3_to_alpha2.get(x, x) for x in GROUP_MEMBERS[grp_name][1]]

--- a/src/transformers/models/marian/convert_marian_tatoeba_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_tatoeba_to_pytorch.py
@@ -34,7 +34,6 @@ from transformers.models.marian.convert_marian_to_pytorch import (
 
 DEFAULT_REPO = "Tatoeba-Challenge"
 DEFAULT_MODEL_DIR = os.path.join(DEFAULT_REPO, "models")
-LANG_CODE_URL = "https://datahub.io/core/language-codes/r/language-codes-3b2.csv"
 ISO_URL = "https://cdn-datasets.huggingface.co/language_codes/iso-639-3.csv"
 ISO_PATH = "lang_code_data/iso-639-3.csv"
 LANG_CODE_PATH = "lang_code_data/language-codes-3b2.csv"
@@ -88,7 +87,7 @@ class TatoebaConverter:
             opus_language_groups_to_hf = convert_opus_name_to_hf_name
             pair_name = opus_language_groups_to_hf(model["_name"])
             convert(save_dir / model["_name"], dest_dir / f"opus-mt-{pair_name}")
-            self.write_model_card(model, dry_run=dry_run)
+            # self.write_model_card(model, dry_run=dry_run)
 
     def expand_group_to_two_letter_codes(self, grp_name):
         return [self.alpha3_to_alpha2.get(x, x) for x in GROUP_MEMBERS[grp_name][1]]
@@ -277,13 +276,17 @@ class TatoebaConverter:
             json.dump(metadata, writeobj)
 
     def download_lang_info(self):
+        global LANG_CODE_PATH
         Path(LANG_CODE_PATH).parent.mkdir(exist_ok=True)
         import wget
+        from huggingface_hub import hf_hub_download
 
         if not os.path.exists(ISO_PATH):
             wget.download(ISO_URL, ISO_PATH)
         if not os.path.exists(LANG_CODE_PATH):
-            wget.download(LANG_CODE_URL, LANG_CODE_PATH)
+            LANG_CODE_PATH = hf_hub_download(
+                repo_id="huggingface/language_codes_marianMT", filename="language-codes-3b2.csv", repo_type="dataset"
+            )
 
     def parse_metadata(self, model_name, repo_path=DEFAULT_MODEL_DIR, method="best"):
         p = Path(repo_path) / model_name

--- a/src/transformers/models/marian/convert_marian_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_to_pytorch.py
@@ -622,6 +622,12 @@ class OpusState:
             bias_tensor = nn.Parameter(torch.FloatTensor(self.final_bias))
             model.model.decoder.embed_tokens.weight = decoder_wemb_tensor
 
+        # handle tied embeddings, otherwise "from_pretrained" loads them incorrectly
+        if self.cfg["tied-embeddings"]:
+            wemb_tensor = nn.Parameter(torch.FloatTensor(self.wemb))
+            bias_tensor = nn.Parameter(torch.FloatTensor(self.final_bias))
+            model.lm_head.weight.data = model.model.decoder.embed_tokens.weight.data.clone()
+
         model.final_logits_bias = bias_tensor
 
         if "Wpos" in state_dict:

--- a/src/transformers/models/marian/convert_marian_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_to_pytorch.py
@@ -624,8 +624,6 @@ class OpusState:
 
         # handle tied embeddings, otherwise "from_pretrained" loads them incorrectly
         if self.cfg["tied-embeddings"]:
-            wemb_tensor = nn.Parameter(torch.FloatTensor(self.wemb))
-            bias_tensor = nn.Parameter(torch.FloatTensor(self.final_bias))
             model.lm_head.weight.data = model.model.decoder.embed_tokens.weight.data.clone()
 
         model.final_logits_bias = bias_tensor


### PR DESCRIPTION
# What does this PR do?

Fixes #26216. After a bit of code exploration I found that problem was in the "tie_weights" method. The issue is that "tie_weights" does not clone, but simply change pointer output_embeddings -> input_embeddings. And since we tie weights at least twice during loading weights (once before loading state dict and the other is after), the weights were being loaded incorrectly.


Why the issue is only in MarianMT and not other models that tie weights? -> Because in other models either the weights already hold the same/tied values , or the order of loading parameters is different from MarianMT. When loading state dict into the MarianMT, "output_embeddings" are loaded last and therefore "input_embeddings" weights data is overriden to will hold same data as "output_embeddings". That way we lose access to actual "input_embeddings" weights data
This is somehow related to an [old PR](https://github.com/huggingface/transformers/pull/24200) I found.


I converted the weights with `python src/transformers/models/marian/convert_marian_tatoeba_to_pytorch.py --models fin-eng --save_dir converted` and checked the correctness of results with the below script. Everything works good.

```python
from transformers import AutoTokenizer, MarianMTModel

tokenizer = AutoTokenizer.from_pretrained("/home/raushan/converted/opus-mt-fin-eng/")
model = MarianMTModel.from_pretrained("/home/raushan/converted/opus-mt-fin-eng/")

inputs = ["Hei siellä", "Miten aurinko sanotaan suomeksi?"]
batch_tokenized = tokenizer(inputs, return_tensors="pt", padding=True)
model_output = model.generate(
    **batch_tokenized, max_new_tokens=100
)
batch_detokenized = tokenizer.batch_decode(
    model_output,
    skip_special_tokens=True,
)

print(batch_detokenized)
```

Marian tests including slow are all passsing on my end.