### PR TITLE
Bugfix: Add the missing "no label" class in ConditionalDetr Object Detection Head

### DIFF
--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -1756,7 +1756,7 @@ class ConditionalDetrForObjectDetection(ConditionalDetrPreTrainedModel):
 
         # Object detection heads
         self.class_labels_classifier = nn.Linear(
-            config.d_model, config.num_labels
+            config.d_model, config.num_labels + 1
         )  # We add one for the "no object" class
         self.bbox_predictor = ConditionalDetrMLPPredictionHead(
             input_dim=config.d_model, hidden_dim=config.d_model, output_dim=4, num_layers=3

--- a/tests/models/conditional_detr/test_modeling_conditional_detr.py
+++ b/tests/models/conditional_detr/test_modeling_conditional_detr.py
@@ -163,13 +163,13 @@ class ConditionalDetrModelTester:
         result = model(pixel_values=pixel_values, pixel_mask=pixel_mask)
         result = model(pixel_values)
 
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_queries, self.num_labels))
+        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_queries, self.num_labels + 1))
         self.parent.assertEqual(result.pred_boxes.shape, (self.batch_size, self.num_queries, 4))
 
         result = model(pixel_values=pixel_values, pixel_mask=pixel_mask, labels=labels)
 
         self.parent.assertEqual(result.loss.shape, ())
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_queries, self.num_labels))
+        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_queries, self.num_labels + 1))
         self.parent.assertEqual(result.pred_boxes.shape, (self.batch_size, self.num_queries, 4))
 
 
@@ -550,7 +550,7 @@ class ConditionalDetrModelIntegrationTests(unittest.TestCase):
             outputs = model(pixel_values, pixel_mask)
 
         # verify logits + box predictions
-        expected_shape_logits = torch.Size((1, model.config.num_queries, model.config.num_labels))
+        expected_shape_logits = torch.Size((1, model.config.num_queries, model.config.num_labels + 1))
         self.assertEqual(outputs.logits.shape, expected_shape_logits)
         expected_slice_logits = torch.tensor(
             [[-10.4372, -5.7558, -8.6764], [-10.5410, -5.8704, -8.0590], [-10.6827, -6.3469, -8.3923]]

--- a/tests/models/conditional_detr/test_modeling_conditional_detr.py
+++ b/tests/models/conditional_detr/test_modeling_conditional_detr.py
@@ -459,7 +459,7 @@ class ConditionalDetrModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
                 expected_shape = (
                     self.model_tester.batch_size,
                     self.model_tester.num_queries,
-                    self.model_tester.num_labels,
+                    self.model_tester.num_labels + 1,
                 )
                 self.assertEqual(outputs.logits.shape, expected_shape)
                 # Confirm out_indices was propogated to backbone


### PR DESCRIPTION
# What does this PR do?

Adds a "no label" class to the object detection head in ConditionalDetr, per the docstring of this class we pass in num_classes equal to our original number of classes, however doing that makes the formulation wrong and it uses up one of the classes of the original dataset (the one with the max label id value) as the negative label, since the +1 is not added here.

This line of code looks like it's copied verbatim from modeling_detr with the comment included but it doesn't actually have the + 1 for whatever reason.