### PR TITLE
Separate out kwargs in processor

### DIFF
--- a/src/transformers/models/clip/processing_clip.py
+++ b/src/transformers/models/clip/processing_clip.py
@@ -94,8 +94,10 @@ class CLIPProcessor(ProcessorMixin):
         """
         tokenizer_kwargs, image_processor_kwargs = {}, {}
         if kwargs:
-            tokenizer_kwargs = {k: v for k,v in kwargs.items() if k not in self.image_processor._valid_processor_keys}
-            image_processor_kwargs = {k:v for k,v in kwargs.items() if k in self.image_processor._valid_processor_keys}
+            tokenizer_kwargs = {k: v for k, v in kwargs.items() if k not in self.image_processor._valid_processor_keys}
+            image_processor_kwargs = {
+                k: v for k, v in kwargs.items() if k in self.image_processor._valid_processor_keys
+            }
 
         if text is None and images is None:
             raise ValueError("You have to specify either text or images. Both cannot be none.")

--- a/src/transformers/models/clip/processing_clip.py
+++ b/src/transformers/models/clip/processing_clip.py
@@ -92,15 +92,19 @@ class CLIPProcessor(ProcessorMixin):
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
+        tokenizer_kwargs, image_processor_kwargs = {}, {}
+        if kwargs:
+            tokenizer_kwargs = {k: v for k,v in kwargs.items() if k not in self.image_processor._valid_processor_keys}
+            image_processor_kwargs = {k:v for k,v in kwargs.items() if k in self.image_processor._valid_processor_keys}
 
         if text is None and images is None:
             raise ValueError("You have to specify either text or images. Both cannot be none.")
 
         if text is not None:
-            encoding = self.tokenizer(text, return_tensors=return_tensors, **kwargs)
+            encoding = self.tokenizer(text, return_tensors=return_tensors, **tokenizer_kwargs)
 
         if images is not None:
-            image_features = self.image_processor(images, return_tensors=return_tensors, **kwargs)
+            image_features = self.image_processor(images, return_tensors=return_tensors, **image_processor_kwargs)
 
         if text is not None and images is not None:
             encoding["pixel_values"] = image_features.pixel_values


### PR DESCRIPTION
# What does this PR do?

Separates out the kwargs that are passed to the processor into tokenizer and image processor kwargs. 

This solves two issues:
* Removes warnings from validation checks that now happen in the image processor (nice proof they're working!)
* Prevents passing kwargs which have a name clash between the two processing classes


Fixes #30106


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?