### PR TITLE
Add atol for sliding window test

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3925,7 +3925,7 @@ class ModelTesterMixin:
 
                 # Only non-padding tokens are expected to match.
                 self.assertTrue(
-                    torch.allclose(res_eager[attention_mask == 1], res_sdpa[attention_mask == 1], rtol=1e-3)
+                    torch.allclose(res_eager[attention_mask == 1], res_sdpa[attention_mask == 1], rtol=1e-4, atol=1e-4)
                 )
 
     @require_flash_attn


### PR DESCRIPTION
As reported (https://huggingface.slack.com/archives/C01NE71C4F7/p1713360898344479), the `test_sdpa_matches_eager_sliding_window` test added in https://github.com/huggingface/transformers/pull/30127 was passing on A100, but not on CPU due to a missing `atol`. Now passing on both.

https://app.circleci.com/pipelines/github/huggingface/transformers/89888/workflows/494537ba-1614-44a1-b8b8-28c01603d3be/jobs/1171908