### PR TITLE
[trainer] allow processor instead of tokenizer

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -584,7 +584,7 @@ def main():
         args=training_args,
         train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
         eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
-        tokenizer=feature_extractor,
+        processor=processor,
         data_collator=data_collator,
         compute_metrics=compute_metrics if training_args.predict_with_generate else None,
     )

--- a/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
+++ b/examples/research_projects/robust-speech-event/run_speech_recognition_ctc_bnb.py
@@ -709,7 +709,7 @@ def main():
         compute_metrics=compute_metrics,
         train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
         eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
-        tokenizer=feature_extractor,
+        processor=processor,
         optimizers=optimizers,
     )
 

--- a/examples/research_projects/xtreme-s/run_xtreme_s.py
+++ b/examples/research_projects/xtreme-s/run_xtreme_s.py
@@ -844,7 +844,7 @@ def main():
             compute_metrics=compute_asr_metric if training_args.predict_with_generate else None,
             train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
             eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
-            tokenizer=feature_extractor,
+            processor=processor,
         )
     else:
         trainer = Trainer(
@@ -855,7 +855,7 @@ def main():
             compute_metrics=compute_asr_metric if is_text_target else compute_classification_metric,
             train_dataset=vectorized_datasets["train"] if training_args.do_train else None,
             eval_dataset=vectorized_datasets["eval"] if training_args.do_eval else None,
-            tokenizer=feature_extractor,
+            processor=processor,
         )
 
     # 8. Finally, we can start training

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -69,13 +69,13 @@ from .models.auto.modeling_auto import (
     MODEL_MAPPING_NAMES,
 )
 from .optimization import Adafactor, get_scheduler
+from .processing_utils import ProcessorMixin
 from .pytorch_utils import (
     ALL_LAYERNORM_LAYERS,
     is_torch_greater_or_equal_than_1_13,
     is_torch_greater_or_equal_than_2_3,
 )
 from .tokenization_utils_base import PreTrainedTokenizerBase
-from .processing_utils import ProcessorMixin
 from .trainer_callback import (
     CallbackHandler,
     DefaultFlowCallback,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -516,9 +516,18 @@ class Trainer:
         ):
             self.place_model_on_device = False
 
-        self.tokenizer = processor if processor is not None else tokenizer
-        if processor is not None and hasattr(processor, "feature_extractor"):
-            tokenizer = processor.feature_extractor
+        if processor is not None and tokenizer is not None:
+            raise ValueError(
+                "You cannot pass both `processor` and `tokenizer` to the Trainer. Only pass the `processor` if defined."
+            )
+        elif processor is not None:
+            self.tokenizer = processor
+            if hasattr(processor, "feature_extractor"):
+                tokenizer = processor.feature_extractor
+            elif hasattr(processor, "tokenizer"):
+                tokenizer = processor.tokenizer
+        else:
+            self.tokenizer = tokenizer
 
         default_collator = (
             DataCollatorWithPadding(tokenizer)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -516,7 +516,7 @@ class Trainer:
         ):
             self.place_model_on_device = False
 
-        self.tokenizer = tokenizer
+        self.tokenizer = processor if processor is not None else tokenizer
         if processor is not None and hasattr(processor, "feature_extractor"):
             tokenizer = processor.feature_extractor
 

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from .trainer_callback import TrainerCallback
     from .trainer_utils import EvalPrediction, PredictionOutput
     from .training_args import TrainingArguments
+    from .processing_utils import ProcessorMixin
 
 
 logger = logging.get_logger(__name__)
@@ -48,6 +49,7 @@ class Seq2SeqTrainer(Trainer):
         train_dataset: Optional[Dataset] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
         tokenizer: Optional["PreTrainedTokenizerBase"] = None,
+        processor: Optional["ProcessorMixin"] = None,
         model_init: Optional[Callable[[], "PreTrainedModel"]] = None,
         compute_metrics: Optional[Callable[["EvalPrediction"], Dict]] = None,
         callbacks: Optional[List["TrainerCallback"]] = None,
@@ -61,6 +63,7 @@ class Seq2SeqTrainer(Trainer):
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
             tokenizer=tokenizer,
+            processor=processor,
             model_init=model_init,
             compute_metrics=compute_metrics,
             callbacks=callbacks,

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -30,11 +30,11 @@ from .utils import logging
 if TYPE_CHECKING:
     from .data.data_collator import DataCollator
     from .modeling_utils import PreTrainedModel
+    from .processing_utils import ProcessorMixin
     from .tokenization_utils_base import PreTrainedTokenizerBase
     from .trainer_callback import TrainerCallback
     from .trainer_utils import EvalPrediction, PredictionOutput
     from .training_args import TrainingArguments
-    from .processing_utils import ProcessorMixin
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
# What does this PR do?

Fixes #23222 by allowing the user to pass the argument `processor` to the Trainer and Seq2SeqTrainer (instead of `tokenizer`). 


This is much more intuitive when training multimodal models, as before we were encouraging users to pass:
```python
trainer = Trainer(
    ...
    tokenizer=processor,
    ...
)
```
Which is super confusing. After this PR, users can do:
```python
trainer = Trainer(
    ...
    processor=processor,
    ...
)
```
Which is much more sensible.


The Trainer does three things with the `tokenizer`:
1. Passes it to the data collator with padding:
https://github.com/huggingface/transformers/blob/f4014e75db0190792b3feeccfc5dc5b5f9f0ce7b/src/transformers/trainer.py#L513-L517
2. Gets the model input name:
https://github.com/huggingface/transformers/blob/f4014e75db0190792b3feeccfc5dc5b5f9f0ce7b/src/transformers/trainer.py#L853
3. Saves it during training:
https://github.com/huggingface/transformers/blob/f4014e75db0190792b3feeccfc5dc5b5f9f0ce7b/src/transformers/trainer.py#L3398-L3399

We can do all of these things directly with the processor as well. Therefore, all we have to do is set the following in the init method of the Trainer:
```python
self.tokenizer = processor if processor is not None else tokenizer
```
