### PR TITLE
Update `workflow_id` in `utils/get_previous_daily_ci.py`

### DIFF
--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -14,8 +14,11 @@ def get_daily_ci_runs(token, num_runs=7):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    # The id of a workflow (not of a workflow run)
-    workflow_id = "636036"
+    # The id of a workflow (not of a workflow run).
+    # From a given workflow run (where we have workflow run id), we can get the workflow id by going to
+    # https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}
+    # and check the `workflow_id` key.
+    workflow_id = "90575235"
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/workflows/{workflow_id}/runs"
     # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results


### PR DESCRIPTION
# What does this PR do?

After #30313, we still don't get the missing new model failure report on slack channel. 

It is because we changed the daily ci and the main workflow file to trigger is a new file (`.github/workflows/self-scheduled-caller.yml`, added in #30012). This change to `workflow_id` which is used in `utils/get_previous_daily_ci.py`. The `new model failure report` relies on this file, and since the `workflow_id` is no longer the correct one, it is not produced.

This PR updates the `workflow_id`.