### PR TITLE
Jax: scipy version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ _deps = [
     "safetensors>=0.4.1",
     "sagemaker>=2.31.0",
     "scikit-learn",
+    "scipy<1.13.0",  # SciPy >= 1.13.0 is not supported with the current jax pin (`jax>=0.4.1,<=0.4.13`)
     "sentencepiece>=0.1.91,!=0.1.92",
     "sigopt",
     "starlette",
@@ -267,7 +268,7 @@ if os.name == "nt":  # windows
     extras["flax"] = []  # jax is not supported on windows
 else:
     extras["retrieval"] = deps_list("faiss-cpu", "datasets")
-    extras["flax"] = deps_list("jax", "jaxlib", "flax", "optax")
+    extras["flax"] = deps_list("jax", "jaxlib", "flax", "optax", "scipy")
 
 extras["tokenizers"] = deps_list("tokenizers")
 extras["ftfy"] = deps_list("ftfy")

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -67,6 +67,7 @@ deps = {
     "safetensors": "safetensors>=0.4.1",
     "sagemaker": "sagemaker>=2.31.0",
     "scikit-learn": "scikit-learn",
+    "scipy": "scipy<1.13.0",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",
     "sigopt": "sigopt",
     "starlette": "starlette",


### PR DESCRIPTION
# What does this PR do?

Pins the scipy version so as to avoid jax import errors. Our pinned jax versions import (e.g.) `scipy.linalg.tril`, which was deprecated -- search for `tril` in [this release page](https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html).

Example of failing import (from a fresh venv, which was getting `scipy==1.13.0`):
```
tests/models/t5/test_modeling_flax_t5.py:45: in <module>
    import optax
../venvs/hf/lib/python3.10/site-packages/optax/__init__.py:18: in <module>
    from optax._src.alias import adabelief
../venvs/hf/lib/python3.10/site-packages/optax/_src/alias.py:24: in <module>
    from optax._src import factorized
../venvs/hf/lib/python3.10/site-packages/optax/_src/factorized.py:27: in <module>
    from optax._src import utils
../venvs/hf/lib/python3.10/site-packages/optax/_src/utils.py:22: in <module>
    import jax.scipy.stats.norm as multivariate_normal                                                                                                ../venvs/hf/lib/python3.10/site-packages/jax/scipy/stats/__init__.py:39: in <module>
    from jax._src.scipy.stats.kde import gaussian_kde as gaussian_kde
../venvs/hf/lib/python3.10/site-packages/jax/_src/scipy/stats/kde.py:26: in <module>
    from jax.scipy import linalg, special
../venvs/hf/lib/python3.10/site-packages/jax/scipy/linalg.py:18: in <module>
    from jax._src.scipy.linalg import (
../venvs/hf/lib/python3.10/site-packages/jax/_src/scipy/linalg.py:408: in <module>
    @_wraps(scipy.linalg.tril)
E   AttributeError: module 'scipy.linalg' has no attribute 'tril'
```