### PR TITLE
Remove `use_square_size` after loading

### DIFF
--- a/src/transformers/models/clip/image_processing_clip.py
+++ b/src/transformers/models/clip/image_processing_clip.py
@@ -143,6 +143,10 @@ class CLIPImageProcessor(BaseImageProcessor):
         # for backwards compatibility of KOSMOS-2
         if "use_square_size" in kwargs:
             self.size = {"height": size["shortest_edge"], "width": size["shortest_edge"]}
+            # Let's remove `use_square_size` (as it is removed from #27690), so the future Kosmos-2 image processors
+            # won't have this attr. being saved. (otherwise, it will enter this if branch while there is no more
+            # `shortest_edge` key.
+            delattr(self, "use_square_size")
 
     def resize(
         self,

--- a/tests/models/kosmos2/test_processor_kosmos2.py
+++ b/tests/models/kosmos2/test_processor_kosmos2.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -83,6 +84,15 @@ class Kosmos2ProcessorTest(unittest.TestCase):
         image_inputs = [Image.fromarray(np.moveaxis(x, 0, -1)) for x in image_inputs]
 
         return image_inputs
+
+    def test_image_procesor_load_save_reload(self):
+        # make sure load from Hub repo. -> save -> reload locally work
+        image_processor = CLIPImageProcessor.from_pretrained("microsoft/kosmos-2-patch14-224")
+        with TemporaryDirectory() as tmp_dir:
+            image_processor.save_pretrained(tmp_dir)
+            reloaded_image_processor = CLIPImageProcessor.from_pretrained(tmp_dir)
+            assert image_processor.to_dict() == reloaded_image_processor.to_dict()
+            assert image_processor.to_json_string() == reloaded_image_processor.to_json_string()
 
     def test_save_load_pretrained_additional_features(self):
         processor = Kosmos2Processor(tokenizer=self.get_tokenizer(), image_processor=self.get_image_processor())


### PR DESCRIPTION
Remove `use_square_size` after loading.

#27690 removed `use_square_size` but keep a backward compatibility for Kosmos-2's image processor.
However, once we load it with a image processor config file, we could and we should remove that no longer used attribute.

Fix #30522