### PR TITLE
Redirect transformers_agents doc to agents

### DIFF
--- a/docs/source/en/_redirects.yml
+++ b/docs/source/en/_redirects.yml
@@ -1,3 +1,4 @@
 # Optimizing inference
 
 perf_infer_gpu_many: perf_infer_gpu_one
+transformers_agents: agents


### PR DESCRIPTION
# What does this PR do?
Redirect the previous `transformers_agents` doc to `agents`.