### PR TITLE
Add on_optimizer_step to callback options

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2304,6 +2304,8 @@ class Trainer:
                         else:
                             grad_norm = _grad_norm
 
+                    self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
+                    
                     self.optimizer.step()
 
                     optimizer_was_run = not self.accelerator.optimizer_step_was_skipped

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2304,9 +2304,8 @@ class Trainer:
                         else:
                             grad_norm = _grad_norm
 
-                    
                     self.optimizer.step()
-                    
+
                     self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
 
                     optimizer_was_run = not self.accelerator.optimizer_step_was_skipped

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2304,9 +2304,10 @@ class Trainer:
                         else:
                             grad_norm = _grad_norm
 
-                    self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
                     
                     self.optimizer.step()
+                    
+                    self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
 
                     optimizer_was_run = not self.accelerator.optimizer_step_was_skipped
                     if optimizer_was_run:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -344,6 +344,12 @@ class TrainerCallback:
         several inputs.
         """
         pass
+    
+    def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        """
+        Event called after the optimizer step but before gradients are zeroed out. Useful for monitoring gradients.
+        """
+        pass
 
     def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """
@@ -470,6 +476,9 @@ class CallbackHandler(TrainerCallback):
         control.should_save = False
         return self.call_event("on_step_begin", args, state, control)
 
+    def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+        return self.call_event("on_optimizer_step", args, state, control)
+    
     def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
         return self.call_event("on_substep_end", args, state, control)
 

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -344,7 +344,7 @@ class TrainerCallback:
         several inputs.
         """
         pass
-    
+
     def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """
         Event called after the optimizer step but before gradients are zeroed out. Useful for monitoring gradients.
@@ -478,7 +478,7 @@ class CallbackHandler(TrainerCallback):
 
     def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
         return self.call_event("on_optimizer_step", args, state, control)
-    
+
     def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
         return self.call_event("on_substep_end", args, state, control)
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -77,7 +77,7 @@ class MyTestTrainerCallback(TrainerCallback):
 
     def on_step_begin(self, args, state, control, **kwargs):
         self.events.append("on_step_begin")
-        
+
     def on_optimizer_step(self, args, state, control, **kwargs):
         self.events.append("on_optimizer_step")
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -77,6 +77,9 @@ class MyTestTrainerCallback(TrainerCallback):
 
     def on_step_begin(self, args, state, control, **kwargs):
         self.events.append("on_step_begin")
+        
+    def on_optimizer_step(self, args, state, control, **kwargs):
+        self.events.append("on_optimizer_step")
 
     def on_step_end(self, args, state, control, **kwargs):
         self.events.append("on_step_end")
@@ -148,7 +151,7 @@ class TrainerCallbackTest(unittest.TestCase):
             expected_events.append("on_epoch_begin")
             for _ in range(train_dl_len):
                 step += 1
-                expected_events += ["on_step_begin", "on_step_end"]
+                expected_events += ["on_step_begin", "on_optimizer_step", "on_step_end"]
                 if step % trainer.args.logging_steps == 0:
                     expected_events.append("on_log")
                 if trainer.args.eval_strategy == IntervalStrategy.STEPS and step % trainer.args.eval_steps == 0:


### PR DESCRIPTION
# Add on_optimizer_step callback option in TrainerCallbacks

Aside: This is my first open source pull request, so any feedback would be much appreciated!

The test `tests/trainer/test_trainer_callback.py` has been modified appropriately to invoke the new callback method.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #31033  (issue)


## Reviewers
As tagged in initial issue - @muellerzr @younesbelkada

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
