### PR TITLE
FIX / TST: Fix expected results on Mistral AWQ test 

### DIFF
--- a/tests/quantization/autoawq/test_awq.py
+++ b/tests/quantization/autoawq/test_awq.py
@@ -288,7 +288,7 @@ class AwqFusedTest(unittest.TestCase):
         "You end up exactly where you started. Where are you?"
     )
 
-    EXPECTED_GENERATION = prompt + "\n\nYou are at the starting point.\n\nIf"
+    EXPECTED_GENERATION = prompt + "\n\nThis is a classic puzzle that has been around for"
     EXPECTED_GENERATION_CUSTOM_MODEL = "Hello,\n\nI have a problem with my 20"
     EXPECTED_GENERATION_MIXTRAL = prompt + " You're on the North Pole.\n\nThe"
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes the Mistral AWQ slow test. This failing was caused by the torch.compile [PR](https://github.com/huggingface/transformers/pull/30642). Since the output is coherent, I think the best is to change the expected output, just like what we did [here](https://github.com/huggingface/transformers/pull/30909). 