### PR TITLE
Add `paths` filter to avoid the chance of being triggered

### DIFF
--- a/.github/workflows/self-new-model-pr-caller.yml
+++ b/.github/workflows/self-new-model-pr-caller.yml
@@ -2,6 +2,8 @@ name: PR slow CI
 
 on:
   pull_request:
+    paths:
+      - "src/transformers/models/*/modeling_*.py"
 
 env:
   HF_HOME: /mnt/cache

--- a/.github/workflows/self-new-model-pr-caller.yml
+++ b/.github/workflows/self-new-model-pr-caller.yml
@@ -110,18 +110,3 @@ jobs:
         with:
           name: ${{ matrix.machine_type }}_run_all_tests_gpu_${{ env.matrix_folders }}_test_reports
           path: /transformers/reports/${{ matrix.machine_type }}_tests_gpu_${{ matrix.folders }}
-
-  slow_test_result:
-      runs-on: ubuntu-22.04
-      name: Check slow test status
-      needs: [check_for_new_model, run_new_model_tests]
-      if: always()
-      steps:
-        - name: Check test status
-          shell: bash
-          # NOT a new model PR --> pass
-          # new model PR --> pass only if `run_new_model_tests` gives `success` (so if the label is not added, we fail
-          # this job even if `run_new_model_tests` has `skipped` status).
-          run: |
-            echo "${{ needs.run_new_model_tests.result }}"
-            if [ "${{ needs.check_for_new_model.outputs.new_model }}" = "" ]; then echo "not new model"; elif [ "${{ needs.run_new_model_tests.result }}" != "success" ]; then echo "failure"; exit -1; else echo "pass"; fi;


### PR DESCRIPTION
# What does this PR do?

We decide to remove the status check from the repository setting, i.e. no more `Check slow test status` as in the following screenshot.

Therefore, we don't need to trigger the workflow file all the time. This PR adds a `paths` filter. The workflow will be triggered only if there is a change matching `src/transformers/models/*/modeling_*.py`.

- For external contributors' PRs, this avoids to click  unnecessary  `Approve and run` most of the time.
- If a change to modeling files, the workflow will still be trigger even if it is not a new model PR.
  -  If it is from external contributor,  `Approve and run` would be shown and waits for click. 
    -  If it is NOT new model PR, reviewers could ignore it however. But if it is  clicked it (after review), it will be ✅  anyway
- If it is a new model PR, the slow tests will be triggered (external PRs need the button to be clicked + assume the required label  `single-model-run-slow` is added), and the reviewers can check it is ✅  or ❌ (which is easy to identify).


<img width="638" alt="Screenshot 2024-04-24 100723" src="https://github.com/huggingface/transformers/assets/2521628/397bfc97-9e77-42a2-8e12-704bb0e6db1b">
