### PR TITLE
Fix faulty rstrip in module loading

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -198,7 +198,10 @@ def get_class_in_module(class_name: str, module_path: Union[str, os.PathLike]) -
     Returns:
         `typing.Type`: The class looked for.
     """
-    name = os.path.normpath(module_path).rstrip(".py").replace(os.path.sep, ".")
+    name = os.path.normpath(module_path)
+    if name.endswith(".py"):
+        name = name[:-3]
+    name = name.replace(os.path.sep, ".")
     module_spec = importlib.util.spec_from_file_location(name, location=Path(HF_MODULES_CACHE) / module_path)
     module = sys.modules.get(name)
     if module is None:


### PR DESCRIPTION
Our module loading code uses `.rstrip(".py")` to remove the python file suffix if present, but this is incorrect, because it actually removes any number of characters in the list `[".", "p", "y"]` from the end of the filename, resulting in an error if the filename ends in `p` or `y`:

```python
>>> "lamp.py".rstrip(".py")
'lam'
```

Python has a proper method for doing what we want here, which is `.removesuffix()`, but it was only added in 3.9, and we still need to support 3.8. Instead, I just do it by hand.

Fixes #31061