### PR TITLE
Immutability for data collators

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -585,40 +585,69 @@ class DataCollatorForSeq2Seq:
     def __call__(self, features, return_tensors=None):
         if return_tensors is None:
             return_tensors = self.return_tensors
-        labels = [feature["labels"] for feature in features] if "labels" in features[0].keys() else None
-        # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
-        # same length to return tensors.
-        no_padding = self.padding is False or self.padding == PaddingStrategy.DO_NOT_PAD
-        if labels is not None and not no_padding:
-            max_padding = self.padding == PaddingStrategy.MAX_LENGTH and self.max_length is not None
-            max_label_length = max(len(l) for l in labels) if not max_padding else self.max_length
-            if self.pad_to_multiple_of is not None:
-                max_label_length = (
-                    (max_label_length + self.pad_to_multiple_of - 1)
-                    // self.pad_to_multiple_of
-                    * self.pad_to_multiple_of
-                )
 
-            padding_side = self.tokenizer.padding_side
-            for feature in features:
-                remainder = [self.label_pad_token_id] * (max_label_length - len(feature["labels"]))
-                if isinstance(feature["labels"], list):
-                    feature["labels"] = (
-                        feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
-                    )
-                elif padding_side == "right":
-                    feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
-                else:
-                    feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
+        label_name = "label" if "label" in features[0].keys() else "labels"
+        labels = [feature[label_name] for feature in features] if label_name in features[0].keys() else None
+        # reconvert list[None] to None if necessary
+        # this might occur when we pass {..., "labels": None}
+        if labels is not None and all(label is None for label in labels):
+            labels = None
+        no_labels_features = [{k: v for k, v in feature.items() if k != label_name} for feature in features]
 
