### PR TITLE
Fix SpeechT5 forward docstrings

### DIFF
--- a/src/transformers/models/speecht5/modeling_speecht5.py
+++ b/src/transformers/models/speecht5/modeling_speecht5.py
@@ -2687,7 +2687,7 @@ class SpeechT5ForTextToSpeech(SpeechT5PreTrainedModel):
         >>> set_seed(555)  # make deterministic
 
         >>> # generate speech
-        >>> speech = model.generate(inputs["input_ids"], speaker_embeddings, vocoder=vocoder)
+        >>> speech = model.generate(inputs["input_ids"], speaker_embeddings=speaker_embeddings, vocoder=vocoder)
         >>> speech.shape
         torch.Size([15872])
         ```


### PR DESCRIPTION
# What does this PR do?

SpeechT5ForTextToSpeech.forward code snippet [was failing](https://github.com/huggingface/transformers/actions/runs/8659540805/job/23745789410), this fixes it!

cc @ydshieh !