### PR TITLE
test_custom_4d_attention_mask skip with sliding window attn

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4328,6 +4328,8 @@ class ModelTesterMixin:
             if not model_class._supports_cache_class:
                 self.skipTest(f"{model_class.__name__} is not guaranteed to work with custom 4D attention masks")
             config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+            if getattr(config, "sliding_window", 0) > 0:
+                self.skipTest(f"{model_class.__name__} with sliding window attention is not supported by this test")
             model = model_class(config).to(device=torch_device, dtype=torch.float32)
 
             (


### PR DESCRIPTION
This is a follow-up to #30348 
`tests/models/qwen2/test_modeling_qwen2.py::Qwen2ModelTest::test_custom_4d_attention_mask` was failing because of use of sliding window attention. 
While this sliding window attention does not preclude use of custom 4D masks, it requires modification of the original `test_custom_4d_attention_mask`.

Summoning @ArthurZucker @gante to review