### PR TITLE
Add chat templating support for KeyDataset in text-generation pipeline

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -244,7 +244,9 @@ class TextGenerationPipeline(Pipeline):
             - **generated_token_ids** (`torch.Tensor` or `tf.Tensor`, present when `return_tensors=True`) -- The token
               ids of the generated text.
         """
-        if isinstance(text_inputs, (list, tuple, KeyDataset)) and isinstance(text_inputs[0], (list, tuple, dict)):
+        if isinstance(
+            text_inputs, (list, tuple, KeyDataset) if is_torch_available() else (list, tuple)
+        ) and isinstance(text_inputs[0], (list, tuple, dict)):
             # We have one or more prompts in list-of-dicts format, so this is chat mode
             if isinstance(text_inputs[0], dict):
                 return super().__call__(Chat(text_inputs), **kwargs)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -3,8 +3,8 @@ import warnings
 from typing import Dict
 
 from ..utils import add_end_docstrings, is_tf_available, is_torch_available
-from .pt_utils import KeyDataset
 from .base import Pipeline, build_pipeline_init_args
+from .pt_utils import KeyDataset
 
 
 if is_torch_available():

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Dict
 
 from ..utils import add_end_docstrings, is_tf_available, is_torch_available
+from .pt_utils import KeyDataset
 from .base import Pipeline, build_pipeline_init_args
 
 
@@ -243,7 +244,7 @@ class TextGenerationPipeline(Pipeline):
             - **generated_token_ids** (`torch.Tensor` or `tf.Tensor`, present when `return_tensors=True`) -- The token
               ids of the generated text.
         """
-        if isinstance(text_inputs, (list, tuple)) and isinstance(text_inputs[0], (list, tuple, dict)):
+        if isinstance(text_inputs, (list, tuple, KeyDataset)) and isinstance(text_inputs[0], (list, tuple, dict)):
             # We have one or more prompts in list-of-dicts format, so this is chat mode
             if isinstance(text_inputs[0], dict):
                 return super().__call__(Chat(text_inputs), **kwargs)
@@ -380,7 +381,8 @@ class TextGenerationPipeline(Pipeline):
                     if isinstance(prompt_text, str):
                         all_text = prompt_text + all_text
                     elif isinstance(prompt_text, Chat):
-                        all_text = prompt_text.messages + [{"role": "assistant", "content": all_text}]
+                        # Explicit list parsing is necessary for parsing chat datasets
+                        all_text = list(prompt_text.messages) + [{"role": "assistant", "content": all_text}]
 
                 record = {"generated_text": all_text}
             records.append(record)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -4,11 +4,11 @@ from typing import Dict
 
 from ..utils import add_end_docstrings, is_tf_available, is_torch_available
 from .base import Pipeline, build_pipeline_init_args
-from .pt_utils import KeyDataset
 
 
 if is_torch_available():
     from ..models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+    from .pt_utils import KeyDataset
 
 if is_tf_available():
     import tensorflow as tf

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -176,10 +176,11 @@ class TextGenerationPipelineTests(unittest.TestCase):
                 [{"generated_text": expected_chat2}],
             ],
         )
-    
+
     @require_torch
     def test_small_chat_model_with_dataset_pt(self):
         from torch.utils.data import Dataset
+
         from transformers.pipelines.pt_utils import KeyDataset
 
         class MyDataset(Dataset):
@@ -196,7 +197,6 @@ class TextGenerationPipelineTests(unittest.TestCase):
 
             def __getitem__(self, i):
                 return {"text": self.data[i]}
-
 
         text_generator = pipeline(
             task="text-generation", model="rocketknight1/tiny-gpt2-with-chatml-template", framework="pt"
@@ -218,7 +218,6 @@ class TextGenerationPipelineTests(unittest.TestCase):
                     {"generated_text": expected_chat},
                 ],
             )
-
 
     @require_tf
     def test_small_model_tf(self):

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -183,37 +183,42 @@ class TextGenerationPipelineTests(unittest.TestCase):
         from transformers.pipelines.pt_utils import KeyDataset
 
         class MyDataset(Dataset):
-            data = [{"role": "system", "content": "This is a system message."},
+            data = [
+                [
+                    {"role": "system", "content": "This is a system message."},
                     {"role": "user", "content": "This is a test"},
-                    {"role": "assistant", "content": "This is a reply"}]
-        
+                    {"role": "assistant", "content": "This is a reply"},
+                ],
+            ]
+
             def __len__(self):
-                return len(self.data)
+                return 1
 
             def __getitem__(self, i):
                 return {"text": self.data[i]}
-        
+
+
         text_generator = pipeline(
             task="text-generation", model="rocketknight1/tiny-gpt2-with-chatml-template", framework="pt"
         )
-        
+
         dataset = MyDataset()
         key_dataset = KeyDataset(dataset, "text")
-        outputs = text_generator(key_dataset, do_sample=False, max_new_tokens=10, return_full_text=True)
-        outputs = list(outputs)
-        
-        expected_chat1 = dataset.data + [
-            {
-                "role": "assistant",
-                "content": " factors factors factors factors factors factors factors factors factors factors",
-            }
-        ]
-        self.assertEqual(
-            outputs,
-            [
-                {"generated_text": expected_chat1},
-            ],
-        )
+
+        for outputs in text_generator(key_dataset, do_sample=False, max_new_tokens=10):
+            expected_chat = dataset.data[0] + [
+                {
+                    "role": "assistant",
+                    "content": " factors factors factors factors factors factors factors factors factors factors",
+                }
+            ]
+            self.assertEqual(
+                outputs,
+                [
+                    {"generated_text": expected_chat},
+                ],
+            )
+
 
     @require_tf
     def test_small_model_tf(self):


### PR DESCRIPTION
# What does this PR do?
Adds direct support for KeyDatasets containing chat messages to the `text-generation` pipeline. Additionally, we now have better compatibility with the docs that explain how to use KeyDatasets with the generation pipeline ([here](https://huggingface.co/docs/transformers/main_classes/pipelines)).

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
