### PR TITLE
doc: add info about wav2vec2 bert in older wav2vec2 models.

### DIFF
--- a/docs/source/en/model_doc/wav2vec2-conformer.md
+++ b/docs/source/en/model_doc/wav2vec2-conformer.md
@@ -27,6 +27,8 @@ The Wav2Vec2-Conformer weights were released by the Meta AI team within the [Fai
 This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
 The original code can be found [here](https://github.com/pytorch/fairseq/tree/main/examples/wav2vec).
 
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+
 ## Usage tips
 
 - Wav2Vec2-Conformer follows the same architecture as Wav2Vec2, but replaces the *Attention*-block with a *Conformer*-block

--- a/docs/source/en/model_doc/wav2vec2-conformer.md
+++ b/docs/source/en/model_doc/wav2vec2-conformer.md
@@ -27,7 +27,7 @@ The Wav2Vec2-Conformer weights were released by the Meta AI team within the [Fai
 This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
 The original code can be found [here](https://github.com/pytorch/fairseq/tree/main/examples/wav2vec).
 
-Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We especially recommend using it for fine-tuning tasks, e.g. as per [this guide](https://huggingface.co/blog/fine-tune-w2v2-bert).
 
 ## Usage tips
 

--- a/docs/source/en/model_doc/wav2vec2.md
+++ b/docs/source/en/model_doc/wav2vec2.md
@@ -33,7 +33,7 @@ recognition with limited amounts of labeled data.*
 
 This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
 
-Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We especially recommend using it for fine-tuning tasks, e.g. as per [this guide](https://huggingface.co/blog/fine-tune-w2v2-bert).
 
 ## Usage tips
 

--- a/docs/source/en/model_doc/wav2vec2.md
+++ b/docs/source/en/model_doc/wav2vec2.md
@@ -33,6 +33,8 @@ recognition with limited amounts of labeled data.*
 
 This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
 
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+
 ## Usage tips
 
 - Wav2Vec2 is a speech model that accepts a float array corresponding to the raw waveform of the speech signal.

--- a/docs/source/en/model_doc/xlsr_wav2vec2.md
+++ b/docs/source/en/model_doc/xlsr_wav2vec2.md
@@ -36,6 +36,8 @@ XLSR-53, a large model pretrained in 53 languages.*
 
 The original code can be found [here](https://github.com/pytorch/fairseq/tree/master/fairseq/models/wav2vec).
 
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+
 ## Usage tips
 
 - XLSR-Wav2Vec2 is a speech model that accepts a float array corresponding to the raw waveform of the speech signal.

--- a/docs/source/en/model_doc/xlsr_wav2vec2.md
+++ b/docs/source/en/model_doc/xlsr_wav2vec2.md
@@ -36,7 +36,7 @@ XLSR-53, a large model pretrained in 53 languages.*
 
 The original code can be found [here](https://github.com/pytorch/fairseq/tree/master/fairseq/models/wav2vec).
 
-Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We specially recommend using it for fine-tuning tasks.
+Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We especially recommend using it for fine-tuning tasks, e.g. as per [this guide](https://huggingface.co/blog/fine-tune-w2v2-bert).
 
 ## Usage tips
 


### PR DESCRIPTION
# What does this PR do?

doc: add info about wav2vec2 bert in older wav2vec2 models.

An attempt to improve the usage of Wav2Vec2 BERT model checkpoints.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

cc: @sanchit-gandhi 