### PR TITLE
Fix: failing CI after #30568

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1905,7 +1905,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return model_embeds
 
         # Update base model and current model config
-        self.config.vocab_size = model_embeds.weight.shape[0]
+        if hasattr(self.config, "text_config"):
+            self.config.text_config.vocab_size = model_embeds.weight.shape[0]
+        else:
+            self.config.vocab_size = model_embeds.weight.shape[0]
         self.vocab_size = model_embeds.weight.shape[0]
 
         # Tie weights again if needed

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1907,8 +1907,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Update base model and current model config
         if hasattr(self.config, "text_config"):
             self.config.text_config.vocab_size = model_embeds.weight.shape[0]
-        else:
-            self.config.vocab_size = model_embeds.weight.shape[0]
+        # TODO: to be removed after v4.42, config.vocab_size is deprecated for models that have a config.text_config
+        self.config.vocab_size = model_embeds.weight.shape[0]
         self.vocab_size = model_embeds.weight.shape[0]
 
         # Tie weights again if needed


### PR DESCRIPTION
# What does this PR do?

Fixes a failing test for Fuyu model after #30568. The solution is to change the corresponding config's vocab size, depending on if it's VLM or LLM. But the old way of setting config's vocab_size is not removed yet, since it's planned to be removed in v4.42 as [commented in Llava configuration.py](https://github.com/huggingface/transformers/blob/d2feb545918a325a3a8373db706ef6fe4ec5776f/src/transformers/models/llava/configuration_llava.py#L144) files