### PR TITLE
Fix LayoutLMv2 init issue and doctest

### DIFF
--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -697,6 +697,10 @@ class LayoutLMv2Model(LayoutLMv2PreTrainedModel):
         self.visual_proj = nn.Linear(config.image_feature_pool_shape[-1], config.hidden_size)
         if self.has_visual_segment_embedding:
             self.visual_segment_embedding = nn.Parameter(nn.Embedding(1, config.hidden_size).weight[0])
+            # For `nn.Parameter`, we need to give it an initialized weight in order to keep reproducibility.
+            # Otherwise, since `_fast_init` is used in `modeling_utils.py`, the layer `nn.Embedding` is not initialized,
+            # and `_init_weights` is not designed to deal with `nn.Parameter`.
+            self.visual_segment_embedding.data.normal_(mean=0.0, std=self.config.initializer_range)
         self.visual_LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.visual_dropout = nn.Dropout(config.hidden_dropout_prob)
 
@@ -822,7 +826,7 @@ class LayoutLMv2Model(LayoutLMv2PreTrainedModel):
         >>> import torch
         >>> from datasets import load_dataset
 
-        >>> set_seed(88)
+        >>> set_seed(0)
 
         >>> processor = AutoProcessor.from_pretrained("microsoft/layoutlmv2-base-uncased")
         >>> model = LayoutLMv2Model.from_pretrained("microsoft/layoutlmv2-base-uncased")
@@ -993,7 +997,7 @@ class LayoutLMv2ForSequenceClassification(LayoutLMv2PreTrainedModel):
         >>> import torch
         >>> from datasets import load_dataset
 
-        >>> set_seed(88)
+        >>> set_seed(0)
 
         >>> dataset = load_dataset("rvl_cdip", split="train", streaming=True)
         >>> data = next(iter(dataset))
@@ -1012,8 +1016,8 @@ class LayoutLMv2ForSequenceClassification(LayoutLMv2PreTrainedModel):
         >>> loss, logits = outputs.loss, outputs.logits
         >>> predicted_idx = logits.argmax(dim=-1).item()
         >>> predicted_answer = dataset.info.features["label"].names[4]
-        >>> predicted_idx, predicted_answer
-        (4, 'advertisement')
+        >>> predicted_idx, predicted_answer  # results are not good without further fine-tuning
+        (7, 'advertisement')
         ```
         """
 
@@ -1172,7 +1176,7 @@ class LayoutLMv2ForTokenClassification(LayoutLMv2PreTrainedModel):
         >>> from PIL import Image
         >>> from datasets import load_dataset
 
-        >>> set_seed(88)
+        >>> set_seed(0)
 
         >>> datasets = load_dataset("nielsr/funsd", split="test")
         >>> labels = datasets.features["ner_tags"].feature.names
@@ -1203,8 +1207,8 @@ class LayoutLMv2ForTokenClassification(LayoutLMv2PreTrainedModel):
 
         >>> predicted_token_class_ids = logits.argmax(-1)
         >>> predicted_tokens_classes = [id2label[t.item()] for t in predicted_token_class_ids[0]]
-        >>> predicted_tokens_classes[:5]
-        ['B-ANSWER', 'B-HEADER', 'B-HEADER', 'B-HEADER', 'B-HEADER']
+        >>> predicted_tokens_classes[:5]  # results are not good without further fine-tuning
+        ['I-HEADER', 'I-HEADER', 'I-QUESTION', 'I-HEADER', 'I-QUESTION']
         ```
         """
 
@@ -1314,7 +1318,7 @@ class LayoutLMv2ForQuestionAnswering(LayoutLMv2PreTrainedModel):
         >>> from PIL import Image
         >>> from datasets import load_dataset
 
-        >>> set_seed(88)
+        >>> set_seed(0)
         >>> processor = AutoProcessor.from_pretrained("microsoft/layoutlmv2-base-uncased")
         >>> model = LayoutLMv2ForQuestionAnswering.from_pretrained("microsoft/layoutlmv2-base-uncased")
 
@@ -1328,12 +1332,12 @@ class LayoutLMv2ForQuestionAnswering(LayoutLMv2PreTrainedModel):
         >>> predicted_start_idx = outputs.start_logits.argmax(-1).item()
         >>> predicted_end_idx = outputs.end_logits.argmax(-1).item()
         >>> predicted_start_idx, predicted_end_idx
-        (154, 287)
+        (30, 191)
 
         >>> predicted_answer_tokens = encoding.input_ids.squeeze()[predicted_start_idx : predicted_end_idx + 1]
         >>> predicted_answer = processor.tokenizer.decode(predicted_answer_tokens)
-        >>> predicted_answer  # results are not very good without further fine-tuning
-        'council mem - bers conducted by trrf treasurer philip g. kuehn to get answers which the public ...
+        >>> predicted_answer  # results are not good without further fine-tuning
+        '44 a. m. to 12 : 25 p. m. 12 : 25 to 12 : 58 p. m. 12 : 58 to 4 : 00 p. m. 2 : 00 to 5 : 00 p. m. coffee break coffee will be served for men and women in the lobby adjacent to exhibit area. please move into exhibit area. ( exhibits open ) trrf general session ( part | ) presiding : lee a. waller trrf vice president “ introductory remarks ” lee a. waller, trrf vice presi - dent individual interviews with trrf public board members and sci - entific advisory council mem - bers conducted by trrf treasurer philip g. kuehn to get answers which the public refrigerated warehousing industry is looking for. plus questions from'
         ```
 
         ```python
@@ -1343,7 +1347,7 @@ class LayoutLMv2ForQuestionAnswering(LayoutLMv2PreTrainedModel):
         >>> predicted_answer_span_start = outputs.start_logits.argmax(-1).item()
         >>> predicted_answer_span_end = outputs.end_logits.argmax(-1).item()
         >>> predicted_answer_span_start, predicted_answer_span_end
-        (154, 287)
+        (30, 191)
         ```
         """
 

