### PR TITLE
Add bounding box converter

### DIFF
--- a/docs/source/en/internal/image_processing_utils.md
+++ b/docs/source/en/internal/image_processing_utils.md
@@ -27,8 +27,6 @@ Most of those are only useful if you are studying the code of the image processo
 
 [[autodoc]] image_transforms.center_to_corners_format
 
-[[autodoc]] image_transforms.corners_to_center_format
-
 [[autodoc]] image_transforms.id_to_rgb
 
 [[autodoc]] image_transforms.normalize

--- a/docs/source/en/internal/image_processing_utils.md
+++ b/docs/source/en/internal/image_processing_utils.md
@@ -25,8 +25,6 @@ Most of those are only useful if you are studying the code of the image processo
 
 [[autodoc]] image_transforms.center_crop
 
-[[autodoc]] image_transforms.center_to_corners_format
-
 [[autodoc]] image_transforms.id_to_rgb
 
 [[autodoc]] image_transforms.normalize
@@ -40,6 +38,10 @@ Most of those are only useful if you are studying the code of the image processo
 [[autodoc]] image_transforms.resize
 
 [[autodoc]] image_transforms.to_pil_image
+
+[[autodoc]] image_transforms.center_to_corners_format
+
+[[autodoc]] image_box_utils.convert_boxes
 
 ## ImageProcessingMixin
 

--- a/docs/source/ja/internal/image_processing_utils.md
+++ b/docs/source/ja/internal/image_processing_utils.md
@@ -27,8 +27,6 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] image_transforms.center_to_corners_format
 
-[[autodoc]] image_transforms.corners_to_center_format
-
 [[autodoc]] image_transforms.id_to_rgb
 
 [[autodoc]] image_transforms.normalize

--- a/docs/source/zh/internal/image_processing_utils.md
+++ b/docs/source/zh/internal/image_processing_utils.md
@@ -27,8 +27,6 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] image_transforms.center_to_corners_format
 
-[[autodoc]] image_transforms.corners_to_center_format
-
 [[autodoc]] image_transforms.id_to_rgb
 
 [[autodoc]] image_transforms.normalize

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1106,6 +1106,7 @@ except OptionalDependencyNotAvailable:
         name for name in dir(dummy_vision_objects) if not name.startswith("_")
     ]
 else:
+    _import_structure["image_box_utils"] = []
     _import_structure["image_processing_utils"] = ["ImageProcessingMixin"]
     _import_structure["image_utils"] = ["ImageFeatureExtractionMixin"]
     _import_structure["models.beit"].extend(["BeitFeatureExtractor", "BeitImageProcessor"])

