### PR TITLE
Do not trigger autoconversion if local_files_only

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3393,7 +3393,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                         if resolved_archive_file is not None:
                             is_sharded = True
 
-                    if resolved_archive_file is not None:
+                    if not local_files_only and resolved_archive_file is not None:
                         if filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]:
                             # If the PyTorch file was found, check if there is a safetensors file on the repository
                             # If there is no safetensors file on the repositories, start an auto conversion


### PR DESCRIPTION
See [slack thread](https://huggingface.slack.com/archives/C016D661PAN/p1716540187510999?thread_ts=1716484668.496509&cid=C016D661PAN) (internal).

Since https://github.com/huggingface/transformers/pull/29846 (cc @LysandreJik) if pytorch weights are loaded and safetensors ones don't exist, we trigger an autoconversion of the weights. This should not impact user's experience. This PR disable the autoconversion call if `local_files_only=True` is passed. 