### PR TITLE
Docs: update example with assisted generation + sample

### DIFF
--- a/docs/source/ko/generation_strategies.md
+++ b/docs/source/ko/generation_strategies.md
@@ -333,5 +333,5 @@ culture, and they allow us to design the'
 >>> assistant_model = AutoModelForCausalLM.from_pretrained(assistant_checkpoint)
 >>> outputs = model.generate(**inputs, assistant_model=assistant_model, do_sample=True, temperature=0.5)
 >>> tokenizer.batch_decode(outputs, skip_special_tokens=True)
-['Alice and Bob are going to the same party. It is a small party, in a small']
+['Alice and Bob, who were both in their early twenties, were both in the process of']
 ```


### PR DESCRIPTION
# What does this PR do?

Fixes example failing doctest, caused by #30778.

The seed is set at the beginning of the example. Before, the assistant model was doing sampling, so it “consumed” the random state set by the seed. Now, the assistant is not doing sampling, so it doesn’t consume the random state. When the main model produces its samples, it sees a different random state!