### PR TITLE
Preserve `ModelOutput` object for compute_metrics evaluation loop in trainer

### DIFF
--- a/examples/pytorch/instance-segmentation/run_instance_segmentation.py
+++ b/examples/pytorch/instance-segmentation/run_instance_segmentation.py
@@ -262,8 +262,8 @@ class Evaluator:
         Returns:
             Mapping[str, float]: Metrics in a form of dictionary {<metric_name>: <metric_value>}
         """
-        prediction_batch = nested_cpu(evaluation_results.predictions)
-        target_batch = nested_cpu(evaluation_results.label_ids)
+        prediction_batch = evaluation_results.predictions
+        target_batch = evaluation_results.label_ids
 
         # For metric computation we need to provide:
         #  - targets in a form of list of dictionaries with keys "masks", "labels"
@@ -353,6 +353,7 @@ def main():
 
     # Set default training arguments for instance segmentation
     training_args.eval_do_concat_batches = False
+    training_args.eval_numpify_tensors = False
     training_args.batch_eval_metrics = True
     training_args.remove_unused_columns = False
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -101,6 +101,7 @@ from .trainer_pt_utils import (
     get_module_class_from_name,
     get_parameter_names,
     nested_concat,
+    nested_cpu,
     nested_detach,
     nested_numpify,
     nested_xla_mesh_reduce,
@@ -3946,13 +3947,19 @@ class Trainer:
         if args.past_index >= 0:
             self._past = None
 
-        # Initialize containers
-        all_losses = EvalLoopContainer(self.args.eval_do_concat_batches, padding_index=-100)
-        all_preds = EvalLoopContainer(self.args.eval_do_concat_batches, padding_index=-100)
-        all_labels = EvalLoopContainer(self.args.eval_do_concat_batches, padding_index=-100)
-        all_inputs = EvalLoopContainer(self.args.eval_do_concat_batches, padding_index=-100)
+        metrics = {}
 
-        metrics = None
+        # In the evaluation (!) stage with metrics computed per each batch (!)
+        # there is no need to store all the epoch data, and we can drop it after each batch.
+        # Thus we can avoid OOM for huge/heavy evaluation datasets, e.g. for image segmentation.
+        is_evaluation_stage = description == "Evaluation"
+        do_accumulate_epoch_data = not (is_evaluation_stage and args.batch_eval_metrics)
+
+        # Initialize containers
+        all_losses = EvalLoopContainer(args.eval_do_concat_batches, padding_index=-100)
+        all_preds = EvalLoopContainer(args.eval_do_concat_batches, padding_index=-100)
+        all_labels = EvalLoopContainer(args.eval_do_concat_batches, padding_index=-100)
+        all_inputs = EvalLoopContainer(args.eval_do_concat_batches, padding_index=-100)
 
         # Will be useful when we have an iterable dataset so don't know its length.
         observed_num_examples = 0
@@ -3968,22 +3975,25 @@ class Trainer:
                     batch_size = observed_batch_size
 
             # Prediction step
-            losses, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
+            losses, logits, labels = self.prediction_step(
+                model,
+                inputs,
+                prediction_loss_only,
+                ignore_keys=ignore_keys,
+                preserve_model_output=args.eval_preserve_model_output,
+            )
             main_input_name = getattr(self.model, "main_input_name", "input_ids")
             inputs_decode = self._prepare_input(inputs[main_input_name]) if args.include_inputs_for_metrics else None
 
             if is_torch_xla_available():
                 xm.mark_step()
 
-            # Update containers
+            # Pad across processes and gather
             if losses is not None:
                 losses = self.gather_function((losses.repeat(batch_size)))
-                all_losses.add(losses)
             if inputs_decode is not None:
                 inputs_decode = self.accelerator.pad_across_processes(inputs_decode, dim=1, pad_index=-100)
                 inputs_decode = self.gather_function((inputs_decode))
-                if not self.args.batch_eval_metrics or description == "Prediction":
-                    all_inputs.add(inputs_decode)
             if labels is not None:
                 # Pad labels here, preparing for preprocess_logits_for_metrics in next logits block.
                 labels = self.accelerator.pad_across_processes(labels, dim=1, pad_index=-100)
@@ -3992,41 +4002,54 @@ class Trainer:
                 if self.preprocess_logits_for_metrics is not None:
                     logits = self.preprocess_logits_for_metrics(logits, labels)
                 logits = self.gather_function((logits))
-                if not self.args.batch_eval_metrics or description == "Prediction":
-                    all_preds.add(logits)
             if labels is not None:
                 labels = self.gather_function((labels))
-                if not self.args.batch_eval_metrics or description == "Prediction":
-                    all_labels.add(labels)
+
+            # Collect inputs, predictions and labels for the whole epoch
+            all_losses.add(losses)
+            if do_accumulate_epoch_data:
+                all_inputs.add(inputs_decode)
+                all_preds.add(logits)
+                all_labels.add(labels)
+
+            # Put tensors on the CPU if we have done enough accumulation steps to save GPU memory
+            if args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0:
+                all_losses.cpu()
+                all_preds.cpu()
+                all_labels.cpu()
+                all_inputs.cpu()
+
+            # Compute metrics on batch if `training_args.batch_eval_metrics=True`
+            if (
+                args.batch_eval_metrics
+                and self.compute_metrics is not None
+                and logits is not None
+                and labels is not None
+            ):
+                eval_batch_inputs = None
+                eval_batch_logits = None
+                eval_batch_labels = None
+
+                nested_convert_func = nested_numpify if args.eval_numpify_tensors else nested_cpu
+
+                if inputs_decode is not None:
+                    eval_batch_inputs = nested_convert_func(inputs_decode)
+                if logits is not None:
+                    eval_batch_logits = nested_convert_func(logits)
+                if labels is not None:
+                    eval_batch_labels = nested_convert_func(labels)
+
+                eval_prediction = EvalPrediction(
+                    predictions=eval_batch_logits,
+                    label_ids=eval_batch_labels,
+                    inputs=eval_batch_inputs,
+                )
+
+                # update or compute metrics
+                do_compute_result = self.accelerator.gradient_state.end_of_dataloader
+                metrics = self.compute_metrics(eval_prediction, compute_result=do_compute_result)
 
             self.control = self.callback_handler.on_prediction_step(args, self.state, self.control)
-
-            if self.args.batch_eval_metrics:
-                if self.compute_metrics is not None and logits is not None and labels is not None:
-                    is_last_step = self.accelerator.gradient_state.end_of_dataloader
-                    if args.include_inputs_for_metrics:
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=logits, label_ids=labels, inputs=inputs),
-                            compute_result=is_last_step,
-                        )
-                    else:
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=logits, label_ids=labels),
-                            compute_result=is_last_step,
-                        )
-
-                del losses, logits, labels, inputs
-                torch.cuda.empty_cache()
-
-            # Gather all tensors and put them back on the CPU if we have done enough accumulation steps.
-            elif args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0:
-                all_losses.to_cpu_and_numpy()
-                all_preds.to_cpu_and_numpy()
-                all_labels.to_cpu_and_numpy()
-                all_inputs.to_cpu_and_numpy()
-
-                del losses, logits, labels, inputs
-                torch.cuda.empty_cache()
 
         # After all calls to `.gather_function`, reset to `gather_for_metrics`:
         self.gather_function = self.accelerator.gather_for_metrics
@@ -4034,11 +4057,11 @@ class Trainer:
             # Clean the state at the end of the evaluation loop
             delattr(self, "_past")
 
-        # Gather all remaining tensors and put them back on the CPU
-        all_losses = all_losses.get_arrays()
-        all_preds = all_preds.get_arrays()
-        all_labels = all_labels.get_arrays()
-        all_inputs = all_inputs.get_arrays()
+        # Get all collected tensors during the loop (all on CPU device)
+        all_losses = all_losses.get(to_numpy=args.eval_numpify_tensors)
+        all_preds = all_preds.get(to_numpy=args.eval_numpify_tensors)
+        all_labels = all_labels.get(to_numpy=args.eval_numpify_tensors)
+        all_inputs = all_inputs.get(to_numpy=args.eval_numpify_tensors)
 
         # Number of samples
         if has_length(eval_dataset):
@@ -4055,21 +4078,15 @@ class Trainer:
         if num_samples == 0 and observed_num_examples > 0:
             num_samples = observed_num_examples
 
-        # Metrics!
+        # Call compute metrics on epoch end only if we didn't compute them on each batch.
         if (
-            self.compute_metrics is not None
+            not args.batch_eval_metrics
+            and self.compute_metrics is not None
             and all_preds is not None
             and all_labels is not None
-            and not self.args.batch_eval_metrics
         ):
-            if args.include_inputs_for_metrics:
-                metrics = self.compute_metrics(
-                    EvalPrediction(predictions=all_preds, label_ids=all_labels, inputs=all_inputs)
-                )
-            else:
-                metrics = self.compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
-        elif metrics is None:
-            metrics = {}
+            eval_predictions = EvalPrediction(predictions=all_preds, label_ids=all_labels, inputs=all_inputs)
+            metrics = self.compute_metrics(eval_predictions)
 
         # To be JSON-serializable, we need to remove numpy types or zero-d tensors
         metrics = denumpify_detensorize(metrics)
@@ -4115,6 +4132,7 @@ class Trainer:
         inputs: Dict[str, Union[torch.Tensor, Any]],
         prediction_loss_only: bool,
         ignore_keys: Optional[List[str]] = None,
+        preserve_model_output: bool = False,
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
         Perform an evaluation step on `model` using `inputs`.
@@ -4134,10 +4152,12 @@ class Trainer:
             ignore_keys (`List[str]`, *optional*):
                 A list of keys in the output of your model (if it is a dictionary) that should be ignored when
                 gathering predictions.
+            preserve_model_output (`bool`, *optional*, defaults to `False`):
+                Whether to return the outputs of the model as `ModelOutput` objects, or to return the outputs unpacked as a tuple.
 
         Return:
-            Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]: A tuple with the loss,
-            logits and labels (each being optional).
+            Tuple[Optional[torch.Tensor], Optional[Union[torch.Tensor, Tuple[torch.Tensor], ModelOutput]], Optional[torch.Tensor]]:
+            A tuple with the loss, tuple of logits/model outputs and labels (each being optional).
         """
         has_labels = False if len(self.label_names) == 0 else all(inputs.get(k) is not None for k in self.label_names)
         # For CLIP-like models capable of returning loss values.
