### PR TITLE
Import structure & first three model refactors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ quality:
 	@python -c "from transformers import *" || (echo '🚨 import failed, this means you introduced unprotected imports! 🚨'; exit 1)
 	ruff check $(check_dirs) setup.py conftest.py
 	ruff format --check $(check_dirs) setup.py conftest.py
-	python utils/custom_init_isort.py --check_only
 	python utils/sort_auto_mappings.py --check_only
 	python utils/check_doc_toc.py
 	python utils/check_docstrings.py --check_all
@@ -62,7 +61,6 @@ quality:
 # Format source code automatically and check is there are any problems left that need manual fixing
 
 extra_style_checks:
-	python utils/custom_init_isort.py
 	python utils/sort_auto_mappings.py
 	python utils/check_doc_toc.py --fix_and_overwrite
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1499,7 +1499,6 @@ else:
             "BertForQuestionAnswering",
             "BertForSequenceClassification",
             "BertForTokenClassification",
-            "BertLayer",
             "BertLMHeadModel",
             "BertModel",
             "BertPreTrainedModel",
@@ -1523,7 +1522,6 @@ else:
             "BigBirdForQuestionAnswering",
             "BigBirdForSequenceClassification",
             "BigBirdForTokenClassification",
-            "BigBirdLayer",
             "BigBirdModel",
             "BigBirdPreTrainedModel",
             "load_tf_weights_in_big_bird",
@@ -1642,7 +1640,6 @@ else:
             "CanineForQuestionAnswering",
             "CanineForSequenceClassification",
             "CanineForTokenClassification",
-            "CanineLayer",
             "CanineModel",
             "CaninePreTrainedModel",
             "load_tf_weights_in_canine",
@@ -1729,7 +1726,6 @@ else:
             "ConvBertForQuestionAnswering",
             "ConvBertForSequenceClassification",
             "ConvBertForTokenClassification",
-            "ConvBertLayer",
             "ConvBertModel",
             "ConvBertPreTrainedModel",
             "load_tf_weights_in_convbert",
@@ -1958,7 +1954,6 @@ else:
             "QDQBertForQuestionAnswering",
             "QDQBertForSequenceClassification",
             "QDQBertForTokenClassification",
-            "QDQBertLayer",
             "QDQBertLMHeadModel",
             "QDQBertModel",
             "QDQBertPreTrainedModel",
@@ -2210,7 +2205,6 @@ else:
             "FNetForQuestionAnswering",
             "FNetForSequenceClassification",
             "FNetForTokenClassification",
-            "FNetLayer",
             "FNetModel",
             "FNetPreTrainedModel",
         ]
@@ -2311,7 +2305,6 @@ else:
             "GPTNeoXForQuestionAnswering",
             "GPTNeoXForSequenceClassification",
             "GPTNeoXForTokenClassification",
-            "GPTNeoXLayer",
             "GPTNeoXModel",
             "GPTNeoXPreTrainedModel",
         ]
@@ -2319,7 +2312,6 @@ else:
     _import_structure["models.gpt_neox_japanese"].extend(
         [
             "GPTNeoXJapaneseForCausalLM",
-            "GPTNeoXJapaneseLayer",
             "GPTNeoXJapaneseModel",
             "GPTNeoXJapanesePreTrainedModel",
         ]
@@ -2551,7 +2543,6 @@ else:
             "LongformerForTokenClassification",
             "LongformerModel",
             "LongformerPreTrainedModel",
-            "LongformerSelfAttention",
         ]
     )
     _import_structure["models.longt5"].extend(
@@ -2584,7 +2575,6 @@ else:
             "LxmertModel",
             "LxmertPreTrainedModel",
             "LxmertVisualFeatureEncoder",
-            "LxmertXLayer",
         ]
     )
     _import_structure["models.m2m_100"].extend(
@@ -2608,7 +2598,9 @@ else:
             "Mamba2PreTrainedModel",
         ]
     )
-    _import_structure["models.marian"].extend(["MarianForCausalLM", "MarianModel", "MarianMTModel"])
+    _import_structure["models.marian"].extend(
+        ["MarianForCausalLM", "MarianModel", "MarianMTModel", "MarianPreTrainedModel"]
+    )
     _import_structure["models.markuplm"].extend(
         [
             "MarkupLMForQuestionAnswering",
@@ -2691,7 +2683,6 @@ else:
             "MobileBertForQuestionAnswering",
             "MobileBertForSequenceClassification",
             "MobileBertForTokenClassification",
-            "MobileBertLayer",
             "MobileBertModel",
             "MobileBertPreTrainedModel",
             "load_tf_weights_in_mobilebert",
@@ -2737,7 +2728,6 @@ else:
             "MPNetForQuestionAnswering",
             "MPNetForSequenceClassification",
             "MPNetForTokenClassification",
-            "MPNetLayer",
             "MPNetModel",
             "MPNetPreTrainedModel",
         ]
@@ -2827,7 +2817,6 @@ else:
             "NystromformerForQuestionAnswering",
             "NystromformerForSequenceClassification",
             "NystromformerForTokenClassification",
-            "NystromformerLayer",
             "NystromformerModel",
             "NystromformerPreTrainedModel",
         ]
@@ -2941,7 +2930,6 @@ else:
             "PerceiverForMultimodalAutoencoding",
             "PerceiverForOpticalFlow",
             "PerceiverForSequenceClassification",
-            "PerceiverLayer",
             "PerceiverModel",
             "PerceiverPreTrainedModel",
         ]
@@ -3077,11 +3065,9 @@ else:
     )
     _import_structure["models.reformer"].extend(
         [
-            "ReformerAttention",
             "ReformerForMaskedLM",
             "ReformerForQuestionAnswering",
             "ReformerForSequenceClassification",
-            "ReformerLayer",
             "ReformerModel",
             "ReformerModelWithLMHead",
             "ReformerPreTrainedModel",
@@ -3102,7 +3088,6 @@ else:
             "RemBertForQuestionAnswering",
             "RemBertForSequenceClassification",
             "RemBertForTokenClassification",
-            "RemBertLayer",
             "RemBertModel",
             "RemBertPreTrainedModel",
             "load_tf_weights_in_rembert",
@@ -3149,7 +3134,6 @@ else:
             "RoCBertForQuestionAnswering",
             "RoCBertForSequenceClassification",
             "RoCBertForTokenClassification",
-            "RoCBertLayer",
             "RoCBertModel",
             "RoCBertPreTrainedModel",
             "load_tf_weights_in_roc_bert",
@@ -3163,7 +3147,6 @@ else:
             "RoFormerForQuestionAnswering",
             "RoFormerForSequenceClassification",
             "RoFormerForTokenClassification",
-            "RoFormerLayer",
             "RoFormerModel",
             "RoFormerPreTrainedModel",
             "load_tf_weights_in_roformer",
@@ -3220,7 +3203,6 @@ else:
             "SegformerDecodeHead",
             "SegformerForImageClassification",
             "SegformerForSemanticSegmentation",
-            "SegformerLayer",
             "SegformerModel",
             "SegformerPreTrainedModel",
         ]
@@ -3279,7 +3261,6 @@ else:
         [
             "SplinterForPreTraining",
             "SplinterForQuestionAnswering",
-            "SplinterLayer",
             "SplinterModel",
             "SplinterPreTrainedModel",
         ]
@@ -3292,7 +3273,6 @@ else:
             "SqueezeBertForSequenceClassification",
             "SqueezeBertForTokenClassification",
             "SqueezeBertModel",
-            "SqueezeBertModule",
             "SqueezeBertPreTrainedModel",
         ]
     )
@@ -3491,7 +3471,6 @@ else:
             "ViltForMaskedLM",
             "ViltForQuestionAnswering",
             "ViltForTokenClassification",
-            "ViltLayer",
             "ViltModel",
             "ViltPreTrainedModel",
         ]
@@ -3511,7 +3490,6 @@ else:
             "VisualBertForQuestionAnswering",
             "VisualBertForRegionToPhraseAlignment",
             "VisualBertForVisualReasoning",
-            "VisualBertLayer",
             "VisualBertModel",
             "VisualBertPreTrainedModel",
         ]
@@ -3527,7 +3505,6 @@ else:
     _import_structure["models.vit_mae"].extend(
         [
             "ViTMAEForPreTraining",
-            "ViTMAELayer",
             "ViTMAEModel",
             "ViTMAEPreTrainedModel",
         ]
@@ -3707,7 +3684,6 @@ else:
             "YosoForQuestionAnswering",
             "YosoForSequenceClassification",
             "YosoForTokenClassification",
-            "YosoLayer",
             "YosoModel",
             "YosoPreTrainedModel",
         ]
@@ -3854,7 +3830,6 @@ else:
     )
     _import_structure["models.bert"].extend(
         [
-            "TFBertEmbeddings",
             "TFBertForMaskedLM",
             "TFBertForMultipleChoice",
             "TFBertForNextSentencePrediction",
@@ -4151,7 +4126,6 @@ else:
             "TFLongformerForTokenClassification",
             "TFLongformerModel",
             "TFLongformerPreTrainedModel",
-            "TFLongformerSelfAttention",
         ]
     )
     _import_structure["models.lxmert"].extend(
@@ -5827,7 +5801,8 @@ if TYPE_CHECKING:
         from .models.llama import LlamaTokenizer
         from .models.m2m_100 import M2M100Tokenizer
         from .models.marian import MarianTokenizer
-        from .models.mbart import MBart50Tokenizer, MBartTokenizer
+        from .models.mbart import MBartTokenizer
+        from .models.mbart50 import MBart50Tokenizer
         from .models.mluke import MLukeTokenizer
         from .models.mt5 import MT5Tokenizer
         from .models.nllb import NllbTokenizer
@@ -6298,7 +6273,6 @@ if TYPE_CHECKING:
             BertForQuestionAnswering,
             BertForSequenceClassification,
             BertForTokenClassification,
-            BertLayer,
             BertLMHeadModel,
             BertModel,
             BertPreTrainedModel,
@@ -6318,7 +6292,6 @@ if TYPE_CHECKING:
             BigBirdForQuestionAnswering,
             BigBirdForSequenceClassification,
             BigBirdForTokenClassification,
-            BigBirdLayer,
             BigBirdModel,
             BigBirdPreTrainedModel,
             load_tf_weights_in_big_bird,
@@ -6413,7 +6386,6 @@ if TYPE_CHECKING:
             CanineForQuestionAnswering,
             CanineForSequenceClassification,
             CanineForTokenClassification,
-            CanineLayer,
             CanineModel,
             CaninePreTrainedModel,
             load_tf_weights_in_canine,
@@ -6486,7 +6458,6 @@ if TYPE_CHECKING:
             ConvBertForQuestionAnswering,
             ConvBertForSequenceClassification,
             ConvBertForTokenClassification,
-            ConvBertLayer,
             ConvBertModel,
             ConvBertPreTrainedModel,
             load_tf_weights_in_convbert,
@@ -6671,7 +6642,6 @@ if TYPE_CHECKING:
             QDQBertForQuestionAnswering,
             QDQBertForSequenceClassification,
             QDQBertForTokenClassification,
-            QDQBertLayer,
             QDQBertLMHeadModel,
             QDQBertModel,
             QDQBertPreTrainedModel,
@@ -6870,7 +6840,6 @@ if TYPE_CHECKING:
             FNetForQuestionAnswering,
             FNetForSequenceClassification,
             FNetForTokenClassification,
-            FNetLayer,
             FNetModel,
             FNetPreTrainedModel,
         )
@@ -6958,13 +6927,11 @@ if TYPE_CHECKING:
             GPTNeoXForQuestionAnswering,
             GPTNeoXForSequenceClassification,
             GPTNeoXForTokenClassification,
-            GPTNeoXLayer,
             GPTNeoXModel,
             GPTNeoXPreTrainedModel,
         )
         from .models.gpt_neox_japanese import (
             GPTNeoXJapaneseForCausalLM,
-            GPTNeoXJapaneseLayer,
             GPTNeoXJapaneseModel,
             GPTNeoXJapanesePreTrainedModel,
         )
@@ -7140,7 +7107,6 @@ if TYPE_CHECKING:
             LongformerForTokenClassification,
             LongformerModel,
             LongformerPreTrainedModel,
-            LongformerSelfAttention,
         )
         from .models.longt5 import (
             LongT5EncoderModel,
@@ -7167,7 +7133,6 @@ if TYPE_CHECKING:
             LxmertModel,
             LxmertPreTrainedModel,
             LxmertVisualFeatureEncoder,
-            LxmertXLayer,
         )
         from .models.m2m_100 import (
             M2M100ForConditionalGeneration,
@@ -7184,7 +7149,7 @@ if TYPE_CHECKING:
             Mamba2Model,
             Mamba2PreTrainedModel,
         )
-        from .models.marian import MarianForCausalLM, MarianModel, MarianMTModel
+        from .models.marian import MarianForCausalLM, MarianModel, MarianMTModel, MarianPreTrainedModel
         from .models.markuplm import (
             MarkupLMForQuestionAnswering,
             MarkupLMForSequenceClassification,
@@ -7250,7 +7215,6 @@ if TYPE_CHECKING:
             MobileBertForQuestionAnswering,
             MobileBertForSequenceClassification,
             MobileBertForTokenClassification,
-            MobileBertLayer,
             MobileBertModel,
             MobileBertPreTrainedModel,
             load_tf_weights_in_mobilebert,
@@ -7286,7 +7250,6 @@ if TYPE_CHECKING:
             MPNetForQuestionAnswering,
             MPNetForSequenceClassification,
             MPNetForTokenClassification,
-            MPNetLayer,
             MPNetModel,
             MPNetPreTrainedModel,
         )
@@ -7358,7 +7321,6 @@ if TYPE_CHECKING:
             NystromformerForQuestionAnswering,
             NystromformerForSequenceClassification,
             NystromformerForTokenClassification,
-            NystromformerLayer,
             NystromformerModel,
             NystromformerPreTrainedModel,
         )
@@ -7446,7 +7408,6 @@ if TYPE_CHECKING:
             PerceiverForMultimodalAutoencoding,
             PerceiverForOpticalFlow,
             PerceiverForSequenceClassification,
-            PerceiverLayer,
             PerceiverModel,
             PerceiverPreTrainedModel,
         )
@@ -7548,11 +7509,9 @@ if TYPE_CHECKING:
             RecurrentGemmaPreTrainedModel,
         )
         from .models.reformer import (
-            ReformerAttention,
             ReformerForMaskedLM,
             ReformerForQuestionAnswering,
             ReformerForSequenceClassification,
-            ReformerLayer,
             ReformerModel,
             ReformerModelWithLMHead,
             ReformerPreTrainedModel,
@@ -7569,7 +7528,6 @@ if TYPE_CHECKING:
             RemBertForQuestionAnswering,
             RemBertForSequenceClassification,
             RemBertForTokenClassification,
-            RemBertLayer,
             RemBertModel,
             RemBertPreTrainedModel,
             load_tf_weights_in_rembert,
@@ -7608,7 +7566,6 @@ if TYPE_CHECKING:
             RoCBertForQuestionAnswering,
             RoCBertForSequenceClassification,
             RoCBertForTokenClassification,
-            RoCBertLayer,
             RoCBertModel,
             RoCBertPreTrainedModel,
             load_tf_weights_in_roc_bert,
@@ -7620,7 +7577,6 @@ if TYPE_CHECKING:
             RoFormerForQuestionAnswering,
             RoFormerForSequenceClassification,
             RoFormerForTokenClassification,
-            RoFormerLayer,
             RoFormerModel,
             RoFormerPreTrainedModel,
             load_tf_weights_in_roformer,
@@ -7665,7 +7621,6 @@ if TYPE_CHECKING:
             SegformerDecodeHead,
             SegformerForImageClassification,
             SegformerForSemanticSegmentation,
-            SegformerLayer,
             SegformerModel,
             SegformerPreTrainedModel,
         )
@@ -7710,7 +7665,6 @@ if TYPE_CHECKING:
         from .models.splinter import (
             SplinterForPreTraining,
             SplinterForQuestionAnswering,
-            SplinterLayer,
             SplinterModel,
             SplinterPreTrainedModel,
         )
@@ -7721,7 +7675,6 @@ if TYPE_CHECKING:
             SqueezeBertForSequenceClassification,
             SqueezeBertForTokenClassification,
             SqueezeBertModel,
-            SqueezeBertModule,
             SqueezeBertPreTrainedModel,
         )
         from .models.stablelm import (
@@ -7870,7 +7823,6 @@ if TYPE_CHECKING:
             ViltForMaskedLM,
             ViltForQuestionAnswering,
             ViltForTokenClassification,
-            ViltLayer,
             ViltModel,
             ViltPreTrainedModel,
         )
@@ -7886,7 +7838,6 @@ if TYPE_CHECKING:
             VisualBertForQuestionAnswering,
             VisualBertForRegionToPhraseAlignment,
             VisualBertForVisualReasoning,
-            VisualBertLayer,
             VisualBertModel,
             VisualBertPreTrainedModel,
         )
@@ -7898,7 +7849,6 @@ if TYPE_CHECKING:
         )
         from .models.vit_mae import (
             ViTMAEForPreTraining,
-            ViTMAELayer,
             ViTMAEModel,
             ViTMAEPreTrainedModel,
         )
@@ -8040,7 +7990,6 @@ if TYPE_CHECKING:
             YosoForQuestionAnswering,
             YosoForSequenceClassification,
             YosoForTokenClassification,
-            YosoLayer,
             YosoModel,
             YosoPreTrainedModel,
         )
@@ -8174,7 +8123,6 @@ if TYPE_CHECKING:
             TFBartPretrainedModel,
         )
         from .models.bert import (
-            TFBertEmbeddings,
             TFBertForMaskedLM,
             TFBertForMultipleChoice,
             TFBertForNextSentencePrediction,
@@ -8228,7 +8176,6 @@ if TYPE_CHECKING:
             TFConvBertForQuestionAnswering,
             TFConvBertForSequenceClassification,
             TFConvBertForTokenClassification,
-            TFConvBertLayer,
             TFConvBertModel,
             TFConvBertPreTrainedModel,
         )
@@ -8413,7 +8360,6 @@ if TYPE_CHECKING:
             TFLongformerForTokenClassification,
             TFLongformerModel,
             TFLongformerPreTrainedModel,
-            TFLongformerSelfAttention,
         )
         from .models.lxmert import (
             TFLxmertForPreTraining,
@@ -8503,7 +8449,6 @@ if TYPE_CHECKING:
             TFRemBertForQuestionAnswering,
             TFRemBertForSequenceClassification,
             TFRemBertForTokenClassification,
-            TFRemBertLayer,
             TFRemBertModel,
             TFRemBertPreTrainedModel,
         )
@@ -8541,7 +8486,6 @@ if TYPE_CHECKING:
             TFRoFormerForQuestionAnswering,
             TFRoFormerForSequenceClassification,
             TFRoFormerForTokenClassification,
-            TFRoFormerLayer,
             TFRoFormerModel,
             TFRoFormerPreTrainedModel,
         )

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -3895,7 +3895,6 @@ else:
             "TFConvBertForQuestionAnswering",
             "TFConvBertForSequenceClassification",
             "TFConvBertForTokenClassification",
-            "TFConvBertLayer",
             "TFConvBertModel",
             "TFConvBertPreTrainedModel",
         ]
@@ -4226,7 +4225,6 @@ else:
             "TFRemBertForQuestionAnswering",
             "TFRemBertForSequenceClassification",
             "TFRemBertForTokenClassification",
-            "TFRemBertLayer",
             "TFRemBertModel",
             "TFRemBertPreTrainedModel",
         ]
@@ -4272,7 +4270,6 @@ else:
             "TFRoFormerForQuestionAnswering",
             "TFRoFormerForSequenceClassification",
             "TFRoFormerForTokenClassification",
-            "TFRoFormerLayer",
             "TFRoFormerModel",
             "TFRoFormerPreTrainedModel",
         ]

--- a/src/transformers/models/albert/__init__.py
+++ b/src/transformers/models/albert/__init__.py
@@ -11,165 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import TYPE_CHECKING
 
-from ...utils import (
-    OptionalDependencyNotAvailable,
-    _LazyModule,
-    is_flax_available,
-    is_sentencepiece_available,
-    is_tf_available,
-    is_tokenizers_available,
-    is_torch_available,
-)
+from ...utils import _LazyModule
+from ...utils.import_utils import define_import_structure
 
-
-_import_structure = {
-    "configuration_albert": ["AlbertConfig", "AlbertOnnxConfig"],
-}
-
-try:
-    if not is_sentencepiece_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["tokenization_albert"] = ["AlbertTokenizer"]
-
-try:
-    if not is_tokenizers_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["tokenization_albert_fast"] = ["AlbertTokenizerFast"]
-
-try:
-    if not is_torch_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["modeling_albert"] = [
-        "AlbertForMaskedLM",
-        "AlbertForMultipleChoice",
-        "AlbertForPreTraining",
-        "AlbertForQuestionAnswering",
-        "AlbertForSequenceClassification",
-        "AlbertForTokenClassification",
-        "AlbertModel",
-        "AlbertPreTrainedModel",
-        "load_tf_weights_in_albert",
-    ]
-
-try:
-    if not is_tf_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["modeling_tf_albert"] = [
-        "TFAlbertForMaskedLM",
-        "TFAlbertForMultipleChoice",
-        "TFAlbertForPreTraining",
-        "TFAlbertForQuestionAnswering",
-        "TFAlbertForSequenceClassification",
-        "TFAlbertForTokenClassification",
-        "TFAlbertMainLayer",
-        "TFAlbertModel",
-        "TFAlbertPreTrainedModel",
-    ]
-
-try:
-    if not is_flax_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["modeling_flax_albert"] = [
-        "FlaxAlbertForMaskedLM",
-        "FlaxAlbertForMultipleChoice",
-        "FlaxAlbertForPreTraining",
-        "FlaxAlbertForQuestionAnswering",
-        "FlaxAlbertForSequenceClassification",
-        "FlaxAlbertForTokenClassification",
-        "FlaxAlbertModel",
-        "FlaxAlbertPreTrainedModel",
-    ]
 
 if TYPE_CHECKING:
-    from .configuration_albert import AlbertConfig, AlbertOnnxConfig
-
-    try:
-        if not is_sentencepiece_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .tokenization_albert import AlbertTokenizer
-
-    try:
-        if not is_tokenizers_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .tokenization_albert_fast import AlbertTokenizerFast
-
-    try:
-        if not is_torch_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .modeling_albert import (
-            AlbertForMaskedLM,
-            AlbertForMultipleChoice,
-            AlbertForPreTraining,
-            AlbertForQuestionAnswering,
-            AlbertForSequenceClassification,
-            AlbertForTokenClassification,
-            AlbertModel,
-            AlbertPreTrainedModel,
-            load_tf_weights_in_albert,
-        )
-
-    try:
-        if not is_tf_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .modeling_tf_albert import (
-            TFAlbertForMaskedLM,
-            TFAlbertForMultipleChoice,
-            TFAlbertForPreTraining,
-            TFAlbertForQuestionAnswering,
-            TFAlbertForSequenceClassification,
-            TFAlbertForTokenClassification,
-            TFAlbertMainLayer,
-            TFAlbertModel,
-            TFAlbertPreTrainedModel,
-        )
-
-    try:
-        if not is_flax_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .modeling_flax_albert import (
-            FlaxAlbertForMaskedLM,
-            FlaxAlbertForMultipleChoice,
-            FlaxAlbertForPreTraining,
-            FlaxAlbertForQuestionAnswering,
-            FlaxAlbertForSequenceClassification,
-            FlaxAlbertForTokenClassification,
-            FlaxAlbertModel,
-            FlaxAlbertPreTrainedModel,
-        )
+    from .configuration_albert import *
+    from .modeling_albert import *
+    from .modeling_flax_albert import *
+    from .modeling_tf_albert import *
+    from .tokenization_albert import *
+    from .tokenization_albert_fast import *
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)
+    _file = globals()["__file__"]
+    sys.modules[__name__] = _LazyModule(__name__, _file, define_import_structure(_file), module_spec=__spec__)

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -20,10 +20,8 @@ from typing import Mapping
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
-from ...utils.import_utils import register
 
 
-@register()
 class AlbertConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlbertModel`] or a [`TFAlbertModel`]. It is used
@@ -153,7 +151,6 @@ class AlbertConfig(PretrainedConfig):
 
 
 # Copied from transformers.models.bert.configuration_bert.BertOnnxConfig with Roberta->Albert
-@register()
 class AlbertOnnxConfig(OnnxConfig):
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -20,8 +20,10 @@ from typing import Mapping
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
+from ...utils.import_utils import register
 
 
+@register()
 class AlbertConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlbertModel`] or a [`TFAlbertModel`]. It is used
@@ -151,6 +153,7 @@ class AlbertConfig(PretrainedConfig):
 
 
 # Copied from transformers.models.bert.configuration_bert.BertOnnxConfig with Roberta->Albert
+@register()
 class AlbertOnnxConfig(OnnxConfig):
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
@@ -165,3 +168,6 @@ class AlbertOnnxConfig(OnnxConfig):
                 ("token_type_ids", dynamic_axis),
             ]
         )
+
+
+__all__ = ["AlbertConfig", "AlbertOnnxConfig"]

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -49,7 +49,6 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
-from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -59,7 +58,6 @@ _CHECKPOINT_FOR_DOC = "albert/albert-base-v2"
 _CONFIG_FOR_DOC = "AlbertConfig"
 
 
-@register()
 def load_tf_weights_in_albert(model, config, tf_checkpoint_path):
     """Load tf checkpoints in a pytorch model."""
     try:
@@ -555,7 +553,6 @@ class AlbertTransformer(nn.Module):
         )
 
 
-@register(backends=("torch",))
 class AlbertPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -688,7 +685,6 @@ ALBERT_INPUTS_DOCSTRING = r"""
     "The bare ALBERT Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertModel(AlbertPreTrainedModel):
     config_class = AlbertConfig
     base_model_prefix = "albert"
@@ -835,7 +831,6 @@ class AlbertModel(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForPreTraining(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
@@ -988,7 +983,6 @@ class AlbertSOPHead(nn.Module):
     "Albert Model with a `language modeling` head on top.",
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForMaskedLM(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
@@ -1104,7 +1098,6 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForSequenceClassification(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1206,7 +1199,6 @@ class AlbertForSequenceClassification(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForTokenClassification(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1290,7 +1282,6 @@ class AlbertForTokenClassification(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForQuestionAnswering(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1394,7 +1385,6 @@ class AlbertForQuestionAnswering(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlbertForMultipleChoice(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -49,6 +49,7 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
+from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -58,6 +59,7 @@ _CHECKPOINT_FOR_DOC = "albert/albert-base-v2"
 _CONFIG_FOR_DOC = "AlbertConfig"
 
 
+@register()
 def load_tf_weights_in_albert(model, config, tf_checkpoint_path):
     """Load tf checkpoints in a pytorch model."""
     try:
@@ -553,6 +555,7 @@ class AlbertTransformer(nn.Module):
         )
 
 
+@register(backends=("torch",))
 class AlbertPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -685,6 +688,7 @@ ALBERT_INPUTS_DOCSTRING = r"""
     "The bare ALBERT Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertModel(AlbertPreTrainedModel):
     config_class = AlbertConfig
     base_model_prefix = "albert"
