### PR TITLE
Rename sanity_evaluation to eval_on_start

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2175,7 +2175,7 @@ class Trainer:
         grad_norm: Optional[float] = None
         self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
 
-        if args.sanity_evaluation:
+        if args.eval_on_start:
             self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
 
         total_batched_samples = 0

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -772,8 +772,8 @@ class TrainingArguments:
             that takes a boolean argument `compute_result`, which when passed `True`, will trigger the final global
             summary statistics from the batch-level summary statistics you've accumulated over the evaluation set.
 
-        sanity_evaluation(`bool`, *optional*, defaults to `False`):
-            Whether or not to perform a sanity check to ensure that the validation steps works correctly. It will be performed before the training.
+        eval_on_start(`bool`, *optional*, defaults to `False`):
+            Whether to perform a evaluation step (sanity check) before the training to ensure the validation steps works correctly.
     """
 
     framework = "pt"
@@ -1330,6 +1330,12 @@ class TrainingArguments:
             "help": "Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`, will instead store them as lists, with each batch kept separate."
         },
     )
+    eval_on_start: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
+        },
+    )
     # Deprecated arguments
     fp16_backend: str = field(
         default="auto",
@@ -1455,13 +1461,6 @@ class TrainingArguments:
     batch_eval_metrics: bool = field(
         default=False,
         metadata={"help": "Break eval metrics calculation into batches to save memory."},
-    )
-
-    sanity_evaluation: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
-        },
     )
 
     def __post_init__(self):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1330,12 +1330,6 @@ class TrainingArguments:
             "help": "Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`, will instead store them as lists, with each batch kept separate."
         },
     )
-    eval_on_start: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
-        },
-    )
     # Deprecated arguments
     fp16_backend: str = field(
         default="auto",
@@ -1461,6 +1455,13 @@ class TrainingArguments:
     batch_eval_metrics: bool = field(
         default=False,
         metadata={"help": "Break eval metrics calculation into batches to save memory."},
+    )
+
+    eval_on_start: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
+        },
     )
 
     def __post_init__(self):


### PR DESCRIPTION
# What does this PR do?

Rename ambiguous training.arg `sanity_evaluation` to `eval_on_start`.

Reasons:

1. The new training arg name is not clear at all. What is `sanity`? Who decides on sanity? The actual code is quite useful and simple but the var name doesn't actually reflect what the code does. 
2. The new `eval_on_start` is clear on the intention without the need to peek at doc. 

Options on naming:

1. Based on existing eval args and naming convention I chose `eval_on_start`. `evaluation_on_start` was considered but since `eval_` is non-ambigious and already part of the arg list, it is more concise. 


## Who can review?

@muellerzr and @SunMarc


