### PR TITLE
[tests] add `require_torch_sdpa` for test that needs sdpa support

### DIFF
--- a/tests/models/cohere/test_modeling_cohere.py
+++ b/tests/models/cohere/test_modeling_cohere.py
@@ -393,6 +393,7 @@ class CohereIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=40, do_sample=False)
         self.assertEqual(tokenizer.batch_decode(output, skip_special_tokens=True), EXPECTED_TEXT)
 
+    @require_torch_multi_gpu
     def test_batched_small_model_logits(self):
         # Since the model is very large, we created a random cohere model so that we can do a simple
         # logits check on it.

--- a/tests/models/cohere/test_modeling_cohere.py
+++ b/tests/models/cohere/test_modeling_cohere.py
@@ -393,7 +393,7 @@ class CohereIntegrationTest(unittest.TestCase):
         output = model.generate(**inputs, max_new_tokens=40, do_sample=False)
         self.assertEqual(tokenizer.batch_decode(output, skip_special_tokens=True), EXPECTED_TEXT)
 
-    @require_torch_multi_gpu
+    @require_torch_sdpa
     def test_batched_small_model_logits(self):
         # Since the model is very large, we created a random cohere model so that we can do a simple
         # logits check on it.

--- a/tests/models/cohere/test_modeling_cohere.py
+++ b/tests/models/cohere/test_modeling_cohere.py
@@ -374,6 +374,7 @@ class CohereModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
 @slow
 class CohereIntegrationTest(unittest.TestCase):
     @require_torch_multi_gpu
+    @require_bitsandbytes
     def test_batched_4bit(self):
         model_id = "CohereForAI/c4ai-command-r-v01-4bit"
 


### PR DESCRIPTION
## What does this PR do?
I got this test failed in my XPU environment. After debugging, I found that the EXPECTED_LOGITS in this test are computed with the assumption that `_attn_implementation` is set to `sdpa`. The code for setting the `_attn_implementation` are [this line](https://github.com/huggingface/transformers/blob/e74d793a3c3c0bc9bf3fb94bb31dd16934b1b0db/src/transformers/modeling_utils.py#L1464) and [this line](https://github.com/huggingface/transformers/blob/e74d793a3c3c0bc9bf3fb94bb31dd16934b1b0db/src/transformers/modeling_utils.py#L1630). I experimented to downgrade my torch version to make `_attn_implementation` value to eager and it fails on CUDA. So we neeed to add the maker `require_torch_sdpa` to this test. 


@ArthurZucker and @amyeroberts
