### PR TITLE
Generate: fix `SinkCache` on Llama models

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -207,7 +207,9 @@ class SinkCache(Cache):
         self.value_cache: List[torch.Tensor] = []
         self.window_length = window_length
         self.num_sink_tokens = num_sink_tokens
-        self.cos_sin_cache = {}
+        self.cos_sin_rerotation_cache = {}
+        self._cos_cache = None
+        self._sin_cache = None
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
 
     @staticmethod
@@ -225,7 +227,7 @@ class SinkCache(Cache):
     def _get_rerotation_cos_sin(
         self, key_states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if key_states.shape[-2] not in self.cos_sin_cache:
+        if key_states.shape[-2] not in self.cos_sin_rerotation_cache:
             # Upcast to float32 temporarily for better accuracy
             cos = cos.to(torch.float32)
             sin = sin.to(torch.float32)
@@ -238,11 +240,11 @@ class SinkCache(Cache):
             rerotation_cos = original_cos * shifted_cos + original_sin * shifted_sin
             rerotation_sin = -original_sin * shifted_cos + original_cos * shifted_sin
 
-            self.cos_sin_cache[key_states.shape[-2]] = (
+            self.cos_sin_rerotation_cache[key_states.shape[-2]] = (
                 rerotation_cos.to(key_states.dtype).unsqueeze(0),
                 rerotation_sin.to(key_states.dtype).unsqueeze(0),
             )
-        return self.cos_sin_cache[key_states.shape[-2]]
+        return self.cos_sin_rerotation_cache[key_states.shape[-2]]
 
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
         """Returns the sequence length of the cached states. A layer index can be optionally passed."""
@@ -292,6 +294,19 @@ class SinkCache(Cache):
         if layer_idx == 0:
             self._seen_tokens += key_states.shape[-2]
 
+        # Update the sin/cos cache, which holds sin/cos values for all possible positions
+        if using_rope and layer_idx==0:
+            # BC: some models still pass `sin`/`cos` with 2 dims. The expected is 3 dims, and no `if` to be needed.
+            if cos.dim() > 2:
+                cos = cos[..., :, :]
+                sin = sin[..., :, :]
+            if self._cos_cache is None:
+                self._cos_cache = cos
+                self._sin_cache = sin
+            elif self._cos_cache.shape[0] < self.window_length:
+                self._cos_cache = torch.cat([self._cos_cache, cos], dim=0)
+                self._sin_cache = torch.cat([self._sin_cache, sin], dim=0)
+
         # [bsz, num_heads, seq_len, head_dim]
         if len(self.key_cache) <= layer_idx:
             # Empty cache
@@ -312,7 +327,7 @@ class SinkCache(Cache):
             # On RoPE models, we need to recompute the Key rotation as the tokens are shifted
             if using_rope:
                 rerotation_cos, rerotation_sin = self._get_rerotation_cos_sin(
-                    key_states, cos[: self.window_length], sin[: self.window_length]
+                    key_states, self._cos_cache[: self.window_length], self._sin_cache[: self.window_length]
                 )
                 if partial_rotation_size is not None:
                     keys_to_keep, keys_pass = (


### PR DESCRIPTION
# What does this PR do?

`SinkCache` has been broken on Llama and Llama-based models since we released the static cache update (v4.38). Now that we are happy with the state of the static cache (#30476), we can move on to fix what we broke along the way 🤗 

In a nutshell, the static cache rework changed the `sin` and `cos` tensors passed around, from the full set of values for all possible positions (up to `config. max_position_embeddings`) to the values used in a forward pass alone. This is a non-negotiable change to achieve top compiled performance.

However, `SinkCache` needs access to the whole `sin` and `cos` tensors, and they are not trivial to compute from scratch in the cache instance (it would need access to the RoPE class, creating a cyclical dependency). The `SinkCache` instance was changed to hold a cache [meta cache 🤯 ] of `sin` and `cos` as it sees them, rebuilding the full tensor internally. Having the full tensor rebuilt, it can operate as expected.

`tests/test_cache_utils.py::CacheIntegrationTest::test_sink_cache_hard` is fixed as a result of this PR. All other sink cache tests were passing (they were not using llama 👼 )