### PR TITLE
Add time-based save, log, eval

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -107,7 +107,7 @@ class TrainerState:
     is_hyper_param_search: bool = False
     trial_name: str = None
     trial_params: Dict[str, Union[str, float, int, bool]] = None
-    time_checkpoints: Dict[Literal["log", "save", "eval"], Optional[datetime.datetime]] = None
+    time_checkpoints: Optional[Dict[Literal["log", "save", "eval"], Optional[datetime.datetime]]] = None
 
     def __post_init__(self):
         if self.log_history is None:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -107,9 +107,7 @@ class TrainerState:
     is_hyper_param_search: bool = False
     trial_name: str = None
     trial_params: Dict[str, Union[str, float, int, bool]] = None
-    time_checkpoints: Dict[Literal["log", "save", "eval"], Optional[datetime.datetime]] = dataclasses.field(
-        default=None, init=False
-    )
+    time_checkpoints: Dict[Literal["log", "save", "eval"], Optional[datetime.datetime]] = None
 
     def __post_init__(self):
         if self.log_history is None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1379,6 +1379,45 @@ class TrainingArguments:
         },
     )
 
+    log_every_minutes: int = field(
+        default=None,
+        metadata={
+            "help": (
+                "Log every X minutes. Should be an integer in minutes. If given, this will trigger logging"
+                " approximately every given minutes in addition to other specified logging strategies. Note that this"
+                " is only an approximation: time since last log will be checked after every step, so for a long step"
+                " duration, this may overshoot the given value. It's best to be conversative in your minutes"
+                " estimation."
+            )
+        },
+    )
+
+    save_every_minutes: int = field(
+        default=None,
+        metadata={
+            "help": (
+                "Save every X minutes. Should be an integer in minutes. If given, this will trigger saving"
+                " approximately every given minutes in addition to other specified save strategies. Note that this"
+                " is only an approximation: time since last save will be checked after every step, so for a long step"
+                " duration, this may overshoot the given value. It's best to be conversative in your minutes"
+                " estimation."
+            )
+        },
+    )
+
+    eval_every_minutes: int = field(
+        default=None,
+        metadata={
+            "help": (
+                "Evaluate every X minutes. Should be an integer in minutes. If given, this will trigger evaluation"
+                " approximately every given minutes in addition to other specified eval strategies. Note that this"
+                " is only an approximation: time since last eval will be checked after every step, so for a long step"
+                " duration, this may overshoot the given value. It's best to be conversative in your minutes"
+                " estimation."
+            )
+        },
+    )
+
     def __post_init__(self):
         # expand paths, if not os.makedirs("~/bar") will make directory
         # in the current directory instead of the actual home


### PR DESCRIPTION
As discussed in https://github.com/huggingface/transformers/issues/29984, this feature PR adds the ability to add an additional "security" for logging, evaluating, and saving. (The last two being the most useful.) It is motivated by HPC environments where a job has a given time (e.g. 72 hours), so just to be sure you may want to save your progress at the 70hr mark. This interval is _in addition_ to the other strategies for saving, logging, and evaluating, and does not replace them! It's sort-of a failsafe.

Details:

- Adds three arguments to `TrainingArguments`: `save_every_minutes`, `log_every_minutes`, and `eval_every_minutes`. Their default is None
- Add `time_checkpoints` as a field to `TrainerState`, which is a dictionary of `[log, save, eval] => datetime object` to track for each event type when its previous event occurred
- Updated `TrainerState.save_to_json` and `TrainerState.load_from_json` to account for the newly added `time_checkpoints`. This is necessary because datetime objects are not serializable. To accommoodate them, we serialize datetime object as an ISO string and deserialize them in the same way. This also ensures that the Trainer callback tests pass
- Updated `DefaultFlowCallback`:
  - Add `on_train_begin` which will set the aforementioned dictionary keys to the `now` timing so the we can start keep tracking at every step whether the interval has been reached
  - Update `on_step_end` to also check our intervals for every log, eval, save event and set `should_X` accordingly. If this is the case, we also update `time_checkpoints[event_type]` with the current time
