### PR TITLE
Video-LLaVa: handle any number of frames

### DIFF
--- a/tests/models/video_llava/test_modeling_video_llava.py
+++ b/tests/models/video_llava/test_modeling_video_llava.py
@@ -487,6 +487,9 @@ class VideoLlavaForConditionalGenerationIntegrationTest(unittest.TestCase):
             repo_id="raushan-testing-hf/videos-test", filename="video_demo.npy", repo_type="dataset"
         )
         video_file = np.load(video_file)
+
+        # let's expand it for 16 frames, to check model can handle any number of frames
+        video_file = video_file.repeat(2, 0)
         inputs = self.processor(prompt, videos=video_file, return_tensors="pt").to(torch_device, torch.float16)
 
         # Make sure that `generate` works


### PR DESCRIPTION
# What does this PR do?

As per title, gives users freedom to sample any number of frames and tune the model with it. The inference will not generate quality text if we sample more than 8 frames, so it's only for those who want to tune with longer videos.

All video-llava tests are passing locally. 