### PR TITLE
PaliGemma - fix processor with no input text

### DIFF
--- a/src/transformers/models/paligemma/processing_paligemma.py
+++ b/src/transformers/models/paligemma/processing_paligemma.py
@@ -177,6 +177,7 @@ class PaliGemmaProcessor(ProcessorMixin):
             logger.warning_once(
                 "You are using PaliGemma without a text prefix. It will perform as a picture-captioning model."
             )
+            text = ""
 
         if isinstance(text, List) and isinstance(images, List):
             if len(images) < len(text):


### PR DESCRIPTION
# What does this PR do?

Fix the paligemma processor raises exception on empty text inputs

## Reproduce

```python
from PIL import Image
from transformers import AutoProcessor

image = Image.new("RGB", (100, 100), (255, 255, 255))
processor = AutoProcessor.from_pretrained("google/paligemma-3b-pt-224")
processor(images=image)
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.10/site-packages/transformers/models/paligemma/processing_paligemma.py", line 190, in __call__
    pass
TypeError: 'NoneType' object is not iterable
```

The following lines require `text` should be a **list**, we need to convert the Nonetype input to a string or list firstly.

https://github.com/huggingface/transformers/blob/92d1d97c05a01160d6e7fcf4198e93bf2cec0dfe/src/transformers/models/paligemma/processing_paligemma.py#L176-L179

https://github.com/huggingface/transformers/blob/92d1d97c05a01160d6e7fcf4198e93bf2cec0dfe/src/transformers/models/paligemma/processing_paligemma.py#L186-L198

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts 