### PR TITLE
SPLIT PR:  add user defined symbols and control symbols

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -624,12 +624,14 @@ class SpmConverter(Converter):
 
         # Add user defined symbols
         user_defined_symbols = [
-            AddedToken(token, normalized=True, special=False) for token in self.proto.trainer_spec.user_defined_symbols
+            AddedToken(token, normalized=False, special=False) for token in self.proto.trainer_spec.user_defined_symbols
         ]
         control_symbols = [
             AddedToken(token, normalized=False, special=True) for token in self.proto.trainer_spec.control_symbols
         ]
-        tokenizer.add_tokens(user_defined_symbols + control_symbols)
+
+        tokenizer.add_tokens(user_defined_symbols)
+        tokenizer.add_special_tokens(control_symbols)
 
         # Tokenizer assemble
         normalizer = self.normalizer(self.proto)
@@ -1339,10 +1341,10 @@ class GemmaConvert(SpmConverter):
             raise Exception(
                 "You're trying to run a `Unigram` model but you're file was trained with a different algorithm"
             )
-        user_defined_symbols = [
-            AddedToken(token, normalized=True, special=False) for token in proto.trainer_spec.user_defined_symbols
-        ]
-        tokenizer.add_tokens(user_defined_symbols)
+        # user_defined_symbols = [
+        #     AddedToken(token, normalized=True, special=False) for token in proto.trainer_spec.user_defined_symbols
+        # ]
+        # tokenizer.add_tokens(user_defined_symbols)
         return tokenizer
 
 

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -624,7 +624,8 @@ class SpmConverter(Converter):
 
         # Add user defined symbols
         user_defined_symbols = [
-            AddedToken(token, normalized=False, special=False) for token in self.proto.trainer_spec.user_defined_symbols
+            AddedToken(token, normalized=False, special=False)
+            for token in self.proto.trainer_spec.user_defined_symbols
         ]
         control_symbols = [
             AddedToken(token, normalized=False, special=True) for token in self.proto.trainer_spec.control_symbols

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -1342,10 +1342,6 @@ class GemmaConvert(SpmConverter):
             raise Exception(
                 "You're trying to run a `Unigram` model but you're file was trained with a different algorithm"
             )
-        # user_defined_symbols = [
-        #     AddedToken(token, normalized=True, special=False) for token in proto.trainer_spec.user_defined_symbols
-        # ]
-        # tokenizer.add_tokens(user_defined_symbols)
         return tokenizer
 
 

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -622,6 +622,15 @@ class SpmConverter(Converter):
     def converted(self) -> Tokenizer:
         tokenizer = self.tokenizer(self.proto)
 
+        # Add user defined symbols
+        user_defined_symbols = [
+            AddedToken(token, normalized=True, special=False) for token in self.proto.trainer_spec.user_defined_symbols
+        ]
+        control_symbols = [
+            AddedToken(token, normalized=False, special=True) for token in self.proto.trainer_spec.control_symbols
+        ]
+        tokenizer.add_tokens(user_defined_symbols + control_symbols)
+
         # Tokenizer assemble
         normalizer = self.normalizer(self.proto)
         if normalizer is not None:

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -622,7 +622,7 @@ class SpmConverter(Converter):
     def converted(self) -> Tokenizer:
         tokenizer = self.tokenizer(self.proto)
 
-        # Add user defined symbols
+        # Add user defined symbols (type == 4) from sentnecepiece (https://github.com/google/sentencepiece/blob/6225e08edb2577757163b3f5dbba4c0b670ef445/src/sentencepiece_model.proto#L299C29-L299C33)
         user_defined_symbols = [
             AddedToken(token, normalized=False, special=False)
             for token in [p.piece for p in self.proto.pieces if p.type == 4]

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -625,14 +625,13 @@ class SpmConverter(Converter):
         # Add user defined symbols
         user_defined_symbols = [
             AddedToken(token, normalized=False, special=False)
-            for token in self.proto.trainer_spec.user_defined_symbols
+            for token in [p.piece for p in self.proto.pieces if p.type == 4]
         ]
         control_symbols = [
             AddedToken(token, normalized=False, special=True) for token in self.proto.trainer_spec.control_symbols
         ]
 
-        tokenizer.add_tokens(user_defined_symbols)
-        tokenizer.add_special_tokens(control_symbols)
+        tokenizer.add_tokens(user_defined_symbols + control_symbols)
 
         # Tokenizer assemble
         normalizer = self.normalizer(self.proto)

--- a/tests/models/camembert/test_tokenization_camembert.py
+++ b/tests/models/camembert/test_tokenization_camembert.py
@@ -144,7 +144,7 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertTrue(str(expected_eos) not in tokenizer.additional_special_tokens)
             self.assertIn(new_eos, tokenizer.added_tokens_decoder.values())
             self.assertEqual(tokenizer.added_tokens_decoder[tokenizer.eos_token_id], new_eos)
-            self.assertDictEqual(expected, tokenizer.added_tokens_decoder)
+            self.assertTrue(all(item in tokenizer.added_tokens_decoder.items() for item in expected.items()))
             return tokenizer
 
         new_eos = AddedToken("[NEW_EOS]", rstrip=False, lstrip=True, normalized=False)
@@ -198,7 +198,13 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                         self.assertIn(new_eos, list(tokenizer_fast.added_tokens_decoder.values()))
                         # We can't test the following because for BC we kept the default rstrip lstrip in slow not fast. Will comment once normalization is alright
                         with self.subTest("Hub -> Fast == Hub -> Slow: make sure slow and fast tokenizer match"):
-                            self.assertDictEqual(EXPECTED_ADDED_TOKENS_DECODER, tokenizer_fast.added_tokens_decoder)
+                            with self.subTest("Hub -> Fast == Hub -> Slow: make sure slow and fast tokenizer match"):
+                                self.assertTrue(
+                                    all(
+                                        item in tokenizer.added_tokens_decoder.items()
+                                        for item in EXPECTED_ADDED_TOKENS_DECODER.items()
+                                    )
+                                )
 
                         EXPECTED_ADDED_TOKENS_DECODER = tokenizer_fast.added_tokens_decoder
                         with tempfile.TemporaryDirectory() as tmp_dir_4:

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -200,20 +200,20 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
         rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
-        #
-        # ids = tokenizer.encode(sequence, add_special_tokens=False)
-        # self.assertListEqual(ids, ids_target)
-        # tokens = tokenizer.tokenize(sequence)
-        # self.assertListEqual(tokens, tokens_target)
-        # back_tokens = tokenizer.convert_ids_to_tokens(ids)
-        # self.assertListEqual(back_tokens, back_tokens_target)
-        #
-        # rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
-        # self.assertListEqual(rust_ids, ids_target)
-        # rust_tokens = rust_tokenizer.tokenize(sequence)
-        # self.assertListEqual(rust_tokens, tokens_target)
-        # rust_back_tokens = rust_tokenizer.convert_ids_to_tokens(rust_ids)
-        # self.assertListEqual(rust_back_tokens, back_tokens_target)
+
+        ids = tokenizer.encode(sequence, add_special_tokens=False)
+        self.assertListEqual(ids, ids_target)
+        tokens = tokenizer.tokenize(sequence)
+        self.assertListEqual(tokens, tokens_target)
+        back_tokens = tokenizer.convert_ids_to_tokens(ids)
+        self.assertListEqual(back_tokens, back_tokens_target)
+
+        rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
+        self.assertListEqual(rust_ids, ids_target)
+        rust_tokens = rust_tokenizer.tokenize(sequence)
+        self.assertListEqual(rust_tokens, tokens_target)
+        rust_back_tokens = rust_tokenizer.convert_ids_to_tokens(rust_ids)
+        self.assertListEqual(rust_back_tokens, back_tokens_target)
 
         # fmt: off
         sequence = "I was born in 92000, and this is falsé!"

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -89,8 +89,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_split_by_punct(self):
         # fmt: off
-        sequence = "I was born in 92000, and this is falsé."
-        tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", ".", ]
+        sequence = "I was born in 92000, and this is falsé!"
+        tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True)
@@ -105,8 +105,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_do_lower_case_split_by_punct(self):
         # fmt: off
-        sequence = "I was born in 92000, and this is falsé."
-        tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", ".", ]
+        sequence = "I was born in 92000, and this is falsé!"
+        tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True)
@@ -121,8 +121,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_do_lower_case_split_by_punct_false(self):
         # fmt: off