-        features = pad_without_fast_tokenizer_warning(
+        # run through tokenizer without labels to ensure no side effects
+        batch = pad_without_fast_tokenizer_warning(
             self.tokenizer,
-            features,
+            no_labels_features,
             padding=self.padding,
             max_length=self.max_length,
             pad_to_multiple_of=self.pad_to_multiple_of,
             return_tensors=return_tensors,
         )
+
+        # we have to pad the labels manually as we cannot rely on `tokenizer.pad` and we need them to be of the same length to return tensors
+        no_padding = self.padding is False or self.padding == PaddingStrategy.DO_NOT_PAD
+        if no_padding:
+            if isinstance(features[0][label_name], list):
+                batch["labels"] = [label for label in labels]
+            else:
+                batch["labels"] = [np.concatenate([label, []]) for label in labels]
+        elif labels is not None and not no_padding:
+            max_padding = self.padding == PaddingStrategy.MAX_LENGTH and self.max_length is not None
+            max_label_length = max(len(l) for l in labels) if not max_padding else self.max_length
+            if self.pad_to_multiple_of is not None:
+                max_label_length = (
+                        (max_label_length + self.pad_to_multiple_of - 1)
+                        // self.pad_to_multiple_of
+                        * self.pad_to_multiple_of
+                )
+
+            padding_side = self.tokenizer.padding_side
+            if isinstance(features[0][label_name], list):
+                batch["labels"] = [
+                    label + [self.label_pad_token_id] * (max_label_length - len(label)) if padding_side == "right"
+                    else [self.label_pad_token_id] * (max_label_length - len(label)) + label
+                    for label in labels
+                ]
+            else:
+                batch["labels"] = [
+                    np.concatenate([label, [self.label_pad_token_id] * (max_label_length - len(label))]) if padding_side == "right"
+                    else np.concatenate([[self.label_pad_token_id] * (max_label_length - len(label)), label])
+                    for label in labels
+                ]
+
+        # reintroduce side effects via tokenizer that return respective datatypes for the `return_tensors` argument
+        if not batch.get("labels", None) is None:
+            if return_tensors == "pt":
+                import torch
+                batch["labels"] = torch.tensor(batch["labels"], dtype=torch.int64)
+            elif return_tensors == "tf":
+                import tensorflow as tf
+                batch["labels"] = tf.constant(batch["labels"], dtype=tf.int64)
+            else:
+                batch["labels"] = np.array(batch["labels"], dtype=np.int64)
+        else:
+            # TODO need confirmation how this should be handled
+            batch["labels"] = None
 
         # prepare decoder_input_ids
         if (
@@ -626,10 +655,10 @@ class DataCollatorForSeq2Seq:
             and self.model is not None
             and hasattr(self.model, "prepare_decoder_input_ids_from_labels")
         ):
-            decoder_input_ids = self.model.prepare_decoder_input_ids_from_labels(labels=features["labels"])
-            features["decoder_input_ids"] = decoder_input_ids
+            decoder_input_ids = self.model.prepare_decoder_input_ids_from_labels(labels=batch["labels"])
+            batch["decoder_input_ids"] = decoder_input_ids
 
-        return features
+        return batch
 
 
 @dataclass

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -651,7 +651,6 @@ class DataCollatorForSeq2Seq:
             else:
                 batch["labels"] = np.array(batch["labels"], dtype=np.int64)
         else:
-            # TODO need confirmation how this should be handled
             batch["labels"] = None
 
         # prepare decoder_input_ids

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -592,12 +592,12 @@ class DataCollatorForSeq2Seq:
         # this might occur when we pass {..., "labels": None}
         if labels is not None and all(label is None for label in labels):
             labels = None
-        no_labels_features = [{k: v for k, v in feature.items() if k != label_name} for feature in features]
+        non_labels_features = [{k: v for k, v in feature.items() if k != label_name} for feature in features]
 
         # run through tokenizer without labels to ensure no side effects
         batch = pad_without_fast_tokenizer_warning(
             self.tokenizer,
-            no_labels_features,
+            non_labels_features,
             padding=self.padding,
             max_length=self.max_length,
             pad_to_multiple_of=self.pad_to_multiple_of,

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -473,20 +473,16 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                 else:
                     self.assertEqual(original[i][key], batch[i][key])
 
-    def _compare_assert_with_collator_on_datatypes(self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False):
+    def _compare_assert_with_collator_on_datatypes(
+        self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False
+    ):
         # using the arguments to recreate the features with their respective (potentially new) datatypes
         features_original = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
         features_batch = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
 
@@ -502,34 +498,25 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
         features_base_multiple_labels = [{"label": (0, 1, 2), "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
 
-        for datatype_input, datatype_label in [(list, int), (list, float), (np.array, int), (np.array, torch.tensor), (list, self._turn_to_none)]:
+        for datatype_input, datatype_label in [
+            (list, int),
+            (list, float),
+            (np.array, int),
+            (np.array, torch.tensor),
+            (list, self._turn_to_none),
+        ]:
             self._compare_assert_with_collator_on_datatypes(
-                default_data_collator,
-                features_base_single_label,
-                "inputs",
-                datatype_input,
-                "label",
-                datatype_label
+                default_data_collator, features_base_single_label, "inputs", datatype_input, "label", datatype_label
             )
 
         for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
             self._compare_assert_with_collator_on_datatypes(
-                default_data_collator,
-                features_base_multiple_labels,
-                "inputs",
-                datatype_input,
-                "label",
-                datatype_label
+                default_data_collator, features_base_multiple_labels, "inputs", datatype_input, "label", datatype_label
             )
 
         features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
         self._compare_assert_with_collator_on_datatypes(
-            default_data_collator,
-            features_base_single_label_alt,
-            "input_ids",
-            list,
-            "label",
-            float
+            default_data_collator, features_base_single_label_alt, "input_ids", list, "label", float
         )
 
     def test_with_padding_collator_immutability(self):
@@ -555,18 +542,13 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
             DataCollatorForTokenClassification(tokenizer),
             DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10),
             DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8),
-            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1)
+            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1),
         ]
 
         for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
             for collator in token_classification_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -576,7 +558,7 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
     def test_seq2seq_collator_immutability(self):
@@ -596,12 +578,7 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
             for collator in seq2seq_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -611,7 +588,7 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
         features_base_no_pad = [
@@ -626,19 +603,25 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                 "input_ids",
                 datatype_input,
                 "labels",
-                datatype_label
+                datatype_label,
             )
 
     def test_language_modelling_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base_no_pad = [{"input_ids": tuple(range(10)), "labels": (1,)}, {"input_ids": tuple(range(10)), "labels": (1,)}]
-        features_base_pad = [{"input_ids": tuple(range(5)), "labels": (1,)}, {"input_ids": tuple(range(5)), "labels": (1,)}]
+        features_base_no_pad = [
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+        ]
+        features_base_pad = [
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+        ]
         lm_collators = [
             DataCollatorForLanguageModeling(tokenizer, mlm=False),
             DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8),
             DataCollatorForLanguageModeling(tokenizer),
-            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
+            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8),
         ]
 
         for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
