### PR TITLE
fix get_scheduler when name is warmup_stable_decay

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -540,6 +540,9 @@ def get_scheduler(
     if name == SchedulerType.INVERSE_SQRT:
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
+    if name == SchedulerType.WARMUP_STABLE_DECAY:
+        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
+
     # All other schedulers require `num_training_steps`
     if num_training_steps is None:
         raise ValueError(f"{name} requires `num_training_steps`, please provide that argument.")

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -36,6 +36,7 @@ if is_torch_available():
         get_inverse_sqrt_schedule,
         get_linear_schedule_with_warmup,
         get_polynomial_decay_schedule_with_warmup,
+        get_scheduler,
         get_wsd_schedule,
     )
 
@@ -175,6 +176,27 @@ class ScheduleInitTest(unittest.TestCase):
                 LambdaScheduleWrapper.wrap_scheduler(scheduler)  # wrap to test picklability of the schedule
             lrs_2 = unwrap_and_save_reload_schedule(scheduler, self.num_steps)
             self.assertListEqual(lrs_1, lrs_2, msg=f"failed for {scheduler_func} in save and reload")
+
+    def test_get_scheduler(self):
+        test_params = [
+            {
+                "name": "warmup_stable_decay",
+                "optimizer": self.optimizer,
+                "num_warmup_steps": 2,
+                "scheduler_specific_kwargs": {"num_stable_steps": 1, "num_decay_steps": 3},
+            },
+            {
+                "name": "warmup_stable_decay",
+                "optimizer": self.optimizer,
+                "num_warmup_steps": 2,
+                "num_training_steps": 10,
+                "scheduler_specific_kwargs": {"num_stable_steps": 1, "num_decay_steps": 3},
+            },
+            {"name": "cosine", "optimizer": self.optimizer, "num_warmup_steps": 2, "num_training_steps": 10},
+        ]
+
+        for param in test_params:
+            self.assertTrue(get_scheduler(**param), msg=f"failed for {param['name']} in get_scheduler")
 
 
 class LambdaScheduleWrapper:


### PR DESCRIPTION
# What does this PR do?

fix #31085

I also add some cases for test.
![iShot_2024-05-30_10 52 20](https://github.com/huggingface/transformers/assets/26846598/1a9fcd98-07ee-4ecb-9477-af29ed6f718f)

![iShot_2024-05-30_10 52 52](https://github.com/huggingface/transformers/assets/26846598/ea7ef4a3-d68d-4cd1-b317-761f2eef76ab)


@ArthurZucker and @amyeroberts 
