### PR TITLE
Add basic eval table logging for WandbCallback

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -695,7 +695,16 @@ class WandbCallback(TrainerCallback):
     A [`TrainerCallback`] that logs metrics, media, model checkpoints to [Weight and Biases](https://www.wandb.com/).
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        trainer: Optional["Trainer"] = None,
+        tokenizer: Optional["PreTrainedTokenizerBase"] = None,
+        dataset: Optional["Dataset"] = None,
+        num_samples: int = 10,
+        freq: int = 1,
+        ignore_tokens: Optional[list] = None,
+    ):
         has_wandb = is_wandb_available()
         if not has_wandb:
             raise RuntimeError("WandbCallback requires wandb to be installed. Run `pip install wandb`.")
@@ -704,6 +713,48 @@ class WandbCallback(TrainerCallback):
 
             self._wandb = wandb
         self._initialized = False
+
+        # Setup for evals if user requests it
+        if os.getenv("WANDB_LOG_EVALS"):
+            if trainer is not None:
+                self.trainer = trainer
+
+            if tokenizer is None:
+                tokenizer = self.trainer.tokenizer
+            self.tokenizer = tokenizer
+
+            if dataset is None:
+                dataset = self.trainer.eval_dataset
+
+            try:
+                sampled_dataset = dataset.select(range(num_samples))
+            except IndexError as e:
+                print(f"WARNING: Could not get those indices: {e=}")
+                sampled_dataset = dataset
+
+            self.sample_dataset = sampled_dataset
+            self.freq = freq
+
+            if ignore_tokens is None:
+                ignore_tokens = [-100]
+
+            padding_token_id = self.tokenizer.pad_token_id
+
+            def replace_ignored_tokens(a):
+                if isinstance(a, np.ndarray):
+                    mask = np.isin(a, ignore_tokens)
+                elif isinstance(a, torch.Tensor):
+                    mask = torch.isin(a, torch.tensor(ignore_tokens, dtype=a.dtype))
+                else:
+                    raise TypeError(f"Unsupported type replace token type {type(a)}")
+
+                a[mask] = padding_token_id
+                return a
+
+            self._replace_ignored_tokens_func = replace_ignored_tokens
+
+            self._collected_eval_rows = []
+
         # log model
         if os.getenv("WANDB_LOG_MODEL", "FALSE").upper() in ENV_VARS_TRUE_VALUES.union({"TRUE"}):
             DeprecationWarning(
@@ -932,6 +983,36 @@ class WandbCallback(TrainerCallback):
         if state.is_world_process_zero:
             metrics = rewrite_logs(metrics)
             self._wandb.log(metrics)
+
+    def on_evaluate(self, args, state, control, **kwargs):
+        if os.getenv("WANDB_LOG_EVALS"):
+            eval_loop_output = self.trainer.eval_loop_output
+
+            inputs = eval_loop_output.inputs
+            decoded_inputs = self.tokenizer.batch_decode(inputs, skip_special_tokens=True)
+
+            preds = eval_loop_output.predictions
+            outputs = preds.argmax(axis=-1)
+            decoded_outputs = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
+
+            expected = eval_loop_output.label_ids
+            expected = self._replace_ignored_tokens_func(expected)
+            decoded_expected = self.tokenizer.batch_decode(expected, skip_special_tokens=True)
+
+            # un-batch and log rows
+            for dec_inp, dec_out, dec_exp in zip(decoded_inputs, decoded_outputs, decoded_expected):
+                row = {
+                    "decoded_inputs": dec_inp,
+                    "decoded_outputs": dec_out,
+                    "decoded_expected": dec_exp,
+                }
+                self._collected_eval_rows.append(row)
+
+            table = self._wandb.Table(columns=list(row.keys()))
+            for row in self._collected_eval_rows:
+                table.add_data(*row.values())
+
+            self._wandb.log({"evaluation_table": table})
 
 
 class CometCallback(TrainerCallback):

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -698,9 +698,9 @@ class WandbCallback(TrainerCallback):
     def __init__(
         self,
         *,
-        trainer: Optional["Trainer"] = None,
-        tokenizer: Optional["PreTrainedTokenizerBase"] = None,
-        dataset: Optional["Dataset"] = None,
+        trainer = None,
+        tokenizer = None,
+        dataset = None,
         num_samples: int = 10,
         freq: int = 1,
         ignore_tokens: Optional[list] = None,

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -698,9 +698,9 @@ class WandbCallback(TrainerCallback):
     def __init__(
         self,
         *,
-        trainer = None,
-        tokenizer = None,
-        dataset = None,
+        trainer=None,
+        tokenizer=None,
+        dataset=None,
         num_samples: int = 10,
         freq: int = 1,
         ignore_tokens: Optional[list] = None,

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1009,7 +1009,7 @@ class WandbCallback(TrainerCallback):
             available_fields = [
                 ("decoded_inputs", decoded_inputs),
                 ("decoded_outputs", decoded_outputs),
-                ("decoded_expected", decoded_expected)
+                ("decoded_expected", decoded_expected),
             ]
             available_fields = [(name, value) for name, value in available_fields if value is not None]
 

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -692,7 +692,7 @@ def save_model_architecture_to_file(model: Any, output_dir: str):
 
 class WandbCallback(TrainerCallback):
     """
-    A [`TrainerCallback`] that logs metrics, media, model checkpoints to [Weight and Biases](https://www.wandb.com/).
+    A [`TrainerCallback`] that logs metrics, media, evals, and model checkpoints to [Weight and Biases](https://www.wandb.com/).
     """
 
     def __init__(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3668,6 +3668,7 @@ class Trainer:
             )
         )
 
+        self.eval_loop_output = output
         self.log(output.metrics)
 
         if DebugOption.TPU_METRICS_DEBUG in self.args.debug:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3939,7 +3939,9 @@ class Trainer:
             if not key.startswith(f"{metric_key_prefix}_"):
                 metrics[f"{metric_key_prefix}_{key}"] = metrics.pop(key)
 
-        return EvalLoopOutput(predictions=all_preds, label_ids=all_labels, metrics=metrics, num_samples=num_samples)
+        return EvalLoopOutput(
+            predictions=all_preds, label_ids=all_labels, metrics=metrics, num_samples=num_samples, inputs=all_inputs
+        )
 
     def _nested_gather(self, tensors, name=None):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -570,6 +570,14 @@ class Trainer:
             )
         default_callbacks = DEFAULT_CALLBACKS + get_reporting_integration_callbacks(self.args.report_to)
         callbacks = default_callbacks if callbacks is None else default_callbacks + callbacks
+
+        # Add a reference to the trainer in case callbacks need it
+        def init_callback(cb):
+            cb.trainer = self
+            return cb
+
+        callbacks = [init_callback(cb) for cb in callbacks]
+
         self.callback_handler = CallbackHandler(
             callbacks, self.model, self.tokenizer, self.optimizer, self.lr_scheduler
         )

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -188,6 +188,7 @@ class EvalLoopOutput(NamedTuple):
     label_ids: Optional[Union[np.ndarray, Tuple[np.ndarray]]]
     metrics: Optional[Dict[str, float]]
     num_samples: Optional[int]
+    inputs: Union[np.ndarray, Tuple[np.ndarray]]
 
 
 class PredictionOutput(NamedTuple):


### PR DESCRIPTION
# What does this PR do?
This PR adds basic support for logging raw evals using `WandbCallback`.
1. Calling `trainer.evaluate()` will log an eval table with inputs and outputs; and
2. Logging is controlled by the `WANDB_LOG_EVALS` env var.

This also adds some changes to trainer internals to support this, including:
1. Updates `EvalLoopOutputs` to include `inputs`
2. Automatically adds a ref to the trainer when instantiating callbacks

Here's an example table that gets logged when the user calls `trainer.evaluate()`
![image](https://github.com/huggingface/transformers/assets/15385696/17918541-8b84-4437-918d-1d97d812ddf3)



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts are you the right person to review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
