### PR TITLE
TST / Quantization: Reverting to torch==2.2.1

### DIFF
--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -9,9 +9,9 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.3.0'
+ARG PYTORCH='2.2.1'
 # Example: `cu102`, `cu113`, etc.
-ARG CUDA='cu121'
+ARG CUDA='cu118'
 
 RUN apt update
 RUN apt install -y git libsndfile1-dev tesseract-ocr espeak-ng python python3-pip ffmpeg


### PR DESCRIPTION
# What does this PR do?

Autoawq and other libraries are not compatible with torch 2.3.0: https://github.com/casper-hansen/AutoAWQ/issues/466

To avoid failures in our CI, let's temporary build torch==2.2.1 in our docker images 

cc @ydshieh @SunMarc 
