### PR TITLE
Update runner tag for PR slow CI

### DIFF
--- a/.github/workflows/self-new-model-pr-caller.yml
+++ b/.github/workflows/self-new-model-pr-caller.yml
@@ -46,7 +46,7 @@ jobs:
         matrix:
           folders: ["${{ needs.check_for_new_model.outputs.new_model }}"]
           machine_type: [single-gpu, multi-gpu]
-      runs-on: ['${{ matrix.machine_type }}', nvidia-gpu, t4, daily-ci]
+      runs-on: ['${{ matrix.machine_type }}', nvidia-gpu, t4, ci]
       container:
         image: huggingface/transformers-all-latest-gpu
         options: --gpus all --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/


### PR DESCRIPTION
# What does this PR do?

#30341 added a new workflow file using the runner `t4, daily-ci` which is also used by daily CI. And they can interfere each other.

After internal discussion with Guillaume, we think the best is to use `t4, ci`.