### PR TITLE
parallel job limit for doctest

### DIFF
--- a/.github/workflows/doctest_job.yml
+++ b/.github/workflows/doctest_job.yml
@@ -23,6 +23,7 @@ jobs:
   run_doctests:
     name: " "
     strategy:
+      max-parallel: 8  # 8 jobs at a time
       fail-fast: false
       matrix:
         split_keys: ${{ fromJson(inputs.split_keys) }}

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -52,6 +52,7 @@ jobs:
     name: "Call doctest jobs"
     needs: setup
     strategy:
+      max-parallel: 1  # 1 split at a time (in `doctest_job.yml`, we set `8` to run 8 jobs at the same time)
       fail-fast: false
       matrix:
         split_keys: ${{ fromJson(needs.setup.outputs.split_keys) }}


### PR DESCRIPTION
# What does this PR do?

@glegendre01 mentioned we limit to set a limit for doctest workflow file, otherwise it will use all runners in the runner group.