### PR TITLE
Set ffmpeg_microphone input to system default on Darwin platform

### DIFF
--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -69,7 +69,7 @@ def ffmpeg_microphone(
         input_ = "default"
     elif system == "Darwin":
         format_ = "avfoundation"
-        input_ = ":0"
+        input_ = ":default"
     elif system == "Windows":
         format_ = "dshow"
         input_ = _get_microphone_name()


### PR DESCRIPTION
# What does this PR do?

Currently, the device index used for audio capture using ffmpeg_microphone is 0, which does not always work as expected. This PR sets the default audio capturing device on the Darwin platform to `:default` which is the ffmpeg supported way to do this.

Fixes #28154

There is no documentation or tests referencing ffmpeg_microphone so I did not update any of it.

I have created a local small test (similar to the [voice assistant tutorial](https://huggingface.co/learn/audio-course/chapter7/voice-assistant) to prove that switching between external mic (airpods) and Mac audio capture works ok.
```
from transformers.pipelines.audio_utils import ffmpeg_microphone_live, ffmpeg_microphone
from transformers import pipeline
import sys
import torch

device = "cuda:0" if torch.cuda.is_available() else "cpu"
transcriber = pipeline(
    "automatic-speech-recognition", model="openai/whisper-small.en", device=device
)

def transcribe(chunk_length_s=15.0, stream_chunk_s=1.5):
    sampling_rate = transcriber.feature_extractor.sampling_rate

    mic = ffmpeg_microphone_live(
        sampling_rate=sampling_rate,
        chunk_length_s=chunk_length_s,
        stream_chunk_s=stream_chunk_s,
    )

    print("Start speaking...")
    for item in transcriber(mic, generate_kwargs={"max_new_tokens": 2048}):
        sys.stdout.write("\033[K")
        print(item["text"], end="\r")
        if not item["partial"][0]:
            break

    return item["text"]

if __name__ == "__main__":
    transcribe()
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ylacombe @Narsil 

