### PR TITLE
Allow for str versions of dicts based on typing

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1401,8 +1401,8 @@ class TrainingArguments:
                 # Check if raw `dict` types are in any of its values
                 if any(arg in (dict, Dict) for arg in get_args(field.type)):
                     # If found, add to the list of fields that can be loaded as a `dict`
-                    dict_fields.append(name)                
-        
+                    dict_fields.append(name)
+
         # Next parse in the `dict` fields
         for name in dict_fields:
             if isinstance(getattr(self, name), str) and getattr(self, name).startswith("{"):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1149,7 +1149,7 @@ class TrainingArguments:
             )
         },
     )
-    accelerator_config: Optional[Union[dict, str, "AcceleratorConfig"]] = field(
+    accelerator_config: Optional[Union[dict, str]] = field(
         default=None,
         metadata={
             "help": (

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1131,7 +1131,7 @@ class TrainingArguments:
         },
     )
     fsdp_config: Optional[Union[dict, str]] = field(
-        default_factory=dict,
+        default=None,
         metadata={
             "help": (
                 "Config to be used with FSDP (Pytorch Fully Sharded  Data Parallel). The value is either a "
@@ -1149,7 +1149,7 @@ class TrainingArguments:
         },
     )
     accelerator_config: Optional[Union[AcceleratorConfig, dict, str]] = field(
-        default_factory=dict,
+        default=None,
         metadata={
             "help": (
                 "Config to be used with the internal Accelerator object initializtion. The value is either a "
@@ -1158,7 +1158,7 @@ class TrainingArguments:
         },
     )
     deepspeed: Optional[Union[dict, str]] = field(
-        default_factory=dict,
+        default=None,
         metadata={
             "help": (
                 "Enable deepspeed and pass the path to deepspeed json config file (e.g. `ds_config.json`) or an already"
@@ -1262,7 +1262,7 @@ class TrainingArguments:
         },
     )
     gradient_checkpointing_kwargs: Optional[Union[dict, str]] = field(
-        default_factory=dict,
+        default=None,
         metadata={
             "help": "Gradient checkpointing key word arguments such as `use_reentrant`. Will be passed to `torch.utils.checkpoint.checkpoint` through `model.gradient_checkpointing_enable`."
         },
@@ -1391,10 +1391,15 @@ class TrainingArguments:
     def __post_init__(self):
         # Parse in args that could be `dict` sent in from the CLI as a string
         for field in VALID_DICT_FIELDS:
+            passed_value = getattr(self, field)
             # We only want to do this if the str starts with a bracket to indiciate a `dict`
             # else its likely a filename if supported
-            if isinstance(getattr(self, field), str) and getattr(self, field).startswith("{"):
-                setattr(self, field, json.loads(getattr(self, field)))
+            if isinstance(passed_value, str) and passed_value.startswith("{"):
+                setattr(self, field, json.loads(passed_value))
+            # Since we default to a blank dict, set it to `None` after parsing
+            elif isinstance(passed_value, dict):
+                if passed_value == {}:
+                    setattr(self, field, None)
 
         # expand paths, if not os.makedirs("~/bar") will make directory
         # in the current directory instead of the actual home

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1149,7 +1149,7 @@ class TrainingArguments:
             )
         },
     )
-    accelerator_config: Optional[Union[dict, str, AcceleratorConfig]] = field(
+    accelerator_config: Optional[Union[dict, str, "AcceleratorConfig"]] = field(
         default=None,
         metadata={
             "help": (

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1397,10 +1397,6 @@ class TrainingArguments:
             # else its likely a filename if supported
             if isinstance(passed_value, str) and passed_value.startswith("{"):
                 setattr(self, field, json.loads(passed_value))
-            # Since we default to a blank dict, set it to `None` after parsing
-            elif isinstance(passed_value, dict):
-                if passed_value == {}:
-                    setattr(self, field, None)
 
         # expand paths, if not os.makedirs("~/bar") will make directory
         # in the current directory instead of the actual home

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -175,7 +175,8 @@ class OptimizerNames(ExplicitEnum):
 
 # Sometimes users will pass in a `str` repr of a dict in the CLI
 # We need to track what fields those can be. Each time a new arg
-# has a dict type, it must be added to this list
+# has a dict type, it must be added to this list.
+# Important: These should be typed with Optional[Union[dict,str,...]]
 VALID_DICT_FIELDS = [
     "accelerator_config",
     "fsdp_config",
@@ -1148,7 +1149,7 @@ class TrainingArguments:
             )
         },
     )
-    accelerator_config: Optional[Union[AcceleratorConfig, dict, str]] = field(
+    accelerator_config: Optional[Union[dict, str, AcceleratorConfig]] = field(
         default=None,
         metadata={
             "help": (


### PR DESCRIPTION
# What does this PR do?

This PR adds support for passing in a string dictionary to arguments that allow a dict in the argparser. For example:

```
python test.py --output_dir testdir --accelerator_config='{"dispatch_batches":"False"}'
```
(`test.py` is just a small script reading the args from the parsers):
```python
from transformers import HfArgumentParser, TrainingArguments

parser = HfArgumentParser((TrainingArguments))

training_args = parser.parse_args_into_dataclasses()

print(training_args)
```

This also fixes issues with typing of not being able to state that `deepspeed` and `fsdp_config` can't have type `dict`. Turns out it's a (very) fun setting with the argparser wrapper we have for these. Types should be declared as (for this):
```python
Optional[Union[dict,str,...]]
```
This is **very** important to get working properly!


Fixes https://github.com/huggingface/transformers/issues/30204


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @pacman100 

Technically everything will go brr if passes, since any call to the CLI/parser happens usually with examples etc. So new tests added, but did manually verify input/output from a basic script locally