### PR TITLE
Fix AutoModel.from_pretrained when the module name ends with y or p

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -198,7 +198,7 @@ def get_class_in_module(class_name: str, module_path: Union[str, os.PathLike]) -
     Returns:
         `typing.Type`: The class looked for.
     """
-    name = os.path.normpath(module_path).rstrip(".py").replace(os.path.sep, ".")
+    name = os.path.normpath(module_path).removesuffix(".py").replace(os.path.sep, ".")
     module_spec = importlib.util.spec_from_file_location(name, location=Path(HF_MODULES_CACHE) / module_path)
     module = sys.modules.get(name)
     if module is None:


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fixes a loading error in `AutoModel.from_pretrained` where module names ending with `y` or `p` were incorrectly altered due to `get_class_in_module` removing these characters.

In the current implementation, `rstrip` is used to remove ".py" as a suffix from the file name, but according to [the Python documentation](https://docs.python.org/3/library/stdtypes.html#str.rstrip), `rstrip` should not be used for this purpose.

> The chars argument is not a suffix; rather, all combinations of its values are stripped

Therefore, in this pull request, I replace `rstrip` with `str.removesuffix()` as recommended by the documentation.
Below are the steps to reproduce the issue and the results after the fix.

### Steps to Reproduce of get_class_in_module

`test_get_class_in_module.py`
```py
from transformers import dynamic_module_utils

print(dynamic_module_utils.get_class_in_module("Foo", "test_ends_with_foo.py"))
print(dynamic_module_utils.get_class_in_module("Yp", "test_ends_with_yp.py"))
print(dynamic_module_utils.get_class_in_module("Y", "test_ends_with_y.py"))
print(dynamic_module_utils.get_class_in_module("P", "test_ends_with_p.py"))
```

```sh
$ HF_MODULES_CACHE="." python test_get_class_in_module.py
<class 'test_ends_with_foo.Foo'> # Correct module name
<class 'test_ends_with_.Yp'>  # Removed yp from module name
<class 'test_ends_with_.Y'>  #  Removed y from module name
<class 'test_ends_with_.P'>. #  Removed p from module name
```




`test_ends_with_foo.py`

```py
class Foo:
    ...
```

`test_ends_with_yp.py`

```py
class Yp:
    ...
```

`test_ends_with_y.py`

```py
class Y:
    ...
```

`test_ends_with_p.py`

```py
class P:
    ...
```

### Steps to Reproduce of AutoModel.from_pretrained

`test_auto_model.py`
```py
from transformers import AutoModel

AutoModel.from_pretrained(
    "line-corporation/clip-japanese-base",
    revision="ff0d63968516eeb4ccec05e11bf679215cdd67d7",
    trust_remote_code=True,
)
```

```sh
$ pip install torch timm
$ python test_auto_model.py
Traceback (most recent call last):
  File "BASE_DIR/test_auto_model.py", line 3, in <module>
    AutoModel.from_pretrained(
  File "BASE_DIR/src/transformers/models/auto/auto_factory.py", line 558, in from_pretrained
    cls.register(config.__class__, model_class, exist_ok=True)
  File "BASE_DIR/src/transformers/models/auto/auto_factory.py", line 584, in register
    raise ValueError(
ValueError: The model class you are passing has a `config_class` attribute that is not consistent with the config class you passed (model has <class 'transformers_modules.line-corporation.clip-japanese-base.ff0d63968516eeb4ccec05e11bf679215cdd67d7.configuration_clyp.CLYPConfig'> and you passed <class 'transformers_modules.line-corporation.clip-japanese-base.ff0d63968516eeb4ccec05e11bf679215cdd67d7.configuration_cl.CLYPConfig'>. Fix one of those so they match!

```

As indicated in the error message, the library expects `configuration_clyp`, but it fails to load because `configuration_cl` (with `yp` removed) is provided.

### Results after the fix.

```sh
$ HF_MODULES_CACHE="." python test_get_class_in_module.py
<class 'test_ends_with_foo.Foo'>
<class 'test_ends_with_yp.Yp'>
<class 'test_ends_with_y.Y'>
<class 'test_ends_with_p.P'>
```

```sh
$ python test_auto_model.py
model.safetensors: 100%|███████████████████████████████████████████████████████████| 787M/787M [00:29<00:00, 26.9MB/s]
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
