### PR TITLE
Fix nightly circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
-            - fetch_all_tests
+            - fetch_tests
 
     nightly:
         when: <<pipeline.parameters.nightly>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
     fetch_all_tests:
         working_directory: ~/transformers
         docker:
-            - image: huggingface/transformers-consistency
+            - image: huggingface/transformers-quality
         parallelism: 1
         steps:
             - checkout
@@ -182,7 +182,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
-            - fetch_tests
+            - fetch_all_tests
 
     nightly:
         when: <<pipeline.parameters.nightly>>


### PR DESCRIPTION
# What does this PR do?

Not really know what happens, but currently `fetch_all_tests` fails at `continuation/continue`. Change the docker image to `huggingface/transformers-quality` works.