### PR TITLE
Fix test `ExamplesTests::test_run_translation`

### DIFF
--- a/examples/pytorch/test_pytorch_examples.py
+++ b/examples/pytorch/test_pytorch_examples.py
@@ -372,6 +372,7 @@ class ExamplesTests(TestCasePlus):
             --predict_with_generate
             --source_lang en_XX
             --target_lang ro_RO
+            --max_source_length 512
         """.split()
 
         with patch.object(sys, "argv", testargs):


### PR DESCRIPTION
# What does this PR do?

`ExamplesTests::test_run_translation`.

@gante  broke this in #29600 by adding a new check
```python
        raise ValueError(
            f"`--max_source_length` is set to {data_args.max_source_length}, but the model only has"
            f" {model.config.max_position_embeddings} position encodings. Consider either reducing"
            f" `--max_source_length` to {model.config.max_position_embeddings} or using a model with larger position "
            "embeddings"
        )
```