### PR TITLE
Blip: Deprecate `BlipModel`

### DIFF
--- a/docs/source/en/model_doc/blip.md
+++ b/docs/source/en/model_doc/blip.md
@@ -66,6 +66,8 @@ The original code can be found [here](https://github.com/salesforce/BLIP).
 
 ## BlipModel
 
+`BlipModel` is going to be deprecated in future versions, please use `BlipForConditionalGeneration`, `BlipForImageTextRetrieval` or `BlipForQuestionAnswering` depending on your usecase.
+
 [[autodoc]] BlipModel
     - forward
     - get_text_features

--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -742,7 +742,12 @@ class BlipVisionModel(BlipPreTrainedModel):
         return self.embeddings
 
 
-@add_start_docstrings(BLIP_START_DOCSTRING)
+@add_start_docstrings(
+    """
+    This model is going to be deprecated in future versions. Please use `BlipForConditionalGeneration`, `BlipForQuestionAnswering` or `BlipForImageTextRetrieval` depending on your usecase.
+    """,
+    BLIP_START_DOCSTRING,
+)
 class BlipModel(BlipPreTrainedModel):
     config_class = BlipConfig
 
@@ -774,6 +779,10 @@ class BlipModel(BlipPreTrainedModel):
         self.visual_projection = nn.Linear(self.vision_embed_dim, self.projection_dim, bias=False)
         self.text_projection = nn.Linear(self.text_embed_dim, self.projection_dim, bias=False)
         self.logit_scale = nn.Parameter(torch.tensor(self.config.logit_scale_init_value))
+
+        logger.warning(
+            "`BlipModel` is going to be deprecated in future release, please use `BlipForConditionalGeneration`, `BlipForQuestionAnswering` or `BlipForImageTextRetrieval` depending on your usecase."
+        )
 
         # Initialize weights and apply final processing
         self.post_init()


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/31199

As pointed out in https://github.com/huggingface/transformers/issues/28034 and https://github.com/huggingface/transformers/issues/25024 , specifically here: https://github.com/huggingface/transformers/issues/28034#issuecomment-1859735216 `BlipModel` is a copy-pasta from CLIPModel and cannot be used as it is using blip weights on the Hub. We should deprecate this class as it bring a lot of confusion to users and progressively remove it from the docs, then remove the `BlipModel` class itself in the future. 

cc @amyeroberts 