### PR TITLE
Workflow: Remove `IS_GITHUB_CI`

### DIFF
--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
 
 env:
-  IS_GITHUB_CI: "1"
   OUTPUT_SLACK_CHANNEL_ID: "C06L2SGMEEA"
   HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache 

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -14,7 +14,6 @@ on:
         required: true
 
 env:
-  IS_GITHUB_CI: "1"
   HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache 
   TRANSFORMERS_IS_CI: yes 


### PR DESCRIPTION
# What does this PR do?

`IS_GITHUB_CI` is a global env variable that is never used anywhere in our repo, it's a copypasta from TRL / PEFT: https://github.com/huggingface/peft/blob/cb0bf077744d11524ec6f68d920f4cfe4ef3e8f3/Makefile#L48

cc @ydshieh 