### PR TITLE
Workflow / ENH: Add SSH into our runners workflow

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   IS_GITHUB_CI: "1"
-  OUTPUT_SLACK_CHANNEL_ID: "C06L2SGMEEA"
   HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache 
   TRANSFORMERS_IS_CI: yes 

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -31,24 +31,25 @@ jobs:
       options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      
-      - name: Install locally transformers & other libs
+      - name: Update clone
+        working-directory: /transformers
         run: |
-          apt install sudo
-          sudo -H pip install --upgrade pip
-          sudo -H pip uninstall -y transformers 
-          sudo -H pip install -U -e ".[testing]" 
-          MAX_JOBS=4 pip install flash-attn --no-build-isolation
-          pip install bitsandbytes
+          git fetch && git checkout ${{ github.sha }}
+
+      - name: Cleanup
+        working-directory: /transformers
+        run: |
+          rm -rf tests/__pycache__
+          rm -rf tests/models/__pycache__
+          rm -rf reports
+
+      - name: Show installed libraries and their versions
+        working-directory: /transformers
+        run: pip freeze
       
       - name: NVIDIA-SMI
         run: |
           nvidia-smi
-      
-      - name: Show installed libraries and their versions
-        run: pip freeze
       
       - name: Tailscale # In order to be able to SSH when a test fails
         uses: huggingface/tailscale-action@v1

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -27,7 +27,7 @@ jobs:
     name: SSH
     runs-on: [single-gpu, nvidia-gpu, ${{ github.event.inputs.runner_type }}, ci]
     container:
-      image: ${{ github.event.inputs.runner_type }}
+      image: ${{ github.event.inputs.docker_image }}
       options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
 
     steps:

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -1,0 +1,61 @@
+name: SSH into our runners
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_type:
+        description: 'Type of runner to test (a10 or t4)'
+        required: true 
+      docker_image:
+        description: 'Name of the Docker image'
+        required: true
+
+env:
+  IS_GITHUB_CI: "1"
+  OUTPUT_SLACK_CHANNEL_ID: "C06L2SGMEEA"
+  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_HOME: /mnt/cache 
+  TRANSFORMERS_IS_CI: yes 
+  OMP_NUM_THREADS: 8 
+  MKL_NUM_THREADS: 8 
+  RUN_SLOW: yes # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access. # This token is created under the bot `hf-transformers-bot`. 
+  SIGOPT_API_TOKEN: ${{ secrets.SIGOPT_API_TOKEN }} 
+  TF_FORCE_GPU_ALLOW_GROWTH: true 
+  RUN_PT_TF_CROSS_TESTS: 1
+
+jobs:
+  ssh_runner:
+    needs: get_modified_models
+    name: SSH
+    runs-on: [single-gpu, nvidia-gpu, ${{ github.event.inputs.runner_type }}, ci]
+    container:
+      image: ${{ github.event.inputs.runner_type }}
+      options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      
+      - name: Install locally transformers & other libs
+        run: |
+          apt install sudo
+          sudo -H pip install --upgrade pip
+          sudo -H pip uninstall -y transformers 
+          sudo -H pip install -U -e ".[testing]" 
+          MAX_JOBS=4 pip install flash-attn --no-build-isolation
+          pip install bitsandbytes
+      
+      - name: NVIDIA-SMI
+        run: |
+          nvidia-smi
+      
+      - name: Show installed libraries and their versions
+        run: pip freeze
+      
+      - name: Tailscale # In order to be able to SSH when a test fails
+        uses: huggingface/tailscale-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_SSH_AUTHKEY }}
+          slackChannel: ${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}
+          slackToken: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+          waitForSSH: true

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -25,7 +25,6 @@ env:
 
 jobs:
   ssh_runner:
-    needs: get_modified_models
     name: SSH
     runs-on: [single-gpu, nvidia-gpu, ${{ github.event.inputs.runner_type }}, ci]
     container:


### PR DESCRIPTION
# What does this PR do?

This PR adds a new workflow that enables developers to easily SSH into our runners and debug the failing tests, as discussed offline with @ydshieh during lunch

cc @glegendre01 
