### PR TITLE
Correctly initialize the text model (Mistral) of Idefics2 with Flash Attention

### DIFF
--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1642,12 +1642,12 @@ class Idefics2Model(Idefics2PreTrainedModel):
             image_hidden_states = self.vision_model(
                 pixel_values=pixel_values,
                 patch_attention_mask=patch_attention_mask,
-            ).last_hidden_state
+            ).last_hidden_state.to(dtype=self.dtype, device=input_ids.device)
 
             # Modality projection & resampling
             image_hidden_states = self.connector(
                 image_hidden_states, attention_mask=patch_attention_mask.view(pixel_values.size(0), -1)
-            )
+            ).to(dtype=self.dtype, device=input_ids.device)
 
         elif image_hidden_states is not None:
             image_hidden_states = image_hidden_states.to(dtype=self.dtype, device=input_ids.device)

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1473,20 +1473,20 @@ class Idefics2Model(Idefics2PreTrainedModel):
         super().__init__(config)
         self.padding_idx = self.config.text_config.pad_token_id
         self.vocab_size = self.config.text_config.vocab_size
-        self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
         self.vision_model = Idefics2VisionTransformer(config.vision_config)
         self.connector = Idefics2Connector(config)
-        text_model_kwargs = {}
-        if self._use_flash_attention_2:
-            text_model_kwargs["use_flash_attention_2"] = True
-            torch_dtype = None
-            if config.text_config.torch_dtype is not None:
-                torch_dtype = config.text_config.torch_dtype
-            elif config.torch_dtype is not None:
-                torch_dtype = config.torch_dtype
-            text_model_kwargs["torch_dtype"] = torch_dtype
-        self.text_model = AutoModel.from_config(config.text_config, **text_model_kwargs)
+        torch_dtype = config.text_config.torch_dtype
+        if config.torch_dtype is not None:
+            torch_dtype = config.torch_dtype
+        attn_implementation = config.text_config._attn_implementation
+        if config._attn_implementation is not None:
+            attn_implementation = config._attn_implementation
+        self.text_model = AutoModel.from_config(
+            config.text_config, 
+            attn_implementation=attn_implementation,
+            torch_dtype=torch_dtype,    
+        )
         self.image_seq_len = config.perceiver_config.resampler_n_latents
         self.image_token_id = self.config.image_token_id
 

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1476,16 +1476,8 @@ class Idefics2Model(Idefics2PreTrainedModel):
 
         self.vision_model = Idefics2VisionTransformer(config.vision_config)
         self.connector = Idefics2Connector(config)
-        torch_dtype = config.text_config.torch_dtype
-        if config.torch_dtype is not None:
-            torch_dtype = config.torch_dtype
-        attn_implementation = config.text_config._attn_implementation
-        if config._attn_implementation is not None:
-            attn_implementation = config._attn_implementation
         self.text_model = AutoModel.from_config(
-            config.text_config, 
-            attn_implementation=attn_implementation,
-            torch_dtype=torch_dtype,    
+            config.text_config, attn_implementation=config._attn_implementation
         )
         self.image_seq_len = config.perceiver_config.resampler_n_latents
         self.image_token_id = self.config.image_token_id


### PR DESCRIPTION
# This PR attempts to resolve the issue of the text model not being loaded with Flash Attention 2

Relevant issue: #30394 

------

Currently, whatever combination of parameters I pass to the instantiation of the Idefics2 models, the text model is not being loaded with Flash Attention 2. Here are several examples:

1. Pass `_attn_implementation` to `from_pretrained`
```
import torch
from transformers import Idefics2ForConditionalGeneration

model = Idefics2ForConditionalGeneration.from_pretrained(
    "HuggingFaceM4/idefics2-8b",
    torch_dtype=torch.bfloat16,
    _attn_implementation="flash_attention_2",
)
print("Mistral model attention implementation: ", model.model.text_model._attn_implementation)
```
Output:
```
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
Loading checkpoint shards: 100%|██████████| 7/7 [00:02<00:00,  3.21it/s]
Mistral model attention implementation:  sdpa
```

2. Pass`attn_implementation` to `from_pretrained`
```
import torch
from transformers import Idefics2ForConditionalGeneration

model = Idefics2ForConditionalGeneration.from_pretrained(
    "HuggingFaceM4/idefics2-8b",
    torch_dtype=torch.bfloat16,
    attn_implementation="flash_attention_2",
)
print("Mistral model attention implementation: ", model.model.text_model._attn_implementation)
```
Output:
```
Loading checkpoint shards: 100%|██████████| 7/7 [00:02<00:00,  3.08it/s]
Mistral model attention implementation:  sdpa
```

3. Pass `config` object with property `_attn_implementation`:
```
import torch
from transformers import AutoConfig, Idefics2ForConditionalGeneration

config = AutoConfig.from_pretrained("HuggingFaceM4/idefics2-8b")
config._attn_implementation = "flash_attention_2"
config.torch_dtype = torch.bfloat16

model = Idefics2ForConditionalGeneration.from_pretrained(
    "HuggingFaceM4/idefics2-8b",
    config=config,
    torch_dtype=torch.bfloat16,
)
print("Mistral model attention implementation: ", model.model.text_model._attn_implementation)
```
Output:
```
Loading checkpoint shards: 100%|██████████| 7/7 [00:02<00:00,  3.09it/s]
Mistral model attention implementation:  sdpa
```

4. Pass both `config` and `attn_implementation` to `from_pretrained`:
```
import torch
from transformers import AutoConfig, Idefics2ForConditionalGeneration

config = AutoConfig.from_pretrained("HuggingFaceM4/idefics2-8b")
config._attn_implementation = "flash_attention_2"
config.torch_dtype = torch.bfloat16

model = Idefics2ForConditionalGeneration.from_pretrained(
    "HuggingFaceM4/idefics2-8b",
    config=config,
    torch_dtype=torch.bfloat16,
    attn_implementation="flash_attention_2",
)
print("Mistral model attention implementation: ", model.model.text_model._attn_implementation)
```
Output:
```
Loading checkpoint shards: 100%|██████████| 7/7 [00:02<00:00,  3.04it/s]
Mistral model attention implementation:  sdpa
```
------

This PR contains a simple patch which would allow the text model to be loaded with Flash Attention. Here is the output with the changes included:

```
import torch
from transformers import AutoConfig, Idefics2ForConditionalGeneration

config = AutoConfig.from_pretrained("HuggingFaceM4/idefics2-8b")
config._attn_implementation = "flash_attention_2"
config.torch_dtype = torch.bfloat16

model = Idefics2ForConditionalGeneration.from_pretrained(
    "HuggingFaceM4/idefics2-8b",
    config=config,
    torch_dtype=torch.bfloat16,
    attn_implementation="flash_attention_2",
)
print("Mistral model attention implementation: ", model.model.text_model._attn_implementation)
```
Output
```
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
The model was loaded with use_flash_attention_2=True, which is deprecated and may be removed in a future release. Please use `attn_implementation="flash_attention_2"` instead.
Loading checkpoint shards: 100%|██████████| 7/7 [00:02<00:00,  3.13it/s]
Mistral model attention implementation:  flash_attention_2
```

It is not an ideal fix, since it requires both passing a `config` object and a `attn_implementation` parameter. Moreover, it relies on the `use_flash_attention_2` parameter which might be deprecated soon. 

Criticism, feedback and requests for changes are welcomed. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Ping: @amyeroberts