### PR TITLE
[tests] rename `test_config_object` to `test_ds_config_object`

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -891,7 +891,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
             self.assertEqual(b, b1)
             self.check_trainer_state_are_the_same(state, state1)
 
-    def test_config_object(self):
+    def test_ds_config_object(self):
         # test that we can switch from zero2 to zero3 in the same process for example
         # test is_zero, etc.
         output_dir = self.get_auto_remove_tmp_dir()


### PR DESCRIPTION
# What does this PR do?
`test_config` is a common test name for many models and is identified as `NOT_DEVICE_TESTS` in the [conftest.py](https://github.com/faaany/transformers/blob/main/conftest.py#L44)). So when users use the test marker `not_device_test` to run the test suit, `tests/deepspeed/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_config_object` will be skipped. But `test_config_object` is not a CPU-only UT and should not be skipped. Can we rename it to `test_ds_config_object`? 

@amyeroberts and @ydshieh 
