### PR TITLE
PaliGemma fix attention mask for finetunes

### DIFF
--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -95,7 +95,7 @@ class PaliGemmaConfig(PretrainedConfig):
         self.hidden_size = hidden_size
         self.vision_config = vision_config
         self.is_encoder_decoder = False
-        self.prefix_suffix_separator_index = prefix_suffix_separator_index  # always \n
+        self.prefix_suffix_separator_index = prefix_suffix_separator_index
 
         if isinstance(self.vision_config, dict):
             vision_config["model_type"] = (

--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -48,7 +48,9 @@ class PaliGemmaConfig(PretrainedConfig):
             Dimension of the multimodal projection space.
         hidden_size (`int`, *optional*, defaults to 2048):
             Dimension of the hidden layer of the Language model.
-        prefix_suffix_separator_index (`<fill_type>`, *optional*, defaults to 108): <fill_docstring>
+        prefix_suffix_separator_index (int, *optional*, defaults to 108):
+            Index of separator between prefix and suffix, since PaliGemma attends to prefix differently.
+            Defaults to index of \n
 
     Example:
 

--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -48,6 +48,7 @@ class PaliGemmaConfig(PretrainedConfig):
             Dimension of the multimodal projection space.
         hidden_size (`int`, *optional*, defaults to 2048):
             Dimension of the hidden layer of the Language model.
+        prefix_suffix_separator_index (`<fill_type>`, *optional*, defaults to 108): <fill_docstring>
 
     Example:
 

--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -48,9 +48,9 @@ class PaliGemmaConfig(PretrainedConfig):
             Dimension of the multimodal projection space.
         hidden_size (`int`, *optional*, defaults to 2048):
             Dimension of the hidden layer of the Language model.
-        prefix_suffix_separator_index (int, *optional*, defaults to 108):
+        prefix_suffix_separator_index (`int`, *optional*, defaults to -101:
             Index of separator between prefix and suffix, since PaliGemma attends to prefix differently.
-            Defaults to index of \n
+            Pass in `labels` similar to `ignore_index`
 
     Example:
 
@@ -85,7 +85,7 @@ class PaliGemmaConfig(PretrainedConfig):
         vocab_size=257152,
         projection_dim=2048,
         hidden_size=2048,
-        prefix_suffix_separator_index=108,
+        prefix_suffix_separator_index=-101,
         **kwargs,
     ):
         self.ignore_index = ignore_index

--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -82,6 +82,7 @@ class PaliGemmaConfig(PretrainedConfig):
         vocab_size=257152,
         projection_dim=2048,
         hidden_size=2048,
+        prefix_suffix_separator_index=108,
         **kwargs,
     ):
         self.ignore_index = ignore_index
@@ -91,6 +92,7 @@ class PaliGemmaConfig(PretrainedConfig):
         self.hidden_size = hidden_size
         self.vision_config = vision_config
         self.is_encoder_decoder = False
