### PR TITLE
Fix SigLip classification doctest

### DIFF
--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -1122,7 +1122,6 @@ class SiglipModel(SiglipPreTrainedModel):
         >>> from transformers import AutoProcessor, AutoModel
         >>> import torch
 
-        >>> torch.manual_seed(3)  # doctest: +IGNORE_RESULT
         >>> model = AutoModel.from_pretrained("google/siglip-base-patch16-224")
         >>> processor = AutoProcessor.from_pretrained("google/siglip-base-patch16-224")
 

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -1243,9 +1243,7 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
         >>> from PIL import Image
         >>> import requests
 
-        >>> # Head will be randomly initialized, predictions will be random if seed is not set.
         >>> torch.manual_seed(3)  # doctest: +IGNORE_RESULT
-
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -1122,6 +1122,7 @@ class SiglipModel(SiglipPreTrainedModel):
         >>> from transformers import AutoProcessor, AutoModel
         >>> import torch
 
+        >>> torch.manual_seed(3)  # doctest: +IGNORE_RESULT
         >>> model = AutoModel.from_pretrained("google/siglip-base-patch16-224")
         >>> processor = AutoProcessor.from_pretrained("google/siglip-base-patch16-224")
 
@@ -1243,7 +1244,9 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
         >>> from PIL import Image
         >>> import requests
 
+        >>> # Head will be randomly initialized, predictions will be random if seed is not set.
         >>> torch.manual_seed(3)  # doctest: +IGNORE_RESULT
+
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
@@ -1258,7 +1261,7 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
         >>> # model predicts one of the two classes
         >>> predicted_class_idx = logits.argmax(-1).item()
         >>> print("Predicted class:", model.config.id2label[predicted_class_idx])
-        Predicted class: LABEL_0
+        Predicted class: LABEL_1
         ```"""
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (


### PR DESCRIPTION
# What does this PR do?

Fixes doctest for SigLip model. 

https://github.com/huggingface/transformers/pull/30435 fixed the initialization bug for the classification head, making sure it was randomly initialized using the `normal_` init method. Previously, the weight was created using `torch.empty` because of the fast_init logic and never properly filled. This meant the array was almost always mostly 0s, leading to the stable label 0 prediction AND the seed never had an effect.
