### PR TITLE
Llama: SDPA FA2 path + static cache fix

### DIFF
--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -533,10 +533,13 @@ class CohereSdpaAttention(CohereAttention):
         cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if output_attentions:
-            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
+            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is
+            # implemented.
             logger.warning_once(
-                "CohereModel is using CohereSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
-                'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+                "CohereModel is using CohereSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` "
+                "does not support `output_attentions=True`. Falling back to the manual attention implementation, "
+                "but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. "
+                'This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
             )
             return super().forward(
                 hidden_states=hidden_states,
@@ -583,15 +586,19 @@ class CohereSdpaAttention(CohereAttention):
         if attention_mask is not None:
             causal_mask = causal_mask[:, :, :, : key_states.shape[-2]]
 
-        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
-        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom
+        # attn_mask. Reference: https://github.com/pytorch/pytorch/issues/112577.
         if query_states.device.type == "cuda" and causal_mask is not None:
             query_states = query_states.contiguous()
             key_states = key_states.contiguous()
             value_states = value_states.contiguous()
 
-        # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash Attention 2 backend, rather
-        # relying on the `is_causal` argument.
+        # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash
+        # Attention 2 backend, rather relying on the `is_causal` argument. If using static cache, we need to drop the
+        # empty KV entries
+        if causal_mask is None and cache_position is not None:
+            key_states = key_states[:, :, : cache_position[-1] + 1, :]
+            value_states = value_states[:, :, : cache_position[-1] + 1, :]
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
             key_states,

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -594,9 +594,9 @@ class CohereSdpaAttention(CohereAttention):
             value_states = value_states.contiguous()
 
         # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash
-        # Attention 2 backend, rather relying on the `is_causal` argument. If using static cache, we need to drop the
-        # empty KV entries
-        if causal_mask is None and cache_position is not None:
+        # Attention 2 backend, rather relying on the `is_causal` argument. In that case, if using static cache, we need
+        # to drop the empty KV entries
+        if causal_mask is None and cache_position is not None and isinstance(past_key_value, StaticCache):
             key_states = key_states[:, :, : cache_position[-1] + 1, :]
             value_states = value_states[:, :, : cache_position[-1] + 1, :]
         attn_output = torch.nn.functional.scaled_dot_product_attention(

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -574,9 +574,9 @@ class GemmaSdpaAttention(GemmaAttention):
             value_states = value_states.contiguous()
 
         # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash
-        # Attention 2 backend, rather relying on the `is_causal` argument. If using static cache, we need to drop the
-        # empty KV entries
-        if causal_mask is None and cache_position is not None:
+        # Attention 2 backend, rather relying on the `is_causal` argument. In that case, if using static cache, we need
+        # to drop the empty KV entries
+        if causal_mask is None and cache_position is not None and isinstance(past_key_value, StaticCache):
             key_states = key_states[:, :, : cache_position[-1] + 1, :]
             value_states = value_states[:, :, : cache_position[-1] + 1, :]
         attn_output = torch.nn.functional.scaled_dot_product_attention(

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -521,10 +521,13 @@ class GemmaSdpaAttention(GemmaAttention):
         cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if output_attentions:
-            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
+            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is
+            # implemented.
             logger.warning_once(
-                "GemmaModel is using GemmaSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
-                'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+                "GemmaModel is using GemmaSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does "
+                "not support `output_attentions=True`. Falling back to the manual attention implementation, "
+                "but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. "
+                'This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
             )
             return super().forward(
                 hidden_states=hidden_states,
@@ -563,15 +566,19 @@ class GemmaSdpaAttention(GemmaAttention):
         if attention_mask is not None:
             causal_mask = causal_mask[:, :, :, : key_states.shape[-2]]
 
-        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
-        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom
+        # attn_mask. Reference: https://github.com/pytorch/pytorch/issues/112577.
         if query_states.device.type == "cuda" and causal_mask is not None:
             query_states = query_states.contiguous()
             key_states = key_states.contiguous()
             value_states = value_states.contiguous()
 
-        # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash Attention 2 backend, rather
-        # relying on the `is_causal` argument.
+        # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash
+        # Attention 2 backend, rather relying on the `is_causal` argument. If using static cache, we need to drop the
+        # empty KV entries
+        if causal_mask is None and cache_position is not None:
+            key_states = key_states[:, :, : cache_position[-1] + 1, :]
+            value_states = value_states[:, :, : cache_position[-1] + 1, :]
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
             key_states,

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -670,11 +670,11 @@ class LlamaSdpaAttention(LlamaAttention):
             value_states = value_states.contiguous()
 
         # In case we are not compiling, we may set `causal_mask` to None, which is required to dispatch to SDPA's Flash
-        # Attention 2 backend, rather relying on the `is_causal` argument. If using static cache, we need to drop the
-        # empty KV entries
-        if causal_mask is None and cache_position is not None:
-            key_states = key_states[:, :, : cache_position[-1] + 1, :]
-            value_states = value_states[:, :, : cache_position[-1] + 1, :]
+        # Attention 2 backend, rather relying on the `is_causal` argument. In that case, if using static cache, we need
+        # to drop the empty KV entries
+        # if causal_mask is None and cache_position is not None and isinstance(past_key_value, StaticCache):
+        #     key_states = key_states[:, :, : cache_position[-1] + 1, :]
+        #     value_states = value_states[:, :, : cache_position[-1] + 1, :]
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
             key_states,
@@ -1080,6 +1080,7 @@ class LlamaModel(LlamaPreTrainedModel):
         if self.config._attn_implementation == "sdpa":
             # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument,
             # in order to dispatch on Flash Attention 2.
+            breakpoint()
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask, inputs_embeds=input_tensor, past_key_values_length=past_seen_tokens
             ):


### PR DESCRIPTION
# What does this PR do?

## Problem
The recently enabled SDPA FA2 path doesn't pass the `attn_mask` (causal mask) argument. As such, when the static cache is used, `S` (see the [SDPA docs](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) for terminology) is the full cache length as opposed to the sequence length. Therefore, the inferred mask in SDPA is incorrect, resulting in bad numerical values. 

PR that introduced the issue: https://github.com/huggingface/transformers/pull/30317. The issue was not caught in our llama testing suite because we didn't have a test for the static cache WITHOUT compilation:
- dynamic cache -> no issue with the length
- static cache + compile -> we manually build the causal attention mask, passing it to sdpa
- static cache -> we don't build the causal mask = `causal mask is None` = problem described above triggered

## Solution
There were two possible paths here:
1. Build and pass a full attention mask, corresponding to the full cache length, to avoid `causal mask is None` (#30414 );
2. Crop empty KV entries (corresponding to the empty cache) before SDPA.

I went with `2`, as it saves us tons of masked computations :) I've also ensured the static cache without compilation is numerically tested in the llama test file.

Fixes #30417 

________________________________

Slow tests ran locally: `llama`, `gemma`, `cohere`, `test_cache_utils.py`.