@@ -650,7 +633,7 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
                 self._compare_assert_with_collator_on_datatypes(
@@ -660,13 +643,16 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
     def test_whole_world_masking_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base = [{"input_ids": list(range(10)), "labels": (1,)}, {"input_ids": list(range(10)), "labels": (1,)}]
+        features_base = [
+            {"input_ids": list(range(10)), "labels": (1,)},
+            {"input_ids": list(range(10)), "labels": (1,)},
+        ]
         whole_word_masking_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
 
         for datatype_input, datatype_label in [(list, list), (np.array, np.array)]:
@@ -677,7 +663,7 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                 datatype_input,
                 "labels",
                 datatype_label,
-                ignore_label=True
+                ignore_label=True,
             )
 
     def test_permutation_language_modelling_collator_immutability(self):
@@ -1127,20 +1113,16 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                 else:
                     self.assertEqual(original[i][key], batch[i][key])
 
-    def _compare_assert_with_collator_on_datatypes(self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False):
+    def _compare_assert_with_collator_on_datatypes(
+        self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False
+    ):
         # using the arguments to recreate the features with their respective (potentially new) datatypes
         features_original = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
         features_batch = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
 
@@ -1156,14 +1138,20 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
         features_base_multiple_labels = [{"label": (0, 1, 2), "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
 
-        for datatype_input, datatype_label in [(list, int), (list, float), (np.array, int), (np.array, tf.constant), (list, self._turn_to_none)]:
+        for datatype_input, datatype_label in [
+            (list, int),
+            (list, float),
+            (np.array, int),
+            (np.array, tf.constant),
+            (list, self._turn_to_none),
+        ]:
             self._compare_assert_with_collator_on_datatypes(
                 lambda x: default_data_collator(x, return_tensors="tf"),
                 features_base_single_label,
                 "inputs",
                 datatype_input,
                 "label",
-                datatype_label
+                datatype_label,
             )
 
         for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
@@ -1173,7 +1161,7 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                 "inputs",
                 datatype_input,
                 "label",
-                datatype_label
+                datatype_label,
             )
 
         features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
@@ -1183,7 +1171,7 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
             "input_ids",
             list,
             "label",
-            float
+            float,
         )
 
     def test_with_padding_collator_immutability(self):
@@ -1209,18 +1197,13 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
             DataCollatorForTokenClassification(tokenizer, return_tensors="tf"),
             DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10, return_tensors="tf"),
             DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8, return_tensors="tf"),
-            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="tf")
+            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="tf"),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
             for collator in token_classification_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -1230,7 +1213,7 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
     def test_seq2seq_collator_immutability(self):
@@ -1243,19 +1226,18 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         seq2seq_collators = [
             DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="tf"),
             DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="tf"),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="tf"),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="tf")
+            DataCollatorForSeq2Seq(
+                tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="tf"
+            ),
+            DataCollatorForSeq2Seq(
+                tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="tf"
+            ),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
             for collator in seq2seq_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -1265,14 +1247,16 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
         features_base_no_pad = [
             {"input_ids": list(range(3)), "labels": list(range(3))},
             {"input_ids": list(range(3)), "labels": list(range(3))},
         ]
-        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="tf")
+        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="tf"
+        )
         for datatype_input, datatype_label in [(list, list)]:
             self._compare_assert_with_collator_on_datatypes(
                 seq2seq_no_padding_collator,
@@ -1280,19 +1264,25 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                 "input_ids",
                 datatype_input,
                 "labels",
-                datatype_label
+                datatype_label,
             )
 
     def test_language_modelling_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base_no_pad = [{"input_ids": tuple(range(10)), "labels": (1,)}, {"input_ids": tuple(range(10)), "labels": (1,)}]
-        features_base_pad = [{"input_ids": tuple(range(5)), "labels": (1,)}, {"input_ids": tuple(range(5)), "labels": (1,)}]
+        features_base_no_pad = [
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+        ]
+        features_base_pad = [
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+        ]
         lm_collators = [
             DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="tf"),
             DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8, return_tensors="tf"),
             DataCollatorForLanguageModeling(tokenizer, return_tensors="tf"),
-            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="tf")
+            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="tf"),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
@@ -1304,7 +1294,7 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
                 self._compare_assert_with_collator_on_datatypes(
@@ -1314,13 +1304,16 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
     def test_whole_world_masking_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base = [{"input_ids": list(range(10)), "labels": (1,)}, {"input_ids": list(range(10)), "labels": (1,)}]
+        features_base = [
+            {"input_ids": list(range(10)), "labels": (1,)},
+            {"input_ids": list(range(10)), "labels": (1,)},
+        ]
         whole_word_masking_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="tf")
 
         for datatype_input, datatype_label in [(list, list), (np.array, np.array)]:
