### PR TITLE
Fix `test_compile_static_cache`

### DIFF
--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -728,7 +728,10 @@ class LlamaIntegrationTest(unittest.TestCase):
                 "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on my eggs, "
                 "my fries, my chicken, my burgers, my hot dogs, my sandwiches, my salads, my p",
             ],
-            7: ['Simply put, the theory of relativity states that 1) the speed of light is constant in all inertial reference frames, and 2) the laws of physics are the same for all inertial reference frames.\nThe theory of relativ', 'My favorite all time favorite condiment is ketchup. I love it on everything. I love it on my eggs, my fries, my chicken, my burgers, my hot dogs, my sandwiches, my salads, my p'],
+            7: [
+                "Simply put, the theory of relativity states that 1) the speed of light is constant in all inertial reference frames, and 2) the laws of physics are the same for all inertial reference frames.\nThe theory of relativ",
+                "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on my eggs, my fries, my chicken, my burgers, my hot dogs, my sandwiches, my salads, my p",
+            ],
             9: [
                 "Simply put, the theory of relativity states that 1) the speed of light is constant in all inertial"
                 " reference frames, and 2) the laws of physics are the same for all inertial reference frames.\nThe "

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -728,13 +728,7 @@ class LlamaIntegrationTest(unittest.TestCase):
                 "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on my eggs, "
                 "my fries, my chicken, my burgers, my hot dogs, my sandwiches, my salads, my p",
             ],
-            7: [
-                "Simply put, the theory of relativity states that 1. surely nothing is faster than light.\nThe theory "
-                "goes that nothing travels faster than light, but the faster you go, the slower everything else will "
-                "be.\nThe theory of relativity",
-                "My favorite all time favorite condiment is ketchup. I love it on hamburgers, hot dogs, fries, eggs, "
-                "and even on a good old fashioned cheeseburger. I love it on everything. I love it so",
-            ],
+            7: ['Simply put, the theory of relativity states that 1) the speed of light is constant in all inertial reference frames, and 2) the laws of physics are the same for all inertial reference frames.\nThe theory of relativ', 'My favorite all time favorite condiment is ketchup. I love it on everything. I love it on my eggs, my fries, my chicken, my burgers, my hot dogs, my sandwiches, my salads, my p'],
             9: [
                 "Simply put, the theory of relativity states that 1) the speed of light is constant in all inertial"
                 " reference frames, and 2) the laws of physics are the same for all inertial reference frames.\nThe "

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -27,6 +27,7 @@ from transformers.testing_utils import (
     is_flaky,
     require_bitsandbytes,
     require_flash_attn,
+    require_read_token,
     require_torch,
     require_torch_gpu,
     require_torch_sdpa,
@@ -658,6 +659,7 @@ class MistralIntegrationTest(unittest.TestCase):
         gc.collect()
 
     @slow
+    @require_read_token
     def test_compile_static_cache(self):
         # `torch==2.2` will throw an error on this test (as in other compilation tests), but torch==2.1.2 and torch>2.2
         # work as intended. See https://github.com/pytorch/pytorch/issues/121943

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -666,6 +666,9 @@ class MistralIntegrationTest(unittest.TestCase):
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest("This test requires torch >= 2.3 to run.")
 
+        if self.cuda_compute_capability_major_version == 7:
+            self.skipTest("This test is failing (`torch.compile` fails) on Nvidia T4 GPU.")
+
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = {
             8: [


### PR DESCRIPTION
# What does this PR do?

Fix or skip `test_compile_static_cache` on Nvida T4 GPU. Those tests **are never run on T4** until we switch to torch 2.3.

- For LLama: just update the output values for T4.
- For Mistral: `torch.compile` failed. Let's skip it for T4 and focus on A10 CI (important model testing CI)
- (Gemma don't need any update)

cc @ArthurZucker @zhenglongjiepheonix 