### PR TITLE
Fix resume_download future warning

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -647,7 +647,7 @@ class PretrainedConfig(PushToHubMixin):
         cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         cache_dir = kwargs.pop("cache_dir", None)
-        force_download = kwargs.pop("force_download", None)
+        force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", None)
         proxies = kwargs.pop("proxies", None)
         token = kwargs.pop("token", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -647,8 +647,8 @@ class PretrainedConfig(PushToHubMixin):
         cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         cache_dir = kwargs.pop("cache_dir", None)
-        force_download = kwargs.pop("force_download", False)
-        resume_download = kwargs.pop("resume_download", False)
+        force_download = kwargs.pop("force_download", None)
+        resume_download = kwargs.pop("resume_download", None)
         proxies = kwargs.pop("proxies", None)
         token = kwargs.pop("token", None)
         local_files_only = kwargs.pop("local_files_only", False)

--- a/tests/test_configuration_utils.py
+++ b/tests/test_configuration_utils.py
@@ -20,6 +20,7 @@ import sys
 import tempfile
 import unittest
 import unittest.mock as mock
+import warnings
 from pathlib import Path
 
 from huggingface_hub import HfFolder, delete_repo
@@ -306,3 +307,10 @@ class ConfigTestUtils(unittest.TestCase):
         self.assertTrue(config._has_non_default_generation_parameters())
         config = BertConfig(min_length=0)  # `min_length = 0` is a default generation kwarg
         self.assertFalse(config._has_non_default_generation_parameters())
+
+    def test_loading_config_do_not_raise_future_warnings(self):
+        """Regression test for https://github.com/huggingface/transformers/issues/31002."""
+        # Loading config should not raise a FutureWarning. It was the case before.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            PretrainedConfig.from_pretrained("bert-base-uncased")


### PR DESCRIPTION
Fix https://github.com/huggingface/transformers/issues/31002 and follow-up https://github.com/huggingface/transformers/issues/30618.

Looks like I forgot a `resume_download` in https://github.com/huggingface/transformers/issues/30618. This PR fixes it to avoid a FutureWarning for which the user can't do much. 

cc @albertvillanova 

Note: this is "simply" as warning but should not trigger any errors. It triggers one in datasets' CI but that's only because of pytest settings.