### PR TITLE
Pass `use_cache` in kwargs for GPTNeoX

### DIFF
--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -1108,6 +1108,7 @@ class GPTNeoXForCausalLM(GPTNeoXPreTrainedModel):
                 "attention_mask": attention_mask,
                 "past_key_values": past_key_values,
                 "position_ids": position_ids,
+                "use_cache": kwargs.get("use_cache"),
             }
         )
 


### PR DESCRIPTION
# What does this PR do?

If we pass in `use_cache` when generating with GPT NeoX in the current main, it will not be used and will be overriden by model config's `use_cache`. This PR passes in user-defined `use_cache` when preparing inputs for generation

Other generative models all support user-defined `use_cache` kwarg already. Tests in `generation/test_utils.py` are passing