### PR TITLE
TST / Workflows: Get slack notifications for docker image build

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -61,7 +61,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the transformers-all-latest-gpu-push-ci docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -106,7 +106,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu-push-ci docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the huggingface/transformers-doc-builder docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the huggingface/transformers-pytorch-gpudocker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -286,7 +286,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the huggingface/transformers-pytorch-amd-gpu-push-ci build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -323,7 +323,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the huggingface/transformers-tensorflow-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -371,7 +371,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the transformers-pytorch-deepspeed-amd-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -408,7 +408,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: "C073ZTN10A1"
+          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
           title: 🤗 Results of the transformers-quantization-latest-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -61,7 +61,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the transformers-all-latest-gpu-push-ci docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -106,7 +106,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER}}
           title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu-push-ci docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -191,7 +191,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the huggingface/transformers-doc-builder docker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the huggingface/transformers-pytorch-gpudocker build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -286,7 +286,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the huggingface/transformers-pytorch-amd-gpu-push-ci build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -323,7 +323,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the huggingface/transformers-tensorflow-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -371,7 +371,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the transformers-pytorch-deepspeed-amd-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
@@ -408,7 +408,7 @@ jobs:
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
-          slack_channel: ${{ secrets.CI_DOCKER_CHANNEL }}
+          slack_channel: ${{ secrets.CI_SLACK_CHANNEL_DOCKER }}
           title: 🤗 Results of the transformers-quantization-latest-gpu build 
           status: ${{ job.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -57,6 +57,15 @@ jobs:
           push: true
           tags: huggingface/transformers-all-latest-gpu-push-ci
 
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the transformers-all-latest-gpu-push-ci docker build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+
   latest-torch-deepspeed-docker:
     name: "Latest PyTorch + DeepSpeed"
     runs-on: [intel-cpu, 8-cpu, ci]
@@ -92,6 +101,15 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-pytorch-deepspeed-latest-gpu${{ inputs.image_postfix }}
+
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu docker build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   # Can't build 2 images in a single job `latest-torch-deepspeed-docker` (for `nvcr.io/nvidia`)
   latest-torch-deepspeed-docker-for-push-ci-daily-build:
@@ -134,6 +152,15 @@ jobs:
           push: true
           tags: huggingface/transformers-pytorch-deepspeed-latest-gpu-push-ci
 
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the transformers-pytorch-deepspeed-latest-gpu-push-ci docker build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+
   doc-builder:
     name: "Doc builder"
     # Push CI doesn't need this image
@@ -159,6 +186,15 @@ jobs:
           context: ./docker/transformers-doc-builder
           push: true
           tags: huggingface/transformers-doc-builder
+
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the huggingface/transformers-doc-builder docker build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   latest-pytorch:
     name: "Latest PyTorch [dev]"
@@ -197,6 +233,15 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-pytorch-gpu
+
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the huggingface/transformers-pytorch-gpudocker build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   latest-pytorch-amd:
     name: "Latest PyTorch (AMD) [dev]"
@@ -237,6 +282,15 @@ jobs:
           push: true
           tags: huggingface/transformers-pytorch-amd-gpu-push-ci
 
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the huggingface/transformers-pytorch-amd-gpu-push-ci build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+
   latest-tensorflow:
     name: "Latest TensorFlow [dev]"
     # Push CI doesn't need this image
@@ -264,6 +318,15 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-tensorflow-gpu
+
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the huggingface/transformers-tensorflow-gpu build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
   latest-pytorch-deepspeed-amd:
     name: "PyTorch + DeepSpeed (AMD) [dev]"
@@ -304,6 +367,15 @@ jobs:
           push: true
           tags: huggingface/transformers-pytorch-deepspeed-amd-gpu-push-ci
 
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the transformers-pytorch-deepspeed-amd-gpu build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+
   latest-quantization-torch-docker:
     name: "Latest Pytorch + Quantization [dev]"
      # Push CI doesn't need this image
@@ -331,3 +403,12 @@ jobs:
             REF=main
           push: true
           tags: huggingface/transformers-quantization-latest-gpu${{ inputs.image_postfix }}
+
+      - name: Post to Slack
+        if: always()
+        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        with:
+          slack_channel: "C073ZTN10A1"
+          title: 🤗 Results of the transformers-quantization-latest-gpu build 
+          status: ${{ job.status }}
+          slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}


### PR DESCRIPTION
# What does this PR do?

As per title, as similarly as https://github.com/huggingface/peft/pull/1723 - I created a new slack channel to receive notifications on the docker image build status for all our docker images 

We do that in PEFT / diffusers (https://github.com/huggingface/diffusers/pull/7938)

Related to: https://github.com/huggingface/transformers/pull/30890

cc @ydshieh 