### PR TITLE
fix: Fixed a `raise` statement

### DIFF
--- a/src/transformers/models/whisper/convert_openai_to_hf.py
+++ b/src/transformers/models/whisper/convert_openai_to_hf.py
@@ -347,9 +347,11 @@ if __name__ == "__main__":
     if args.convert_preprocessor:
         try:
             if not _is_package_available("tiktoken"):
-                raise """`tiktoken` is not installed, use `pip install tiktoken` to convert the tokenizer"""
-        except Exception:
-            pass
+                raise ModuleNotFoundError(
+                    """`tiktoken` is not installed, use `pip install tiktoken` to convert the tokenizer"""
+                )
+        except Exception as e:
+            print(str(e))
         else:
             from tiktoken.load import load_tiktoken_bpe
 

--- a/src/transformers/models/whisper/convert_openai_to_hf.py
+++ b/src/transformers/models/whisper/convert_openai_to_hf.py
@@ -351,7 +351,7 @@ if __name__ == "__main__":
                     """`tiktoken` is not installed, use `pip install tiktoken` to convert the tokenizer"""
                 )
         except Exception as e:
-            print(str(e))
+            print(e)
         else:
             from tiktoken.load import load_tiktoken_bpe
 


### PR DESCRIPTION
# What does this PR do?
`raise` must be followed by an exception instance or an exception class. Raising a literal (like a `str` in this case) will raise a `TypeError` at runtime and here we are not printing the message also. So, I have updated the code accordingly.

https://github.com/huggingface/transformers/blob/c63f15890377530044bcd2574e3e672907a5152a/src/transformers/models/whisper/convert_openai_to_hf.py#L350

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts
