### PR TITLE
🚨 out_indices always a list

### DIFF
--- a/src/transformers/utils/backbone_utils.py
+++ b/src/transformers/utils/backbone_utils.py
@@ -151,7 +151,7 @@ class BackboneMixin:
         self.num_features = [stage["num_chs"] for stage in self._backbone.feature_info.info]
 
         # In some timm versions, out_indices reflects the input type of out_indices on the `create_model` call,
-        # in later versions >= 1, it is always a
+        # in later versions >= 1, it is always a tuple
         out_indices = list(self._backbone.feature_info.out_indices)
         out_features = self._backbone.feature_info.module_name()
 

--- a/src/transformers/utils/backbone_utils.py
+++ b/src/transformers/utils/backbone_utils.py
@@ -47,8 +47,6 @@ def verify_out_features_out_indices(
             )
 
     if out_indices is not None:
-        if isinstance(out_indices, tuple):
-            out_indices = list(out_indices)
         if not isinstance(out_indices, list):
             raise ValueError(f"out_indices must be a list, got {type(out_indices)}")
         # Convert negative indices to their positive equivalent: [-1,] -> [len(stage_names) - 1,]
@@ -124,6 +122,7 @@ def get_aligned_output_features_output_indices(
         out_indices (`List[int]` or `Tuple[int]`): The indices of the features for the backbone to output.
         stage_names (`List[str]`): The names of the stages of the backbone.
     """
+    out_indices = list(out_indices) if out_indices is not None else None
     # First verify that the out_features and out_indices are valid
     verify_out_features_out_indices(out_features=out_features, out_indices=out_indices, stage_names=stage_names)
     output_features, output_indices = _align_output_features_output_indices(

--- a/src/transformers/utils/backbone_utils.py
+++ b/src/transformers/utils/backbone_utils.py
@@ -47,7 +47,7 @@ def verify_out_features_out_indices(
             )
 
     if out_indices is not None:
-        if isinstance(out_indices, (tuple,)):
+        if isinstance(out_indices, tuple):
             out_indices = list(out_indices)
         if not isinstance(out_indices, list):
             raise ValueError(f"out_indices must be a list, got {type(out_indices)}")

--- a/src/transformers/utils/backbone_utils.py
+++ b/src/transformers/utils/backbone_utils.py
@@ -47,8 +47,10 @@ def verify_out_features_out_indices(
             )
 
     if out_indices is not None:
-        if not isinstance(out_indices, (list, tuple)):
-            raise ValueError(f"out_indices must be a list or tuple, got {type(out_indices)}")
+        if isinstance(out_indices, (tuple,)):
+            out_indices = list(out_indices)
+        if not isinstance(out_indices, list):
+            raise ValueError(f"out_indices must be a list, got {type(out_indices)}")
         # Convert negative indices to their positive equivalent: [-1,] -> [len(stage_names) - 1,]
         positive_indices = tuple(idx % len(stage_names) if idx < 0 else idx for idx in out_indices)
         if any(idx for idx in positive_indices if idx not in range(len(stage_names))):
@@ -58,7 +60,7 @@ def verify_out_features_out_indices(
             msg += f"(equivalent to {positive_indices}))" if positive_indices != out_indices else ""
             raise ValueError(msg)
         if positive_indices != tuple(sorted(positive_indices)):
-            sorted_negative = tuple(idx for _, idx in sorted(zip(positive_indices, out_indices), key=lambda x: x[0]))
+            sorted_negative = [idx for _, idx in sorted(zip(positive_indices, out_indices), key=lambda x: x[0])]
             raise ValueError(
                 f"out_indices must be in the same order as stage_names, expected {sorted_negative} got {out_indices}"
             )
@@ -147,7 +149,10 @@ class BackboneMixin:
         # the timm model has out_features = ['act', 'layer1', 'layer2', 'layer3', 'layer4']
         self.stage_names = [stage["module"] for stage in self._backbone.feature_info.info]
         self.num_features = [stage["num_chs"] for stage in self._backbone.feature_info.info]
-        out_indices = self._backbone.feature_info.out_indices
+
+        # In some timm versions, out_indices reflects the input type of out_indices on the `create_model` call,
+        # in later versions >= 1, it is always a
+        out_indices = list(self._backbone.feature_info.out_indices)
         out_features = self._backbone.feature_info.module_name()
 
         # We verify the out indices and out features are valid

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -131,7 +131,7 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
         # Out indices are set to the last layer by default. For timm models, we don't know
         # the number of layers in advance, so we set it to (-1,), whereas for transformers
         # models, we set it to [len(stage_names) - 1] (kept for backward compatibility).
-        self.assertEqual(timm_model.out_indices, (-1,))
+        self.assertEqual(timm_model.out_indices, [-1])
         self.assertEqual(transformers_model.out_indices, [len(timm_model.stage_names) - 1])
 
         timm_model = AutoBackbone.from_pretrained(timm_checkpoint, use_timm_backbone=True, out_indices=[1, 2, 3])

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -97,13 +97,7 @@ class BackboneUtilsTester(unittest.TestCase):
         with pytest.raises(
             ValueError, match="out_features and out_indices should have the same length if both are set"
         ):
-            verify_out_features_out_indices(
-                ["a", "b"],
-                [
-                    0,
-                ],
-                ["a", "b", "c"],
-            )
+            verify_out_features_out_indices(["a", "b"], [0], ["a", "b", "c"])
 
         # Out features should match out indices
         with pytest.raises(

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -77,17 +77,17 @@ class BackboneUtilsTester(unittest.TestCase):
             verify_out_features_out_indices(["a", "a"], None, ["a"])
 
         # Out indices must be a list or tuple
-        with pytest.raises(ValueError, match="out_indices must be a list or tuple, got <class 'int'>"):
+        with pytest.raises(ValueError, match="out_indices must be a list, got <class 'int'>"):
             verify_out_features_out_indices(None, 0, ["a", "b"])
 
         # Out indices must be a subset of stage names
         with pytest.raises(
-            ValueError, match=r"out_indices must be valid indices for stage_names \['a'\], got \(0, 1\)"
+            ValueError, match=r"out_indices must be valid indices for stage_names \['a'\], got \[0, 1\]"
         ):
             verify_out_features_out_indices(None, (0, 1), ["a"])
 
         # Out indices must contain no duplicates
-        with pytest.raises(ValueError, match=r"out_indices must not contain any duplicates, got \(0, 0\)"):
+        with pytest.raises(ValueError, match=r"out_indices must not contain any duplicates, got \[0, 0\]"):
             verify_out_features_out_indices(None, (0, 0), ["a"])
 
         # Out features and out indices must be the same length
@@ -110,7 +110,7 @@ class BackboneUtilsTester(unittest.TestCase):
             verify_out_features_out_indices(["b", "a"], (0, 1), ["a", "b"])
 
         with pytest.raises(
-            ValueError, match=r"out_indices must be in the same order as stage_names, expected \(-2, 1\) got \(1, -2\)"
+            ValueError, match=r"out_indices must be in the same order as stage_names, expected \[-2, 1\] got \[1, -2\]"
         ):
             verify_out_features_out_indices(["a", "b"], (1, -2), ["a", "b"])
 

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -70,52 +70,61 @@ class BackboneUtilsTester(unittest.TestCase):
         with pytest.raises(
             ValueError, match=r"out_features must be a subset of stage_names: \['a'\] got \['a', 'b'\]"
         ):
-            verify_out_features_out_indices(["a", "b"], (0, 1), ["a"])
+            verify_out_features_out_indices(["a", "b"], [0, 1], ["a"])
 
         # Out features must contain no duplicates
         with pytest.raises(ValueError, match=r"out_features must not contain any duplicates, got \['a', 'a'\]"):
             verify_out_features_out_indices(["a", "a"], None, ["a"])
 
-        # Out indices must be a list or tuple
+        # Out indices must be a list
         with pytest.raises(ValueError, match="out_indices must be a list, got <class 'int'>"):
             verify_out_features_out_indices(None, 0, ["a", "b"])
+
+        with pytest.raises(ValueError, match="out_indices must be a list, got <class 'tuple'>"):
+            verify_out_features_out_indices(None, (0, 1), ["a", "b"])
 
         # Out indices must be a subset of stage names
         with pytest.raises(
             ValueError, match=r"out_indices must be valid indices for stage_names \['a'\], got \[0, 1\]"
         ):
-            verify_out_features_out_indices(None, (0, 1), ["a"])
+            verify_out_features_out_indices(None, [0, 1], ["a"])
 
         # Out indices must contain no duplicates
         with pytest.raises(ValueError, match=r"out_indices must not contain any duplicates, got \[0, 0\]"):
-            verify_out_features_out_indices(None, (0, 0), ["a"])
+            verify_out_features_out_indices(None, [0, 0], ["a"])
 
         # Out features and out indices must be the same length
         with pytest.raises(
             ValueError, match="out_features and out_indices should have the same length if both are set"
         ):
-            verify_out_features_out_indices(["a", "b"], (0,), ["a", "b", "c"])
+            verify_out_features_out_indices(
+                ["a", "b"],
+                [
+                    0,
+                ],
+                ["a", "b", "c"],
+            )
 
         # Out features should match out indices
         with pytest.raises(
             ValueError, match="out_features and out_indices should correspond to the same stages if both are set"
         ):
-            verify_out_features_out_indices(["a", "b"], (0, 2), ["a", "b", "c"])
+            verify_out_features_out_indices(["a", "b"], [0, 2], ["a", "b", "c"])
 
         # Out features and out indices should be in order
         with pytest.raises(
             ValueError,
             match=r"out_features must be in the same order as stage_names, expected \['a', 'b'\] got \['b', 'a'\]",
         ):
-            verify_out_features_out_indices(["b", "a"], (0, 1), ["a", "b"])
+            verify_out_features_out_indices(["b", "a"], [0, 1], ["a", "b"])
 
         with pytest.raises(
             ValueError, match=r"out_indices must be in the same order as stage_names, expected \[-2, 1\] got \[1, -2\]"
         ):
-            verify_out_features_out_indices(["a", "b"], (1, -2), ["a", "b"])
+            verify_out_features_out_indices(["a", "b"], [1, -2], ["a", "b"])
 
         # Check passes with valid inputs
-        verify_out_features_out_indices(["a", "b", "d"], (0, 1, -1), ["a", "b", "c", "d"])
+        verify_out_features_out_indices(["a", "b", "d"], [0, 1, -1], ["a", "b", "c", "d"])
 
     def test_backbone_mixin(self):
         backbone = BackboneMixin()


### PR DESCRIPTION
# What does this PR do?

Recent updates to timm changed the type of the attribute `model.feature_info.out_indices`. Previously, `out_indices` would reflect the input type of `out_indices` on the `create_model` call i.e. either `tuple` or `list`. Now, this value is always a tuple. This causes the following failure on main:

```
FAILED tests/models/timm_backbone/test_modeling_timm_backbone.py::TimmBackboneModelTest::test_timm_transformer_backbone_equivalence - AssertionError: (1, 2, 3) != [1, 2, 3]
```
Example CI run: https://app.circleci.com/pipelines/github/huggingface/transformers/93542/workflows/38bfe697-908c-4d2c-a05c-7b99090fb084/jobs/1226834

As list are more useful and consistent for us -- we cannot save tuples in configs, they must be converted to lists first -- we instead choose to cast `out_indices` to always be a list. 

This has the possibility of being a slight breaking change if users are creating models and relying on `out_indices` on being a tuple. As this property only happens when a new model is created, and not if it's saved and reloaded (because of the config), then I think this has a low chance of having much of an impact. 

The following tests were run to make sure everything is still OK: 

```
pytest tests/utils/test_backbone_utils.py
pytest tests/models/timm_backbone/test_modeling_timm_backbone.py
pytest tests/models/swin/test_modeling_swin.py::SwinBackboneTest
```