### PR TITLE
Fix the error message for importing bitsandbytes when not installed.

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -15,6 +15,10 @@ if is_bitsandbytes_available():
     import torch.nn as nn
 
     from ..pytorch_utils import Conv1D
+else:
+    raise ImportError(
+        "The `transformers.integrations.bitsandbytes` module depends on the `bitsandbytes` library, which is not installed."
+    )
 
 if is_accelerate_available():
     import accelerate


### PR DESCRIPTION
# What does this PR do?
As illustrated in https://github.com/huggingface/transformers/issues/31273, the error message for importing the bitsandbytes when the package is not installed should be raised to notify the user, instead of showing the problem about `torch`.

Fixes # (issue)
https://github.com/huggingface/transformers/issues/31273

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
Integrations:
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada
