### PR TITLE
Using assistant in AutomaticSpeechRecognitionPipeline with different encoder size

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1104,8 +1104,7 @@ class GenerationMixin:
         if not assistant_model.config.is_encoder_decoder:
             attributes_to_check = [attr for attr in dir(self.config) if attr.startswith("encoder_")]
             are_equal = all(
-                getattr(self.config, attr) == getattr(assistant_model.config, attr)
-                for attr in attributes_to_check
+                getattr(self.config, attr) == getattr(assistant_model.config, attr) for attr in attributes_to_check
             )
             if not are_equal:
                 raise ValueError(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1109,7 +1109,7 @@ class GenerationMixin:
             )
             if not are_equal:
                 raise ValueError(
-                    "The main model and the assistant don't have encoders of the same size. "
+                    "The main model and the assistant don't have compatible encoder-dependent input shapes. "
                     "Ensure you load the assistant with the correct encoder-decoder class, e.g. `AutoModelForSpeechSeq2Seq` for Whisper."
                 )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1099,8 +1099,8 @@ class GenerationMixin:
 
     def _validate_assistant(self, assistant_model):
         if assistant_model is not None:
-            if type(self).__name__ in MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING._model_mapping.values():
-                if type(assistant_model).__name__ in MODEL_FOR_CAUSAL_LM_MAPPING._model_mapping.values():
+            if self.config.is_encoder_decoder:
+                if not assistant_model.config.is_encoder_decoder:
                     attributes_to_check = [attr for attr in dir(self.config) if attr.startswith("encoder_")]
                     are_equal = all(
                         getattr(self.config, attr) == getattr(assistant_model.config, attr)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1098,22 +1098,23 @@ class GenerationMixin:
             raise TypeError(exception_message)
 
     def _validate_assistant(self, assistant_model):
-        if assistant_model is not None:
-            if self.config.is_encoder_decoder:
-                if not assistant_model.config.is_encoder_decoder:
-                    attributes_to_check = [attr for attr in dir(self.config) if attr.startswith("encoder_")]
-                    are_equal = all(
-                        getattr(self.config, attr) == getattr(assistant_model.config, attr)
-                        for attr in attributes_to_check
-                    )
-                    if not are_equal:
-                        raise ValueError(
-                            "The main model and the assistant don't have encoders of the same size. "
-                            "Ensure you load the assistant with the correct encoder-decoder class, e.g. `AutoModelForSpeechSeq2Seq` for Whisper."
-                        )
+        if assistant_model is None or not self.config.is_encoder_decoder:
+            return
 
-                if not self.config.vocab_size == assistant_model.config.vocab_size:
-                    raise ValueError("Make sure the main and assistant model use the same tokenizer")
+        if not assistant_model.config.is_encoder_decoder:
+            attributes_to_check = [attr for attr in dir(self.config) if attr.startswith("encoder_")]
+            are_equal = all(
+                getattr(self.config, attr) == getattr(assistant_model.config, attr)
+                for attr in attributes_to_check
+            )
+            if not are_equal:
+                raise ValueError(
+                    "The main model and the assistant don't have encoders of the same size. "
+                    "Ensure you load the assistant with the correct encoder-decoder class, e.g. `AutoModelForSpeechSeq2Seq` for Whisper."
+                )
+
+        if not self.config.vocab_size == assistant_model.config.vocab_size:
+            raise ValueError("Make sure the main and assistant model use the same tokenizer")
 
     def _validate_model_kwargs(self, model_kwargs: Dict[str, Any]):
         """Validates model kwargs for generation. Generate argument typos will also be caught here."""

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1102,7 +1102,8 @@ class GenerationMixin:
             return
 
         if not assistant_model.config.is_encoder_decoder:
-            attributes_to_check = [attr for attr in dir(self.config) if attr.startswith("encoder_")]
+            attributes_to_check = ["encoder_attention_heads", "encoder_ffn_dim", "encoder_layers"]
+            attributes_to_check = [attr for attr in dir(self.config) if attr in attributes_to_check]
             are_equal = all(
                 getattr(self.config, attr) == getattr(assistant_model.config, attr) for attr in attributes_to_check
             )

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1098,10 +1098,10 @@ class GenerationMixin:
             raise TypeError(exception_message)
 
     def _validate_assistant(self, assistant_model):
-        if assistant_model is None or not self.config.is_encoder_decoder:
+        if assistant_model is None:
             return
 
-        if not assistant_model.config.is_encoder_decoder:
+        if self.config.is_encoder_decoder and not assistant_model.config.is_encoder_decoder:
             attributes_to_check = ["encoder_attention_heads", "encoder_ffn_dim", "encoder_layers"]
             attributes_to_check = [attr for attr in dir(assistant_model.config) if attr in attributes_to_check]
             are_equal = all(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1109,7 +1109,7 @@ class GenerationMixin:
                     if not are_equal:
                         raise ValueError(
                             "The main model and the assistant don't have encoders of the same size. "
-                            "Load the assistant with AutoModelForSpeechSeq2Seq",
+                            "Ensure you load the assistant with the correct encoder-decoder class, e.g. `AutoModelForSpeechSeq2Seq` for Whisper."
                         )
 
                 if not self.config.vocab_size == assistant_model.config.vocab_size:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1103,7 +1103,7 @@ class GenerationMixin:
 
         if not assistant_model.config.is_encoder_decoder:
             attributes_to_check = ["encoder_attention_heads", "encoder_ffn_dim", "encoder_layers"]
-            attributes_to_check = [attr for attr in dir(self.config) if attr in attributes_to_check]
+            attributes_to_check = [attr for attr in dir(assistant_model.config) if attr in attributes_to_check]
             are_equal = all(
                 getattr(self.config, attr) == getattr(assistant_model.config, attr) for attr in attributes_to_check
             )

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -480,6 +480,14 @@ class WhisperGenerationMixin:
                 FutureWarning,
             )
 
+        if "assistant_model" in kwargs:
+            if kwargs["assistant_model"].config.encoder_attention_heads != self.model.config.encoder_attention_heads:
+                if not type(kwargs["assistant_model"]).__name__ == "WhisperForConditionalGeneration":
+                    raise ValueError(
+                        "The main model and the assistant don't have encoders of the same size.",
+                        "please load the assistant using WhisperForConditionalGeneration",
+                    )
+
         # 1. prepare generation config
         generation_config, kwargs = self._prepare_generation_config(generation_config, **kwargs)
 

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -480,14 +480,6 @@ class WhisperGenerationMixin:
                 FutureWarning,
             )
 
