### PR TITLE
Skip failing Object Detection example for now

### DIFF
--- a/examples/pytorch/test_pytorch_examples.py
+++ b/examples/pytorch/test_pytorch_examples.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import sys
+import unittest
 from unittest.mock import patch
 
 from transformers import ViTMAEForPreTraining, Wav2Vec2ForPreTraining
@@ -613,6 +614,10 @@ class ExamplesTests(TestCasePlus):
             self.assertGreaterEqual(result["eval_overall_accuracy"], 0.1)
 
     @patch.dict(os.environ, {"WANDB_DISABLED": "true"})
+    @unittest.skipIf(
+        backend_device_count(torch_device) > 1,
+        "TODO @qubvel, index out of bounds for bounding boxes when running on multi-accelerator",
+    )
     def test_run_object_detection(self):
         tmp_dir = self.get_auto_remove_tmp_dir()
         testargs = f"""


### PR DESCRIPTION
# What does this PR do?

This PR skips the failing object detection example when running on multiple GPUs until it's fixed.

cc @qubvel 

Fixes main CI for Accelerate


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts 