### PR TITLE
filter flash_attn optional imports loading remote code

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -150,7 +150,7 @@ def get_imports(filename: Union[str, os.PathLike]) -> List[str]:
     # filter out try/except block so in custom code we can have try/except imports
     content = re.sub(r"\s*try\s*:\s*.*?\s*except\s*.*?:", "", content, flags=re.MULTILINE | re.DOTALL)
     # filter out imports under is_flash_attn_2_available block for avoid import issues in cpu only environment
-    content = re.sub(r"if is_flash_attn_*available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE)
+    content = re.sub(r"if is_flash_attn_[0-9]+_available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE)
 
     # Imports of the form `import xxx`
     imports = re.findall(r"^\s*import\s+(\S+)\s*$", content, flags=re.MULTILINE)

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -149,6 +149,8 @@ def get_imports(filename: Union[str, os.PathLike]) -> List[str]:
 
     # filter out try/except block so in custom code we can have try/except imports
     content = re.sub(r"\s*try\s*:\s*.*?\s*except\s*.*?:", "", content, flags=re.MULTILINE | re.DOTALL)
+    # filter out imports under is_flash_attn_2_available block for avoid import issues in cpu only environment
+    content = re.sub(r"if is_flash_attn_*available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE)
 
     # Imports of the form `import xxx`
     imports = re.findall(r"^\s*import\s+(\S+)\s*$", content, flags=re.MULTILINE)

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -151,7 +151,7 @@ def get_imports(filename: Union[str, os.PathLike]) -> List[str]:
     content = re.sub(r"\s*try\s*:\s*.*?\s*except\s*.*?:", "", content, flags=re.MULTILINE | re.DOTALL)
     # filter out imports under is_flash_attn_2_available block for avoid import issues in cpu only environment
     content = re.sub(
-        r"if is_flash_attn_[0-9]+_available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE
+        r"if is_flash_attn[a-zA-Z0-9_]+available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE
     )
 
     # Imports of the form `import xxx`

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -150,7 +150,9 @@ def get_imports(filename: Union[str, os.PathLike]) -> List[str]:
     # filter out try/except block so in custom code we can have try/except imports
     content = re.sub(r"\s*try\s*:\s*.*?\s*except\s*.*?:", "", content, flags=re.MULTILINE | re.DOTALL)
     # filter out imports under is_flash_attn_2_available block for avoid import issues in cpu only environment
-    content = re.sub(r"if is_flash_attn_[0-9]+_available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE)
+    content = re.sub(
+        r"if is_flash_attn_[0-9]+_available\(\):\s*(from flash_attn\s*.*\s*)+", "", content, flags=re.MULTILINE
+    )
 
     # Imports of the form `import xxx`
     imports = re.findall(r"^\s*import\s+(\S+)\s*$", content, flags=re.MULTILINE)


### PR DESCRIPTION
# What does this PR do?

in some remote available models code, we can meet optional import flash_attention module without try-except block. 
Examples:
phi3-vision - https://huggingface.co/microsoft/Phi-3-vision-128k-instruct/blob/main/modeling_phi3_v.py#L52
orion-14b - https://huggingface.co/OrionStarAI/Orion-14B-Chat/blob/main/modeling_orion.py#L36
deepseek-moe - https://huggingface.co/deepseek-ai/deepseek-moe-16b-base/blob/main/modeling_deepseek.py#L54
nanoLLAVA- https://huggingface.co/qnguyen3/nanoLLaVA/blob/main/modeling_llava_qwen2.py#L861


loading such model in environment where flash_attn package is not installed failed with trust_remote_code flag. It may be problematic to install and import this package (e.g. for environment where no cuda and torch installed for cpu only) for some environment. This PR update dependencies search logic for checking dynamic modules loading.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
