### PR TITLE
fix: Replaced deprecated `logger.warn` with `logger.warning`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2225,7 +2225,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             self._set_gradient_checkpointing(enable=True, gradient_checkpointing_func=gradient_checkpointing_func)
         else:
             self.apply(partial(self._set_gradient_checkpointing, value=True))
-            logger.warn(
+            logger.warning(
                 "You are using an old version of the checkpointing format that is deprecated (We will also silently ignore `gradient_checkpointing_kwargs` in case you passed it)."
                 "Please update to the new format on your modeling file. To use the new format, you need to completely remove the definition of the method `_set_gradient_checkpointing` in your model."
             )
@@ -2273,7 +2273,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if not _is_using_old_format:
                 self._set_gradient_checkpointing(enable=False)
             else:
-                logger.warn(
+                logger.warning(
                     "You are using an old version of the checkpointing format that is deprecated (We will also silently ignore `gradient_checkpointing_kwargs` in case you passed it)."
                     "Please update to the new format on your modeling file. To use the new format, you need to completely remove the definition of the method `_set_gradient_checkpointing` in your model."
                 )

--- a/src/transformers/models/fastspeech2_conformer/tokenization_fastspeech2_conformer.py
+++ b/src/transformers/models/fastspeech2_conformer/tokenization_fastspeech2_conformer.py
@@ -130,14 +130,14 @@ class FastSpeech2ConformerTokenizer(PreTrainedTokenizer):
 
     # Override since phonemes cannot be converted back to strings
     def decode(self, token_ids, **kwargs):
-        logger.warn(
+        logger.warning(
             "Phonemes cannot be reliably converted to a string due to the one-many mapping, converting to tokens instead."
         )
         return self.convert_ids_to_tokens(token_ids)
 
     # Override since phonemes cannot be converted back to strings
     def convert_tokens_to_string(self, tokens, **kwargs):
-        logger.warn(
+        logger.warning(
             "Phonemes cannot be reliably converted to a string due to the one-many mapping, returning the tokens."
         )
         return tokens

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -985,16 +985,16 @@ class WhisperGenerationMixin:
             "{}, but will be ignored."
         )
         if condition_on_prev_tokens is not None:
-            logger.warn(warning_prefix.format(f"condition_on_prev_tokens is set to {condition_on_prev_tokens}"))
+            logger.warning(warning_prefix.format(f"condition_on_prev_tokens is set to {condition_on_prev_tokens}"))
 
         if compression_ratio_threshold is not None:
-            logger.warn(warning_prefix.format(f"compression_ratio_threshold is set to {compression_ratio_threshold}"))
+            logger.warning(warning_prefix.format(f"compression_ratio_threshold is set to {compression_ratio_threshold}"))
 
         if logprob_threshold is not None:
-            logger.warn(warning_prefix.format(f"logprob_threshold is set to {logprob_threshold}"))
+            logger.warning(warning_prefix.format(f"logprob_threshold is set to {logprob_threshold}"))
 
         if no_speech_threshold is not None:
-            logger.warn(warning_prefix.format(f"no_speech_threshold is set to {no_speech_threshold}"))
+            logger.warning(warning_prefix.format(f"no_speech_threshold is set to {no_speech_threshold}"))
 
         # when passing temperature as a list it cannot just be ignored => throw error in this case
         if isinstance(temperature, (list, tuple)):

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -988,7 +988,9 @@ class WhisperGenerationMixin:
             logger.warning(warning_prefix.format(f"condition_on_prev_tokens is set to {condition_on_prev_tokens}"))
 
         if compression_ratio_threshold is not None:
-            logger.warning(warning_prefix.format(f"compression_ratio_threshold is set to {compression_ratio_threshold}"))
+            logger.warning(
+                warning_prefix.format(f"compression_ratio_threshold is set to {compression_ratio_threshold}")
+            )
 
         if logprob_threshold is not None:
             logger.warning(warning_prefix.format(f"logprob_threshold is set to {logprob_threshold}"))

--- a/src/transformers/quantizers/quantizer_aqlm.py
+++ b/src/transformers/quantizers/quantizer_aqlm.py
@@ -88,7 +88,7 @@ class AqlmHfQuantizer(HfQuantizer):
         if aqlm_supports_training:
             return True
         else:
-            logger.warn(
+            logger.warning(
                 f"Currently installed `aqlm` version ({importlib.metadata.version('aqlm')}) doesn't support training. If you wish to train a quantized model, please update `aqlm` with `pip install aqlm>=1.0.2`"
             )
             return False


### PR DESCRIPTION
# What does this PR do?
`logging.warn` and `logging.Logger.warn` are deprecated in favor of `logging.warning` and `logging.Logger.warning`, which are functionally equivalent. (https://docs.python.org/3/library/logging.html#logging.warning)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts @ArthurZucker 