### PR TITLE
Fix perceiver latent initialization modeling_idefics2.py

### DIFF
--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1251,7 +1251,7 @@ class Idefics2PerceiverResampler(nn.Module):
         self.rms_norm_eps = config.text_config.rms_norm_eps
 
         # Create Latents for Perceiver
-        self.latents = nn.Parameter(torch.ones(self.n_latents, self.hidden_size))
+        self.latents = nn.Parameter(torch.randn(self.n_latents, self.hidden_size))
 
         # Create Transformer Blocks
         self.layers = nn.ModuleList([Idefics2PerceiverLayer(config, idx) for idx in range(self.depth)])


### PR DESCRIPTION
# What does this PR do?

The perceiver resampler in idefics2 initializes latents as ones, but they should be initialized as random numbers with a gaussian distribution (see this implementation: https://github.com/lucidrains/perceiver-pytorch/blob/main/perceiver_pytorch/perceiver_io.py#L153). This should fix instability issues for training


Models:

=- vision models: @amyeroberts