### PR TITLE
remove irrelevant japanese sentence from generation_strategies.md

### DIFF
--- a/docs/source/ja/generation_strategies.md
+++ b/docs/source/ja/generation_strategies.md
@@ -220,8 +220,6 @@ that\'s a terrible feeling."']
 
 このデコーディング戦略を有効にするには、`num_beams`（追跡する仮説の数）を1よりも大きな値に指定します。
 
-希望されるテキストの翻訳がお手伝いできて嬉しいです！もしさらなる質問やサポートが必要な場合は、お気軽にお知らせください。
-
 ```python
 >>> from transformers import AutoModelForCausalLM, AutoTokenizer
 


### PR DESCRIPTION
# What does this PR do?

Remove the irrelevant Japanese sentence from generation_strategies.md. 
The sentence "希望されるテキストの翻訳がお手伝いできて嬉しいです！.." translates to "I'm happy to help you with the translation! ..". 
This seems like a typical phrase from ChatGPT :)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.