### PR TITLE
[WIP] Dynamic length in static cache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -861,16 +861,16 @@ class StaticCache(Cache):
         Return:
             A tuple containing the updated key and value states.
         """
-        cache_info = cache_kwargs.get("cache_info")
+        cache_position = cache_kwargs.get("cache_position")
         k_out = self.key_cache[layer_idx]
         v_out = self.value_cache[layer_idx]
 
-        if cache_info is None:
+        if cache_position is None:
             k_out.copy_(key_states)
             v_out.copy_(value_states)
         else:
-            k_out[:, :, cache_info.position] = key_states
-            v_out[:, :, cache_info.position] = value_states
+            k_out[:, :, cache_position] = key_states
+            v_out[:, :, cache_position] = value_states
 
         return k_out, v_out
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -23,13 +23,6 @@ if is_hqq_available():
 logger = logging.get_logger(__name__)
 
 
-class CacheInfo:
-
-    def __init__(self, position, length):
-        self.position = position
-        self._length = length
-
-
 @dataclass
 class Cache:
     """

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -865,7 +865,7 @@ class StaticCache(Cache):
         k_out = self.key_cache[layer_idx]
         v_out = self.value_cache[layer_idx]
 
-        if cache_position is None:
+        if cache_info is None:
             k_out.copy_(key_states)
             v_out.copy_(value_states)
         else:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -23,6 +23,13 @@ if is_hqq_available():
 logger = logging.get_logger(__name__)
 
 
+class CacheInfo:
+
+    def __init__(self, position, length):
+        self.position = position
+        self._length = length
+
+
 @dataclass
 class Cache:
     """
@@ -854,7 +861,7 @@ class StaticCache(Cache):
         Return:
             A tuple containing the updated key and value states.
         """
-        cache_position = cache_kwargs.get("cache_position")
+        cache_info = cache_kwargs.get("cache_info")
         k_out = self.key_cache[layer_idx]
         v_out = self.value_cache[layer_idx]
 
@@ -862,8 +869,8 @@ class StaticCache(Cache):
             k_out.copy_(key_states)
             v_out.copy_(value_states)
         else:
