### PR TITLE
[whisper] fix multilingual fine-tuning

### DIFF
--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -458,6 +458,7 @@ def main():
         model.generation_config.forced_decoder_ids = model_args.forced_decoder_ids
     else:
         model.generation_config.forced_decoder_ids = None
+        model.config.forced_decoder_ids = None
 
     if model_args.suppress_tokens is not None:
         logger.warning(

--- a/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
+++ b/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py
@@ -441,12 +441,8 @@ def main():
     if hasattr(model.generation_config, "is_multilingual") and model.generation_config.is_multilingual:
         # We only need to set the language and task ids in a multilingual setting
         tokenizer.set_prefix_tokens(language=data_args.language, task=data_args.task)
-        model.generation_config.update(
-            **{
-                "language": data_args.language,
-                "task": data_args.task,
-            }
-        )
+        model.generation_config.language = data_args.language
+        model.generation_config.task = data_args.task
     elif data_args.language is not None:
         raise ValueError(
             "Setting language token for an English-only checkpoint is not permitted. The language argument should "
@@ -460,6 +456,8 @@ def main():
             "Please use the `language` and `task` arguments instead"
         )
         model.generation_config.forced_decoder_ids = model_args.forced_decoder_ids
+    else:
+        model.generation_config.forced_decoder_ids = None
 
     if model_args.suppress_tokens is not None:
         logger.warning(


### PR DESCRIPTION
# What does this PR do?

Fixes #30654.

<details>

<summary> The script previously failed with the following args, but passes after this fix: </summary>

```sh
python run_speech_recognition_seq2seq.py \
	--model_name_or_path="openai/whisper-small" \
	--dataset_name="mozilla-foundation/common_voice_11_0" \
	--dataset_config_name="hi" \
	--language="hindi" \
	--task="transcribe" \
	--train_split_name="train+validation" \
	--eval_split_name="test" \
	--max_steps="5" \
	--output_dir="./whisper-small-hi" \
	--per_device_train_batch_size="16" \
	--gradient_accumulation_steps="2" \
	--per_device_eval_batch_size="16" \
	--logging_steps="25" \
	--learning_rate="1e-5" \
	--warmup_steps="2" \
	--eval_strategy="steps" \
	--eval_steps="5" \
	--save_strategy="steps" \
	--save_steps="5" \
	--generation_max_length="20" \
	--preprocessing_num_workers="16" \
	--max_duration_in_seconds="30" \
	--text_column_name="sentence" \
	--freeze_feature_encoder="False" \
	--gradient_checkpointing \
	--fp16 \
	--overwrite_output_dir \
	--do_train \
	--do_eval \
	--predict_with_generate \
	--use_auth_token
```

</details>