### PR TITLE
Separate tokenizer tests

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -148,7 +148,12 @@ class CircleCIJob:
                         expanded_tests.extend(glob.glob("tests/models/**/test_tokenization*.py", recursive=True))
                     elif self.name in ["flax","torch","tf"]:
                         name = self.name if self.name != "torch" else ""
-                        expanded_tests.extend(glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True))
+                        if self.name == "torch":
+                            all_tests = glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True) 
+                            filtered = [k for k in all_tests if ("_tf_") not in k and "_flax_" not in k]
+                            expanded_tests.expand(filtered)
+                        else:
+                            expanded_tests.extend(glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True))
                     else:
                         expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 elif test == "tests/pipelines":

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -132,7 +132,7 @@ class CircleCIJob:
             if tests is None:
                 folder = os.environ["test_preparation_dir"]
                 test_file = os.path.join(folder, "filtered_test_list.txt")
-                if os.path.exists(test_file):
+                if os.path.exists(test_file): # We take this job's tests from the filtered test_list.txt
                     with open(test_file) as f:
                         tests = f.read().split(" ")
 
@@ -144,7 +144,10 @@ class CircleCIJob:
                 if test.endswith(".py"):
                     expanded_tests.append(test)
                 elif test == "tests/models":
-                    expanded_tests.extend(glob.glob("tests/models/**/test*.py", recursive=True))
+                    if "tokenization" in self.name:
+                        expanded_tests.extend(glob.glob("tests/models/**/test_tokenization*.py", recursive=True))
+                    else:
+                        expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 elif test == "tests/pipelines":
                     expanded_tests.extend([os.path.join(test, x) for x in os.listdir(test)])
                 else:
@@ -228,6 +231,14 @@ torch_and_flax_job = CircleCIJob(
 
 torch_job = CircleCIJob(
     "torch",
+    docker_image=[{"image": "huggingface/transformers-torch-light"}],
+    install_steps=["uv venv && uv pip install ."],
+    parallelism=6,
+    pytest_num_workers=16
+)
+
+tokenization_job = CircleCIJob(
+    "tokenization",
     docker_image=[{"image": "huggingface/transformers-torch-light"}],
     install_steps=["uv venv && uv pip install ."],
     parallelism=6,
@@ -404,6 +415,7 @@ REGULAR_TESTS = [
     hub_job,
     onnx_job,
     exotic_models_job,
+    tokenization_job
 ]
 EXAMPLES_TESTS = [
     examples_torch_job,

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -146,6 +146,9 @@ class CircleCIJob:
                 elif test == "tests/models":
                     if "tokenization" in self.name:
                         expanded_tests.extend(glob.glob("tests/models/**/test_tokenization*.py", recursive=True))
+                    elif self.name in ["flax","torch","tf"]:
+                        name = self.name if self.name != "torch" else ""
+                        expanded_tests.extend(glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True))
                     else:
                         expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 elif test == "tests/pipelines":

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -152,7 +152,7 @@ class CircleCIJob:
                     else:
                         expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 elif test == "tests/pipelines":
-                    expanded_tests.extend([os.path.join(test, x) for x in os.listdir(test)])
+                    expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True)) 
                 else:
                     expanded_tests.append(test)
             tests = " ".join(expanded_tests)

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -151,7 +151,7 @@ class CircleCIJob:
                         if self.name == "torch":
                             all_tests = glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True) 
                             filtered = [k for k in all_tests if ("_tf_") not in k and "_flax_" not in k]
-                            expanded_tests.expand(filtered)
+                            expanded_tests.extend(filtered)
                         else:
                             expanded_tests.extend(glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True))
                     else:


### PR DESCRIPTION
# What does this PR do?
Make sure we run the tokenization specific tests in this workflow. Should allow better splitting.
This reduces the `iddle` time of the torch/tf/flax jobs. Improving further the time ci take to run.

In this PR I make sure that only the _tf_ _flax_ test files are passed to the corresponding tests, but this might not fair well with testing that the tests are protected WDYT? 