### PR TITLE
add new lr_scheduler_type: step_lr

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -391,10 +391,10 @@ def get_step_lr(
     optimizer,
     num_warmup_steps,
     num_training_steps,
-    gamma=0.1, 
-    last_epoch=-1, 
+    gamma=0.1,
+    last_epoch=-1,
     verbose="False"
-):  
+):
     """
     Create a schedule with a learning rate that decays by gamma every
     num_training_steps. Notice that such decay can happen simultaneously with
@@ -414,7 +414,7 @@ def get_step_lr(
     Return:
         `torch.optim.lr_scheduler.StepLR` with the appropriate schedule.
     """
-    
+
     return StepLR(optimizer, num_training_steps, gamma, last_epoch, verbose)
 
 

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -22,7 +22,7 @@ from typing import Callable, Iterable, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import LambdaLR, ReduceLROnPlateau
+from torch.optim.lr_scheduler import LambdaLR, ReduceLROnPlateau, StepLR
 
 from .trainer_pt_utils import LayerWiseDummyOptimizer, LayerWiseDummyScheduler
 from .trainer_utils import SchedulerType
@@ -387,6 +387,37 @@ def get_cosine_with_min_lr_schedule_with_warmup(
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
 
+def get_step_lr(
+    optimizer,
+    num_warmup_steps,
+    num_training_steps,
+    gamma=0.1, 
+    last_epoch=-1, 
+    verbose="False"
+):  
+    """
+    Create a schedule with a learning rate that decays by gamma every
+    num_training_steps. Notice that such decay can happen simultaneously with
+    other changes to the learning rate from outside this scheduler. When
+    last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        num_warmup_steps (int): Reserved for future use to maintain interface compatibility.
+        num_training_steps (int): Period of learning rate decay.
+        gamma (float): Multiplicative factor of learning rate decay.
+            Default: 0.1.
+        last_epoch (int): The index of last epoch. Default: -1.
+        verbose (bool): If ``True``, prints a message to stdout for
+            each update. Default: ``False``.
+
+    Return:
+        `torch.optim.lr_scheduler.StepLR` with the appropriate schedule.
+    """
+    
+    return StepLR(optimizer, num_training_steps, gamma, last_epoch, verbose)
+
+
 TYPE_TO_SCHEDULER_FUNCTION = {
     SchedulerType.LINEAR: get_linear_schedule_with_warmup,
     SchedulerType.COSINE: get_cosine_schedule_with_warmup,
@@ -397,6 +428,7 @@ TYPE_TO_SCHEDULER_FUNCTION = {
     SchedulerType.INVERSE_SQRT: get_inverse_sqrt_schedule,
     SchedulerType.REDUCE_ON_PLATEAU: get_reduce_on_plateau_schedule,
     SchedulerType.COSINE_WITH_MIN_LR: get_cosine_with_min_lr_schedule_with_warmup,
+    SchedulerType.STEP_LR: get_step_lr
 }
 
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -412,6 +412,7 @@ class SchedulerType(ExplicitEnum):
     INVERSE_SQRT = "inverse_sqrt"
     REDUCE_ON_PLATEAU = "reduce_lr_on_plateau"
     COSINE_WITH_MIN_LR = "cosine_with_min_lr"
+    STEP_LR = "step_lr"
 
 
 class TrainerMemoryTracker:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Added a new learning rate scheduler: `step_lr`. This was implemented through the `TYPE_TO_SCHEDULER_FUNCTION get_step_lr`, based on the existing class `torch.optim.lr_scheduler.StepLR`. It retains the same parameters as other functions and uses `num_training_steps` to represent `step_size`, ensuring consistency.



<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
