### PR TITLE
remove redundant logging from longformer

### DIFF
--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -1593,7 +1593,7 @@ class LongformerModel(LongformerPreTrainedModel):
         # this path should be recorded in the ONNX export, it is fine with padding_len == 0 as well
         if padding_len > 0:
             logger.warning_once(
-                f"Input ids are automatically padded from {seq_len} to {seq_len + padding_len} to be a multiple of "
+                f"Input ids are automatically padded to be a multiple of "
                 f"`config.attention_window`: {attention_window}"
             )
             if input_ids is not None:


### PR DESCRIPTION
# What does this PR do?

Longformer `warning_once` call contains pretty unique information. This PR removes some of that info so that the message should actually only be logged once. 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker and @younesbelkada


