### PR TITLE
Fix seq2seq collator padding

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -122,7 +122,8 @@ class ModelArguments:
         metadata={"help": "Deprecated. Please use the `language` and `task` arguments instead."},
     )
     suppress_tokens: List[int] = field(
-        default=None, metadata={
+        default=None,
+        metadata={
             "help": (
                 "Deprecated. The use of `suppress_tokens` should not be required for the majority of fine-tuning examples."
                 "Should you need to use `suppress_tokens`, please manually update them in the fine-tuning script directly."

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -588,8 +588,10 @@ class DataCollatorForSeq2Seq:
         labels = [feature["labels"] for feature in features] if "labels" in features[0].keys() else None
         # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
         # same length to return tensors.
-        if labels is not None:
-            max_label_length = max(len(l) for l in labels)
+        no_padding = self.padding == False or self.padding == PaddingStrategy.DO_NOT_PAD
+        if labels is not None and not no_padding:
+            max_padding = self.padding == PaddingStrategy.MAX_LENGTH and self.max_length is not None
+            max_label_length = max(len(l) for l in labels) if not max_padding else self.max_length
             if self.pad_to_multiple_of is not None:
                 max_label_length = (
                     (max_label_length + self.pad_to_multiple_of - 1)

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -588,7 +588,7 @@ class DataCollatorForSeq2Seq:
         labels = [feature["labels"] for feature in features] if "labels" in features[0].keys() else None
         # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
         # same length to return tensors.
-        no_padding = self.padding == False or self.padding == PaddingStrategy.DO_NOT_PAD
+        no_padding = self.padding is False or self.padding == PaddingStrategy.DO_NOT_PAD
         if labels is not None and not no_padding:
             max_padding = self.padding == PaddingStrategy.MAX_LENGTH and self.max_length is not None
             max_label_length = max(len(l) for l in labels) if not max_padding else self.max_length

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -939,9 +939,9 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
 
         data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np")
-        with self.assertRaises(ValueError):
-            # expects an error due to unequal shapes to create tensor
-            data_collator(features)
+        # numpy doesn't have issues handling unequal shapes via `dtype=object`
+        # with self.assertRaises(ValueError):
+        #     data_collator(features)
         batch = data_collator([features[0], features[0]])
         self.assertEqual(batch["input_ids"][0].tolist(), features[0]["input_ids"])
         self.assertEqual(batch["input_ids"][1].tolist(), features[0]["input_ids"])

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -32,8 +32,8 @@ from transformers import (
     is_torch_available,
     set_seed,
 )
-from transformers.utils import PaddingStrategy
 from transformers.testing_utils import require_tf, require_torch
+from transformers.utils import PaddingStrategy
 
 
 if is_torch_available():
@@ -582,7 +582,9 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].numpy().tolist(), list(range(3)) + [-100] * 3)
         self.assertEqual(batch["labels"][1].numpy().tolist(), list(range(6)))
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="tf")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="tf"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape.as_list(), [2, 7])
         self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
@@ -601,7 +603,9 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].numpy().tolist(), features[0]["labels"])
         self.assertEqual(batch["labels"][1].numpy().tolist(), features[0]["labels"])
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="tf")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="tf"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape.as_list(), [2, 8])
         self.assertEqual(batch["labels"].shape.as_list(), [2, 8])
@@ -609,7 +613,9 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         # side effects on labels cause mismatch on longest strategy
         features = create_features()
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="tf")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="tf"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape.as_list(), [2, 6])
         self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
@@ -921,7 +927,9 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 3)
         self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape, (2, 7))
         self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
@@ -940,7 +948,9 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].tolist(), features[0]["labels"])
         self.assertEqual(batch["labels"][1].tolist(), features[0]["labels"])
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape, (2, 8))
         self.assertEqual(batch["labels"].shape, (2, 8))
