### PR TITLE
Upload (daily) CI results to Hub

### DIFF
--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -84,6 +84,7 @@ jobs:
         # `quantization/bnb` to `quantization_bnb` is required, as the artifact names use `_` instead of `/`.
         run: |
           sudo apt-get install -y curl
+          pip install huggingface_hub
           pip install slack_sdk
           pip show slack_sdk
           python utils/notification_service_quantization.py "${{ inputs.quantization_matrix }}" 

--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -19,6 +19,8 @@ on:
         required: true
         type: string
 
+env:
+  TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN: ${{ secrets.TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN }}
 
 jobs:
   send_results:

--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -56,6 +56,7 @@ jobs:
         # empty string, and the called script still get one argument (which is the emtpy string).
         run: |
           sudo apt-get install -y curl
+          pip install huggingface_hub
           pip install slack_sdk
           pip show slack_sdk
           python utils/notification_service.py "${{ inputs.folder_slices }}"

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -13,22 +13,21 @@
 # limitations under the License.
 
 import ast
-import datetime
 import collections
+import datetime
 import functools
 import json
 import operator
 import os
 import re
-import requests
 import sys
 import time
-
-from huggingface_hub import HfApi
 from typing import Dict, List, Optional, Union
 
+import requests
 from get_ci_error_statistics import get_jobs
 from get_previous_daily_ci import get_last_daily_ci_reports
+from huggingface_hub import HfApi
 from slack_sdk import WebClient
 
 

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -13,22 +13,26 @@
 # limitations under the License.
 
 import ast
+import datetime
 import collections
 import functools
 import json
 import operator
 import os
 import re
+import requests
 import sys
 import time
+
+from huggingface_hub import HfApi
 from typing import Dict, List, Optional, Union
 
-import requests
 from get_ci_error_statistics import get_jobs
 from get_previous_daily_ci import get_last_daily_ci_reports
 from slack_sdk import WebClient
 
 
+api = HfApi()
 client = WebClient(token=os.environ["CI_SLACK_BOT_TOKEN"])
 
 NON_MODEL_TEST_MODULES = [
@@ -1154,11 +1158,24 @@ if __name__ == "__main__":
     if not os.path.isdir(os.path.join(os.getcwd(), f"ci_results_{job_name}")):
         os.makedirs(os.path.join(os.getcwd(), f"ci_results_{job_name}"))
 
+    target_workflow = "huggingface/transformers/.github/workflows/self-scheduled-caller.yml@refs/heads/main"
+    is_scheduled_ci_run = os.environ.get("CI_WORKFLOW_REF") == target_workflow
+
     # Only the model testing job is concerned: this condition is to avoid other jobs to upload the empty list as
     # results.
     if job_name == "run_models_gpu":
         with open(f"ci_results_{job_name}/model_results.json", "w", encoding="UTF-8") as fp:
             json.dump(model_results, fp, indent=4, ensure_ascii=False)
+
+        # upload results to Hub dataset (only for the scheduled daily CI run on `main`)
+        if is_scheduled_ci_run:
+            api.upload_file(
+                path_or_fileobj=f"ci_results_{job_name}/model_results.json",
+                path_in_repo=datetime.datetime.today().strftime('%Y-%m-%d'),
+                repo_id="hf-internal-testing/transformers_daily_ci",
+                repo_type="dataset",
+                token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),
+            )
 
     # Must have the same keys as in `additional_results`.
     # The values are used as the file names where to save the corresponding CI job results.
@@ -1172,10 +1189,19 @@ if __name__ == "__main__":
         with open(f"ci_results_{job_name}/{test_to_result_name[job]}_results.json", "w", encoding="UTF-8") as fp:
             json.dump(job_result, fp, indent=4, ensure_ascii=False)
 
+        # upload results to Hub dataset (only for the scheduled daily CI run on `main`)
+        if is_scheduled_ci_run:
+            api.upload_file(
+                path_or_fileobj=f"ci_results_{job_name}/{test_to_result_name[job]}_results.json",
+                path_in_repo=datetime.datetime.today().strftime('%Y-%m-%d'),
+                repo_id="hf-internal-testing/transformers_daily_ci",
+                repo_type="dataset",
+                token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),
+            )
+
     prev_ci_artifacts = None
