### PR TITLE
Remove float64 cast for OwlVit and OwlV2 to support MPS device

### DIFF
--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -1276,7 +1276,6 @@ class Owlv2ClassPredictionHead(nn.Module):
             if query_mask.ndim > 1:
                 query_mask = torch.unsqueeze(query_mask, dim=-2)
 
-            pred_logits = pred_logits.to(torch.float64)
             pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
             pred_logits = pred_logits.to(torch.float32)
 

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1257,7 +1257,6 @@ class OwlViTClassPredictionHead(nn.Module):
             if query_mask.ndim > 1:
                 query_mask = torch.unsqueeze(query_mask, dim=-2)
 
-            pred_logits = pred_logits.to(torch.float64)
             pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
             pred_logits = pred_logits.to(torch.float32)
 


### PR DESCRIPTION
# What does this PR do?

Remove `pred_logits` float64 casting, to support "mps" device for OwlVit and OwlV2.
It seems like we can safely remove float64 cast, two lines later there is a cast to float32.

```diff
- pred_logits = pred_logits.to(torch.float64)
pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
pred_logits = pred_logits.to(torch.float32)
```

The [orignal repo](https://github.com/google-research/scenic/blob/e08103067d2033470e5d072a0f4117a02f6f9a4a/scenic/projects/owl_vit/layers.py#L249) does not contain float64 cast, but probably there was a specific reason to do that. Super safe variant might be 

```diff
- pred_logits = pred_logits.to(torch.float64)
+ pred_logits = pred_logits.to(torch.float32)
pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
pred_logits = pred_logits.to(torch.float32)
```


Fixes # (issue)
https://github.com/huggingface/transformers/issues/31060

## Who can review?
@LysandreJik @NielsRogge 