@@ -1331,7 +1324,7 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                 datatype_input,
                 "labels",
                 datatype_label,
-                ignore_label=True
+                ignore_label=True,
             )
 
     def test_permutation_language_modelling_collator_immutability(self):
@@ -1770,20 +1763,16 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                 else:
                     self.assertEqual(original[i][key], batch[i][key])
 
-    def _compare_assert_with_collator_on_datatypes(self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False):
+    def _compare_assert_with_collator_on_datatypes(
+        self, collator, base, input_key, input_datatype, label_key, label_datatype, ignore_label=False
+    ):
         # using the arguments to recreate the features with their respective (potentially new) datatypes
         features_original = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
         features_batch = [
-            {
-                label_key: label_datatype(sample[label_key]),
-                input_key: input_datatype(sample[input_key])
-            }
+            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
             for sample in base
         ]
 
@@ -1799,14 +1788,20 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
         features_base_multiple_labels = [{"label": (0, 1, 2), "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
 
-        for datatype_input, datatype_label in [(list, int), (list, float), (np.array, int), (np.array, np.array), (list, self._turn_to_none)]:
+        for datatype_input, datatype_label in [
+            (list, int),
+            (list, float),
+            (np.array, int),
+            (np.array, np.array),
+            (list, self._turn_to_none),
+        ]:
             self._compare_assert_with_collator_on_datatypes(
                 lambda x: default_data_collator(x, return_tensors="np"),
                 features_base_single_label,
                 "inputs",
                 datatype_input,
                 "label",
-                datatype_label
+                datatype_label,
             )
 
         for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
@@ -1816,7 +1811,7 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                 "inputs",
                 datatype_input,
                 "label",
-                datatype_label
+                datatype_label,
             )
 
         features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
@@ -1826,7 +1821,7 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
             "input_ids",
             list,
             "label",
-            float
+            float,
         )
 
     def test_with_padding_collator_immutability(self):
@@ -1852,18 +1847,13 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
             DataCollatorForTokenClassification(tokenizer, return_tensors="np"),
             DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10, return_tensors="np"),
             DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8, return_tensors="np"),
-            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="np")
+            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="np"),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
             for collator in token_classification_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -1873,7 +1863,7 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
     def test_seq2seq_collator_immutability(self):
@@ -1886,19 +1876,18 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         seq2seq_collators = [
             DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="np"),
             DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np"),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np"),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np")
+            DataCollatorForSeq2Seq(
+                tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np"
+            ),
+            DataCollatorForSeq2Seq(
+                tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np"
+            ),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
             for collator in seq2seq_collators:
                 self._compare_assert_with_collator_on_datatypes(
-                    collator,
-                    features_base,
-                    "input_ids",
-                    datatype_input,
-                    "labels",
-                    datatype_label
+                    collator, features_base, "input_ids", datatype_input, "labels", datatype_label
                 )
 
         self._compare_assert_with_collator_on_datatypes(
@@ -1908,14 +1897,16 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
             datatype_input,
             "labels",
             datatype_label,
-            ignore_label=True
+            ignore_label=True,
         )
 
         features_base_no_pad = [
             {"input_ids": list(range(3)), "labels": list(range(3))},
             {"input_ids": list(range(3)), "labels": list(range(3))},
         ]
-        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np")
+        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(
+            tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np"
+        )
         for datatype_input, datatype_label in [(list, list)]:
             self._compare_assert_with_collator_on_datatypes(
                 seq2seq_no_padding_collator,
@@ -1923,19 +1914,25 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                 "input_ids",
                 datatype_input,
                 "labels",
-                datatype_label
+                datatype_label,
             )
 
     def test_language_modelling_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base_no_pad = [{"input_ids": tuple(range(10)), "labels": (1,)}, {"input_ids": tuple(range(10)), "labels": (1,)}]
-        features_base_pad = [{"input_ids": tuple(range(5)), "labels": (1,)}, {"input_ids": tuple(range(5)), "labels": (1,)}]
+        features_base_no_pad = [
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+            {"input_ids": tuple(range(10)), "labels": (1,)},
+        ]
+        features_base_pad = [
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+            {"input_ids": tuple(range(5)), "labels": (1,)},
+        ]
         lm_collators = [
             DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="np"),
             DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8, return_tensors="np"),
             DataCollatorForLanguageModeling(tokenizer, return_tensors="np"),
