### PR TITLE
fix: Replaced deprecated `typing.Text`  with `str`

### DIFF
--- a/examples/research_projects/tapex/wikisql_utils.py
+++ b/examples/research_projects/tapex/wikisql_utils.py
@@ -21,7 +21,7 @@ import re
 
 # The following script is adapted from the script of TaPas.
 # Original: https://github.com/google-research/tapas/master/wikisql_utils.py
-from typing import Any, List, Text
+from typing import Any, List
 
 
 EMPTY_ANSWER = "none"
@@ -114,7 +114,7 @@ class _Operator(enum.Enum):
 class _Condition:
     """Represents an SQL where clauses (e.g A = "a" or B > 5)."""
 
-    column: Text
+    column: str
     operator: _Operator
     cmp_value: Any
 

--- a/src/transformers/models/tapas/tokenization_tapas.py
+++ b/src/transformers/models/tapas/tokenization_tapas.py
@@ -24,7 +24,7 @@ import os
 import re
 import unicodedata
 from dataclasses import dataclass
-from typing import Callable, Dict, Generator, List, Optional, Text, Tuple, Union
+from typing import Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -70,19 +70,19 @@ class TokenCoordinates:
 
 @dataclass
 class TokenizedTable:
-    rows: List[List[List[Text]]]
+    rows: List[List[List[str]]]
     selected_tokens: List[TokenCoordinates]
 
 
 @dataclass(frozen=True)
 class SerializedExample:
-    tokens: List[Text]
+    tokens: List[str]
     column_ids: List[int]
     row_ids: List[int]
     segment_ids: List[int]
 
 
-def _is_inner_wordpiece(token: Text):
+def _is_inner_wordpiece(token: str):
     return token.startswith("##")
 
 
@@ -2224,14 +2224,14 @@ class NumericValueSpan:
 
 @dataclass
 class Cell:
-    text: Text
+    text: str
     numeric_value: Optional[NumericValue] = None
 
 
 @dataclass
 class Question:
-    original_text: Text  # The original raw question string.
-    text: Text  # The question string after normalization.
+    original_text: str  # The original raw question string.
+    text: str  # The question string after normalization.
     numeric_spans: Optional[List[NumericValueSpan]] = None
 
 


### PR DESCRIPTION
# What does this PR do?
`typing.Text` is an alias for `str`, and only exists for Python 2 compatibility. As of Python 3.11, typing.Text is deprecated. 
Use `str` instead.

For Reference: 
https://docs.python.org/3/library/typing.html#typing.Text
https://docs.astral.sh/ruff/rules/typing-text-str-alias/

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts
