### PR TITLE
Generation: get special tokens from model config

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1370,18 +1370,29 @@ class GenerationMixin:
         """
 
         # Convert special tokens to tensors (if they exist)
-        def _tensor_or_none(token, device=None):
+        def _tensor_or_none(token_from_kwargs, token_from_config, device=None):
             if device is None:
                 device = self.device
 
+            token = token_from_kwargs if token_from_kwargs is not None else token_from_config
             if token is None or isinstance(token, torch.Tensor):
                 return token
             return torch.tensor(token, device=device, dtype=torch.long)
 
-        bos_token_id = _tensor_or_none(generation_config.bos_token_id, device=device)
-        eos_token_id = _tensor_or_none(generation_config.eos_token_id, device=device)
-        pad_token_id = _tensor_or_none(generation_config.pad_token_id, device=device)
-        decoder_start_token_id = _tensor_or_none(generation_config.decoder_start_token_id, device=device)
+        # If user passes a `GenerationConfig` type as kwargs, we have to check model's generation config for special tokens (#30892)
+        # Mostly user-define configs do not contain special tokens, and we do not update user-defined `GenerationConfig` with model's config
+        bos_token_id = _tensor_or_none(
+            generation_config.bos_token_id, self.generation_config.bos_token_id, device=device
+        )
+        eos_token_id = _tensor_or_none(
+            generation_config.eos_token_id, self.generation_config.eos_token_id, device=device
+        )
+        pad_token_id = _tensor_or_none(
+            generation_config.pad_token_id, self.generation_config.pad_token_id, device=device
+        )
+        decoder_start_token_id = _tensor_or_none(
+            generation_config.decoder_start_token_id, self.generation_config.decoder_start_token_id, device=device
+        )
         decoder_start_token_id = decoder_start_token_id if decoder_start_token_id is not None else bos_token_id
 
         # We can have more than one eos token. Always treat it as a 1D tensor (when it exists).

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1381,7 +1381,7 @@ class GenerationMixin:
         bos_token_id = _tensor_or_none(generation_config.bos_token_id, device=device)
         eos_token_id = _tensor_or_none(generation_config.eos_token_id, device=device)
         pad_token_id = _tensor_or_none(generation_config.pad_token_id, device=device)
-        
+
         # for BC we also check `decoder_start_token_id` from model's generation config
         decoder_start_token_id = (
             generation_config.decoder_start_token_id


### PR DESCRIPTION
# What does this PR do?

Fixed #30892 . The error, described in the linked issue, was caused by passing a `GenerationConfig` type instead of a kwarg. If a user passes `GenerationConfig` we do not update it with model's generation config, thus cannot get special tokens used by the model. Two options were:
1. Update the user's `GenerationConfig` by that of models in the `_prepare_generation_config`
2. Try to get special tokens from the config, if not then from self.config 

I think the first option can mess-up with what the user wants when generating, for ex by adding a `do_sample=True` from model's generation config. So I went for option-2