### PR TITLE
Fix OWLv2 post_process_object_detection for multiple images

### DIFF
--- a/src/transformers/models/owlv2/image_processing_owlv2.py
+++ b/src/transformers/models/owlv2/image_processing_owlv2.py
@@ -524,19 +524,11 @@ class Owlv2ImageProcessor(BaseImageProcessor):
             else:
                 img_h, img_w = target_sizes.unbind(1)
 
-            # rescale coordinates
-            width_ratio = 1
-            height_ratio = 1
+            # Rescale coordinates, image is padded to square for inference,
+            # that is why we need to scale boxes to the max size
+            size = torch.max(img_h, img_w)
+            scale_fct = torch.stack([size, size, size, size], dim=1).to(boxes.device)
 
-            if img_w < img_h:
-                width_ratio = img_w / img_h
-            elif img_h < img_w:
-                height_ratio = img_h / img_w
-
-            img_w = img_w / width_ratio
-            img_h = img_h / height_ratio
-
-            scale_fct = torch.stack([img_w, img_h, img_w, img_h], dim=1).to(boxes.device)
             boxes = boxes * scale_fct[:, None, :]
 
         results = []

--- a/tests/models/owlv2/test_image_processor_owlv2.py
+++ b/tests/models/owlv2/test_image_processor_owlv2.py
@@ -130,17 +130,42 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         model = Owlv2ForObjectDetection.from_pretrained(checkpoint)
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
-        inputs = processor(text=["cat"], images=image, return_tensors="pt")
+        text = ["cat"]
+        target_size = image.size[::-1]
+        expected_boxes = torch.tensor(
+            [
+                [341.66656494140625, 23.38756561279297, 642.321044921875, 371.3482971191406],
+                [6.753320693969727, 51.96149826049805, 326.61810302734375, 473.12982177734375],
+            ]
+        )
 
+        # single image
+        inputs = processor(text=[text], images=[image], return_tensors="pt")
         with torch.no_grad():
             outputs = model(**inputs)
 
-        target_sizes = torch.tensor([image.size[::-1]])
-        results = processor.post_process_object_detection(outputs, threshold=0.2, target_sizes=target_sizes)[0]
+        results = processor.post_process_object_detection(outputs, threshold=0.2, target_sizes=[target_size])[0]
 
-        boxes = results["boxes"].tolist()
-        self.assertEqual(boxes[0], [341.66656494140625, 23.38756561279297, 642.321044921875, 371.3482971191406])
-        self.assertEqual(boxes[1], [6.753320693969727, 51.96149826049805, 326.61810302734375, 473.12982177734375])
+        boxes = results["boxes"]
+        self.assertTrue(
+            torch.allclose(boxes, expected_boxes, atol=1e-2),
+            f"Single image bounding boxes fail. Expected {expected_boxes}, got {boxes}",
+        )
+
+        # batch of images
+        inputs = processor(text=[text, text], images=[image, image], return_tensors="pt")
+        with torch.no_grad():
+            outputs = model(**inputs)
+        results = processor.post_process_object_detection(
+            outputs, threshold=0.2, target_sizes=[target_size, target_size]
+        )
+
+        for result in results:
+            boxes = result["boxes"]
+            self.assertTrue(
+                torch.allclose(boxes, expected_boxes, atol=1e-2),
+                f"Batch image bounding boxes fail. Expected {expected_boxes}, got {boxes}",
+            )
 
     @unittest.skip("OWLv2 doesn't treat 4 channel PIL and numpy consistently yet")  # FIXME Amy
     def test_call_numpy_4_channels(self):


### PR DESCRIPTION
# What does this PR do?

Fix OWLv2 post_process_object_detection for multiple images. Currently fails due to direct comparison `img_h > img_w`, while that might be tensors with multiple values.

Fixes #31077

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)
- [x] Did you write any new necessary tests?


## Who can review?

@amyeroberts 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
