### PR TITLE
FIX: Add `accelerate` as a hard requirement

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3048,6 +3048,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 " ignored."
             )
 
+        if gguf_file is not None and not is_accelerate_available():
+            raise ValueError("accelerate is required when loading a GGUF file `pip install accelerate`.")
+
         if commit_hash is None:
             if not isinstance(config, PretrainedConfig):
                 # We make a call to the config file first (which may be absent) to get the commit hash as soon as possible


### PR DESCRIPTION
# What does this PR do?

While trying to reproduce: https://github.com/huggingface/transformers/issues/30889 - I was hitting an obscure issue on a fresh new Google Colab environment

```bash
Converting and de-quantizing GGUF tensors...: 100%|██████████| 201/201 [00:25<00:00,  7.86it/s]
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
[<ipython-input-6-5f6842b815e2>](https://localhost:8080/#) in <cell line: 6>()
      4 filename = "tinyllama-1.1b-chat-v1.0.Q6_K.gguf"
      5 
----> 6 model = AutoModelForCausalLM.from_pretrained(model_id, gguf_file=filename)
      7 tokenizer = AutoTokenizer.from_pretrained(model_id, gguf_file=filename)

3 frames
[/usr/local/lib/python3.10/dist-packages/transformers/models/auto/auto_factory.py](https://localhost:8080/#) in from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs)
    561         elif type(config) in cls._model_mapping.keys():
    562             model_class = _get_model_class(config, cls._model_mapping)
--> 563             return model_class.from_pretrained(
    564                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs
    565             )

[/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py](https://localhost:8080/#) in from_pretrained(cls, pretrained_model_name_or_path, config, cache_dir, ignore_mismatched_sizes, force_download, local_files_only, token, revision, use_safetensors, *model_args, **kwargs)
   3752                 offload_index,
   3753                 error_msgs,
-> 3754             ) = cls._load_pretrained_model(
   3755                 model,
   3756                 state_dict,

[/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py](https://localhost:8080/#) in _load_pretrained_model(cls, model, state_dict, loaded_keys, resolved_archive_file, pretrained_model_name_or_path, ignore_mismatched_sizes, sharded_metadata, _fast_init, low_cpu_mem_usage, device_map, offload_folder, offload_state_dict, dtype, hf_quantizer, keep_in_fp32_modules, gguf_path)
   4141             # For GGUF models `state_dict` is never set to None as the state dict is always small
   4142             if gguf_path:
-> 4143                 error_msgs, offload_index, state_dict_index = _load_state_dict_into_meta_model(
   4144                     model_to_load,
   4145                     state_dict,

[/usr/local/lib/python3.10/dist-packages/transformers/modeling_utils.py](https://localhost:8080/#) in _load_state_dict_into_meta_model(model, state_dict, loaded_state_dict_keys, start_prefix, expected_keys, device_map, offload_folder, offload_index, state_dict_folder, state_dict_index, dtype, hf_quantizer, is_safetensors, keep_in_fp32_modules, unexpected_keys)
    885         ):
    886             # For backward compatibility with older versions of `accelerate` and for non-quantized params
--> 887             set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)
    888         else:
    889             hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict, unexpected_keys)

NameError: name 'set_module_tensor_to_device' is not defined
```

This is because we forgot to add `accelerate` as a hard dependency when loading GGUF files, hence the `set_module_tensor_to_device` is not correctly imported for users that run that script on a env that do not have accelerate installed

The fix is to simply raise an error for users that try to load a GGUF file if accelerate is not installed

cc @amyeroberts 