### PR TITLE
fix accelerate tests for roberta xl

### DIFF
--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -572,7 +572,7 @@ class XLMRobertaXLPreTrainedModel(PreTrainedModel):
 
     config_class = XLMRobertaXLConfig
     base_model_prefix = "roberta"
-    _no_split_modules = ["XLMRobertaXLEmbeddings", "XLMRobertaXLSelfAttention"]
+    _no_split_modules = ["XLMRobertaXLEmbeddings", "XLMRobertaXLLayer"]
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):

--- a/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
+++ b/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
@@ -387,7 +387,7 @@ class XLMRobertaXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTes
         else {}
     )
 
-    model_split_percents = [0.5,0.85,0.95]
+    model_split_percents = [0.5, 0.85, 0.95]
 
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(

--- a/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
+++ b/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
@@ -387,6 +387,8 @@ class XLMRobertaXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTes
         else {}
     )
 
+    model_split_percents = [0.5,0.85,0.95]
+
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(
         self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name


### PR DESCRIPTION
# What does this do ? 
This PR fixes the `no_split_modules` for roberta xl model introduced in this PR #31223. Also, we need to change model_split_percents, so that we made sure to have enough space on the first gpu for the embeddings. The tests are passing: 

```
tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py::XLMRobertaXLModelTest::test_cpu_offload If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
[2024-06-06 14:56:19,427] [INFO] [real_accelerator.py:191:get_accelerator] Setting ds_accelerator to cuda (auto detect)
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
PASSED
tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py::XLMRobertaXLModelTest::test_disk_offload_bin If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
PASSED
tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py::XLMRobertaXLModelTest::test_disk_offload_safetensors If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
PASSED
tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py::XLMRobertaXLModelTest::test_model_parallelism If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
If you want to use `RobertaLMHeadModel` as a standalone, add `is_decoder=True.`
PASSED
```

cc @ydshieh since you pinged me on this one