### PR TITLE
Reducing memory usage: removing useless logits computation in generate()

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -119,6 +119,10 @@ class AssistedCandidateGenerator(CandidateGenerator):
                     value.detach().to(device) if isinstance(value, torch.Tensor) else copy.deepcopy(value)
                 )
 
+        # Remove potential default "num_logits_to_keep" key
+        if "num_logits_to_keep" in assistant_kwargs.keys() and not assistant_model._supports_num_logits_to_keep():
+            del assistant_kwargs["num_logits_to_keep"]
+
         if "assistant_encoder_outputs" in model_kwargs:
             assistant_kwargs["encoder_outputs"] = model_kwargs["assistant_encoder_outputs"]
         elif assistant_model.config.is_encoder_decoder:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1889,7 +1889,7 @@ class GenerationMixin:
         # dynamically overrides this value as it can need more than the last token logits
         if self._supports_num_logits_to_keep() and "num_logits_to_keep" not in model_kwargs:
             model_kwargs["num_logits_to_keep"] = 1
-            
+
         self._validate_generated_length(generation_config, input_ids_length, has_default_max_length)
 
         # 7. Prepare the cache.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1606,8 +1606,12 @@ class GenerationMixin:
         Return True if the current model supports the keyword argument `num_logits_to_keep` in forward()
         to save memory. Checking it in this way allows to avoid using a new model attribute.
         """
-        # Dummy call to check if `num_logits_to_keep` is present in output dict
-        dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None)
+        # Dummy call to check if `num_logits_to_keep` is present in output dict (encoder_outputs needs to be passed
+        # for prophetnet model to avoid AssertionError but can be anything except None)
+        if "prophetnet" in self.__class__.__name__.lower():
+            dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None, encoder_outputs=0)
+        else:
+            dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None)
         return "num_logits_to_keep" in dummy
 
     def _prepare_special_tokens(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1607,7 +1607,7 @@ class GenerationMixin:
         to save memory. Checking it in this way allows to avoid using a new model attribute.
         """
         # Dummy call to check if `num_logits_to_keep` is present in output dict
