### PR TITLE
Fix missing `prev_ci_results`

### DIFF
--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -57,6 +57,15 @@ jobs:
           pip install slack_sdk
           pip show slack_sdk
           python utils/notification_service.py "${{ inputs.folder_slices }}"
+
+      # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.
+      - name: Failure table artifacts
+        # Only the model testing job is concerned for this step
+        if: ${{ inputs.job == 'run_tests_gpu' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: prev_ci_results
+          path: prev_ci_results
       
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -76,12 +85,3 @@ jobs:
           pip install slack_sdk
           pip show slack_sdk
           python utils/notification_service_quantization.py "${{ inputs.quantization_matrix }}" 
-  
-      # Upload complete failure tables, as they might be big and only truncated versions could be sent to Slack.
-      - name: Failure table artifacts
-        # Only the model testing job is concerned for this step
-        if: ${{ inputs.job == 'run_tests_gpu' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: prev_ci_results
-          path: prev_ci_results


### PR DESCRIPTION
# What does this PR do?

#29914 added a new step in slack report workflow, but it used `actions/checkout@v4` after the first part (about model CI job). This indeed removes all files in the same directory, so the `actions/checkout@v4` created in the first part is moved, and the last step of uploading artifact can't find it. This makes the `new mdoel failures` missing in the slack report channel.