### PR TITLE
Fix DETA save_pretrained

### DIFF
--- a/src/transformers/models/deta/modeling_deta.py
+++ b/src/transformers/models/deta/modeling_deta.py
@@ -1888,7 +1888,7 @@ class DetaModel(DetaPreTrainedModel):
 )
 class DetaForObjectDetection(DetaPreTrainedModel):
     # When using clones, all layers > 0 will be clones, but layer 0 *is* required
-    _tied_weights_keys = [r"bbox_embed\.\d+"]
+    _tied_weights_keys = [r"bbox_embed\.\d+", r"class_embed\.\d+"]
     # We can't initialize the model on meta device as some weights are modified during the initialization
     _no_split_modules = None
 

--- a/tests/models/deta/test_modeling_deta.py
+++ b/tests/models/deta/test_modeling_deta.py
@@ -15,8 +15,10 @@
 """ Testing suite for the PyTorch DETA model. """
 
 
+import collections
 import inspect
 import math
+import re
 import unittest
 
 from transformers import DetaConfig, ResNetConfig, is_torch_available, is_torchvision_available, is_vision_available
@@ -31,6 +33,8 @@ from ...test_pipeline_mixin import PipelineTesterMixin
 
 if is_torch_available():
     import torch
+
+    from transformers.pytorch_utils import id_tensor_storage
 
 if is_torchvision_available():
     from transformers import DetaForObjectDetection, DetaModel
@@ -519,6 +523,43 @@ class DetaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
                         [0.0, 1.0],
                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                     )
+
+    # Inspired by tests.test_modeling_common.ModelTesterMixin.test_tied_weights_keys
+    def test_tied_weights_keys(self):
+        for model_class in self.all_model_classes:
+            # We need to pass model class name to correctly initialize the config.
+            # If we don't pass it, the config for `DetaForObjectDetection`` will be initialized
+            # with `two_stage=False` and the test will fail because for that case `class_embed`
+            # weights are not tied.
+            config, _ = self.model_tester.prepare_config_and_inputs_for_common(model_class_name=model_class.__name__)
+            config.tie_word_embeddings = True
+
+            model_tied = model_class(config)
+
+            ptrs = collections.defaultdict(list)
+            for name, tensor in model_tied.state_dict().items():
+                ptrs[id_tensor_storage(tensor)].append(name)
+
+            # These are all the pointers of shared tensors.
+            tied_params = [names for _, names in ptrs.items() if len(names) > 1]
+
+            tied_weight_keys = model_tied._tied_weights_keys if model_tied._tied_weights_keys is not None else []
+            # Detect we get a hit for each key
+            for key in tied_weight_keys:
+                if not any(re.search(key, p) for group in tied_params for p in group):
+                    raise ValueError(f"{key} is not a tied weight key for {model_class}.")
+
+            # Removed tied weights found from tied params -> there should only be one left after
+            for key in tied_weight_keys:
+                for i in range(len(tied_params)):
+                    tied_params[i] = [p for p in tied_params[i] if re.search(key, p) is None]
+
+            tied_params = [group for group in tied_params if len(group) > 1]
+            self.assertListEqual(
+                tied_params,
+                [],
+                f"Missing `_tied_weights_keys` for {model_class}: add all of {tied_params} except one.",
+            )
 
 
 TOLERANCE = 1e-4

--- a/tests/models/deta/test_modeling_deta.py
+++ b/tests/models/deta/test_modeling_deta.py
@@ -546,8 +546,8 @@ class DetaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
             tied_weight_keys = model_tied._tied_weights_keys if model_tied._tied_weights_keys is not None else []
             # Detect we get a hit for each key
             for key in tied_weight_keys:
-                if not any(re.search(key, p) for group in tied_params for p in group):
-                    raise ValueError(f"{key} is not a tied weight key for {model_class}.")
+                is_tied_key = any(re.search(key, p) for group in tied_params for p in group)
+                self.assertTrue(is_tied_key, f"{key} is not a tied weight key for {model_class}.")
 
             # Removed tied weights found from tied params -> there should only be one left after
             for key in tied_weight_keys:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2025,8 +2025,8 @@ class ModelTesterMixin:
             tied_weight_keys = model_tied._tied_weights_keys if model_tied._tied_weights_keys is not None else []
             # Detect we get a hit for each key
             for key in tied_weight_keys:
-                if not any(re.search(key, p) for group in tied_params for p in group):
-                    raise ValueError(f"{key} is not a tied weight key for {model_class}.")
+                is_tied_key = any(re.search(key, p) for group in tied_params for p in group)
+                self.assertTrue(is_tied_key, f"{key} is not a tied weight key for {model_class}.")
 
             # Removed tied weights found from tied params -> there should only be one left after
             for key in tied_weight_keys:


### PR DESCRIPTION
# What does this PR do?

`save_pretrained` is not working for `DetaForObjectDetection`. This PR is supposed to fix this error.

A simple script to reproduce:
```python
from transformers import DetaConfig, DetaForObjectDetection

config = DetaConfig()
model = DetaForObjectDetection(config)
model.save_pretrained("output_dir/")
```

or

```python
from transformers import AutoModelForObjectDetection

model = AutoModelForObjectDetection.from_pretrained("jozhang97/deta-resnet-50")
model.save_pretrained("output_dir/")
```

The following error occurs:

```
RuntimeError: The weights trying to be saved contained shared tensors [{'model.decoder.class_embed.0.weight', 'class_embed.0.weight'}, {'model.decoder.class_embed.0.bias', 'class_embed.0.bias'}, {'model.decoder.class_embed.1.weight', 'class_embed.1.weight'}, {'model.decoder.class_embed.1.bias', 'class_embed.1.bias'}, {'model.decoder.class_embed.2.weight', 'class_embed.2.weight'}, {'model.decoder.class_embed.2.bias', 'class_embed.2.bias'}, {'model.decoder.class_embed.3.weight', 'class_embed.3.weight'}, {'class_embed.3.bias', 'model.decoder.class_embed.3.bias'}, {'model.decoder.class_embed.4.weight', 'class_embed.4.weight'}, {'model.decoder.class_embed.4.bias', 'class_embed.4.bias'}, {'model.decoder.class_embed.5.weight', 'class_embed.5.weight'}, {'class_embed.5.bias', 'model.decoder.class_embed.5.bias'}, {'class_embed.6.weight', 'model.decoder.class_embed.6.weight'}, {'class_embed.6.bias', 'model.decoder.class_embed.6.bias'}] that are mismatching the transformers base configuration. Try saving using `safe_serialization=False` or remove this tensor sharing.
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
