### PR TITLE
Don't run fp16 MusicGen tests on CPU

### DIFF
--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -35,6 +35,7 @@ from transformers.testing_utils import (
     is_torch_available,
     require_flash_attn,
     require_torch,
+    require_torch_accelerator,
     require_torch_fp16,
     require_torch_gpu,
     require_torch_sdpa,
@@ -1483,6 +1484,7 @@ class MusicgenTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             self.assertIsNotNone(output_ids_generate)
 
     @require_torch_fp16
+    @require_torch_accelerator  # not all operations are supported in fp16 on CPU
     def test_generate_fp16(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs()
 

--- a/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
@@ -35,6 +35,7 @@ from transformers.testing_utils import (
     is_torchaudio_available,
     require_flash_attn,
     require_torch,
+    require_torch_accelerator,
     require_torch_fp16,
     require_torch_gpu,
     require_torch_sdpa,
@@ -1465,6 +1466,7 @@ class MusicgenMelodyTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
             self.assertIsNotNone(output_ids_generate)
 
     @require_torch_fp16
+    @require_torch_accelerator  # not all operations are supported in fp16 on CPU
     def test_generate_fp16(self):
         config, input_dict = self.model_tester.prepare_config_and_inputs()
 


### PR DESCRIPTION
# What does this PR do?

Another victim of the torch 2.3 release - fp16 is now marked as available for CPU, but the necessary operations are implemented for the MusicGen and MusicGen melody generation tests. 

Adding an extract requirement that a torch accelerator is used to avoid running on CPU. 

Fixes failing tests on main. Example run: https://app.circleci.com/pipelines/github/huggingface/transformers/90749/workflows/b93e2c68-695f-4aee-a944-9f86b6a1d369/jobs/1185031