### PR TITLE
Add  AutoRound quantization support

### DIFF
--- a/docs/source/en/main_classes/quantization.md
+++ b/docs/source/en/main_classes/quantization.md
@@ -56,3 +56,7 @@ Learn how to quantize models in the [Quantization](../quantization) guide.
 ## HqqConfig
 
 [[autodoc]] HqqConfig
+
+## AutoRoundConfig
+
+[[autodoc]] AutoRoundConfig

--- a/docs/source/en/quantization/autoround.md
+++ b/docs/source/en/quantization/autoround.md
@@ -1,0 +1,92 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# AutoRound
+Make sure you have auto-round installed:
+
+```bash
+pip install auto-round
+```
+
+
+AutoRound supports various backends, including AutoRound, QBits (primarily for x86 CPUs), and GPTQ. Please note that models using the GPTQ backend cannot switch to other backends due to differences in packing.
+
+
+## AutoRound Backend
+This backend primarily reuses the AutoGPTQ kernel but addresses the asymmetry accuracy drop issue.
+
+
+
+
+## Exllamav2
+To use the backend, please install auto-round from source, otherwise it will switch to triton backend automatically. Only supports 4 bits.
+```bash
+git clone https://github.com/intel/auto-round.git
+cd auto-round && pip install -vvv --no-build-isolation -e .
+```
+
+## Triton
+Supports 2,4,8 bits
+
+## Example
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+model_name = "Intel/Qwen2-7B-int4-inc"
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+text = "There is a girl who likes adventure,"
+inputs = tokenizer(text, return_tensors="pt").to(model.device)
+print(tokenizer.decode(model.generate(**inputs, max_new_tokens=50, do_sample=False)[0]))
+```
+
+
+# Qbits backend
+This backend is for CPU, mainly for Intel CPU. It supports 2,4,8 bits
+Please install intel-extension-for-transformers first
+```bash
+pip3 install intel-extension-for-transformers
+```
+## Example
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+model_name = "Intel/Qwen2-7B-int4-inc"
+from transformers import AutoRoundConfig
+quantization_config = AutoRoundConfig(
+   backend="cpu"
+)
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cpu",quantization_config=quantization_config)
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+text = "There is a girl who likes adventure,"
+inputs = tokenizer(text, return_tensors="pt").to(model.device)
+print(tokenizer.decode(model.generate(**inputs, max_new_tokens=50, do_sample=False)[0]))
+```
+
+# GPTQ backend
+Support 2,4,8 bits
+Please install auto-gptq first
+```bash
+pip3 install auto-gptq
+```
+## Example
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+model_name = "Intel/Mistral-7B-v0.1-int4-inc-lmhead"
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+text = "There is a girl who likes adventure,"
+inputs = tokenizer(text, return_tensors="pt").to(model.device)
+print(tokenizer.decode(model.generate(**inputs, max_new_tokens=50, do_sample=False)[0]))
+```

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -912,6 +912,7 @@ _import_structure = {
     ],
     "utils.quantization_config": [
         "AqlmConfig",
+        "AutoRoundConfig",
         "AwqConfig",
         "BitsAndBytesConfig",
         "EetqConfig",
@@ -5558,6 +5559,7 @@ if TYPE_CHECKING:
     # bitsandbytes config
     from .utils.quantization_config import (
         AqlmConfig,
+        AutoRoundConfig,
         AwqConfig,
         BitsAndBytesConfig,
         EetqConfig,

--- a/src/transformers/integrations/__init__.py
+++ b/src/transformers/integrations/__init__.py
@@ -18,8 +18,10 @@ from ..utils import _LazyModule
 
 _import_structure = {
     "aqlm": ["replace_with_aqlm_linear"],
-    "autoround": ["convert_auto_round_model",
-                  "post_init_auto_round_model"],
+    "autoround": [
+        "convert_auto_round_model",
+        "post_init_auto_round_model",
+    ],
     "awq": [
         "fuse_awq_modules",
         "post_init_awq_exllama_modules",

--- a/src/transformers/integrations/__init__.py
+++ b/src/transformers/integrations/__init__.py
@@ -18,6 +18,8 @@ from ..utils import _LazyModule
 
 _import_structure = {
     "aqlm": ["replace_with_aqlm_linear"],
+    "autoround": ["convert_auto_round_model",
+                  "post_init_auto_round_model"],
     "awq": [
         "fuse_awq_modules",
         "post_init_awq_exllama_modules",
@@ -99,6 +101,10 @@ _import_structure = {
 
 if TYPE_CHECKING:
     from .aqlm import replace_with_aqlm_linear
+    from .autoround import (
+        convert_auto_round_model,
+        post_init_auto_round_model,
+    )
     from .awq import (
         fuse_awq_modules,
         post_init_awq_exllama_modules,

--- a/src/transformers/integrations/autoround.py
+++ b/src/transformers/integrations/autoround.py
@@ -1,0 +1,183 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Union
+
+from ..modeling_utils import Conv1D
+from ..utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+    import torch.nn as nn
+
+
+def get_module(module, key):
+    """Get module from model by key name.
+
+    Args:
+        module (torch.nn.Module): original model
+        key (str): module name to be replaced
+    """
+    name_list = key.split(".")
+    for name in name_list:
+        module = getattr(module, name, None)
+    return module
+
+
+def set_module(model, key, new_module):
+    """Set new module into model by key name.
+
+    Args:
+        model (torch.nn.Module): original model
+        key (str): module name to be replaced
+        new_module (torch.nn.Module): new module to be inserted
+    """
+    module = model
+    name_list = key.split(".")
+    for name in name_list[:-1]:
+        if hasattr(module, name):
+            module = getattr(module, name)
+    setattr(module, name_list[-1], new_module)
+
+
+def convert_auto_round_model(model: nn.Module, quantization_config):
+    """Convert the model to an AutoRound model by getting and replacing the layers.
+
+    Args:
+        model (`nn.Module`):
+            Model to be converted
+        quantization_config:
+            Configuration settings for quantization.
+    """
+    from auto_round.utils import get_layer_names_in_block
+
+    layer_names = get_layer_names_in_block(model)
+    bits = quantization_config.bits
+    group_size = quantization_config.group_size
+    data_type = quantization_config.data_type
+    sym = quantization_config.sym
+    extra_config = {}
+    if hasattr(quantization_config, "extra_config"):
+        extra_config = quantization_config.extra_config
+    layer_names += extra_config.keys()
+    layer_names = list(set(layer_names))
+    layer_configs = {}
+    for layer_name in layer_names:
+        layer_configs[layer_name] = {}
+        if layer_name not in extra_config:
+            layer_configs[layer_name]["bits"] = bits
+            layer_configs[layer_name]["group_size"] = group_size
+            layer_configs[layer_name]["data_type"] = data_type
+            layer_configs[layer_name]["sym"] = sym
+        else:
+            layer_configs[layer_name]["bits"] = extra_config[layer_name].get("bits", bits)
+            layer_configs[layer_name]["group_size"] = extra_config[layer_name].get("group_size", group_size)
+            layer_configs[layer_name]["data_type"] = extra_config[layer_name].get("data_type", data_type)
+            layer_configs[layer_name]["sym"] = extra_config[layer_name].get("sym", sym)
+    backend = quantization_config.backend
+    _replace_by_quant_layers(model, layer_configs, backend)
+    return model
+
+
+def get_device(obj: Union[torch.Tensor, nn.Module]):
+    """Returns the device of a given tensor or module.
+
+    Args:
+        obj (Union[torch.Tensor, nn.Module]):
+            The tensor or module for which to determine the device.
+
+    Returns:
+        torch.device:
+            The device on which the tensor or module resides.
+
+    Raises:
+        TypeError:
+            If the input is neither a torch.Tensor nor an nn.Module.
+    """
+    if isinstance(obj, torch.Tensor):
+        return obj.device
+    return next(obj.parameters()).device
+
+
+def _replace_by_quant_layers(module: nn.Module, layer_configs, backend):
+    """Replaces linear layers in `module` by `QuantLinear`
+
+    Args: module (nn.Module): The module containing layers to be quantized. layer_configs (dict): A dictionary
+    containing configuration parameters for the quantization of specific layers. Keys are the names of the layers,
+    and values are configuration parameters. backend (str): The backend to be used for the quantization process.
+
+    Returns:
+        nn.Module:
+            The modified module with linear layers replaced by `QuantLinear` layers.
+
+    """
+    from auto_round.utils import dynamic_import_inference_linear
+
+    for layer_name in layer_configs.keys():
+        config = layer_configs[layer_name]
+        bits = config["bits"]
+        group_size = config["group_size"]
+        if not (bits <= 8):
+            continue
+
+        layer = get_module(module, layer_name)
+        device = get_device(layer)
+        QuantLinear = dynamic_import_inference_linear(bits, group_size, backend)
+        if isinstance(layer, nn.Linear):
+            in_features = layer.in_features
+            out_features = layer.out_features
+        elif isinstance(layer, Conv1D):
+            in_features = layer.weight.shape[0]
+            out_features = layer.weight.shape[1]
+        bias = layer.bias is not None
+        new_layer = QuantLinear(
+            bits,
+            group_size,
+            in_features,
+            out_features,
+            bias,
+            weight_dtype=layer.weight.dtype,
+        )
+
+        new_layer.device = device
+        set_module(module, layer_name, new_layer)
+
+
+def qbits_post_init(model):
+    dep_check = True
+    import auto_round_extension.qbits.qlinear_qbits as qlinear_qbits
+
+    for layer in model.modules():
+        if isinstance(layer, qlinear_qbits.QuantLinear):
+            if dep_check:
+                layer.req_check()
+            layer.post_init()
+            dep_check = False
+    return model
+
+
+def post_init_auto_round_model(model):
+    """Post-initialization that require device information, for example buffers initialization on device.
+
+    Args:
+        model (`nn.Module`):
+            The input model
+    """
+    from auto_round_extension.cuda.post_init import autoround_post_init
+
+    model = autoround_post_init(model)
+    # there are no side-effects after call qbits_post_init when model quant-type not equal to qbits.
+    model = qbits_post_init(model)
+
+    return model

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -17,6 +17,7 @@ from typing import Dict, Optional, Union
 from ..models.auto.configuration_auto import AutoConfig
 from ..utils.quantization_config import (
     AqlmConfig,
+    AutoRoundConfig,
     AwqConfig,
     BitsAndBytesConfig,
     EetqConfig,
@@ -27,6 +28,7 @@ from ..utils.quantization_config import (
     QuantoConfig,
 )
 from .quantizer_aqlm import AqlmHfQuantizer
+from .quantizer_auto_round import AutoRoundQuantizer
 from .quantizer_awq import AwqQuantizer
 from .quantizer_bnb_4bit import Bnb4BitHfQuantizer
 from .quantizer_bnb_8bit import Bnb8BitHfQuantizer
@@ -45,6 +47,7 @@ AUTO_QUANTIZER_MAPPING = {
     "quanto": QuantoHfQuantizer,
     "eetq": EetqHfQuantizer,
     "hqq": HqqHfQuantizer,
+    "intel/auto-round": AutoRoundQuantizer,
 }
 
 AUTO_QUANTIZATION_CONFIG_MAPPING = {
@@ -56,6 +59,7 @@ AUTO_QUANTIZATION_CONFIG_MAPPING = {
     "aqlm": AqlmConfig,
     "quanto": QuantoConfig,
     "hqq": HqqConfig,
+    "intel/auto-round": AutoRoundConfig,
 }
 
 
@@ -156,7 +160,7 @@ class AutoHfQuantizer:
         if isinstance(quantization_config, dict):
             quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
 
-        if isinstance(quantization_config, (GPTQConfig, AwqConfig)) and quantization_config_from_args is not None:
+        if isinstance(quantization_config, (GPTQConfig, AwqConfig, AutoRoundConfig)) and quantization_config_from_args is not None:
             # special case for GPTQ / AWQ config collision
             loading_attr_dict = quantization_config_from_args.get_loading_attributes()
             for attr, val in loading_attr_dict.items():

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -160,7 +160,10 @@ class AutoHfQuantizer:
         if isinstance(quantization_config, dict):
             quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
 
-        if isinstance(quantization_config, (GPTQConfig, AwqConfig, AutoRoundConfig)) and quantization_config_from_args is not None:
+        if (
+            isinstance(quantization_config, (GPTQConfig, AwqConfig, AutoRoundConfig))
+            and quantization_config_from_args is not None
+        ):
             # special case for GPTQ / AWQ config collision
             loading_attr_dict = quantization_config_from_args.get_loading_attributes()
             for attr, val in loading_attr_dict.items():

--- a/src/transformers/quantizers/quantizer_auto_round.py
+++ b/src/transformers/quantizers/quantizer_auto_round.py
@@ -1,0 +1,80 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import importlib
+from typing import TYPE_CHECKING
+
+from packaging import version
+
+from .base import HfQuantizer
+
+
+if TYPE_CHECKING:
+    from ..modeling_utils import PreTrainedModel
+
+from ..utils import is_auto_round_available, is_torch_available, logging
+
+
+if is_torch_available():
+    import torch
+
+logger = logging.get_logger(__name__)
+
+
+class AutoRoundQuantizer(HfQuantizer):
+    """
+    Optimize Weight Rounding via Signed Gradient Descent for the Quantization of LLMs (https://arxiv.org/abs/2309.05516)
+    """
+
+    # AutoRound requires data calibration - we support only inference
+    requires_calibration = True
+
+    required_packages = ["auto-round", "accelerate"]
+
+    def __init__(self, quantization_config, **kwargs):
+        super().__init__(quantization_config, **kwargs)
+
+    def validate_environment(self, device_map, **kwargs):
+        if not is_auto_round_available():
+            raise ImportError(
+                "Loading an AUTOROUND quantized model requires auto-round library (`pip install auto-round`)"
+            )
+        elif version.parse(importlib.metadata.version("auto_round")) <= version.parse("0.2.0"):
+            raise ImportError(
+                "You need a version of auto_round > 0.2.0 to use AutoRound: `pip install --upgrade auto-round`"
+            )
+
+    def update_torch_dtype(self, torch_dtype):
+        if torch_dtype is None:
+            torch_dtype = torch.float16
+        elif torch_dtype != torch.float16:
+            logger.warning("We suggest you to set `torch_dtype=torch.float16` for better efficiency with AutoRound.")
+        return torch_dtype
+
+    def _process_model_before_weight_loading(self, model: "PreTrainedModel", **kwargs):
+        from ..integrations import convert_auto_round_model
+
+        model = convert_auto_round_model(model, self.quantization_config)
+
+    def _process_model_after_weight_loading(self, model):
+        from ..integrations import post_init_auto_round_model
+
+        model = post_init_auto_round_model(model)
+
+    @property
+    def is_serializable(self):
+        return True
+
+    @property
+    def is_trainable(self):
+        return True

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -58,6 +58,7 @@ from .utils import (
     is_aqlm_available,
     is_auto_awq_available,
     is_auto_gptq_available,
+    is_auto_round_available,
     is_av_available,
     is_bitsandbytes_available,
     is_bs4_available,
@@ -1107,6 +1108,13 @@ def require_auto_awq(test_case):
     Decorator for auto_awq dependency
     """
     return unittest.skipUnless(is_auto_awq_available(), "test requires autoawq")(test_case)
+
+
+def require_auto_round(test_case):
+    """
+    Decorator for auto_round dependency
+    """
+    return unittest.skipUnless(is_auto_round_available(), "test requires auto-round")(test_case)
 
 
 def require_quanto(test_case):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -113,6 +113,7 @@ from .import_utils import (
     is_aqlm_available,
     is_auto_awq_available,
     is_auto_gptq_available,
+    is_auto_round_available,
     is_av_available,
     is_bitsandbytes_available,
     is_bs4_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -134,6 +134,7 @@ _onnx_available = _is_package_available("onnx")
 _openai_available = _is_package_available("openai")
 _optimum_available = _is_package_available("optimum")
 _auto_gptq_available = _is_package_available("auto_gptq")
+_auto_round_available = _is_package_available("auto_round")
 # `importlib.metadata.version` doesn't work with `awq`
 _auto_awq_available = importlib.util.find_spec("awq") is not None
 _quanto_available = _is_package_available("quanto")
@@ -865,6 +866,10 @@ def is_quanto_available():
 
 def is_auto_gptq_available():
     return _auto_gptq_available
+
+
+def is_auto_round_available():
+    return _auto_round_available
 
 
 def is_eetq_available():

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -290,6 +290,7 @@ class HqqConfig(QuantizationConfigMixin):
 
         return serializable_config_dict
 
+
 @dataclass
 class AutoRoundConfig(QuantizationConfigMixin):
     """

--- a/tests/quantization/autoround/test_autoround.py
+++ b/tests/quantization/autoround/test_autoround.py
@@ -1,0 +1,116 @@
+import gc
+import tempfile
+import unittest
+
+from transformers import AutoModelForCausalLM, AutoRoundConfig, AutoTokenizer
+from transformers.testing_utils import (
+    require_accelerate,
+    require_auto_gptq,
+    require_auto_round,
+    require_torch_gpu,
+    require_torch_multi_gpu,
+    slow,
+    torch_device,
+)
+from transformers.utils import is_torch_available
+
+
+if is_torch_available():
+    import torch
+
+
+@slow
+@require_torch_gpu
+@require_auto_round
+@require_auto_gptq
+@require_accelerate
+class AutoRoundTestGPTQKernel(unittest.TestCase):
+    model_name = "Intel/Mistral-7B-v0.1-int4-inc-lmhead"
+    input_text = "There is a girl who likes adventure,"
+
+    EXPECTED_OUTPUT = "There is a girl who likes adventure, and she is a little bit crazy. She is a little bit crazy because she likes to do things that are dangerous. She likes to climb mountains, and she likes to swim in the ocean. She"
+
+    device_map = "cuda"
+
+    # called only once for all test in this class
+    @classmethod
+    def setUpClass(cls):
+        """
+        Setup quantized model
+        """
+        torch.cuda.synchronize()
+        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
+        cls.quantized_model = AutoModelForCausalLM.from_pretrained(
+            cls.model_name, device_map=cls.device_map, torch_dtype=torch.float16
+        )
+
+    def tearDown(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+        gc.collect()
+
+    def test_quantized_model(self):
+        """
+        Simple test that checks if the quantized model is working properly
+        """
+        input_ids = self.tokenizer(self.input_text, return_tensors="pt").to(torch_device)
+        output = self.quantized_model.generate(**input_ids, max_new_tokens=40, do_sample=False)
+        self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+
+    def test_raise_if_non_quantized(self):
+        model_id = "facebook/opt-125m"
+        quantization_config = AutoRoundConfig(bits=4)
+        with self.assertRaises(ValueError):
+            _ = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=quantization_config)
+
+    def test_quantized_model_bf16(self):
+        """
+        Simple test that checks if the quantized model is working properly with bf16
+        """
+        input_ids = self.tokenizer(self.input_text, return_tensors="pt").to(torch_device)
+
+        quantized_model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype=torch.bfloat16).to(
+            torch_device
+        )
+
+        output = quantized_model.generate(**input_ids, max_new_tokens=40)
+        self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+
+    def test_quantized_model_no_device_map(self):
+        """
+        Simple test that checks if the quantized model is working properly
+        """
+        input_ids = self.tokenizer(self.input_text, return_tensors="pt").to(torch_device)
+
+        quantized_model = AutoModelForCausalLM.from_pretrained(self.model_name).to(torch_device)
+        output = quantized_model.generate(**input_ids, max_new_tokens=40)
+
+        self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+
+    #
+    def test_save_pretrained(self):
+        """
+        Simple test that checks if the quantized model is working properly after being saved and loaded
+        """
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.quantized_model.save_pretrained(tmpdirname)
+            model = AutoModelForCausalLM.from_pretrained(tmpdirname, device_map=self.device_map)
+
+            input_ids = self.tokenizer(self.input_text, return_tensors="pt").to(torch_device)
+
+            output = model.generate(**input_ids, max_new_tokens=40)
+            self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+
+    #
+    @require_torch_multi_gpu
+    def test_quantized_model_multi_gpu(self):
+        """
+        Simple test that checks if the quantized model is working properly with multiple GPUs
+        """
+        input_ids = self.tokenizer(self.input_text, return_tensors="pt").to(torch_device)
+
+        quantized_model = AutoModelForCausalLM.from_pretrained(self.model_name, device_map="auto")
+
+        output = quantized_model.generate(**input_ids, max_new_tokens=40)
+
+        self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)


### PR DESCRIPTION
This PR is intended to add support for AutoRound quantizer to the transformers library.
Paper  https://arxiv.org/abs/2309.05516
Git https://github.com/intel/auto-round

AutoRound supports mixed group size and bit-width quantization, as well as qbits kernels for CPU inference.

Currently, AutoRound needs to be installed from the source. We will address your concerns and release a new version before merging