-        if "assistant_model" in kwargs:
-            if kwargs["assistant_model"].config.encoder_attention_heads != self.model.config.encoder_attention_heads:
-                if not type(kwargs["assistant_model"]).__name__ == "WhisperForConditionalGeneration":
-                    raise ValueError(
-                        "The main model and the assistant don't have encoders of the same size.",
-                        "please load the assistant using WhisperForConditionalGeneration",
-                    )
-
         # 1. prepare generation config
         generation_config, kwargs = self._prepare_generation_config(generation_config, **kwargs)
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -508,8 +508,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
+            if generate_kwargs["assistant_model"]:
+                generate_kwargs["input_features"] = inputs
+
             tokens = self.model.generate(
-                inputs=inputs,
                 attention_mask=attention_mask,
                 **generate_kwargs,
             )

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -498,6 +498,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                             generate_kwargs["num_frames"] = stride[0] // self.feature_extractor.hop_length
                         else:
                             generate_kwargs["num_frames"] = [s[0] // self.feature_extractor.hop_length for s in stride]
+                    else:
+                        generate_kwargs["num_frames"] = num_frames
 
             tokens = self.model.generate(
                 inputs=inputs,

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -509,6 +509,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
             tokens = self.model.generate(
+                inputs=inputs, 
                 attention_mask=attention_mask,
                 **generate_kwargs,
             )

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -508,7 +508,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
-            if generate_kwargs["assistant_model"]:
+            if "assistant_model" in generate_kwargs:
                 generate_kwargs["input_features"] = inputs
 
             tokens = self.model.generate(

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -509,7 +509,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
 
             tokens = self.model.generate(
-                inputs=inputs, 
+                inputs=inputs,
                 attention_mask=attention_mask,
                 **generate_kwargs,
             )

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -486,6 +486,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                     "Seq2Seq speech recognition model requires either a "
                     f"`input_features` or `input_values` key, but only has {model_inputs.keys()}"
                 )
+            if "assistant_model" in generate_kwargs:
+                generate_kwargs["input_features"] = inputs
 
             # custom processing for Whisper timestamps and word-level timestamps
             if return_timestamps and self.type == "seq2seq_whisper":
@@ -507,9 +509,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 generate_kwargs["input_features"] = inputs
             else:
                 generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
-
-            if "assistant_model" in generate_kwargs:
-                generate_kwargs["input_features"] = inputs
 
             tokens = self.model.generate(
                 attention_mask=attention_mask,

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1177,10 +1177,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         transcription_non_ass = pipe(sample.copy(), generate_kwargs={"assistant_model": assistant_model})["text"]
         total_time_assist = time.time() - start_time
 
-        inputs = {
-            "sampling_rate": sample["audio"]["sampling_rate"],
-            "raw": np.array(sample["audio"]["array"]),
-        }
 
         start_time = time.time()
         transcription_ass = pipe(inputs=inputs)["text"]

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1174,7 +1174,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
 
         start_time = time.time()
-        transcription_non_ass = pipe(inputs=inputs, generate_kwargs={"assistant_model": assistant_model})["text"]
+        transcription_non_ass = pipe(sample.copy(), generate_kwargs={"assistant_model": assistant_model})["text"]
         total_time_assist = time.time() - start_time
 
         inputs = {

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1179,7 +1179,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
 
         start_time = time.time()
-        transcription_ass = pipe(inputs=inputs)["text"]
+        transcription_ass = pipe(sample)["text"]
         total_time_non_assist = time.time() - start_time
 
         assert transcription_ass == transcription_non_ass

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1178,13 +1178,12 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         transcription_ass = pipe(sample)["text"]
         total_time_non_assist = time.time() - start_time
 
-        assert transcription_ass == transcription_non_ass
-        assert (
-            transcription_ass
-            == " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+        self.assertEqual(transcription_ass, transcription_non_ass)
+        self.assertEqual(
+            transcription_ass,
+            " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
         )
-
-        assert total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster"
+        self.assertTrue(total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster") 
 
     @slow
     def test_speculative_decoding_whisper_distil(self):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1145,7 +1145,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
     def test_speculative_decoding_whisper_non_distil(self):
         # Load data:
         dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation[:1]")
-        sample = dataset[0]
+        sample = dataset[0]["audio"]
 
         # Load model:
         model_id = "openai/whisper-large-v2"

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1172,10 +1172,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             generate_kwargs={"language": "en"},
         )
 
-        inputs = {
-            "sampling_rate": sample["audio"]["sampling_rate"],
-            "raw": np.array(sample["audio"]["array"]),
-        }
 
         start_time = time.time()
         transcription_non_ass = pipe(inputs=inputs, generate_kwargs={"assistant_model": assistant_model})["text"]

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1181,9 +1181,9 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(transcription_ass, transcription_non_ass)
         self.assertEqual(
             transcription_ass,
-            " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+            " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
         )
-        self.assertTrue(total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster") 
+        self.assertTrue(total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster")
 
     @slow
     def test_speculative_decoding_whisper_distil(self):
@@ -1222,12 +1222,12 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         transcription_ass = pipe(sample)["text"]
         total_time_non_assist = time.time() - start_time
 
-        assert transcription_ass == transcription_non_ass
-        assert (
-            transcription_ass
-            == " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+        self.assertEqual(transcription_ass, transcription_non_ass)
+        self.assertEqual(
+            transcription_ass,
+            " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
         )
-        assert total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster"
+        self.assertEqual(total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster")
 
     @slow
     @require_torch

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import unittest
 
 import numpy as np
@@ -23,6 +24,8 @@ from transformers import (
     MODEL_FOR_CTC_MAPPING,
     MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
     AutoFeatureExtractor,
+    AutoModelForCausalLM,
+    AutoModelForSpeechSeq2Seq,
     AutoProcessor,
     AutoTokenizer,
     Speech2TextForConditionalGeneration,
@@ -1137,6 +1140,119 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             output,
             {"text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."},
         )
+
+    @slow
+    def test_speculative_decoding_whisper_non_distil(self):
+        # Load data:
+        dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation[:1]")
+        sample = dataset[0]
+
+        # Load model:
+        model_id = "openai/whisper-large-v2"
+        processor = AutoProcessor.from_pretrained(model_id)
+        model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            model_id,
+            low_cpu_mem_usage=True,
+            use_safetensors=True,
+        )
+
+        # Load assistant:
+        assistant_model_id = "openai/whisper-tiny"
+        assistant_model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            assistant_model_id,
+            low_cpu_mem_usage=True,
+            use_safetensors=True,
+        )
+
+        # Load pipeline:
+        pipe = AutomaticSpeechRecognitionPipeline(
+            model=model,
+            tokenizer=processor.tokenizer,
+            feature_extractor=processor.feature_extractor,
+            generate_kwargs={"language": "en"},
+        )
+
+        inputs = {
+            "sampling_rate": sample["audio"]["sampling_rate"],
+            "raw": np.array(sample["audio"]["array"]),
+        }
+
+        start_time = time.time()
+        transcription_non_ass = pipe(inputs=inputs, generate_kwargs={"assistant_model": assistant_model})["text"]
+        total_time_assist = time.time() - start_time
+
+        inputs = {
+            "sampling_rate": sample["audio"]["sampling_rate"],
+            "raw": np.array(sample["audio"]["array"]),
+        }
+
+        start_time = time.time()
+        transcription_ass = pipe(inputs=inputs)["text"]
+        total_time_non_assist = time.time() - start_time
+
+        assert transcription_ass == transcription_non_ass
+        assert (
+            transcription_ass
+            == " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+        )
+
+        assert total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster"
+
+    @slow
+    def test_speculative_decoding_whisper_distil(self):
+        # Load data:
+        dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation[:1]")
+        sample = dataset[0]
+
+        # Load model:
+        model_id = "openai/whisper-large-v2"
+        processor = AutoProcessor.from_pretrained(model_id)
+        model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            model_id,
+            low_cpu_mem_usage=True,
+            use_safetensors=True,
+        )
+
+        # Load assistant:
+        assistant_model_id = "distil-whisper/distil-large-v2"
+        assistant_model = AutoModelForCausalLM.from_pretrained(
+            assistant_model_id,
+            low_cpu_mem_usage=True,
+            use_safetensors=True,
+        )
+
+        # Load pipeline:
+        pipe = AutomaticSpeechRecognitionPipeline(
+            model=model,
+            tokenizer=processor.tokenizer,
+            feature_extractor=processor.feature_extractor,
+            generate_kwargs={"language": "en"},
+        )
+
+        inputs = {
+            "sampling_rate": sample["audio"]["sampling_rate"],
+            "raw": np.array(sample["audio"]["array"]),
+        }
+
+        start_time = time.time()
+        transcription_non_ass = pipe(inputs=inputs, generate_kwargs={"assistant_model": assistant_model})["text"]
+        total_time_assist = time.time() - start_time
+
+        inputs = {
+            "sampling_rate": sample["audio"]["sampling_rate"],
+            "raw": np.array(sample["audio"]["array"]),
+        }
+
+        start_time = time.time()
+        transcription_ass = pipe(inputs=inputs)["text"]
+        total_time_non_assist = time.time() - start_time
+
+        assert transcription_ass == transcription_non_ass
+        assert (
+            transcription_ass
+            == " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."
+        )
+        assert total_time_non_assist > total_time_assist, "Make sure that assistant decoding is faster"
 
     @slow
     @require_torch


### PR DESCRIPTION
This PR aims at fixing issue #30611: 

- First: an error will be thrown if the assistant and main models encoders don't have the same size, and the assistant is loaded using `AutoModelForCausalLM`. 

- Second: This PR makes the pipeline work when using an assistant with a different encoder size (loaded with   `AutoModelForSpeechSeq2Seq`) than the main model: 

When using AutomaticSpeechRecognitionPipeline, If we use an assistant with a different encoder size than the main model , the pipeline is broken and we get the following error message: 

```
ValueError: Whisper expects the mel input features to be of length 3000, but found 1500. Make sure to pad the input mel features to 3000.
```

## Explanation of the solution

When doing short form generation with the pipeline, `input_features` aren't passed to the generate method, which instead takes the output of the main model's encoder. 

If the main model and the assistant don't share the same encoder, the encoder_output passed to generate cannot be used by the assistant for generation, and we get an error. 

The solution here is to also pass the `input_features` to the generate method to be used by the assistant. 

## Who can review?

@sanchit-gandhi 