+        self.prefix_suffix_separator_index = prefix_suffix_separator_index # always \n
 
         if isinstance(self.vision_config, dict):
             vision_config["model_type"] = (

--- a/src/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/transformers/models/paligemma/configuration_paligemma.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" PaliGemmamodel configuration"""
+"""PaliGemmamodel configuration"""
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -92,7 +92,7 @@ class PaliGemmaConfig(PretrainedConfig):
         self.hidden_size = hidden_size
         self.vision_config = vision_config
         self.is_encoder_decoder = False
-        self.prefix_suffix_separator_index = prefix_suffix_separator_index # always \n
+        self.prefix_suffix_separator_index = prefix_suffix_separator_index  # always \n
 
         if isinstance(self.vision_config, dict):
             vision_config["model_type"] = (

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -282,14 +282,19 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         self.vocab_size = model_embeds.num_embeddings
         return model_embeds
 
-    def construct_causal_mask_with_block_attention(self, attention_mask, input_ids, text_mask, inputs_embeds):
+    def construct_causal_mask_with_block_attention(
+        self, attention_mask, input_ids, text_mask, inputs_embeds
+    ):
         # Modified from gemma
         target_length = attention_mask.shape[-1]
-        dtype, device = inputs_embeds.dtype,  inputs_embeds.device
+        dtype, device = inputs_embeds.dtype, inputs_embeds.device
         min_dtype = torch.finfo(dtype).min
-        sequence_length =  input_ids.shape[1]
+        sequence_length = input_ids.shape[1]
         causal_mask = torch.full(
-            (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
+            (sequence_length, target_length),
+            fill_value=min_dtype,
+            dtype=dtype,
+            device=device,
         )
         if sequence_length != 1:
             causal_mask = torch.triu(causal_mask, diagonal=1)
@@ -297,26 +302,37 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         mask = input_ids == self.config.prefix_suffix_separator_index
         # Get the index of the first \n in each row
         indices = mask.int().cumsum(dim=1).eq(1).int().argmax(dim=1, keepdim=True)
-        range_tensor = torch.arange(mask.size(1), device=device).unsqueeze(0).unsqueeze(1)  # [1, 1, l]
+        range_tensor = (
+            torch.arange(mask.size(1), device=device).unsqueeze(0).unsqueeze(1)
+        )  # [1, 1, l]
 
         # Create the full block attention mask
         prefix_and_image_and_pad_mask = range_tensor < indices.view(-1, 1, 1)
-        prefix_and_image_and_pad_mask = prefix_and_image_and_pad_mask.expand(-1, mask.size(1), -1)
+        prefix_and_image_and_pad_mask = prefix_and_image_and_pad_mask.expand(
+            -1, mask.size(1), -1
+        )
         causal_mask = causal_mask[None, :].expand(input_ids.shape[0], -1, -1)
         causal_mask[prefix_and_image_and_pad_mask] = 0
         causal_mask = causal_mask[:, None, :, :].expand(-1, 1, -1, -1)
         if attention_mask is not None:
-            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            causal_mask = (
+                causal_mask.clone()
+            )  # copy to contiguous memory for in-place edit
             mask_length = attention_mask.shape[-1]
             # padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
             padding_mask = attention_mask[:, None, None, :]
             padding_mask = padding_mask == 0
-            causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
-                padding_mask, min_dtype
-            )
-        boolean_mask = text_mask.unsqueeze(1).unsqueeze(2).expand(-1, causal_mask.size(1), causal_mask.size(2), -1) == 0
+            causal_mask[:, :, :, :mask_length] = causal_mask[
+                :, :, :, :mask_length
+            ].masked_fill(padding_mask, min_dtype)
+        boolean_mask = (
+            text_mask.unsqueeze(1)
+            .unsqueeze(2)
+            .expand(-1, causal_mask.size(1), causal_mask.size(2), -1)
+            == 0
+        )
 
-        causal_mask.masked_fill_(boolean_mask, 0) 
+        causal_mask.masked_fill_(boolean_mask, 0)
         return causal_mask
 
     def _merge_input_ids_with_image_features(self, image_features, inputs_embeds, input_ids, attention_mask, labels):

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -282,6 +282,43 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         self.vocab_size = model_embeds.num_embeddings
         return model_embeds
 
+    def construct_causal_mask_with_block_attention(self, attention_mask, input_ids, text_mask, inputs_embeds):
+        # Modified from gemma
+        target_length = attention_mask.shape[-1]
+        dtype, device = inputs_embeds.dtype,  inputs_embeds.device
+        min_dtype = torch.finfo(dtype).min
+        sequence_length =  input_ids.shape[1]
+        causal_mask = torch.full(
+            (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
+        )
+        if sequence_length != 1:
+            causal_mask = torch.triu(causal_mask, diagonal=1)
+
+        mask = input_ids == self.config.prefix_suffix_separator_index
+        # Get the index of the first \n in each row
+        indices = mask.int().cumsum(dim=1).eq(1).int().argmax(dim=1, keepdim=True)
+        range_tensor = torch.arange(mask.size(1), device=device).unsqueeze(0).unsqueeze(1)  # [1, 1, l]
+
+        # Create the full block attention mask
+        prefix_and_image_and_pad_mask = range_tensor < indices.view(-1, 1, 1)
+        prefix_and_image_and_pad_mask = prefix_and_image_and_pad_mask.expand(-1, mask.size(1), -1)
+        causal_mask = causal_mask[None, :].expand(input_ids.shape[0], -1, -1)
+        causal_mask[prefix_and_image_and_pad_mask] = 0
+        causal_mask = causal_mask[:, None, :, :].expand(-1, 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            mask_length = attention_mask.shape[-1]
+            # padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
+            padding_mask = attention_mask[:, None, None, :]
+            padding_mask = padding_mask == 0
+            causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+                padding_mask, min_dtype
+            )
+        boolean_mask = text_mask.unsqueeze(1).unsqueeze(2).expand(-1, causal_mask.size(1), causal_mask.size(2), -1) == 0
+
+        causal_mask.masked_fill_(boolean_mask, 0) 
+        return causal_mask
+
     def _merge_input_ids_with_image_features(self, image_features, inputs_embeds, input_ids, attention_mask, labels):
         _, _, embed_dim = image_features.shape
         batch_size, sequence_length = input_ids.shape
@@ -305,11 +342,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             image_mask.unsqueeze(-1).expand_as(final_embedding), scaled_image_features
         )
         final_embedding = torch.where(pad_mask_expanded, torch.zeros_like(final_embedding), final_embedding)
-
-        final_attention_mask_4d = attention_mask.unsqueeze(1).unsqueeze(2) * attention_mask.unsqueeze(1).unsqueeze(-1)
-        final_attention_mask_4d = final_attention_mask_4d.float().expand(
-            -1, self.config.text_config.num_key_value_heads, -1, -1
-        )
+        causal_mask = self.construct_causal_mask_with_block_attention(attention_mask, input_ids, text_mask, inputs_embeds)
 
         # position_ids = torch.arange(0, sequence_length, device=input_ids.device).expand(batch_size, -1)
         # position_ids = torch.where(input_ids == self.pad_token_id, torch.ones_like(position_ids), position_ids)
@@ -322,7 +355,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             final_labels = torch.where(input_ids != self.pad_token_id, labels, final_labels)
         else:
             final_labels = None
-        return final_embedding, final_attention_mask_4d, final_labels, position_ids
+        return final_embedding, causal_mask, final_labels, position_ids
 
     @add_start_docstrings_to_model_forward(PALIGEMMA_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=PaliGemmaCausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -312,7 +312,6 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         if attention_mask is not None:
             causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
             mask_length = attention_mask.shape[-1]
-            # padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
             padding_mask = attention_mask[:, None, None, :]
             padding_mask = padding_mask == 0
             causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" PyTorch PaliGemmamodel."""
+"""PyTorch PaliGemmamodel."""
+
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
@@ -282,9 +283,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         self.vocab_size = model_embeds.num_embeddings
         return model_embeds
 
-    def construct_causal_mask_with_block_attention(
-        self, attention_mask, input_ids, text_mask, inputs_embeds
-    ):
+    def construct_causal_mask_with_block_attention(self, attention_mask, input_ids, text_mask, inputs_embeds):
         # Modified from gemma
         target_length = attention_mask.shape[-1]
         dtype, device = inputs_embeds.dtype, inputs_embeds.device
@@ -302,34 +301,25 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         mask = input_ids == self.config.prefix_suffix_separator_index
         # Get the index of the first \n in each row
         indices = mask.int().cumsum(dim=1).eq(1).int().argmax(dim=1, keepdim=True)
-        range_tensor = (
-            torch.arange(mask.size(1), device=device).unsqueeze(0).unsqueeze(1)
-        )  # [1, 1, l]
+        range_tensor = torch.arange(mask.size(1), device=device).unsqueeze(0).unsqueeze(1)  # [1, 1, l]
 
         # Create the full block attention mask
         prefix_and_image_and_pad_mask = range_tensor < indices.view(-1, 1, 1)
-        prefix_and_image_and_pad_mask = prefix_and_image_and_pad_mask.expand(
-            -1, mask.size(1), -1
-        )
+        prefix_and_image_and_pad_mask = prefix_and_image_and_pad_mask.expand(-1, mask.size(1), -1)
         causal_mask = causal_mask[None, :].expand(input_ids.shape[0], -1, -1)
         causal_mask[prefix_and_image_and_pad_mask] = 0
         causal_mask = causal_mask[:, None, :, :].expand(-1, 1, -1, -1)
         if attention_mask is not None:
-            causal_mask = (
-                causal_mask.clone()
-            )  # copy to contiguous memory for in-place edit
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
             mask_length = attention_mask.shape[-1]
             # padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
             padding_mask = attention_mask[:, None, None, :]
             padding_mask = padding_mask == 0
-            causal_mask[:, :, :, :mask_length] = causal_mask[
-                :, :, :, :mask_length
-            ].masked_fill(padding_mask, min_dtype)
+            causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+                padding_mask, min_dtype
+            )
         boolean_mask = (
-            text_mask.unsqueeze(1)
-            .unsqueeze(2)
-            .expand(-1, causal_mask.size(1), causal_mask.size(2), -1)
-            == 0
+            text_mask.unsqueeze(1).unsqueeze(2).expand(-1, causal_mask.size(1), causal_mask.size(2), -1) == 0
         )
 
         causal_mask.masked_fill_(boolean_mask, 0)
@@ -358,7 +348,9 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             image_mask.unsqueeze(-1).expand_as(final_embedding), scaled_image_features
         )
         final_embedding = torch.where(pad_mask_expanded, torch.zeros_like(final_embedding), final_embedding)
-        causal_mask = self.construct_causal_mask_with_block_attention(attention_mask, input_ids, text_mask, inputs_embeds)
+        causal_mask = self.construct_causal_mask_with_block_attention(
+            attention_mask, input_ids, text_mask, inputs_embeds
+        )
 
         # position_ids = torch.arange(0, sequence_length, device=input_ids.device).expand(batch_size, -1)
         # position_ids = torch.where(input_ids == self.pad_token_id, torch.ones_like(position_ids), position_ids)

--- a/src/transformers/models/paligemma/processing_paligemma.py
+++ b/src/transformers/models/paligemma/processing_paligemma.py
@@ -329,17 +329,11 @@ class PaliGemmaProcessor(ProcessorMixin):
 
         labels_suffix = suffix_input_ids
 
-        input_ids = [
-            ids + suffix_ids for ids, suffix_ids in zip(pre_input_ids, suffix_input_ids)
-        ]
+        input_ids = [ids + suffix_ids for ids, suffix_ids in zip(pre_input_ids, suffix_input_ids)]
         attention_masks = [
-            mask + suffix_mask
-            for mask, suffix_mask in zip(pre_attention_masks, suffix_attention_masks)
+            mask + suffix_mask for mask, suffix_mask in zip(pre_attention_masks, suffix_attention_masks)
         ]
-        labels = [
-            label + suffix_label
-            for label, suffix_label in zip(labels_prefix, labels_suffix)
-        ]
+        labels = [label + suffix_label for label, suffix_label in zip(labels_prefix, labels_suffix)]
 
         labels = self.tokenizer.pad(
             {"input_ids": labels},


### PR DESCRIPTION
# What does this PR do?

Previously, the PaliGemma attention mask was a 4d attention mask of all 1s, which preempted any downstream causal mask creation by Gemma. [PaliGemma has full attention over the image tokens and the prefix of the prompt, and causal attention over the suffix.](https://github.com/google-research/big_vision/blob/main/big_vision/configs/proj/paligemma/README.md) This PR implements that logic, allowing for finetuning PaliGemma without label leakage.

(Additionally, I noticed that using the GemmaTokenizerFast led to incorrect tokenization of tokens like <loc0000> character by character, whereas using GemmaTokenizer did proper tokenization. Be sure to set `use_fast=False` when instantiating the PaliGemma processor. I'll make an issue for this observation
edit: ah, [looks like that is a known issue?](https://github.com/huggingface/transformers/issues/30824)).



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @molbap @merveenoyan 