--- a/src/transformers/image_box_utils.py
+++ b/src/transformers/image_box_utils.py
@@ -478,17 +478,14 @@ def convert_boxes(
     """
     Convert boxes from one format to another.
 
-    Supported boxes formats:
-        A single box of shape (B,), where B is 4 or more elements, and the first 4 elements are the
-        coordinates of the box. The box can be represented as
-            - torch.Tensor | np.ndarray | List[float, ...]
-
-        Boxes from one image, a set of boxes (N, B) where N is the number of boxes. The boxes can be represented as
-            - torch.Tensor | np.ndarray | List[List[float, ...]]
-
-        Boxes from multiple images, a set of images with their boxes (I, N, B), where I is number of images.
-        May be represented as a single 3d array/tensor or most likely as a list of arrays/tensors
-            - torch.Tensor | np.ndarray | List[torch.Tensor | np.ndarray] | List[List[List[float, ...]]]
+    Bounding boxes can be provided as:
+        - A single box (torch.Tensor | np.ndarray | List[float, ...]): Box of shape (B,), where B is 4 or more elements, 
+        and the first 4 elements are the coordinates of the box. 
+        - Boxes from one image (torch.Tensor | np.ndarray | List[List[float, ...]]): A set of boxes (N, B) where N is 
+        the number of boxes.
+        - Boxes from multiple images (torch.Tensor | np.ndarray | List[torch.Tensor | np.ndarray] | List[List[List[float, ...]]]):
+        A set of images with their boxes (I, N, B), where I is number of images. Can be represented as a single 3D array/tensor 
+        or most likely as a list of 2D arrays/tensors. 
 
     Supported input/output bounding box formats:
         - `absolute_xyxy` (aliases: `pascal_voc`, `xyxy`): [x_min, y_min, x_max, y_max]
@@ -499,11 +496,15 @@ def convert_boxes(
         - `relative_xcycwh` (aliases: `yolo`, `xcycwh`): [center_x, center_y, width, height] normalized to [0, 1] by image size
 
     Args:
-        boxes: A single box / boxes from one image / boxes from multiple images
-        input_format: format of the input boxes
-        output_format: format of the output boxes
-        image_size: (height, width) of the image if boxes are from one image, or list of (height, width) for each image
-        check: warn/raise/None
+        boxes: A single box / boxes from one image / boxes from multiple images.
+        input_format (str): Format of the input boxes.
+        output_format (str): Format of the output boxes.
+        image_size (Optional[torch.tensor | List | Tuple]): (height, width) of the image if boxes are from one image, or list of (height, width) tuples 
+            if provided boxes from multiple images.
+        check (Optional[str]): Whether to check bounding boxes or not.
+            - `"warn"` raise warning if bounding boxes are outside image borders or have negative width/height.
+            - `"raise"` raise error if bounding boxes are outside image borders or have negative width/height.
+            - `None` no checks are performed.
 
     Returns:
         boxes: Boxes converted to output format with the same shape and data type as the input boxes

--- a/src/transformers/image_box_utils.py
+++ b/src/transformers/image_box_utils.py
@@ -337,18 +337,18 @@ def check_absolute_boxes_xyxy(boxes: ArrayType, check: str) -> None:
         log_or_raise(message, check)
 
 
-def _convert_boxes_arrays(
+def _convert_boxes_arrays_2d(
     boxes: ArrayType,
     input_format: str,
     output_format: str,
-    image_size: Optional[ArrayType | List] = None,
+    image_size: Optional[Union[ArrayType, List]] = None,
     check: Optional[str] = "warn",
 ) -> ArrayType:
     """
     Convert array/tensor boxes from one format to another
 
     Args:
-        boxes: 1d/2d/3d array, where the last dim is 4 or more elements representing the box coordinates
+        boxes: 2D array, where the last dim is 4 or more elements representing the box coordinates
         input_format: format of the input boxes
         output_format: format of the output boxes
         image_size: tensor of shape (2,) where 2 is the image size (height, width)
@@ -396,10 +396,10 @@ def _convert_boxes_arrays(
 
 
 def _convert_boxes_recursively(
-    boxes: ArrayType | List | Tuple,
+    boxes: Union[ArrayType, List, Tuple],
     input_format: str,
     output_format: str,
-    image_size: Optional[ArrayType | List] = None,
+    image_size: Optional[Union[ArrayType, List]] = None,
     check: Optional[str] = "warn",
 ):
     depth = get_depth_of_nested_objects(boxes)
@@ -436,7 +436,7 @@ def _convert_boxes_recursively(
 
     # Base of recursion.
     if depth == 2 and is_array_type(boxes):
-        return _convert_boxes_arrays(boxes, input_format, output_format, image_size, check)
+        return _convert_boxes_arrays_2d(boxes, input_format, output_format, image_size, check)
 
     # Recursive approach.
     elif depth == 1 and isinstance(boxes, (list, tuple) or is_array_type(boxes)):
@@ -469,10 +469,10 @@ def _convert_boxes_recursively(
 
 
 def convert_boxes(
-    boxes: ArrayType | List | Tuple,
+    boxes: Union[ArrayType, List, Tuple],
     input_format: str,
     output_format: str,
-    image_size: Optional[ArrayType | List | Tuple] = None,
+    image_size: Optional[Union[ArrayType, List, Tuple]] = None,
     check: Optional[str] = "warn",
 ):
     """

--- a/src/transformers/image_box_utils.py
+++ b/src/transformers/image_box_utils.py
@@ -479,13 +479,13 @@ def convert_boxes(
     Convert boxes from one format to another.
 
     Bounding boxes can be provided as:
-        - A single box (torch.Tensor | np.ndarray | List[float, ...]): Box of shape (B,), where B is 4 or more elements, 
-        and the first 4 elements are the coordinates of the box. 
-        - Boxes from one image (torch.Tensor | np.ndarray | List[List[float, ...]]): A set of boxes (N, B) where N is 
+        - A single box (torch.Tensor | np.ndarray | List[float, ...]): Box of shape (B,), where B is 4 or more elements,
+        and the first 4 elements are the coordinates of the box.
+        - Boxes from one image (torch.Tensor | np.ndarray | List[List[float, ...]]): A set of boxes (N, B) where N is
         the number of boxes.
         - Boxes from multiple images (torch.Tensor | np.ndarray | List[torch.Tensor | np.ndarray] | List[List[List[float, ...]]]):
-        A set of images with their boxes (I, N, B), where I is number of images. Can be represented as a single 3D array/tensor 
-        or most likely as a list of 2D arrays/tensors. 
+        A set of images with their boxes (I, N, B), where I is number of images. Can be represented as a single 3D array/tensor
+        or most likely as a list of 2D arrays/tensors.
 
     Supported input/output bounding box formats:
         - `absolute_xyxy` (aliases: `pascal_voc`, `xyxy`): [x_min, y_min, x_max, y_max]
@@ -499,7 +499,7 @@ def convert_boxes(
         boxes: A single box / boxes from one image / boxes from multiple images.
         input_format (str): Format of the input boxes.
         output_format (str): Format of the output boxes.
-        image_size (Optional[torch.tensor | List | Tuple]): (height, width) of the image if boxes are from one image, or list of (height, width) tuples 
+        image_size (Optional[torch.tensor | List | Tuple]): (height, width) of the image if boxes are from one image, or list of (height, width) tuples
             if provided boxes from multiple images.
         check (Optional[str]): Whether to check bounding boxes or not.
             - `"warn"` raise warning if bounding boxes are outside image borders or have negative width/height.

--- a/src/transformers/image_box_utils.py
+++ b/src/transformers/image_box_utils.py
@@ -1,0 +1,522 @@
+import logging
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+
+from .utils import (
+    is_numpy_array,
+    is_torch_available,
+    is_torch_tensor,
+)
+
+
+if is_torch_available():
+    import torch
+
+
+# TODO: align with transformers logging
+logger = logging.getLogger(__name__)
+
+ArrayType = Union["torch.Tensor", np.ndarray]
+
+
+SUPPORTED_BOX_FORMATS = [
+    "absolute_xyxy",
+    "absolute_xywh",
+    "absolute_xcycwh",
+    "relative_xyxy",
+    "relative_xywh",
+    "relative_xcycwh",
+    "coco",
+    "pascal_voc",
+    "yolo",
+    "albumentations",
+    "xyxy",
+    "xywh",
+    "xcycwh",
+]
+
+
+BOX_FORMAT_MAPPING = {
+    "coco": "absolute_xywh",
+    "pascal_voc": "absolute_xyxy",
+    "yolo": "relative_xcycwh",
+    "albumentations": "relative_xyxy",
+    "xyxy": "absolute_xyxy",
+    "xywh": "absolute_xywh",
+    "xcycwh": "relative_xcycwh",
+    "absolute_xyxy": "absolute_xyxy",
+    "absolute_xywh": "absolute_xywh",
+    "absolute_xcycwh": "absolute_xcycwh",
+    "relative_xyxy": "relative_xyxy",
+    "relative_xywh": "relative_xywh",
+    "relative_xcycwh": "relative_xcycwh",
+}
+
+
+class BoxOutOfBoundsError(Exception):
+    pass
+
+
+class NotValidBoxError(Exception):
+    pass
+
+
+def is_array_type(obj) -> bool:
+    return is_torch_tensor(obj) or isinstance(obj, np.ndarray)
+
+
+def is_numpy_scalar(obj) -> bool:
+    return isinstance(obj, (np.floating, np.integer))
+
+
+def is_numpy_object(obj) -> bool:
+    return is_numpy_array(obj) or is_numpy_scalar(obj)
+
+
+def validate_box_format(format: str) -> None:
+    if format not in SUPPORTED_BOX_FORMATS:
+        raise ValueError(f"Unsupported box format: {format}, supported formats are {SUPPORTED_BOX_FORMATS}")
+
+
+def map_box_format(format: str) -> str:
+    return BOX_FORMAT_MAPPING[format]
+
+
+def get_depth_of_nested_objects(obj) -> int:
+    if is_torch_tensor(obj) or is_numpy_array(obj):
+        return obj.ndim
+    elif isinstance(obj, (list, tuple)):
+        if not obj:
+            return 2  # empty list/tuple could not be a box, we treat it as image with no boxes
+        return get_depth_of_nested_objects(obj[0]) + 1
+    elif isinstance(obj, (int, float)) or is_numpy_scalar(obj):
+        return 0
+    else:
+        raise NotImplementedError(f"Unsupported type of object: {type(obj)}")
+
+
+# ------------------------------------------------------------------------------------------------
+# Basic framework-agnostic operations
+# ------------------------------------------------------------------------------------------------
+
+
+def _shape(obj: ArrayType) -> List[int]:
+    if is_torch_tensor(obj) or is_numpy_array(obj):
+        return list(obj.shape)
+    else:
+        raise NotImplementedError(f"Unsupported type {type(obj)}")
+
+
+def _split(objects: ArrayType, axis: int = -1) -> List[ArrayType]:
+    if is_torch_tensor(objects):
+        return objects.unbind(dim=axis)
+    elif is_numpy_array(objects):
+        n_splits = objects.shape[axis]
+        return [np.take(objects, i, axis=axis) for i in range(n_splits)]
+    else:
+        raise NotImplementedError(f"Unsupported type {type(objects)}")
+
+
+def _stack(objects: List[ArrayType], axis: int = 0) -> ArrayType:
+    if all(is_torch_tensor(x) for x in objects):
+        return torch.stack(objects, dim=axis)
+    elif all(is_numpy_object(x) for x in objects):
+        return np.stack(objects, axis=axis)
+    else:
+        raise NotImplementedError(f"Unsupported type in {[type(x) for x in objects]}")
+
+
+def _make_like(obj: ArrayType, like: ArrayType) -> ArrayType:
+    if is_torch_tensor(like):
+        return torch.tensor(obj).to(like.device)
+    elif is_numpy_array(like):
+        return np.array(obj)
+    else:
+        raise NotImplementedError(f"Unsupported type {type(like)}")
+
+
+def _max(obj: Union[ArrayType, int, float]) -> Union[ArrayType, int, float]:
+    if is_torch_tensor(obj):
+        return obj.max().item()
+    elif is_numpy_array(obj):
+        return obj.max()
+    elif isinstance(obj, (int, float)) or is_numpy_scalar(obj):
+        return obj
+    else:
+        raise NotImplementedError(f"Unsupported type {type(obj)}")
+
+
+def _min(obj: Union[ArrayType, int, float]) -> Union[ArrayType, int, float]:
+    if is_torch_tensor(obj):
+        return obj.min().item()
+    elif is_numpy_array(obj):
+        return obj.min()
+    elif isinstance(obj, (int, float)) or is_numpy_scalar(obj):
+        return obj
+    else:
+        raise NotImplementedError(f"Unsupported type {type(obj)}")
+
+
+def _expand_on_zero_dim(obj: Union[ArrayType, List, Tuple]) -> Union[ArrayType, List, Tuple]:
+    if is_torch_tensor(obj):
+        return obj.unsqueeze(dim=0)
+    elif is_numpy_array(obj):
+        return np.expand_dims(obj, axis=0)
+    elif isinstance(obj, list):
+        return [obj]
+    elif isinstance(obj, tuple):
+        return (obj,)
+    else:
+        raise NotImplementedError(f"Unsupported type {type(obj)}")
+
+
+# ------------------------------------------------------------------------------------------------
+# Format converters
+# ------------------------------------------------------------------------------------------------
+
+
+def _convert_xcycwh_to_xyxy(boxes: ArrayType) -> ArrayType:
+    """
+    Convert boxes from (center_x, center_y, width, height) to (x0, y0, x1, y1)
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    cx, cy, w, h, *rest = _split(boxes, axis=-1)
+    x_min = cx - w / 2
+    y_min = cy - h / 2
+    x_max = cx + w / 2
+    y_max = cy + h / 2
+    return _stack([x_min, y_min, x_max, y_max, *rest], axis=-1)
+
+
+def _convert_xyxy_to_xcycwh(boxes: ArrayType) -> ArrayType:
+    """
+    Convert boxes from (x0, y0, x1, y1) to (center_x, center_y, width, height)
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    x_min, y_min, x_max, y_max, *rest = _split(boxes, axis=-1)
+    cx = (x_min + x_max) / 2
+    cy = (y_min + y_max) / 2
+    w = x_max - x_min
+    h = y_max - y_min
+    return _stack([cx, cy, w, h, *rest], axis=-1)
+
+
+def _convert_xywh_to_xyxy(boxes: ArrayType) -> ArrayType:
+    """
+    Convert boxes from (x, y, w, h) to (x0, y0, x1, y1)
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    x_min, y_min, w, h, *rest = _split(boxes, axis=-1)
+    x_max = x_min + w
+    y_max = y_min + h
+    return _stack([x_min, y_min, x_max, y_max, *rest], axis=-1)
+
+
+def _convert_xyxy_to_xywh(boxes: ArrayType) -> ArrayType:
+    """
+    Convert boxes from (x0, y0, x1, y1) to (x, y, w, h)
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    x_min, y_min, x_max, y_max, *rest = _split(boxes, axis=-1)
+    w = x_max - x_min
+    h = y_max - y_min
+    return _stack([x_min, y_min, w, h, *rest], axis=-1)
+
+
+def _convert_relative_to_absolute(boxes: ArrayType, image_size: ArrayType) -> ArrayType:
+    """
+    Convert boxes from relative to absolute coordinates
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+        image_size: tensor of shape (2,) where 2 is the image size (height, width)
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    image_size = _make_like(image_size, like=boxes)
+    height, width = _split(image_size, axis=-1)
+    x_rel, y_rel, x_or_w_rel, y_or_h_rel, *rest = _split(boxes, axis=-1)
+    x_abs = x_rel * width
+    y_abs = y_rel * height
+    x_or_w_abs = x_or_w_rel * width
+    y_or_h_abs = y_or_h_rel * height
+    return _stack([x_abs, y_abs, x_or_w_abs, y_or_h_abs, *rest], axis=-1)
+
+
+def _convert_absolute_to_relative(boxes: ArrayType, image_size: ArrayType) -> ArrayType:
+    """
+    Convert boxes from absolute to relative coordinates
+    Args:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+        image_size: tensor of shape (2,) where 2 is the image size (height, width)
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+    height, width = _make_like(image_size, like=boxes)
+    x_abs, y_abs, x_or_w_abs, y_or_h_abs, *rest = _split(boxes, axis=-1)
+    x_rel = x_abs / width
+    y_rel = y_abs / height
+    x_or_w_rel = x_or_w_abs / width
+    y_or_h_rel = y_or_h_abs / height
+    return _stack([x_rel, y_rel, x_or_w_rel, y_or_h_rel, *rest], axis=-1)
+
+
+# ------------------------------------------------------------------------------------------------
+# Box conversion operations
+# ------------------------------------------------------------------------------------------------
+
+
+def log_or_raise(message: str, check: str) -> None:
+    if check == "warn":
+        logger.warning(message)
+    elif check == "raise":
+        raise BoxOutOfBoundsError(message)
+
+
+def check_relative_boxes_xyxy(boxes: ArrayType, check: str) -> None:
+    # Check if boxes are in the range [0, 1]
+    max_value = _max(boxes)
+    min_value = _min(boxes)
+    if max_value > 1 or min_value < 0:
+        message = (
+            "Relative boxes are expected to be in the range [0, 1], "
+            "but some of your boxes are outside of this range."
+        )
+        log_or_raise(message, check)
+
+    # Check if width and height are positive
+    x_min, y_min, x_max, y_max, *_ = _split(boxes, axis=-1)
+    w = x_max - x_min
+    h = y_max - y_min
+    if _min(w) <= 0 or _min(h) <= 0:
+        message = (
+            "Width and height of your boxes are expected to be positive, "
+            "but some of your boxes have non-positive width or height."
+        )
+        log_or_raise(message, check)
+
+
+def check_absolute_boxes_xyxy(boxes: ArrayType, check: str) -> None:
+    # Check if boxes coordinates are non-negative
+    max_value = _max(boxes)
+    min_value = _min(boxes)
+    if min_value < 0:
+        message = "Some of your boxes are outside of image boundaries."
+        log_or_raise(message, check)
+
+    # Check that maximum coordinate is greater than 2,
+    # otherwise it is very unlikely for absolute boxes
+    if max_value < 2:
+        message = (
+            "Maximum coordinate value of your boxes is less than 2.0, which "
+            "is unexpected for absolute boxes. You might have relative boxes."
+        )
+        log_or_raise(message, check)
+
+    # Check if width and height are positive
+    x_min, y_min, x_max, y_max, *_ = _split(boxes, axis=-1)
+    w = x_max - x_min
+    h = y_max - y_min
+    if _min(w) <= 0 or _min(h) <= 0:
+        message = (
+            "Width and height of your boxes are expected to be positive, "
+            "but some of your boxes have non-positive width or height."
+        )
+        log_or_raise(message, check)
+
+
+def _convert_boxes_arrays(
+    boxes: ArrayType,
+    input_format: str,
+    output_format: str,
+    image_size: Optional[ArrayType | List] = None,
+    check: Optional[str] = "warn",
+) -> ArrayType:
+    """
+    Convert array/tensor boxes from one format to another
+
+    Args:
+        boxes: 1d/2d/3d array, where the last dim is 4 or more elements representing the box coordinates
+        input_format: format of the input boxes
+        output_format: format of the output boxes
+        image_size: tensor of shape (2,) where 2 is the image size (height, width)
+    Returns:
+        boxes: tensor of shape (N, 4) where N is the number of boxes
+    """
+
+    input_scale, input_coords_type = input_format.split("_")
+    output_scale, output_coords_type = output_format.split("_")
+
+    if input_scale != output_scale and image_size is None:
+        raise ValueError(
+            f"Expected `image_size` to be provided when converting from {input_scale} to {output_scale} coordinates"
+        )
+
+    # type conversion to intermediate "xyxy" format from any input format
+    if input_coords_type == "xywh":
+        xyxy_boxes = _convert_xywh_to_xyxy(boxes)
+    elif input_coords_type == "xcycwh":
+        xyxy_boxes = _convert_xcycwh_to_xyxy(boxes)
+    else:
+        xyxy_boxes = boxes
+
+    # here we can go with some basic validation for "xyxy" format
+    if check is not None and input_scale == "relative":
+        check_relative_boxes_xyxy(xyxy_boxes, check)
+    elif check is not None and input_scale == "absolute":
+        check_absolute_boxes_xyxy(xyxy_boxes, check)
+
+    # type conversion from intermediate "xyxy" to any output format
+    if output_coords_type == "xywh":
+        converted_boxes = _convert_xyxy_to_xywh(xyxy_boxes)
+    elif output_coords_type == "xcycwh":
+        converted_boxes = _convert_xyxy_to_xcycwh(xyxy_boxes)
+    else:
+        converted_boxes = xyxy_boxes
+
+    # scale conversion (relative -> absolute or absolute -> relative)
+    if input_scale == "relative" and output_scale == "absolute":
+        converted_boxes = _convert_relative_to_absolute(converted_boxes, image_size)
+    elif input_scale == "absolute" and output_scale == "relative":
+        converted_boxes = _convert_absolute_to_relative(converted_boxes, image_size)
+
+    return converted_boxes
+
+
+def _convert_boxes_recursively(
+    boxes: ArrayType | List | Tuple,
+    input_format: str,
+    output_format: str,
+    image_size: Optional[ArrayType | List] = None,
+    check: Optional[str] = "warn",
+):
+    depth = get_depth_of_nested_objects(boxes)
+
+    # check for "empty" boxes/images
+    if len(boxes) == 0:
+        return boxes
+    elif is_array_type(boxes) and _shape(boxes)[-1] == 0:
+        return boxes
+
+    # check for unsupported depths
+    if depth > 3:
+        raise ValueError(
+            f"Expected boxes to have at most 3 dimensions (n_images, n_boxes, coords), got {depth} dimensions."
+        )
+
+    # check image size is provided correctly
+    if depth == 3 and image_size is not None:
+        image_depth = get_depth_of_nested_objects(image_size)
+        if image_depth == 1:
+            raise ValueError(f"Expected get list of image_sizes but get a single image size: {image_size}.")
+        elif len(image_size) != len(boxes):
+            raise ValueError(
+                f"Expected the same number of images and image sizes, got {len(boxes)} images and {len(image_size)} image sizes."
+            )
+    if depth < 3 and image_size is not None and len(image_size) != 2:
+        raise ValueError(f"Expected image_size to have 2 elements (height, width), got {len(image_size)} elements.")
+
+    # check box has enough coordinates
+    if depth == 1 and len(boxes) < 4:
+        raise ValueError(f"Expected boxes to have at least 4 elements, got {len(boxes)} elements.")
+    if is_array_type(boxes) and _shape(boxes)[-1] < 4:
+        raise ValueError(f"Expected boxes to have at least 4 elements, got {_shape(boxes)[-1]} elements.")
+
+    # Base of recursion.
+    if depth == 2 and is_array_type(boxes):
+        return _convert_boxes_arrays(boxes, input_format, output_format, image_size, check)
+
+    # Recursive approach.
+    elif depth == 1 and isinstance(boxes, (list, tuple) or is_array_type(boxes)):
+        boxes_2d = _expand_on_zero_dim(boxes)
+        return _convert_boxes_recursively(boxes_2d, input_format, output_format, image_size, check)[0]
+
+    elif depth == 2 and isinstance(boxes, (list, tuple)):
+        np_boxes = np.array(boxes)
+        np_converted_boxes = _convert_boxes_recursively(np_boxes, input_format, output_format, image_size, check)
+        converted_boxes = np_converted_boxes.tolist()
+        if isinstance(boxes, tuple):
+            converted_boxes = tuple([tuple(box) for box in converted_boxes])
+        return converted_boxes
+
+    elif depth == 3 and isinstance(boxes, (list, tuple)):
+        image_sizes = image_size if image_size is not None else [None] * len(boxes)
+        return type(boxes)(
+            [_convert_boxes_recursively(b, input_format, output_format, s, check) for b, s in zip(boxes, image_sizes)]
+        )
+
+    elif depth == 3 and is_array_type(boxes):
+        image_sizes = image_size if image_size is not None else [None] * len(boxes)
+        converted_boxes = [
+            _convert_boxes_recursively(b, input_format, output_format, s, check) for b, s in zip(boxes, image_sizes)
+        ]
+        return _stack(converted_boxes, axis=0)
+
+    else:
+        raise ValueError(f"Unsupported type of boxes: {type(boxes)}")
+
+
+def convert_boxes(
+    boxes: ArrayType | List | Tuple,
+    input_format: str,
+    output_format: str,
+    image_size: Optional[ArrayType | List | Tuple] = None,
+    check: Optional[str] = "warn",
+):
+    """
+    Convert boxes from one format to another.
+
+    Supported boxes formats:
+        A single box of shape (B,), where B is 4 or more elements, and the first 4 elements are the
+        coordinates of the box. The box can be represented as
+            - torch.Tensor | np.ndarray | List[float, ...]
+
+        Boxes from one image, a set of boxes (N, B) where N is the number of boxes. The boxes can be represented as
+            - torch.Tensor | np.ndarray | List[List[float, ...]]
+
+        Boxes from multiple images, a set of images with their boxes (I, N, B), where I is number of images.
+        May be represented as a single 3d array/tensor or most likely as a list of arrays/tensors
+            - torch.Tensor | np.ndarray | List[torch.Tensor | np.ndarray] | List[List[List[float, ...]]]
+
+    Supported input/output bounding box formats:
+        - `absolute_xyxy` (aliases: `pascal_voc`, `xyxy`): [x_min, y_min, x_max, y_max]
+        - `absolute_xywh` (aliases: `coco`, `xywh`): [x_min, y_min, width, height]
+        - `absolute_xcycwh`: [center_x, center_y, width, height]
+        - `relative_xyxy` (aliases: `albumentations`): [x_min, y_min, x_max, y_max] normalized to [0, 1] by image size
+        - `relative_xywh`: [x_min, y_min, width, height] normalized to [0, 1] by image size
+        - `relative_xcycwh` (aliases: `yolo`, `xcycwh`): [center_x, center_y, width, height] normalized to [0, 1] by image size
+
+    Args:
+        boxes: A single box / boxes from one image / boxes from multiple images
+        input_format: format of the input boxes
+        output_format: format of the output boxes
+        image_size: (height, width) of the image if boxes are from one image, or list of (height, width) for each image
+        check: warn/raise/None
+
+    Returns:
+        boxes: Boxes converted to output format with the same shape and data type as the input boxes
+    """
+
+    validate_box_format(input_format)
+    validate_box_format(output_format)
+
+    # map to standard format: relative/absolute + xyxy/xywh/xcycwh
+    input_format = map_box_format(input_format)
+    output_format = map_box_format(output_format)
+
+    if not (is_array_type(boxes) or isinstance(boxes, (list, tuple))):
+        raise ValueError(f"Unsupported type of boxes: {type(boxes)}")
+
+    return _convert_boxes_recursively(boxes, input_format, output_format, image_size, check)

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -555,65 +555,6 @@ def center_to_corners_format(bboxes_center: TensorType) -> TensorType:
     raise ValueError(f"Unsupported input type {type(bboxes_center)}")
 
 
-def _corners_to_center_format_torch(bboxes_corners: "torch.Tensor") -> "torch.Tensor":
-    top_left_x, top_left_y, bottom_right_x, bottom_right_y = bboxes_corners.unbind(-1)
-    b = [
-        (top_left_x + bottom_right_x) / 2,  # center x
-        (top_left_y + bottom_right_y) / 2,  # center y
-        (bottom_right_x - top_left_x),  # width
-        (bottom_right_y - top_left_y),  # height
-    ]
-    return torch.stack(b, dim=-1)
-
-
-def _corners_to_center_format_numpy(bboxes_corners: np.ndarray) -> np.ndarray:
-    top_left_x, top_left_y, bottom_right_x, bottom_right_y = bboxes_corners.T
-    bboxes_center = np.stack(
-        [
-            (top_left_x + bottom_right_x) / 2,  # center x
-            (top_left_y + bottom_right_y) / 2,  # center y
-            (bottom_right_x - top_left_x),  # width
-            (bottom_right_y - top_left_y),  # height
-        ],
-        axis=-1,
-    )
-    return bboxes_center
-
-
-def _corners_to_center_format_tf(bboxes_corners: "tf.Tensor") -> "tf.Tensor":
-    top_left_x, top_left_y, bottom_right_x, bottom_right_y = tf.unstack(bboxes_corners, axis=-1)
-    bboxes_center = tf.stack(
-        [
-            (top_left_x + bottom_right_x) / 2,  # center x
-            (top_left_y + bottom_right_y) / 2,  # center y
-            (bottom_right_x - top_left_x),  # width
-            (bottom_right_y - top_left_y),  # height
-        ],
-        axis=-1,
-    )
-    return bboxes_center
-
-
-def corners_to_center_format(bboxes_corners: TensorType) -> TensorType:
-    """
-    Converts bounding boxes from corners format to center format.
-
-    corners format: contains the coordinates for the top-left and bottom-right corners of the box
-        (top_left_x, top_left_y, bottom_right_x, bottom_right_y)
-    center format: contains the coordinate for the center of the box and its the width, height dimensions
-        (center_x, center_y, width, height)
-    """
-    # Inverse function accepts different input types so implemented here too
-    if is_torch_tensor(bboxes_corners):
-        return _corners_to_center_format_torch(bboxes_corners)
-    elif isinstance(bboxes_corners, np.ndarray):
-        return _corners_to_center_format_numpy(bboxes_corners)
-    elif is_tf_tensor(bboxes_corners):
-        return _corners_to_center_format_tf(bboxes_corners)
-
-    raise ValueError(f"Unsupported input type {type(bboxes_corners)}")
-
-
 # 2 functions below copied from https://github.com/cocodataset/panopticapi/blob/master/panopticapi/utils.py
 # Copyright (c) 2018, Alexander Kirillov
 # All rights reserved.

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -484,7 +484,7 @@ def post_process_panoptic_sample(
         masks (`torch.Tensor`):
             The predicted segmentation masks for this sample.
         boxes (`torch.Tensor`):
-            The prediced bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
+            The predicted bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
             width, height)` and values between `[0, 1]`, relative to the size the image (disregarding padding).
         processed_size (`Tuple[int, int]`):
             The processed size of the image `(height, width)`, as returned by the preprocessing step i.e. the size
@@ -503,11 +503,6 @@ def post_process_panoptic_sample(
 
     cur_scores = scores[keep]
     cur_classes = labels[keep]
-    cur_boxes = center_to_corners_format(boxes[keep])
-
-    if len(cur_boxes) != len(cur_classes):
-        raise ValueError("Not as many boxes as there are classes")
-
     cur_masks = masks[keep]
     cur_masks = resize(cur_masks[:, None], processed_size, resample=PILImageResampling.BILINEAR)
     cur_masks = safe_squeeze(cur_masks, 1)

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -26,7 +26,6 @@ from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    corners_to_center_format,
     id_to_rgb,
     pad,
     rescale,
@@ -188,17 +187,16 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 
 # Copied from transformers.models.detr.image_processing_detr.normalize_annotation
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
-    image_height, image_width = image_size
-    norm_annotation = {}
-    for key, value in annotation.items():
-        if key == "boxes":
-            boxes = value
-            boxes = corners_to_center_format(boxes)
-            boxes /= np.asarray([image_width, image_height, image_width, image_height], dtype=np.float32)
-            norm_annotation[key] = boxes
-        else:
-            norm_annotation[key] = value
-    return norm_annotation
+    """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
+    if "boxes" in annotation:
+        annotation = dict(**annotation)  # shallow copy
+        annotation["boxes"] = convert_boxes(
+            annotation["boxes"],
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_size,
+        )
+    return annotation
 
 
 # Copied from transformers.models.detr.image_processing_detr.max_across_indices

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -189,7 +189,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -22,10 +22,10 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Un
 import numpy as np
 
 from ...feature_extraction_utils import BatchFeature
+from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    center_to_corners_format,
     corners_to_center_format,
     id_to_rgb,
     pad,
@@ -1478,13 +1478,11 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         scores = topk_values
         topk_boxes = torch.div(topk_indexes, out_logits.shape[2], rounding_mode="floor")
         labels = topk_indexes % out_logits.shape[2]
-        boxes = center_to_corners_format(out_bbox)
-        boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
+        boxes = torch.gather(out_bbox, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
 
-        # and from relative [0, 1] to absolute [0, height] coordinates
-        img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1)
-        boxes = boxes * scale_fct[:, None, :]
+        boxes = convert_boxes(
+            boxes, input_format="relative_xcycwh", output_format="absolute_xyxy", image_size=target_sizes
+        )
 
         results = [{"scores": s, "labels": l, "boxes": b} for s, l, b in zip(scores, labels, boxes)]
 
@@ -1492,7 +1490,12 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
 
     # Copied from transformers.models.deformable_detr.image_processing_deformable_detr.DeformableDetrImageProcessor.post_process_object_detection with DeformableDetr->ConditionalDetr
     def post_process_object_detection(
-        self, outputs, threshold: float = 0.5, target_sizes: Union[TensorType, List[Tuple]] = None, top_k: int = 100
+        self,
+        outputs,
+        threshold: float = 0.5,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        top_k: int = 100,
+        output_bbox_format: Optional[str] = None,
     ):
         """
         Converts the raw output of [`ConditionalDetrForObjectDetection`] into final bounding boxes in (top_left_x,
@@ -1508,6 +1511,10 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
                 (height, width) of each image in the batch. If left to None, predictions will not be resized.
             top_k (`int`, *optional*, defaults to 100):
                 Keep only top k bounding boxes before filtering by thresholding.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
 
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
@@ -1521,26 +1528,25 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
 
+        if output_bbox_format is None:
+            output_bbox_format = "absolute_xyxy" if target_sizes is not None else "relative_xyxy"
+
+        # Post process labels and scores
         prob = out_logits.sigmoid()
         prob = prob.view(out_logits.shape[0], -1)
         k_value = min(top_k, prob.size(1))
         topk_values, topk_indexes = torch.topk(prob, k_value, dim=1)
         scores = topk_values
-        topk_boxes = torch.div(topk_indexes, out_logits.shape[2], rounding_mode="floor")
         labels = topk_indexes % out_logits.shape[2]
-        boxes = center_to_corners_format(out_bbox)
-        boxes = torch.gather(boxes, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
 
-        # and from relative [0, 1] to absolute [0, height] coordinates
-        if target_sizes is not None:
-            if isinstance(target_sizes, List):
-                img_h = torch.Tensor([i[0] for i in target_sizes])
-                img_w = torch.Tensor([i[1] for i in target_sizes])
-            else:
-                img_h, img_w = target_sizes.unbind(1)
-            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
-            boxes = boxes * scale_fct[:, None, :]
+        # Post process boxes
+        topk_boxes = torch.div(topk_indexes, out_logits.shape[2], rounding_mode="floor")
+        boxes = torch.gather(out_bbox, 1, topk_boxes.unsqueeze(-1).repeat(1, 1, 4))
+        boxes = convert_boxes(
+            boxes, input_format="relative_xcycwh", output_format=output_bbox_format, image_size=target_sizes
+        )
 
+        # Filter out low confidence boxes
         results = []
         for s, l, b in zip(scores, labels, boxes):
             score = s[s > threshold]

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -187,7 +187,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -482,7 +482,7 @@ def post_process_panoptic_sample(
         masks (`torch.Tensor`):
             The predicted segmentation masks for this sample.
         boxes (`torch.Tensor`):
-            The prediced bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
+            The predicted bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
             width, height)` and values between `[0, 1]`, relative to the size the image (disregarding padding).
         processed_size (`Tuple[int, int]`):
             The processed size of the image `(height, width)`, as returned by the preprocessing step i.e. the size
@@ -501,11 +501,6 @@ def post_process_panoptic_sample(
 
     cur_scores = scores[keep]
     cur_classes = labels[keep]
-    cur_boxes = center_to_corners_format(boxes[keep])
-
-    if len(cur_boxes) != len(cur_classes):
-        raise ValueError("Not as many boxes as there are classes")
-
     cur_masks = masks[keep]
     cur_masks = resize(cur_masks[:, None], processed_size, resample=PILImageResampling.BILINEAR)
     cur_masks = safe_squeeze(cur_masks, 1)

--- a/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/image_processing_deformable_detr.py
@@ -26,7 +26,6 @@ from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    corners_to_center_format,
     id_to_rgb,
     pad,
     rescale,
@@ -186,17 +185,16 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 
 # Copied from transformers.models.detr.image_processing_detr.normalize_annotation
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
-    image_height, image_width = image_size
-    norm_annotation = {}
-    for key, value in annotation.items():
-        if key == "boxes":
-            boxes = value
-            boxes = corners_to_center_format(boxes)
-            boxes /= np.asarray([image_width, image_height, image_width, image_height], dtype=np.float32)
-            norm_annotation[key] = boxes
-        else:
-            norm_annotation[key] = value
-    return norm_annotation
+    """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
+    if "boxes" in annotation:
+        annotation = dict(**annotation)  # shallow copy
+        annotation["boxes"] = convert_boxes(
+            annotation["boxes"],
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_size,
+        )
+    return annotation
 
 
 # Copied from transformers.models.detr.image_processing_detr.max_across_indices

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -181,7 +181,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/deta/image_processing_deta.py
+++ b/src/transformers/models/deta/image_processing_deta.py
@@ -24,7 +24,6 @@ from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    corners_to_center_format,
     pad,
     rescale,
     resize,
@@ -180,17 +179,16 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 
 # Copied from transformers.models.detr.image_processing_detr.normalize_annotation
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
-    image_height, image_width = image_size
-    norm_annotation = {}
-    for key, value in annotation.items():
-        if key == "boxes":
-            boxes = value
-            boxes = corners_to_center_format(boxes)
-            boxes /= np.asarray([image_width, image_height, image_width, image_height], dtype=np.float32)
-            norm_annotation[key] = boxes
-        else:
-            norm_annotation[key] = value
-    return norm_annotation
+    """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
+    if "boxes" in annotation:
+        annotation = dict(**annotation)  # shallow copy
+        annotation["boxes"] = convert_boxes(
+            annotation["boxes"],
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_size,
+        )
+    return annotation
 
 
 # Copied from transformers.models.detr.image_processing_detr.max_across_indices

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -25,7 +25,6 @@ from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    corners_to_center_format,
     id_to_rgb,
     pad,
     rescale,
@@ -182,17 +181,16 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 
 
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
-    image_height, image_width = image_size
-    norm_annotation = {}
-    for key, value in annotation.items():
-        if key == "boxes":
-            boxes = value
-            boxes = corners_to_center_format(boxes)
-            boxes /= np.asarray([image_width, image_height, image_width, image_height], dtype=np.float32)
-            norm_annotation[key] = boxes
-        else:
-            norm_annotation[key] = value
-    return norm_annotation
+    """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
+    if "boxes" in annotation:
+        annotation = dict(**annotation)  # shallow copy
+        annotation["boxes"] = convert_boxes(
+            annotation["boxes"],
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_size,
+        )
+    return annotation
 
 
 # Copied from transformers.models.vilt.image_processing_vilt.max_across_indices

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -183,7 +183,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
@@ -489,7 +489,7 @@ def post_process_panoptic_sample(
         masks (`torch.Tensor`):
             The predicted segmentation masks for this sample.
         boxes (`torch.Tensor`):
-            The prediced bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
+            The predicted bounding boxes for this sample. The boxes are in the normalized format `(center_x, center_y,
             width, height)` and values between `[0, 1]`, relative to the size the image (disregarding padding).
         processed_size (`Tuple[int, int]`):
             The processed size of the image `(height, width)`, as returned by the preprocessing step i.e. the size
@@ -508,11 +508,6 @@ def post_process_panoptic_sample(
 
     cur_scores = scores[keep]
     cur_classes = labels[keep]
-    cur_boxes = center_to_corners_format(boxes[keep])
-
-    if len(cur_boxes) != len(cur_classes):
-        raise ValueError("Not as many boxes as there are classes")
-
     cur_masks = masks[keep]
     cur_masks = resize(cur_masks[:, None], processed_size, resample=PILImageResampling.BILINEAR)
     cur_masks = safe_squeeze(cur_masks, 1)

--- a/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
@@ -194,7 +194,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/image_processing_grounding_dino.py
@@ -26,7 +26,6 @@ from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    corners_to_center_format,
     id_to_rgb,
     pad,
     rescale,
@@ -193,17 +192,16 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 
 # Copied from transformers.models.detr.image_processing_detr.normalize_annotation
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
-    image_height, image_width = image_size
-    norm_annotation = {}
-    for key, value in annotation.items():
-        if key == "boxes":
-            boxes = value
-            boxes = corners_to_center_format(boxes)
-            boxes /= np.asarray([image_width, image_height, image_width, image_height], dtype=np.float32)
-            norm_annotation[key] = boxes
-        else:
-            norm_annotation[key] = value
-    return norm_annotation
+    """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
+    if "boxes" in annotation:
+        annotation = dict(**annotation)  # shallow copy
+        annotation["boxes"] = convert_boxes(
+            annotation["boxes"],
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_size,
+        )
+    return annotation
 
 
 # Copied from transformers.models.detr.image_processing_detr.max_across_indices

--- a/src/transformers/models/owlv2/image_processing_owlv2.py
+++ b/src/transformers/models/owlv2/image_processing_owlv2.py
@@ -525,11 +525,13 @@ class Owlv2ImageProcessor(BaseImageProcessor):
 
         # Post process boxes
         boxes = convert_boxes(
-            boxes, input_format="relative_xcycwh", output_format="relative_xyxy",
+            boxes,
+            input_format="relative_xcycwh",
+            output_format="relative_xyxy",
         )
 
         # Convert from relative [0, 1] to absolute [0, height] coordinates
-        # We do not convert it directly, because it includes some coordinates 
+        # We do not convert it directly, because it includes some coordinates
         # rescaling because of padding area
         # TODO: (Pavel) figure out how to simplify this postprocessing
         if target_sizes is not None:

--- a/src/transformers/models/owlv2/image_processing_owlv2.py
+++ b/src/transformers/models/owlv2/image_processing_owlv2.py
@@ -19,9 +19,9 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
+from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, BatchFeature
 from ...image_transforms import (
-    center_to_corners_format,
     pad,
     to_channel_dimension_format,
 )
@@ -482,7 +482,11 @@ class Owlv2ImageProcessor(BaseImageProcessor):
         return BatchFeature(data=data, tensor_type=return_tensors)
 
     def post_process_object_detection(
-        self, outputs, threshold: float = 0.1, target_sizes: Union[TensorType, List[Tuple]] = None
+        self,
+        outputs,
+        threshold: float = 0.1,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        output_bbox_format: Optional[str] = None,
     ):
         """
         Converts the raw output of [`OwlViTForObjectDetection`] into final bounding boxes in (top_left_x, top_left_y,
@@ -496,6 +500,11 @@ class Owlv2ImageProcessor(BaseImageProcessor):
             target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
                 Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
                 `(height, width)` of each image in the batch. If unset, predictions will not be resized.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
+
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
             in the batch as predicted by the model.
@@ -509,20 +518,24 @@ class Owlv2ImageProcessor(BaseImageProcessor):
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
 
+        # Post process labels and scores
         probs = torch.max(logits, dim=-1)
         scores = torch.sigmoid(probs.values)
         labels = probs.indices
 
-        # Convert to [x0, y0, x1, y1] format
-        boxes = center_to_corners_format(boxes)
+        # Post process boxes
+        boxes = convert_boxes(
+            boxes, input_format="relative_xcycwh", output_format="relative_xyxy",
+        )
 
         # Convert from relative [0, 1] to absolute [0, height] coordinates
+        # We do not convert it directly, because it includes some coordinates 
+        # rescaling because of padding area
+        # TODO: (Pavel) figure out how to simplify this postprocessing
         if target_sizes is not None:
             if isinstance(target_sizes, List):
-                img_h = torch.Tensor([i[0] for i in target_sizes])
-                img_w = torch.Tensor([i[1] for i in target_sizes])
-            else:
-                img_h, img_w = target_sizes.unbind(1)
+                target_sizes = torch.tensor(target_sizes)
+            img_h, img_w = target_sizes.unbind(1)
 
             # rescale coordinates
             width_ratio = 1
@@ -539,6 +552,7 @@ class Owlv2ImageProcessor(BaseImageProcessor):
             scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
             boxes = boxes * scale_fct[:, None, :]
 
+        # Filter out low confidence boxes
         results = []
         for s, l, b in zip(scores, labels, boxes):
             score = s[s > threshold]
@@ -549,7 +563,14 @@ class Owlv2ImageProcessor(BaseImageProcessor):
         return results
 
     # Copied from transformers.models.owlvit.image_processing_owlvit.OwlViTImageProcessor.post_process_image_guided_detection
-    def post_process_image_guided_detection(self, outputs, threshold=0.0, nms_threshold=0.3, target_sizes=None):
+    def post_process_image_guided_detection(
+        self,
+        outputs,
+        threshold: float = 0.0,
+        nms_threshold: float = 0.3,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        output_bbox_format: Optional[str] = None,
+    ):
         """
         Converts the output of [`OwlViTForObjectDetection.image_guided_detection`] into the format expected by the COCO
         api.
@@ -565,6 +586,10 @@ class Owlv2ImageProcessor(BaseImageProcessor):
                 Tensor of shape (batch_size, 2) where each entry is the (height, width) of the corresponding image in
                 the batch. If set, predicted normalized bounding boxes are rescaled to the target sizes. If left to
                 None, predictions will not be unnormalized.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
 
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
@@ -578,11 +603,17 @@ class Owlv2ImageProcessor(BaseImageProcessor):
         if target_sizes.shape[1] != 2:
             raise ValueError("Each element of target_sizes must contain the size (h, w) of each image of the batch")
 
+        if output_bbox_format is None:
+            output_bbox_format = "absolute_xyxy" if target_sizes is not None else "relative_xyxy"
+
+        # Post process labels and scores
         probs = torch.max(logits, dim=-1)
         scores = torch.sigmoid(probs.values)
 
-        # Convert to [x0, y0, x1, y1] format
-        target_boxes = center_to_corners_format(target_boxes)
+        # Post process boxes
+        target_boxes = convert_boxes(
+            target_boxes, input_format="relative_xcycwh", output_format=output_bbox_format, image_size=target_sizes
+        )
 
         # Apply non-maximum suppression (NMS)
         if nms_threshold < 1.0:
@@ -594,11 +625,6 @@ class Owlv2ImageProcessor(BaseImageProcessor):
                     ious = box_iou(target_boxes[idx][i, :].unsqueeze(0), target_boxes[idx])[0][0]
                     ious[i] = -1.0  # Mask self-IoU.
                     scores[idx][ious > nms_threshold] = 0.0
-
-        # Convert from relative [0, 1] to absolute [0, height] coordinates
-        img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(target_boxes.device)
-        target_boxes = target_boxes * scale_fct[:, None, :]
 
         # Compute box display alphas based on prediction scores
         results = []

--- a/src/transformers/models/owlvit/image_processing_owlvit.py
+++ b/src/transformers/models/owlvit/image_processing_owlvit.py
@@ -19,10 +19,10 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
+from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import (
     center_crop,
-    center_to_corners_format,
     rescale,
     resize,
     to_channel_dimension_format,
@@ -464,20 +464,20 @@ class OwlViTImageProcessor(BaseImageProcessor):
         scores = torch.sigmoid(probs.values)
         labels = probs.indices
 
-        # Convert to [x0, y0, x1, y1] format
-        boxes = center_to_corners_format(boxes)
-
-        # Convert from relative [0, 1] to absolute [0, height] coordinates
-        img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
-        boxes = boxes * scale_fct[:, None, :]
+        boxes = convert_boxes(
+            boxes, input_format="relative_xcycwh", output_format="absolute_xyxy", image_size=target_sizes
+        )
 
         results = [{"scores": s, "labels": l, "boxes": b} for s, l, b in zip(scores, labels, boxes)]
 
         return results
 
     def post_process_object_detection(
-        self, outputs, threshold: float = 0.1, target_sizes: Union[TensorType, List[Tuple]] = None
+        self,
+        outputs,
+        threshold: float = 0.1,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        output_bbox_format: Optional[str] = None,
     ):
         """
         Converts the raw output of [`OwlViTForObjectDetection`] into final bounding boxes in (top_left_x, top_left_y,
@@ -491,6 +491,11 @@ class OwlViTImageProcessor(BaseImageProcessor):
             target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
                 Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
                 `(height, width)` of each image in the batch. If unset, predictions will not be resized.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
+
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
             in the batch as predicted by the model.
@@ -504,24 +509,20 @@ class OwlViTImageProcessor(BaseImageProcessor):
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
 
+        if output_bbox_format is None:
+            output_bbox_format = "absolute_xyxy" if target_sizes is not None else "relative_xyxy"
+
+        # Post process labels and scores
         probs = torch.max(logits, dim=-1)
         scores = torch.sigmoid(probs.values)
         labels = probs.indices
 
-        # Convert to [x0, y0, x1, y1] format
-        boxes = center_to_corners_format(boxes)
+        # Post process boxes
+        boxes = convert_boxes(
+            boxes, input_format="relative_xcycwh", output_format=output_bbox_format, image_size=target_sizes
+        )
 
-        # Convert from relative [0, 1] to absolute [0, height] coordinates
-        if target_sizes is not None:
-            if isinstance(target_sizes, List):
-                img_h = torch.Tensor([i[0] for i in target_sizes])
-                img_w = torch.Tensor([i[1] for i in target_sizes])
-            else:
-                img_h, img_w = target_sizes.unbind(1)
-
-            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
-            boxes = boxes * scale_fct[:, None, :]
-
+        # Filter out low confidence boxes
         results = []
         for s, l, b in zip(scores, labels, boxes):
             score = s[s > threshold]
@@ -532,7 +533,14 @@ class OwlViTImageProcessor(BaseImageProcessor):
         return results
 
     # TODO: (Amy) Make compatible with other frameworks
-    def post_process_image_guided_detection(self, outputs, threshold=0.0, nms_threshold=0.3, target_sizes=None):
+    def post_process_image_guided_detection(
+        self,
+        outputs,
+        threshold: float = 0.0,
+        nms_threshold: float = 0.3,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        output_bbox_format: Optional[str] = None,
+    ):
         """
         Converts the output of [`OwlViTForObjectDetection.image_guided_detection`] into the format expected by the COCO
         api.
@@ -548,6 +556,10 @@ class OwlViTImageProcessor(BaseImageProcessor):
                 Tensor of shape (batch_size, 2) where each entry is the (height, width) of the corresponding image in
                 the batch. If set, predicted normalized bounding boxes are rescaled to the target sizes. If left to
                 None, predictions will not be unnormalized.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
 
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
@@ -561,11 +573,17 @@ class OwlViTImageProcessor(BaseImageProcessor):
         if target_sizes.shape[1] != 2:
             raise ValueError("Each element of target_sizes must contain the size (h, w) of each image of the batch")
 
+        if output_bbox_format is None:
+            output_bbox_format = "absolute_xyxy" if target_sizes is not None else "relative_xyxy"
+
+        # Post process labels and scores
         probs = torch.max(logits, dim=-1)
         scores = torch.sigmoid(probs.values)
 
-        # Convert to [x0, y0, x1, y1] format
-        target_boxes = center_to_corners_format(target_boxes)
+        # Post process boxes
+        target_boxes = convert_boxes(
+            target_boxes, input_format="relative_xcycwh", output_format=output_bbox_format, image_size=target_sizes
+        )
 
         # Apply non-maximum suppression (NMS)
         if nms_threshold < 1.0:
@@ -577,11 +595,6 @@ class OwlViTImageProcessor(BaseImageProcessor):
                     ious = box_iou(target_boxes[idx][i, :].unsqueeze(0), target_boxes[idx])[0][0]
                     ious[i] = -1.0  # Mask self-IoU.
                     scores[idx][ious > nms_threshold] = 0.0
-
-        # Convert from relative [0, 1] to absolute [0, height] coordinates
-        img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(target_boxes.device)
-        target_boxes = target_boxes * scale_fct[:, None, :]
 
         # Compute box display alphas based on prediction scores
         results = []

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -204,7 +204,7 @@ def safe_squeeze(arr: np.ndarray, axis: Optional[int] = None) -> np.ndarray:
 def normalize_annotation(annotation: Dict, image_size: Tuple[int, int]) -> Dict:
     """Convert annotation boxes from absolute xyxy (pascal voc) to relative xcycwh (yolo) format."""
     if "boxes" in annotation:
-        annotation = dict(**annotation)  # shallow copy
+        annotation = annotation.copy()  # shallow copy
         annotation["boxes"] = convert_boxes(
             annotation["boxes"],
             input_format="absolute_xyxy",

--- a/src/transformers/models/yolos/image_processing_yolos.py
+++ b/src/transformers/models/yolos/image_processing_yolos.py
@@ -20,10 +20,10 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Un
 import numpy as np
 
 from ...feature_extraction_utils import BatchFeature
+from ...image_box_utils import convert_boxes
 from ...image_processing_utils import BaseImageProcessor, get_size_dict
 from ...image_transforms import (
     PaddingMode,
-    center_to_corners_format,
     corners_to_center_format,
     id_to_rgb,
     pad,
@@ -1382,19 +1382,20 @@ class YolosImageProcessor(BaseImageProcessor):
         prob = nn.functional.softmax(out_logits, -1)
         scores, labels = prob[..., :-1].max(-1)
 
-        # convert to [x0, y0, x1, y1] format
-        boxes = center_to_corners_format(out_bbox)
-        # and from relative [0, 1] to absolute [0, height] coordinates
-        img_h, img_w = target_sizes.unbind(1)
-        scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
-        boxes = boxes * scale_fct[:, None, :]
+        boxes = convert_boxes(
+            out_bbox, input_format="relative_xcycwh", output_format="absolute_xyxy", image_size=target_sizes
+        )
 
         results = [{"scores": s, "labels": l, "boxes": b} for s, l, b in zip(scores, labels, boxes)]
         return results
 
     # Copied from transformers.models.detr.image_processing_detr.DetrImageProcessor.post_process_object_detection with Detr->Yolos
     def post_process_object_detection(
-        self, outputs, threshold: float = 0.5, target_sizes: Union[TensorType, List[Tuple]] = None
+        self,
+        outputs,
+        threshold: float = 0.5,
+        target_sizes: Union[TensorType, List[Tuple]] = None,
+        output_bbox_format: Optional[str] = None,
     ):
         """
         Converts the raw output of [`YolosForObjectDetection`] into final bounding boxes in (top_left_x, top_left_y,
@@ -1408,6 +1409,11 @@ class YolosImageProcessor(BaseImageProcessor):
             target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
                 Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
                 `(height, width)` of each image in the batch. If unset, predictions will not be resized.
+            output_bbox_format (`str`, *optional*, defaults to None):
+                The format of the output bounding boxes. If left to None, the format will be set to `"absolute_xyxy"`
+                if `target_sizes` is provided, else it will be set to `"relative_xyxy"`. See [`convert_boxes`] for
+                supported formats.
+
         Returns:
             `List[Dict]`: A list of dictionaries, each dictionary containing the scores, labels and boxes for an image
             in the batch as predicted by the model.
@@ -1420,23 +1426,19 @@ class YolosImageProcessor(BaseImageProcessor):
                     "Make sure that you pass in as many target sizes as the batch dimension of the logits"
                 )
 
+        if output_bbox_format is None:
+            output_bbox_format = "absolute_xyxy" if target_sizes is not None else "relative_xyxy"
+
+        # Post process labels and scores
         prob = nn.functional.softmax(out_logits, -1)
         scores, labels = prob[..., :-1].max(-1)
 
-        # Convert to [x0, y0, x1, y1] format
-        boxes = center_to_corners_format(out_bbox)
+        # Post process boxes
+        boxes = convert_boxes(
+            out_bbox, input_format="relative_xcycwh", output_format=output_bbox_format, image_size=target_sizes
+        )
 
-        # Convert from relative [0, 1] to absolute [0, height] coordinates
-        if target_sizes is not None:
-            if isinstance(target_sizes, List):
-                img_h = torch.Tensor([i[0] for i in target_sizes])
-                img_w = torch.Tensor([i[1] for i in target_sizes])
-            else:
-                img_h, img_w = target_sizes.unbind(1)
-
-            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
-            boxes = boxes * scale_fct[:, None, :]
-
+        # Filter out low confidence boxes
         results = []
         for s, l, b in zip(scores, labels, boxes):
             score = s[s > threshold]

--- a/tests/models/owlv2/test_image_processor_owlv2.py
+++ b/tests/models/owlv2/test_image_processor_owlv2.py
@@ -145,7 +145,9 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
                 [6.753320693969727, 51.96149826049805, 326.61810302734375, 473.12982177734375],
             ]
         )
-        self.assertTrue(torch.allclose(boxes, expected, atol=1e-3), f"max diff: {torch.abs(boxes - expected).max().item()}")
+        self.assertTrue(
+            torch.allclose(boxes, expected, atol=1e-3), f"max diff: {torch.abs(boxes - expected).max().item()}"
+        )
 
     @unittest.skip("OWLv2 doesn't treat 4 channel PIL and numpy consistently yet")  # FIXME Amy
     def test_call_numpy_4_channels(self):

--- a/tests/models/owlv2/test_image_processor_owlv2.py
+++ b/tests/models/owlv2/test_image_processor_owlv2.py
@@ -138,9 +138,14 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         target_sizes = torch.tensor([image.size[::-1]])
         results = processor.post_process_object_detection(outputs, threshold=0.2, target_sizes=target_sizes)[0]
 
-        boxes = results["boxes"].tolist()
-        self.assertEqual(boxes[0], [341.66656494140625, 23.38756561279297, 642.321044921875, 371.3482971191406])
-        self.assertEqual(boxes[1], [6.753320693969727, 51.96149826049805, 326.61810302734375, 473.12982177734375])
+        boxes = torch.tensor(results["boxes"])
+        expected = torch.tensor(
+            [
+                [341.66656494140625, 23.38756561279297, 642.321044921875, 371.3482971191406],
+                [6.753320693969727, 51.96149826049805, 326.61810302734375, 473.12982177734375],
+            ]
+        )
+        self.assertTrue(torch.allclose(boxes, expected, atol=1e-3), f"max diff: {torch.abs(boxes - expected).max().item()}")
 
     @unittest.skip("OWLv2 doesn't treat 4 channel PIL and numpy consistently yet")  # FIXME Amy
     def test_call_numpy_4_channels(self):

--- a/tests/test_image_box_utils.py
+++ b/tests/test_image_box_utils.py
@@ -1,0 +1,408 @@
+# coding=utf-8
+# Copyright 2023 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+from itertools import product
+
+import numpy as np
+from parameterized import parameterized
+
+import transformers.image_box_utils as image_box_utils
+from transformers import is_torch_available
+from transformers.testing_utils import require_torch
+
+
+random.seed(42463)
+
+if is_torch_available():
+    import torch
+
+
+NORMAL_TESTING_CASES = {
+    "image_size": [460, 640],
+    "boxes": {
+        "absolute_xyxy": [
+            [387, 441, 431, 450],
+            [134, 57, 568, 440],
+            [306, 274, 342, 428],
+            [22, 252, 501, 308],
+            [498, 349, 618, 428],
+        ],
+        "absolute_xywh": [
+            [387, 441, 44, 9],
+            [134, 57, 434, 383],
+            [306, 274, 36, 154],
+            [22, 252, 479, 56],
+            [498, 349, 120, 79],
+        ],
+        "absolute_xcycwh": [
+            [409.0, 445.5, 44.0, 9.0],
+            [351.0, 248.5, 434.0, 383.0],
+            [324.0, 351.0, 36.0, 154.0],
+            [261.5, 280.0, 479.0, 56.0],
+            [558.0, 388.5, 120.0, 79.0],
+        ],
+        "relative_xyxy": [
+            [0.6047, 0.9587, 0.6734, 0.9783],
+            [0.2094, 0.1239, 0.8875, 0.9565],
+            [0.4781, 0.5957, 0.5344, 0.9304],
+            [0.0344, 0.5478, 0.7828, 0.6696],
+            [0.7781, 0.7587, 0.9656, 0.9304],
+        ],
+        "relative_xywh": [
+            [0.6047, 0.9587, 0.0688, 0.0196],
+            [0.2094, 0.1239, 0.6781, 0.8326],
+            [0.4781, 0.5957, 0.05625, 0.3348],
+            [0.0344, 0.5478, 0.7484, 0.1217],
+            [0.7781, 0.7587, 0.1875, 0.1717],
+        ],
+        "relative_xcycwh": [
+            [0.6391, 0.9685, 0.0688, 0.0196],
+            [0.5484, 0.5402, 0.6781, 0.8326],
+            [0.5063, 0.7630, 0.0563, 0.3348],
+            [0.4086, 0.6087, 0.7484, 0.1217],
+            [0.8719, 0.8446, 0.1875, 0.1717],
+        ],
+    },
+}
+
+
+OOB_TESTING_CASES = {
+    "image_size": [100, 200],  # height, width
+    "boxes": {
+        "absolute_xyxy": [
+            [-1, 0, 9, 15],  # x_min oob
+            [50, -1, 60, 9],  # y_min oob
+            [190, 0, 200, 10],  # x_max oob
+            [189, 90, 199, 100],  # y_max oob
+        ],
+        "absolute_xywh": [
+            [-1, 0, 10, 15],  # x_min oob
+            [50, -1, 10, 10],  # y_min oob
+            [190, 0, 10, 10],  # x_max oob
+            [189, 90, 10, 10],  # y_max oob
+        ],
+        "absolute_xcycwh": [
+            [4, 7.5, 10, 15],  # x_min oob
+            [55, 4, 10, 10],  # y_min oob
+            [195, 5, 10, 10],  # x_max oob
+            [194, 95, 10, 10],  # y_max oob
+        ],
+    },
+}
+
+
+def rescale_boxes(boxes, boxes_format, src_image_size, dst_image_size):
+    if "relative" in boxes_format:
+        return boxes
+    src_height, src_width = src_image_size
+    dst_height, dst_width = dst_image_size
+    rescaled_boxes = []
+    for x1, y1, x2, y2 in boxes:
+        x1 = (x1 / src_width) * dst_width
+        x2 = (x2 / src_width) * dst_width
+        y1 = (y1 / src_height) * dst_height
+        y2 = (y2 / src_height) * dst_height
+        rescaled_box = [x1, y1, x2, y2]
+        # rescaled_box = [round(x, 4) for x in rescaled_box]
+        rescaled_boxes.append(rescaled_box)
+    return rescaled_boxes
+
+
+def make_3d_cases_from_2d(cases_2d: dict):
+    cases_3d = {
+        "image_size": [],
+        "boxes": {box_format: [] for box_format in cases_2d["boxes"]},
+    }
+
+    n_boxes = len(cases_2d["boxes"]["absolute_xyxy"])
+
+    # we will sample form 2d cases with rescaling
+    for n_samples in range(n_boxes + 1):
+        scale = random.uniform(0.5, 2.0)
+        choices = random.sample(range(n_boxes), n_samples)
+
+        # rescale image size
+        original_image_size = cases_2d["image_size"]
+        new_image_size = [int(dim * scale) for dim in original_image_size]
+        cases_3d["image_size"].append(new_image_size)
+
+        # select and rescale boxes
+        for boxes_format, boxes in cases_2d["boxes"].items():
+            boxes = [boxes[i] for i in choices]
+            rescaled_boxes = rescale_boxes(boxes, boxes_format, original_image_size, new_image_size)
+            cases_3d["boxes"][boxes_format].append(rescaled_boxes)
+
+    return cases_3d
+
+
+@require_torch
+class UtilBoundingBoxConverters(unittest.TestCase):
+    @parameterized.expand(product(NORMAL_TESTING_CASES["boxes"].keys(), repeat=2))
+    def test_normal_cases_1d(self, input_format, output_format):
+        image_size = NORMAL_TESTING_CASES["image_size"]
+        boxes_expected = NORMAL_TESTING_CASES["boxes"][output_format]
+        boxes_input = NORMAL_TESTING_CASES["boxes"][input_format]
+
+        # we will just iterate over 2d cases
+        for box_input, box_expected in zip(boxes_input, boxes_expected):
+            box_converted = image_box_utils.convert_boxes(
+                boxes=box_input, input_format=input_format, output_format=output_format, image_size=image_size
+            )
+
+            box_converted = np.array(box_converted)
+            box_expected = np.array(box_expected)
+
+            tolerance = 1e-4 if "relative" in output_format else 0.05
+            self.assertTrue(np.allclose(box_converted, box_expected, atol=tolerance))
+
+    @parameterized.expand(product(NORMAL_TESTING_CASES["boxes"].keys(), repeat=2))
+    def test_normal_cases_2d(self, input_format, output_format):
+        image_size = NORMAL_TESTING_CASES["image_size"]
+        boxes_expected = NORMAL_TESTING_CASES["boxes"][output_format]
+        boxes_input = NORMAL_TESTING_CASES["boxes"][input_format]
+
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_input, input_format=input_format, output_format=output_format, image_size=image_size
+        )
+
+        boxes_converted = np.array(boxes_converted)
+        boxes_expected = np.array(boxes_expected)
+
+        tolerance = 1e-4 if "relative" in output_format else 0.05
+        self.assertTrue(np.allclose(boxes_converted, boxes_expected, atol=tolerance))
+
+    @parameterized.expand(product(NORMAL_TESTING_CASES["boxes"].keys(), repeat=2))
+    def test_normal_cases_3d(self, input_format, output_format):
+        cases_3d = make_3d_cases_from_2d(NORMAL_TESTING_CASES)
+        image_size = cases_3d["image_size"]
+        boxes_expected = cases_3d["boxes"][output_format]
+        boxes_input = cases_3d["boxes"][input_format]
+
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_input, input_format=input_format, output_format=output_format, image_size=image_size
+        )
+
+        for image_boxes_expected, image_boxes_converted in zip(boxes_expected, boxes_converted):
+            image_boxes_converted = np.array(image_boxes_converted)
+            image_boxes_expected = np.array(image_boxes_expected)
+
+            tolerance = 1e-4 if "relative" in output_format else 0.1
+            self.assertTrue(np.allclose(image_boxes_converted, image_boxes_expected, atol=tolerance))
+
+    @parameterized.expand(product(NORMAL_TESTING_CASES["boxes"].keys(), repeat=2))
+    def test_normal_cases_3d_arrays(self, input_format, output_format):
+        image_size = NORMAL_TESTING_CASES["image_size"]
+        boxes_expected = NORMAL_TESTING_CASES["boxes"][output_format]
+        boxes_input = NORMAL_TESTING_CASES["boxes"][input_format]
+
+        # numpy
+        image_size = np.array([image_size] * 3)
+        boxes_input = np.array([boxes_input] * 3)
+        boxes_expected = np.array([boxes_expected] * 3)
+
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_input, input_format=input_format, output_format=output_format, image_size=image_size
+        )
+
+        tolerance = 1e-4 if "relative" in output_format else 0.1
+        self.assertIsInstance(boxes_converted, np.ndarray)
+        self.assertTrue(np.allclose(boxes_converted, boxes_expected, atol=tolerance))
+
+        # torch
+        boxes_input = torch.tensor(boxes_input).float()
+        boxes_expected = torch.tensor(boxes_expected).float()
+
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_input, input_format=input_format, output_format=output_format, image_size=image_size
+        )
+
+        tolerance = 1e-4 if "relative" in output_format else 0.1
+        self.assertIsInstance(boxes_converted, torch.Tensor)
+        self.assertTrue(torch.allclose(boxes_converted, boxes_expected, atol=tolerance))
+
+    @parameterized.expand(product(OOB_TESTING_CASES["boxes"].keys(), repeat=2))
+    def test_oob_cases(self, input_format, output_format):
+        image_size = OOB_TESTING_CASES["image_size"]
+        boxes_expected = OOB_TESTING_CASES["boxes"][output_format]
+        boxes_input = OOB_TESTING_CASES["boxes"][input_format]
+
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_input, input_format=input_format, output_format=output_format, image_size=image_size
+        )
+
+        boxes_converted = np.array(boxes_converted)
+        boxes_expected = np.array(boxes_expected)
+
+        self.assertTrue(np.allclose(boxes_converted, boxes_expected, atol=1e-4))
+
+    @parameterized.expand(
+        [
+            [[-0.5, 0.1, 0.5, 0.9], "relative_xyxy"],  # negative x_min
+            [[0.5, 0.1, 0.5, 1.1], "relative_xyxy"],  # x_max > 1
+            [[0.1, 0.1, 0.21, 0.21], "relative_xcycwh"],  # xc - width < 0
+            [[0.8, 0.7, 0.21, 0.21], "relative_xywh"],  # xc + width > 1
+            [[0.7, 0.8, 0.21, 0.21], "relative_xywh"],  # yc + height > 1
+            [[0.7, 0.8, -0.1, 0.21], "relative_xywh"],  # negative width
+            [[-5, 0, 10, 10], "absolute_xywh"],  # negative x_min
+            [[0, -5, 10, 10], "absolute_xywh"],  # negative y_min
+            [[20, 20, -10, 10], "absolute_xywh"],  # negative width
+            [[-1, 0, 10, 10], "absolute_xyxy", (100, 100)],  # negative x_min
+            [[10, 0, 9, 10], "absolute_xyxy", (100, 100)],  # x_max < x_min -> negative width
+            # check for upper bound is not implemented for absolute boxes
+        ]
+    )
+    def test_oob_exceptions(self, box, box_format, image_size=(100, 100)):
+        with self.assertRaises(image_box_utils.BoxOutOfBoundsError):
+            image_box_utils.convert_boxes(
+                boxes=box, input_format=box_format, output_format="absolute_xyxy", image_size=image_size, check="raise"
+            )
+
+    @parameterized.expand(
+        [
+            ["tensor", 3],
+            ["tensor", 2],
+            ["array", 3],
+            ["array", 2],
+            ["tuple", 1],
+            ["tuple", 2],
+            ["tuple", 3],
+            ["list", 1],
+            ["list", 2],
+            ["list", 3],
+        ]
+    )
+    def test_different_types_support(self, dtype, from_depth):
+        type_mapping = {
+            "tensor": torch.tensor,
+            "array": np.array,
+            "tuple": tuple,
+            "list": list,
+        }
+        boxes_absolute_xyxy = [
+            [
+                [10, 20, 30, 40],
+                [20, 30, 40, 50],
+            ],
+            [
+                [30, 40, 50, 60],
+            ],
+            [
+                # image with no boxes
+            ],
+        ]
+        image_sizes = [(100, 100), (200, 200), (300, 300)]
+
+        def convert_to_dtype(data, to_dtype, depth):
+            if depth == 1:
+                return to_dtype(data)
+            return [convert_to_dtype(d, to_dtype, depth - 1) for d in data]
+
+        to_dtype = type_mapping[dtype]
+        boxes_original = convert_to_dtype(boxes_absolute_xyxy, to_dtype, from_depth)
+
+        # make two conversions
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_original,
+            input_format="absolute_xyxy",
+            output_format="relative_xcycwh",
+            image_size=image_sizes,
+        )
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_converted,
+            input_format="relative_xcycwh",
+            output_format="absolute_xyxy",
+            image_size=image_sizes,
+        )
+
+        # check if the conversion is correct
+        for boxes_src, boxes_dst in zip(boxes_original, boxes_converted):
+            boxes_src = np.array(boxes_src)
+            boxes_dst = np.array(boxes_dst)
+            self.assertTrue(np.allclose(boxes_src, boxes_dst, atol=1e-4))
+
+    @parameterized.expand(
+        [
+            ["coco", "absolute_xywh"],
+            ["pascal_voc", "absolute_xyxy"],
+            ["albumentations", "relative_xyxy"],
+            ["yolo", "relative_xcycwh"],
+            ["xyxy", "absolute_xyxy"],
+            ["xywh", "absolute_xywh"],
+            ["xcycwh", "relative_xcycwh"],
+        ]
+    )
+    def test_aliases(self, alias, box_format):
+        boxes_expected = np.array(NORMAL_TESTING_CASES["boxes"][box_format])
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes_expected,
+            input_format=alias,
+            output_format=box_format,
+        )
+        self.assertTrue(np.allclose(boxes_converted, boxes_expected, atol=1e-4))
+
+    def test_wrong_input_exceptions(self):
+        # 4d tensor/array
+        boxes = np.ones((2, 2, 2, 4))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="absolute_xyxy", output_format="absolute_xywh")
+
+        # incorrect boxes, just 3 coordinates
+        boxes = np.ones((2, 2, 3))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="absolute_xyxy", output_format="absolute_xywh")
+
+        # image size is not provided
+        boxes = np.ones((2, 2, 4))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="absolute_xyxy", output_format="relative_xywh")
+
+        # image size with wrong length
+        boxes = np.ones((2, 2, 4))
+        image_size = np.ones((1, 2))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(
+                boxes=boxes, input_format="absolute_xyxy", output_format="relative_xywh", image_size=image_size
+            )
+
+        # incorrect input format
+        boxes = np.ones((2, 2, 4))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="format", output_format="relative_xywh")
+
+        # incorrect output format
+        boxes = np.ones((2, 2, 4))
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="absolute_xyxy", output_format="format")
+
+        # variable length boxes
+        boxes = [
+            [10, 20, 30, 40],
+            [20, 30, 40],
+        ]
+        with self.assertRaises(ValueError):
+            image_box_utils.convert_boxes(boxes=boxes, input_format="absolute_xyxy", output_format="absolute_xywh")
+
+    def test_normal_boxes_with_extra(self):
+        # random boxes relative_xcycwh, add to make them valid
+        boxes = np.random.rand(5, 6) / 2 + 0.5
+        boxes_converted = image_box_utils.convert_boxes(
+            boxes=boxes, input_format="relative_xcycwh", output_format="absolute_xyxy", image_size=[100, 100]
+        )
+
+        extra = boxes[..., 4:]
+        converted_extra = boxes_converted[..., 4:]
+        self.assertTrue(np.allclose(extra, converted_extra, atol=1e-4))

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -38,7 +38,6 @@ if is_vision_available():
         center_crop,
         center_to_corners_format,
         convert_to_rgb,
