### PR TITLE
Update masked_language_modeling.md

### DIFF
--- a/docs/source/en/tasks/masked_language_modeling.md
+++ b/docs/source/en/tasks/masked_language_modeling.md
@@ -245,6 +245,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
+...     tokenizer=tokenizer,
 ... )
 
 >>> trainer.train()


### PR DESCRIPTION
The definition of Trainer must be added with a tokenizer parameter.

Fixes # (issue)
Models without a passed tokenizer will not be usable for evaluation.