### PR TITLE
T5 Static Cache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -469,7 +469,7 @@ class T5StaticCache(Cache):
         )
         self.dtype = dtype
         self.device = device
-        self.max_cache_len = config.max_target_positions - 2
+        self.max_cache_len = maxlen
         for k in range(config.num_hidden_layers):
             new_layer_key_cache = torch.zeros(
                 decoder_cache_shape, dtype=self.dtype, device=self.device)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -448,3 +448,109 @@ class StaticCache(Cache):
             # In-place ops prevent breaking the static address
             self.key_cache[layer_idx].zero_()
             self.value_cache[layer_idx].zero_()
+
+class T5StaticCache(Cache):
+    def __init__(self, config, dtype, device, existing_cache, maxlen = 256, batch_size = 1):
+        self.key_cache = []
+        self.value_cache = []
+        self.e_key_cache = []
+        self.e_value_cache = []
+        encoder_cache_shape = (
+            batch_size,
+            config.num_heads,
+            maxlen,
+            config.d_model // config.num_heads
+        )
+        decoder_cache_shape = (
+            batch_size,
+            config.num_heads,
+            maxlen,
+            config.d_model // config.num_heads
+        )
+        self.dtype = dtype
+        self.device = device
+        self.max_cache_len = config.max_target_positions - 2
+        for k in range(config.num_hidden_layers):
+            new_layer_key_cache = torch.zeros(
+                decoder_cache_shape, dtype=self.dtype, device=self.device)
+            new_layer_value_cache = torch.zeros(
+                decoder_cache_shape, dtype=self.dtype, device=self.device)
+            e_key_cache = torch.zeros(encoder_cache_shape, dtype=self.dtype, device=self.device)
+            e_value_cache = torch.zeros(encoder_cache_shape, dtype=self.dtype, device=self.device)
+            torch._dynamo.mark_static_address(new_layer_key_cache)
+            torch._dynamo.mark_static_address(new_layer_value_cache)
+            torch._dynamo.mark_static_address(e_key_cache)
+            torch._dynamo.mark_static_address(e_value_cache)
+            e_key_cache[:, :, :, :] = existing_cache[k][2].clone()
+            e_value_cache[:, :, :, :] = existing_cache[k][3].clone()
+            self.key_cache.append(new_layer_key_cache)
+            self.value_cache.append(new_layer_value_cache)
+            self.e_key_cache.append(e_key_cache)
+            self.e_value_cache.append(e_value_cache)
+            
+            self.update(
+                existing_cache[k][0].clone(),
+                existing_cache[k][1].clone(),
+                k,
+                cache_kwargs = {
+                    'cache_position': torch.arange(existing_cache[k][0].shape[2], device = self.device)
+                }
+            )
+                
+    def get_seq_length(self, layer_idx = 0) -> int:
+        return (self.key_cache[layer_idx][0, 0].any(dim=-1)).sum()
+
+    def get_max_length(self):
+        return self.max_cache_len
+            
+    def update(
+        self,
+        key_states,
+        value_states,
+        layer_idx: int,
+        cache_kwargs = None,
+    ):
+        cache_position = cache_kwargs.get("cache_position")
+        k_out = self.key_cache[layer_idx]
+        v_out = self.value_cache[layer_idx]
+
+        k_out[:, :, cache_position] = key_states
+        v_out[:, :, cache_position] = value_states
+
+        return k_out, v_out
+    
+    def reset(self, existing_cache = None):
+        for layer_idx in range(len(self.key_cache)):
+            self.key_cache[layer_idx].zero_()
+            self.value_cache[layer_idx].zero_()
+            self.e_key_cache[layer_idx].zero_()
+            self.e_value_cache[layer_idx].zero_()
+        
+        if existing_cache is not None:
+            for k in range(len(self.e_value_cache)):
+                self.e_key_cache[k][:, :, :, :] = existing_cache[k][2].clone()
+                self.e_value_cache[k][:, :, :, :] = existing_cache[k][3].clone()
+                
+                self.update(
+                    existing_cache[k][0].clone(),
+                    existing_cache[k][1].clone(),
+                    k,
+                    cache_kwargs = {
+                        'cache_position': torch.arange(existing_cache[k][0].shape[2], device = self.device)
+                    }
+                )
+                
+    
+    def __getitem__(self, layer_idx: int):
+        return (
+            self.key_cache[layer_idx], 
+            self.value_cache[layer_idx], 
+            self.e_key_cache[layer_idx],
+            self.e_value_cache[layer_idx],
+        )
+    
+    def delete(self):
+        del self.key_cache
+        del self.value_cache
+        del self.e_key_cache
+        del self.e_value_cache

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -25,8 +25,8 @@ import torch
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
-from transformers.activations import ACT2FN
-from transformers.modeling_outputs import (
+from ...activations import ACT2FN
+from ...modeling_outputs import (
     BaseModelOutput,
     BaseModelOutputWithPastAndCrossAttentions,
     Seq2SeqLMOutput,
@@ -35,10 +35,10 @@ from transformers.modeling_outputs import (
     Seq2SeqSequenceClassifierOutput,
     TokenClassifierOutput,
 )
-from transformers.modeling_utils import PreTrainedModel
-from transformers.cache_utils import Cache, T5StaticCache
-from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS, find_pruneable_heads_and_indices, prune_linear_layer
-from transformers.utils import (
+from ...modeling_utils import PreTrainedModel
+from ...cache_utils import Cache, T5StaticCache
+from ...pytorch_utils import ALL_LAYERNORM_LAYERS, find_pruneable_heads_and_indices, prune_linear_layer
+from ...utils import (
     DUMMY_INPUTS,
     DUMMY_MASK,
     add_start_docstrings,
@@ -47,8 +47,8 @@ from transformers.utils import (
     logging,
     replace_return_docstrings,
 )
-from transformers.utils.model_parallel_utils import assert_device_map, get_device_map
-from transformers.models.t5.configuration_t5 import T5Config
+from ...utils.model_parallel_utils import assert_device_map, get_device_map
+from .configuration_t5 import T5Config
 
 
 logger = logging.get_logger(__name__)

--- a/t5-static-cache-non-compile.ipynb
+++ b/t5-static-cache-non-compile.ipynb
@@ -1,0 +1,386 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f52fc5be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip3.10 install -e ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7c8d1edc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/husein/.local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<module 'transformers' from '/home/husein/mesolitica/t5-static-cache/src/transformers/__init__.py'>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import transformers\n",
+    "\n",
+    "transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4bd75ae0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers.cache_utils import T5StaticCache\n",
+    "from transformers import T5ForConditionalGeneration, T5Tokenizer\n",
+    "\n",
+    "model_id      = \"mesolitica/translation-t5-small-standard-bahasa-cased-v2\"\n",
+    "compute_dtype = torch.bfloat16\n",
+    "device        = \"cuda:0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a843c59d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n"
+     ]
+    }
+   ],
+   "source": [
+    "model     = T5ForConditionalGeneration.from_pretrained(model_id, torch_dtype=compute_dtype) \n",
+    "tokenizer = T5Tokenizer.from_pretrained(model_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4a78c2a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = model.cuda()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c8f5059a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hqq.models.hf.base import AutoHQQHFModel\n",
+    "from hqq.core.quantize import *\n",
+    "from hqq.utils.patching import prepare_for_inference\n",
+    "import hqq.models.base as hqq_base\n",
+    "\n",
+    "hqq_base._QUANT_LAYERS = [torch.nn.Linear, HQQLinear]\n",
+    "\n",
+    "quant_config = BaseQuantizeConfig(nbits=4, group_size=64, quant_scale=False, quant_zero=False, axis=1) \n",
+    "HQQLinear.set_backend(HQQBackend.PYTORCH)\n",
+    "\n",
+    "# AutoHQQHFModel.quantize_model(model.model.encoder, quant_config=quant_config, compute_dtype=compute_dtype, device=device)\n",
+    "# AutoHQQHFModel.quantize_model(model.model.decoder, quant_config=quant_config, compute_dtype=compute_dtype, device=device)\n",
+    "\n",
+    "# AutoHQQHFModel.set_auto_linear_tags(model.model.encoder)\n",
+    "# prepare_for_inference(model.model.encoder)\n",
+    "\n",
+    "# AutoHQQHFModel.set_auto_linear_tags(model.model.decoder)\n",
+    "# prepare_for_inference(model.model.decoder, backend='torchao_int4')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "287142d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# model.encoder.forward = torch.compile(model.encoder.forward, mode='reduce-overhead', fullgraph=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6b0f8e82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "842004aa",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 337 ms, sys: 134 ms, total: 471 ms\n",
+      "Wall time: 469 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "with torch.no_grad():\n",
+    "    s = 'SHAH ALAM Malaysia - Pertubuhan Kebajikan Anak Bersatu Selangor bersetuju pihak kerajaan mewujudkan Suruhanjaya Siasatan Diraja untuk menyiasat isu kartel daging.'\n",
+    "    input_ids = tokenizer(f'terjemah ke Inggeris: {s}', return_tensors = 'pt', max_length = 2048, padding = 'max_length').to('cuda')\n",
+    "    out_encoder = model.encoder(**input_ids)\n",
+    "    out_encoder = out_encoder[0].clone()\n",
+    "    encoder_attention_mask = input_ids['attention_mask']\n",
+    "    labels = torch.tensor([[model.config.decoder_start_token_id]], device = device)\n",
+    "    out_decoder = model.decoder(labels, encoder_hidden_states=out_encoder,\n",
+    "                               past_key_values = None, \n",
+    "                               encoder_attention_mask = encoder_attention_mask,use_cache = True)\n",
+    "    past_key_values = out_decoder.past_key_values\n",
+    "    proj = model.lm_head(out_decoder.last_hidden_state[:,-1:]).argmax(-1).clone()\n",
+    "    s = tokenizer.decode(proj[0])\n",
+    "    if cache is None:\n",
+    "        cache = T5StaticCache(model.config, compute_dtype, device, past_key_values, \n",
+    "                  maxlen = input_ids['input_ids'].shape[1])\n",
+    "    else:\n",
+    "        cache.reset(past_key_values)\n",
+    "    seq_length = past_key_values[0][0].shape[2]\n",
+    "    cache_position = seq_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b44c32f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def decode_one_tokens(\n",
+    "    model,\n",
+    "    cur_token,\n",
+    "    encoder_attention_mask,\n",
+    "    past_key_values, \n",
+    "    cache_position, \n",
+    "    out_encoder,\n",
+    "):\n",
+    "    out_decoder = model.decoder(\n",
+    "        cur_token,\n",
+    "        encoder_hidden_states=out_encoder,\n",
+    "        past_key_values=past_key_values,\n",
+    "        return_dict = False,\n",
+    "        cache_position = cache_position,\n",
+    "        encoder_attention_mask = encoder_attention_mask,\n",
+    "        use_cache = True,\n",
+    "    )\n",
+    "    sequence_output = out_decoder[0]\n",
+    "    sequence_output = sequence_output * (model.model_dim**-0.5)\n",
+    "    lm_logits = model.lm_head(sequence_output)\n",
+    "    new_token = lm_logits.argmax(-1)[:,-1:]\n",
+    "    return new_token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "85d5d5d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a0809a4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 25.5 ms, sys: 879 µs, total: 26.4 ms\n",
+      "Wall time: 25.2 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "with torch.no_grad():\n",
+    "    s = 'Pertubuhan Kebajikan Anak Bersatu Selangor bersetuju pihak kerajaan mewujudkan Suruhanjaya Siasatan Diraja untuk menyiasat isu kartel daging.'\n",
+    "    input_ids = tokenizer(f'terjemah ke Inggeris: {s}', return_tensors = 'pt', max_length = 2048, padding = 'max_length').to('cuda')\n",
+    "    out_encoder = model.encoder(**input_ids)\n",
+    "    out_encoder = out_encoder[0].clone()\n",
+    "    encoder_attention_mask = input_ids['attention_mask']\n",
+    "    labels = torch.tensor([[model.config.decoder_start_token_id]], device = device)\n",
+    "    out_decoder = model.decoder(labels, encoder_hidden_states=out_encoder,\n",
+    "                               past_key_values = None, \n",
+    "                               encoder_attention_mask = encoder_attention_mask,use_cache = True)\n",
+    "    past_key_values = out_decoder.past_key_values\n",
+    "    proj = model.lm_head(out_decoder.last_hidden_state[:,-1:]).argmax(-1).clone()\n",
+    "    s = tokenizer.decode(proj[0])\n",
+    "    cache.reset(past_key_values)\n",
+    "    seq_length = past_key_values[0][0].shape[2]\n",
+    "    cache_position = seq_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a6b09604",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 tensor([[32100]], device='cuda:0') The \n",
+      "1 tensor([[1584]], device='cuda:0') The Selangor\n",
+      "2 tensor([[32100]], device='cuda:0') The Selangor \n",
+      "3 tensor([[485]], device='cuda:0') The Selangor United\n",
+      "4 tensor([[32100]], device='cuda:0') The Selangor United \n",
+      "5 tensor([[6127]], device='cuda:0') The Selangor United Children\n",
+      "6 tensor([[12]], device='cuda:0') The Selangor United Children'\n",
+      "7 tensor([[16]], device='cuda:0') The Selangor United Children's\n",
+      "8 tensor([[32100]], device='cuda:0') The Selangor United Children's \n",
+      "9 tensor([[18034]], device='cuda:0') The Selangor United Children's Welfare\n",
+      "10 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare \n",
+      "11 tensor([[7620]], device='cuda:0') The Selangor United Children's Welfare Organization\n",
+      "12 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization \n",
+      "13 tensor([[2948]], device='cuda:0') The Selangor United Children's Welfare Organization agreed\n",
+      "14 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed \n",
+      "15 tensor([[27]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that\n",
+      "16 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that \n",
+      "17 tensor([[15]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the\n",
+      "18 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the \n",
+      "19 tensor([[218]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government\n",
+      "20 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government \n",
+      "21 tensor([[9266]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish\n",
+      "22 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish \n",
+      "23 tensor([[21]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a\n",
+      "24 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a \n",
+      "25 tensor([[2586]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal\n",
+      "26 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal \n",
+      "27 tensor([[3020]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission\n",
+      "28 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission \n",
+      "29 tensor([[18]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of\n",
+      "30 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of \n",
+      "31 tensor([[30295]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry\n",
+      "32 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry \n",
+      "33 tensor([[19]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to\n",
+      "34 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to \n",
+      "35 tensor([[8462]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate\n",
+      "36 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate \n",
+      "37 tensor([[15]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the\n",
+      "38 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the \n",
+      "39 tensor([[633]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue\n",
+      "40 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue \n",
+      "41 tensor([[18]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of\n",
+      "42 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of \n",
+      "43 tensor([[7230]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat\n",
+      "44 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat \n",
+      "45 tensor([[22128]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartel\n",
+      "46 tensor([[16]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels\n",
+      "47 tensor([[3]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels.\n",
+      "48 tensor([[1]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels.</s>\n",
+      "CPU times: user 182 ms, sys: 3.85 ms, total: 186 ms\n",
+      "Wall time: 185 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "before = time.time()\n",
+    "with torch.no_grad():\n",
+    "    for i in range(2048):\n",
+    "        proj = decode_one_tokens(\n",
+    "            model = model,\n",
+    "            cur_token = proj,\n",
+    "            encoder_attention_mask = encoder_attention_mask,\n",
+    "            past_key_values = cache,\n",
+    "            cache_position = cache_position,\n",
+    "            out_encoder = out_encoder,\n",
+    "        ).clone()\n",
+    "        s += tokenizer.decode(proj[0])\n",
+    "        print(i, proj, s)\n",
+    "        cache_position += 1\n",
+    "        \n",
+    "        if bool(proj[0] == model.config.eos_token_id):\n",
+    "            break\n",
+    "            \n",
+    "after = time.time() - before"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6b797ca4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "259.57796367162115"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i / after"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3.10",
+   "language": "python",
+   "name": "python3.10"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/t5-static-cache.ipynb
+++ b/t5-static-cache.ipynb
@@ -1,0 +1,404 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f52fc5be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip3.10 install -e ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7c8d1edc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/husein/.local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<module 'transformers' from '/home/husein/mesolitica/t5-static-cache/src/transformers/__init__.py'>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import transformers\n",
+    "\n",
+    "transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4bd75ae0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers.cache_utils import T5StaticCache\n",
+    "from transformers import T5ForConditionalGeneration, T5Tokenizer\n",
+    "\n",
+    "model_id      = \"mesolitica/translation-t5-small-standard-bahasa-cased-v2\"\n",
+    "compute_dtype = torch.bfloat16\n",
+    "device        = \"cuda:0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a843c59d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.\n"
+     ]
+    }
+   ],
+   "source": [
+    "model     = T5ForConditionalGeneration.from_pretrained(model_id, torch_dtype=compute_dtype) \n",
+    "tokenizer = T5Tokenizer.from_pretrained(model_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4a78c2a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = model.cuda()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c8f5059a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hqq.models.hf.base import AutoHQQHFModel\n",
+    "from hqq.core.quantize import *\n",
+    "from hqq.utils.patching import prepare_for_inference\n",
+    "import hqq.models.base as hqq_base\n",
+    "\n",
+    "hqq_base._QUANT_LAYERS = [torch.nn.Linear, HQQLinear]\n",
+    "\n",
+    "quant_config = BaseQuantizeConfig(nbits=4, group_size=64, quant_scale=False, quant_zero=False, axis=1) \n",
+    "HQQLinear.set_backend(HQQBackend.PYTORCH)\n",
+    "\n",
+    "# AutoHQQHFModel.quantize_model(model.model.encoder, quant_config=quant_config, compute_dtype=compute_dtype, device=device)\n",
+    "# AutoHQQHFModel.quantize_model(model.model.decoder, quant_config=quant_config, compute_dtype=compute_dtype, device=device)\n",
+    "\n",
+    "# AutoHQQHFModel.set_auto_linear_tags(model.model.encoder)\n",
+    "# prepare_for_inference(model.model.encoder)\n",
+    "\n",
+    "# AutoHQQHFModel.set_auto_linear_tags(model.model.decoder)\n",
+    "# prepare_for_inference(model.model.decoder, backend='torchao_int4')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "287142d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# model.encoder.forward = torch.compile(model.encoder.forward, mode='reduce-overhead', fullgraph=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6b0f8e82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cache = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "842004aa",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 23 ms, sys: 0 ns, total: 23 ms\n",
+      "Wall time: 22.2 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "with torch.no_grad():\n",
+    "    s = 'SHAH ALAM Malaysia - Pertubuhan Kebajikan Anak Bersatu Selangor bersetuju pihak kerajaan mewujudkan Suruhanjaya Siasatan Diraja untuk menyiasat isu kartel daging.'\n",
+    "    input_ids = tokenizer(f'terjemah ke Inggeris: {s}', return_tensors = 'pt', max_length = 2048, padding = 'max_length').to('cuda')\n",
+    "    out_encoder = model.encoder(**input_ids)\n",
+    "    out_encoder = out_encoder[0].clone()\n",
+    "    encoder_attention_mask = input_ids['attention_mask']\n",
+    "    labels = torch.tensor([[model.config.decoder_start_token_id]], device = device)\n",
+    "    out_decoder = model.decoder(labels, encoder_hidden_states=out_encoder,\n",
+    "                               past_key_values = None, \n",
+    "                               encoder_attention_mask = encoder_attention_mask,use_cache = True)\n",
+    "    past_key_values = out_decoder.past_key_values\n",
+    "    proj = model.lm_head(out_decoder.last_hidden_state[:,-1:]).argmax(-1).clone()\n",
+    "    s = tokenizer.decode(proj[0])\n",
+    "    if cache is None:\n",
+    "        cache = T5StaticCache(model.config, compute_dtype, device, past_key_values, \n",
+    "                  maxlen = input_ids['input_ids'].shape[1])\n",
+    "    else:\n",
+    "        cache.reset(past_key_values)\n",
+    "    seq_length = past_key_values[0][0].shape[2]\n",
+    "    cache_position = seq_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b44c32f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def decode_one_tokens(\n",
+    "    model,\n",
+    "    cur_token,\n",
+    "    encoder_attention_mask,\n",
+    "    past_key_values, \n",
+    "    cache_position, \n",
+    "    out_encoder,\n",
+    "):\n",
+    "    out_decoder = model.decoder(\n",
+    "        cur_token,\n",
+    "        encoder_hidden_states=out_encoder,\n",
+    "        past_key_values=past_key_values,\n",
+    "        return_dict = False,\n",
+    "        cache_position = cache_position,\n",
+    "        encoder_attention_mask = encoder_attention_mask,\n",
+    "        use_cache = True,\n",
+    "    )\n",
+    "    sequence_output = out_decoder[0]\n",
+    "    sequence_output = sequence_output * (model.model_dim**-0.5)\n",
+    "    lm_logits = model.lm_head(sequence_output)\n",
+    "    new_token = lm_logits.argmax(-1)[:,-1:]\n",
+    "    return new_token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b6a50a6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decode_one_tokens = torch.compile(decode_one_tokens, mode=\"reduce-overhead\", fullgraph=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "85d5d5d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "a0809a4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 21.8 ms, sys: 0 ns, total: 21.8 ms\n",
+      "Wall time: 21.2 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "with torch.no_grad():\n",
+    "    s = 'Pertubuhan Kebajikan Anak Bersatu Selangor bersetuju pihak kerajaan mewujudkan Suruhanjaya Siasatan Diraja untuk menyiasat isu kartel daging.'\n",
+    "    input_ids = tokenizer(f'terjemah ke Inggeris: {s}', return_tensors = 'pt', max_length = 2048, padding = 'max_length').to('cuda')\n",
+    "    out_encoder = model.encoder(**input_ids)\n",
+    "    out_encoder = out_encoder[0].clone()\n",
+    "    encoder_attention_mask = input_ids['attention_mask']\n",
+    "    labels = torch.tensor([[model.config.decoder_start_token_id]], device = device)\n",
+    "    out_decoder = model.decoder(labels, encoder_hidden_states=out_encoder,\n",
+    "                               past_key_values = None, \n",
+    "                               encoder_attention_mask = encoder_attention_mask,use_cache = True)\n",
+    "    past_key_values = out_decoder.past_key_values\n",
+    "    proj = model.lm_head(out_decoder.last_hidden_state[:,-1:]).argmax(-1).clone()\n",
+    "    s = tokenizer.decode(proj[0])\n",
+    "    cache.reset(past_key_values)\n",
+    "    seq_length = past_key_values[0][0].shape[2]\n",
+    "    cache_position = seq_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "a6b09604",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 tensor([[32100]], device='cuda:0') The \n",
+      "1 tensor([[1584]], device='cuda:0') The Selangor\n",
+      "2 tensor([[32100]], device='cuda:0') The Selangor \n",
+      "3 tensor([[485]], device='cuda:0') The Selangor United\n",
+      "4 tensor([[32100]], device='cuda:0') The Selangor United \n",
+      "5 tensor([[6127]], device='cuda:0') The Selangor United Children\n",
+      "6 tensor([[12]], device='cuda:0') The Selangor United Children'\n",
+      "7 tensor([[16]], device='cuda:0') The Selangor United Children's\n",
+      "8 tensor([[32100]], device='cuda:0') The Selangor United Children's \n",
+      "9 tensor([[18034]], device='cuda:0') The Selangor United Children's Welfare\n",
+      "10 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare \n",
+      "11 tensor([[7620]], device='cuda:0') The Selangor United Children's Welfare Organization\n",
+      "12 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization \n",
+      "13 tensor([[2948]], device='cuda:0') The Selangor United Children's Welfare Organization agreed\n",
+      "14 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed \n",
+      "15 tensor([[27]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that\n",
+      "16 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that \n",
+      "17 tensor([[15]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the\n",
+      "18 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the \n",
+      "19 tensor([[218]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government\n",
+      "20 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government \n",
+      "21 tensor([[9266]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish\n",
+      "22 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish \n",
+      "23 tensor([[21]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a\n",
+      "24 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a \n",
+      "25 tensor([[2586]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal\n",
+      "26 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal \n",
+      "27 tensor([[3020]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission\n",
+      "28 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission \n",
+      "29 tensor([[18]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of\n",
+      "30 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of \n",
+      "31 tensor([[30295]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry\n",
+      "32 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry \n",
+      "33 tensor([[19]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to\n",
+      "34 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to \n",
+      "35 tensor([[8462]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate\n",
+      "36 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate \n",
+      "37 tensor([[15]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the\n",
+      "38 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the \n",
+      "39 tensor([[633]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue\n",
+      "40 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue \n",
+      "41 tensor([[18]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of\n",
+      "42 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of \n",
+      "43 tensor([[7230]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat\n",
+      "44 tensor([[32100]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat \n",
+      "45 tensor([[22128]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartel\n",
+      "46 tensor([[16]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels\n",
+      "47 tensor([[3]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels.\n",
+      "48 tensor([[1]], device='cuda:0') The Selangor United Children's Welfare Organization agreed that the government establish a Royal Commission of Inquiry to investigate the issue of meat cartels.</s>\n",
+      "CPU times: user 54.2 ms, sys: 0 ns, total: 54.2 ms\n",
+      "Wall time: 53 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "before = time.time()\n",
+    "with torch.no_grad():\n",
+    "    for i in range(2048):\n",
+    "        proj = decode_one_tokens(\n",
+    "            model = model,\n",
+    "            cur_token = proj,\n",
+    "            encoder_attention_mask = encoder_attention_mask,\n",
+    "            past_key_values = cache,\n",
+    "            cache_position = cache_position,\n",
+    "            out_encoder = out_encoder,\n",
+    "        ).clone()\n",
+    "        s += tokenizer.decode(proj[0])\n",
+    "        print(i, proj, s)\n",
+    "        cache_position += 1\n",
+    "        \n",
+    "        if bool(proj[0] == model.config.eos_token_id):\n",
+    "            break\n",
+    "            \n",
+    "after = time.time() - before"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "6b797ca4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "905.746397513013"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i / after"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40ad6d73",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3.10",
+   "language": "python",
+   "name": "python3.10"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This enable to use torch.compile for T5 generation to enable faster generation.

Compiled static cache able to achieve 905.746397513013 tokens / sec while non-compiled got 259.57796367162115 tokens / sec on Small T5 60M parameters.

1. Notebook for non-compiled, https://github.com/mesolitica/t5-static-cache/blob/main/t5-static-cache-non-compile.ipynb
2. Notebook for compiled, https://github.com/mesolitica/t5-static-cache/blob/main/t5-static-cache.ipynb

## Still work in progress

1. Current forked only work to use static cache, need to follow caching steps as Llama.
3. There are so many conditions need to fulfill first.
4. Only worked on Pytorch 2.4.0.dev20240508+cu121 version, not yet released as stable for custom function reduce-overhead torch compile.