### PR TITLE
Fix env.py in cases where torch is not present

### DIFF
--- a/src/transformers/commands/env.py
+++ b/src/transformers/commands/env.py
@@ -83,7 +83,8 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             )
 
         pt_version = "not installed"
-        pt_cuda_available = "NA"
+        pt_cuda_available = False
+        pt_npu_available = False
         if is_torch_available():
             import torch
 
@@ -92,7 +93,7 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             pt_npu_available = is_torch_npu_available()
 
         tf_version = "not installed"
-        tf_cuda_available = "NA"
+        tf_cuda_available = False
         if is_tf_available():
             import tensorflow as tf
 
@@ -126,8 +127,8 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             "Safetensors version": f"{safetensors_version}",
             "Accelerate version": f"{accelerate_version}",
             "Accelerate config": f"{accelerate_config_str}",
-            "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available})",
-            "Tensorflow version (GPU?)": f"{tf_version} ({tf_cuda_available})",
+            "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available if pt_cuda_available else 'NA'})",
+            "Tensorflow version (GPU?)": f"{tf_version} ({tf_cuda_available if tf_cuda_available else 'NA'})",
             "Flax version (CPU?/GPU?/TPU?)": f"{flax_version} ({jax_backend})",
             "Jax version": f"{jax_version}",
             "JaxLib version": f"{jaxlib_version}",

--- a/src/transformers/commands/env.py
+++ b/src/transformers/commands/env.py
@@ -83,8 +83,7 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             )
 
         pt_version = "not installed"
-        pt_cuda_available = False
-        pt_npu_available = False
+        pt_cuda_available = "NA"
         if is_torch_available():
             import torch
 
@@ -93,7 +92,7 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             pt_npu_available = is_torch_npu_available()
 
         tf_version = "not installed"
-        tf_cuda_available = False
+        tf_cuda_available = "NA"
         if is_tf_available():
             import tensorflow as tf
 
@@ -127,20 +126,21 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             "Safetensors version": f"{safetensors_version}",
             "Accelerate version": f"{accelerate_version}",
             "Accelerate config": f"{accelerate_config_str}",
-            "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available if pt_cuda_available else 'NA'})",
-            "Tensorflow version (GPU?)": f"{tf_version} ({tf_cuda_available if tf_cuda_available else 'NA'})",
+            "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available})",
+            "Tensorflow version (GPU?)": f"{tf_version} ({tf_cuda_available})",
             "Flax version (CPU?/GPU?/TPU?)": f"{flax_version} ({jax_backend})",
             "Jax version": f"{jax_version}",
             "JaxLib version": f"{jaxlib_version}",
             "Using distributed or parallel set-up in script?": "<fill in>",
         }
-        if pt_cuda_available:
-            info["Using GPU in script?"] = "<fill in>"
-            info["GPU type"] = torch.cuda.get_device_name()
-        elif pt_npu_available:
-            info["Using NPU in script?"] = "<fill in>"
-            info["NPU type"] = torch.npu.get_device_name()
-            info["CANN version"] = torch.version.cann
+        if is_torch_available():
+            if pt_cuda_available:
+                info["Using GPU in script?"] = "<fill in>"
+                info["GPU type"] = torch.cuda.get_device_name()
+            elif pt_npu_available:
+                info["Using NPU in script?"] = "<fill in>"
+                info["NPU type"] = torch.npu.get_device_name()
+                info["CANN version"] = torch.version.cann
 
         print("\nCopy-and-paste the text below in your GitHub issue and FILL OUT the two last points.\n")
         print(self.format_dict(info))


### PR DESCRIPTION
Recent changes to `env.py` in #31003 cause issues when torch isn't installed. The cause is that because pt_cuda_available defaults to "NA", which is a truthy value, the `if pt_cuda_available:` block is executed even if torch is not present, which causes our TF and Flax tests to fail. This PR should hopefully fix them!