### PR TITLE
🚨 Update image_processing_vitmatte.py

### DIFF
--- a/src/transformers/models/vitmatte/image_processing_vitmatte.py
+++ b/src/transformers/models/vitmatte/image_processing_vitmatte.py
@@ -133,9 +133,9 @@ class VitMatteImageProcessor(BaseImageProcessor):
 
         height, width = get_image_size(image, input_data_format)
 
-        if height % size_divisibility != 0 or width % size_divisibility != 0:
-            pad_height = size_divisibility - height % size_divisibility
-            pad_width = size_divisibility - width % size_divisibility
+        pad_height = 0 if height % size_divisibility == 0 else size_divisibility - height % size_divisibility
+        pad_width = 0 if width % size_divisibility == 0 else size_divisibility - width % size_divisibility
+        if pad_width + pad_height > 0:
             padding = ((0, pad_height), (0, pad_width))
             image = pad(image, padding=padding, data_format=data_format, input_data_format=input_data_format)
 

--- a/tests/models/vitmatte/test_image_processing_vitmatte.py
+++ b/tests/models/vitmatte/test_image_processing_vitmatte.py
@@ -192,3 +192,7 @@ class VitMatteImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         image = np.random.randn(3, 249, 491)
         images = image_processing.pad_image(image)
         assert images.shape == (3, 256, 512)
+
+        image = np.random.randn(3, 249, 512)
+        images = image_processing.pad_image(image)
+        assert images.shape == (3, 256, 512)


### PR DESCRIPTION
In the previous implementation, if either dimension wasn't divisible by factor, then both would be padded even if only one needed it.

For example, for divisible factor 32, if I have an image of size `(1024, 819)`, then I would expect a padded size of `(1024, 832)`. However, with the current implementation, even though 1024 is divisible by 32, it will be padded by a full 32 pixels, and the output size is `(1056, 832)`.

This PR fixes that 🐛  by computing dimensions individually.