### PR TITLE
🚨 fix(SigLip): remove spurious exclusion of first vision output token

### DIFF
--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -1329,7 +1329,7 @@ class SiglipForImageClassification(SiglipPreTrainedModel):
         sequence_output = outputs[0]
 
         # average pool the patch tokens
-        sequence_output = torch.mean(sequence_output[:, 1:, :], dim=1)
+        sequence_output = torch.mean(sequence_output, dim=1)
         # apply classifier
         logits = self.classifier(sequence_output)
 


### PR DESCRIPTION
Looks like the first token is spuriously excluded from the average pooling because this code was copy & pasted from `modeling_clip`, which does prepend a `[CLS]` token. However SigLip has no such special token, so it would seem we are needlessly excluding a token from being included?

p.s. why not use the `pooled_output` from the model's map head vs averaging the last hidden states? 