### PR TITLE
fix: link to HF repo/tree/revision when a file is missing

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -451,7 +451,7 @@ def cached_file(
             revision = "main"
         raise EnvironmentError(
             f"{path_or_repo_id} does not appear to have a file named {full_filename}. Checkout "
-            f"'https://huggingface.co/{path_or_repo_id}/{revision}' for available files."
+            f"'https://huggingface.co/{path_or_repo_id}/tree/{revision}' for available files."
         ) from e
     except HTTPError as err:
         resolved_file = _get_cache_file_to_return(path_or_repo_id, full_filename, cache_dir, revision)


### PR DESCRIPTION
When `cached_file` fails to download a file from a valid HF model, it reports `Checkout 'https://huggingface.co/{path_or_repo_id}/{revision}' for available files.` But [this gets a 404](https://huggingface.co/monsoon-nlp/tinyllama-mixpretrain-uniprottune/main). The correct link would include `/tree/{revision}`.

- It works for both branch names (e.g. `main`) and [commit IDs](https://huggingface.co/monsoon-nlp/hindi-bert/tree/c54eb831ba59dccff82d0bc7add9fd182606a9c7)
- Another error message already uses this URL https://github.com/huggingface/transformers/blob/main/src/transformers/utils/hub.py#L371
( edit: #29369 ) 

I had the error come up when trying to load a tokenizer from a LoRA repo instead of the base model repo: https://colab.research.google.com/drive/1pqdFMgo_6kqHfCGR5-qCIC6A_py5f84H?usp=sharing

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?