-        corners_to_center_format,
         flip_channel_order,
         get_resize_output_image_size,
         id_to_rgb,
@@ -378,17 +377,6 @@ class ImageTransformsTester(unittest.TestCase):
         bbox_center = np.array([[10, 20, 4, 8], [15, 16, 3, 4]])
         expected = np.array([[8, 16, 12, 24], [13.5, 14, 16.5, 18]])
         self.assertTrue(np.allclose(center_to_corners_format(bbox_center), expected))
-
-        # Check that the function and inverse function are inverse of each other
-        self.assertTrue(np.allclose(corners_to_center_format(center_to_corners_format(bbox_center)), bbox_center))
-
-    def test_corners_to_center_format(self):
-        bbox_corners = np.array([[8, 16, 12, 24], [13.5, 14, 16.5, 18]])
-        expected = np.array([[10, 20, 4, 8], [15, 16, 3, 4]])
-        self.assertTrue(np.allclose(corners_to_center_format(bbox_corners), expected))
-
-        # Check that the function and inverse function are inverse of each other
-        self.assertTrue(np.allclose(center_to_corners_format(corners_to_center_format(bbox_corners)), bbox_corners))
 
     def test_rgb_to_id(self):
         # test list input


### PR DESCRIPTION
# What does this PR do?

