### PR TITLE
(Docs) Fix object_detection.md: Do not convert from RGB to BGR for augmentations

### DIFF
--- a/docs/source/en/tasks/object_detection.md
+++ b/docs/source/en/tasks/object_detection.md
@@ -250,7 +250,7 @@ Now you can combine the image and annotation transformations to use on a batch o
 ...     image_ids = examples["image_id"]
 ...     images, bboxes, area, categories = [], [], [], []
 ...     for image, objects in zip(examples["image"], examples["objects"]):
-...         image = np.array(image.convert("RGB"))[:, :, ::-1]
+...         image = np.array(image.convert("RGB"))
 ...         out = transform(image=image, bboxes=objects["bbox"], category=objects["category"])
 
 ...         area.append(objects["area"])


### PR DESCRIPTION
# What does this PR do?

The docs of Albumenations here say that they use RGB instead of BGR: https://albumentations.ai/docs/examples/example/#read-the-image-from-the-disk-and-convert-it-from-the-bgr-color-space-to-the-rgb-color-space

The object detection notebook/docs however reverse the color channel dimension after opening the image as RGB and therefore pass BGR. My PR removes the reversal of channel dimension to correct this.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?