### PR TITLE
Fix attn mask for static cache

### DIFF
--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1234,6 +1234,11 @@ class CohereForCausalLM(CoherePreTrainedModel):
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 
+        # otherwise zeros in static kv cache are not masked, which leads to incorrect generation
+        if has_static_cache and attention_mask is not None:
+            attention_mask_zeros = torch.zeros_like(attention_mask)[: max_cache_length - past_length]
+            attention_mask = torch.cat([attention_mask, attention_mask_zeros], dim=-1)
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1216,6 +1216,11 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 
+        # otherwise zeros in static kv cache are not masked, which leads to incorrect generation
+        if has_static_cache and attention_mask is not None:
+            attention_mask_zeros = torch.zeros_like(attention_mask)[: max_cache_length - past_length]
+            attention_mask = torch.cat([attention_mask, attention_mask_zeros], dim=-1)
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1312,6 +1312,11 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 
+        # otherwise zeros in static kv cache are not masked, which leads to incorrect generation
+        if has_static_cache and attention_mask is not None:
+            attention_mask_zeros = torch.zeros_like(attention_mask)[: max_cache_length - past_length]
+            attention_mask = torch.cat([attention_mask, attention_mask_zeros], dim=-1)
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1293,6 +1293,11 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
             if past_key_values:
                 position_ids = position_ids[:, -input_ids.shape[1] :]
 
+        # otherwise zeros in static kv cache are not masked, which leads to incorrect generation
+        if has_static_cache and attention_mask is not None:
+            attention_mask_zeros = torch.zeros_like(attention_mask)[: max_cache_length - past_length]
+            attention_mask = torch.cat([attention_mask, attention_mask_zeros], dim=-1)
+
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and past_key_values is None:
             model_inputs = {"inputs_embeds": inputs_embeds}


### PR DESCRIPTION
# What does this PR do?

Fixes #30400. 

It was found that when static cache returns key and values if "length=max_length", the zeros are not masked out. That is why the generation starts returning gibberish at larger max_new_tokens, and is more expressed in "sdpa" attention which just falls back to its internal causal mask.

All slow tests in the models are passing for me locally.