### PR TITLE
Include passthrough to free_memory

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4573,7 +4573,7 @@ class Trainer:
             wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
             raise NotImplementedError(f"`{wrapper}` doesn't support `auto_find_batch_size`.")
 
-    def release_memory(self, *models):
+    def free_memory(self, *models):
         """
         Will release all references to the internal objects stored and call the garbage collector.
 
@@ -4588,10 +4588,11 @@ class Trainer:
         >>> model = MyModel()
         >>> trainer = Trainer(model, ...)
         >>> trainer.train()
-        >>> model = trainer.release_memory(model)
+        >>> model = trainer.free_memory(model)
         ```
         """
-        return release_memory(*models)
+        *models, self.optimizer = release_memory(*models, self.optimizer)
+        return models
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4591,7 +4591,10 @@ class Trainer:
         >>> model = trainer.free_memory(model)
         ```
         """
-        *models, self.optimizer = release_memory(*models, self.optimizer)
+        # We need to have these references so they can be set to `None`
+        *models, self.optimizer, self.model, self.deepspeed, self.model_wrapped = release_memory(
+            *models, self.optimizer, self.model, self.deepspeed, self.model_wrapped
+        )
         return models
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):


### PR DESCRIPTION
# What does this PR do?

Per request in https://github.com/huggingface/accelerate/pull/2716, this PR introduces a passthrough `Trainer.free_memory` function. 

Now, since most of the refs are built inside the `Trainer` the user really only needs to include/pass through a `model` rather than needing *everything else*

Secondary fix to https://github.com/huggingface/transformers/issues/28178


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @pacman100 