### PR TITLE
Word-level timestamps broken for short-form audio

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -411,6 +411,9 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         if len(inputs.shape) != 1:
             raise ValueError("We expect a single channel audio input for AutomaticSpeechRecognitionPipeline")
 
+        if not chunk_length_s:
+            chunk_length_s = inputs.shape[0] / self.feature_extractor.sampling_rate
+
         if chunk_length_s:
             if stride_length_s is None:
                 stride_length_s = chunk_length_s / 6

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -446,7 +446,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 processed = self.feature_extractor(
                     inputs, sampling_rate=self.feature_extractor.sampling_rate, return_tensors="pt"
                 )
-                extra["segment_size"] = len(inputs)
+                if stride is None:
+                    extra["segment_size"] = len(inputs)
 
             if self.torch_dtype is not None:
                 processed = processed.to(dtype=self.torch_dtype)

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -491,7 +491,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                             generate_kwargs["num_frames"] = [s[0] // self.feature_extractor.hop_length for s in stride]
 
                     if stride is None:
-                        generate_kwargs["num_frames"] = segment_size // self.feature_extractor.hop_length
+                        if isinstance(segment_size, int):
+                            generate_kwargs["num_frames"] = segment_size // self.feature_extractor.hop_length
+                        else:
+                            generate_kwargs["num_frames"] = segment_size[0] // self.feature_extractor.hop_length
 
             if self.type == "seq2seq_whisper" and inputs.shape[-1] > self.feature_extractor.nb_max_frames:
                 generate_kwargs["input_features"] = inputs

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -463,6 +463,9 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         segment_size = model_inputs.pop("segment_size", None)
         is_last = model_inputs.pop("is_last")
 
+        if stride is not None and segment_size is not None: 
+            raise ValueError("segment_size must be used only when stride is None")
+
         if self.type in {"seq2seq", "seq2seq_whisper"}:
             encoder = self.model.get_encoder()
             # Consume values so we can let extra information flow freely through

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -490,7 +490,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                         else:
                             generate_kwargs["num_frames"] = [s[0] // self.feature_extractor.hop_length for s in stride]
 
-                    if stride is None:
+                    else:
                         if isinstance(segment_size, int):
                             generate_kwargs["num_frames"] = segment_size // self.feature_extractor.hop_length
                         else:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -463,7 +463,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         segment_size = model_inputs.pop("segment_size", None)
         is_last = model_inputs.pop("is_last")
 
-        if stride is not None and segment_size is not None: 
+        if stride is not None and segment_size is not None:
             raise ValueError("segment_size must be used only when stride is None")
 
         if self.type in {"seq2seq", "seq2seq_whisper"}:

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -762,10 +762,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         array = np.concatenate(
             [ds[40]["audio"]["array"], ds[41]["audio"]["array"], ds[42]["audio"]["array"], ds[43]["audio"]["array"]]
         )
-        pipe = pipeline(
-            model="openai/whisper-large-v3",
-            return_timestamps=True,
-        )
+        pipe = pipeline(model="openai/whisper-large-v3", return_timestamps=True)
 
         output = pipe(ds[40]["audio"])
         self.assertDictEqual(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -757,6 +757,97 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
     @slow
     @require_torch
+    def test_whisper_large_timestamp_prediction(self):
+        ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation").sort("id")
+        array = np.concatenate(
+            [ds[40]["audio"]["array"], ds[41]["audio"]["array"], ds[42]["audio"]["array"], ds[43]["audio"]["array"]]
+        )
+        pipe = pipeline(
+            model="openai/whisper-large-v3",
+            return_timestamps=True,
+        )
+
+        output = pipe(ds[40]["audio"])
+        self.assertDictEqual(
+            output,
+            {
+                "text": " A man said to the universe, Sir, I exist.",
+                "chunks": [{"text": " A man said to the universe, Sir, I exist.", "timestamp": (0.0, 4.08)}],
+            },
+        )
+
+        output = pipe(array, chunk_length_s=10)
+
+        self.assertDictEqual(
+            nested_simplify(output),
+            {
+                "chunks": [
+                    {"timestamp": (0.0, 2.0), "text": (" A man said to the universe,")},
+                    {"timestamp": (2.0, 4.1), "text": (" Sir, I exist.")},
+                    {"timestamp": (5.14, 5.96), "text": (" Sweat covered")},
+                    {"timestamp": (5.96, 8.02), "text": (" Breon's body, trickling into")},
+                    {"timestamp": (8.02, 10.67), "text": (" the tight loincloth that was the only garment he wore,")},
+                    {"timestamp": (10.67, 13.67), "text": (" the cut on his chest still dripping blood,")},
+                    {"timestamp": (13.67, 17.61), "text": (" the ache of his overstrained eyes.")},
+                    {
+                        "timestamp": (17.61, 24.0),
+                        "text": (
+                            " Even the soaring arena around him with thousands of spectators were trivialities not worth thinking about."
+                        ),
+                    },
+                    {
+                        "timestamp": (24.0, 29.94),
+                        "text": (" His instant of panic was followed by a small, sharp blow high on his chest."),
+                    },
+                ],
+                "text": (
+                    " A man said to the universe, Sir, I exist. Sweat covered Breon's"
+                    " body, trickling into the tight loincloth that was the only garment"
+                    " he wore, the cut on his chest still dripping blood, the ache of his"
+                    " overstrained eyes. Even the soaring arena around him with thousands"
+                    " of spectators were trivialities not worth thinking about. His "
+                    "instant of panic was followed by a small, sharp blow high on his chest."
+                ),
+            },
+        )
+
+        output = pipe(array)
+        self.assertDictEqual(
+            output,
+            {
+                "chunks": [
+                    {"timestamp": (0.0, 1.96), "text": " A man said to the universe,"},
+                    {"timestamp": (2.7, 4.1), "text": " Sir, I exist."},
+                    {"timestamp": (5.14, 6.84), "text": " Sweat covered Brion's body,"},
+                    {
+                        "timestamp": (7.4, 10.68),
+                        "text": " trickling into the tight loincloth that was the only garment he wore,",
+                    },
+                    {"timestamp": (11.6, 13.94), "text": " the cut on his chest still dripping blood,"},
+                    {"timestamp": (14.78, 16.72), "text": " the ache of his overstrained eyes,"},
+                    {
+                        "timestamp": (17.32, 21.16),
+                        "text": " even the soaring arena around him with the thousands of spectators",
+                    },
+                    {"timestamp": (21.16, 23.94), "text": " were trivialities not worth thinking about."},
+                    {
+                        "timestamp": (24.42, 29.94),
+                        "text": " His instant panic was followed by a small sharp blow high on his chest.",
+                    },
+                ],
+                "text": (
+                    " A man said to the universe, Sir, I exist. Sweat covered Brion's body,"
+                    " trickling into the tight loincloth that was the only garment he wore, "
+                    "the cut on his chest still dripping blood, the ache of his overstrained "
+                    "eyes, even the soaring arena around him with the thousands of spectators "
+                    "were trivialities not worth thinking about. His instant panic was followed "
+                    "by a small sharp blow high on his chest."
+                ),
+            },
+        )
+
+    @slow
+    @require_torch
     def test_whisper_word_timestamps_batched(self):
         pipe = pipeline(
             task="automatic-speech-recognition",
@@ -788,6 +879,50 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
                 {"text": " welcome", "timestamp": (4.3, 4.6)},
                 {"text": " his", "timestamp": (4.6, 4.94)},
                 {"text": " gospel.", "timestamp": (4.94, 5.82)},
+            ],
+        }
+
+        # batch size 1: copy the audio sample since pipeline consumes it
+        output = pipe(sample.copy(), batch_size=1)
+        self.assertDictEqual(output, EXPECTED_OUTPUT)
+
+        # batch size 2: input audio is chunked into smaller pieces so it's testing batching
+        output = pipe(sample, batch_size=2)
+        self.assertDictEqual(output, EXPECTED_OUTPUT)
+
+    @slow
+    @require_torch
+    def test_whisper_large_word_timestamps_batched(self):
+        pipe = pipeline(
+            task="automatic-speech-recognition",
+            model="openai/whisper-large-v3",
+            chunk_length_s=3,
+            return_timestamps="word",
+        )
+        data = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+        sample = data[0]["audio"]
+
+        # not the same output as test_simple_whisper_asr because of chunking
+        EXPECTED_OUTPUT = {
+            "text": " Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.",
+            "chunks": [
+                {"text": " Mr.", "timestamp": (0.0, 0.72)},
+                {"text": " Quilter", "timestamp": (0.72, 1.08)},
+                {"text": " is", "timestamp": (1.08, 1.3)},
+                {"text": " the", "timestamp": (1.3, 1.44)},
+                {"text": " apostle", "timestamp": (1.44, 1.78)},
+                {"text": " of", "timestamp": (1.78, 2.18)},
+                {"text": " the", "timestamp": (2.18, 2.28)},
+                {"text": " middle", "timestamp": (2.28, 2.48)},
+                {"text": " classes,", "timestamp": (2.48, 3.0)},
+                {"text": " and", "timestamp": (3.0, 3.4)},
+                {"text": " we", "timestamp": (3.4, 3.5)},
+                {"text": " are", "timestamp": (3.5, 3.6)},
+                {"text": " glad", "timestamp": (3.6, 3.84)},
+                {"text": " to", "timestamp": (3.84, 4.1)},
+                {"text": " welcome", "timestamp": (4.1, 4.42)},
+                {"text": " his", "timestamp": (4.38, 4.68)},
+                {"text": " gospel.", "timestamp": (4.68, 5.36)},
             ],
         }
 

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -896,7 +896,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         pipe = pipeline(
             task="automatic-speech-recognition",
             model="openai/whisper-large-v3",
-            chunk_length_s=3,
             return_timestamps="word",
         )
         data = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
@@ -906,23 +905,23 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         EXPECTED_OUTPUT = {
             "text": " Mr. Quilter is the apostle of the middle classes, and we are glad to welcome his gospel.",
             "chunks": [
-                {"text": " Mr.", "timestamp": (0.0, 0.72)},
-                {"text": " Quilter", "timestamp": (0.72, 1.08)},
-                {"text": " is", "timestamp": (1.08, 1.3)},
+                {"text": " Mr.", "timestamp": (0.0, 0.74)},
+                {"text": " Quilter", "timestamp": (0.74, 1.04)},
+                {"text": " is", "timestamp": (1.04, 1.3)},
                 {"text": " the", "timestamp": (1.3, 1.44)},
-                {"text": " apostle", "timestamp": (1.44, 1.78)},
-                {"text": " of", "timestamp": (1.78, 2.18)},
+                {"text": " apostle", "timestamp": (1.44, 1.74)},
+                {"text": " of", "timestamp": (1.74, 2.18)},
                 {"text": " the", "timestamp": (2.18, 2.28)},
-                {"text": " middle", "timestamp": (2.28, 2.48)},
-                {"text": " classes,", "timestamp": (2.48, 3.0)},
+                {"text": " middle", "timestamp": (2.28, 2.5)},
+                {"text": " classes,", "timestamp": (2.5, 3.0)},
                 {"text": " and", "timestamp": (3.0, 3.4)},
                 {"text": " we", "timestamp": (3.4, 3.5)},
                 {"text": " are", "timestamp": (3.5, 3.6)},
                 {"text": " glad", "timestamp": (3.6, 3.84)},
                 {"text": " to", "timestamp": (3.84, 4.1)},
-                {"text": " welcome", "timestamp": (4.1, 4.42)},
-                {"text": " his", "timestamp": (4.38, 4.68)},
-                {"text": " gospel.", "timestamp": (4.68, 5.36)},
+                {"text": " welcome", "timestamp": (4.1, 4.4)},
+                {"text": " his", "timestamp": (4.4, 4.7)},
+                {"text": " gospel.", "timestamp": (4.7, 5.34)},
             ],
         }
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR aims at fixing issue #30224: word-level timestamps is currently broken in Whisper large/large-v2/large-v3/distil-large-v3. The problem comes from the fact that `num_frames` isn't passed to the generate method when stride is None. 

I suggest simply adding a new extra argument to the output of the `preprocess` method, called `segment_size`, which will store the input length in the case of short form audios. It will be passed to the `_forward` method and used when stride is None to compute `generate_kwargs["num_frames"] = segment_size // self.feature_extractor.hop_length`. 

This seems to fix the problem. Is there any particular test that should be run regarding this issue?

## Who can review?

@sanchit-gandhi 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
