### PR TITLE
Benchmark GitHub Actions workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           HF_TOKEN=${{ secrets.TRANSFORMERS_BENCHMARK_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
 
       - name: Benchmark (merged to main event)
-        if: github.event_name == 'workflow_run'
+        if: github.event_name == 'push' && github.ref_name == 'run_benchmark_on_github'
         working-directory: /transformers
         run: |
           python3 -m pip install optimum-benchmark>=0.2.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ name: Self-hosted runner (benchmark)
 on:
   schedule:
     - cron: "17 2 * * *"
+  workflow_call:
 
 env:
   HF_HOME: /mnt/cache
@@ -26,8 +27,16 @@ jobs:
         working-directory: /transformers
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
-      - name: Benchmark
+      - name: Benchmark (daily)
+        if: github.event_name == 'schedule'
         working-directory: /transformers
         run: |
           python3 -m pip install optimum-benchmark>=0.2.0
           HF_TOKEN=${{ secrets.TRANSFORMERS_BENCHMARK_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+
+      - name: Benchmark (merged to main event)
+        if: github.event_name == 'workflow_run'
+        working-directory: /transformers
+        run: |
+          python3 -m pip install optimum-benchmark>=0.2.0
+          HF_TOKEN=${{ secrets.TRANSFORMERS_BENCHMARK_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results_merge_event --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           HF_TOKEN=${{ secrets.TRANSFORMERS_BENCHMARK_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
 
       - name: Benchmark (merged to main event)
-        if: github.event_name == 'push' && github.ref_name == 'run_benchmark_on_github'
+        if: github.event_name == 'push' && github.ref_name == 'main'
         working-directory: /transformers
         run: |
           python3 -m pip install optimum-benchmark>=0.2.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
-          python3 benchmark/benchmark.py --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.HF_HUB_READ_TOKEN }} python3 benchmark/benchmark.py --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,10 +3,6 @@ name: Self-hosted runner (benchmark)
 on:
   schedule:
     - cron: "17 2 * * *"
-  push:
-    branches:
-      - run_benchmark
-      - benchmark_on_github
 
 env:
   HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
-          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d')/summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,31 @@
+name: Self-hosted runner (benchmark)
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  push:
+    branches:
+      - run_benchmark
+      - benchmark_on_github
+
+env:
+  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_HOME: /mnt/cache
+  TRANSFORMERS_IS_CI: yes
+  TF_FORCE_GPU_ALLOW_GROWTH: true
+
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: [single-gpu, nvidia-gpu, a10, ci]
+    container:
+      image: huggingface/transformers-all-latest-gpu
+      options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install locally transformers & other libs
+        run: |
+          echo "Hello Benchmark"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
-          HF_TOKEN=${{ secrets.HF_HUB_READ_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,6 +33,7 @@ jobs:
         run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
 
       - name: Benchmark
+        working-directory: /transformers
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: /transformers
         run: |
           python3 -m pip install optimum-benchmark>=0.2.0
-          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.TRANSFORMERS_BENCHMARK_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
-          HF_TOKEN=${{ secrets.HF_HUB_READ_TOKEN }} python3 benchmark/benchmark.py --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.HF_HUB_READ_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
-          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d')/summary.json --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun
+          HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,10 +23,16 @@ jobs:
       image: huggingface/transformers-all-latest-gpu
       options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - name: Update clone
+        working-directory: /transformers
+        run: |
+          git fetch && git checkout ${{ github.sha }}
 
-      - name: Install locally transformers & other libs
+      - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
+        working-directory: /transformers
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e .
+
+      - name: Benchmark
         run: |
           echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,9 +5,7 @@ on:
     - cron: "17 2 * * *"
 
 env:
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache
-  TRANSFORMERS_IS_CI: yes
   TF_FORCE_GPU_ALLOW_GROWTH: true
 
 
@@ -31,6 +29,5 @@ jobs:
       - name: Benchmark
         working-directory: /transformers
         run: |
-          echo "Hello Benchmark"
           python3 -m pip install optimum-benchmark>=0.2.0
           HF_TOKEN=${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }} python3 benchmark/benchmark.py --repo_id hf-internal-testing/benchmark_results --path_in_repo $(date +'%Y-%m-%d') --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Install locally transformers & other libs
         run: |
           echo "Hello Benchmark"
+          python3 -m pip install optimum-benchmark>=0.2.0
           python3 benchmark/benchmark.py --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,3 +29,4 @@ jobs:
       - name: Install locally transformers & other libs
         run: |
           echo "Hello Benchmark"
+          python3 benchmark/benchmark.py --config-dir benchmark/config --config-name generation --commit=${{ github.sha }} backend.model=google/gemma-2b backend.cache_implementation=null,static backend.torch_compile=false,true --multirun

--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -134,3 +134,8 @@ jobs:
           slackChannel: ${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}
           slackToken: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           waitForSSH: true
+
+  benchmark:
+    name: Benchmark workflow
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -317,8 +317,8 @@ if __name__ == "__main__":
 
         # Upload to Hub
         api = HfApi()
-        api.upload_file(
-            path_or_fileobj=os.path.join(exp_run_dir, "summary.json"),
+        api.upload_folder(
+            folder_path=exp_run_dir,
             path_in_repo=args.path_in_repo,
             repo_id=args.repo_id,
             repo_type="dataset",

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -314,12 +314,13 @@ if __name__ == "__main__":
 
         combined_summary = combine_summaries(run_summaries)
 
-        # Upload to Hub
-        api = HfApi()
-        api.upload_folder(
-            folder_path=exp_run_dir,
-            path_in_repo=args.path_in_repo,
-            repo_id=args.repo_id,
-            repo_type="dataset",
-            token=args.token,
-        )
+        if args.repo_id is not None and args.path_in_repo is not None:
+            # Upload to Hub
+            api = HfApi()
+            api.upload_folder(
+                folder_path=exp_run_dir,
+                path_in_repo=args.path_in_repo,
+                repo_id=args.repo_id,
+                repo_type="dataset",
+                token=args.token,
+            )

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -145,7 +145,6 @@ def summarize(run_dir, metrics, expand_metrics=False):
         with open(os.path.join(report_dir, "summary.json"), "w") as fp:
             json.dump(summary, fp, indent=4)
 
-    # TODO: upload to Hub
     return summaries
 
 


### PR DESCRIPTION
# What does this PR do?

Benchmark GitHub Actions workflow.

[Workflow run page](https://github.com/huggingface/transformers/actions/runs/9318192661/job/25650027316)
[Dataset on the Hub](https://huggingface.co/datasets/hf-internal-testing/benchmark_results/tree/main)

(Not done yet)
- Maybe change decoding steps from 128 to 1024
- Run against Llama2 too

We are mostly only interested in `summary.json` file.

However, I am uploading the whole directory of an experiment in each run. The reason is to keep the benchmark config files available if we ever need to access this information. However, this seems a bit too much (too many files for which most of time they remain the same across different dates)