@@ -4165,23 +4185,23 @@ class Trainer:
 
         with torch.no_grad():
             if is_sagemaker_mp_enabled():
-                raw_outputs = smp_forward_only(model, inputs)
+                outputs = smp_forward_only(model, inputs)
                 if has_labels or loss_without_labels:
-                    if isinstance(raw_outputs, dict):
-                        loss_mb = raw_outputs["loss"]
-                        logits_mb = tuple(v for k, v in raw_outputs.items() if k not in ignore_keys + ["loss"])
+                    if isinstance(outputs, dict):
+                        loss_mb = outputs["loss"]
+                        logits_mb = tuple(v for k, v in outputs.items() if k not in ignore_keys + ["loss"])
                     else:
-                        loss_mb = raw_outputs[0]
-                        logits_mb = raw_outputs[1:]
+                        loss_mb = outputs[0]
+                        logits_mb = outputs[1:]
 
                     loss = loss_mb.reduce_mean().detach().cpu()
                     logits = smp_nested_concat(logits_mb)
                 else:
                     loss = None
-                    if isinstance(raw_outputs, dict):
-                        logits_mb = tuple(v for k, v in raw_outputs.items() if k not in ignore_keys)
+                    if isinstance(outputs, dict):
+                        logits_mb = tuple(v for k, v in outputs.items() if k not in ignore_keys)
                     else:
