### PR TITLE
[Feature Extractors] Fix kwargs to pre-trained

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -566,16 +566,16 @@ class FeatureExtractionMixin(PushToHubMixin):
         """
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
 
-        feature_extractor = cls(**feature_extractor_dict)
-
         # Update feature_extractor with kwargs if needed
         to_remove = []
         for key, value in kwargs.items():
-            if hasattr(feature_extractor, key):
-                setattr(feature_extractor, key, value)
+            if key in feature_extractor_dict:
+                feature_extractor_dict[key] = value
                 to_remove.append(key)
         for key in to_remove:
             kwargs.pop(key, None)
+
+        feature_extractor = cls(**feature_extractor_dict)
 
         logger.info(f"Feature extractor {feature_extractor}")
         if return_unused_kwargs:

--- a/tests/models/whisper/test_feature_extraction_whisper.py
+++ b/tests/models/whisper/test_feature_extraction_whisper.py
@@ -142,6 +142,20 @@ class WhisperFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.
         self.assertTrue(np.allclose(mel_1, mel_2))
         self.assertEqual(dict_first, dict_second)
 
+    def test_feat_extract_from_pretrained_kwargs(self):
+        feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            saved_file = feat_extract_first.save_pretrained(tmpdirname)[0]
+            check_json_file_has_correct_format(saved_file)
+            feat_extract_second = self.feature_extraction_class.from_pretrained(
+                tmpdirname, feature_size=2 * self.feat_extract_dict["feature_size"]
+            )
+
+        mel_1 = feat_extract_first.mel_filters
+        mel_2 = feat_extract_second.mel_filters
+        self.assertTrue(2 * mel_1.shape[1] == mel_2.shape[1])
+
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus
         feature_extractor = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())


### PR DESCRIPTION
# What does this PR do?

It was reported by @osanseviero that when instantiating a feature extractor from pre-trained, setting kwargs occasionally leads to incorrect behaviour. This is particularly the case for Whisper, where setting the argument `feature_size` can have no effect on the number of Mel-bins:

```python
from transformers import WhisperFeatureExtractor

# initialise from kwargs -> mel filters matches feature size
feature_extractor = WhisperFeatureExtractor(feature_size=100)
print(f"From kwargs: feature size {feature_extractor.feature_size}, mel filters {feature_extractor.mel_filters.shape[1]}")

# initialise from pre-trained with kwargs -> mel filters not updated to new feature size
feature_extractor = WhisperFeatureExtractor.from_pretrained("openai/whisper-tiny", feature_size=100)
print(f"From pre-trained: feature size {feature_extractor.feature_size}, mel filters {feature_extractor.mel_filters.shape[1]}")
```
**Print Output:**
```
From kwargs: feature size 100, mel filters 100
From pre-trained: feature size 100, mel filters 80
```

This is because of the order in which we set the args in the feature extractor. We first pass all the arguments that we have saved in the `preprocessor_config.json` file: https://github.com/huggingface/transformers/blob/8127f39624f587bdb04d55ab655df1753de7720a/src/transformers/feature_extraction_utils.py#L569

And subsequently override any kwargs that we got from the user: https://github.com/huggingface/transformers/blob/8127f39624f587bdb04d55ab655df1753de7720a/src/transformers/feature_extraction_utils.py#L573-L575

The problem with this method is that for Whisper, we set some attributes based on the values of others in the init. E.g. we set `mel_filters` based on the value of `feature_size`:
https://github.com/huggingface/transformers/blob/8127f39624f587bdb04d55ab655df1753de7720a/src/transformers/models/whisper/feature_extraction_whisper.py#L87-L89

These **won't** be updated properly with our current method, since we're only updating the attribute `feature_size`, and not subsequently recomputing the correct `mel_filters`.

The simple fix is to give priority to the user kwargs and ensure these are passed to the init.