--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -700,10 +700,6 @@ class LayoutLMv2Model(LayoutLMv2PreTrainedModel):
         self.visual_proj = nn.Linear(config.image_feature_pool_shape[-1], config.hidden_size)
         if self.has_visual_segment_embedding:
             self.visual_segment_embedding = nn.Parameter(nn.Embedding(1, config.hidden_size).weight[0])
-            # For `nn.Parameter`, we need to give it an initialized weight in order to keep reproducibility.
-            # Otherwise, since `_fast_init` is used in `modeling_utils.py`, the layer `nn.Embedding` is not initialized,
-            # and `_init_weights` is not designed to deal with `nn.Parameter`.
-            ### self.visual_segment_embedding.data.normal_(mean=0.0, std=self.config.initializer_range)
         self.visual_LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.visual_dropout = nn.Dropout(config.hidden_dropout_prob)
 

--- a/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/modeling_layoutlmv2.py
@@ -503,6 +503,9 @@ class LayoutLMv2PreTrainedModel(PreTrainedModel):
         elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
+        elif isinstance(module, LayoutLMv2Model):
+            if hasattr(module, "visual_segment_embedding"):
+                module.visual_segment_embedding.data.normal_(mean=0.0, std=self.config.initializer_range)
 
 
 def my_convert_sync_batchnorm(module, process_group=None):
@@ -700,7 +703,7 @@ class LayoutLMv2Model(LayoutLMv2PreTrainedModel):
             # For `nn.Parameter`, we need to give it an initialized weight in order to keep reproducibility.
             # Otherwise, since `_fast_init` is used in `modeling_utils.py`, the layer `nn.Embedding` is not initialized,
             # and `_init_weights` is not designed to deal with `nn.Parameter`.
-            self.visual_segment_embedding.data.normal_(mean=0.0, std=self.config.initializer_range)
+            ### self.visual_segment_embedding.data.normal_(mean=0.0, std=self.config.initializer_range)
         self.visual_LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.visual_dropout = nn.Dropout(config.hidden_dropout_prob)
 


### PR DESCRIPTION
# What does this PR do?

(I think I have done all I can do for doctest - there are 2 other failures where I ping other people)

`LayoutLMv2Model.visual_segment_embedding`'s initialization (when it is not in a checkpoint) won't be reproducible even if seed is set. This is because it is defined

> self.visual_segment_embedding = nn.Parameter(nn.Embedding(1, config.hidden_size).weight[0])

and we have `_fast_init` used in loading +`_init_weights` is not designed to deal with `nn.Parameter`.

This PR fixes the reproducibility issue by initializing `visual_segment_embedding` explicitly.

Remark: such places requiring this fix is very few - so we don't destroy the purpose of having `_fast_init`.