### PR TITLE
skip `test_model_parallelism` for 2 model test classes

### DIFF
--- a/tests/models/deformable_detr/test_modeling_deformable_detr.py
+++ b/tests/models/deformable_detr/test_modeling_deformable_detr.py
@@ -232,6 +232,12 @@ class DeformableDetrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineT
         self.model_tester = DeformableDetrModelTester(self)
         self.config_tester = ConfigTester(self, config_class=DeformableDetrConfig, has_text_modality=False)
 
+    @unittest.skip(
+        "This starts to fail since 2024/05/24, but earlier commits also fail now and affect many other tests. The error is `an illegal memory access was encountered`."
+    )
+    def test_model_parallelism(self):
+        super().test_model_parallelism()
+
     def test_config(self):
         # we don't test common_properties and arguments_init as these don't apply for Deformable DETR
         self.config_tester.create_and_test_config_to_json_string()

--- a/tests/models/rwkv/test_modeling_rwkv.py
+++ b/tests/models/rwkv/test_modeling_rwkv.py
@@ -304,6 +304,12 @@ class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
             standardMsg = "%s not found in %s" % (safe_repr(member), safe_repr(container))
             self.fail(self._formatMessage(msg, standardMsg))
 
+    @unittest.skip(
+        "This starts to fail since 2024/05/24, but earlier commits also fail now and affect many other tests. The error is `an illegal memory access was encountered`."
+    )
+    def test_model_parallelism(self):
+        super().test_model_parallelism()
+
     def test_config(self):
         self.config_tester.run_common_tests()
 


### PR DESCRIPTION
# What does this PR do?

We get many failures (` RuntimeError: CUDA error: an illegal memory access was encountered`) in multi-gpu tests since May 24 for rkwv and deformable_detr. It is caused by `test_model_parallelism` which itself cause many other tests to fail.

https://github.com/huggingface/transformers/actions/runs/9248300038/job/25438485848
https://github.com/huggingface/transformers/actions/runs/9248300038/job/25438482290

Let's skip it to have a better CI state. 