### PR TITLE
remove jax example

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -426,17 +426,6 @@ examples_tensorflow_job = CircleCIJob(
 )
 
 
-examples_flax_job = CircleCIJob(
-    "examples_flax",
-    cache_name="flax_examples",
-    install_steps=[
-        "pip install --upgrade --upgrade-strategy eager pip",
-        "pip install -U --upgrade-strategy eager .[flax,testing,sentencepiece]",
-        "pip install -U --upgrade-strategy eager -r examples/flax/_tests_requirements.txt",
-    ],
-)
-
-
 hub_job = CircleCIJob(
     "hub",
     additional_env={"HUGGINGFACE_CO_STAGING": True},
@@ -565,7 +554,6 @@ REGULAR_TESTS = [
 EXAMPLES_TESTS = [
     examples_torch_job,
     examples_tensorflow_job,
-    examples_flax_job,
 ]
 PIPELINE_TESTS = [
     pipelines_torch_job,


### PR DESCRIPTION
# What does this PR do?
The job only tests a single example, GLUE and that's it. SLOW tests are not even run. Let's remove this ! 