### PR TITLE
FIX / Workflow: Change tailscale trigger condition

### DIFF
--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -127,7 +127,7 @@ jobs:
           slack_token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
 
       - name: Tailscale # In order to be able to SSH when a test fails
-        if: ${{ failure() || runner.debug == '1'}}
+        if: ${{ runner.debug == '1'}}
         uses: huggingface/tailscale-action@v1
         with:
           authkey: ${{ secrets.TAILSCALE_SSH_AUTHKEY }}


### PR DESCRIPTION
# What does this PR do?

Changes the tailscale trigger condition to `debug` only to avoid creating many runners in our infra and create instances only when explicitly triggered - as discussed offline with guillaume

cc @ydshieh @glegendre01 
