### PR TITLE
PEFT: Access active_adapters as a property in Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2533,7 +2533,7 @@ class Trainer:
                 if os.path.exists(resume_from_checkpoint):
                     # For BC for older PEFT versions
                     if hasattr(model, "active_adapters"):
-                        active_adapters = model.active_adapters()
+                        active_adapters = model.active_adapters
                         if len(active_adapters) > 1:
                             logger.warning("Multiple active adapters detected will only consider the first adapter")
                         active_adapter = active_adapters[0]
@@ -2626,8 +2626,8 @@ class Trainer:
                     ):
                         # For BC for older PEFT versions
                         if hasattr(model, "active_adapters"):
-                            active_adapter = model.active_adapters()[0]
-                            if len(model.active_adapters()) > 1:
+                            active_adapter = model.active_adapters[0]
+                            if len(model.active_adapters) > 1:
                                 logger.warning("Detected multiple active adapters, will only consider the first one")
                         else:
                             active_adapter = model.active_adapter


### PR DESCRIPTION
PEFTModel has a property called `active_adapters`. It was being accessed as a function which led to the below error.
Seeing issues such as 
```
    trainer.train()
  File "C:\dev\anaconda3\envs\env-gpu\Lib\site-packages\transformers\trainer.py", line 1885, in train
    return inner_training_loop(
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\dev\anaconda3\envs\env-gpu\Lib\site-packages\transformers\trainer.py", line 2339, in _inner_training_loop
    self._load_best_model()
  File "C:\dev\anaconda3\envs\env-gpu\Lib\site-packages\transformers\trainer.py", line 2629, in _load_best_model
    active_adapter = model.active_adapters()[0]
                     ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'list' object is not callable
``` 
Issue seems similar to #30754 and was likely introduced in #30738

Fixes: https://github.com/huggingface/transformers/issues/30754

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@younesbelkada 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
