### PR TITLE
Add condition to `benchmark` job in `push-important-models.yml`

### DIFF
--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -136,5 +136,7 @@ jobs:
 
   benchmark:
     name: Benchmark workflow
+    needs: get_modified_models
+    if: ${{ needs.get_modified_models.outputs.matrix != '[]' && needs.get_modified_models.outputs.matrix != '' && fromJson(needs.get_modified_models.outputs.matrix)[0] != null }}
     uses: ./.github/workflows/benchmark.yml
     secrets: inherit


### PR DESCRIPTION
# What does this PR do?

For now, we want to run this benchmark only when some important models are modified in the merged into `main` event.
