### PR TITLE
pytest -rsfE

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run all tests on GPU
         working-directory: /transformers
-        run: python3 -m pytest -rs -v --make-reports=${{ inputs.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
+        run: python3 -m pytest -rsfE -v --make-reports=${{ inputs.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
 
       - name: Failure short reports
         if: ${{ failure() }}

--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run FA2 tests
         id: run_fa2_tests
         run:
-          pytest -rs -m "flash_attn_test" --make-reports=${{ matrix.model-name }}_fa2_tests/ tests/${{ matrix.model-name }}/test_modeling_*
+          pytest -rsfE -m "flash_attn_test" --make-reports=${{ matrix.model-name }}_fa2_tests/ tests/${{ matrix.model-name }}/test_modeling_*
       
       - name: "Test suite reports artifacts: ${{ matrix.model-name }}_fa2_tests"
         if: ${{ always() }}
@@ -108,7 +108,7 @@ jobs:
         id: run_integration_tests
         if: always()
         run:
-          pytest -rs -k "IntegrationTest"  --make-reports=tests_integration_${{ matrix.model-name }} tests/${{ matrix.model-name }}/test_modeling_*
+          pytest -rsfE -k "IntegrationTest"  --make-reports=tests_integration_${{ matrix.model-name }} tests/${{ matrix.model-name }}/test_modeling_*
       
       - name: "Test suite reports artifacts: tests_integration_${{ matrix.model-name }}"
         if: ${{ always() }}

--- a/.github/workflows/self-pr-slow-ci.yml
+++ b/.github/workflows/self-pr-slow-ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run all tests on GPU
         working-directory: /transformers
-        run: python3 -m pytest -v -rs --make-reports=${{ matrix.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
+        run: python3 -m pytest -v -rsfE --make-reports=${{ matrix.machine_type }}_run_models_gpu_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
 
       - name: Failure short reports
         if: ${{ failure() }}


### PR DESCRIPTION
# What does this PR do?

In #30318, @ArthurZucker and me decided to use `-rs` to show the skipped tests. However, this won't show the failed tests in the summary, neither the error out tests.

This PR uses `-rsfE` to show all tests except the passing one.

Without this PR
```
SKIPPED [1] tests/test_tokenization_common.py:1583: start to fail after # 29473. See https://github.com/huggingface/transformers/pull/29473#pullrequestreview-1945687810
SKIPPED [1] tests/test_tokenization_common.py:1971: No padding token.
SKIPPED [1] tests/test_tokenization_common.py:2005: No padding token.

```

With this PR
```
SKIPPED [1] tests/test_tokenization_common.py:1583: start to fail after # 29473. See https://github.com/huggingface/transformers/pull/29473#pullrequestreview-1945687810
SKIPPED [1] tests/test_tokenization_common.py:1971: No padding token.
SKIPPED [1] tests/test_tokenization_common.py:2005: No padding token.
FAILED tests/models/codegen/test_tokenization_codegen.py::CodeGenTokenizationTest::test_split_special_tokens - AssertionError: False is not true
FAILED tests/models/codegen/test_tokenization_codegen.py::CodeGenTokenizationTest::test_truncation - AssertionError: '\nif len_a > len_b:\n      result = a\nelse:\n      result = b' != '\nif len_a > len_b:      result = a\nelse:      result = b'

```