Intorduces `output_bbox_format` parameter for `postprocess_for_object_detection`.
Adds the `convert_boxes` function to convert boxes from one format to another, e.g. from YOLO to Pascal VOC.

```python
boxes = convert_boxes(
    boxes, input_format="relative_xcycwh", output_format="absolute_xyxy", image_size=target_sizes
)
```

 - works with `np.array`, `torch.tensor`, `list`, `tuple` (could be easily extended to `jax` and `tf`)
 - works with single box shape=(4,) , image boxes shape=(N, 4), multiple images boxes List[(N, 4)]
 - supports boxes with extra metadata, e.g. `box=[x_min, y_min, x_max, y_max, color, class, ...]`
 - supports format aliases. e.g. `yolo`, `coco`
 
Supported input/output bounding box formats:
    - `absolute_xyxy` (aliases: `pascal_voc`, `xyxy`): [x_min, y_min, x_max, y_max]
    - `absolute_xywh` (aliases: `coco`, `xywh`): [x_min, y_min, width, height]
    - `absolute_xcycwh`: [center_x, center_y, width, height]
    - `relative_xyxy` (aliases: `albumentations`): [x_min, y_min, x_max, y_max] normalized to [0, 1] by image size
    - `relative_xywh`: [x_min, y_min, width, height] normalized to [0, 1] by image size
    - `relative_xcycwh` (aliases: `yolo`, `xcycwh`): [center_x, center_y, width, height] normalized to [0, 1] by image size

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@amyeroberts could you please look at this draft, looks a bit overсomplicated, probably we should drop some functionality in favor to simplification.
