### PR TITLE
Add attention upcast for GPT-NeoX

### DIFF
--- a/src/transformers/models/gpt_neox/configuration_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/configuration_gpt_neox.py
@@ -128,6 +128,7 @@ class GPTNeoXConfig(PretrainedConfig):
         use_parallel_residual=True,
         rope_scaling=None,
         attention_bias=True,
+        upcast_attn=False,
         **kwargs,
     ):
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
@@ -150,6 +151,7 @@ class GPTNeoXConfig(PretrainedConfig):
         self.use_parallel_residual = use_parallel_residual
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
+        self.upcast_attn = upcast_attn
         self._rope_scaling_validation()
 
         if self.hidden_size % self.num_attention_heads != 0:


### PR DESCRIPTION
# What does this PR do?

This PR adds a flag to upcast the QK.T matmul step in the attention layer, for better numerical stability when using fp16. 
This is the same as the upcast added to GPT-2 in https://github.com/huggingface/transformers/pull/13573

Without this step, smaller models often overflow during the softmax. For example:
```
train = load_dataset('EleutherAI/pile-deduped-pythia-random-sampled', split='train')
train = train.cast_column('Tokens', datasets.Sequence(datasets.Value('int64')))
train = train.with_format('torch')
train_loader = DataLoader(train, batch_size=32)
x = next(iter(train_loader))['Tokens'].to('cuda')

model = AutoModelForCausalLM.from_pretrained(f'EleutherAI/pythia-14m').to('cuda')
with torch.autocast(enabled=True, device_type='cuda', dtype=torch.float16):
    out = model(input_ids=x, labels=x)
print(out.loss.item()) # nan

config = AutoConfig.from_pretrained('EleutherAI/pythia-14m')
config.upcast_attn = True
model = AutoModelForCausalLM.from_pretrained('EleutherAI/pythia-14m', config=config).to('cuda')
with torch.autocast(enabled=True, device_type='cuda', dtype=torch.float16):
    out = model(input_ids=x, labels=x)
print(out.loss.item()) # 4.708
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@younesbelkada @zphang 