### PR TITLE
Update ds_config_zero3.json

### DIFF
--- a/tests/deepspeed/ds_config_zero3.json
+++ b/tests/deepspeed/ds_config_zero3.json
@@ -7,11 +7,9 @@
         "hysteresis": 2,
         "min_loss_scale": 1
     },
-
     "bf16": {
         "enabled": "auto"
     },
-
     "optimizer": {
         "type": "AdamW",
         "params": {
@@ -21,7 +19,6 @@
             "weight_decay": "auto"
         }
     },
-
     "scheduler": {
         "type": "WarmupLR",
         "params": {
@@ -30,15 +27,14 @@
             "warmup_num_steps": "auto"
         }
     },
-
     "zero_optimization": {
         "stage": 3,
         "offload_optimizer": {
-            "device": "cpu",
+            "device": "none",
             "pin_memory": true
         },
         "offload_param": {
-            "device": "cpu",
+            "device": "none",
             "pin_memory": true
         },
         "overlap_comm": true,
@@ -51,7 +47,6 @@
         "stage3_max_reuse_distance": 1e9,
         "stage3_gather_16bit_weights_on_model_save": true
     },
-
     "gradient_accumulation_steps": "auto",
     "gradient_clipping": "auto",
     "steps_per_print": 2000,


### PR DESCRIPTION
# What does this PR do?
1. Instead of pinning deepspeed and making a lot of changes to the self-hosted runners in https://github.com/huggingface/transformers/pull/30801, this disables CPU offloading which are leading to 12 test failures. This PR needs to be reverted once the DeepSpeed fixes the issue: https://github.com/microsoft/DeepSpeed/issues/5538