### PR TITLE
Use the `Index_copy` method to update static cache inplace

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 
 from .configuration_utils import PretrainedConfig
-from .utils import is_hqq_available, is_quanto_available, logging
+from .utils import is_hqq_available, is_quanto_available, logging, is_torch_xla_available
 
 if is_quanto_available():
     from quanto import QBitsTensor, qint2, qint4
@@ -790,6 +790,23 @@ class StaticCache(Cache):
         cache_position = cache_kwargs.get("cache_position")
         k_out = self.key_cache[layer_idx]
         v_out = self.value_cache[layer_idx]
+
+        if is_torch_xla_available(): # If torch_xla is available, do out-of-place operation on KV_Cache and create a new list
+            k_out = k_out.index_copy(2, cache_position, key_states)
+            v_out = v_out.index_copy(2, cache_position, value_states)
+
+            updated_key_cache = [
+                k_out if i == layer_idx else self.key_cache[i] for i in range(len(self.key_cache))
+            ]
+
+            updated_value_cache = [
+                v_out if i == layer_idx else self.value_cache[i] for i in range(len(self.value_cache))
+            ]
+
+            self.key_cache = updated_key_cache
+            self.value_cache = updated_value_cache
+
+            return k_out, v_out
 
         k_out.index_copy_(2, cache_position, key_states)
         v_out.index_copy_(2, cache_position, value_states)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -9,7 +9,6 @@ import torch
 from .configuration_utils import PretrainedConfig
 from .utils import is_hqq_available, is_quanto_available, logging
 
-
 if is_quanto_available():
     from quanto import QBitsTensor, qint2, qint4
 
@@ -792,8 +791,8 @@ class StaticCache(Cache):
         k_out = self.key_cache[layer_idx]
         v_out = self.value_cache[layer_idx]
 
-        k_out[:, :, cache_position] = key_states
-        v_out[:, :, cache_position] = value_states
+        k_out.index_copy_(2, cache_position, key_states)
+        v_out.index_copy_(2, cache_position, value_states)
 
         return k_out, v_out
 


### PR DESCRIPTION
Use the `Index_copy` method to update the static cache inplace and avoid recompilation during each iteration in XLA

# What does this PR do?
The PR focuses on avoiding repeated recompilation during each iteration in XLA by performing in-place updates on the static cache. Specifically, it replaces direct tensor indexing assignments with `index_copy_` method calls. This technique ensures that cache updates are executed without triggering full tensor recompilations, improving runtime performance.

### Code Changes

**Original Code:**
```python
k_out[:, :, cache_position] = key_states
v_out[:, :, cache_position] = value_states
```

**Updated Code:**
```python
k_out.index_copy_(2, cache_position, key_states)
v_out.index_copy_(2, cache_position, value_states)
```




## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?

 @zucchini-nlp @gante 



Edit: 

- #### Discussion: [31126](https://github.com/huggingface/transformers/issues/31126)
- The code was further updated to create a new list instead of performing in-place updates to avoid recompilation in XLA.


