### PR TITLE
FIX / OPT: Fix OPT multi-GPU training for `OPTForQuestionAnswering`

### DIFF
--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1427,8 +1427,8 @@ class OPTForQuestionAnswering(OPTPreTrainedModel):
                 end_positions = end_positions.squeeze(-1)
             # sometimes the start/end positions are outside our model inputs, we ignore these terms
             ignored_index = start_logits.size(1)
-            start_positions = start_positions.clamp(0, ignored_index)
-            end_positions = end_positions.clamp(0, ignored_index)
+            start_positions = start_positions.clamp(0, ignored_index).to(logits.device)
+            end_positions = end_positions.clamp(0, ignored_index).to(logits.device)
 
             loss_fct = CrossEntropyLoss(ignore_index=ignored_index)
             start_loss = loss_fct(start_logits, start_positions)


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/31037

In order to perform OPT multi-GPU training (when the model is split across multiple GPUs), `device_map='auto'` the lm_head might be on another device than the first device, leading to device mismatch error. One could make sure to set a custom device_map in order to set the lm_head on the first device but this simple fix covers the usecase where people load the model with device_map="auto"

Note we apply a similar trick for all models when computing the LM-loss e.g.: https://github.com/huggingface/transformers/blob/22dab246c5605d2fca0597eed84d16a783bc3e22/src/transformers/models/llama/modeling_llama.py#L1196 we just forgot to do it for QuestionAnswering classes

 cc @amyeroberts 
