### PR TITLE
fix: Fixed `type annotation` for compatability with python 3.8

### DIFF
--- a/src/transformers/models/whisper/convert_openai_to_hf.py
+++ b/src/transformers/models/whisper/convert_openai_to_hf.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 import urllib
 import warnings
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, List
 
 import torch
 from huggingface_hub.utils import insecure_hashlib
@@ -252,7 +252,7 @@ def convert_openai_whisper_to_tfms(
 
 
 # Adapted from https://github.com/openai/tiktoken/issues/60#issuecomment-1499977960
-def _bpe(mergeable_ranks, token: bytes, max_rank=None) -> list[bytes]:
+def _bpe(mergeable_ranks, token: bytes, max_rank=None) -> List[bytes]:
     parts = [bytes([b]) for b in token]
     while True:
         min_idx = None

--- a/src/transformers/models/whisper/convert_openai_to_hf.py
+++ b/src/transformers/models/whisper/convert_openai_to_hf.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 import urllib
 import warnings
-from typing import Any, Optional, Tuple, List
+from typing import Any, List, Optional, Tuple
 
 import torch
 from huggingface_hub.utils import insecure_hashlib


### PR DESCRIPTION
# What does this PR do?
Using `list[...]` instead of `List[...]` without the `from __future__ import annotations` import will cause runtime errors on Python versions prior to **3.9**. Since, we are supporting python versions from `3.8`, this needs to be fixed.

I used the following [`ruff`](https://docs.astral.sh/ruff/rules/future-required-type-annotation/) check to catch these.

For reference: https://peps.python.org/pep-0585/


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @amyeroberts 