### PR TITLE
Updated docs of `forward` in `Idefics2ForConditionalGeneration` with correct `ignore_index` value

### DIFF
--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1776,9 +1776,9 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         Args:
             labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
-                config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
-                (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
-
+                config.vocab_size]` or `model.image_token_id` (where `model` is your instance of `Idefics2ForConditionalGeneration`).
+                Tokens with indices set to `model.image_token_id` are ignored (masked), the loss is only
+                computed for the tokens with labels in `[0, ..., config.vocab_size]`.
         Returns:
 
         Example:


### PR DESCRIPTION


# What does this PR do?

The docs in the `forward` method of the `Idefics2ForConditionalGeneration` incorrectly states that `-100` is the value in the `labels` variable for which the `CrossEntropyLoss` will ignore the appropriate indices:
https://github.com/huggingface/transformers/blob/277db238b70c5c8bb5a445b75becbfd79644db42/src/transformers/models/idefics2/modeling_idefics2.py#L1777-L1780

However, it can be seen in this line that in fact the model uses the `image_token_id` as an ignore index:

https://github.com/huggingface/transformers/blob/277db238b70c5c8bb5a445b75becbfd79644db42/src/transformers/models/idefics2/modeling_idefics2.py#L1860

This PR updates the docs with the correct information.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Ping @amyeroberts 
