### PR TITLE
Fix VideoLlava imports

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -5759,8 +5759,8 @@ if TYPE_CHECKING:
         from .models.swin2sr import Swin2SRImageProcessor
         from .models.tvlt import TvltImageProcessor
         from .models.tvp import TvpImageProcessor
-        from .models.videomae import VideoMAEFeatureExtractor, VideoMAEImageProcessor
         from .models.video_llava import VideoLlavaImageProcessor
+        from .models.videomae import VideoMAEFeatureExtractor, VideoMAEImageProcessor
         from .models.vilt import ViltFeatureExtractor, ViltImageProcessor, ViltProcessor
         from .models.vit import ViTFeatureExtractor, ViTImageProcessor
         from .models.vit_hybrid import ViTHybridImageProcessor

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1160,6 +1160,7 @@ else:
     _import_structure["models.swin2sr"].append("Swin2SRImageProcessor")
     _import_structure["models.tvlt"].append("TvltImageProcessor")
     _import_structure["models.tvp"].append("TvpImageProcessor")
+    _import_structure["models.video_llava"].append("VideoLlavaImageProcessor")
     _import_structure["models.videomae"].extend(["VideoMAEFeatureExtractor", "VideoMAEImageProcessor"])
     _import_structure["models.vilt"].extend(["ViltFeatureExtractor", "ViltImageProcessor", "ViltProcessor"])
     _import_structure["models.vit"].extend(["ViTFeatureExtractor", "ViTImageProcessor"])
@@ -3243,7 +3244,6 @@ else:
     _import_structure["models.video_llava"].extend(
         [
             "VideoLlavaForConditionalGeneration",
-            "VideoLlavaImageProcessor",
             "VideoLlavaPreTrainedModel",
             "VideoLlavaProcessor",
         ]
@@ -5760,6 +5760,7 @@ if TYPE_CHECKING:
         from .models.tvlt import TvltImageProcessor
         from .models.tvp import TvpImageProcessor
         from .models.videomae import VideoMAEFeatureExtractor, VideoMAEImageProcessor
+        from .models.video_llava import VideoLlavaImageProcessor
         from .models.vilt import ViltFeatureExtractor, ViltImageProcessor, ViltProcessor
         from .models.vit import ViTFeatureExtractor, ViTImageProcessor
         from .models.vit_hybrid import ViTHybridImageProcessor
@@ -7437,7 +7438,6 @@ if TYPE_CHECKING:
         )
         from .models.video_llava import (
             VideoLlavaForConditionalGeneration,
-            VideoLlavaImageProcessor,
             VideoLlavaPreTrainedModel,
             VideoLlavaProcessor,
         )

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -8417,13 +8417,6 @@ class VideoLlavaForConditionalGeneration(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class VideoLlavaImageProcessor(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class VideoLlavaPreTrainedModel(metaclass=DummyObject):
     _backends = ["torch"]
 

--- a/src/transformers/utils/dummy_vision_objects.py
+++ b/src/transformers/utils/dummy_vision_objects.py
@@ -534,6 +534,13 @@ class TvpImageProcessor(metaclass=DummyObject):
         requires_backends(self, ["vision"])
 
 
+class VideoLlavaImageProcessor(metaclass=DummyObject):
+    _backends = ["vision"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["vision"])
+
+
 class VideoMAEFeatureExtractor(metaclass=DummyObject):
     _backends = ["vision"]
 


### PR DESCRIPTION
# What does this PR do?

Currently, it's not possible to run `from transformers import *` when Pillow is not installed in the environment. 

This is because [in the model init](https://github.com/huggingface/transformers/blob/4e17e7dcf8ac7c72268151823e82ff8db8c8fcba/src/transformers/models/video_llava/__init__.py#L25), the image processor import is protected by `is_vision_available`, but the [same pattern isn't reflected in the module init](https://github.com/huggingface/transformers/blob/4e17e7dcf8ac7c72268151823e82ff8db8c8fcba/src/transformers/__init__.py#L3246). 