### PR TITLE
[tests] use the correct label column name  

### DIFF
--- a/tests/deepspeed/test_model_zoo.py
+++ b/tests/deepspeed/test_model_zoo.py
@@ -270,6 +270,7 @@ def make_task_cmds():
             --dataset_name hf-internal-testing/cats_vs_dogs_sample
             --remove_unused_columns False
             --max_steps 10
+            --label_column_name labels
             --image_processor_name {DS_TESTS_DIRECTORY}/vit_feature_extractor.json
             --label_column_name labels
         """,


### PR DESCRIPTION
## What does this PR do?
```bash
pytest tests/deepspeed/test_model_zoo.py::TestDeepSpeedModelZoo::test_zero_to_fp32_zero2_img_clas_vit -rA
```
The test above fails with the following message: 
```bash
stderr: Traceback (most recent call last):
stderr:   File "/mnt/code/examples/pytorch/image-classification/run_image_classification.py", line 451, in <module>
stderr:     main()
stderr:   File "/mnt/code/examples/pytorch/image-classification/run_image_classification.py", line 282, in main
stderr:     raise ValueError(
stderr: ValueError: --label_column_name label not found in dataset 'hf-internal-testing/cats_vs_dogs_sample'. Make sure to set `--label_column_name` to the correct text column - one of image, labels.
```
The fact is that the test dataset `hf-internal-testing/cats_vs_dogs_sample` contains 2 columns: `image` and `labels`. Since the default label name is "label" for `run_image_classification.py`, we need to explicitly set the label column name for this task. 

After the fix, the test passes. Below is a code snippet from the successful test result:
```bash
stderr: [INFO|trainer.py:2085] 2024-06-12 16:04:51,440 >>
stderr: 
stderr: Training completed. Do not forget to share your model on huggingface.co/models =)
stderr: 
stderr: 
100%|██████████| 10/10 [00:06<00:00,  1.61it/s]
stderr: [INFO|trainer.py:3057] 2024-06-12 16:04:51,445 >> Saving model checkpoint to /tmp/tmp6hh60e8s
stderr: [INFO|configuration_utils.py:471] 2024-06-12 16:04:51,445 >> Configuration saved in /tmp/tmp6hh60e8s/config.json
stderr: [INFO|modeling_utils.py:2474] 2024-06-12 16:04:51,448 >> Model weights saved in /tmp/tmp6hh60e8s/model.safetensors
stderr: [INFO|image_processing_utils.py:257] 2024-06-12 16:04:51,448 >> Image processor saved in /tmp/tmp6hh60e8s/preprocessor_config.json
stderr: [INFO|modelcard.py:450] 2024-06-12 16:04:51,894 >> Dropping the following result as it does not have all the necessary fields:
stderr: {'task': {'name': 'Image Classification', 'type': 'image-classification'}, 'dataset': {'name': 'hf-internal-testing/cats_vs_dogs_sample', 'type': 'cats_vs_dogs_sample', 'config': 'default', 'split': 'train', 'args': 'default'}}
================================================= short test summary info =================================================
PASSED tests/deepspeed/test_model_zoo.py::TestDeepSpeedModelZoo::test_zero_to_fp32_zero2_img_clas_vit
========================================= 1 passed, 1 warning in 86.02s (0:01:26) =========================================
```

