### PR TITLE
Deprecate TF weight conversion since we have full Safetensors support now

### DIFF
--- a/src/transformers/commands/pt_to_tf.py
+++ b/src/transformers/commands/pt_to_tf.py
@@ -267,6 +267,13 @@ class PTtoTFCommand(BaseTransformersCLICommand):
         return pt_input, tf_input
 
     def run(self):
+        self._logger.warning(
+            "\n\nConverting PyTorch weights to TensorFlow is deprecated and will be removed in v4.43. "
+            "Instead, we recommend that you convert PyTorch weights to Safetensors, an improved "
+            "format that can be loaded by any framework, including TensorFlow. For more information, "
+            "please see the Safetensors conversion guide: "
+            "https://huggingface.co/docs/safetensors/en/convert-weights\n\n"
+        )
         # hub version 0.9.0 introduced the possibility of programmatically opening PRs with normal write tokens.
         if version.parse(huggingface_hub.__version__) < version.parse("0.9.0"):
             raise ImportError(


### PR DESCRIPTION
Transformers has a `pt-to-tf` script for generating TF weights. However, we don't really want people using this anymore - TF can load `.safetensors` fine, so adding `tf_model.h5` is much less helpful than adding `.safetensors`.

This PR adds a deprecation warning, and hopefully we can remove the function entirely in a couple of versions.