### PR TITLE
[QoL fix] [Image processing] Add warning on assumption of channel dim

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -204,7 +204,9 @@ def infer_channel_dimension_format(
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 
     if image.shape[first_dim] in num_channels and image.shape[last_dim] in num_channels:
-        warnings.warn(f'The channel dimension format is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension.')
+        warnings.warn(
+            f"The channel dimension format is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension."
+        )
         return ChannelDimension.FIRST
     elif image.shape[first_dim] in num_channels:
         return ChannelDimension.FIRST

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -205,7 +205,7 @@ def infer_channel_dimension_format(
 
     if image.shape[first_dim] in num_channels and image.shape[last_dim] in num_channels:
         warnings.warn(
-            f"The channel dimension format is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension."
+            f"The channel dimension is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension. Please specify with input_data_format if this is incorrect."
         )
         return ChannelDimension.FIRST
     elif image.shape[first_dim] in num_channels:

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -203,8 +203,8 @@ def infer_channel_dimension_format(
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 
     if image.shape[first_dim] in num_channels and image.shape[last_dim] in num_channels:
-        warnings.warn(
-            f"The channel dimension is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension. Please specify with input_data_format if this is incorrect."
+        logger.warning(
+            f"The channel dimension is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension."
         )
         return ChannelDimension.FIRST
     elif image.shape[first_dim] in num_channels:

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -15,6 +15,7 @@
 
 import base64
 import os
+import warnings
 from io import BytesIO
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -202,7 +203,10 @@ def infer_channel_dimension_format(
     else:
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 
-    if image.shape[first_dim] in num_channels:
+    if image.shape[first_dim] in num_channels and image.shape[last_dim] in num_channels:
+        warnings.warn(f'The channel dimension format is ambiguous. Got image shape {image.shape}. Assuming channels are the first dimension.')
+        return ChannelDimension.FIRST
+    elif image.shape[first_dim] in num_channels:
         return ChannelDimension.FIRST
     elif image.shape[last_dim] in num_channels:
         return ChannelDimension.LAST

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -15,7 +15,6 @@
 
 import base64
 import os
-import warnings
 from io import BytesIO
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 

--- a/src/transformers/models/siglip/image_processing_siglip.py
+++ b/src/transformers/models/siglip/image_processing_siglip.py
@@ -216,7 +216,6 @@ class SiglipImageProcessor(BaseImageProcessor):
             size=size,
             resample=resample,
         )
-
         # All transformations expect numpy arrays.
         images = [to_numpy_array(image) for image in images]
 

--- a/src/transformers/models/siglip/image_processing_siglip.py
+++ b/src/transformers/models/siglip/image_processing_siglip.py
@@ -216,6 +216,10 @@ class SiglipImageProcessor(BaseImageProcessor):
             size=size,
             resample=resample,
         )
+        # if inputs are all PIL.Image, it is in channel last after conversion to np.ndarray. Save that information to avoid ambiguity.
+        if all(isinstance(image, PIL.Image.Image) for image in images):
+            input_data_format = ChannelDimension.LAST
+
         # All transformations expect numpy arrays.
         images = [to_numpy_array(image) for image in images]
 

--- a/src/transformers/models/siglip/image_processing_siglip.py
+++ b/src/transformers/models/siglip/image_processing_siglip.py
@@ -216,9 +216,6 @@ class SiglipImageProcessor(BaseImageProcessor):
             size=size,
             resample=resample,
         )
-        # if inputs are all PIL.Image, it is in channel last after conversion to np.ndarray. Save that information to avoid ambiguity.
-        if all(isinstance(image, PIL.Image.Image) for image in images):
-            input_data_format = ChannelDimension.LAST
 
         # All transformations expect numpy arrays.
         images = [to_numpy_array(image) for image in images]


### PR DESCRIPTION
Sometimes the input image can have height or width 1 and in HWC format. One example is if you `np.asarray(PIL.Image)`. The current function to infer channel dim assumes the CHW silently which can cause confusion to users as the image will be wrongly processed as a grayscale image, which will raise further, harder to interpret errors when running through models.

This PR adds a warning when this happens. ~It also set the channel dim to last if inputs are PIL.Image as they are always in HWC after `np.asarray`, avoiding ambiguity in this case.~

The default behaviour of assuming first dim as the channel has not changed to prevent any breaking changes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts 