### PR TITLE
fix overflow for bfloat16 when using cuda kernel.

### DIFF
--- a/src/transformers/modeling_attn_mask_utils.py
+++ b/src/transformers/modeling_attn_mask_utils.py
@@ -183,7 +183,10 @@ class AttentionMaskConverter:
 
         inverted_mask = 1.0 - expanded_mask
 
-        return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)
+        # using torch.finfo causes overflow when using F.scaled_dot_product_attention.
+        # it is safe using torch.finfo(dtype).min / 2 instead of torch.finfo(dtype).min.
+        # especially for bfloat16.
+        return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min / 2)
 
     @staticmethod
     def _unmask_unattended(


### PR DESCRIPTION
# What does this PR do?
using `torch.finfo(dtype).min / 2` instead of `torch.finfo(dtype).min` to avoid overflow caculation when using `F.scaled_dot_product_attention`, especially bfloat16.

Fixes # (issue)
* https://github.com/huggingface/transformers/issues/31035#issuecomment-2149675331

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
 @ArthurZucker and @younesbelkada