@@ -948,7 +958,9 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         # side effects on labels cause mismatch on longest strategy
         features = create_features()
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np")
+        data_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np"
+        )
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape, (2, 6))
         self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -23,6 +23,7 @@ from transformers import (
     BertTokenizer,
     DataCollatorForLanguageModeling,
     DataCollatorForPermutationLanguageModeling,
+    DataCollatorForSeq2Seq,
     DataCollatorForTokenClassification,
     DataCollatorForWholeWordMask,
     DataCollatorWithPadding,
@@ -31,6 +32,7 @@ from transformers import (
     is_torch_available,
     set_seed,
 )
+from transformers.utils import PaddingStrategy
 from transformers.testing_utils import require_tf, require_torch
 
 
@@ -198,6 +200,83 @@ class DataCollatorIntegrationTest(unittest.TestCase):
         batch = data_collator(features)
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
         self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
+
+    def _test_data_collator_for_seq2seq(self, to_torch):
+        def create_features(to_torch):
+            if to_torch:
+                features = [
+                    {"input_ids": torch.tensor(list(range(3))), "labels": torch.tensor(list(range(3)))},
+                    {"input_ids": torch.tensor(list(range(6))), "labels": torch.tensor(list(range(6)))},
+                ]
+            else:
+                features = [
+                    {"input_ids": list(range(3)), "labels": list(range(3))},
+                    {"input_ids": list(range(6)), "labels": list(range(6))},
+                ]
+            return features
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = create_features(to_torch)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST)
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 3)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7)
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 7]))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)) + [tokenizer.pad_token_id] * 1)
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 7]))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 4)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+        with self.assertRaises(ValueError):
+            # expects an error due to unequal shapes to create tensor
+            data_collator(features)
+        batch = data_collator([features[0], features[0]])
+        input_ids = features[0]["input_ids"] if not to_torch else features[0]["input_ids"].tolist()
+        labels = features[0]["labels"] if not to_torch else features[0]["labels"].tolist()
+        self.assertEqual(batch["input_ids"][0].tolist(), input_ids)
+        self.assertEqual(batch["input_ids"][1].tolist(), input_ids)
+        self.assertEqual(batch["labels"][0].tolist(), labels)
+        self.assertEqual(batch["labels"][1].tolist(), labels)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8)
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 8]))
+
+        # side effects on labels cause mismatch on longest strategy
+        features = create_features(to_torch)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1)
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-1] * 3)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
+
+        for feature in features:
+            feature.pop("labels")
+
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+
+    def test_data_collator_for_seq2seq_with_lists(self):
+        self._test_data_collator_for_seq2seq(to_torch=False)
+
+    def test_data_collator_for_seq2seq_with_pt(self):
+        self._test_data_collator_for_seq2seq(to_torch=True)
 
     def _test_no_pad_and_pad(self, no_pad_features, pad_features):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -484,6 +563,68 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"].shape.as_list(), [2, 6])
         self.assertEqual(batch["labels"][0].numpy().tolist(), [0, 1, 2] + [-1] * 3)
 
+    def test_data_collator_for_seq2seq(self):
+        def create_features():
+            return [
+                {"input_ids": list(range(3)), "labels": list(range(3))},
+                {"input_ids": list(range(6)), "labels": list(range(6))},
+            ]
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = create_features()
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="tf")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 6])
+        self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].numpy().tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape.as_list(), [2, 6])
+        self.assertEqual(batch["labels"][0].numpy().tolist(), list(range(3)) + [-100] * 3)
+        self.assertEqual(batch["labels"][1].numpy().tolist(), list(range(6)))
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="tf")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 7])
+        self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
+        self.assertEqual(batch["input_ids"][1].numpy().tolist(), list(range(6)) + [tokenizer.pad_token_id] * 1)
+        self.assertEqual(batch["labels"].shape.as_list(), [2, 7])
+        self.assertEqual(batch["labels"][0].numpy().tolist(), list(range(3)) + [-100] * 4)
+        self.assertEqual(batch["labels"][1].numpy().tolist(), list(range(6)) + [-100] * 1)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+        with self.assertRaises(ValueError):
+            # expects an error due to unequal shapes to create tensor
+            data_collator(features)
+        batch = data_collator([features[0], features[0]])
+        self.assertEqual(batch["input_ids"][0].numpy().tolist(), features[0]["input_ids"])
+        self.assertEqual(batch["input_ids"][1].numpy().tolist(), features[0]["input_ids"])
+        self.assertEqual(batch["labels"][0].numpy().tolist(), features[0]["labels"])
+        self.assertEqual(batch["labels"][1].numpy().tolist(), features[0]["labels"])
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="tf")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 8])
+        self.assertEqual(batch["labels"].shape.as_list(), [2, 8])
+
+        # side effects on labels cause mismatch on longest strategy
+        features = create_features()
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="tf")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 6])
+        self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].numpy().tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape.as_list(), [2, 6])
+        self.assertEqual(batch["labels"][0].numpy().tolist(), list(range(3)) + [-1] * 3)
+        self.assertEqual(batch["labels"][1].numpy().tolist(), list(range(6)))
+
+        for feature in features:
+            feature.pop("labels")
+
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape.as_list(), [2, 6])
+        self.assertEqual(batch["input_ids"][0].numpy().tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+
     def _test_no_pad_and_pad(self, no_pad_features, pad_features):
         tokenizer = BertTokenizer(self.vocab_file)
         data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="tf")
