### PR TITLE
[Gemma, Llama] Remove unused attribute

### DIFF
--- a/src/transformers/models/gemma/tokenization_gemma.py
+++ b/src/transformers/models/gemma/tokenization_gemma.py
@@ -77,8 +77,6 @@ class GemmaTokenizer(PreTrainedTokenizer):
             extra spaces.
         use_default_system_prompt (`bool`, *optional*, defaults to `False`):
             Whether or not the default system prompt for Gemma should be used.
-        spaces_between_special_tokens (`bool`, *optional*, defaults to `False`):
-            Whether or not to add spaces between special tokens.
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
@@ -96,7 +94,6 @@ class GemmaTokenizer(PreTrainedTokenizer):
         add_eos_token=False,
         clean_up_tokenization_spaces=False,
         use_default_system_prompt=False,
-        spaces_between_special_tokens=False,
         **kwargs,
     ):
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
@@ -123,7 +120,6 @@ class GemmaTokenizer(PreTrainedTokenizer):
             sp_model_kwargs=self.sp_model_kwargs,
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
             use_default_system_prompt=use_default_system_prompt,
-            spaces_between_special_tokens=spaces_between_special_tokens,
             **kwargs,
         )
 

--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -95,8 +95,6 @@ class LlamaTokenizer(PreTrainedTokenizer):
             extra spaces.
         use_default_system_prompt (`bool`, *optional*, defaults to `False`):
             Whether or not the default system prompt for Llama should be used.
-        spaces_between_special_tokens (`bool`, *optional*, defaults to `False`):
-            Whether or not to add spaces between special tokens.
         legacy (`bool`, *optional*):
             Whether or not the `legacy` behavior of the tokenizer should be used. Legacy is before the merge of #24622
             and #25224 which includes fixes to properly handle tokens that appear after special tokens. A simple
@@ -140,7 +138,6 @@ class LlamaTokenizer(PreTrainedTokenizer):
         add_eos_token=False,
         clean_up_tokenization_spaces=False,
         use_default_system_prompt=False,
-        spaces_between_special_tokens=False,
         legacy=None,
         add_prefix_space=True,
         **kwargs,
@@ -179,7 +176,6 @@ class LlamaTokenizer(PreTrainedTokenizer):
             sp_model_kwargs=self.sp_model_kwargs,
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
             use_default_system_prompt=use_default_system_prompt,
-            spaces_between_special_tokens=spaces_between_special_tokens,
             legacy=legacy,
             add_prefix_space=add_prefix_space,
             **kwargs,


### PR DESCRIPTION
# What does this PR do?

This PR removes the `spaces_between_special_tokens` attribute from `GemmaTokenizer` and `LlamaTokenizer` since that attribute doesn't do anything. This is because the `_decode` [method](https://github.com/huggingface/transformers/blob/d9850abd407821fb9f4ad5aabb206adad3610f75/src/transformers/tokenization_utils.py#L991-L997) in `tokenization_utils.py` doesn't make use of this attribute, it only accepts a flag which defaults to `True`.

Alternatively, we could make sure that that attribute actually does something, by checking in the `_decode` method whether the tokenizer has it set. Up for discussion