### PR TITLE
Avoid duplication in PR slow CI model list

### DIFF
--- a/utils/pr_slow_ci_models.py
+++ b/utils/pr_slow_ci_models.py
@@ -142,4 +142,4 @@ if __name__ == "__main__":
     new_model = get_new_model()
     specified_models = get_models(args.commit_message)
     models = ([] if new_model == "" else [new_model]) + specified_models
-    print(models)
+    print(sorted(set(models)))


### PR DESCRIPTION
# What does this PR do?

If there are duplicated items, the upload artifacts step would fail as shown in 

https://github.com/huggingface/transformers/actions/runs/8935717727/job/24544707905?pr=30136

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run