### PR TITLE
Prevent `TextGenerationPipeline._sanitize_parameters` from overriding previously provided parameters

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -117,19 +117,25 @@ class TextGenerationPipeline(Pipeline):
         prefix=None,
         handle_long_generation=None,
         stop_sequence=None,
-        add_special_tokens=False,
         truncation=None,
-        padding=False,
         max_length=None,
         **generate_kwargs,
     ):
-        preprocess_params = {
-            "add_special_tokens": add_special_tokens,
-            "truncation": truncation,
-            "padding": padding,
-            "max_length": max_length,
-        }
+        preprocess_params = {}
+        
+        add_special_tokens = False
+        if "add_special_tokens" in generate_kwargs:
+            preprocess_params["add_special_tokens"] = generate_kwargs["add_special_tokens"]
+            add_special_tokens = generate_kwargs["add_special_tokens"]
+
+        if "padding" in generate_kwargs:
+            preprocess_params["padding"] = generate_kwargs["padding"]
+            
+        if truncation is not None:
+            preprocess_params["truncation"] = truncation
+
         if max_length is not None:
+            preprocess_params["max_length"] = max_length
             generate_kwargs["max_length"] = max_length
 
         if prefix is not None:

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -133,7 +133,7 @@ class TextGenerationPipeline(Pipeline):
         **generate_kwargs,
     ):
         preprocess_params = {}
-        
+
         add_special_tokens = False
         if "add_special_tokens" in generate_kwargs:
             preprocess_params["add_special_tokens"] = generate_kwargs["add_special_tokens"]
@@ -141,7 +141,7 @@ class TextGenerationPipeline(Pipeline):
 
         if "padding" in generate_kwargs:
             preprocess_params["padding"] = generate_kwargs["padding"]
-            
+
         if truncation is not None:
             preprocess_params["truncation"] = truncation
 


### PR DESCRIPTION
# What does this PR do?

Below is the code example I used. The `max_length` and `truncation` (as well as `padding` and `add_special_tokens`) parameters passed to the `pipeline` method are overridden when generating output.
```
from transformers import pipeline


template_inst = "Instruct: {prompt}\nOutput:"
max_length = 25

text_generator = pipeline("text-generation", model="openai-gpt", max_length=max_length, max_new_tokens=30, truncation=True)
results = text_generator(template_inst.format(prompt="The personal life of William Shakespeare is somewhat of a mystery. There are two primary sources that provide historians with an outline of his life. One is his work, and the other is official documentation such as church and court records. However, these provide only brief sketches of specific events in his life and yield little insight into the man himself. When Was Shakespeare Born?"))

print(results)
```

Print out `preprocess_params` variables in `Pipeline.__call__()` method:
![image](https://github.com/huggingface/transformers/assets/33386396/dad267c3-f167-4506-ae88-fd47b2987f43)
```
Kwargs: {}
self._preprocess_params: {'add_special_tokens': False, 'truncation': True, 'padding': False, 'max_length': 25, 'max_new_tokens': 30}
preprocess_params: {'add_special_tokens': False, 'truncation': None, 'padding': False, 'max_length': None}
preprocess_params (after): {'add_special_tokens': False, 'truncation': None, 'padding': False, 'max_length': None, 'max_new_tokens': 30}
```
As shown in the output, after `self._sanitize_parameters()` is called, both `truncation` and `max_length` are set to `None`.

I know we can pass the preprocess parameters when calling `text_generator` method (see code above). However, it just doesn't make sense to me that the previous parameters provided should be overridden. Hence I made the change. Feel free to improve if needed 😃 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
- pipelines: @Narsil

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