-            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
+            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np"),
         ]
 
         for datatype_input, datatype_label in [(list, list)]:
@@ -1947,7 +1944,7 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
                 self._compare_assert_with_collator_on_datatypes(
@@ -1957,13 +1954,16 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                     datatype_input,
                     "labels",
                     datatype_label,
-                    ignore_label=True
+                    ignore_label=True,
                 )
 
     def test_whole_world_masking_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_base = [{"input_ids": list(range(10)), "labels": (1,)}, {"input_ids": list(range(10)), "labels": (1,)}]
+        features_base = [
+            {"input_ids": list(range(10)), "labels": (1,)},
+            {"input_ids": list(range(10)), "labels": (1,)},
+        ]
         whole_word_masking_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="np")
 
         for datatype_input, datatype_label in [(list, list), (np.array, np.array)]:
@@ -1974,7 +1974,7 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                 datatype_input,
                 "labels",
                 datatype_label,
-                ignore_label=True
+                ignore_label=True,
             )
 
     def test_permutation_language_modelling_collator_immutability(self):

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -1359,16 +1359,16 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
 
         features_original = [
             {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "input_ids": tf.convert_to_tensor([0, 1, 2, 3, 4]),
+                "token_type_ids": tf.convert_to_tensor([0, 1, 2, 3, 4]),
                 "sentence_order_label": i,
             }
             for i in range(2)
         ]
         features_batch = [
             {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "input_ids": tf.convert_to_tensor([0, 1, 2, 3, 4]),
+                "token_type_ids": tf.convert_to_tensor([0, 1, 2, 3, 4]),
                 "sentence_order_label": i,
             }
             for i in range(2)
@@ -2005,16 +2005,16 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
 
         features_original = [
             {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "input_ids": np.array([0, 1, 2, 3, 4]),
+                "token_type_ids": np.array([0, 1, 2, 3, 4]),
                 "sentence_order_label": i,
             }
             for i in range(2)
         ]
         features_batch = [
             {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "input_ids": np.array([0, 1, 2, 3, 4]),
+                "token_type_ids": np.array([0, 1, 2, 3, 4]),
                 "sentence_order_label": i,
             }
             for i in range(2)

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -488,7 +488,9 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                 original.pop(label_key)
                 batch.pop(label_key)
 
-        self._validate_original_data_against_collated_data(collator=collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_default_collator_immutability(self):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
@@ -502,17 +504,32 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
             (list, self._turn_to_none),
         ]:
             self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=default_data_collator, base_data=features_base_single_label, input_key="inputs", input_datatype=datatype_input, label_key="label", label_datatype=datatype_label
+                collator=default_data_collator,
+                base_data=features_base_single_label,
+                input_key="inputs",
+                input_datatype=datatype_input,
+                label_key="label",
+                label_datatype=datatype_label,
             )
 
         for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
             self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=default_data_collator, base_data=features_base_multiple_labels, input_key="inputs", input_datatype=datatype_input, label_key="label", label_datatype=datatype_label
+                collator=default_data_collator,
+                base_data=features_base_multiple_labels,
+                input_key="inputs",
+                input_datatype=datatype_input,
+                label_key="label",
+                label_datatype=datatype_label,
             )
 
         features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=default_data_collator, base_data=features_base_single_label_alt, input_key="input_ids", input_datatype=list, label_key="label", label_datatype=float
+            collator=default_data_collator,
+            base_data=features_base_single_label_alt,
+            input_key="input_ids",
+            input_datatype=list,
+            label_key="label",
+            label_datatype=float,
         )
 
     def test_with_padding_collator_immutability(self):
@@ -522,10 +539,14 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         features_batch = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
 
         data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10)
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_for_token_classification_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -544,7 +565,12 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
             for collator in token_classification_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -574,7 +600,12 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
             for collator in seq2seq_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -669,11 +700,15 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
 
         no_pad_features_original = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
         no_pad_features_batch = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch
+        )
 
         pad_features_original = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
         pad_features_batch = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch
+        )
 
     def test_next_sentence_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -688,10 +723,14 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer)
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_sentence_order_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -714,10 +753,14 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer)
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )
 
 
 @require_tf
@@ -1126,7 +1169,9 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
                 original.pop(label_key)
                 batch.pop(label_key)
 
