### PR TITLE
Whisper: fix asr pipeline with seq2seq assistant model

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -468,7 +468,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             raise ValueError("segment_size must be used only when stride is None")
 
         if self.type in {"seq2seq", "seq2seq_whisper"}:
-            encoder = self.model.get_encoder()
             # Consume values so we can let extra information flow freely through
             # the pipeline (important for `partial` in microphone)
             if "input_features" in model_inputs:
@@ -500,11 +499,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                         else:
                             generate_kwargs["num_frames"] = segment_size[0] // self.feature_extractor.hop_length
 
-            if self.type == "seq2seq_whisper" and inputs.shape[-1] > self.feature_extractor.nb_max_frames:
-                generate_kwargs["input_features"] = inputs
-            else:
-                generate_kwargs["encoder_outputs"] = encoder(inputs, attention_mask=attention_mask)
-
+            generate_kwargs["input_features"] = inputs
             tokens = self.model.generate(
                 attention_mask=attention_mask,
                 **generate_kwargs,

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -499,8 +499,8 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                         else:
                             generate_kwargs["num_frames"] = segment_size[0] // self.feature_extractor.hop_length
 
-            generate_kwargs["input_features"] = inputs
             tokens = self.model.generate(
+                inputs,
                 attention_mask=attention_mask,
                 **generate_kwargs,
             )


### PR DESCRIPTION
# What does this PR do?

Fixes #29869 
Fixes #30407
Fixes #30611 (related PR: #30637)

The ASR pipeline was preparing the encoder outputs before `generate` (and not passing `input_features`), but that's not needed: the exact same preparation is done inside `generate`, as it is a hard requirement to generate with encoder-decoder models.

However, by not passing `input_features`, it was blocking the proper use of encoder-decoder assistants that used a different `encoder` output shape (= decoder input shape), and thus needed the inputs to run their own encoding step.

Contrarily to #30637, this fix relies on lowering the complexity of our codebase 👼 