### PR TITLE
Fixing `name 'torch' is not defined` in `bitsandbytes` integration

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -332,7 +332,7 @@ def get_keys_to_not_convert(model):
 
 
 # Copied from PEFT: https://github.com/huggingface/peft/blob/47b3712898539569c02ec5b3ed4a6c36811331a1/src/peft/utils/integrations.py#L41
-def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
+def dequantize_bnb_weight(weight: "torch.nn.Parameter", state=None):
     """
     Helper function to dequantize 4bit or 8bit bnb weights.
 


### PR DESCRIPTION
With `transformers==4.41.2` and this:

```python
from transformers import AutoModelForCausalLM, QuantoConfig

AutoModelForCausalLM.from_pretrained(
    "microsoft/phi-2", low_cpu_mem_usage=True, quantization_config=QuantoConfig(weights="int8")
)
```

I hit this traceback:

```none
  File "/Users/user/code/repo/venv/lib/python3.12/site-packages/transformers/integrations/bitsandbytes.py", line 331, in <module>
    def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
                                      ^^^^^
NameError: name 'torch' is not defined
```

---

An alternate would be requiring importers to first run `import torch`

Cc @younesbelkada @SunMarc @amyeroberts @ArthurZucker based on recent PR reviewers for this file