### PR TITLE
Make chat templates part of ProcessorMixin

### DIFF
--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -62,7 +62,7 @@ class Idefics2Processor(ProcessorMixin):
     image_processor_class = "Idefics2ImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
-    def __init__(self, image_processor, tokenizer=None, image_seq_len: int = 64, **kwargs):
+    def __init__(self, image_processor, tokenizer=None, image_seq_len: int = 64, chat_template: str = None, **kwargs):
         if image_processor is None:
             raise ValueError("You need to specify an `image_processor`.")
         if tokenizer is None:
@@ -72,6 +72,7 @@ class Idefics2Processor(ProcessorMixin):
         self.image_token = AddedToken("<image>", normalized=False, special=True)
         self.end_of_utterance_token = AddedToken("<end_of_utterance>", normalized=False, special=True)
         self.image_seq_len = image_seq_len
+        self.chat_template = chat_template
 
         tokens_to_add = {
             "additional_special_tokens": [self.fake_image_token, self.image_token, self.end_of_utterance_token]

--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -74,14 +74,13 @@ class Idefics2Processor(ProcessorMixin):
         self.image_token = AddedToken("<image>", normalized=False, special=True)
         self.end_of_utterance_token = AddedToken("<end_of_utterance>", normalized=False, special=True)
         self.image_seq_len = image_seq_len
-        self.chat_template = chat_template
 
         tokens_to_add = {
             "additional_special_tokens": [self.fake_image_token, self.image_token, self.end_of_utterance_token]
         }
         tokenizer.add_special_tokens(tokens_to_add)
 
-        super().__init__(image_processor, tokenizer)
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
     def _extract_images_from_prompts(self, prompts):
         prompt_images = []

--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -57,8 +57,7 @@ class Idefics2Processor(ProcessorMixin):
             This parameter is used to build the string from the input prompt and image tokens and should match the
             config.perceiver_config.resampler_n_latents value for the model used.
         chat_template (`str`, *optional*): A Jinja template which will be used to convert lists of messages
-            in a chat into a tokenizable string. This argument is optional, and only relevant to processors that support
-            chat inputs.
+            in a chat into a tokenizable string.
     """
 
     attributes = ["image_processor", "tokenizer"]

--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -56,6 +56,9 @@ class Idefics2Processor(ProcessorMixin):
             The length of the image sequence i.e. the number of <image> tokens per image in the input.
             This parameter is used to build the string from the input prompt and image tokens and should match the
             config.perceiver_config.resampler_n_latents value for the model used.
+        chat_template (`str`, *optional*): A Jinja template which will be used to convert lists of messages
+            in a chat into a tokenizable string. This argument is optional, and only relevant to processors that support
+            chat inputs.
     """
 
     attributes = ["image_processor", "tokenizer"]

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -37,6 +37,8 @@ class LlavaProcessor(ProcessorMixin):
             The image processor is a required input.
         tokenizer ([`LlamaTokenizerFast`], *optional*):
             The tokenizer is a required input.
+        chat_template (`str`, *optional*): A Jinja template which will be used to convert lists of messages
+            in a chat into a tokenizable string.
     """
 
     attributes = ["image_processor", "tokenizer"]

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -43,8 +43,8 @@ class LlavaProcessor(ProcessorMixin):
     image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
-    def __init__(self, image_processor=None, tokenizer=None):
-        super().__init__(image_processor, tokenizer)
+    def __init__(self, image_processor=None, tokenizer=None, chat_template=None):
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
     def __call__(
         self,

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -37,6 +37,8 @@ class LlavaNextProcessor(ProcessorMixin):
             The image processor is a required input.
         tokenizer ([`LlamaTokenizerFast`], *optional*):
             The tokenizer is a required input.
+        chat_template (`str`, *optional*): A Jinja template which will be used to convert lists of messages
+            in a chat into a tokenizable string.
     """
 
     attributes = ["image_processor", "tokenizer"]

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -43,8 +43,8 @@ class LlavaNextProcessor(ProcessorMixin):
     image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
-    def __init__(self, image_processor=None, tokenizer=None):
-        super().__init__(image_processor, tokenizer)
+    def __init__(self, image_processor=None, tokenizer=None, chat_template=None):
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
 
     def __call__(
         self,

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -41,10 +41,6 @@ from .utils import (
 )
 
 
-if TYPE_CHECKING:
-    from .pipelines.conversational import Conversation
-
-
 logger = logging.get_logger(__name__)
 
 # Dynamically import the Transformers module to grab the attribute classes of the processor form their names.
@@ -533,7 +529,7 @@ class ProcessorMixin(PushToHubMixin):
 
     def apply_chat_template(
         self,
-        conversation: Union[List[Dict[str, str]], "Conversation"],
+        conversation: Union[List[Dict[str, str]]],
         chat_template: Optional[str] = None,
         tokenize: bool = False,
         **kwargs,

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -539,15 +539,11 @@ class ProcessorMixin(PushToHubMixin):
         **kwargs,
     ) -> str:
         """
-        Overrides the tokenizer's `apply_chat_template` method to apply the IDEFICS2 chat template by default
-        if no chat template is provided.
-
-        By default, the output isn't tokenized. This is because the IDEFICS2 chat template is designed to insert
-        the image token <image> into the sequence according to the message, but does not handle expanding the image
-        tokens to the sequence length or adding the surrounding tokens e.g. <fake_image_token>.
+        Similar to the `apply_chat_template` method on tokenizers, this method applies a Jinja template to input
+        conversations to turn them into a single tokenizable string.
 
         Args:
-            conversation (`Union[List[Dict, str, str], "Conversation"]`):
+            conversation (`List[Dict, str, str]`):
                 The conversation to format.
             chat_template (`Optional[str]`, *optional*):
                 The Jinja template to use for formatting the conversation. If not provided, the default chat template
@@ -555,7 +551,7 @@ class ProcessorMixin(PushToHubMixin):
             tokenize (`bool`, *optional*, defaults to `False`):
                 Whether to tokenize the output or not.
             **kwargs:
-                Additional keyword arguments for the tokenizer's `apply_chat_template` method.
+                Additional keyword arguments
         """
 
         if chat_template is None:

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -63,7 +63,8 @@ class ProcessorMixin(PushToHubMixin):
     This is a mixin used to provide saving/loading functionality for all processor classes.
     """
 
-    attributes = ["feature_extractor", "tokenizer", "chat_template"]
+    attributes = ["feature_extractor", "tokenizer"]
+    optional_attributes = ["chat_template"]
     # Names need to be attr_class for attr in attributes
     feature_extractor_class = None
     tokenizer_class = None
@@ -71,6 +72,9 @@ class ProcessorMixin(PushToHubMixin):
 
     # args have to match the attributes class attribute
     def __init__(self, *args, **kwargs):
+        # First, extract optional attributes from kwargs if present
+        for optional_attribute in self.optional_attributes:
+            setattr(self, optional_attribute, kwargs.pop(optional_attribute, None))
         # Sanitize args and kwargs
         for key in kwargs:
             if key not in self.attributes:

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -73,6 +73,7 @@ class ProcessorMixin(PushToHubMixin):
     # args have to match the attributes class attribute
     def __init__(self, *args, **kwargs):
         # First, extract optional attributes from kwargs if present
+        # Optional attributes can never be positional arguments
         for optional_attribute in self.optional_attributes:
             setattr(self, optional_attribute, kwargs.pop(optional_attribute, None))
         # Sanitize args and kwargs

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -22,7 +22,7 @@ import json
 import os
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .dynamic_module_utils import custom_object_save
 from .tokenization_utils_base import PreTrainedTokenizerBase

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -561,7 +561,7 @@ class ProcessorMixin(PushToHubMixin):
         if chat_template is None:
             if self.chat_template is not None:
                 chat_template = self.chat_template
-            else:
+            elif getattr(self, "default_chat_template", None) is not None:
                 logger.warning_once(
                     "No chat template is set for this processor, falling back to a default class-level template. This is "
                     "very error-prone, because models are often trained with templates different from the class default! "
@@ -570,6 +570,12 @@ class ProcessorMixin(PushToHubMixin):
                     "then to ensure that this model continues working without issues."
                 )
                 chat_template = self.default_chat_template
+            else:
+                raise ValueError(
+                    "No chat template is set for this processor. Please either set the `chat_template` attribute, "
+                    "or provide a chat template as an argument. See "
+                    "https://huggingface.co/docs/transformers/main/en/chat_templating for more information."
+                )
         return self.tokenizer.apply_chat_template(
             conversation, chat_template=chat_template, tokenize=tokenize, **kwargs
         )


### PR DESCRIPTION
Right now, IDEFICS2 supports chat templates, but in class-specific code. In this PR, we'll try to move that support to the generic `ProcessorMixin` so that we don't have to keep duplicating it as more VLMs (like LLaVA) start to need chat templates.

Draft PR for now until I make sure this doesn't break things!