### PR TITLE
Make EosTokenCriteria compatible with mps

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -146,7 +146,18 @@ class EosTokenCriteria(StoppingCriteria):
 
     @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.BoolTensor:
-        is_done = torch.isin(input_ids[:, -1], self.eos_token_id.to(input_ids.device))
+        if input_ids.device.type == "mps":
+            # https://github.com/pytorch/pytorch/issues/77764#issuecomment-2067838075
+            is_done = (
+                input_ids[:, -1]
+                .tile(self.eos_token_id.shape[0], 1)
+                .eq(self.eos_token_id.unsqueeze(1).to(input_ids.device))
+                .sum(dim=0)
+                .bool()
+                .squeeze()
+            )
+        else:
+            is_done = torch.isin(input_ids[:, -1], self.eos_token_id.to(input_ids.device))
         return is_done
 
 


### PR DESCRIPTION
# What does this PR do?

EOS termination was moved to stopped criteria in #29459. It uses `torch.isin()`, which is not compatible with the `mps` device: https://github.com/pytorch/pytorch/issues/77764#issuecomment-2067838075. This PR uses the old method to detect whether any of the EOS tokens were found in the generated sequences.

Fixes https://github.com/huggingface/transformers/pull/29459#issuecomment-2066324318


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
