### PR TITLE
Workflow: Update tailscale to release version

### DIFF
--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Tailscale # In order to be able to SSH when a test fails
         if: ${{ failure() || runner.debug == '1'}}
-        uses: huggingface/tailscale-action@ssh-improvments
+        uses: huggingface/tailscale-action@v1
         with:
           authkey: ${{ secrets.TAILSCALE_SSH_AUTHKEY }}
           slackChannel: ${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}


### PR DESCRIPTION
# What does this PR do?

For the new push important models workflow, we were using a dev version of the tailscale GHA, now that a proper v1 has been released, we should switch to it - as discussed offline with @glegendre01 

cc @glegendre01 @ydshieh @amyeroberts 
