### PR TITLE
Fix num_hidden_layers in initialization of new model in Mamba

### DIFF
--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -402,7 +402,7 @@ class MambaPreTrainedModel(PreTrainedModel):
                     # Having just p *= scale would repeatedly scale it down
                     nn.init.kaiming_uniform_(p, a=math.sqrt(5))
                     with torch.no_grad():
-                        p /= math.sqrt(self.config.num_layers)
+                        p /= math.sqrt(self.config.num_hidden_layers)
 
 
 @dataclass


### PR DESCRIPTION
# What does this PR do?
Originally, the initialization was using config.num_layers instead of config.num_hidden_layers. This fixes that.


## Fixes 
Initialization would use a parameter not in the config (num_layers)


- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@ArthurZucker and @younesbelkada