-            k_out[:, :, cache_position] = key_states
-            v_out[:, :, cache_position] = value_states
+            k_out[:, :, cache_info.position] = key_states
+            v_out[:, :, cache_info.position] = value_states
 
         return k_out, v_out
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -904,8 +904,8 @@ class GemmaModel(GemmaPreTrainedModel):
             return_legacy_cache = True  # noqa: F841
             past_key_values = DynamicCache.from_legacy_cache(past_key_values)
 
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         if cache_length is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             cache_length = past_seen_tokens + inputs_embeds.shape[1]
 
         cache_position = torch.arange(

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -907,9 +907,10 @@ class GemmaModel(GemmaPreTrainedModel):
         if cache_length is None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             cache_length = past_seen_tokens + inputs_embeds.shape[1]
-            cache_position = torch.arange(
-                past_seen_tokens, cache_length, device=inputs_embeds.device
-            )
+
+        cache_position = torch.arange(
+            past_seen_tokens, cache_length, device=inputs_embeds.device
+        )
 
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -29,7 +29,7 @@ from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache, CacheInfo, DynamicCache, StaticCache
+from ...cache_utils import Cache, DynamicCache, StaticCache
 from ...modeling_attn_mask_utils import AttentionMaskConverter
 from ...modeling_outputs import (
     BaseModelOutputWithPast,

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -281,9 +281,16 @@ class GemmaAttention(nn.Module):
         cos, sin = self.rotary_emb(value_states, position_ids)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
+        if q_len > 1:
+            # prefill
+            cache_position = torch.arange(cache_info._length, dtype=torch.int32, device=hidden_states.device)
+        else:
+            # decoding
+            cache_position = torch.tensor([cache_info._length - 1], dtype=torch.int32, device=hidden_states.device)
+
         if past_key_value is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
-            cache_kwargs = {"sin": sin, "cos": cos, "cache_info": cache_info}
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         key_states = repeat_kv(key_states, self.num_key_value_groups)

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -266,7 +266,7 @@ class GemmaAttention(nn.Module):
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         bsz, q_len, _ = hidden_states.size()
 
@@ -283,10 +283,10 @@ class GemmaAttention(nn.Module):
 
         if q_len > 1:
             # prefill
-            cache_position = torch.arange(cache_info._length, dtype=torch.int32, device=hidden_states.device)
+            cache_position = torch.arange(cache_length, dtype=torch.int32, device=hidden_states.device)
         else:
             # decoding
-            cache_position = torch.tensor([cache_info._length - 1], dtype=torch.int32, device=hidden_states.device)
+            cache_position = torch.tensor([cache_length - 1], dtype=torch.int32, device=hidden_states.device)
 
         if past_key_value is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
@@ -347,7 +347,7 @@ class GemmaFlashAttention2(GemmaAttention):
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if isinstance(past_key_value, StaticCache):
             raise ValueError(
@@ -373,9 +373,16 @@ class GemmaFlashAttention2(GemmaAttention):
         cos, sin = self.rotary_emb(value_states, position_ids)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
+        if q_len > 1:
+            # prefill
+            cache_position = torch.arange(cache_length, dtype=torch.int32, device=hidden_states.device)
+        else:
+            # decoding
+            cache_position = torch.tensor([cache_length - 1], dtype=torch.int32, device=hidden_states.device)
+
         if past_key_value is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
-            cache_kwargs = {"sin": sin, "cos": cos, "cache_info": cache_info}
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # TODO: These transpose are quite inefficient but Flash Attention requires the layout [batch_size, sequence_length, num_heads, head_dim]. We would need to refactor the KV cache
@@ -538,7 +545,7 @@ class GemmaSdpaAttention(GemmaAttention):
         past_key_value: Optional[Cache] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if output_attentions:
             # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
@@ -553,7 +560,7 @@ class GemmaSdpaAttention(GemmaAttention):
                 past_key_value=past_key_value,
                 output_attentions=output_attentions,
                 use_cache=use_cache,
-                cache_info=cache_info,
+                cache_length=cache_length,
             )
 
         bsz, q_len, _ = hidden_states.size()
@@ -571,10 +578,10 @@ class GemmaSdpaAttention(GemmaAttention):
 
         if q_len > 1:
             # prefill
-            cache_position = torch.arange(cache_info._length, dtype=torch.int32, device=hidden_states.device)
+            cache_position = torch.arange(cache_length, dtype=torch.int32, device=hidden_states.device)
         else:
             # decoding
-            cache_position = torch.tensor([cache_info._length - 1], dtype=torch.int32, device=hidden_states.device)
+            cache_position = torch.tensor([cache_length - 1], dtype=torch.int32, device=hidden_states.device)
 
         if past_key_value is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
@@ -599,10 +606,10 @@ class GemmaSdpaAttention(GemmaAttention):
         # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
         is_causal = True if causal_mask is None and q_len > 1 else False
 
-        if cache_info._length > 0:
-            key_states = key_states[:, :, :cache_info._length, :]
-            value_states = value_states[:, :, :cache_info._length, :]
-            causal_mask = causal_mask[:, :, :, :cache_info._length] if causal_mask is not None else causal_mask
+        if cache_length > 0:
+            key_states = key_states[:, :, :cache_length, :]
+            value_states = value_states[:, :, :cache_length, :]
+            causal_mask = causal_mask[:, :, :, :cache_length] if causal_mask is not None else causal_mask
 
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             query_states,
@@ -647,7 +654,7 @@ class GemmaDecoderLayer(nn.Module):
         past_key_value: Optional[Cache] = None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """
@@ -681,7 +688,7 @@ class GemmaDecoderLayer(nn.Module):
             past_key_value=past_key_value,
             output_attentions=output_attentions,
             use_cache=use_cache,
-            cache_info=cache_info,
+            cache_length=cache_length,
         )
         hidden_states = residual + hidden_states
 
@@ -869,7 +876,7 @@ class GemmaModel(GemmaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -897,18 +904,18 @@ class GemmaModel(GemmaPreTrainedModel):
             return_legacy_cache = True  # noqa: F841
             past_key_values = DynamicCache.from_legacy_cache(past_key_values)
 
-        if cache_info is None:
+        if cache_length is None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_length = past_seen_tokens + inputs_embeds.shape[1]
             cache_position = torch.arange(
-                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+                past_seen_tokens, cache_length, device=inputs_embeds.device
             )
-            cache_info = CacheInfo(position=cache_position, length=int(cache_position[-1]) + 1)
 
         if position_ids is None:
-            position_ids = cache_info.position.unsqueeze(0)
+            position_ids = cache_position.unsqueeze(0)
 
         causal_mask = self._update_causal_mask(
-            attention_mask, inputs_embeds, cache_info, past_key_values, output_attentions
+            attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
 
         # embed positions
@@ -945,7 +952,7 @@ class GemmaModel(GemmaPreTrainedModel):
                     past_key_values,
                     output_attentions,
                     use_cache,
-                    cache_info,
+                    cache_length,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -955,7 +962,7 @@ class GemmaModel(GemmaPreTrainedModel):
                     past_key_value=past_key_values,
                     output_attentions=output_attentions,
                     use_cache=use_cache,
-                    cache_info=cache_info,
+                    cache_length=cache_length,
                 )
 
             hidden_states = layer_outputs[0]
@@ -989,7 +996,7 @@ class GemmaModel(GemmaPreTrainedModel):
         self,
         attention_mask: torch.Tensor,
         input_tensor: torch.Tensor,
-        cache_info: torch.Tensor,
+        cache_position: torch.Tensor,
         past_key_values: Cache,
         output_attentions: bool,
     ):
@@ -1042,7 +1049,7 @@ class GemmaModel(GemmaPreTrainedModel):
             )
             if sequence_length != 1:
                 causal_mask = torch.triu(causal_mask, diagonal=1)
-            causal_mask *= torch.arange(target_length, device=device) > cache_info.position.reshape(-1, 1)
+            causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
             causal_mask = causal_mask[None, None, :, :].expand(input_tensor.shape[0], 1, -1, -1)
             if attention_mask is not None:
                 causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
@@ -1110,7 +1117,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        cache_info: Optional[torch.LongTensor] = None,
+        cache_length: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1154,7 +1161,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            cache_info=cache_info,
+            cache_length=cache_length,
         )
 
         hidden_states = outputs[0]
@@ -1191,14 +1198,14 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         past_key_values=None,
         attention_mask=None,
         inputs_embeds=None,
-        cache_info=None,
+        cache_length=None,
         use_cache=True,
         **kwargs,
     ):
         past_length = 0
         if past_key_values is not None:
             # Past key values are always initialized with a `Cache` object -> no need for if-else anymore
-            past_length = cache_info.position[0] if cache_info is not None else past_key_values.get_seq_length()
+            past_length = past_key_values.get_seq_length()
             max_cache_length = (
                 torch.tensor(past_key_values.get_max_length(), device=input_ids.device)
                 if past_key_values.get_max_length() is not None
@@ -1243,17 +1250,13 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
             model_inputs = {"input_ids": input_ids.contiguous()}
 
         input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
-        if cache_info is None:
-            cache_position = torch.arange(past_length, past_length + input_length, device=input_ids.device)
-            cache_info = CacheInfo(position=cache_position, length=int(cache_position[-1]) + 1)
-        elif use_cache:
-            cache_position = cache_info.position[-input_length:]
-            cache_info = CacheInfo(position=cache_position, length=int(cache_position[-1]) + 1)
+        if cache_length is None:
+            cache_length = past_length + input_length
 
         model_inputs.update(
             {
                 "position_ids": position_ids,
-                "cache_info": cache_info,
+                "cache_length": cache_length,
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1252,7 +1252,8 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
 
         input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
         if cached_length is None:
-            cached_length = past_length + input_length
+            # It must be a python int
+            cached_length = int(past_length + input_length)
 
         model_inputs.update(
             {

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1199,7 +1199,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         past_key_values=None,
         attention_mask=None,
         inputs_embeds=None,
-        cache_length=None,
+        cached_length=None,
         use_cache=True,
         **kwargs,
     ):
@@ -1251,13 +1251,13 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
             model_inputs = {"input_ids": input_ids.contiguous()}
 
         input_length = position_ids.shape[-1] if position_ids is not None else input_ids.shape[-1]
-        if cache_length is None:
-            cache_length = past_length + input_length
+        if cached_length is None:
+            cached_length = past_length + input_length
 
         model_inputs.update(
             {
                 "position_ids": position_ids,
-                "cache_length": cache_length,
+                "cache_length": cached_length,
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1184,7 +1184,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         past_length = 0
         if past_key_values is not None:
             # Past key values are always initialized with a `Cache` object -> no need for if-else anymore
-            past_length = cache_info.position[0] if cache_position is not None else past_key_values.get_seq_length()
+            past_length = cache_info.position[0] if cache_info is not None else past_key_values.get_seq_length()
             max_cache_length = (
                 torch.tensor(past_key_values.get_max_length(), device=input_ids.device)
                 if past_key_values.get_max_length() is not None


### PR DESCRIPTION
# What does this PR do?

**The current version is a minimal change that works, maybe not the best way**

Current static cache is nice (when running with `torch.compile`). However, in each generation step, the new position (to be generated) computes the attentions against all positions in the cache, which is not optimal. In fact, we only need to compute the attentions against the positions prior the current position. 

This PR implement dynamic length computation with static cache, which work with `torch.compile`. The following table demonstrate the speedup gain (with `torch.compile`) of this implementation over the current `main` branch.

The correctness is verified by

> RUN_SLOW=1 TF_FORCE_GPU_ALLOW_GROWTH=true python3 -m pytest -v tests/models/gemma/test_modeling_gemma.py -k "test_compile_static_cache"

The data below is based on 
<details>

<summary>this script</summary>

```python
import os
import torch
import datetime

from transformers import AutoTokenizer, AutoModelForCausalLM

token = "ADD_YOUR_OWN_TOKEN"

os.environ["TOKENIZERS_PARALLELISM"] = "false"

batch_size = 1
n_iter = 5

ckpt = "google/gemma-2b"

tokenizer = AutoTokenizer.from_pretrained(ckpt, token=token)
model = AutoModelForCausalLM.from_pretrained(ckpt, token=token, torch_dtype=torch.float16).to("cuda")

model.generation_config.max_new_tokens = 1024
model.generation_config.max_new_tokens = 1024

model.generation_config.cache_implementation = "static"
model.forward = torch.compile(model.forward, mode="reduce-overhead", fullgraph=True)

input_text = "Why dogs are cute."
input_ids = tokenizer([input_text] * batch_size, return_tensors="pt").to("cuda")

for i in range(n_iter):
    s = datetime.datetime.now()
    outputs = model.generate(**input_ids, do_sample=False)
    t = datetime.datetime.now()
    e = (t-s).total_seconds()
    print(e)
```

</details>

with some modification to run it with different configurations, running on `A100` with `torch==2.3+cu121`.

# Benchmark

**I will re-run (part of) the benchmark as the following numbers are on top of of an older commit of `main`**

[benchmark data on the hub](https://huggingface.co/datasets/ydshieh/A100_cache_benchmark_dynamic_length/tree/main)

## Static cache compiled: full length v.s. optimal length (this PR)

### gemma-2b (18 layers)


| seq. length  | speedup |
| ------------- | ------------- |
| 1024 | 1.03 x |
| 2048 | 1.11 x |
| 4096 | 1.24 x |
| 8192 | 1.38 x |


