### PR TITLE
PEFT / Trainer: Make use of `model.active_adapters()` instead of deprecated `model.active_adapter` whenever possible

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2620,6 +2620,7 @@ class Trainer:
             else:
                 if _is_peft_model(model):
                     # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
+                    # TODO: in the future support only specific min PEFT versions
                     if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(
                         model, "load_adapter"
                     ):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2528,14 +2528,22 @@ class Trainer:
             # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
             if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
                 if os.path.exists(resume_from_checkpoint):
-                    if adapter_subdirs:
+                    # For BC for older PEFT versions
+                    if hasattr(model, "active_adapters"):
+                        active_adapters = model.active_adapters()
+                        if len(active_adapters) > 1:
+                            logger.warning("Multiple active adapters detected will only consider the first adapter")
+                        active_adapter = active_adapters[0]
+                    else:
                         active_adapter = model.active_adapter
+                    
+                    if adapter_subdirs:
                         for subdir_name in adapter_subdirs:
                             peft_id = os.path.join(resume_from_checkpoint, subdir_name)
                             model.load_adapter(peft_id, subdir_name, is_trainable=(subdir_name == active_adapter))
                         model.set_adapter(active_adapter)
                     else:
-                        model.load_adapter(resume_from_checkpoint, model.active_adapter, is_trainable=True)
+                        model.load_adapter(resume_from_checkpoint, active_adapters, is_trainable=True)
                 else:
                     logger.warning(
                         "The intermediate checkpoints of PEFT may not be saved correctly, "
@@ -2610,8 +2618,16 @@ class Trainer:
                 if _is_peft_model(model):
                     # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
                     if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
+                        # For BC for older PEFT versions
+                        if hasattr(model, "active_adapters"):
+                            active_adapter = model.active_adapters()[0]
+                            if len(model.active_adapters()) > 1:
+                                logger.warning("Detected multiple active adapters, will only consider the first one")
+                        else:
+                            active_adapter = model.active_adapter
+                        
                         if os.path.exists(best_adapter_model_path) or os.path.exists(best_safe_adapter_model_path):
-                            model.load_adapter(self.state.best_model_checkpoint, model.active_adapter)
+                            model.load_adapter(self.state.best_model_checkpoint, active_adapter)
                             # Load_adapter has no return value present, modify it when appropriate.
                             from torch.nn.modules.module import _IncompatibleKeys
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2526,7 +2526,7 @@ class Trainer:
         # Load adapters following PR # 24096
         elif _is_peft_model(model):
             # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
-            if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
+            if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(model, "load_adapter"):
                 if os.path.exists(resume_from_checkpoint):
                     # For BC for older PEFT versions
                     if hasattr(model, "active_adapters"):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2617,7 +2617,7 @@ class Trainer:
             else:
                 if _is_peft_model(model):
                     # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
-                    if hasattr(model, "active_adapter") and hasattr(model, "load_adapter"):
+                    if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(model, "load_adapter"):
                         # For BC for older PEFT versions
                         if hasattr(model, "active_adapters"):
                             active_adapter = model.active_adapters()[0]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2526,6 +2526,7 @@ class Trainer:
         # Load adapters following PR # 24096
         elif _is_peft_model(model):
             # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
+            # TODO: in the future support only specific min PEFT versions
             if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(
                 model, "load_adapter"
             ):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2543,7 +2543,7 @@ class Trainer:
                             model.load_adapter(peft_id, subdir_name, is_trainable=(subdir_name == active_adapter))
                         model.set_adapter(active_adapter)
                     else:
-                        model.load_adapter(resume_from_checkpoint, active_adapters, is_trainable=True)
+                        model.load_adapter(resume_from_checkpoint, active_adapter, is_trainable=True)
                 else:
                     logger.warning(
                         "The intermediate checkpoints of PEFT may not be saved correctly, "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2526,7 +2526,9 @@ class Trainer:
         # Load adapters following PR # 24096
         elif _is_peft_model(model):
             # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
-            if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(model, "load_adapter"):
+            if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(
+                model, "load_adapter"
+            ):
                 if os.path.exists(resume_from_checkpoint):
                     # For BC for older PEFT versions
                     if hasattr(model, "active_adapters"):
@@ -2536,7 +2538,7 @@ class Trainer:
                         active_adapter = active_adapters[0]
                     else:
                         active_adapter = model.active_adapter
-                    
+
                     if adapter_subdirs:
                         for subdir_name in adapter_subdirs:
                             peft_id = os.path.join(resume_from_checkpoint, subdir_name)
@@ -2617,7 +2619,9 @@ class Trainer:
             else:
                 if _is_peft_model(model):
                     # If train a model using PEFT & LoRA, assume that adapter have been saved properly.
-                    if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(model, "load_adapter"):
+                    if (hasattr(model, "active_adapter") or hasattr(model, "active_adapters")) and hasattr(
+                        model, "load_adapter"
+                    ):
                         # For BC for older PEFT versions
                         if hasattr(model, "active_adapters"):
                             active_adapter = model.active_adapters()[0]
@@ -2625,7 +2629,7 @@ class Trainer:
                                 logger.warning("Detected multiple active adapters, will only consider the first one")
                         else:
                             active_adapter = model.active_adapter
-                        
+
                         if os.path.exists(best_adapter_model_path) or os.path.exists(best_safe_adapter_model_path):
                             model.load_adapter(self.state.best_model_checkpoint, active_adapter)
                             # Load_adapter has no return value present, modify it when appropriate.


### PR DESCRIPTION
As per title and as mentioned offline by @BenjaminBossan, `model.active_adapter` will be deprecated soon, let's make sure to slowly force Trainer to fallback into `model.active_adapters` instead

cc @BenjaminBossan @amyeroberts 