### PR TITLE
Generation / FIX: Fix multi-device generation

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1519,6 +1519,7 @@ class GenerationMixin:
         requires_attention_mask = "encoder_outputs" not in model_kwargs
         kwargs_has_attention_mask = model_kwargs.get("attention_mask", None) is not None
 
+        device = None
         if "input_ids" in model_kwargs:
             device = model_kwargs["input_ids"].device
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1524,8 +1524,8 @@ class GenerationMixin:
             inputs, generation_config.bos_token_id, model_kwargs
         )
         batch_size = inputs_tensor.shape[0]
-        device = inputs_tensor.device
 
+        device = inputs_tensor.device
         self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
 
         # decoder-only models must use left-padding for batched generation.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -470,17 +470,15 @@ class GenerationMixin:
             raise ValueError(
                 "Can't infer missing attention mask on `mps` device. Please provide an `attention_mask` or use a different device."
             )
-
+       
         is_pad_token_in_inputs = (pad_token_id is not None) and (
-            torch.isin(elements=inputs, test_elements=pad_token_id.to(inputs.device)).any()
+                torch.isin(elements=inputs, test_elements=pad_token_id.to(inputs.device)).any()
         )
         is_pad_token_not_equal_to_eos_token_id = (eos_token_id is None) or ~(
-            torch.isin(elements=eos_token_id, test_elements=pad_token_id).any()
-        ).to(inputs.device)
+                torch.isin(elements=eos_token_id, test_elements=pad_token_id).any()
+                ).to(inputs.device)
         can_infer_attention_mask = is_pad_token_in_inputs * is_pad_token_not_equal_to_eos_token_id
-        attention_mask_from_padding = (
-            inputs.ne(pad_token_id.to(inputs.device)).long().to(default_attention_mask.device)
-        )
+        attention_mask_from_padding = inputs.ne(pad_token_id.to(inputs.device)).long().to(default_attention_mask.device)
         attention_mask = (
             attention_mask_from_padding * can_infer_attention_mask + default_attention_mask * ~can_infer_attention_mask
         )
@@ -1388,11 +1386,7 @@ class GenerationMixin:
             raise ValueError(
                 "`decoder_start_token_id` or `bos_token_id` has to be defined for encoder-decoder generation."
             )
-        if (
-            eos_token_id is not None
-            and eos_token_id.device.type != "meta"
-            and (torch.is_floating_point(eos_token_id) or (eos_token_id < 0).any())
-        ):
+        if eos_token_id is not None and (torch.is_floating_point(eos_token_id) or (eos_token_id < 0).any()):
             logger.warning(
                 f"`eos_token_id` should consist of positive integers, but is {eos_token_id}. Your generation will not "
                 "stop until the maximum length is reached. Depending on other flags, it may even crash."
@@ -2389,10 +2383,8 @@ class GenerationMixin:
 
             # finished sentences should have their next token be a padding token
             if has_eos_stopping_criteria:
-                next_tokens = next_tokens * unfinished_sequences + pad_token_id.to(unfinished_sequences.device) * (
-                    1 - unfinished_sequences
-                )
-
+                next_tokens = next_tokens * unfinished_sequences + pad_token_id.to(unfinished_sequences.device) * (1 - unfinished_sequences)
+            
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
             if streamer is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1362,7 +1362,6 @@ class GenerationMixin:
 
             if token is None or isinstance(token, torch.Tensor):
                 return token
-            # device = self.device if self.device.type != "meta" else torch.device("cpu")
             return torch.tensor(token, device=device, dtype=torch.long)
 
         bos_token_id = _tensor_or_none(generation_config.bos_token_id, device=device)
@@ -1520,7 +1519,8 @@ class GenerationMixin:
         requires_attention_mask = "encoder_outputs" not in model_kwargs
         kwargs_has_attention_mask = model_kwargs.get("attention_mask", None) is not None
 
-        device = model_kwargs["input_ids"].device
+        if "input_ids" in model_kwargs:
+            device = model_kwargs["input_ids"].device
 
         self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -467,7 +467,7 @@ class GenerationMixin:
             raise ValueError(
                 "Can't infer missing attention mask on `mps` device. Please provide an `attention_mask` or use a different device."
             )
-       
+
         is_pad_token_in_inputs = (pad_token_id is not None) and (
             torch.isin(elements=inputs, test_elements=pad_token_id).any()
         )
@@ -1341,7 +1341,10 @@ class GenerationMixin:
         return self._static_cache
 
     def _prepare_special_tokens(
-        self, generation_config: GenerationConfig, kwargs_has_attention_mask: Optional[bool] = None, device: Optional[Union[torch.device, str]] = None
+        self,
+        generation_config: GenerationConfig,
+        kwargs_has_attention_mask: Optional[bool] = None,
+        device: Optional[Union[torch.device, str]] = None,
     ):
         """
         Prepares the special tokens for generation, overwriting the generation config with their processed versions
@@ -1515,7 +1518,7 @@ class GenerationMixin:
         accepts_attention_mask = "attention_mask" in set(inspect.signature(self.forward).parameters.keys())
         requires_attention_mask = "encoder_outputs" not in model_kwargs
         kwargs_has_attention_mask = model_kwargs.get("attention_mask", None) is not None
-      
+
         device = None
         if "input_ids" in model_kwargs and isinstance(model_kwargs["input_ids"], torch.Tensor):
             device = model_kwargs["input_ids"].device
@@ -2389,7 +2392,7 @@ class GenerationMixin:
             # finished sentences should have their next token be a padding token
             if has_eos_stopping_criteria:
                 next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
-            
+
             # update generated ids, model inputs, and length for next step
             input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
             if streamer is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1519,17 +1519,14 @@ class GenerationMixin:
         requires_attention_mask = "encoder_outputs" not in model_kwargs
         kwargs_has_attention_mask = model_kwargs.get("attention_mask", None) is not None
 
-        device = None
-        if "input_ids" in model_kwargs and isinstance(model_kwargs["input_ids"], torch.Tensor):
-            device = model_kwargs["input_ids"].device
-
-        self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
-
         # 3. Define model inputs
         inputs_tensor, model_input_name, model_kwargs = self._prepare_model_inputs(
             inputs, generation_config.bos_token_id, model_kwargs
         )
         batch_size = inputs_tensor.shape[0]
+        device = inputs_tensor.device
+
+        self._prepare_special_tokens(generation_config, kwargs_has_attention_mask, device=device)
 
         # decoder-only models must use left-padding for batched generation.
         if not self.config.is_encoder_decoder and not is_torchdynamo_compiling():

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -461,9 +461,6 @@ class GenerationMixin:
         if not is_input_ids:
             return default_attention_mask
 
-        if pad_token_id is not None and pad_token_id.device.type == "meta":
-            return default_attention_mask
-
         # Otherwise we have may have information -> try to infer the attention mask
         if inputs.device.type == "mps":
             # mps does not support torch.isin (https://github.com/pytorch/pytorch/issues/77764)


### PR DESCRIPTION
# What does this PR do?

Fixes failing tests for multi-device (e.g. Multi-GPU, GPU + CPU etc) generation. The fix is simply to make sure `pad_token_id` and all other special tokens are initialized on the correct device (e.g. for models offloaded on CPU `self.device` return `"meta"` which breaks the generation after 😢 )

cc @gante @ArthurZucker 