### PR TITLE
Fix llava next tie_word_embeddings config 

### DIFF
--- a/src/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/transformers/models/llava_next/configuration_llava_next.py
@@ -55,6 +55,8 @@ class LlavaNextConfig(PretrainedConfig):
         image_grid_pinpoints (`List`, *optional*, defaults to `[[336, 672], [672, 336], [672, 672], [1008, 336], [336, 1008]]`):
             A list of possible resolutions to use for processing high resolution images. Each item in the list should be a tuple or list
             of the form `(height, width)`.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to tie weight embeddings
 
     Example:
 

--- a/src/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/transformers/models/llava_next/configuration_llava_next.py
@@ -56,7 +56,7 @@ class LlavaNextConfig(PretrainedConfig):
             A list of possible resolutions to use for processing high resolution images. Each item in the list should be a tuple or list
             of the form `(height, width)`.
         tie_word_embeddings (`bool`, *optional*, defaults to `False`):
-            Whether to tie weight embeddings
+            Whether the model's input and output word embeddings should be tied.
 
     Example:
 

--- a/src/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/transformers/models/llava_next/configuration_llava_next.py
@@ -90,6 +90,7 @@ class LlavaNextConfig(PretrainedConfig):
         vision_feature_select_strategy="default",
         vision_feature_layer=-2,
         image_grid_pinpoints=None,
+        tie_word_embeddings=False,
         **kwargs,
     ):
         self.ignore_index = ignore_index
@@ -138,4 +139,4 @@ class LlavaNextConfig(PretrainedConfig):
 
         self.text_config = text_config
 
-        super().__init__(**kwargs)
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)


### PR DESCRIPTION
# What does this PR do ?
This PR fixes the llava next config. We set `tie_word_embeddings` to `False` since we don't tie the weights at all (actually the `tie_weights` is redefined to call the `language_model.tie_weights() instead`). 
This fixes the following issue https://github.com/huggingface/transformers/issues/30001 where we get a warning about untied weights. This happens because we don't find any tied weights even though `tie_word_embeddings` is set to `True`. 