### PR TITLE
Fix YOLOS image processor resizing

### DIFF
--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -120,7 +120,7 @@ def get_size_with_aspect_ratio(image_size, size, max_size=None) -> Tuple[int, in
         if max_original_size / min_original_size * size > max_size:
             size = int(round(max_size * min_original_size / max_original_size))
 
-    if width < height and width != size:
+    if width <= height and width != size:
         height = int(size * height / width)
         width = size
     elif height < width and height != size:

--- a/tests/models/yolos/test_image_processing_yolos.py
+++ b/tests/models/yolos/test_image_processing_yolos.py
@@ -201,7 +201,10 @@ class YolosImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMix
         # create torch tensors as image
         image = torch.randint(0, 256, image_size, dtype=torch.uint8)
         processed_image = image_processor(
-            image, size={"longest_edge": longest_edge, "shortest_edge": shortest_edge}, do_pad=False, return_tensors="pt"
+            image,
+            size={"longest_edge": longest_edge, "shortest_edge": shortest_edge},
+            do_pad=False,
+            return_tensors="pt",
         )["pixel_values"]
 
         shape = list(processed_image.shape[-2:])

--- a/tests/models/yolos/test_image_processing_yolos.py
+++ b/tests/models/yolos/test_image_processing_yolos.py
@@ -100,7 +100,7 @@ class YolosImageProcessingTester(unittest.TestCase):
                 if max_original_size / min_original_size * size > max_size:
                     size = int(round(max_size * min_original_size / max_original_size))
 
-            if width < height and width != size:
+            if width <= height and width != size:
                 height = int(size * height / width)
                 width = size
             elif height < width and height != size:

--- a/tests/models/yolos/test_image_processing_yolos.py
+++ b/tests/models/yolos/test_image_processing_yolos.py
@@ -187,22 +187,27 @@ class YolosImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMix
 
     @parameterized.expand(
         [
-            ((3, 100, 1500),),
-            ((3, 400, 400),),
-            ((3, 1500, 1500),),
+            ((3, 100, 1500), 1333, 800),
+            ((3, 400, 400), 1333, 800),
+            ((3, 1500, 1500), 1333, 800),
+            ((3, 800, 1333), 1333, 800),
+            ((3, 1333, 800), 1333, 800),
+            ((3, 800, 800), 400, 400),
         ]
     )
-    def test_resize_max_size_respected(self, image_size):
+    def test_resize_max_size_respected(self, image_size, longest_edge, shortest_edge):
         image_processor = self.image_processing_class(**self.image_processor_dict)
 
         # create torch tensors as image
         image = torch.randint(0, 256, image_size, dtype=torch.uint8)
         processed_image = image_processor(
-            image, size={"longest_edge": 1333, "shortest_edge": 800}, do_pad=False, return_tensors="pt"
+            image, size={"longest_edge": longest_edge, "shortest_edge": shortest_edge}, do_pad=False, return_tensors="pt"
         )["pixel_values"]
 
-        self.assertTrue(processed_image.shape[-1] <= 1333, f"Expected width <= 1333, got {processed_image.shape[-1]}")
-        self.assertTrue(processed_image.shape[-2] <= 800, f"Expected height <= 800, got {processed_image.shape[-2]}")
+        shape = list(processed_image.shape[-2:])
+        max_size, min_size = max(shape), min(shape)
+        self.assertTrue(max_size <= 1333, f"Expected max_size <= 1333, got image shape {shape}")
+        self.assertTrue(min_size <= 800, f"Expected min_size <= 800, got image shape {shape}")
 
     @slow
     def test_call_pytorch_with_coco_detection_annotations(self):


### PR DESCRIPTION
# What does this PR do?

I observed that the YOLOS model failed with OOM while training. After some investigation, I found that square images are not properly resized by YOLOS image processor even if do_resize=True. The size parameter is not respected even if the max size of the image is larger than `longest_edge`.

Example to reproduce:
```python
import torch
from transformers import YolosImageProcessor

images = torch.randint(0, 256, (1, 3, 1500, 1500), dtype=torch.uint8)
processor = YolosImageProcessor(size={"longest_edge": 1333, "shortest_edge": 800}, do_resize=True)

# Resize the image
result = processor(images=images, return_tensors="pt")
print(result["pixel_values"].shape)

# >>> torch.Size([1, 3, 1488, 1488])
```

I am going to
1) submit a test that fails on square images
2) submit a fix

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
