### PR TITLE
Faster image processor

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -136,8 +136,13 @@ class BatchFeature(UserDict):
                 raise ImportError("Unable to convert output to PyTorch tensors format, PyTorch is not installed.")
             import torch  # noqa
 
+            def recursive_ndarray_check(value):
+                if isinstance(value, (list, tuple)) and len(value) > 0:
+                    return recursive_ndarray_check(value[0])
+                return isinstance(value, np.ndarray)
+
             def as_tensor(value):
-                if isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], np.ndarray):
+                if recursive_ndarray_check(value):
                     value = np.array(value)
                 return torch.tensor(value)
 

--- a/src/transformers/models/detr/image_processing_detr.py
+++ b/src/transformers/models/detr/image_processing_detr.py
@@ -1215,7 +1215,7 @@ class DetrImageProcessor(BaseImageProcessor):
             padded_images.append(padded_image)
             padded_annotations.append(padded_annotation)
 
-        data = {"pixel_values": padded_images}
+        data = {"pixel_values": np.array(padded_images) if return_tensors is not None else padded_images}
 
         if return_pixel_mask:
             masks = [
@@ -1490,7 +1490,10 @@ class DetrImageProcessor(BaseImageProcessor):
                 to_channel_dimension_format(image, data_format, input_channel_dim=input_data_format)
                 for image in images
             ]
-            encoded_inputs = BatchFeature(data={"pixel_values": images}, tensor_type=return_tensors)
+            encoded_inputs = BatchFeature(
+                data={"pixel_values": np.array(images) if return_tensors is not None else images},
+                tensor_type=return_tensors,
+            )
             if annotations is not None:
                 encoded_inputs["labels"] = [
                     BatchFeature(annotation, tensor_type=return_tensors) for annotation in annotations

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -360,7 +360,7 @@ class VideoMAEImageProcessor(BaseImageProcessor):
             for video in videos
         ]
 
-        # Speeds up tensor conversion - see: https://github.com/huggingface/transformers/pull/28221/files
+        print(f"return_tensors {return_tensors}")
         data = {"pixel_values": np.asarray(videos) if return_tensors is not None else videos}
 
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -360,5 +360,5 @@ class VideoMAEImageProcessor(BaseImageProcessor):
             for video in videos
         ]
 
-        data = {"pixel_values": videos}
+        data = {"pixel_values": np.asarray(videos)}
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -360,7 +360,7 @@ class VideoMAEImageProcessor(BaseImageProcessor):
             for video in videos
         ]
 
-        if return_tensors is not None: 
-            # Speeds up tensor conversion - see: https://github.com/huggingface/transformers/pull/28221/files
-            data = {"pixel_values": np.asarray(videos)}
+        # Speeds up tensor conversion - see: https://github.com/huggingface/transformers/pull/28221/files
+        data = {"pixel_values": np.asarray(videos) if return_tensors == "pt" else videos}
+
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -360,7 +360,6 @@ class VideoMAEImageProcessor(BaseImageProcessor):
             for video in videos
         ]
 
-        print(f"return_tensors {return_tensors}")
         data = {"pixel_values": np.asarray(videos) if return_tensors is not None else videos}
 
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -361,6 +361,6 @@ class VideoMAEImageProcessor(BaseImageProcessor):
         ]
 
         # Speeds up tensor conversion - see: https://github.com/huggingface/transformers/pull/28221/files
-        data = {"pixel_values": np.asarray(videos) if return_tensors == "pt" else videos}
+        data = {"pixel_values": np.asarray(videos) if return_tensors is not None else videos}
 
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -360,5 +360,7 @@ class VideoMAEImageProcessor(BaseImageProcessor):
             for video in videos
         ]
 
-        data = {"pixel_values": np.asarray(videos)}
+        if return_tensors is not None: 
+            # Speeds up tensor conversion - see: https://github.com/huggingface/transformers/pull/28221/files
+            data = {"pixel_values": np.asarray(videos)}
         return BatchFeature(data=data, tensor_type=return_tensors)

--- a/tests/models/detr/test_image_processing_detr.py
+++ b/tests/models/detr/test_image_processing_detr.py
@@ -648,8 +648,9 @@ class DetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMixi
 
     def test_convert_list2ndarray(self):
         import numpy as np
+
         image_processor = DetrImageProcessor(size={"longest_edge": 200, "shortest_edge": 200}, return_tensors="pt")
-        image_list = list([(np.random.rand(200, 200, 3)*255).astype(np.uint8)]*128)
+        image_list = list([(np.random.rand(200, 200, 3) * 255).astype(np.uint8)] * 128)
 
         inputs = image_processor(images=image_list, input_data_format="channels_last", return_tensors="pt")
         self.assertEqual(inputs["pixel_values"].size(), torch.Size([128, 3, 200, 200]))

--- a/tests/models/detr/test_image_processing_detr.py
+++ b/tests/models/detr/test_image_processing_detr.py
@@ -645,3 +645,11 @@ class DetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMixi
         )
         inputs = image_processor(images=[image_5], return_tensors="pt")
         self.assertEqual(inputs["pixel_values"].shape, torch.Size([1, 3, 50, 50]))
+
+    def test_convert_list2ndarray(self):
+        import numpy as np
+        image_processor = DetrImageProcessor(size={"longest_edge": 200, "shortest_edge": 200}, return_tensors="pt")
+        image_list = list([(np.random.rand(200, 200, 3)*255).astype(np.uint8)]*128)
+
+        inputs = image_processor(images=image_list, input_data_format="channels_last", return_tensors="pt")
+        self.assertEqual(inputs["pixel_values"].size(), torch.Size([128, 3, 200, 200]))

--- a/tests/models/videomae/test_image_processing_videomae.py
+++ b/tests/models/videomae/test_image_processing_videomae.py
@@ -215,7 +215,7 @@ class VideoMAEImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
 
     def test_convert_list2ndarray(self):
         image_processing = self.image_processing_class(**self.image_processor_dict)
-        video_sequences = list([(np.random.rand(200, 200, 3)*255).astype(np.uint8)]*128)
+        video_sequences = list([(np.random.rand(200, 200, 3) * 255).astype(np.uint8)] * 128)
 
         model_inputs = image_processing(images=video_sequences, input_data_format="channels_last", return_tensors="pt")
         self.assertEqual(model_inputs["pixel_values"].size(), torch.Size([1, 128, 3, 18, 18]))

--- a/tests/models/videomae/test_image_processing_videomae.py
+++ b/tests/models/videomae/test_image_processing_videomae.py
@@ -212,3 +212,10 @@ class VideoMAEImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         self.assertEqual(
             tuple(encoded_videos.shape), (self.image_processor_tester.batch_size, *expected_output_video_shape)
         )
+
+    def test_convert_list2ndarray(self):
+        image_processing = self.image_processing_class(**self.image_processor_dict)
+        video_sequences = list([(np.random.rand(200, 200, 3)*255).astype(np.uint8)]*128)
+
+        model_inputs = image_processing(images=video_sequences, input_data_format="channels_last", return_tensors="pt")
+        self.assertEqual(model_inputs["pixel_values"].size(), torch.Size([1, 128, 3, 18, 18]))


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
My attempt to #31205, most of the work were already done in #28221. I just added the adoption in `detr` and include new tests in both `videomae` and `detr` as suggested.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@amyeroberts @ikergarcia1996
The tests might be a bit artificial would love to switch it to a more realistic use case, e.g maybe make a list of actual videos and images. The image processor from `videomae` didn't really triggered the recursive check but the one from `detr` did. Let me know if this is what you are looking for and then I will fix the rest of `detr` variants.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
