### PR TITLE
Fix repo. fetch/checkout in PR slow CI job

### DIFF
--- a/.github/workflows/self-new-model-pr-caller.yml
+++ b/.github/workflows/self-new-model-pr-caller.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Update clone
         working-directory: /transformers
-        run: git fetch && git checkout ${{ github.event.pull_request.head.sha }}
+        run: git fetch && git fetch origin pull/${{ github.event.pull_request.number }}/head:pull/${{ github.event.pull_request.number }}/merge && git checkout pull/${{ github.event.pull_request.number }}/merge
 
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers


### PR DESCRIPTION
# What does this PR do?

Fix repo. fetch/checkout in PR slow CI job.

The previous way:

> git fetch && git checkout ${{ github.event.pull_request.head.sha }}

only works for a pull request that is pushed to a branch of `huggingface/transformers`. 

For PRs from outside contributors (so push to a forked repository), it will fail.

The new way

> git fetch origin pull/${{ github.event.pull_request.number }}/head:pull/${{ github.event.pull_request.number }}/merge && git checkout pull/${{ github.event.pull_request.number }}/merge

works in both cases.

