### PR TITLE
Jamba: revert skipped test 

### DIFF
--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -503,10 +503,6 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
             # They should result in very similar logits
             self.assertTrue(torch.allclose(next_logits_wo_padding, next_logits_with_padding, atol=3e-3))
 
-    @unittest.skip("Jamba has its own special cache type")  # FIXME: @gante
-    def test_assisted_decoding_matches_greedy_search_0_random(self):
-        pass
-
     @require_flash_attn
     @require_torch_gpu
     @require_bitsandbytes

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -250,6 +250,8 @@ class MambaModelTester:
 @require_torch
 class MambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (MambaModel, MambaForCausalLM) if is_torch_available() else ()
+    # NOTE :`all_generative_model_classes` does not exist -- the tests it triggers check the attention outputs, which
+    # mamba does not have
     fx_compatible = False  # FIXME let's try to support this @ArthurZucker
     test_torchscript = False  # FIXME let's try to support this @ArthurZucker
     test_missing_keys = False

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -250,7 +250,7 @@ class MambaModelTester:
 @require_torch
 class MambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (MambaModel, MambaForCausalLM) if is_torch_available() else ()
-    # NOTE :`all_generative_model_classes` does not exist -- the tests it triggers check the attention outputs, which
+    # NOTE :`all_generative_model_classes` does not exist -- the tests it triggers request the attention outputs, which
     # mamba does not have
     fx_compatible = False  # FIXME let's try to support this @ArthurZucker
     test_torchscript = False  # FIXME let's try to support this @ArthurZucker


### PR DESCRIPTION
# What does this PR do?

Fixes #30828 🤗 

Jamba: reverts skipped test, it is now passing on `main`
Mamba: `all_generative_model_classes` is not set on Mamba's tests, as it requests the attention outputs in the `generate` calls (which mamba doesn't have). Added a comment regarding that on `MambaModelTest`

(feel free to merge if you approve)