### PR TITLE
Apply the change deprecating `resume_download` param to unchanged lines to be consistent across the source code

### DIFF
--- a/examples/research_projects/lxmert/utils.py
+++ b/examples/research_projects/lxmert/utils.py
@@ -182,7 +182,7 @@ class Config:
     def get_config_dict(cls, pretrained_model_name_or_path: str, **kwargs):
         cache_dir = kwargs.pop("cache_dir", None)
         force_download = kwargs.pop("force_download", False)
-        resume_download = kwargs.pop("resume_download", False)
+        resume_download = kwargs.pop("resume_download", None)
         proxies = kwargs.pop("proxies", None)
         local_files_only = kwargs.pop("local_files_only", False)
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -536,7 +536,7 @@ class PretrainedConfig(PushToHubMixin):
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force to (re-)download the configuration files and override the cached versions if
                 they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -808,7 +808,7 @@ class GenerationConfig(PushToHubMixin):
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force to (re-)download the configuration files and override the cached versions if
                 they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):

--- a/src/transformers/modeling_flax_utils.py
+++ b/src/transformers/modeling_flax_utils.py
@@ -591,7 +591,7 @@ class FlaxPreTrainedModel(PushToHubMixin, FlaxGenerationMixin):
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -123,7 +123,7 @@ FROM_PRETRAINED_TORCH_DOCSTRING = """
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):
@@ -222,7 +222,7 @@ FROM_PRETRAINED_TF_DOCSTRING = """
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -878,7 +878,7 @@ class AutoConfig:
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download the model weights and configuration files and override the
                 cached versions if they exist.
-            resume_download:
+            resume_download (defaults to `None`):
                 Deprecated and ignored. All downloads are now resumed by default when possible.
                 Will be removed in v5 of Transformers.
             proxies (`Dict[str, str]`, *optional*):

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -302,7 +302,7 @@ def cached_file(
         force_download (`bool`, *optional*, defaults to `False`):
             Whether or not to force to (re-)download the configuration files and override the cached versions if they
             exist.
-        resume_download:
+        resume_download (defaults to `None`):
             Deprecated and ignored. All downloads are now resumed by default when possible.
             Will be removed in v5 of Transformers.
         proxies (`Dict[str, str]`, *optional*):
@@ -503,7 +503,7 @@ def get_file_from_repo(
         force_download (`bool`, *optional*, defaults to `False`):
             Whether or not to force to (re-)download the configuration files and override the cached versions if they
             exist.
-        resume_download:
+        resume_download (defaults to `None`):
             Deprecated and ignored. All downloads are now resumed by default when possible.
             Will be removed in v5 of Transformers.
         proxies (`Dict[str, str]`, *optional*):


### PR DESCRIPTION
Apply the change deprecating 'resume_download' param to unchanged lines to be consistent across the source code

# What does this PR do?

Apply the change made in [PR - Respect resume_download deprecation #30620](https://github.com/huggingface/transformers/pull/30620) to the rest of the source code where the param is used.

<!-- Remove if not applicable -->

Follow-up fixes to [issue #30618](https://github.com/huggingface/transformers/issues/30618)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. 
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Tagging the author of [PR - Respect resume_download deprecation #30620](https://github.com/huggingface/transformers/pull/30620) @Wauplin