@@ -831,6 +835,7 @@ class AlbertModel(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForPreTraining(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
@@ -983,6 +988,7 @@ class AlbertSOPHead(nn.Module):
     "Albert Model with a `language modeling` head on top.",
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForMaskedLM(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
@@ -1098,6 +1104,7 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForSequenceClassification(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1199,6 +1206,7 @@ class AlbertForSequenceClassification(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForTokenClassification(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1282,6 +1290,7 @@ class AlbertForTokenClassification(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForQuestionAnswering(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1385,6 +1394,7 @@ class AlbertForQuestionAnswering(AlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlbertForMultipleChoice(AlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig):
         super().__init__(config)
@@ -1466,3 +1476,16 @@ class AlbertForMultipleChoice(AlbertPreTrainedModel):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+
+__all__ = [
+    "load_tf_weights_in_albert",
+    "AlbertPreTrainedModel",
+    "AlbertModel",
+    "AlbertForPreTraining",
+    "AlbertForMaskedLM",
+    "AlbertForSequenceClassification",
+    "AlbertForTokenClassification",
+    "AlbertForQuestionAnswering",
+    "AlbertForMultipleChoice",
+]

--- a/src/transformers/models/albert/modeling_flax_albert.py
+++ b/src/transformers/models/albert/modeling_flax_albert.py
@@ -42,7 +42,6 @@ from ...modeling_flax_utils import (
     overwrite_call_docstring,
 )
 from ...utils import ModelOutput, add_start_docstrings, add_start_docstrings_to_model_forward, logging
-from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -506,7 +505,6 @@ class FlaxAlbertSOPHead(nn.Module):
         return logits
 
 
-@register(backends=("flax",))
 class FlaxAlbertPreTrainedModel(FlaxPreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -676,7 +674,6 @@ class FlaxAlbertModule(nn.Module):
     "The bare Albert Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertModel(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertModule
 
@@ -745,7 +742,6 @@ class FlaxAlbertForPreTrainingModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertForPreTraining(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForPreTrainingModule
 
@@ -829,7 +825,6 @@ class FlaxAlbertForMaskedLMModule(nn.Module):
 
 
 @add_start_docstrings("""Albert Model with a `language modeling` head on top.""", ALBERT_START_DOCSTRING)
-@register(backends=("flax",))
 class FlaxAlbertForMaskedLM(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForMaskedLMModule
 
@@ -900,7 +895,6 @@ class FlaxAlbertForSequenceClassificationModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertForSequenceClassification(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForSequenceClassificationModule
 
@@ -974,7 +968,6 @@ class FlaxAlbertForMultipleChoiceModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertForMultipleChoice(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForMultipleChoiceModule
 
@@ -1048,7 +1041,6 @@ class FlaxAlbertForTokenClassificationModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertForTokenClassification(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForTokenClassificationModule
 
@@ -1117,7 +1109,6 @@ class FlaxAlbertForQuestionAnsweringModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("flax",))
 class FlaxAlbertForQuestionAnswering(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForQuestionAnsweringModule
 

--- a/src/transformers/models/albert/modeling_flax_albert.py
+++ b/src/transformers/models/albert/modeling_flax_albert.py
@@ -42,6 +42,7 @@ from ...modeling_flax_utils import (
     overwrite_call_docstring,
 )
 from ...utils import ModelOutput, add_start_docstrings, add_start_docstrings_to_model_forward, logging
+from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -505,6 +506,7 @@ class FlaxAlbertSOPHead(nn.Module):
         return logits
 
 
+@register(backends=("flax",))
 class FlaxAlbertPreTrainedModel(FlaxPreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -674,6 +676,7 @@ class FlaxAlbertModule(nn.Module):
     "The bare Albert Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertModel(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertModule
 
@@ -742,6 +745,7 @@ class FlaxAlbertForPreTrainingModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertForPreTraining(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForPreTrainingModule
 
@@ -825,6 +829,7 @@ class FlaxAlbertForMaskedLMModule(nn.Module):
 
 
 @add_start_docstrings("""Albert Model with a `language modeling` head on top.""", ALBERT_START_DOCSTRING)
+@register(backends=("flax",))
 class FlaxAlbertForMaskedLM(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForMaskedLMModule
 
@@ -895,6 +900,7 @@ class FlaxAlbertForSequenceClassificationModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertForSequenceClassification(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForSequenceClassificationModule
 
@@ -968,6 +974,7 @@ class FlaxAlbertForMultipleChoiceModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertForMultipleChoice(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForMultipleChoiceModule
 
@@ -1041,6 +1048,7 @@ class FlaxAlbertForTokenClassificationModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertForTokenClassification(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForTokenClassificationModule
 
@@ -1109,6 +1117,7 @@ class FlaxAlbertForQuestionAnsweringModule(nn.Module):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("flax",))
 class FlaxAlbertForQuestionAnswering(FlaxAlbertPreTrainedModel):
     module_class = FlaxAlbertForQuestionAnsweringModule
 
@@ -1119,3 +1128,14 @@ append_call_sample_docstring(
     FlaxQuestionAnsweringModelOutput,
     _CONFIG_FOR_DOC,
 )
+
+__all__ = [
+    "FlaxAlbertPreTrainedModel",
+    "FlaxAlbertModel",
+    "FlaxAlbertForPreTraining",
+    "FlaxAlbertForMaskedLM",
+    "FlaxAlbertForSequenceClassification",
+    "FlaxAlbertForMultipleChoice",
+    "FlaxAlbertForTokenClassification",
+    "FlaxAlbertForQuestionAnswering",
+]

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -56,7 +56,6 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
-from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -511,7 +510,6 @@ class TFAlbertTransformer(keras.layers.Layer):
                     layer.build(None)
 
 
-@register(backends=("tf",))
 class TFAlbertPreTrainedModel(TFPreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -587,7 +585,6 @@ class TFAlbertMLMHead(keras.layers.Layer):
 
 
 @keras_serializable
-@register(backends=("tf",))
 class TFAlbertMainLayer(keras.layers.Layer):
     config_class = AlbertConfig
 
@@ -861,7 +858,6 @@ ALBERT_INPUTS_DOCSTRING = r"""
     "The bare Albert Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertModel(TFAlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
@@ -919,7 +915,6 @@ class TFAlbertModel(TFAlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertForPreTraining(TFAlbertPreTrainedModel, TFAlbertPreTrainingLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"predictions.decoder.weight"]
@@ -1051,7 +1046,6 @@ class TFAlbertSOPHead(keras.layers.Layer):
 
 
 @add_start_docstrings("""Albert Model with a `language modeling` head on top.""", ALBERT_START_DOCSTRING)
-@register(backends=("tf",))
 class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions.decoder.weight"]
@@ -1165,7 +1159,6 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertForSequenceClassification(TFAlbertPreTrainedModel, TFSequenceClassificationLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"predictions"]
@@ -1260,7 +1253,6 @@ class TFAlbertForSequenceClassification(TFAlbertPreTrainedModel, TFSequenceClass
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertForTokenClassification(TFAlbertPreTrainedModel, TFTokenClassificationLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]
@@ -1356,7 +1348,6 @@ class TFAlbertForTokenClassification(TFAlbertPreTrainedModel, TFTokenClassificat
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertForQuestionAnswering(TFAlbertPreTrainedModel, TFQuestionAnsweringLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]
@@ -1464,7 +1455,6 @@ class TFAlbertForQuestionAnswering(TFAlbertPreTrainedModel, TFQuestionAnsweringL
     """,
     ALBERT_START_DOCSTRING,
 )
-@register(backends=("tf",))
 class TFAlbertForMultipleChoice(TFAlbertPreTrainedModel, TFMultipleChoiceLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]

--- a/src/transformers/models/albert/modeling_tf_albert.py
+++ b/src/transformers/models/albert/modeling_tf_albert.py
@@ -56,6 +56,7 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
+from ...utils.import_utils import register
 from .configuration_albert import AlbertConfig
 
 
@@ -510,6 +511,7 @@ class TFAlbertTransformer(keras.layers.Layer):
                     layer.build(None)
 
 
+@register(backends=("tf",))
 class TFAlbertPreTrainedModel(TFPreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -585,6 +587,7 @@ class TFAlbertMLMHead(keras.layers.Layer):
 
 
 @keras_serializable
+@register(backends=("tf",))
 class TFAlbertMainLayer(keras.layers.Layer):
     config_class = AlbertConfig
 
@@ -858,6 +861,7 @@ ALBERT_INPUTS_DOCSTRING = r"""
     "The bare Albert Model transformer outputting raw hidden-states without any specific head on top.",
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertModel(TFAlbertPreTrainedModel):
     def __init__(self, config: AlbertConfig, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
@@ -915,6 +919,7 @@ class TFAlbertModel(TFAlbertPreTrainedModel):
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertForPreTraining(TFAlbertPreTrainedModel, TFAlbertPreTrainingLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"predictions.decoder.weight"]
@@ -1046,6 +1051,7 @@ class TFAlbertSOPHead(keras.layers.Layer):
 
 
 @add_start_docstrings("""Albert Model with a `language modeling` head on top.""", ALBERT_START_DOCSTRING)
+@register(backends=("tf",))
 class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions.decoder.weight"]
@@ -1159,6 +1165,7 @@ class TFAlbertForMaskedLM(TFAlbertPreTrainedModel, TFMaskedLanguageModelingLoss)
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertForSequenceClassification(TFAlbertPreTrainedModel, TFSequenceClassificationLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"predictions"]
@@ -1253,6 +1260,7 @@ class TFAlbertForSequenceClassification(TFAlbertPreTrainedModel, TFSequenceClass
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertForTokenClassification(TFAlbertPreTrainedModel, TFTokenClassificationLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]
@@ -1348,6 +1356,7 @@ class TFAlbertForTokenClassification(TFAlbertPreTrainedModel, TFTokenClassificat
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertForQuestionAnswering(TFAlbertPreTrainedModel, TFQuestionAnsweringLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]
@@ -1455,6 +1464,7 @@ class TFAlbertForQuestionAnswering(TFAlbertPreTrainedModel, TFQuestionAnsweringL
     """,
     ALBERT_START_DOCSTRING,
 )
+@register(backends=("tf",))
 class TFAlbertForMultipleChoice(TFAlbertPreTrainedModel, TFMultipleChoiceLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
     _keys_to_ignore_on_load_unexpected = [r"pooler", r"predictions"]
@@ -1558,3 +1568,16 @@ class TFAlbertForMultipleChoice(TFAlbertPreTrainedModel, TFMultipleChoiceLoss):
         if getattr(self, "classifier", None) is not None:
             with tf.name_scope(self.classifier.name):
                 self.classifier.build([None, None, self.config.hidden_size])
+
+
+__all__ = [
+    "TFAlbertPreTrainedModel",
+    "TFAlbertModel",
+    "TFAlbertForPreTraining",
+    "TFAlbertForMaskedLM",
+    "TFAlbertForSequenceClassification",
+    "TFAlbertForTokenClassification",
+    "TFAlbertForQuestionAnswering",
+    "TFAlbertForMultipleChoice",
+    "TFAlbertMainLayer",
+]

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -23,7 +23,7 @@ import sentencepiece as spm
 
 from ...tokenization_utils import AddedToken, PreTrainedTokenizer
 from ...utils import logging
-from ...utils.import_utils import register
+from ...utils.import_utils import export
 
 
 logger = logging.get_logger(__name__)
@@ -33,7 +33,7 @@ VOCAB_FILES_NAMES = {"vocab_file": "spiece.model"}
 SPIECE_UNDERLINE = "▁"
 
 
-@register(backends=("sentencepiece",))
+@export(backends=("sentencepiece",))
 class AlbertTokenizer(PreTrainedTokenizer):
     """
     Construct an ALBERT tokenizer. Based on [SentencePiece](https://github.com/google/sentencepiece).

--- a/src/transformers/models/albert/tokenization_albert.py
+++ b/src/transformers/models/albert/tokenization_albert.py
@@ -23,6 +23,7 @@ import sentencepiece as spm
 
 from ...tokenization_utils import AddedToken, PreTrainedTokenizer
 from ...utils import logging
+from ...utils.import_utils import register
 
 
 logger = logging.get_logger(__name__)
@@ -32,6 +33,7 @@ VOCAB_FILES_NAMES = {"vocab_file": "spiece.model"}
 SPIECE_UNDERLINE = "▁"
 
 
+@register(backends=("sentencepiece",))
 class AlbertTokenizer(PreTrainedTokenizer):
     """
     Construct an ALBERT tokenizer. Based on [SentencePiece](https://github.com/google/sentencepiece).
@@ -343,3 +345,6 @@ class AlbertTokenizer(PreTrainedTokenizer):
                 fi.write(content_spiece_model)
 
         return (out_vocab_file,)
+
+
+__all__ = ["AlbertTokenizer"]

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple
 from ...tokenization_utils import AddedToken
 from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import is_sentencepiece_available, logging
+from ...utils.import_utils import register
 
 
 if is_sentencepiece_available():
@@ -35,6 +36,7 @@ VOCAB_FILES_NAMES = {"vocab_file": "spiece.model", "tokenizer_file": "tokenizer.
 SPIECE_UNDERLINE = "▁"
 
 
+@register(backends=("tokenizers",))
 class AlbertTokenizerFast(PreTrainedTokenizerFast):
     """
     Construct a "fast" ALBERT tokenizer (backed by HuggingFace's *tokenizers* library). Based on
@@ -207,3 +209,6 @@ class AlbertTokenizerFast(PreTrainedTokenizerFast):
             copyfile(self.vocab_file, out_vocab_file)
 
         return (out_vocab_file,)
+
+
+__all__ = ["AlbertTokenizerFast"]

--- a/src/transformers/models/albert/tokenization_albert_fast.py
+++ b/src/transformers/models/albert/tokenization_albert_fast.py
@@ -21,7 +21,6 @@ from typing import List, Optional, Tuple
 from ...tokenization_utils import AddedToken
 from ...tokenization_utils_fast import PreTrainedTokenizerFast
 from ...utils import is_sentencepiece_available, logging
-from ...utils.import_utils import register
 
 
 if is_sentencepiece_available():
@@ -36,7 +35,6 @@ VOCAB_FILES_NAMES = {"vocab_file": "spiece.model", "tokenizer_file": "tokenizer.
 SPIECE_UNDERLINE = "▁"
 
 
-@register(backends=("tokenizers",))
 class AlbertTokenizerFast(PreTrainedTokenizerFast):
     """
     Construct a "fast" ALBERT tokenizer (backed by HuggingFace's *tokenizers* library). Based on

--- a/src/transformers/models/align/__init__.py
+++ b/src/transformers/models/align/__init__.py
@@ -13,57 +13,16 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...utils import (
-    OptionalDependencyNotAvailable,
-    _LazyModule,
-    is_torch_available,
-)
+from ...utils import _LazyModule
+from ...utils.import_utils import define_import_structure
 
-
-_import_structure = {
-    "configuration_align": [
-        "AlignConfig",
-        "AlignTextConfig",
-        "AlignVisionConfig",
-    ],
-    "processing_align": ["AlignProcessor"],
-}
-
-try:
-    if not is_torch_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["modeling_align"] = [
-        "AlignModel",
-        "AlignPreTrainedModel",
-        "AlignTextModel",
-        "AlignVisionModel",
-    ]
 
 if TYPE_CHECKING:
-    from .configuration_align import (
-        AlignConfig,
-        AlignTextConfig,
-        AlignVisionConfig,
-    )
-    from .processing_align import AlignProcessor
-
-    try:
-        if not is_torch_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .modeling_align import (
-            AlignModel,
-            AlignPreTrainedModel,
-            AlignTextModel,
-            AlignVisionModel,
-        )
-
+    from .configuration_align import *
+    from .modeling_align import *
+    from .processing_align import *
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)
+    _file = globals()["__file__"]
+    sys.modules[__name__] = _LazyModule(__name__, _file, define_import_structure(_file), module_spec=__spec__)

--- a/src/transformers/models/align/configuration_align.py
+++ b/src/transformers/models/align/configuration_align.py
@@ -17,8 +17,6 @@
 import os
 from typing import TYPE_CHECKING, List, Union
 
-from ...utils.import_utils import register
-
 
 if TYPE_CHECKING:
     pass
@@ -30,7 +28,6 @@ from ...utils import logging
 logger = logging.get_logger(__name__)
 
 
-@register()
 class AlignTextConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlignTextModel`]. It is used to instantiate a
@@ -155,7 +152,6 @@ class AlignTextConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-@register()
 class AlignVisionConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlignVisionModel`]. It is used to instantiate a
@@ -295,7 +291,6 @@ class AlignVisionConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-@register()
 class AlignConfig(PretrainedConfig):
     r"""
     [`AlignConfig`] is the configuration class to store the configuration of a [`AlignModel`]. It is used to

--- a/src/transformers/models/align/configuration_align.py
+++ b/src/transformers/models/align/configuration_align.py
@@ -17,6 +17,8 @@
 import os
 from typing import TYPE_CHECKING, List, Union
 
+from ...utils.import_utils import register
+
 
 if TYPE_CHECKING:
     pass
@@ -28,6 +30,7 @@ from ...utils import logging
 logger = logging.get_logger(__name__)
 
 
+@register()
 class AlignTextConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlignTextModel`]. It is used to instantiate a
@@ -152,6 +155,7 @@ class AlignTextConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
+@register()
 class AlignVisionConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlignVisionModel`]. It is used to instantiate a
@@ -291,6 +295,7 @@ class AlignVisionConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
+@register()
 class AlignConfig(PretrainedConfig):
     r"""
     [`AlignConfig`] is the configuration class to store the configuration of a [`AlignModel`]. It is used to
@@ -378,3 +383,6 @@ class AlignConfig(PretrainedConfig):
         """
 
         return cls(text_config=text_config.to_dict(), vision_config=vision_config.to_dict(), **kwargs)
+
+
+__all__ = ["AlignTextConfig", "AlignVisionConfig", "AlignConfig"]

--- a/src/transformers/models/align/modeling_align.py
+++ b/src/transformers/models/align/modeling_align.py
@@ -20,7 +20,6 @@ from typing import Any, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
-from IPython.terminal.pt_inputhooks import backends
 from torch import nn
 
 from ...activations import ACT2FN

--- a/src/transformers/models/align/modeling_align.py
+++ b/src/transformers/models/align/modeling_align.py
@@ -38,6 +38,7 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
+from ...utils.import_utils import register
 from .configuration_align import AlignConfig, AlignTextConfig, AlignVisionConfig
 
 
@@ -1165,6 +1166,7 @@ class AlignTextPooler(nn.Module):
         return pooled_output
 
 
+@register(backends=("torch",))
 class AlignPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -1198,6 +1200,7 @@ class AlignPreTrainedModel(PreTrainedModel):
     """The text model from ALIGN without any head or projection on top.""",
     ALIGN_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlignTextModel(AlignPreTrainedModel):
     config_class = AlignTextConfig
     _no_split_modules = ["AlignTextEmbeddings"]
@@ -1325,6 +1328,7 @@ class AlignTextModel(AlignPreTrainedModel):
     """The vision model from ALIGN without any head or projection on top.""",
     ALIGN_START_DOCSTRING,
 )
+@register(backends=("torch",))
 class AlignVisionModel(AlignPreTrainedModel):
     config_class = AlignVisionConfig
     main_input_name = "pixel_values"
@@ -1411,6 +1415,7 @@ class AlignVisionModel(AlignPreTrainedModel):
 
 
 @add_start_docstrings(ALIGN_START_DOCSTRING)
+@register(backends=("torch",))
 class AlignModel(AlignPreTrainedModel):
     config_class = AlignConfig
 
@@ -1636,3 +1641,6 @@ class AlignModel(AlignPreTrainedModel):
             text_model_output=text_outputs,
             vision_model_output=vision_outputs,
         )
+
+
+__all__ = ["AlignPreTrainedModel", "AlignTextModel", "AlignVisionModel", "AlignModel"]

--- a/src/transformers/models/align/modeling_align.py
+++ b/src/transformers/models/align/modeling_align.py
@@ -20,6 +20,7 @@ from typing import Any, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
+from IPython.terminal.pt_inputhooks import backends
 from torch import nn
 
 from ...activations import ACT2FN
@@ -38,7 +39,6 @@ from ...utils import (
     logging,
     replace_return_docstrings,
 )
-from ...utils.import_utils import register
 from .configuration_align import AlignConfig, AlignTextConfig, AlignVisionConfig
 
 
@@ -1166,7 +1166,6 @@ class AlignTextPooler(nn.Module):
         return pooled_output
 
 
-@register(backends=("torch",))
 class AlignPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -1200,7 +1199,6 @@ class AlignPreTrainedModel(PreTrainedModel):
     """The text model from ALIGN without any head or projection on top.""",
     ALIGN_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlignTextModel(AlignPreTrainedModel):
     config_class = AlignTextConfig
     _no_split_modules = ["AlignTextEmbeddings"]
@@ -1328,7 +1326,6 @@ class AlignTextModel(AlignPreTrainedModel):
     """The vision model from ALIGN without any head or projection on top.""",
     ALIGN_START_DOCSTRING,
 )
-@register(backends=("torch",))
 class AlignVisionModel(AlignPreTrainedModel):
     config_class = AlignVisionConfig
     main_input_name = "pixel_values"
@@ -1415,7 +1412,6 @@ class AlignVisionModel(AlignPreTrainedModel):
 
 
 @add_start_docstrings(ALIGN_START_DOCSTRING)
-@register(backends=("torch",))
 class AlignModel(AlignPreTrainedModel):
     config_class = AlignConfig
 

--- a/src/transformers/models/align/processing_align.py
+++ b/src/transformers/models/align/processing_align.py
@@ -16,8 +16,6 @@
 Image/Text processor class for ALIGN
 """
 
-from ...utils.import_utils import register
-
 
 try:
     from typing import Unpack
@@ -42,7 +40,6 @@ class AlignProcessorKwargs(ProcessingKwargs, total=False):
     }
 
 
-@register()
 class AlignProcessor(ProcessorMixin):
     r"""
     Constructs an ALIGN processor which wraps [`EfficientNetImageProcessor`] and

--- a/src/transformers/models/align/processing_align.py
+++ b/src/transformers/models/align/processing_align.py
@@ -16,7 +16,7 @@
 Image/Text processor class for ALIGN
 """
 
-from typing import List, Union
+from ...utils.import_utils import register
 
 
 try:
@@ -42,6 +42,7 @@ class AlignProcessorKwargs(ProcessingKwargs, total=False):
     }
 
 
+@register()
 class AlignProcessor(ProcessorMixin):
     r"""
     Constructs an ALIGN processor which wraps [`EfficientNetImageProcessor`] and
@@ -162,3 +163,6 @@ class AlignProcessor(ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         image_processor_input_names = self.image_processor.model_input_names
         return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+
+__all__ = ["AlignProcessor"]

--- a/src/transformers/models/align/processing_align.py
+++ b/src/transformers/models/align/processing_align.py
@@ -16,6 +16,8 @@
 Image/Text processor class for ALIGN
 """
 
+from typing import List, Union
+
 
 try:
     from typing import Unpack

--- a/src/transformers/models/altclip/__init__.py
+++ b/src/transformers/models/altclip/__init__.py
@@ -13,55 +13,16 @@
 # limitations under the License.
 from typing import TYPE_CHECKING
 
-from ...utils import OptionalDependencyNotAvailable, _LazyModule, is_tokenizers_available, is_torch_available
-
-
-_import_structure = {
-    "configuration_altclip": [
-        "AltCLIPConfig",
-        "AltCLIPTextConfig",
-        "AltCLIPVisionConfig",
-    ],
-    "processing_altclip": ["AltCLIPProcessor"],
-}
-
-try:
-    if not is_torch_available():
-        raise OptionalDependencyNotAvailable()
-except OptionalDependencyNotAvailable:
-    pass
-else:
-    _import_structure["modeling_altclip"] = [
-        "AltCLIPPreTrainedModel",
-        "AltCLIPModel",
-        "AltCLIPTextModel",
-        "AltCLIPVisionModel",
-    ]
+from ...utils import _LazyModule
+from ...utils.import_utils import define_import_structure
 
 
 if TYPE_CHECKING:
-    from .configuration_altclip import (
-        AltCLIPConfig,
-        AltCLIPTextConfig,
-        AltCLIPVisionConfig,
-    )
-    from .processing_altclip import AltCLIPProcessor
-
-    try:
-        if not is_torch_available():
-            raise OptionalDependencyNotAvailable()
-    except OptionalDependencyNotAvailable:
-        pass
-    else:
-        from .modeling_altclip import (
-            AltCLIPModel,
-            AltCLIPPreTrainedModel,
-            AltCLIPTextModel,
-            AltCLIPVisionModel,
-        )
-
-
+    from .configuration_altclip import *
+    from .modeling_altclip import *
+    from .processing_altclip import *
 else:
     import sys
 
-    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)
+    _file = globals()["__file__"]
+    sys.modules[__name__] = _LazyModule(__name__, _file, define_import_structure(_file), module_spec=__spec__)

--- a/src/transformers/models/altclip/configuration_altclip.py
+++ b/src/transformers/models/altclip/configuration_altclip.py
@@ -19,13 +19,11 @@ from typing import Union
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
-from ...utils.import_utils import register
 
 
 logger = logging.get_logger(__name__)
 
 
-@register()
 class AltCLIPTextConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPTextModel`]. It is used to instantiate a
@@ -144,7 +142,6 @@ class AltCLIPTextConfig(PretrainedConfig):
         self.project_dim = project_dim
 
 
-@register()
 class AltCLIPVisionConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPModel`]. It is used to instantiate an
@@ -255,7 +252,6 @@ class AltCLIPVisionConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
-@register()
 class AltCLIPConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPModel`]. It is used to instantiate an

--- a/src/transformers/models/altclip/configuration_altclip.py
+++ b/src/transformers/models/altclip/configuration_altclip.py
@@ -19,11 +19,13 @@ from typing import Union
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
+from ...utils.import_utils import register
 
 
 logger = logging.get_logger(__name__)
 
 
+@register()
 class AltCLIPTextConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPTextModel`]. It is used to instantiate a
@@ -142,6 +144,7 @@ class AltCLIPTextConfig(PretrainedConfig):
         self.project_dim = project_dim
 
 
+@register()
 class AltCLIPVisionConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPModel`]. It is used to instantiate an
@@ -252,6 +255,7 @@ class AltCLIPVisionConfig(PretrainedConfig):
         return cls.from_dict(config_dict, **kwargs)
 
 
+@register()
 class AltCLIPConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AltCLIPModel`]. It is used to instantiate an
@@ -398,3 +402,6 @@ class AltCLIPConfig(PretrainedConfig):
         """
 
         return cls(text_config=text_config.to_dict(), vision_config=vision_config.to_dict(), **kwargs)
+
+
+__all__ = ["AltCLIPTextConfig", "AltCLIPVisionConfig", "AltCLIPConfig"]

--- a/src/transformers/models/altclip/modeling_altclip.py
+++ b/src/transformers/models/altclip/modeling_altclip.py
@@ -33,7 +33,6 @@ from ...modeling_outputs import (
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import apply_chunking_to_forward, find_pruneable_heads_and_indices, prune_linear_layer
 from ...utils import ModelOutput, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
-from ...utils.import_utils import register
 from .configuration_altclip import AltCLIPConfig, AltCLIPTextConfig, AltCLIPVisionConfig
 
 
@@ -1022,7 +1021,6 @@ class AltCLIPVisionEmbeddings(nn.Module):
         return embeddings
 
 
-@register(backends=("torch",))
 class AltCLIPPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -1138,7 +1136,6 @@ class AltCLIPVisionTransformer(nn.Module):
         )
 
 
-@register(backends=("torch",))
 class AltCLIPVisionModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPVisionConfig
     main_input_name = "pixel_values"
@@ -1370,7 +1367,6 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
         )
 
 
-@register(backends=("torch",))
 class AltCLIPTextModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPTextConfig
 
@@ -1463,7 +1459,6 @@ class AltCLIPTextModel(AltCLIPPreTrainedModel):
         )
 
 
-@register(backends=("torch",))
 class AltCLIPModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPConfig
 

--- a/src/transformers/models/altclip/modeling_altclip.py
+++ b/src/transformers/models/altclip/modeling_altclip.py
@@ -33,6 +33,7 @@ from ...modeling_outputs import (
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import apply_chunking_to_forward, find_pruneable_heads_and_indices, prune_linear_layer
 from ...utils import ModelOutput, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
+from ...utils.import_utils import register
 from .configuration_altclip import AltCLIPConfig, AltCLIPTextConfig, AltCLIPVisionConfig
 
 
@@ -1021,6 +1022,7 @@ class AltCLIPVisionEmbeddings(nn.Module):
         return embeddings
 
 
+@register(backends=("torch",))
 class AltCLIPPreTrainedModel(PreTrainedModel):
     """
     An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
@@ -1136,6 +1138,7 @@ class AltCLIPVisionTransformer(nn.Module):
         )
 
 
+@register(backends=("torch",))
 class AltCLIPVisionModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPVisionConfig
     main_input_name = "pixel_values"
@@ -1367,6 +1370,7 @@ class AltRobertaModel(AltCLIPPreTrainedModel):
         )
 
 
+@register(backends=("torch",))
 class AltCLIPTextModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPTextConfig
 
@@ -1459,6 +1463,7 @@ class AltCLIPTextModel(AltCLIPPreTrainedModel):
         )
 
 
+@register(backends=("torch",))
 class AltCLIPModel(AltCLIPPreTrainedModel):
     config_class = AltCLIPConfig
 
@@ -1694,3 +1699,6 @@ def create_position_ids_from_input_ids(input_ids, padding_idx, past_key_values_l
     mask = input_ids.ne(padding_idx).int()
     incremental_indices = (torch.cumsum(mask, dim=1).type_as(mask) + past_key_values_length) * mask
     return incremental_indices.long() + padding_idx
+
+
+__all__ = ["AltCLIPPreTrainedModel", "AltCLIPVisionModel", "AltCLIPTextModel", "AltCLIPModel"]

--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -20,8 +20,10 @@ import warnings
 
 from ...processing_utils import ProcessorMixin
 from ...tokenization_utils_base import BatchEncoding
+from ...utils.import_utils import register
 
 
+@register()
 class AltCLIPProcessor(ProcessorMixin):
     r"""
     Constructs a AltCLIP processor which wraps a CLIP image processor and a XLM-Roberta tokenizer into a single
@@ -130,3 +132,6 @@ class AltCLIPProcessor(ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         image_processor_input_names = self.image_processor.model_input_names
         return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+
+__all__ = ["AltCLIPProcessor"]

--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -20,10 +20,8 @@ import warnings
 
 from ...processing_utils import ProcessorMixin
 from ...tokenization_utils_base import BatchEncoding
-from ...utils.import_utils import register
 
 
-@register()
 class AltCLIPProcessor(ProcessorMixin):
     r"""
     Constructs a AltCLIP processor which wraps a CLIP image processor and a XLM-Roberta tokenizer into a single

--- a/src/transformers/models/speech_to_text/__init__.py
+++ b/src/transformers/models/speech_to_text/__init__.py
@@ -100,5 +100,6 @@ if TYPE_CHECKING:
 
 else:
     import sys
+    print(type(__spec__))
 
     sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)

--- a/src/transformers/models/speech_to_text/__init__.py
+++ b/src/transformers/models/speech_to_text/__init__.py
@@ -100,6 +100,4 @@ if TYPE_CHECKING:
 
 else:
     import sys
-    print(type(__spec__))
-
     sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)

--- a/src/transformers/models/speech_to_text/__init__.py
+++ b/src/transformers/models/speech_to_text/__init__.py
@@ -100,4 +100,5 @@ if TYPE_CHECKING:
 
 else:
     import sys
+
     sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -1262,13 +1262,6 @@ class BertForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class BertLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class BertLMHeadModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -1362,13 +1355,6 @@ class BigBirdForSequenceClassification(metaclass=DummyObject):
 
 
 class BigBirdForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class BigBirdLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -1862,13 +1848,6 @@ class CanineForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class CanineLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class CanineModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -2224,13 +2203,6 @@ class ConvBertForSequenceClassification(metaclass=DummyObject):
 
 
 class ConvBertForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class ConvBertLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -3138,13 +3110,6 @@ class QDQBertForSequenceClassification(metaclass=DummyObject):
 
 
 class QDQBertForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class QDQBertLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -4133,13 +4098,6 @@ class FNetForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class FNetLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class FNetModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -4572,13 +4530,6 @@ class GPTNeoXForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class GPTNeoXLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class GPTNeoXModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -4594,13 +4545,6 @@ class GPTNeoXPreTrainedModel(metaclass=DummyObject):
 
 
 class GPTNeoXJapaneseForCausalLM(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class GPTNeoXJapaneseLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -5437,13 +5381,6 @@ class LongformerPreTrainedModel(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class LongformerSelfAttention(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class LongT5EncoderModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -5584,13 +5521,6 @@ class LxmertVisualFeatureEncoder(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class LxmertXLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class M2M100ForConditionalGeneration(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -5669,6 +5599,13 @@ class MarianModel(metaclass=DummyObject):
 
 
 class MarianMTModel(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
+class MarianPreTrainedModel(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -6011,13 +5948,6 @@ class MobileBertForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class MobileBertLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class MobileBertModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -6178,13 +6108,6 @@ class MPNetForSequenceClassification(metaclass=DummyObject):
 
 
 class MPNetForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class MPNetLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -6556,13 +6479,6 @@ class NystromformerForSequenceClassification(metaclass=DummyObject):
 
 
 class NystromformerForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class NystromformerLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -6987,13 +6903,6 @@ class PerceiverForOpticalFlow(metaclass=DummyObject):
 
 
 class PerceiverForSequenceClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class PerceiverLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -7469,13 +7378,6 @@ class RecurrentGemmaPreTrainedModel(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class ReformerAttention(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class ReformerForMaskedLM(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -7491,13 +7393,6 @@ class ReformerForQuestionAnswering(metaclass=DummyObject):
 
 
 class ReformerForSequenceClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class ReformerLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -7582,13 +7477,6 @@ class RemBertForSequenceClassification(metaclass=DummyObject):
 
 
 class RemBertForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class RemBertLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -7802,13 +7690,6 @@ class RoCBertForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class RoCBertLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class RoCBertModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -7863,13 +7744,6 @@ class RoFormerForSequenceClassification(metaclass=DummyObject):
 
 
 class RoFormerForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class RoFormerLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -8097,13 +7971,6 @@ class SegformerForSemanticSegmentation(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class SegformerLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class SegformerModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -8314,13 +8181,6 @@ class SplinterForQuestionAnswering(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class SplinterLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class SplinterModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -8371,13 +8231,6 @@ class SqueezeBertForTokenClassification(metaclass=DummyObject):
 
 
 class SqueezeBertModel(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class SqueezeBertModule(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -9092,13 +8945,6 @@ class ViltForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class ViltLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class ViltModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -9176,13 +9022,6 @@ class VisualBertForVisualReasoning(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class VisualBertLayer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class VisualBertModel(metaclass=DummyObject):
     _backends = ["torch"]
 
@@ -9226,13 +9065,6 @@ class ViTPreTrainedModel(metaclass=DummyObject):
 
 
 class ViTMAEForPreTraining(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class ViTMAELayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -9951,13 +9783,6 @@ class YosoForSequenceClassification(metaclass=DummyObject):
 
 
 class YosoForTokenClassification(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class YosoLayer(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_sentencepiece_objects.py
+++ b/src/transformers/utils/dummy_sentencepiece_objects.py
@@ -128,14 +128,14 @@ class MarianTokenizer(metaclass=DummyObject):
         requires_backends(self, ["sentencepiece"])
 
 
-class MBart50Tokenizer(metaclass=DummyObject):
+class MBartTokenizer(metaclass=DummyObject):
     _backends = ["sentencepiece"]
 
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["sentencepiece"])
 
 
-class MBartTokenizer(metaclass=DummyObject):
+class MBart50Tokenizer(metaclass=DummyObject):
     _backends = ["sentencepiece"]
 
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/dummy_tf_objects.py
+++ b/src/transformers/utils/dummy_tf_objects.py
@@ -478,13 +478,6 @@ class TFBartPretrainedModel(metaclass=DummyObject):
         requires_backends(self, ["tf"])
 
 
-class TFBertEmbeddings(metaclass=DummyObject):
-    _backends = ["tf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["tf"])
-
-
 class TFBertForMaskedLM(metaclass=DummyObject):
     _backends = ["tf"]
 
@@ -766,13 +759,6 @@ class TFConvBertForSequenceClassification(metaclass=DummyObject):
 
 
 class TFConvBertForTokenClassification(metaclass=DummyObject):
-    _backends = ["tf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["tf"])
-
-
-class TFConvBertLayer(metaclass=DummyObject):
     _backends = ["tf"]
 
     def __init__(self, *args, **kwargs):
@@ -1717,13 +1703,6 @@ class TFLongformerPreTrainedModel(metaclass=DummyObject):
         requires_backends(self, ["tf"])
 
 
-class TFLongformerSelfAttention(metaclass=DummyObject):
-    _backends = ["tf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["tf"])
-
-
 class TFLxmertForPreTraining(metaclass=DummyObject):
     _backends = ["tf"]
 
@@ -2179,13 +2158,6 @@ class TFRemBertForTokenClassification(metaclass=DummyObject):
         requires_backends(self, ["tf"])
 
 
-class TFRemBertLayer(metaclass=DummyObject):
-    _backends = ["tf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["tf"])
-
-
 class TFRemBertModel(metaclass=DummyObject):
     _backends = ["tf"]
 
@@ -2383,13 +2355,6 @@ class TFRoFormerForSequenceClassification(metaclass=DummyObject):
 
 
 class TFRoFormerForTokenClassification(metaclass=DummyObject):
-    _backends = ["tf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["tf"])
-
-
-class TFRoFormerLayer(metaclass=DummyObject):
     _backends = ["tf"]
 
     def __init__(self, *args, **kwargs):

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -29,7 +29,6 @@ from itertools import chain
 from types import ModuleType
 from typing import Any, Optional, Tuple, Union, List
 
-from nltk.downloader import update
 from packaging import version
 
 from . import logging
@@ -1638,7 +1637,7 @@ class _LazyModule(ModuleType):
                 for backend in backends:
                     if backend not in BACKENDS_MAPPING:
                         raise ValueError(
-                            f"Error: the following backend: '{backend}' was specified around object {item} but isn't specified in the backends mapping."
+                            f"Error: the following backend: '{backend}' was specified around object {module} but isn't specified in the backends mapping."
                         )
                     callable, error = BACKENDS_MAPPING[backend]
                     if not callable():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1761,6 +1761,9 @@ def export(*, backends=()):
       to execute correctly without instantiating it
     - The '@export' string is used to dynamically import objects
     """
+    for backend in backends:
+        if backend not in BACKENDS_MAPPING:
+            raise ValueError(f"Backend should be defined in the BACKENDS_MAPPING. Offending backend: {backend}")
 
     if not isinstance(backends, tuple):
         raise ValueError("Backends should be a tuple.")
@@ -1915,7 +1918,7 @@ def define_import_structure(module_path):
 
         # Objects that have a `@export` assigned to them will get exported
         # with the backends specified in the decorator as well as the file backends.
-        registered_objects = set()
+        exported_objects = set()
         if '@export' in file_content:
             lines = file_content.split("\n")
             for index, line in enumerate(lines):
@@ -1986,7 +1989,7 @@ def define_import_structure(module_path):
                         start_index = 6 if line.startswith("class") else 4
                         object_name = line[start_index:].split("(")[0].strip(":")
                         module_requirements[backends][module_name].add(object_name)
-                        registered_objects.add(object_name)
+                        exported_objects.add(object_name)
 
                 if not skip_line:
                     previous_line = line
@@ -1996,7 +1999,7 @@ def define_import_structure(module_path):
         # These objects are exported with the file backends.
         if '__all__' in file_content:
             for _all_object in fetch__all__(file_content):
-                if _all_object not in registered_objects:
+                if _all_object not in exported_objects:
 
                     backends = frozenset(base_requirements)
                     if backends not in module_requirements:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1887,14 +1887,20 @@ def create_import_structure_from_path(module_path):
     """
     import_structure = {}
     if os.path.isdir(module_path):
+
+        directory = module_path
+        adjacent_modules = []
+
         for f in os.listdir(module_path):
             if f != "__pycache__" and os.path.isdir(os.path.join(module_path, f)):
-                import_structure[f] = define_import_structure(os.path.join(module_path, f))
-        directory = module_path
+                import_structure[f] = create_import_structure_from_path(os.path.join(module_path, f))
+
+            elif not os.path.isdir(os.path.join(directory, f)):
+                adjacent_modules.append(f)
+
     else:
         directory = os.path.dirname(module_path)
-
-    adjacent_modules = [f for f in os.listdir(directory) if not os.path.isdir(os.path.join(directory, f))]
+        adjacent_modules = [f for f in os.listdir(directory) if not os.path.isdir(os.path.join(directory, f))]
 
     # We're only taking a look at files different from __init__.py
     # We could theoretically export things directly from the __init__.py

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1890,12 +1890,16 @@ def define_import_structure(module_path):
 
     module_requirements = {}
     for module_name in adjacent_modules:
+
+        # Only modules ending in `.py` are accepted here.
+        if not module_name.endswith('.py'):
+            continue
+
         with open(os.path.join(directory, module_name)) as f:
             file_content = f.read()
 
         # Remove the .py suffix
-        if module_name.endswith(".py"):
-            module_name = module_name[:-3]
+        module_name = module_name[:-3]
 
         previous_line = ""
         previous_index = 0

--- a/tests/models/longformer/test_modeling_longformer.py
+++ b/tests/models/longformer/test_modeling_longformer.py
@@ -34,8 +34,8 @@ if is_torch_available():
         LongformerForSequenceClassification,
         LongformerForTokenClassification,
         LongformerModel,
-        LongformerSelfAttention,
     )
+    from transformers.models.longformer.modeling_longformer import LongformerSelfAttention
 
 
 class LongformerModelTester:

--- a/tests/models/longformer/test_modeling_tf_longformer.py
+++ b/tests/models/longformer/test_modeling_tf_longformer.py
@@ -37,8 +37,8 @@ if is_tf_available():
         TFLongformerForSequenceClassification,
         TFLongformerForTokenClassification,
         TFLongformerModel,
-        TFLongformerSelfAttention,
     )
+    from transformers.models.longformer.modeling_tf_longformer import TFLongformerSelfAttention
     from transformers.tf_utils import shape_list
 
 

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -40,11 +40,11 @@ if is_torch_available():
         ReformerForMaskedLM,
         ReformerForQuestionAnswering,
         ReformerForSequenceClassification,
-        ReformerLayer,
         ReformerModel,
         ReformerModelWithLMHead,
         ReformerTokenizer,
     )
+    from transformers.models.reformer.modeling_reformer import ReformerLayer
 
 
 class ReformerModelTester:

--- a/tests/utils/import_structures/failing_export.py
+++ b/tests/utils/import_structures/failing_export.py
@@ -1,0 +1,24 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fmt: off
+
+from transformers.utils.import_utils import export
+
+
+@export(backends=("random_item_that_should_not_exist",))
+class A0:
+    def __init__(self):
+        pass
+

--- a/tests/utils/import_structures/failing_export.py
+++ b/tests/utils/import_structures/failing_export.py
@@ -21,4 +21,3 @@ from transformers.utils.import_utils import export
 class A0:
     def __init__(self):
         pass
-

--- a/tests/utils/import_structures/import_structure_raw_register.py
+++ b/tests/utils/import_structures/import_structure_raw_register.py
@@ -1,0 +1,61 @@
+# fmt: off
+
+from transformers.utils.import_utils import register
+
+
+@register()
+class A0:
+    def __init__(self):
+        pass
+
+
+@register()
+def a0():
+    pass
+
+
+@register(backends=("torch", "tf"))
+class A1:
+    def __init__(self):
+        pass
+
+
+@register(backends=("torch", "tf"))
+def a1():
+    pass
+
+
+@register(
+    backends=("torch", "tf")
+)
+class A2:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=("torch", "tf")
+)
+def a2():
+    pass
+
+
+@register(
+    backends=(
+        "torch",
+        "tf"
+    )
+)
+class A3:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=(
+            "torch",
+            "tf"
+    )
+)
+def a3():
+    pass

--- a/tests/utils/import_structures/import_structure_raw_register.py
+++ b/tests/utils/import_structures/import_structure_raw_register.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # fmt: off
 
 from transformers.utils.import_utils import export

--- a/tests/utils/import_structures/import_structure_raw_register.py
+++ b/tests/utils/import_structures/import_structure_raw_register.py
@@ -1,31 +1,31 @@
 # fmt: off
 
-from transformers.utils.import_utils import register
+from transformers.utils.import_utils import export
 
 
-@register()
+@export()
 class A0:
     def __init__(self):
         pass
 
 
-@register()
+@export()
 def a0():
     pass
 
 
-@register(backends=("torch", "tf"))
+@export(backends=("torch", "tf"))
 class A1:
     def __init__(self):
         pass
 
 
-@register(backends=("torch", "tf"))
+@export(backends=("torch", "tf"))
 def a1():
     pass
 
 
-@register(
+@export(
     backends=("torch", "tf")
 )
 class A2:
@@ -33,14 +33,14 @@ class A2:
         pass
 
 
-@register(
+@export(
     backends=("torch", "tf")
 )
 def a2():
     pass
 
 
-@register(
+@export(
     backends=(
         "torch",
         "tf"
@@ -51,7 +51,7 @@ class A3:
         pass
 
 
-@register(
+@export(
     backends=(
             "torch",
             "tf"
@@ -59,3 +59,8 @@ class A3:
 )
 def a3():
     pass
+
+@export(backends=())
+class A4:
+    def __init__(self):
+        pass

--- a/tests/utils/import_structures/import_structure_register_with_comments.py
+++ b/tests/utils/import_structures/import_structure_register_with_comments.py
@@ -1,55 +1,51 @@
 # fmt: off
 
-from transformers.utils.import_utils import register
+from transformers.utils.import_utils import export
 
 
-@register()
+@export()
 # That's a statement
 class B0:
     def __init__(self):
         pass
 
 
-@register()
+@export()
 # That's a statement
 def b0():
     pass
 
 
-@register(backends=("torch", "tf"))
+@export(backends=("torch", "tf"))
 # That's a statement
 class B1:
     def __init__(self):
         pass
 
 
-@register(backends=("torch", "tf"))
+@export(backends=("torch", "tf"))
 # That's a statement
 def b1():
     pass
 
 
-@register(
-    backends=("torch", "tf")
-)
+@export(backends=("torch", "tf"))
 # That's a statement
 class B2:
     def __init__(self):
         pass
 
 
-@register(
-    backends=("torch", "tf")
-)
+@export(backends=("torch", "tf"))
 # That's a statement
 def b2():
     pass
 
 
-@register(
+@export(
     backends=(
-            "torch",
-            "tf"
+        "torch",
+        "tf"
     )
 )
 # That's a statement
@@ -58,10 +54,10 @@ class B3:
         pass
 
 
-@register(
+@export(
     backends=(
-            "torch",
-            "tf"
+        "torch",
+        "tf"
     )
 )
 # That's a statement

--- a/tests/utils/import_structures/import_structure_register_with_comments.py
+++ b/tests/utils/import_structures/import_structure_register_with_comments.py
@@ -1,0 +1,69 @@
+# fmt: off
+
+from transformers.utils.import_utils import register
+
+
+@register()
+# That's a statement
+class B0:
+    def __init__(self):
+        pass
+
+
+@register()
+# That's a statement
+def b0():
+    pass
+
+
+@register(backends=("torch", "tf"))
+# That's a statement
+class B1:
+    def __init__(self):
+        pass
+
+
+@register(backends=("torch", "tf"))
+# That's a statement
+def b1():
+    pass
+
+
+@register(
+    backends=("torch", "tf")
+)
+# That's a statement
+class B2:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=("torch", "tf")
+)
+# That's a statement
+def b2():
+    pass
+
+
+@register(
+    backends=(
+            "torch",
+            "tf"
+    )
+)
+# That's a statement
+class B3:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=(
+            "torch",
+            "tf"
+    )
+)
+# That's a statement
+def b3():
+    pass

--- a/tests/utils/import_structures/import_structure_register_with_comments.py
+++ b/tests/utils/import_structures/import_structure_register_with_comments.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # fmt: off
 
 from transformers.utils.import_utils import export

--- a/tests/utils/import_structures/import_structure_register_with_duplicates.py
+++ b/tests/utils/import_structures/import_structure_register_with_duplicates.py
@@ -1,0 +1,67 @@
+# fmt: off
+
+from transformers.utils.import_utils import register
+
+
+@register(backends=("torch", "torch"))
+class C0:
+    def __init__(self):
+        pass
+
+
+@register(backends=("torch", "torch"))
+def c0():
+    pass
+
+
+@register(backends=("torch", "torch"))
+# That's a statement
+class C1:
+    def __init__(self):
+        pass
+
+
+@register(backends=("torch", "torch"))
+# That's a statement
+def c1():
+    pass
+
+
+@register(
+    backends=("torch", "torch")
+)
+# That's a statement
+class C2:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=("torch", "torch")
+)
+# That's a statement
+def c2():
+    pass
+
+
+@register(
+    backends=(
+        "torch",
+        "torch"
+    )
+)
+# That's a statement
+class C3:
+    def __init__(self):
+        pass
+
+
+@register(
+    backends=(
+        "torch",
+        "torch"
+    )
+)
+# That's a statement
+def c3():
+    pass

--- a/tests/utils/import_structures/import_structure_register_with_duplicates.py
+++ b/tests/utils/import_structures/import_structure_register_with_duplicates.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # fmt: off
 
 from transformers.utils.import_utils import export

--- a/tests/utils/import_structures/import_structure_register_with_duplicates.py
+++ b/tests/utils/import_structures/import_structure_register_with_duplicates.py
@@ -1,50 +1,46 @@
 # fmt: off
 
-from transformers.utils.import_utils import register
+from transformers.utils.import_utils import export
 
 
-@register(backends=("torch", "torch"))
+@export(backends=("torch", "torch"))
 class C0:
     def __init__(self):
         pass
 
 
-@register(backends=("torch", "torch"))
+@export(backends=("torch", "torch"))
 def c0():
     pass
 
 
-@register(backends=("torch", "torch"))
+@export(backends=("torch", "torch"))
 # That's a statement
 class C1:
     def __init__(self):
         pass
 
 
-@register(backends=("torch", "torch"))
+@export(backends=("torch", "torch"))
 # That's a statement
 def c1():
     pass
 
 
-@register(
-    backends=("torch", "torch")
-)
+@export(backends=("torch", "torch"))
 # That's a statement
 class C2:
     def __init__(self):
         pass
 
 
-@register(
-    backends=("torch", "torch")
-)
+@export(backends=("torch", "torch"))
 # That's a statement
 def c2():
     pass
 
 
-@register(
+@export(
     backends=(
         "torch",
         "torch"
@@ -56,7 +52,7 @@ class C3:
         pass
 
 
-@register(
+@export(
     backends=(
         "torch",
         "torch"

--- a/tests/utils/test_import_structure.py
+++ b/tests/utils/test_import_structure.py
@@ -1,0 +1,94 @@
+import os
+import unittest
+from pathlib import Path
+
+from transformers.utils.import_utils import define_import_structure, spread_import_structure
+
+
+import_structures = Path("import_structures")
+
+
+def fetch__all__(file_content):
+    """
+    Returns the content of the __all__ variable in the file content.
+    Returns None if not defined, otherwise returns a list of strings.
+    """
+    lines = file_content.split("\n")
+    for line_index in range(len(lines)):
+        line = lines[line_index]
+        if line.startswith("__all__ = "):
+            # __all__ is defined on a single line
+            if line.endswith("]"):
+                return [obj.strip("\"' ") for obj in line.split("=")[1].strip(" []").split(",")]
+
+            # __all__ is defined on multiple lines
+            else:
+                _all = []
+                for __all__line_index in range(line_index + 1, len(lines)):
+                    if lines[__all__line_index].strip() == "]":
+                        return _all
+                    else:
+                        _all.append(lines[__all__line_index].strip("\"', "))
+
+
+class TestImportStructures(unittest.TestCase):
+    base_transformers_path = Path(__file__).parent.parent.parent
+    models_path = base_transformers_path / "src" / "transformers" / "models"
+    models_import_structure = spread_import_structure(define_import_structure(models_path))
+
+    def test_definition(self):
+        import_structure = define_import_structure(import_structures)
+        import_structure_definition = {
+            frozenset(()): {
+                "import_structure_raw_register": ["A0", "a0"],
+                "import_structure_register_with_comments": ["B0", "b0"],
+            },
+            frozenset(("tf", "torch")): {
+                "import_structure_raw_register": ["A1", "a1", "A2", "a2", "A3", "a3"],
+                "import_structure_register_with_comments": ["B1", "b1", "B2", "b2", "B3", "b3"],
+            },
+            frozenset(("torch",)): {
+                "import_structure_register_with_duplicates": ["C0", "c0", "C1", "c1", "C2", "c2", "C3", "c3"],
+            },
+        }
+
+        self.assertDictEqual(import_structure, import_structure_definition)
+
+    def test_transformers_specific_model_import(self):
+        """
+        This test ensures that there is equivalence between what is written down in __all__ and what is
+        written down with register().
+
+        It doesn't test the backends attributed to register().
+        """
+        for architecture in os.listdir(self.models_path):
+            if (
+                os.path.isfile(self.models_path / architecture)
+                or architecture.startswith("_")
+                or architecture == "deprecated"
+            ):
+                continue
+
+            with self.subTest(f"Testing arch {architecture}"):
+                import_structure = define_import_structure(self.models_path / architecture)
+                backend_agnostic_import_structure = {}
+                for requirement, module_object_mapping in import_structure.items():
+                    for module, objects in module_object_mapping.items():
+                        if module not in backend_agnostic_import_structure:
+                            backend_agnostic_import_structure[module] = []
+
+                        backend_agnostic_import_structure[module].extend(objects)
+
+                for module, objects in backend_agnostic_import_structure.items():
+                    with open(self.models_path / architecture / f"{module}.py") as f:
+                        content = f.read()
+                        _all = fetch__all__(content)
+
+                        if _all is None:
+                            raise ValueError(f"{module} doesn't have __all__ defined.")
+
+                        error_message = (
+                            f"self.models_path / architecture / f'{module}.py doesn't seem to be defined correctly:\n"
+                            f"Defined in __all__: {sorted(_all)}\nDefined with register: {sorted(objects)}"
+                        )
+                        self.assertListEqual(sorted(objects), sorted(_all), msg=error_message)

--- a/tests/utils/test_import_structure.py
+++ b/tests/utils/test_import_structure.py
@@ -92,3 +92,7 @@ class TestImportStructures(unittest.TestCase):
                             f"Defined in __all__: {sorted(_all)}\nDefined with register: {sorted(objects)}"
                         )
                         self.assertListEqual(sorted(objects), sorted(_all), msg=error_message)
+
+    def test_export_backend_should_be_defined(self):
+        with self.assertRaisesRegex(ValueError, "Backend should be defined in the BACKENDS_MAPPING"):
+            pass

--- a/tests/utils/test_import_structure.py
+++ b/tests/utils/test_import_structure.py
@@ -40,15 +40,15 @@ class TestImportStructures(unittest.TestCase):
         import_structure = define_import_structure(import_structures)
         import_structure_definition = {
             frozenset(()): {
-                "import_structure_raw_register": ["A0", "a0"],
-                "import_structure_register_with_comments": ["B0", "b0"],
+                "import_structure_raw_register": {"A0", "a0", "A4"},
+                "import_structure_register_with_comments": {"B0", "b0"},
             },
             frozenset(("tf", "torch")): {
-                "import_structure_raw_register": ["A1", "a1", "A2", "a2", "A3", "a3"],
-                "import_structure_register_with_comments": ["B1", "b1", "B2", "b2", "B3", "b3"],
+                "import_structure_raw_register": {"A1", "a1", "A2", "a2", "A3", "a3"},
+                "import_structure_register_with_comments": {"B1", "b1", "B2", "b2", "B3", "b3"},
             },
             frozenset(("torch",)): {
-                "import_structure_register_with_duplicates": ["C0", "c0", "C1", "c1", "C2", "c2", "C3", "c3"],
+                "import_structure_register_with_duplicates": {"C0", "c0", "C1", "c1", "C2", "c2", "C3", "c3"},
             },
         }
 

--- a/utils/custom_init_isort.py
+++ b/utils/custom_init_isort.py
@@ -244,7 +244,7 @@ def sort_imports(file: str, check_only: bool = True):
         code = f.read()
 
     # If the file is not a custom init, there is nothing to do.
-    if "_import_structure" not in code:
+    if "_import_structure" not in code or "define_import_structure" in code:
         return
 
     # Blocks of indent level 0


### PR DESCRIPTION
## Simplifying the import structure

This is the first PR that aims to facilitate adding new models by reducing the overhead caused by the `__init__.py` contributions.

It introduces three new concepts:
- The `export` keyword, which accepts the `backends` tuple as input.
- The `define_import_structure`, which accepts a filepath as input.
- The `__all__` keyword for easy exports

This approach adds a little overhead to what is currently done as it needs to open files and do some string checks across files. It is negligible compared to framework instantiations like `torch` but should still be highlighted; this approach is extremely specific to `transformers` and to the fact that we want to reduce the barrier of contributions to a minimum.

### `@export`

The `export` keyword acts as an exporter. For now this is limited to the `src/transformers/models` path only, but if accepted, it can be propagated to the entire repository.

Using the `@export` decorator on a class or method exports it to be importable by third-parties. In doing so, it accepts a tuple of `backends`. In case a backend isn't installed, the object can still be imported; but using any method or attribute on this object will raise an error. 

This method aims to deprecate and replace the use of `dummy_xxx` modules and objects.

### `define_import_structure`

This method relies on all the objects in a module being correctly marked with `@register` and with the correct backends. It replaces the current complex dict structure dedicated to Lazy loading, and continues supporting lazy loading.

### The `__all__` keyword

This keyword is used here principally for static type checkers that cannot understand the `@register` keyword. Correctly exporting objects through this enables correct type hinting/type checking.

The `define_import_structure` keyword acts in conjunction with the `__all__` method and the `@export` decorator to correctly identify which imports depend on what backends so as to reflect that in the lazy import scheme. 

The rest of the model refactor is here: https://github.com/huggingface/transformers/pull/31330