### PR TITLE
Docs / PEFT: Add PEFT API documentation

### DIFF
--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -81,7 +81,7 @@ model = AutoModelForCausalLM.from_pretrained(model_id)
 model.load_adapter(peft_model_id)
 ```
 
-Check out the API documentation section below for more details.
+Check out the [API documentation](#API-documentation) section below for more details.
 
 ## Load in 8bit or 4bit
 
@@ -239,6 +239,7 @@ model.add_adapter(lora_config)
     - enable_adapters
     - active_adapters
     - get_adapter_state_dict
+
 
 
 

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -81,7 +81,7 @@ model = AutoModelForCausalLM.from_pretrained(model_id)
 model.load_adapter(peft_model_id)
 ```
 
-Check out the [API documentation](#API-documentation) section below for more details.
+Check out the [API documentation](#API-docs) section below for more details.
 
 ## Load in 8bit or 4bit
 

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -81,6 +81,8 @@ model = AutoModelForCausalLM.from_pretrained(model_id)
 model.load_adapter(peft_model_id)
 ```
 
+Check out the API documentation section below for more details.
+
 ## Load in 8bit or 4bit
 
 The `bitsandbytes` integration supports 8bit and 4bit precision data types, which are useful for loading large models because it saves memory (see the `bitsandbytes` integration [guide](./quantization#bitsandbytes-integration) to learn more). Add the `load_in_8bit` or `load_in_4bit` parameters to [`~PreTrainedModel.from_pretrained`] and set `device_map="auto"` to effectively distribute the model to your hardware:
@@ -226,6 +228,18 @@ lora_config = LoraConfig(
 
 model.add_adapter(lora_config)
 ```
+
+## API docs
+
+[[autodoc]] integrations.PeftAdapterMixin
+    - load_adapter
+    - add_adapter
+    - set_adapter
+    - disable_adapters
+    - enable_adapters
+    - active_adapters
+    - get_adapter_state_dict
+
 
 
 <!--

--- a/docs/source/en/peft.md
+++ b/docs/source/en/peft.md
@@ -81,7 +81,7 @@ model = AutoModelForCausalLM.from_pretrained(model_id)
 model.load_adapter(peft_model_id)
 ```
 
-Check out the [API documentation](#API-docs) section below for more details.
+Check out the [API documentation](#transformers.integrations.PeftAdapterMixin) section below for more details.
 
 ## Load in 8bit or 4bit
 


### PR DESCRIPTION
# What does this PR do?

Currently in the PEFT integration docs, the API documentation is missing, this PR adds it as discussed internally: https://huggingface.slack.com/archives/C04L3MWLE6B/p1716843071520559

cc @osanseviero @stevhliu 