@@ -760,6 +901,68 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
         self.assertEqual(batch["labels"].shape, (2, 6))
         self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-1] * 3)
+
+    def test_data_collator_for_seq2seq(self):
+        def create_features():
+            return [
+                {"input_ids": list(range(3)), "labels": list(range(3))},
+                {"input_ids": list(range(6)), "labels": list(range(6))},
+            ]
+
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = create_features()
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="np")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape, (2, 6))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 3)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 7))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)) + [tokenizer.pad_token_id] * 1)
+        self.assertEqual(batch["labels"].shape, (2, 7))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 4)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+        with self.assertRaises(ValueError):
+            # expects an error due to unequal shapes to create tensor
+            data_collator(features)
+        batch = data_collator([features[0], features[0]])
+        self.assertEqual(batch["input_ids"][0].tolist(), features[0]["input_ids"])
+        self.assertEqual(batch["input_ids"][1].tolist(), features[0]["input_ids"])
+        self.assertEqual(batch["labels"][0].tolist(), features[0]["labels"])
+        self.assertEqual(batch["labels"][1].tolist(), features[0]["labels"])
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 8))
+        self.assertEqual(batch["labels"].shape, (2, 8))
+
+        # side effects on labels cause mismatch on longest strategy
+        features = create_features()
+
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np")
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
+        self.assertEqual(batch["labels"].shape, (2, 6))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-1] * 3)
+        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
+
+        for feature in features:
+            feature.pop("labels")
+
+        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
 
     def _test_no_pad_and_pad(self, no_pad_features, pad_features):
         tokenizer = BertTokenizer(self.vocab_file)

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -593,7 +593,7 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].numpy().tolist(), list(range(3)) + [-100] * 4)
         self.assertEqual(batch["labels"][1].numpy().tolist(), list(range(6)) + [-100] * 1)
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="tf")
         with self.assertRaises(ValueError):
             # expects an error due to unequal shapes to create tensor
             data_collator(features)
@@ -938,7 +938,7 @@ class NumpyDataCollatorIntegrationTest(unittest.TestCase):
         self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 4)
         self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np")
         with self.assertRaises(ValueError):
             # expects an error due to unequal shapes to create tensor
             data_collator(features)


### PR DESCRIPTION
# What does this PR do?
`DataCollatorForSeq2Seq` currently only supports the `longest` and silently the `no_padding` strategies. This PR adds some checks to ensure the padding strategy is respected if valid (e.g. `max_length` without a given max length defaults back to `longest`).

Furthermore, added tests for the collator in the style of the `DataCollatorForTokenClassification` for all kinds of supported datatypes (pt, tf, np). 

Something to note: The seq2seq collator causes side effects on the features' labels that are passed. I don't think it's a big deal but thought I'd clarify why I produce features twice within a single test.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #30521 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
@Rocketknight1 @amyeroberts 