-                        logits_mb = raw_outputs
+                        logits_mb = outputs
                     logits = smp_nested_concat(logits_mb)
             else:
                 if has_labels or loss_without_labels:
@@ -4207,6 +4227,10 @@ class Trainer:
 
         if prediction_loss_only:
             return (loss, None, None)
+
+        if preserve_model_output:
+            outputs = nested_detach(outputs)
+            return (loss, outputs, labels)
 
         logits = nested_detach(logits)
         if len(logits) == 1:

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -249,6 +249,7 @@ class Seq2SeqTrainer(Trainer):
         inputs: Dict[str, Union[torch.Tensor, Any]],
         prediction_loss_only: bool,
         ignore_keys: Optional[List[str]] = None,
+        preserve_model_output: bool = False,
         **gen_kwargs,
     ) -> Tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
@@ -266,6 +267,8 @@ class Seq2SeqTrainer(Trainer):
                 argument `labels`. Check your model's documentation for all accepted arguments.
             prediction_loss_only (`bool`):
                 Whether or not to return the loss only.
+            preserve_model_output (`bool`, *optional*, defaults to `False`):
+                Whether to return the outputs of the model as `ModelOutput` objects, or to return the outputs unpacked as a tuple.
             gen_kwargs:
                 Additional `generate` specific kwargs.
 
