### PR TITLE
Pipeline: fix `pad_token_id` again

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -896,7 +896,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             and self.tokenizer.pad_token_id is not None
             and self.model.generation_config.pad_token_id is None
         ):
-            kwargs["pad_token_id"] = self.tokenizer.pad_token_id
+            self.model.generation_config.pad_token_id = self.tokenizer.pad_token_id
 
         self.call_count = 0
         self._batch_size = kwargs.pop("batch_size", None)


### PR DESCRIPTION
# What does this PR do?

Related to PR #30285. The earlier PR caused audio-to-text pipelines to fail in daily doctest CI, because they do not accept pad-token-id in kwargs. This should be a better solution, to set pad token directly in model's config