### PR TITLE
[Object detection pipeline] Lower threshold

### DIFF
--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -83,7 +83,7 @@ class ObjectDetectionPipeline(Pipeline):
 
                 The pipeline accepts either a single image or a batch of images. Images in a batch must all be in the
                 same format: all as HTTP(S) links, all as local paths, or all as PIL images.
-            threshold (`float`, *optional*, defaults to 0.9):
+            threshold (`float`, *optional*, defaults to 0.5):
                 The probability necessary to make a prediction.
             timeout (`float`, *optional*, defaults to None):
                 The maximum time in seconds to wait for fetching images from the web. If None, no timeout is set and

--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -120,7 +120,7 @@ class ObjectDetectionPipeline(Pipeline):
             model_outputs["bbox"] = model_inputs["bbox"]
         return model_outputs
 
-    def postprocess(self, model_outputs, threshold=0.9):
+    def postprocess(self, model_outputs, threshold=0.5):
         target_size = model_outputs["target_size"]
         if self.tokenizer is not None:
             # This is a LayoutLMForTokenClassification variant.


### PR DESCRIPTION
# What does this PR do?

This PR proposes to lower the default threshold of the object detection pipeline. It is currently set to 0.9, which causes a lot of inference widgets to not show any detected objects.

