### PR TITLE
Prevent crash with `WandbCallback` with third parties

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -786,15 +786,10 @@ class WandbCallback(TrainerCallback):
             self._wandb.run._label(code="transformers_trainer")
 
             # add number of model parameters to wandb config
-            if any(
-                (
-                    isinstance(model, PreTrainedModel),
-                    isinstance(model, PushToHubMixin),
-                    (is_tf_available() and isinstance(model, TFPreTrainedModel)),
-                    (is_torch_available() and isinstance(model, torch.nn.Module)),
-                )
-            ):
+            try:
                 self._wandb.config["model/num_parameters"] = model.num_parameters()
+            except AttributeError:
+                pass
 
             # log the initial model and architecture to an artifact
             with tempfile.TemporaryDirectory() as temp_dir:
@@ -812,6 +807,7 @@ class WandbCallback(TrainerCallback):
                         "initial_model": True,
                     },
                 )
+                model: PreTrainedModel = model
                 model.save_pretrained(temp_dir)
                 # add the architecture to a separate text file
                 save_model_architecture_to_file(model, temp_dir)

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -807,7 +807,6 @@ class WandbCallback(TrainerCallback):
                         "initial_model": True,
                     },
                 )
-                model: PreTrainedModel = model
                 model.save_pretrained(temp_dir)
                 # add the architecture to a separate text file
                 save_model_architecture_to_file(model, temp_dir)

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -789,7 +789,7 @@ class WandbCallback(TrainerCallback):
             try:
                 self._wandb.config["model/num_parameters"] = model.num_parameters()
             except AttributeError:
-                pass
+                logger.info("Could not log the number of model parameters in Weights & Biases.")
 
             # log the initial model and architecture to an artifact
             with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# What does this PR do?

This PR fixes a dodgy if-statement introduced in #30135 that attempts to check whether a model has a `num_parameters` method. Currently, if
```python
(is_torch_available() and isinstance(model, torch.nn.Module))
```
is True, then the model does not necessarily have a `num_parameters` method. Instead, I've replaced it with an "Easier to ask for forgiveness than permission" principle which should be much safer.

This is currently breaking Sentence Transformers training with W&B.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts as she reviewed #30135
@muellerz 

- Tom Aarsen
