### PR TITLE
Adding variant as a keyword to config.save_pretrained

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2429,7 +2429,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Save the config
         if is_main_process:
             if not _hf_peft_config_loaded:
-                model_to_save.config.save_pretrained(save_directory)
+                model_to_save.config.save_pretrained(save_directory, variant=variant)
             if self.can_generate():
                 # generation config built from the model config + the model config holds generation kwargs -> generate
                 # may revert to legacy behavior if the two don't match
@@ -2449,7 +2449,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                             "removing any generation kwargs from the model config. This warning will be raised to an "
                             "exception in v4.41."
                         )
-                model_to_save.generation_config.save_pretrained(save_directory)
+                model_to_save.generation_config.save_pretrained(save_directory, variant=variant)
 
             if _hf_peft_config_loaded:
                 logger.info(
@@ -2476,7 +2476,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 active_adapter = active_adapter[0]
 
                 current_peft_config = self.peft_config[active_adapter]
-                current_peft_config.save_pretrained(save_directory)
+                current_peft_config.save_pretrained(save_directory, variant=variant)
 
         # Save the model
         if state_dict is None:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -60,6 +60,7 @@ from transformers.testing_utils import (
     torch_device,
 )
 from transformers.utils import (
+    CONFIG_NAME,
     SAFE_WEIGHTS_INDEX_NAME,
     SAFE_WEIGHTS_NAME,
     WEIGHTS_INDEX_NAME,
@@ -631,9 +632,12 @@ class ModelUtilsTest(TestCasePlus):
             model.save_pretrained(tmp_dir, variant="v2", safe_serialization=False)
 
             weights_name = ".".join(WEIGHTS_NAME.split(".")[:-1] + ["v2"] + ["bin"])
+            config_name = ".".join(CONFIG_NAME.split(".")[:-1] + ["v2"] + ["json"])
 
             weights_file = os.path.join(tmp_dir, weights_name)
+            config_file = os.path.join(tmp_dir, config_name)
             self.assertTrue(os.path.isfile(weights_file))
+            self.assertTrue(os.path.isfile(config_file))
             self.assertFalse(os.path.isfile(os.path.join(tmp_dir, WEIGHTS_NAME)))
 
             with self.assertRaises(EnvironmentError):


### PR DESCRIPTION
# What does this PR do?

When saving a model of type `PreTrainedModel` via `save_pretrained` you can add a variant argument so that the final model name can be `model.vision.safetensors` or `model.text.safetensors`. However, this capability is not extended to configuration files. This is a PR to add this capability

Fixes # (issue)
If in a file you do the following, you only get one configuration file with the last config
```python
vision_model.save_pretrained(save_directory, variant="vision")
text_model.save_pretrained(save_directory, variant="text")
```

**Note: Tests are failing.** Will fix those issues if this PR is useful in the first place. Please let me know if this PR will be accepted if I fix the rest of the tests.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

cc @fxmarty