### PR TITLE
[Grounding DINO] Add support for cross-attention in GroundingDinoMultiHeadAttention

### DIFF
--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -818,7 +818,7 @@ class GroundingDinoTextEnhancerLayer(nn.Module):
             attention_masks = attention_masks[:, None, :, :]
             attention_masks = attention_masks.repeat(1, self.num_heads, 1, 1)
 
-            dtype = torch.float16
+            dtype = hidden_states.dtype
             attention_masks = attention_masks.to(dtype=dtype)  # fp16 compatibility
             attention_masks = (1.0 - attention_masks) * torch.finfo(dtype).min
 
@@ -1432,7 +1432,7 @@ class GroundingDinoDecoderLayer(nn.Module):
             1, self.num_attention_heads, self.num_queries, 1
         )
 
-        dtype = torch.float16
+        dtype = text_encoder_hidden_states.dtype
         text_encoder_attention_mask = text_encoder_attention_mask.to(dtype=dtype)  # fp16 compatibility
         text_encoder_attention_mask = text_encoder_attention_mask * torch.finfo(dtype).min
 

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -1427,14 +1427,15 @@ class GroundingDinoDecoderLayer(nn.Module):
 
         # Cross-Attention Text
         queries = self.with_pos_embed(hidden_states, position_embeddings)
-        text_encoder_attention_mask = text_encoder_attention_mask[:, None, None, :]
-        text_encoder_attention_mask = text_encoder_attention_mask.repeat(
-            1, self.num_attention_heads, self.num_queries, 1
-        )
+        if text_encoder_attention_mask is not None:
+            dtype = text_encoder_hidden_states.dtype
 
-        dtype = text_encoder_hidden_states.dtype
-        text_encoder_attention_mask = text_encoder_attention_mask.to(dtype=dtype)  # fp16 compatibility
-        text_encoder_attention_mask = text_encoder_attention_mask * torch.finfo(dtype).min
+            text_encoder_attention_mask = text_encoder_attention_mask[:, None, None, :]
+            text_encoder_attention_mask = text_encoder_attention_mask.repeat(
+                1, self.num_attention_heads, self.num_queries, 1
+            )
+            text_encoder_attention_mask = text_encoder_attention_mask.to(dtype=dtype)
+            text_encoder_attention_mask = text_encoder_attention_mask * torch.finfo(dtype).min
 
         hidden_states, text_cross_attn_weights = self.encoder_attn_text(
             queries=queries,


### PR DESCRIPTION
# What does this PR do?

This PR fixes https://github.com/huggingface/transformers/issues/30176 by adding support for cross-attention masking and related integration test.

Now one can do batched inference with different text lengths such as:

```python
import torch
from transformers import AutoModelForZeroShotObjectDetection, AutoProcessor

model_id = "IDEA-Research/grounding-dino-tiny"

model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id)
processor = AutoProcessor.from_pretrained(model_id)

images = [...]
text = ["a cat. a remote control.", "a person. a cat. a remote control. a couch."]

inputs = processor(images=image, text=text, padding="longest", return_tensors="pt")

with torch.no_grad():
    outputs = model(**inputs)
```