### PR TITLE
fix jamba slow foward for multi-gpu

### DIFF
--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -231,6 +231,7 @@ class HybridMambaAttentionDynamicCache(DynamicCache):
         conv_kernel_size = config.mamba_d_conv
         self.conv_states = []
         self.ssm_states = []
+        print(self.device_map)
         for i in range(config.num_hidden_layers):
             if self.layers_block_type[i] == "mamba":
                 self.conv_states += [
@@ -908,7 +909,7 @@ class JambaMambaMixer(nn.Module):
                 ssm_state = cache_params.ssm_states[self.layer_idx].clone()
             else:
                 ssm_state = cache_params.ssm_states[self.layer_idx]
-            # compatibility with multi-gpu forward
+
             ssm_state = ssm_state.to(hidden_states.device)
 
             if cache_params.has_previous_state and seq_len == 1 and \

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -231,7 +231,6 @@ class HybridMambaAttentionDynamicCache(DynamicCache):
         conv_kernel_size = config.mamba_d_conv
         self.conv_states = []
         self.ssm_states = []
-        print(self.device_map)
         for i in range(config.num_hidden_layers):
             if self.layers_block_type[i] == "mamba":
                 self.conv_states += [
@@ -914,7 +913,9 @@ class JambaMambaMixer(nn.Module):
 
             if cache_params.has_previous_state and seq_len == 1 and \
                     cache_params.conv_states[self.layer_idx].shape[0] == batch_size:
-                conv_state = cache_params.conv_states[self.layer_idx]                   # [batch, intermediate_size, conv_kernel_size]
+                
+                
+                = cache_params.conv_states[self.layer_idx]                   # [batch, intermediate_size, conv_kernel_size]
                 conv_state = torch.roll(conv_state, shifts=-1, dims=-1)
                 conv_state[:, :, -1] = hidden_states[:, :, 0]
                 cache_params.conv_states[self.layer_idx] = conv_state

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -913,9 +913,7 @@ class JambaMambaMixer(nn.Module):
 
             if cache_params.has_previous_state and seq_len == 1 and \
                     cache_params.conv_states[self.layer_idx].shape[0] == batch_size:
-                
-                
-                = cache_params.conv_states[self.layer_idx]                   # [batch, intermediate_size, conv_kernel_size]
+                conv_state = cache_params.conv_states[self.layer_idx]                   # [batch, intermediate_size, conv_kernel_size]
                 conv_state = torch.roll(conv_state, shifts=-1, dims=-1)
                 conv_state[:, :, -1] = hidden_states[:, :, 0]
                 cache_params.conv_states[self.layer_idx] = conv_state

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -908,6 +908,8 @@ class JambaMambaMixer(nn.Module):
                 ssm_state = cache_params.ssm_states[self.layer_idx].clone()
             else:
                 ssm_state = cache_params.ssm_states[self.layer_idx]
+            # compatibility with multi-gpu forward
+            ssm_state = ssm_state.to(hidden_states.device)
 
             if cache_params.has_previous_state and seq_len == 1 and \
                     cache_params.conv_states[self.layer_idx].shape[0] == batch_size:
@@ -952,7 +954,6 @@ class JambaMambaMixer(nn.Module):
         discrete_A = torch.exp(A[None, :, None, :] * discrete_time_step[:, :, :, None]) # [batch, intermediate_size, seq_len, ssm_state_size]
         discrete_B = discrete_time_step[:, :, :, None] * B[:, None, :, :].float()       # [batch, intermediade_size, seq_len, ssm_state_size]
         deltaB_u = discrete_B * hidden_states[:, :, :, None].float()
-
         # 3.c perform the recurrence y ← SSM(A, B, C)(x)
         scan_outputs = []
         for i in range(seq_len):


### PR DESCRIPTION
# What does this PR do ?
This PR makes the slow forward of Jamba model compatible with multi-gpu setup with use_cache=True.  The issue is that the cache is not initialized on the right device. Not sure we want to refactor the cache since the `key_cache` and and `value_cache` are handled correctly. This is just specific to `ssm_states`. Moving the tensor manually should only impact the first forward also. After the first forward, the cache will be correctly initialized. 
Fixes https://github.com/huggingface/transformers/issues/30367 

Code: 

```python
import os
from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig

prompt = "def quicksort(arr):\n"
tokenizer = AutoTokenizer.from_pretrained("ai21labs/Jamba-tiny-random")
tokenizer.pad_token = tokenizer.eos_token
config = AutoConfig.from_pretrained("ai21labs/Jamba-tiny-random")
# change the following to switch between fast and slow forward 
config.use_mamba_kernels=False 
model = AutoModelForCausalLM.from_pretrained(
    "ai21labs/Jamba-tiny-random",
    device_map="auto",
    config = config
)
print(model.hf_device_map)
print(model.config)
inputs = tokenizer.encode(prompt, return_tensors="pt")
outputs = model.generate(input_ids=inputs.to(model.device), max_new_tokens=512, do_sample=False)
print(tokenizer.decode(outputs[0]))
```