### PR TITLE
Switch from `cached_download` to `hf_hub_download` in remaining occurrences

### DIFF
--- a/docs/source/en/tasks/semantic_segmentation.md
+++ b/docs/source/en/tasks/semantic_segmentation.md
@@ -245,11 +245,12 @@ You'll also want to create a dictionary that maps a label id to a label class wh
 
 ```py
 >>> import json
->>> from huggingface_hub import cached_download, hf_hub_url
+>>> from pathlib import Path
+>>> from huggingface_hub import hf_hub_download
 
 >>> repo_id = "huggingface/label-files"
 >>> filename = "ade20k-id2label.json"
->>> id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+>>> id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
 >>> id2label = {int(k): v for k, v in id2label.items()}
 >>> label2id = {v: k for k, v in id2label.items()}
 >>> num_labels = len(id2label)

--- a/docs/source/ja/tasks/semantic_segmentation.md
+++ b/docs/source/ja/tasks/semantic_segmentation.md
@@ -83,11 +83,12 @@ pip install -q datasets transformers evaluate
 
 ```py
 >>> import json
->>> from huggingface_hub import cached_download, hf_hub_url
+>>> from pathlib import Path
+>>> from huggingface_hub import hf_hub_download
 
 >>> repo_id = "huggingface/label-files"
 >>> filename = "ade20k-id2label.json"
->>> id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+>>> id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
 >>> id2label = {int(k): v for k, v in id2label.items()}
 >>> label2id = {v: k for k, v in id2label.items()}
 >>> num_labels = len(id2label)

--- a/docs/source/ja/tasks/sequence_classification.md
+++ b/docs/source/ja/tasks/sequence_classification.md
@@ -83,11 +83,12 @@ pip install -q datasets transformers evaluate
 
 ```py
 >>> import json
->>> from huggingface_hub import cached_download, hf_hub_url
+>>> from pathlib import Path
+>>> from huggingface_hub import hf_hub_download
 
 >>> repo_id = "huggingface/label-files"
 >>> filename = "ade20k-id2label.json"
->>> id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+>>> id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
 >>> id2label = {int(k): v for k, v in id2label.items()}
 >>> label2id = {v: k for k, v in id2label.items()}
 >>> num_labels = len(id2label)

--- a/docs/source/ko/tasks/semantic_segmentation.md
+++ b/docs/source/ko/tasks/semantic_segmentation.md
@@ -82,11 +82,12 @@ pip install -q datasets transformers evaluate
 
 ```py
 >>> import json
->>> from huggingface_hub import cached_download, hf_hub_url
+>>> from pathlib import Path
+>>> from huggingface_hub import hf_hub_download
 
 >>> repo_id = "huggingface/label-files"
 >>> filename = "ade20k-id2label.json"
->>> id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+>>> id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
 >>> id2label = {int(k): v for k, v in id2label.items()}
 >>> label2id = {v: k for k, v in id2label.items()}
 >>> num_labels = len(id2label)

--- a/src/transformers/models/cvt/convert_cvt_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/cvt/convert_cvt_original_pytorch_checkpoint_to_pytorch.py
@@ -19,9 +19,10 @@ URL: https://github.com/microsoft/CvT"""
 import argparse
 import json
 from collections import OrderedDict
+from pathlib import Path
 
 import torch
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 
 from transformers import AutoImageProcessor, CvtConfig, CvtForImageClassification
 
