### PR TITLE
Set greater_is_better to False if metric_for_best_model ends with "loss"

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -464,8 +464,8 @@ class TrainingArguments:
             Use in conjunction with `load_best_model_at_end` and `metric_for_best_model` to specify if better models
             should have a greater metric or not. Will default to:
 
-            - `True` if `metric_for_best_model` is set to a value that isn't `"loss"` or `"eval_loss"`.
-            - `False` if `metric_for_best_model` is not set, or set to `"loss"` or `"eval_loss"`.
+            - `True` if `metric_for_best_model` is set to a value that doesn't end in `"loss"`.
+            - `False` if `metric_for_best_model` is not set, or set to a value that ends in `"loss"`.
         ignore_data_skip (`bool`, *optional*, defaults to `False`):
             When resuming training, whether or not to skip the epochs and batches to get the data loading at the same
             stage as in the previous training. If set to `True`, the training will begin faster (as that skipping step
@@ -1582,7 +1582,7 @@ class TrainingArguments:
         ) and self.metric_for_best_model is None:
             self.metric_for_best_model = "loss"
         if self.greater_is_better is None and self.metric_for_best_model is not None:
-            self.greater_is_better = self.metric_for_best_model not in ["loss", "eval_loss"]
+            self.greater_is_better = not(self.metric_for_best_model.endswith("loss"))
         if self.run_name is None:
             self.run_name = self.output_dir
         if self.framework == "pt" and is_torch_available():

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1582,7 +1582,7 @@ class TrainingArguments:
         ) and self.metric_for_best_model is None:
             self.metric_for_best_model = "loss"
         if self.greater_is_better is None and self.metric_for_best_model is not None:
-            self.greater_is_better = not(self.metric_for_best_model.endswith("loss"))
+            self.greater_is_better = not (self.metric_for_best_model.endswith("loss"))
         if self.run_name is None:
             self.run_name = self.output_dir
         if self.framework == "pt" and is_torch_available():


### PR DESCRIPTION
Prior to this PR greater_is_better (used for determining if the best checkpoint, for example) would be set to False if users didn't set it explicitly and either metric_for_best_model is unset or it's one of "loss" or "eval_loss".

This PR simplifies the logic to simply check if metric_for_best_model ends with loss.

Background: Despite having read the documentation a while back I forgot about this behavior and updated my script to evaluate against multiple datasets, for each one I compute the "eval_dataset-name_loss" metric. You can imagine my surprise that after 7h of training I realized that the worst model was saved and all work was lost :)

@ArthurZucker @muellerzr