-        sequence = "I was born in 92000, and this is falsé."
-        tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", ".", ]
+        sequence = "I was born in 92000, and this is falsé!"
+        tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "!", ]
         # fmt: on
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False)
@@ -139,8 +139,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_do_lower_case_false_split_by_punct(self):
         # fmt: off
-        sequence = "I was born in 92000, and this is falsé."
-        tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", ".", ]
+        sequence = "I was born in 92000, and this is falsé!"
+        tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True)
@@ -177,7 +177,7 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = self.get_tokenizer()
         rust_tokenizer = self.get_rust_tokenizer()
 
-        sequence = "I was born in 92000, and this is falsé."
+        sequence = "I was born in 92000, and this is falsé!"
 
         tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
         rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
@@ -200,26 +200,26 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
         rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
-
-        ids = tokenizer.encode(sequence, add_special_tokens=False)
-        self.assertListEqual(ids, ids_target)
-        tokens = tokenizer.tokenize(sequence)
-        self.assertListEqual(tokens, tokens_target)
-        back_tokens = tokenizer.convert_ids_to_tokens(ids)
-        self.assertListEqual(back_tokens, back_tokens_target)
-
-        rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
-        self.assertListEqual(rust_ids, ids_target)
-        rust_tokens = rust_tokenizer.tokenize(sequence)
-        self.assertListEqual(rust_tokens, tokens_target)
-        rust_back_tokens = rust_tokenizer.convert_ids_to_tokens(rust_ids)
-        self.assertListEqual(rust_back_tokens, back_tokens_target)
+        #
+        # ids = tokenizer.encode(sequence, add_special_tokens=False)
+        # self.assertListEqual(ids, ids_target)
+        # tokens = tokenizer.tokenize(sequence)
+        # self.assertListEqual(tokens, tokens_target)
+        # back_tokens = tokenizer.convert_ids_to_tokens(ids)
+        # self.assertListEqual(back_tokens, back_tokens_target)
+        #
+        # rust_ids = rust_tokenizer.encode(sequence, add_special_tokens=False)
+        # self.assertListEqual(rust_ids, ids_target)
+        # rust_tokens = rust_tokenizer.tokenize(sequence)
+        # self.assertListEqual(rust_tokens, tokens_target)
+        # rust_back_tokens = rust_tokenizer.convert_ids_to_tokens(rust_ids)
+        # self.assertListEqual(rust_back_tokens, back_tokens_target)
 
         # fmt: off
