### PR TITLE
Patch CLIP image preprocessor

### DIFF
--- a/src/transformers/models/clip/image_processing_clip.py
+++ b/src/transformers/models/clip/image_processing_clip.py
@@ -141,7 +141,7 @@ class CLIPImageProcessor(BaseImageProcessor):
         ]
 
         # for backwards compatibility of KOSMOS-2
-        if "use_square_size" in kwargs and kwargs["use_square_size"] == True:
+        if "use_square_size" in kwargs and kwargs["use_square_size"] is True:
             self.size = {"height": size["shortest_edge"], "width": size["shortest_edge"]}
             # Let's remove `use_square_size` (as it is removed from #27690), so the future Kosmos-2 image processors
             # won't have this attr. being saved. (otherwise, it will enter this if branch while there is no more

--- a/src/transformers/models/clip/image_processing_clip.py
+++ b/src/transformers/models/clip/image_processing_clip.py
@@ -141,7 +141,7 @@ class CLIPImageProcessor(BaseImageProcessor):
         ]
 
         # for backwards compatibility of KOSMOS-2
-        if "use_square_size" in kwargs:
+        if "use_square_size" in kwargs and kwargs["use_square_size"] == True:
             self.size = {"height": size["shortest_edge"], "width": size["shortest_edge"]}
             # Let's remove `use_square_size` (as it is removed from #27690), so the future Kosmos-2 image processors
             # won't have this attr. being saved. (otherwise, it will enter this if branch while there is no more

--- a/src/transformers/models/clip/image_processing_clip.py
+++ b/src/transformers/models/clip/image_processing_clip.py
@@ -141,7 +141,7 @@ class CLIPImageProcessor(BaseImageProcessor):
         ]
 
         # for backwards compatibility of KOSMOS-2
-        if "use_square_size" in kwargs and kwargs["use_square_size"] is True:
+        if "use_square_size" in kwargs and kwargs["use_square_size"]:
             self.size = {"height": size["shortest_edge"], "width": size["shortest_edge"]}
             # Let's remove `use_square_size` (as it is removed from #27690), so the future Kosmos-2 image processors
             # won't have this attr. being saved. (otherwise, it will enter this if branch while there is no more


### PR DESCRIPTION
# What does this PR do?
Using diffusers `save_pretrained` give me an preprocessor config like bellow
```
{
  "_valid_processor_keys": [
    "images",
    "do_resize",
    "size",
    "resample",
    "do_center_crop",
    "crop_size",
    "do_rescale",
    "rescale_factor",
    "do_normalize",
    "image_mean",
    "image_std",
    "do_convert_rgb",
    "return_tensors",
    "data_format",
    "input_data_format"
  ],
  "crop_size": {
    "height": 224,
    "width": 224
  },
  "do_center_crop": true,
  "do_convert_rgb": true,
  "do_normalize": true,
  "do_rescale": true,
  "do_resize": true,
  "image_mean": [
    0.48145466,
    0.4578275,
    0.40821073
  ],
  "image_processor_type": "CLIPFeatureExtractor",
  "image_std": [
    0.26862954,
    0.26130258,
    0.27577711
  ],
  "resample": 3,
  "rescale_factor": 0.00392156862745098,
  "size": {
    "height": 224,
    "width": 224
  },
  "use_square_size": false
}
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

which could not initialize `CLIPImageProcessor` due to the following error

```bash
self.size = {"height": size["shortest_edge"], "width": size["shortest_edge"]}
KeyError: 'shortest_edge
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
