### PR TITLE
Pipeline VQA: Add support for list of images and questions as pipeline input

### DIFF
--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -17,9 +17,7 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 
-@add_end_docstrings(
-    build_pipeline_init_args(has_tokenizer=True, has_image_processor=True)
-)
+@add_end_docstrings(build_pipeline_init_args(has_tokenizer=True, has_image_processor=True))
 class VisualQuestionAnsweringPipeline(Pipeline):
     """
     Visual Question Answering pipeline using a `AutoModelForVisualQuestionAnswering`. This pipeline is currently only
@@ -59,9 +57,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
         super().__init__(*args, **kwargs)
         self.check_model_type(MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES)
 
-    def _sanitize_parameters(
-        self, top_k=None, padding=None, truncation=None, timeout=None, **kwargs
-    ):
+    def _sanitize_parameters(self, top_k=None, padding=None, truncation=None, timeout=None, **kwargs):
         preprocess_params, postprocess_params = {}, {}
         if padding is not None:
             preprocess_params["padding"] = padding
@@ -114,12 +110,8 @@ class VisualQuestionAnsweringPipeline(Pipeline):
             - **label** (`str`) -- The label identified by the model.
             - **score** (`int`) -- The score attributed by the model for that label.
         """
-        is_image_batch = isinstance(image, list) and all(
-            isinstance(item, (Image.Image, str)) for item in image
-        )
-        is_question_batch = isinstance(question, list) and all(
-            isinstance(item, str) for item in question
-        )
+        is_image_batch = isinstance(image, list) and all(isinstance(item, (Image.Image, str)) for item in image)
+        is_question_batch = isinstance(question, list) and all(isinstance(item, str) for item in question)
         if isinstance(image, (Image.Image, str)) and isinstance(question, str):
             inputs = {"image": image, "question": question}
         elif is_image_batch and isinstance(question, str):
@@ -130,7 +122,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
             question_image_pairs = []
             for q in question:
                 for im in image:
