### PR TITLE
[WIP] - Adding bfloat16 support to SequenceFeatureExtractor

### DIFF
--- a/src/transformers/feature_extraction_sequence_utils.py
+++ b/src/transformers/feature_extraction_sequence_utils.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 
 from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
-from .utils import PaddingStrategy, TensorType, is_tf_tensor, is_torch_tensor, logging, to_numpy
+from .utils import PaddingStrategy, TensorType, is_tf_tensor, is_torch_tensor, logging
 
 
 logger = logging.get_logger(__name__)
@@ -171,11 +171,6 @@ class SequenceFeatureExtractor(FeatureExtractionMixin):
                     "Should be one of a python, numpy, pytorch or tensorflow object."
                 )
 
-        for key, value in processed_features.items():
-            if isinstance(value[0], (int, float)):
-                processed_features[key] = to_numpy(value)
-            else:
-                processed_features[key] = [to_numpy(v) for v in value]
 
         # Convert padding_strategy in PaddingStrategy
         padding_strategy = self._get_padding_strategies(padding=padding, max_length=max_length)

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -138,7 +138,11 @@ class BatchFeature(UserDict):
             def as_tensor(value):
                 if isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], np.ndarray):
                     value = np.array(value)
-                return torch.tensor(value)
+                    return torch.tensor(value)
+
+                elif isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], torch.Tensor):
+                    value = torch.stack(value, dim=0)
+                    return value
 
             is_tensor = torch.is_tensor
         elif tensor_type == TensorType.JAX:

--- a/src/transformers/models/whisper/feature_extraction_whisper.py
+++ b/src/transformers/models/whisper/feature_extraction_whisper.py
@@ -166,13 +166,19 @@ class WhisperFeatureExtractor(SequenceFeatureExtractor):
             normed_input_values = []
 
             for vector, length in zip(input_values, attention_mask.sum(-1)):
-                normed_slice = (vector - vector[:length].mean()) / np.sqrt(vector[:length].var() + 1e-7)
+                if isinstance(vector, np.ndarray):
+                    normed_slice = (vector - vector[:length].mean()) / np.sqrt(vector[:length].var() + 1e-7)
+                elif isinstance(vector, torch.Tensor):
+                    normed_slice = (vector - vector[:length].mean()) / torch.sqrt(vector[:length].var() + 1e-7)
                 if length < normed_slice.shape[0]:
                     normed_slice[length:] = padding_value
 
                 normed_input_values.append(normed_slice)
         else:
-            normed_input_values = [(x - x.mean()) / np.sqrt(x.var() + 1e-7) for x in input_values]
+            if isinstance(input_values, np.ndarray):
+                normed_input_values = [(x - x.mean()) / np.sqrt(x.var() + 1e-7) for x in input_values]
+            elif isinstance(input_values, torch.Tensor):
+                normed_input_values = [(x - x.mean()) / torch.sqrt(x.var() + 1e-7) for x in input_values]
 
         return normed_input_values
 


### PR DESCRIPTION
## Goal

The goal of this PR is to add bfloat16 support to SequenceFeatureExtractor and solve issue #30035. 

- To do this, I remove the `to_numpy` conversion applied by the `pad` method in `SequenceFeatureExtractor', as we don't need to convert the tensors to numpy before applying padding.  

- I adapt code to make it work with the changes (small fixes in `_get_is_as_tensor_fns` in `BatchFeature` and `zero_mean_unit_var_norm` in `Wav2Vec2FeatureExtractor`). 

- I finally apply the changes to Whisper / SpeechT5 / SeamleddM4T as they follow the same logic as `Wav2Vec2FeatureExtractor`. 

I still need to add some tests. 

## Who can review 

cc @sanchit-gandhi 

