### PR TITLE
Qwen: incorrect setup flag

### DIFF
--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -821,7 +821,6 @@ class Qwen2PreTrainedModel(PreTrainedModel):
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
     _supports_sdpa = True
-    _supports_cache_class = True
 
     def _init_weights(self, module):
         std = self.config.initializer_range


### PR DESCRIPTION
# What does this PR do?

Qwen does not support the new cache classes, contrarily to what was defined in the flag. 

Fixes the broken test on `main` as a result of merging #30348 