### PR TITLE
Render chat template tojson filter as unicode

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1853,6 +1853,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             raise TemplateError(message)
 
         jinja_env = ImmutableSandboxedEnvironment(trim_blocks=True, lstrip_blocks=True)
+        jinja_env.policies['json.dumps_kwargs']['ensure_ascii'] = False
         jinja_env.globals["raise_exception"] = raise_exception
         return jinja_env.from_string(chat_template)
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1853,7 +1853,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             raise TemplateError(message)
 
         jinja_env = ImmutableSandboxedEnvironment(trim_blocks=True, lstrip_blocks=True)
-        jinja_env.policies['json.dumps_kwargs']['ensure_ascii'] = False
+        jinja_env.policies["json.dumps_kwargs"]["ensure_ascii"] = False
         jinja_env.globals["raise_exception"] = raise_exception
         return jinja_env.from_string(chat_template)
 


### PR DESCRIPTION
# What does this PR do?

<details>
<summary>Rant about lack of special capabilties templates...</summary>

I wish more models that have extra capabilities like f.ex. function calling would start using the power available in chat templates instead of implementing their own inference mini-stacks (`Mistral`, `Berkeley`, et al.; I'm looking at you) that you would have to add as model-specific dependencies to use those features "as intended".

Shout out to `Cohere` for actually making an effort here, however it's a shame they did not follow it to completion to also include the final `tool` role to enable the full round-trip with natural language response to the function call (see my Mistral `GGUF` for a fully functional example of this).
</details>

I've been using the jinja2 `tojson` filter in a couple of chat templates to render function calling instructions, which is working very well, however sometimes this will introduce escaped unicode characters, which is undesirable.

I'm mainly using `GGUF`s, so have not used `tojson` with `transformers` yet, but I imagine this could be a useful feature for many recent models if only they started using chat templates properly (see rant).

This PR simply changes the default parameters of `tojson` so that the JSON is rendered in unicode.

Examples of (`GGUF`) models using `tojson`:
* [openfunctions-v2](https://huggingface.co/CISCai/gorilla-openfunctions-v2-SOTA-GGUF)
* [Mistral-7B-Instruct-v0.3](https://huggingface.co/CISCai/Mistral-7B-Instruct-v0.3-SOTA-GGUF)

Submitted similar PR to abetlen/llama-cpp-python#1486

## Who can review?

@ArthurZucker