-    if job_name == "run_models_gpu":
-        target_workflow = "huggingface/transformers/.github/workflows/self-scheduled-caller.yml@refs/heads/main"
-        if os.environ.get("CI_WORKFLOW_REF") == target_workflow:
+    if is_scheduled_ci_run:
+        if job_name == "run_models_gpu":
             # Get the last previously completed CI's failure tables
             artifact_names = [f"ci_results_{job_name}"]
             output_dir = os.path.join(os.getcwd(), "previous_reports")

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1171,7 +1171,7 @@ if __name__ == "__main__":
         if is_scheduled_ci_run:
             api.upload_file(
                 path_or_fileobj=f"ci_results_{job_name}/model_results.json",
-                path_in_repo=datetime.datetime.today().strftime('%Y-%m-%d'),
+                path_in_repo=f"{datetime.datetime.today().strftime('%Y-%m-%d')}/ci_results_{job_name}/model_results.json",
                 repo_id="hf-internal-testing/transformers_daily_ci",
                 repo_type="dataset",
                 token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),
@@ -1193,7 +1193,7 @@ if __name__ == "__main__":
         if is_scheduled_ci_run:
             api.upload_file(
                 path_or_fileobj=f"ci_results_{job_name}/{test_to_result_name[job]}_results.json",
-                path_in_repo=datetime.datetime.today().strftime('%Y-%m-%d'),
+                path_in_repo=f"{datetime.datetime.today().strftime('%Y-%m-%d')}/ci_results_{job_name}/{test_to_result_name[job]}_results.json",
                 repo_id="hf-internal-testing/transformers_daily_ci",
                 repo_type="dataset",
                 token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),

--- a/utils/notification_service_quantization.py
+++ b/utils/notification_service_quantization.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ast
+import datetime
 import json
 import os
 import sys
@@ -28,9 +29,11 @@ from notification_service import (
     retrieve_artifact,
     retrieve_available_artifacts,
 )
+from huggingface_hub import HfApi
 from slack_sdk import WebClient
 
 
+api = HfApi()
 client = WebClient(token=os.environ["CI_SLACK_BOT_TOKEN"])
 
 
@@ -248,6 +251,19 @@ if __name__ == "__main__":
 
     with open(f"ci_results_{job_name}/quantization_results.json", "w", encoding="UTF-8") as fp:
         json.dump(quantization_results, fp, indent=4, ensure_ascii=False)
+
+    target_workflow = "huggingface/transformers/.github/workflows/self-scheduled-caller.yml@refs/heads/main"
+    is_scheduled_ci_run = os.environ.get("CI_WORKFLOW_REF") == target_workflow
+
+    # upload results to Hub dataset (only for the scheduled daily CI run on `main`)
+    if is_scheduled_ci_run:
+        api.upload_file(
+            path_or_fileobj=f"ci_results_{job_name}/quantization_results.json",
+            path_in_repo=f"{datetime.datetime.today().strftime('%Y-%m-%d')}/ci_results_{job_name}/quantization_results.json",
+            repo_id="hf-internal-testing/transformers_daily_ci",
+            repo_type="dataset",
+            token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),
+        )
 
     message = QuantizationMessage(
         title,

--- a/utils/notification_service_quantization.py
+++ b/utils/notification_service_quantization.py
@@ -21,6 +21,7 @@ import time
 from typing import Dict
 
 from get_ci_error_statistics import get_jobs
+from huggingface_hub import HfApi
 from notification_service import (
     Message,
     handle_stacktraces,
@@ -29,7 +30,6 @@ from notification_service import (
     retrieve_artifact,
     retrieve_available_artifacts,
 )
-from huggingface_hub import HfApi
 from slack_sdk import WebClient
 
 


### PR DESCRIPTION
# What does this PR do?

Let's start to upload the results to a Hub dataset [hf-internal-testing/transformers_daily_ci](https://huggingface.co/datasets/hf-internal-testing/transformers_daily_ci/tree/main/2024-05-31) and use this dataset to build a visualization dashboard 🚀 !

So far I take the advantage of the daily CI workflow run - upload directly from there instead of fetching the finished workflow run afterward.

I didn't change any format in the raw reports (but processed in the workflow), but I believe it contains everything required to perform visualization/analysis.

[A dummy run](https://github.com/huggingface/transformers/actions/runs/9320789057) gives [hf-internal-testing/transformers_daily_ci](https://huggingface.co/datasets/hf-internal-testing/transformers_daily_ci/tree/main/2024-05-31)
 