### PR TITLE
Bugfix: WandbCallback uploads initial model checkpoint

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -813,6 +813,9 @@ class WandbCallback(TrainerCallback):
                         "initial_model": True,
                     },
                 )
+                # log initial model checkpoint if also logging later checkpoints
+                if self._log_model in ("end", "checkpoint"):
+                    model.save_pretrained(temp_dir)
                 # add the architecture to a separate text file
                 save_model_architecture_to_file(model, temp_dir)
 

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -813,9 +813,6 @@ class WandbCallback(TrainerCallback):
                         "initial_model": True,
                     },
                 )
-                # log initial model checkpoint if also logging later checkpoints
-                if self._log_model in ("end", "checkpoint"):
-                    model.save_pretrained(temp_dir)
                 # add the architecture to a separate text file
                 save_model_architecture_to_file(model, temp_dir)
 

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -797,7 +797,7 @@ class WandbCallback(TrainerCallback):
             except AttributeError:
                 logger.info("Could not log the number of model parameters in Weights & Biases.")
 
-            # log the initial model and architecture to an artifact
+            # log the initial model architecture to an artifact
             with tempfile.TemporaryDirectory() as temp_dir:
                 model_name = (
                     f"model-{self._wandb.run.id}"

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -813,7 +813,6 @@ class WandbCallback(TrainerCallback):
                         "initial_model": True,
                     },
                 )
-                model.save_pretrained(temp_dir)
                 # add the architecture to a separate text file
                 save_model_architecture_to_file(model, temp_dir)
 


### PR DESCRIPTION
# What does this PR do?
It seems that #30135 inadvertently makes WandbCallback _always_ upload the initial model checkpoint to wandb, without any way to disabling this, and irrespective of model size. I think this is obviously not intended behaviour.

This also breaks training with FSDP, as apparently calling `model.save_pretrained()` messes things up for later `model.forward()` calls.

<!-- Remove if not applicable -->

Fixes #30896 #30895


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@pacman100 @muellerzr @amyeroberts