### PR TITLE
Fix `Fatal Python error: Bus error` in `ZeroShotAudioClassificationPipelineTests`

### DIFF
--- a/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_audio_classification.py
@@ -32,7 +32,7 @@ class ZeroShotAudioClassificationPipelineTests(unittest.TestCase):
         audio_classifier = pipeline(
             task="zero-shot-audio-classification", model="hf-internal-testing/tiny-clap-htsat-unfused"
         )
-        dataset = load_dataset("ashraq/esc50")
+        dataset = load_dataset("hf-internal-testing/ashraq-esc50-1-dog-example")
         audio = dataset["train"]["audio"][-1]["array"]
         output = audio_classifier(audio, candidate_labels=["Sound of a dog", "Sound of vaccum cleaner"])
         self.assertEqual(
@@ -52,7 +52,7 @@ class ZeroShotAudioClassificationPipelineTests(unittest.TestCase):
             model="laion/clap-htsat-unfused",
         )
         # This is an audio of a dog
-        dataset = load_dataset("ashraq/esc50")
+        dataset = load_dataset("hf-internal-testing/ashraq-esc50-1-dog-example")
         audio = dataset["train"]["audio"][-1]["array"]
         output = audio_classifier(audio, candidate_labels=["Sound of a dog", "Sound of vaccum cleaner"])
 


### PR DESCRIPTION
# What does this PR do?

Same fix as in [here](https://github.com/huggingface/transformers/commit/cbc2cc187aeefd85aac8bb1660d5874ddc1164d2#diff-185d4b35e509f8dc00eb38307d0afc56ea5d1ae526c499dd63b157179cce2e14)

Currently, torch pipeline tests timeout on GitHub Actions (after `6 hours`), see [here](https://github.com/huggingface/transformers/actions/runs/8682815917/job/23807891346). This starts on March 21 daily CI run - not clear what changes caused it, but I see `Fatal Python error: Bus error` is in March 21's log but not in March 20.

And with this PR, the run seems to be quite fast, [40 mins in this run](https://github.com/huggingface/transformers/actions/runs/8716531699/job/23910217304)

(this PR only fixes the timeout issue, not all the failing tests in torch pipeline job)
