### PR TITLE
Fix donut token2json multiline

### DIFF
--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -149,7 +149,9 @@ class DonutProcessor(ProcessorMixin):
                 end_token = end_token.group()
                 start_token_escaped = re.escape(start_token)
                 end_token_escaped = re.escape(end_token)
-                content = re.search(f"{start_token_escaped}(.*?){end_token_escaped}", tokens, re.IGNORECASE)
+                content = re.search(
+                    f"{start_token_escaped}(.*?){end_token_escaped}", tokens, re.IGNORECASE | re.DOTALL
+                )
                 if content is not None:
                     content = content.group(1).strip()
                     if r"<s_" in content and r"</s_" in content:  # non-leaf node

--- a/tests/models/donut/test_processing_donut.py
+++ b/tests/models/donut/test_processing_donut.py
@@ -35,6 +35,8 @@ class DonutProcessorTest(unittest.TestCase):
             "zip": "30301",
             "phone": "123-4567",
             "nicknames": [{"nickname": "Johnny"}, {"nickname": "JD"}],
+            "multiline": "text\nwith\nnewlines",
+            "empty": "",
         }
 
         sequence = (
@@ -42,6 +44,8 @@ class DonutProcessorTest(unittest.TestCase):
             "<s_state>GA</s_state><s_zip>30301</s_zip><s_phone>123-4567</s_phone>"
             "<s_nicknames><s_nickname>Johnny</s_nickname>"
             "<sep/><s_nickname>JD</s_nickname></s_nicknames>"
+            "<s_multiline>text\nwith\nnewlines</s_multiline>"
+            "<s_empty></s_empty>"
         )
         actual_json = self.processor.token2json(sequence)
 


### PR DESCRIPTION
# What does this PR do?

Close the issue with token2json processing method for Donut

> There is a bug in the implementation of the function token2json in the DonutProcessor class. It doesn't work when there are multilines in a value as shown in the example below. It is related the regex code.

Fixes # (issue)
https://github.com/huggingface/transformers/issues/30272

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
