### PR TITLE
Add WSD scheduler

### DIFF
--- a/docs/source/en/main_classes/optimizer_schedules.md
+++ b/docs/source/en/main_classes/optimizer_schedules.md
@@ -66,6 +66,8 @@ The `.optimization` module provides:
 
 [[autodoc]] get_inverse_sqrt_schedule
 
+[[autodoc]] get_wsd_schedule
+
 ### Warmup (TensorFlow)
 
 [[autodoc]] WarmUp

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -3910,6 +3910,7 @@ else:
         "get_inverse_sqrt_schedule",
         "get_linear_schedule_with_warmup",
         "get_polynomial_decay_schedule_with_warmup",
+        "get_wsd_schedule",
         "get_scheduler",
     ]
     _import_structure["pytorch_utils"] = [
@@ -8413,6 +8414,7 @@ if TYPE_CHECKING:
             get_inverse_sqrt_schedule,
             get_linear_schedule_with_warmup,
             get_polynomial_decay_schedule_with_warmup,
+            get_wsd_schedule,
             get_scheduler,
         )
         from .pytorch_utils import Conv1D, apply_chunking_to_forward, prune_layer

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -8414,8 +8414,8 @@ if TYPE_CHECKING:
             get_inverse_sqrt_schedule,
             get_linear_schedule_with_warmup,
             get_polynomial_decay_schedule_with_warmup,
-            get_wsd_schedule,
             get_scheduler,
+            get_wsd_schedule,
         )
         from .pytorch_utils import Conv1D, apply_chunking_to_forward, prune_layer
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -3910,8 +3910,8 @@ else:
         "get_inverse_sqrt_schedule",
         "get_linear_schedule_with_warmup",
         "get_polynomial_decay_schedule_with_warmup",
-        "get_wsd_schedule",
         "get_scheduler",