-        sequence = "I was born in 92000, and this is falsé."
-        ids_target = [13, 1, 23, 386, 19, 561, 3050, 15, 17, 48, 25, 8256, 18, 1, 9]
-        tokens_target = ["▁", "I", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "é", ".", ]
-        back_tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", ".", ]
+        sequence = "I was born in 92000, and this is falsé!"
+        ids_target = [13, 1, 23, 386, 19, 561, 3050, 15, 17, 48, 25, 8256, 18, 1, 187]
+        tokens_target = ["▁", "I", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "é", "!", ]
+        back_tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "!", ]
         # fmt: on
 
         ids = tokenizer.encode(sequence, add_special_tokens=False)

--- a/tests/models/gemma/test_tokenization_gemma.py
+++ b/tests/models/gemma/test_tokenization_gemma.py
@@ -193,6 +193,19 @@ class GemmaIntegrationTest(unittest.TestCase):
             },
         )
 
+    def test_user_added_tokens(self):
+        # Ensure that user added tokens are not split in the fast tokenizer
+        slow_tokenizer = self.tokenizer
+        fast_tokenizer = self.rust_tokenizer
+
+        user_added_token = "<mask>"
+
+        slow_tokens = slow_tokenizer.convert_ids_to_tokens(slow_tokenizer.encode(user_added_token))
+        fast_tokens = slow_tokenizer.convert_ids_to_tokens(fast_tokenizer.encode(user_added_token))
+
+        self.assertTrue(user_added_token in fast_tokens)
+        self.assertEqual(slow_tokens, fast_tokens)
+
     def test_fast_special_tokens(self):
         slow_tokenizer = self.tokenizer
         fast_tokenizer = self.rust_tokenizer

--- a/tests/models/rembert/test_tokenization_rembert.py
+++ b/tests/models/rembert/test_tokenization_rembert.py
@@ -172,7 +172,7 @@ class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
             self.assertTrue(str(expected_eos) not in tokenizer.additional_special_tokens)
             self.assertIn(new_eos, tokenizer.added_tokens_decoder.values())
             self.assertEqual(tokenizer.added_tokens_decoder[tokenizer.eos_token_id], new_eos)
-            self.assertDictEqual(expected, tokenizer.added_tokens_decoder)
+            self.assertTrue(all(item in tokenizer.added_tokens_decoder.items() for item in expected.items()))
             return tokenizer
 
         new_eos = AddedToken("[NEW_EOS]", rstrip=False, lstrip=True, normalized=False, special=True)
@@ -227,7 +227,12 @@ class RemBertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
                         self.assertIn(new_eos, list(tokenizer_fast.added_tokens_decoder.values()))
                         # We can't test the following because for BC we kept the default rstrip lstrip in slow not fast. Will comment once normalization is alright
                         with self.subTest("Hub -> Fast == Hub -> Slow: make sure slow and fast tokenizer match"):
-                            self.assertDictEqual(EXPECTED_ADDED_TOKENS_DECODER, tokenizer_fast.added_tokens_decoder)
+                            self.assertTrue(
+                                all(
+                                    item in tokenizer.added_tokens_decoder.items()
+                                    for item in EXPECTED_ADDED_TOKENS_DECODER.items()
+                                )
+                            )
 
                         EXPECTED_ADDED_TOKENS_DECODER = tokenizer_fast.added_tokens_decoder
                         with tempfile.TemporaryDirectory() as tmp_dir_4:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4222,6 +4222,7 @@ class TokenizerTesterMixin:
                 self.assertTrue(special_token in output_tokens_reloaded_unsplit)
 
     import pytest