@@ -276,7 +279,11 @@ class Seq2SeqTrainer(Trainer):
 
         if not self.args.predict_with_generate or prediction_loss_only:
             return super().prediction_step(
-                model, inputs, prediction_loss_only=prediction_loss_only, ignore_keys=ignore_keys
+                model,
+                inputs,
+                prediction_loss_only=prediction_loss_only,
+                ignore_keys=ignore_keys,
+                preserve_model_output=preserve_model_output,
             )
 
         has_labels = "labels" in inputs

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -706,6 +706,12 @@ class TrainingArguments:
         eval_do_concat_batches (`bool`, *optional*, defaults to `True`):
             Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`,
             will instead store them as lists, with each batch kept separate.
+        eval_preserve_model_output (`bool`, *optional*, defaults to `False`):
+            Whether to return the outputs of the model as `ModelOutput` objects during evaluation, or to return
+            the outputs unpacked as a tuple.
+        eval_numpify_tensors (`bool`, *optional*, defaults to `True`):
+            Whether to convert the tensors to numpy arrays before passing them to the `compute_metrics` function
+            and returning from `Trainer.evaluation_loop`.
         auto_find_batch_size (`bool`, *optional*, defaults to `False`)
             Whether to find a batch size that will fit into memory automatically through exponential decay, avoiding
             CUDA Out-of-Memory errors. Requires accelerate to be installed (`pip install accelerate`)
@@ -1357,6 +1363,18 @@ class TrainingArguments:
         default=True,
         metadata={
             "help": "Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`, will instead store them as lists, with each batch kept separate."
+        },
+    )
+    eval_preserve_model_output: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to return the outputs of the model as `ModelOutput` objects during evaluation, or to return the outputs unpacked as a tuple."
+        },
+    )
+    eval_numpify_tensors: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to convert the tensors to numpy arrays before passing them to the `compute_metrics` function and returning from `Trainer.evaluation_loop`."
         },
     )
     # Deprecated arguments

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -251,8 +251,8 @@ class AlmostAccuracyBatched:
         if isinstance(labels, tuple):
             labels = labels[0]
         batch_size = len(predictions)
-        true = torch.abs(predictions - labels) <= self.thresh
-        acc = true.type(torch.FloatTensor).mean().item()
+        true = np.abs(predictions - labels) <= self.thresh
+        acc = true.astype(np.float32).mean().item()
         self.batch_acc.extend([acc] * batch_size)
         if compute_result:
             result = {"accuracy": np.mean(self.batch_acc).item()}


### PR DESCRIPTION
# What does this PR do?

### Preserve `ModelOutput` for evaluation loop
**Motivation**: During the evaluation, the trainer returns tuples instead of `ModelOutput` objects, however, image_processors expect `ModelOutput` for the postprocessing of predictions. This significantly reduces the generalization of training scripts for different models of the same type.

**Solution**: Introduced training argument `eval_preserve_model_output`. If set to `True`, then `ModelOutput` objects are preserved and passed to `compute_metrics`, otherwise model outputs are converted to tuples. `False` by default for BC.


### Fix discrepancies in return type for `batch_eval_metrics`

Current `main` behavior:
- if `batch_eval_metrics=True` on **device** (e.g. GPU) torch tenors are passed to the `compute_metrics` function
- if `batch_eval_metrics=False` **CPU** numpy arrays are passed to the `compute_metrics` function

Suggested behavior:
- Tensors are always moved to the CPU
- If training argument `eval_numpify_tensors=True`, then tensors are converted to numpy arrays, otherwise returned as torch tensors (`True` by default for BC)

This change is breaking for `batch_eval_metrics=True` but in favor of making outputs consistent, `batch_eval_metrics` was introduced in #28769 (about a month ago), I guess we can still change its behavior.



## Who can review?