+        "get_wsd_schedule",
     ]
     _import_structure["pytorch_utils"] = [
         "Conv1D",

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -386,6 +386,65 @@ def get_cosine_with_min_lr_schedule_with_warmup(
     )
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
+def _get_wsd_scheduler_lambda(
+    current_step: int, *, num_warmup_steps: int, num_stable_steps: int, num_decay_steps: int, num_cycles: float, min_lr_ratio: float
+):
+    if current_step < num_warmup_steps:
+        return float(current_step) / float(max(1, num_warmup_steps))
+    if current_step < num_warmup_steps + num_stable_steps:
+        return 1.0
+    if current_step < num_warmup_steps + num_stable_steps + num_decay_steps:
+        progress = float(current_step - num_warmup_steps - num_stable_steps) / float(max(1, num_decay_steps))
+        value = max(0.0, 0.5 * (1.0 + math.cos(math.pi * float(num_cycles) * 2.0 * progress)))
+        return (1.0 - min_lr_ratio) * value + min_lr_ratio
+    return min_lr_ratio
+
+def get_wsd_scheduler(
+    optimizer: Optimizer,
+    num_warmup_steps: int,
+    num_stable_steps: int,
+    num_decay_steps: int,
+    min_lr_ratio: float = 0,
+    num_cycles: float = 0.5,
+    last_epoch: int = -1
+):
+    """
+    Create a schedule with a learning rate that has three stages:
+    1. linear increase from 0 to initial lr.
+    2. constant lr (equal to initial lr).
+    3. decrease following the values of the cosine function between the initial lr set in the optimizer to
+       a fraction of initial lr.
+
+    Args:
+        optimizer ([`~torch.optim.Optimizer`]):
+            The optimizer for which to schedule the learning rate.
+        num_warmup_steps (`int`):
+            The number of steps for the warmup phase.
+        num_stable_steps (`int`):
+            The number of steps for the stable phase.
+        num_decay_steps (`int`):
+            The number of steps for the cosine annealing phase.
+        min_lr_ratio (`float`, *optional*, defaults to 0):
+            The minimum learning rate as a ratio of the initial learning rate.
+        num_cycles (`float`, *optional*, defaults to 0.5):
+            The number of waves in the cosine schedule (the defaults is to just decrease from the max value to 0
+            following a half-cosine).
+        last_epoch (`int`, *optional*, defaults to -1):
+            The index of the last epoch when resuming training.
+
+    Return:
+        `torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
+    """
+    lr_lambda = partial(
+        _get_wsd_scheduler_lambda,
+        num_warmup_steps=num_warmup_steps,
+        num_stable_steps=num_stable_steps,
+        num_decay_steps=num_decay_steps,
+        min_lr_ratio=min_lr_ratio,
+        num_cycles=num_cycles,
+    )
+    return LambdaLR(optimizer, lr_lambda, last_epoch)
+
 
 TYPE_TO_SCHEDULER_FUNCTION = {
     SchedulerType.LINEAR: get_linear_schedule_with_warmup,
@@ -397,6 +456,7 @@ TYPE_TO_SCHEDULER_FUNCTION = {
     SchedulerType.INVERSE_SQRT: get_inverse_sqrt_schedule,
     SchedulerType.REDUCE_ON_PLATEAU: get_reduce_on_plateau_schedule,
     SchedulerType.COSINE_WITH_MIN_LR: get_cosine_with_min_lr_schedule_with_warmup,
+    SchedulerType.WARMUP_STABLE_DECAY: get_wsd_scheduler,
 }
 
 

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -386,8 +386,15 @@ def get_cosine_with_min_lr_schedule_with_warmup(
     )
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
+
 def _get_wsd_scheduler_lambda(
-    current_step: int, *, num_warmup_steps: int, num_stable_steps: int, num_decay_steps: int, num_cycles: float, min_lr_ratio: float
+    current_step: int,
+    *,
+    num_warmup_steps: int,
+    num_stable_steps: int,
+    num_decay_steps: int,
+    num_cycles: float,
+    min_lr_ratio: float,
 ):
     if current_step < num_warmup_steps:
         return float(current_step) / float(max(1, num_warmup_steps))
@@ -399,6 +406,7 @@ def _get_wsd_scheduler_lambda(
         return (1.0 - min_lr_ratio) * value + min_lr_ratio
     return min_lr_ratio
 
+
 def get_wsd_schedule(
     optimizer: Optimizer,
     num_warmup_steps: int,
@@ -406,7 +414,7 @@ def get_wsd_schedule(
     num_decay_steps: int,
     min_lr_ratio: float = 0,
     num_cycles: float = 0.5,
-    last_epoch: int = -1
+    last_epoch: int = -1,
 ):
     """
     Create a schedule with a learning rate that has three stages:

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -399,7 +399,7 @@ def _get_wsd_scheduler_lambda(
         return (1.0 - min_lr_ratio) * value + min_lr_ratio
     return min_lr_ratio
 
-def get_wsd_scheduler(
+def get_wsd_schedule(
     optimizer: Optimizer,
     num_warmup_steps: int,
     num_stable_steps: int,
@@ -456,7 +456,7 @@ TYPE_TO_SCHEDULER_FUNCTION = {
     SchedulerType.INVERSE_SQRT: get_inverse_sqrt_schedule,
     SchedulerType.REDUCE_ON_PLATEAU: get_reduce_on_plateau_schedule,
     SchedulerType.COSINE_WITH_MIN_LR: get_cosine_with_min_lr_schedule_with_warmup,
-    SchedulerType.WARMUP_STABLE_DECAY: get_wsd_scheduler,
+    SchedulerType.WARMUP_STABLE_DECAY: get_wsd_schedule,
 }
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -412,6 +412,7 @@ class SchedulerType(ExplicitEnum):
     INVERSE_SQRT = "inverse_sqrt"
     REDUCE_ON_PLATEAU = "reduce_lr_on_plateau"
     COSINE_WITH_MIN_LR = "cosine_with_min_lr"
+    WARMUP_STABLE_DECAY = "warmup_stable_decay"
 
 
 class TrainerMemoryTracker:

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -10011,6 +10011,10 @@ def get_inverse_sqrt_schedule(*args, **kwargs):
     requires_backends(get_inverse_sqrt_schedule, ["torch"])
 
 
+def get_wsd_schedule(*args, **kwargs):
+    requires_backends(get_wsd_schedule, ["torch"])
+
+
 def get_linear_schedule_with_warmup(*args, **kwargs):
     requires_backends(get_linear_schedule_with_warmup, ["torch"])
 

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -10019,12 +10019,12 @@ def get_polynomial_decay_schedule_with_warmup(*args, **kwargs):
     requires_backends(get_polynomial_decay_schedule_with_warmup, ["torch"])
 
 
-def get_wsd_schedule(*args, **kwargs):
-    requires_backends(get_wsd_schedule, ["torch"])
-
-
 def get_scheduler(*args, **kwargs):
     requires_backends(get_scheduler, ["torch"])
+
+
+def get_wsd_schedule(*args, **kwargs):
+    requires_backends(get_wsd_schedule, ["torch"])
 
 
 class Conv1D(metaclass=DummyObject):

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -10011,16 +10011,16 @@ def get_inverse_sqrt_schedule(*args, **kwargs):
     requires_backends(get_inverse_sqrt_schedule, ["torch"])
 
 
-def get_wsd_schedule(*args, **kwargs):
-    requires_backends(get_wsd_schedule, ["torch"])
-
-
 def get_linear_schedule_with_warmup(*args, **kwargs):
     requires_backends(get_linear_schedule_with_warmup, ["torch"])
 
 
 def get_polynomial_decay_schedule_with_warmup(*args, **kwargs):
     requires_backends(get_polynomial_decay_schedule_with_warmup, ["torch"])
+
+
+def get_wsd_schedule(*args, **kwargs):
+    requires_backends(get_wsd_schedule, ["torch"])
 
 
 def get_scheduler(*args, **kwargs):

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -36,6 +36,7 @@ if is_torch_available():
         get_inverse_sqrt_schedule,
         get_linear_schedule_with_warmup,
         get_polynomial_decay_schedule_with_warmup,
+        get_wsd_schedule,
     )
 
 
@@ -149,6 +150,10 @@ class ScheduleInitTest(unittest.TestCase):
             get_inverse_sqrt_schedule: (
                 {"num_warmup_steps": 2},
                 [0.0, 5.0, 10.0, 8.165, 7.071, 6.325, 5.774, 5.345, 5.0, 4.714],
+            ),
+            get_wsd_schedule: (
+                {"num_warmup_steps": 2, "num_stable_steps": 2, "num_decay_steps": 3, "min_lr_ratio": 0.1},
+                [0.0, 5.0, 10.0, 10.0, 10.0, 7.75, 3.25, 1.0, 1.0, 1.0],
             ),
         }
 


### PR DESCRIPTION
# What does this PR do?

This PR adds the Warmup-Stable-Decay learning rate scheduler. The scheduler and its benefits are described in detail in the MiniCPM [blog post](https://shengdinghu.notion.site/MiniCPM-Unveiling-the-Potential-of-End-side-Large-Language-Models-d4d3a8c426424654a4e80e42a711cb20). In short, it allows continuous training and performs better than standard cosine scheduler.

Here is an example of learning rate dynamics with this schedule:
![image](https://github.com/huggingface/transformers/assets/3251552/49659bfe-4b3d-415d-980e-5cfc81c2e2fd)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@muellerzr, @pacman100