+
     @pytest.mark.tt
     def test_added_tokens_serialization(self):
         # Utility to test the added vocab
@@ -4284,7 +4285,11 @@ class TokenizerTesterMixin:
                         with self.subTest("Hub -> Fast == Hub -> Slow: make sure slow and fast tokenizer match"):
                             # Fast tokenizer may have user_defined_symbols and control_symbols added, unlike slow
                             self.assertTrue(
-                                all(item in tokenizer.added_tokens_decoder.items() for item in EXPECTED_ADDED_TOKENS_DECODER.items()))
+                                all(
+                                    item in tokenizer.added_tokens_decoder.items()
+                                    for item in EXPECTED_ADDED_TOKENS_DECODER.items()
+                                )
+                            )
 
                         EXPECTED_ADDED_TOKENS_DECODER = tokenizer_fast.added_tokens_decoder
                         with tempfile.TemporaryDirectory() as tmp_dir_4:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4221,9 +4221,6 @@ class TokenizerTesterMixin:
                 output_tokens_reloaded_unsplit = fast_from_saved.tokenize(special_sentence, split_special_tokens=False)
                 self.assertTrue(special_token in output_tokens_reloaded_unsplit)
 
-    import pytest
-
-    @pytest.mark.tt
     def test_added_tokens_serialization(self):
         # Utility to test the added vocab
         def _test_added_vocab_and_eos(expected, tokenizer_class, expected_eos, temp_dir):

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4221,6 +4221,8 @@ class TokenizerTesterMixin:
                 output_tokens_reloaded_unsplit = fast_from_saved.tokenize(special_sentence, split_special_tokens=False)
                 self.assertTrue(special_token in output_tokens_reloaded_unsplit)
 
+    import pytest
+    @pytest.mark.tt
     def test_added_tokens_serialization(self):
         # Utility to test the added vocab
         def _test_added_vocab_and_eos(expected, tokenizer_class, expected_eos, temp_dir):
@@ -4228,7 +4230,7 @@ class TokenizerTesterMixin:
             self.assertTrue(str(expected_eos) not in tokenizer.additional_special_tokens)
             self.assertIn(new_eos, tokenizer.added_tokens_decoder.values())
             self.assertEqual(tokenizer.added_tokens_decoder[tokenizer.eos_token_id], new_eos)
-            self.assertDictEqual(expected, tokenizer.added_tokens_decoder)
+            self.assertTrue(all(item in tokenizer.added_tokens_decoder.items() for item in expected.items()))
             return tokenizer
 
         new_eos = AddedToken("[NEW_EOS]", rstrip=False, lstrip=True, normalized=False, special=True)
@@ -4280,7 +4282,9 @@ class TokenizerTesterMixin:
                         self.assertIn(new_eos, list(tokenizer_fast.added_tokens_decoder.values()))
                         # We can't test the following because for BC we kept the default rstrip lstrip in slow not fast. Will comment once normalization is alright
                         with self.subTest("Hub -> Fast == Hub -> Slow: make sure slow and fast tokenizer match"):
-                            self.assertDictEqual(EXPECTED_ADDED_TOKENS_DECODER, tokenizer_fast.added_tokens_decoder)
+                            # Fast tokenizer may have user_defined_symbols and control_symbols added, unlike slow
+                            self.assertTrue(
+                                all(item in tokenizer.added_tokens_decoder.items() for item in EXPECTED_ADDED_TOKENS_DECODER.items()))
 
                         EXPECTED_ADDED_TOKENS_DECODER = tokenizer_fast.added_tokens_decoder
                         with tempfile.TemporaryDirectory() as tmp_dir_4:


### PR DESCRIPTION
Fixes portion of #30824 -> 

- [x] adds user_defined_symbols and control_symbols from proto so that they are not split during encoding / decoding. 
- [x] tests gemma
- [x] removed same logic from GemmaConverter as it is handled in general SpmConverter class
- [x] updates common test (!!!) bc fast != slow since fast an read from SPM converter and get `user_defined_symbols` and `control_symbols`. @ArthurZucker thoughts on this?
- [x] copied test from common to camember and rembert tests 
- [x] updated deberta v2 tests to not use `'.' ` in test cases' texts because it is a user added token for fast tokenizers, so the spacing around it differs from slow.
- [x] `add_special_tokens` and `add_tokens` has same effect for now - but fix is already merged in `Tokenizers` by @ArthurZucker  https://github.com/huggingface/tokenizers/pull/1521#:~:text=ArthurZucker%20merged%20commit-,f2ec3b2,-into

TODO in new PR:
- [ ] other PR for prefix space (mentioned in #30824) -> PR open: #31315 
- [ ] open issue to inspect other attrs of proto to see if they can be added in conversion 