@@ -283,7 +284,7 @@ def convert_cvt_checkpoint(cvt_model, image_size, cvt_file_name, pytorch_dump_fo
 
     repo_id = "huggingface/label-files"
     num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, img_labels_file, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, img_labels_file, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
 
     id2label = id2label

--- a/src/transformers/models/deformable_detr/convert_deformable_detr_to_pytorch.py
+++ b/src/transformers/models/deformable_detr/convert_deformable_detr_to_pytorch.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import requests
 import torch
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from PIL import Image
 
 from transformers import DeformableDetrConfig, DeformableDetrForObjectDetection, DeformableDetrImageProcessor
@@ -109,7 +109,7 @@ def convert_deformable_detr_checkpoint(
     config.num_labels = 91
     repo_id = "huggingface/label-files"
     filename = "coco-detection-id2label.json"
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/deprecated/deta/convert_deta_resnet_to_pytorch.py
+++ b/src/transformers/models/deprecated/deta/convert_deta_resnet_to_pytorch.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import requests
 import torch
-from huggingface_hub import cached_download, hf_hub_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from PIL import Image
 
 from transformers import DetaConfig, DetaForObjectDetection, DetaImageProcessor
@@ -48,7 +48,7 @@ def get_deta_config():
     config.num_labels = 91
     repo_id = "huggingface/label-files"
     filename = "coco-detection-id2label.json"
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/deprecated/deta/convert_deta_swin_to_pytorch.py
+++ b/src/transformers/models/deprecated/deta/convert_deta_swin_to_pytorch.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import requests
 import torch
-from huggingface_hub import cached_download, hf_hub_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from PIL import Image
 
 from transformers import DetaConfig, DetaForObjectDetection, DetaImageProcessor, SwinConfig
@@ -63,7 +63,7 @@ def get_deta_config(model_name):
         filename = "coco-detection-id2label.json"
 
     config.num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
     config.id2label = id2label
     config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
+++ b/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import requests
 import torch
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from PIL import Image
 
 from transformers import DPTConfig, DPTForDepthEstimation, DPTForSemanticSegmentation, DPTImageProcessor
@@ -61,7 +61,7 @@ def get_dpt_config(checkpoint_url):
         config.patch_size = 16
         repo_id = "huggingface/label-files"
         filename = "ade20k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+        id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/dpt/convert_dpt_to_pytorch.py
+++ b/src/transformers/models/dpt/convert_dpt_to_pytorch.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import requests
 import torch
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from PIL import Image
 
 from transformers import DPTConfig, DPTForDepthEstimation, DPTForSemanticSegmentation, DPTImageProcessor
@@ -49,7 +49,7 @@ def get_dpt_config(checkpoint_url):
         config.num_labels = 150
         repo_id = "huggingface/label-files"
         filename = "ade20k-id2label.json"
-        id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+        id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
         id2label = {int(k): v for k, v in id2label.items()}
         config.id2label = id2label
         config.label2id = {v: k for k, v in id2label.items()}

--- a/src/transformers/models/regnet/convert_regnet_seer_10b_to_pytorch.py
+++ b/src/transformers/models/regnet/convert_regnet_seer_10b_to_pytorch.py
@@ -30,7 +30,7 @@ from typing import Dict, List, Tuple
 import torch
 import torch.nn as nn
 from classy_vision.models.regnet import RegNet, RegNetParams
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from torch import Tensor
 from vissl.models.model_helpers import get_trunk_forward_outputs
 
@@ -165,7 +165,7 @@ def convert_weights_and_push(save_directory: Path, model_name: str = None, push_
 
     repo_id = "huggingface/label-files"
     num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
 
     id2label = id2label

--- a/src/transformers/models/regnet/convert_regnet_to_pytorch.py
+++ b/src/transformers/models/regnet/convert_regnet_to_pytorch.py
@@ -25,7 +25,7 @@ import timm
 import torch
 import torch.nn as nn
 from classy_vision.models.regnet import RegNet, RegNetParams, RegNetY32gf, RegNetY64gf, RegNetY128gf
-from huggingface_hub import cached_download, hf_hub_url
+from huggingface_hub import hf_hub_download
 from torch import Tensor
 from vissl.models.model_helpers import get_trunk_forward_outputs
 
@@ -225,7 +225,7 @@ def convert_weights_and_push(save_directory: Path, model_name: str = None, push_
 
     repo_id = "huggingface/label-files"
     num_labels = num_labels
-    id2label = json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
+    id2label = json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
     id2label = {int(k): v for k, v in id2label.items()}
 
     id2label = id2label


### PR DESCRIPTION
(somehow related to https://github.com/huggingface/huggingface_hub/pull/2317)

This PR get rids of the remaining `cached_download` in favor of the more robust `hf_hub_download`. Cached_download is quite legacy (replaced since Aug 2022) and I'd like to completely drop it at some point. The core part of `transformers`'s logic made the switch quite some time ago already.

Main change is basically to go from 

```py
json.load(open(cached_download(hf_hub_url(repo_id, filename, repo_type="dataset")), "r"))
```

to 

```py
json.loads(Path(hf_hub_download(repo_id, filename, repo_type="dataset")).read_text())
```

I used `Path(...).read_text()` to avoid opening the file without closing it.

**Note:** there is still one occurrence of `cached_download` in [./src/transformers/models/deprecated/van/convert_van_to_pytorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/deprecated/van/convert_van_to_pytorch.py) but since it is in a `deprecated/` folder, I did not bother maintaining it.