-                    question_image_pairs.append({"image": im, "question": question})
+                    question_image_pairs.append({"image": im, "question": q})
             inputs = question_image_pairs
         else:
             """
@@ -151,9 +143,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
             padding=padding,
             truncation=truncation,
         )
-        image_features = self.image_processor(
-            images=image, return_tensors=self.framework
-        )
+        image_features = self.image_processor(images=image, return_tensors=self.framework)
         model_inputs.update(image_features)
         return model_inputs
 
@@ -167,11 +157,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
     def postprocess(self, model_outputs, top_k=5):
         if self.model.can_generate():
             return [
-                {
-                    "answer": self.tokenizer.decode(
-                        output_ids, skip_special_tokens=True
-                    ).strip()
-                }
+                {"answer": self.tokenizer.decode(output_ids, skip_special_tokens=True).strip()}
                 for output_ids in model_outputs
             ]
         else:
@@ -186,7 +172,4 @@ class VisualQuestionAnsweringPipeline(Pipeline):
 
             scores = scores.tolist()
             ids = ids.tolist()
-            return [
-                {"score": score, "answer": self.model.config.id2label[_id]}
-                for score, _id in zip(scores, ids)
-            ]
+            return [{"score": score, "answer": self.model.config.id2label[_id]} for score, _id in zip(scores, ids)]

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,7 +1,5 @@
 from typing import List, Union
 
-from transformers.pipelines.pt_utils import KeyDataset
-
 from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging
 from .base import Pipeline, build_pipeline_init_args
 
@@ -15,6 +13,7 @@ if is_torch_available():
     from ..models.auto.modeling_auto import (
         MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES,
     )
+    from .pt_utils import KeyDataset
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,9 +1,9 @@
-from typing import Union, List
+from typing import List, Union
+
+from transformers.pipelines.pt_utils import KeyDataset
 
 from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging
 from .base import Pipeline, build_pipeline_init_args
-
-from transformers.pipelines.pt_utils import KeyDataset
 
 
 if is_vision_available():
@@ -97,7 +97,6 @@ class VisualQuestionAnsweringPipeline(Pipeline):
                 The pipeline accepts either a single image or a batch of images. If given a single image, it can be
                 broadcasted to multiple questions.
                 For dataset: the passed in dataset must be of type `transformers.pipelines.pt_utils.KeyDataset`
-                
                 Example:
                 ```python
                 >>> from transformers.pipelines.pt_utils import KeyDataset

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -72,7 +72,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
 
     def __call__(
         self,
-        image: Union["Image.Image", str, List["Image.Image"], List[str], KeyDataset],
+        image: Union["Image.Image", str, List["Image.Image"], List[str]],
         question: Union[str, List[str]] = None,
         **kwargs,
     ):

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -10,9 +10,7 @@ if is_vision_available():
     from ..image_utils import load_image
 
 if is_torch_available():
-    from ..models.auto.modeling_auto import (
-        MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES,
-    )
+    from ..models.auto.modeling_auto import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES
     from .pt_utils import KeyDataset
 
 logger = logging.get_logger(__name__)
@@ -72,7 +70,7 @@ class VisualQuestionAnsweringPipeline(Pipeline):
 
     def __call__(
         self,
-        image: Union["Image.Image", str, List["Image.Image"], List[str]],
+        image: Union["Image.Image", str, List["Image.Image"], List[str], "KeyDataset"],
         question: Union[str, List[str]] = None,
         **kwargs,
     ):

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+from datasets import load_dataset
+
 from transformers import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING, is_vision_available
 from transformers.pipelines import pipeline
 from transformers.pipelines.pt_utils import KeyDataset
@@ -28,7 +30,6 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from datasets import load_dataset
 
 from .test_pipelines_common import ANY
 

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -172,6 +172,50 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
         self.assertEqual(outputs, [[{"answer": "two"}]] * 2)
 
+    @require_torch
+    def test_small_model_pt_image_list(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="hf-internal-testing/tiny-vilt-random-vqa")
+        images = [
+            "./tests/fixtures/tests_samples/COCO/000000039769.png",
+            "./tests/fixtures/tests_samples/COCO/000000004016.png",
+        ]
+
+        outputs = vqa_pipeline(image=images, question="How many cats are there?", top_k=1)
+        self.assertEqual(
+            outputs, [[{"score": ANY(float), "answer": ANY(str)}], [{"score": ANY(float), "answer": ANY(str)}]]
+        )
+
+    @require_torch
+    def test_small_model_pt_question_list(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="hf-internal-testing/tiny-vilt-random-vqa")
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        questions = ["How many cats are there?", "Are there any dogs?"]
+
+        outputs = vqa_pipeline(image=image, question=questions, top_k=1)
+        self.assertEqual(
+            outputs, [[{"score": ANY(float), "answer": ANY(str)}], [{"score": ANY(float), "answer": ANY(str)}]]
+        )
+
+    @require_torch
+    def test_small_model_pt_both_list(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="hf-internal-testing/tiny-vilt-random-vqa")
+        images = [
+            "./tests/fixtures/tests_samples/COCO/000000039769.png",
+            "./tests/fixtures/tests_samples/COCO/000000004016.png",
+        ]
+        questions = ["How many cats are there?", "Are there any dogs?"]
+
+        outputs = vqa_pipeline(image=images, question=questions, top_k=1)
+        self.assertEqual(
+            outputs,
+            [
+                [{"score": ANY(float), "answer": ANY(str)}],
+                [{"score": ANY(float), "answer": ANY(str)}],
+                [{"score": ANY(float), "answer": ANY(str)}],
+                [{"score": ANY(float), "answer": ANY(str)}],
+            ],
+        )
+
     @require_tf
     @unittest.skip("Visual question answering not implemented in TF")
     def test_small_model_tf(self):

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -16,6 +16,7 @@ import unittest
 
 from transformers import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING, is_vision_available
 from transformers.pipelines import pipeline
+from transformers.pipelines.pt_utils import KeyDataset
 from transformers.testing_utils import (
     is_pipeline_test,
     is_torch_available,
@@ -27,6 +28,7 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
+from datasets import load_dataset
 
 from .test_pipelines_common import ANY
 
@@ -211,6 +213,21 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
             [
                 [{"score": ANY(float), "answer": ANY(str)}],
                 [{"score": ANY(float), "answer": ANY(str)}],
+                [{"score": ANY(float), "answer": ANY(str)}],
+                [{"score": ANY(float), "answer": ANY(str)}],
+            ],
+        )
+
+    @require_torch
+    def test_small_model_pt_dataset(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="hf-internal-testing/tiny-vilt-random-vqa")
+        dataset = load_dataset("hf-internal-testing/dummy_image_text_data", split="train[:2]")
+        question = "What's in the image?"
+
+        outputs = vqa_pipeline(image=KeyDataset(dataset, "image"), question=question, top_k=1)
+        self.assertEqual(
+            outputs,
+            [
                 [{"score": ANY(float), "answer": ANY(str)}],
                 [{"score": ANY(float), "answer": ANY(str)}],
             ],

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -18,7 +18,6 @@ from datasets import load_dataset
 
 from transformers import MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING, is_vision_available
 from transformers.pipelines import pipeline
-from transformers.pipelines.pt_utils import KeyDataset
 from transformers.testing_utils import (
     is_pipeline_test,
     is_torch_available,
@@ -36,6 +35,8 @@ from .test_pipelines_common import ANY
 
 if is_torch_available():
     import torch
+
+    from transformers.pipelines.pt_utils import KeyDataset
 
 
 if is_vision_available():


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #31216  

This PR will allow passing list of either `PIL.Image` or `str` as pipeline argument (and `list[str]` for questions). Passing dataset (in form of `.pt_utils.KeyDataset`) is also allowed.
So this code will now work (passing the dataset as list)
```python
from transformers import pipeline
dataset = datasets.load_dataset("frgfm/imagenette", "full_size", "validation[:10]")
oracle = pipeline(task="vqa", model="dandelin/vilt-b32-finetuned-vqa")
oracle(question="What's in this image?", image=dataset['image'], top_k=1)
```

This also works:
```python
from transformers.pipelines.pt_utls import KeyDataset

oracle(question="What's in this image?", image=KeyDataset(dataset, "image"), top_k=1)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