-        dummy = self.prepare_inputs_for_generation(torch.ones(1), attention_mask=None)
+        dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None)
         return "num_logits_to_keep" in dummy
 
     def _prepare_special_tokens(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2590,7 +2590,7 @@ class GenerationMixin:
                 # next logit for contrastive search to select top-k candidate tokens
                 # Clone is needed to avoid keeping a hanging ref to outputs.logits which may be very large for this first iteration
                 # (the clone itself is always small)
-                logit_for_next_step = outputs.logits[:, -1, :].clone()
+                logit_for_next_step = outputs.logits[:, -1, :].clone().float()
 
                 model_kwargs = self._update_model_kwargs_for_generation(
                     outputs,
@@ -2778,7 +2778,7 @@ class GenerationMixin:
 
                     next_past_key_values = tuple(new_key_values)
 
-            logit_for_next_step = torch.stack(torch.split(logits, top_k))[range(batch_size), selected_idx, :]
+            logit_for_next_step = torch.stack(torch.split(logits, top_k))[range(batch_size), selected_idx, :].float()
 
             # Rebuilds the relevant parts of the model output for the selected token, for use in the next iteration
             if self.config.is_encoder_decoder:
@@ -2966,7 +2966,7 @@ class GenerationMixin:
 
             # Clone is needed to avoid keeping a hanging ref to outputs.logits which may be very large for first iteration
             # (the clone itself is always small)
-            next_token_logits = outputs.logits[:, -1, :].clone()
+            next_token_logits = outputs.logits[:, -1, :].clone().float()
 
             # pre-process distribution
             next_token_scores = logits_processor(input_ids, next_token_logits)
@@ -3210,7 +3210,7 @@ class GenerationMixin:
 
             # Clone is needed to avoid keeping a hanging ref to outputs.logits which may be very large for first iteration
             # (the clone itself is always small)
-            next_token_logits = outputs.logits[:, -1, :].clone()
+            next_token_logits = outputs.logits[:, -1, :].clone().float()
             next_token_scores = nn.functional.log_softmax(
                 next_token_logits, dim=-1
             )  # (batch_size * num_beams, vocab_size)
@@ -3484,7 +3484,7 @@ class GenerationMixin:
 
                 # select outputs of beams of current group only
                 # No need to clone() the logits here as they will not retain outputs.logits at the end of the loop
-                next_token_logits = outputs.logits[batch_group_indices, -1, :]
+                next_token_logits = outputs.logits[batch_group_indices, -1, :].float()
 
                 next_token_scores = nn.functional.log_softmax(
                     next_token_logits, dim=-1
@@ -3739,7 +3739,7 @@ class GenerationMixin:
 
             # Clone is needed to avoid keeping a hanging ref to outputs.logits which may be very large for first iteration
             # (the clone itself is always small)
-            next_token_logits = outputs.logits[:, -1, :].clone()
+            next_token_logits = outputs.logits[:, -1, :].clone().float()
             next_token_scores = nn.functional.log_softmax(
                 next_token_logits, dim=-1
             )  # (batch_size * num_beams, vocab_size)
@@ -3999,7 +3999,7 @@ class GenerationMixin:
 
             # 2.3. Process the new logits
             new_logits = outputs.logits[:, -candidate_length - 1 :]  # excludes the input prompt if present
-            next_token_logits = new_logits.clone()
+            next_token_logits = new_logits.clone().float()
             if len(logits_processor) > 0:
                 for i in range(candidate_length + 1):
                     new_logits[:, i, :] = logits_processor(candidate_input_ids[:, : cur_len + i], new_logits[:, i, :])

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1606,13 +1606,7 @@ class GenerationMixin:
         Return True if the current model supports the keyword argument `num_logits_to_keep` in forward()
         to save memory. Checking it in this way allows to avoid using a new model attribute.
         """
-        # Dummy call to check if `num_logits_to_keep` is present in output dict (encoder_outputs needs to be passed
-        # for prophetnet model to avoid AssertionError but can be anything except None)
-        if "prophetnet" in self.__class__.__name__.lower():
-            dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None, encoder_outputs=0)
-        else:
-            dummy = self.prepare_inputs_for_generation(torch.ones(1, 1), attention_mask=None)
-        return "num_logits_to_keep" in dummy
+        return "num_logits_to_keep" in set(inspect.signature(self.forward).parameters.keys())
 
     def _prepare_special_tokens(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1607,7 +1607,7 @@ class GenerationMixin:
         to save memory. Checking it in this way allows to avoid using a new model attribute.
         """
         # Dummy call to check if `num_logits_to_keep` is present in output dict
-        dummy = self.prepare_inputs_for_generation(input_ids=torch.ones(1))
+        dummy = self.prepare_inputs_for_generation(torch.ones(1), attention_mask=None)
         return "num_logits_to_keep" in dummy
 
     def _prepare_special_tokens(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1887,7 +1887,7 @@ class GenerationMixin:
         # If the model supports `num_logits_to_keep` in forward(), set it to 1 to avoid computing the whole
         # logit matrix. This can save a lot of memory during the first forward pass. Note that assisted decoding
         # dynamically overrides this value as it can need more than the last token logits
-        if self._supports_num_logits_to_keep():
+        if self._supports_num_logits_to_keep() and "num_logits_to_keep" not in model_kwargs:
             model_kwargs["num_logits_to_keep"] = 1
             
         self._validate_generated_length(generation_config, input_ids_length, has_default_max_length)

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1071,13 +1071,12 @@ class CohereForCausalLM(CoherePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
         logits = logits * self.logit_scale
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -44,6 +44,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1077,7 +1078,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1024,7 +1024,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1033,10 +1033,10 @@ class CohereForCausalLM(CoherePreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1082,11 +1082,8 @@ class CohereForCausalLM(CoherePreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
         logits = logits * self.logit_scale
 
         loss = None
@@ -1125,7 +1122,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1077,7 +1077,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1080,7 +1080,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1071,12 +1071,13 @@ class CohereForCausalLM(CoherePreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
         logits = logits * self.logit_scale
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1080,10 +1080,10 @@ class CohereForCausalLM(CoherePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
         logits = logits * self.logit_scale
 

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1083,7 +1083,7 @@ class CohereForCausalLM(CoherePreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
         logits = logits * self.logit_scale
 

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -1275,7 +1275,7 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""Forward function for causal language modeling.
 
@@ -1285,10 +1285,10 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1335,10 +1335,7 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
 
         hidden_states = outputs[0]
         # No upscaling to float was ever done for Dbrx
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states)
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
@@ -1390,7 +1387,7 @@ class DbrxForCausalLM(DbrxPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1097,7 +1097,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1085,10 +1085,12 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
+
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1085,12 +1085,10 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-
+        logits = logits.float()
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1038,6 +1038,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1045,6 +1046,11 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1085,10 +1091,21 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1121,6 +1138,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1177,6 +1195,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1038,7 +1038,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1047,10 +1047,10 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1096,11 +1096,8 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1138,7 +1135,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1094,10 +1094,10 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1094,7 +1094,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1091,7 +1091,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -43,6 +43,7 @@ from ...utils import (
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1091,7 +1092,7 @@ class GemmaForCausalLM(GemmaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1056,7 +1056,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
             logits = torch.tanh(logits)
             logits = logits * self.config.final_logit_softcapping
 
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = logits.float()
         loss = None
         if labels is not None:

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -41,6 +41,7 @@ from ...utils import (
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1044,6 +1045,10 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        if labels is None and not is_torchdynamo_compiling():
+            logger.warning_once(
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
         if self.config.final_logit_softcapping is not None:

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1047,7 +1047,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -987,6 +987,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -994,6 +995,11 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1038,15 +1044,19 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
         if self.config.final_logit_softcapping is not None:
             logits = logits / self.config.final_logit_softcapping
             logits = torch.tanh(logits)
             logits = logits * self.config.final_logit_softcapping
 
+        # TODO: remove the float() operation in v4.45
         logits = logits.float()
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1079,6 +1089,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1139,6 +1150,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1601,10 +1601,10 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1591,12 +1591,11 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             labels = labels.to(logits.device)
             # Shift so that tokens < n predict n
             if attention_mask is not None:

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1591,11 +1591,12 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             labels = labels.to(logits.device)
             # Shift so that tokens < n predict n
             if attention_mask is not None:

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1604,7 +1604,7 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1598,7 +1598,7 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -33,6 +33,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1598,7 +1599,7 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1601,7 +1601,7 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -1640,7 +1640,13 @@ class Idefics2ForConditionalGeneration(Idefics2PreTrainedModel):
         )
 
     def prepare_inputs_for_generation(
-        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, num_logits_to_keep=None, **kwargs
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        num_logits_to_keep=None,
+        **kwargs,
     ):
         past_length = 0
         # Omit tokens covered by past_key_values

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1500,7 +1500,7 @@ class JambaForCausalLM(JambaPreTrainedModel):
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
         if labels is None and not is_torchdynamo_compiling:
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # TODO: remove this float() operations in v4.44
         logits = logits.float()

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1500,7 +1500,7 @@ class JambaForCausalLM(JambaPreTrainedModel):
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
         if labels is None and not is_torchdynamo_compiling:
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # TODO: remove this float() operations in v4.44
         logits = logits.float()

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1493,15 +1493,14 @@ class JambaForCausalLM(JambaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         if num_logits_to_keep is None:
             logits = self.lm_head(hidden_states)
         else:
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1502,7 +1502,7 @@ class JambaForCausalLM(JambaPreTrainedModel):
             logger.warning_once(
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
-        # TODO: remove this float() operations in v4.44
+        # TODO: remove the float() operations in v4.46
         logits = logits.float()
 
         loss = None

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -49,8 +49,8 @@ from ...utils.import_utils import (
     is_causal_conv1d_available,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
-    is_torchdynamo_compiling,
     is_mamba_ssm_available,
+    is_torchdynamo_compiling,
 )
 from .configuration_jamba import JambaConfig
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1493,14 +1493,15 @@ class JambaForCausalLM(JambaPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         if num_logits_to_keep is None:
             logits = self.lm_head(hidden_states)
         else:
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -49,6 +49,7 @@ from ...utils.import_utils import (
     is_causal_conv1d_available,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     is_mamba_ssm_available,
 )
 from .configuration_jamba import JambaConfig
@@ -1497,7 +1498,7 @@ class JambaForCausalLM(JambaPreTrainedModel):
             logits = self.lm_head(hidden_states)
         else:
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling:
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1497,7 +1497,7 @@ class JambaForCausalLM(JambaPreTrainedModel):
             logits = self.lm_head(hidden_states)
         else:
             logits = self.lm_head(hidden_states[..., -num_logits_to_keep:, :])
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1291,7 +1291,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1253,6 +1253,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1260,6 +1261,11 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
         """
@@ -1285,11 +1291,21 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1339,6 +1355,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         output_router_logits=False,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1371,6 +1388,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
                 "output_router_logits": output_router_logits,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1294,7 +1294,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1253,7 +1253,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1262,10 +1262,10 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
         """
@@ -1296,11 +1296,8 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1355,7 +1352,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         output_router_logits=False,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -37,6 +37,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1291,7 +1292,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1294,10 +1294,10 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1297,7 +1297,7 @@ class JetMoeForCausalLM(JetMoePreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1207,7 +1207,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         else:
             if labels is None and not is_torchdynamo_compiling():
                 logger.warning_once(
-                    "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                    "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
             # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1205,7 +1205,10 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             if num_logits_to_keep is None:
                 logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
             else:
-                logits = [F.linear(hidden_states[:, -num_logits_to_keep:, :], lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
+                logits = [
+                    F.linear(hidden_states[:, -num_logits_to_keep:, :], lm_head_slices[i])
+                    for i in range(self.config.pretraining_tp)
+                ]
             logits = torch.cat(logits, dim=-1)
         else:
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1146,7 +1146,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[Union[int, None]] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1204,7 +1204,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
             logits = torch.cat(logits, dim=-1)
         else:
-            if labels is None:
+            if labels is None and not torch.compiler.is_compiling():
                 logger.warning_once(
                     "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1146,7 +1146,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1155,10 +1155,10 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1209,11 +1209,8 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
                     "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-            # TODO: remove those 2 float() operations in v4.44
-            if num_logits_to_keep is None:
-                logits = self.lm_head(hidden_states).float()
-            else:
-                logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+            # TODO: remove the float() operation in v4.44
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1251,7 +1248,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1253,6 +1253,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1310,7 +1311,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
-                "num_logits_to_keep": kwargs["num_logits_to_keep"] if "num_logits_to_keep" in kwargs else None,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -44,6 +44,7 @@ from ...utils import (
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1204,7 +1205,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
             logits = [F.linear(hidden_states, lm_head_slices[i]) for i in range(self.config.pretraining_tp)]
             logits = torch.cat(logits, dim=-1)
         else:
-            if labels is None and not torch.compiler.is_compiling():
+            if labels is None and not is_torchdynamo_compiling():
                 logger.warning_once(
                     "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1206,7 +1206,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         else:
             if labels is None:
                 logger.warning_once(
-                    'Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)'
+                    "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
             # TODO: remove those 2 float() operations in v4.44

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1210,7 +1210,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
                     "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-            # TODO: remove the float() operation in v4.45
+            # TODO: remove the float() operation in v4.46
             logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1207,10 +1207,10 @@ class LlamaForCausalLM(LlamaPreTrainedModel):
         else:
             if labels is None and not is_torchdynamo_compiling():
                 logger.warning_once(
-                    "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                    "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
                 )
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-            # TODO: remove the float() operation in v4.44
+            # TODO: remove the float() operation in v4.45
             logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1053,7 +1053,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -996,7 +996,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1005,10 +1005,10 @@ class MistralForCausalLM(MistralPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1055,11 +1055,8 @@ class MistralForCausalLM(MistralPreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1097,7 +1094,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1050,7 +1050,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1056,7 +1056,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -42,6 +42,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1050,7 +1051,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1050,11 +1050,16 @@ class MistralForCausalLM(MistralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        if labels is None:
+            logger.warning_once(
+                'Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)'
+            )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
         if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states)
+            logits = self.lm_head(hidden_states).float()
         else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -996,7 +996,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[Union[int, None]] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1053,10 +1053,10 @@ class MistralForCausalLM(MistralPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -996,6 +996,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[Union[int, None]] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1003,6 +1004,11 @@ class MistralForCausalLM(MistralPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1044,11 +1050,15 @@ class MistralForCausalLM(MistralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
-        logits = self.lm_head(hidden_states)
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
             logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
@@ -1082,6 +1092,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1116,6 +1127,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1052,7 +1052,7 @@ class MistralForCausalLM(MistralPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None:
             logger.warning_once(
-                'Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)'
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove those 2 float() operations in v4.44

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1044,11 +1044,12 @@ class MistralForCausalLM(MistralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1298,7 +1298,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1292,7 +1292,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1286,12 +1286,11 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1295,7 +1295,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1295,10 +1295,10 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1233,6 +1233,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1240,6 +1241,11 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1286,11 +1292,21 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1339,6 +1355,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         output_router_logits=False,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1371,6 +1388,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
                 "output_router_logits": output_router_logits,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -43,6 +43,7 @@ from ...utils import (
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1292,7 +1293,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1233,7 +1233,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1242,10 +1242,10 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1297,11 +1297,8 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1355,7 +1352,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         output_router_logits=False,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1286,11 +1286,12 @@ class MixtralForCausalLM(MixtralPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1085,7 +1085,7 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -42,6 +42,7 @@ from ...utils import (
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1029,6 +1030,7 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1036,6 +1038,11 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1076,11 +1083,19 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
+        if labels is None and not is_torchdynamo_compiling():
+            logger.warning_once(
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+        # TODO: remove the float() operation in v4.45
         logits = logits.float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1113,6 +1128,7 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1170,6 +1186,7 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1089,7 +1089,7 @@ class NemotronForCausalLM(NemotronPreTrainedModel):
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = logits.float()
 
         loss = None

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1116,12 +1116,11 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1128,7 +1128,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1122,7 +1122,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1125,10 +1125,10 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1125,7 +1125,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -42,6 +42,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1122,7 +1123,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1116,11 +1116,12 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1068,7 +1068,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1077,10 +1077,10 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1127,11 +1127,8 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1169,7 +1166,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1068,6 +1068,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1075,6 +1076,11 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1116,11 +1122,21 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1153,6 +1169,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1210,6 +1227,7 @@ class OlmoForCausalLM(OlmoPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -885,6 +885,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -892,6 +893,11 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -933,7 +939,11 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
+        # No upscaling to float was ever done for Persimmon
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
@@ -970,6 +980,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1027,6 +1038,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -885,7 +885,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -894,10 +894,10 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -940,10 +940,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
 
         hidden_states = outputs[0]
         # No upscaling to float was ever done for Persimmon
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states)
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
@@ -980,7 +977,7 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1169,6 +1169,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1176,6 +1177,11 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1217,11 +1223,21 @@ class PhiForCausalLM(PhiPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1255,6 +1271,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1312,6 +1329,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1217,12 +1217,11 @@ class PhiForCausalLM(PhiPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1217,11 +1217,12 @@ class PhiForCausalLM(PhiPreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1169,7 +1169,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1178,10 +1178,10 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1228,11 +1228,8 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1271,7 +1268,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1226,7 +1226,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1223,7 +1223,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -41,6 +41,7 @@ from ...utils import (
     get_torch_version,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1223,7 +1224,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1229,7 +1229,7 @@ class PhiForCausalLM(PhiPreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1226,10 +1226,10 @@ class PhiForCausalLM(PhiPreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1257,12 +1257,11 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1263,7 +1263,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -40,6 +40,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1263,7 +1264,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1266,10 +1266,10 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1210,7 +1210,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1219,10 +1219,10 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1268,11 +1268,8 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1311,7 +1308,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1210,6 +1210,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1217,6 +1218,11 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1257,11 +1263,21 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1295,6 +1311,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1352,6 +1369,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1266,7 +1266,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1269,7 +1269,7 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1257,11 +1257,12 @@ class Phi3ForCausalLM(Phi3PreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1127,7 +1127,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1121,7 +1121,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1115,12 +1115,11 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1067,6 +1067,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1074,6 +1075,11 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1115,11 +1121,21 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1153,6 +1169,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1210,6 +1227,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1124,7 +1124,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1115,11 +1115,12 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1124,10 +1124,10 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -42,6 +42,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1121,7 +1122,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1067,7 +1067,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1076,10 +1076,10 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1126,11 +1126,8 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1169,7 +1166,7 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1296,11 +1296,12 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1305,7 +1305,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1244,6 +1244,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1251,6 +1252,11 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1296,11 +1302,21 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1349,6 +1365,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1406,6 +1423,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1244,7 +1244,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         output_router_logits: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, MoeCausalLMOutputWithPast]:
         r"""
         Args:
@@ -1253,10 +1253,10 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1307,11 +1307,8 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove those 2 float() operations in v4.44
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states).float()
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
+        # TODO: remove the float() operation in v4.44
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
@@ -1365,7 +1362,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1296,12 +1296,11 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1302,7 +1302,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -43,6 +43,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1302,7 +1303,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1308,7 +1308,7 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1305,10 +1305,10 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1164,7 +1164,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        num_logits_to_keep: Optional[int] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1173,10 +1173,10 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
 
-            num_logits_to_keep (`int` or `None`, *optional*):
-                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
-                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
-                    can save memory, which becomes pretty significant for long sequences.
+            num_logits_to_keep (`int`, *optional*):
+                Calculate logits for the last `num_logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
 
         Returns:
 
@@ -1218,10 +1218,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
 
         hidden_states = outputs[0]
         # No upscaling to float was ever done for StableLm
-        if num_logits_to_keep is None:
-            logits = self.lm_head(hidden_states)
-        else:
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
@@ -1258,7 +1255,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
-        num_logits_to_keep=None,
+        num_logits_to_keep=0,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1164,6 +1164,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1171,6 +1172,11 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1211,7 +1217,11 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
+        # No upscaling to float was ever done for StableLm
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:
@@ -1248,6 +1258,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1305,6 +1316,7 @@ class StableLmForCausalLM(StableLmPreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1100,10 +1100,10 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.44
+        # TODO: remove the float() operation in v4.45
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -42,6 +42,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_flash_attn_2_available,
     is_flash_attn_greater_or_equal_2_10,
+    is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
 )
@@ -1097,7 +1098,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None and not torch.compiler.is_compiling():
+        if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1091,11 +1091,12 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
+        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
-        logits = logits.float()
 
         loss = None
         if labels is not None:
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1100,7 +1100,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         hidden_states = outputs[0]
         if labels is None and not is_torchdynamo_compiling():
             logger.warning_once(
-                "Starting from v4.45, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         # TODO: remove the float() operation in v4.45

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1043,6 +1043,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: Optional[int] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -1050,6 +1051,11 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
                 Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                 config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                 (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            num_logits_to_keep (`int` or `None`, *optional*):
+                    Calculate logits for the last `num_logits_to_keep` tokens. If `None`, calculate logits for all
+                    `input_ids`. Only last token logits are needed for generation, and calculating them only for that token
+                    can save memory, which becomes pretty significant for long sequences.
 
         Returns:
 
@@ -1091,11 +1097,21 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
-        logits = logits.float()
+        if labels is None:
+            logger.warning_once(
+                "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
+            )
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        # TODO: remove those 2 float() operations in v4.44
+        if num_logits_to_keep is None:
+            logits = self.lm_head(hidden_states).float()
+        else:
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None
         if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
@@ -1129,6 +1145,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         cache_position=None,
         position_ids=None,
         use_cache=True,
+        num_logits_to_keep=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
@@ -1186,6 +1203,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
                 "past_key_values": past_key_values,
                 "use_cache": use_cache,
                 "attention_mask": attention_mask,
+                "num_logits_to_keep": num_logits_to_keep,
             }
         )
         return model_inputs

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1103,7 +1103,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
                 "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        # TODO: remove the float() operation in v4.45
+        # TODO: remove the float() operation in v4.46
         logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :]).float()
 
         loss = None

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1097,7 +1097,7 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        if labels is None:
+        if labels is None and not torch.compiler.is_compiling():
             logger.warning_once(
                 "Starting from v4.44, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
             )

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1091,12 +1091,11 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel):
         )
 
         hidden_states = outputs[0]
-        # Casting of the logits to float will happen in generate() in inference mode to save memory
         logits = self.lm_head(hidden_states)
+        logits = logits.float()
 
         loss = None
         if labels is not None:
-            logits = logits.float()
             # Shift so that tokens < n predict n
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1833,7 +1833,7 @@ class GenerationTesterMixin:
             if "num_logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):
                 self.skipTest(reason="This model does not support `num_logits_to_keep` argument.")
 
-            config, input_ids, attention_mask = self._get_input_ids_and_config()
+            config, input_ids, attention_mask = self._get_input_ids_and_config(batch_size=1)
             config.use_cache = True
             config.is_decoder = True
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1828,6 +1828,41 @@ class GenerationTesterMixin:
                 output_compiled = compiled_generate(model_inputs, generation_config=generation_config)
                 self.assertListEqual(output_dynamic.tolist(), output_compiled.tolist())
 
+    def test_generate_with_num_logits_to_keep(self):
+        for model_class in self.all_generative_model_classes:
+            if "num_logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):
+                self.skipTest(reason="This model does not support `num_logits_to_keep` argument.")
+
+            config, input_ids, attention_mask = self._get_input_ids_and_config()
+            config.use_cache = True
+            config.is_decoder = True
+
+            model = model_class(config).to(torch_device).eval()
+            assistant_model = model
+            # All generation methods (except assisted decoding) rely on always extracting the last token logits of the
+            # full logits matrix, so testing out only greedy search and assisted decoding is enough (if it works,
+            # other methods will work as well)
+            strategies = [
+                {
+                    "max_new_tokens": 10,
+                    "do_sample": False,
+                },
+                {
+                    "max_new_tokens": 10,
+                    "do_sample": False,
+                    "assistant_model": assistant_model,
+                },
+            ]
+
+            for generation_kwargs in strategies:
+                # Setting num_logits_to_keep at 0 keeps all logits (old behavior)
+                with_all_logits = model.generate(
+                    input_ids, attention_mask=attention_mask, **generation_kwargs, num_logits_to_keep=0
+                )
+                # By default, num_logits_to_keep is automatically set to 1 if not provided (new behavior)
+                without_all_logits = model.generate(input_ids, attention_mask=attention_mask, **generation_kwargs)
+                self.assertListEqual(with_all_logits.tolist(), without_all_logits.tolist())
+
     def _check_outputs(self, output, input_ids, config, use_cache=False, num_return_sequences=1):
         batch_size, seq_length = input_ids.shape
         num_sequences_in_output = batch_size * num_return_sequences

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1854,7 +1854,9 @@ class GenerationTesterMixin:
                 },
             ]
 
-            for generation_kwargs in strategies:
+            for i, generation_kwargs in enumerate(strategies):
+                if i == 1 and model_class._is_stateful:
+                    self.skipTest(reason="Stateful models don't support assisted generation")
                 # Setting num_logits_to_keep at 0 keeps all logits (old behavior)
                 with_all_logits = model.generate(
                     input_ids, attention_mask=attention_mask, **generation_kwargs, num_logits_to_keep=0

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4824,6 +4824,27 @@ class ModelTesterMixin:
         self.assertTrue(record_time < 0.15 * graph_warmup_time)
         self.assertTrue(opt_time < record_time)
 
+    def test_forward_with_num_logits_to_keep(self):
+        for model_class in self.all_generative_model_classes:
+            if "num_logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):
+                self.skipTest(reason="This model does not support `num_logits_to_keep` argument.")
+
+            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
+            batch_size, sequence_length = inputs["input_ids"].shape
+            vocab_size = config.vocab_size
+            model = model_class(config).to(device=torch_device).eval()
+
+            # num_logits_to_keep=0 is a special case meaning "keep all logits"
+            all_logits = model(**inputs, num_logits_to_keep=0).logits
+            last_token_logits = model(**inputs, num_logits_to_keep=1).logits
+
+            # Assert all shapes are correct
+            self.assertEqual(tuple(all_logits.shape), (batch_size, sequence_length, vocab_size))
+            self.assertEqual(tuple(last_token_logits.shape), (batch_size, 1, vocab_size))
+
+            # Assert the last tokens are actually the same
+            self.assertEqual(all_logits[:, -1, :].tolist(), last_token_logits.tolist())
+
 
 global_rng = random.Random()
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4843,7 +4843,7 @@ class ModelTesterMixin:
             self.assertEqual(tuple(last_token_logits.shape), (batch_size, 1, vocab_size))
 
             # Assert the last tokens are actually the same
-            self.assertTrue(torch.allclose(all_logits[:, -1, :], last_token_logits))
+            self.assertTrue(torch.allclose(all_logits[:, -1:, :], last_token_logits))
 
 
 global_rng = random.Random()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4843,7 +4843,7 @@ class ModelTesterMixin:
             self.assertEqual(tuple(last_token_logits.shape), (batch_size, 1, vocab_size))
 
             # Assert the last tokens are actually the same
-            self.assertEqual(all_logits[:, -1, :].tolist(), last_token_logits.tolist())
+            self.assertTrue(torch.allclose(all_logits[:, -1, :], last_token_logits))
 
 
 global_rng = random.Random()


### PR DESCRIPTION
# What does this PR do?

This is the PR related to the discussion in #30860. 
I followed was has been done in `Jamba` and added support for the `num_logits_to_keep` argument in `forward()`. However, even if this argument is `None`, the logits will only be upcasted to float if `labels` are passed (in order to accurately compute the loss). Otherwise, the upcasting only happen in the `generate()` functions.

For now, I only modified `Llama` and `Mistral`, but if you agree on the changes I will add support for more models.

## Benchmarks

Here I provide some benchmarks of the peak memory usage. For each input size, I generated 10 additional tokens.
Of course, since for few additional tokens the memory peak scales only with the first forward pass (at least when computing the whole logits matrix), and that the first forward scales linearly with input size and batch size (with new attention algorithms), the gain is actually constant for all input sizes and generation methods (except for contrastive search, which artificially increase the batch size after the first forward, thus the memory usage is slightly different). However, I still provide results for all generation methods here for completeness.

Basically we get: 
Llama3 8B -> MIND-BLOWING 3.62 memory usage reduction factor (due to large vocabulary)
Llama2 7B -> 1.17 reduction factor
Mistral 7B -> 1.32 reduction factor

Note that the memory reduction shown here is **on top** of whatever gains #30536 already provides for small new additional tokens, as I am comparing memory with the main transformers branch after it was merged. It integrates very nicely with that last PR, as the last one was providing most benefits when generating  more tokens, and this one provides gains for small new number of tokens.

[greedy.pdf](https://github.com/user-attachments/files/15645353/greedy.pdf)
[sample.pdf](https://github.com/user-attachments/files/15645374/sample.pdf)
[beam sample.pdf](https://github.com/user-attachments/files/15645320/beam.sample.pdf)
[beam search.pdf](https://github.com/user-attachments/files/15645334/beam.search.pdf)
[group beam search.pdf](https://github.com/user-attachments/files/15645364/group.beam.search.pdf)
[contrastive search.pdf](https://github.com/user-attachments/files/15645344/contrastive.search.pdf)

Here is a link to the benchmark script: https://gist.github.com/Cyrilvallez/92f48e402aa2968c854a8128796f50c3

## Who can review?

@ArthurZucker @gante Let me know what you think about the proposed changes! 
