### PR TITLE
Skip failing JetMOE generation tests

### DIFF
--- a/tests/models/jetmoe/test_modeling_jetmoe.py
+++ b/tests/models/jetmoe/test_modeling_jetmoe.py
@@ -472,6 +472,14 @@ class JetMoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         self.skipTest("JetMoe flash attention does not support right padding")
 
+    @unittest.skip("TODO: @ArthurZucker - Breaks after #30536 ")
+    def test_beam_sample_generate(self):
+        pass
+
+    @unittest.skip("TODO: @ArthurZucker - Breaks after #30536 ")
+    def test_generate_from_inputs_embeds_decoder_only(self):
+        pass
+
 
 @require_torch
 class JetMoeIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Two JetMOE generation tests started failing after the merge of #30536 - skipping them for now to make `main` happy again and avoid blocking PRs.  

```
FAILED tests/models/jetmoe/test_modeling_jetmoe.py::JetMoeModelTest::test_beam_sample_generate - RuntimeError: cannot reshape tensor of 0 elements into shape [4, 0, 2, -1] because the unspecified dimension size -1 can be any value and is ambiguous
FAILED tests/models/jetmoe/test_modeling_jetmoe.py::JetMoeModelTest::test_generate_from_inputs_embeds_decoder_only - AssertionError: AssertionError not raised
```

Example run: https://app.circleci.com/pipelines/github/huggingface/transformers/94919/workflows/7b36e120-b4ce-45d4-ba80-15a681557e87/jobs/1247043

cc @ArthurZucker 