### PR TITLE
PEFT: Properly warn users when PEFT is not installed

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3073,9 +3073,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 commit_hash = getattr(config, "_commit_hash", None)
 
+        _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None)
+        if not is_peft_available() and _adapter_model_path is not None:
+            logger.warning(
+                f"Adapters detected within {pretrained_model_name_or_path} but PEFT is not installed in your environment, make sure to have"
+                " PEFT installed to correctly load this model `pip install -U peft`."
+            )
+        
         if is_peft_available():
-            _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None)
-
             if _adapter_model_path is None:
                 _adapter_model_path = find_adapter_config_file(
                     pretrained_model_name_or_path,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3073,7 +3073,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 commit_hash = getattr(config, "_commit_hash", None)
 
-        _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None) if adapter_kwargs is not None elese None
+        _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None) if adapter_kwargs is not None else None
         if not is_peft_available() and _adapter_model_path is not None:
             logger.warning(
                 f"Adapters detected within {pretrained_model_name_or_path} but PEFT is not installed in your environment, make sure to have"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3073,7 +3073,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             else:
                 commit_hash = getattr(config, "_commit_hash", None)
 
-        _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None)
+        _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None) if adapter_kwargs is not None elese None
         if not is_peft_available() and _adapter_model_path is not None:
             logger.warning(
                 f"Adapters detected within {pretrained_model_name_or_path} but PEFT is not installed in your environment, make sure to have"


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/31214

Updates the PEFT model loading logic to properly warn users when PEFT is not installed in their env and try to load an adapter model

Context: https://huggingface.slack.com/archives/C04L3MWLE6B/p1717430298492739

cc @amyeroberts @osanseviero @BenjaminBossan 