-        self._validate_original_data_against_collated_data(collator=collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_default_collator_immutability(self):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
@@ -1175,10 +1220,14 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         features_batch = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
 
         data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_for_token_classification_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -1197,7 +1246,12 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list)]:
             for collator in token_classification_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -1231,7 +1285,12 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list)]:
             for collator in seq2seq_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -1328,11 +1387,15 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
 
         no_pad_features_original = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
         no_pad_features_batch = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch
+        )
 
         pad_features_original = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
         pad_features_batch = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch
+        )
 
     def test_next_sentence_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -1347,10 +1410,14 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_sentence_order_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -1373,10 +1440,14 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="tf")
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )
 
 
 class NumpyDataCollatorIntegrationTest(unittest.TestCase):
@@ -1772,7 +1843,9 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
                 original.pop(label_key)
                 batch.pop(label_key)
 
-        self._validate_original_data_against_collated_data(collator=collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_default_collator_immutability(self):
         features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
@@ -1821,10 +1894,14 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         features_batch = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
 
         data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=data_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=data_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_for_token_classification_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -1843,7 +1920,12 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list)]:
             for collator in token_classification_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -1877,7 +1959,12 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         for datatype_input, datatype_label in [(list, list)]:
             for collator in seq2seq_collators:
                 self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator, base_data=features_base, input_key="input_ids", input_datatype=datatype_input, label_key="labels", label_datatype=datatype_label
+                    collator=collator,
+                    base_data=features_base,
+                    input_key="input_ids",
+                    input_datatype=datatype_input,
+                    label_key="labels",
+                    label_datatype=datatype_label,
                 )
 
         self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
@@ -1974,11 +2061,15 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
 
         no_pad_features_original = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
         no_pad_features_batch = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch
+        )
 
         pad_features_original = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
         pad_features_batch = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch
+        )
 
     def test_next_sentence_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -1993,10 +2084,14 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
         nsp_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=nsp_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=nsp_collator, original_data=features_original, batch_data=features_batch
+        )
 
     def test_sentence_order_prediction_collator_immutability(self):
         tokenizer = BertTokenizer(self.vocab_file)
@@ -2019,7 +2114,11 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
         ]
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )
 
         sop_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(collator=sop_collator, original_data=features_original, batch_data=features_batch)
+        self._validate_original_data_against_collated_data(
+            collator=sop_collator, original_data=features_original, batch_data=features_batch
+        )

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -468,8 +468,6 @@ class DataCollatorImmutabilityTest(unittest.TestCase):
                     self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
                 elif isinstance(original[i][key], torch.Tensor):
                     self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
-                elif isinstance(original[i][key], tf.Tensor):
-                    self.assertEqual(original[i][key].numpy().tolist(), batch[i][key].numpy().tolist())
                 else:
                     self.assertEqual(original[i][key], batch[i][key])
 
@@ -1105,8 +1103,6 @@ class TFDataCollatorImmutabilityTest(unittest.TestCase):
         for i in range(len(original)):
             for key in original[i].keys():
                 if isinstance(original[i][key], np.ndarray):
-                    self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
-                elif isinstance(original[i][key], torch.Tensor):
                     self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
                 elif isinstance(original[i][key], tf.Tensor):
                     self.assertEqual(original[i][key].numpy().tolist(), batch[i][key].numpy().tolist())
@@ -1756,10 +1752,6 @@ class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
             for key in original[i].keys():
                 if isinstance(original[i][key], np.ndarray):
                     self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
-                elif isinstance(original[i][key], torch.Tensor):
-                    self.assertEqual(original[i][key].tolist(), batch[i][key].tolist())
-                elif isinstance(original[i][key], tf.Tensor):
-                    self.assertEqual(original[i][key].numpy().tolist(), batch[i][key].numpy().tolist())
                 else:
                     self.assertEqual(original[i][key], batch[i][key])
 


### PR DESCRIPTION
# What does this PR do?
Introduces new tests that check if a data collator might introduce side effects, i.e. the given input changes after the call to the collator. Motivated by #30556 

Furthermore, fixes the seq2seq collator to not introduce side effects on the given input's labels. This is done by:
- Passing only relevant features to the tokenizer to pad.
- Manually crafting the labels afterwards.
- Reintroducing tokenizer behaviour by converting labels to the respective datatype (pt, tf, np).
As a side note, added some more checks on `None` labels, especially when given `"labels": None` in the dictionary. 

Last remarks: 
- The test handles most of the cases that are introduced in the base tests but if I missed something give me a heads up :D 
- I'm not sure how to handle it when the user introduces `None` labels. For now, I return them by `None` again.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
@amyeroberts @Rocketknight1 