### PR TITLE
Update `dtype_byte_size` to handle torch.float8_e4m3fn/float8_e5m2 types

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -324,7 +324,7 @@ def dtype_byte_size(dtype):
     """
     if dtype == torch.bool:
         return 1 / 8
-    bit_search = re.search(r"[^\d](\d+)$", str(dtype))
+    bit_search = re.search(r"[^\d](\d+)_?", str(dtype))
     if bit_search is None:
         raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
     bit_size = int(bit_search.groups()[0])

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -487,9 +487,9 @@ class ModelUtilsTest(TestCasePlus):
             (torch.int16, 2),
             (torch.uint8, 1),
             (torch.int8, 1),
-            (torch.bool, 1),
             (torch.float8_e4m3fn, 1),
             (torch.float8_e5m2, 1),
+            (torch.bool, 0.125),
         ]
 
         for torch_dtype, bytes_per_element in torch_dtypes_and_bytes:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -101,7 +101,12 @@ if is_torch_available():
         _prepare_4d_attention_mask,
         _prepare_4d_causal_attention_mask,
     )
-    from transformers.modeling_utils import _find_disjoint, _find_identical, shard_checkpoint
+    from transformers.modeling_utils import (
+        _find_disjoint, 
+        _find_identical, 
+        dtype_byte_size,
+        shard_checkpoint,
+    )
 
     # Fake pretrained models for tests
     class BaseModel(PreTrainedModel):
@@ -464,6 +469,31 @@ class ModelUtilsTest(TestCasePlus):
                     self.assertEqual(
                         module.__class__.__name__, mistral_attention_classes[requested_attn_implementation]
                     )
+
+    def test_torch_dtype_byte_sizes(self):
+        torch_dtypes_and_bytes = [
+            (torch.double, 8),
+            (torch.float64, 8),
+            (torch.float, 4),
+            (torch.float32, 4),
+            (torch.half, 2),
+            (torch.float16, 2),
+            (torch.bfloat16, 2),
+            (torch.long, 8),
+            (torch.int64, 8),
+            (torch.int, 4),
+            (torch.int32, 4),
+            (torch.short, 2),
+            (torch.int16, 2),
+            (torch.uint8, 1),
+            (torch.int8, 1),
+            (torch.bool, 1),
+            (torch.float8_e4m3fn, 1),
+            (torch.float8_e5m2, 1),
+        ]
+
+        for torch_dtype, bytes_per_element in torch_dtypes_and_bytes:
+            self.assertEqual(dtype_byte_size(torch_dtype), bytes_per_element)
 
     def test_no_super_init_config_and_model(self):
         config = NoSuperInitConfig(attribute=32)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -102,8 +102,8 @@ if is_torch_available():
         _prepare_4d_causal_attention_mask,
     )
     from transformers.modeling_utils import (
-        _find_disjoint, 
-        _find_identical, 
+        _find_disjoint,
+        _find_identical,
         dtype_byte_size,
         shard_checkpoint,
     )


### PR DESCRIPTION
# What does this PR do?

Currently using the new `torch.float8_e4m3fn` dtype will cause an error because `dtype_byte_size()` doesn't know where to find the number of bits in the dtype string.

Code to reproduce:
```python
from transformers import AutoModelForCausalLM
import torch

model = AutoModelForCausalLM.from_pretrained("echarlaix/tiny-random-mistral")
model.lm_head.weight = torch.nn.Parameter(model.lm_head.weight.to(torch.float8_e4m3fn))
model.save_pretrained("test")
```

Error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/michael/venvs/test/lib/python3.10/site-packages/transformers/modeling_utils.py", line 2557, in save_pretrained
    shards, index = shard_checkpoint(state_dict, max_shard_size=max_shard_size, weights_name=weights_name)
  File "/home/michael/venvs/test/lib/python3.10/site-packages/transformers/modeling_utils.py", line 381, in shard_checkpoint
    weight_size = weight.numel() * dtype_byte_size(weight.dtype)
  File "/home/michael/venvs/test/lib/python3.10/site-packages/transformers/modeling_utils.py", line 328, in dtype_byte_size
    raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
ValueError: `dtype` is not a valid dtype: torch.float8_e4m3fn.
```

We can fix this by changing the regex from `[^\d](\d+)$` to `[^\d](\d+)_?` so we match on every set of numbers following an alphabetical character. This can match multiple groups, but we can always look at the first group to get the first number which is significant. See the picture below for a demonstration of the matches on all numbered pytorch dtypes:
<img width="802" alt="Screenshot 2024-04-25 at 12 27 07 PM" src="https://github.com/huggingface/transformers/assets/3195154/867548ce-dcbc-4233-a19a-6c59ee986d3f">

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Tagging @sgugger since they touched this function last.
