### PR TITLE
fix: Fixed `ruff` configuration to avoid deprecated configuration warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,18 @@
 [tool.ruff]
+line-length = 119
+
+[tool.ruff.lint]
 # Never enforce `E501` (line length violations).
 ignore = ["C901", "E501", "E741", "F402", "F823" ]
 select = ["C", "E", "F", "I", "W"]
-line-length = 119
 
 # Ignore import violations in all `__init__.py` files.
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403", "F811"]
 "src/transformers/file_utils.py" = ["F401"]
 "src/transformers/utils/dummy_*.py" = ["F401"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-after-imports = 2
 known-first-party = ["transformers"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,4 @@ markers = [
     "flash_attn_test: marks tests related to flash attention (deselect with '-m \"not flash_attn_test\"')",
     "bitsandbytes: select (or deselect with `not`) bitsandbytes integration tests",
 ]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,3 @@ markers = [
     "flash_attn_test: marks tests related to flash attention (deselect with '-m \"not flash_attn_test\"')",
     "bitsandbytes: select (or deselect with `not`) bitsandbytes integration tests",
 ]
-


### PR DESCRIPTION
# What does this PR do?
Currently, if we run `ruff`, we are getting the following warning

![image](https://github.com/huggingface/transformers/assets/87087741/a08486e1-8d8e-4c33-a813-d5fb0c74369d)

This is because, the configuration that is currently used for ruff in `pyproject.toml` is deprecated. So, I have updated the configuration according to the updated configuration rules of [`ruff`](https://docs.astral.sh/ruff/configuration/). The warning is no longer coming and all the `ruff` checks are also successfully passing.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
From my observations through git blame of `pyproject.toml`
@ArthurZucker 