### PR TITLE
Improve `PreTrainedTokenizerFast` loading time when there are many added tokens

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -173,7 +173,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         # uses the information stored in `added_tokens_decoder`.
         # this is costly for fast tokenizers as we re-compute the regex again. But not all tokens are added tokens
         # Use hash to speed up the very slow operation `token not in added_tokens_decoder`.
-        added_tokens_decoder_hash = set(hash(token) for token in self.added_tokens_decoder)
+        added_tokens_decoder_hash = {hash(token) for token in self.added_tokens_decoder}
         tokens_to_add = [
             token
             for index, token in sorted(added_tokens_decoder.items(), key=lambda x: x[0])

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -173,11 +173,11 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         # uses the information stored in `added_tokens_decoder`.
         # this is costly for fast tokenizers as we re-compute the regex again. But not all tokens are added tokens
         # Use hash to speed up the very slow operation `token not in added_tokens_decoder`.
-        added_tokens_decoder_hash = {hash(token) for token in self.added_tokens_decoder}
+        added_tokens_decoder_hash = {hash(repr(token)) for token in self.added_tokens_decoder}
         tokens_to_add = [
             token
             for index, token in sorted(added_tokens_decoder.items(), key=lambda x: x[0])
-            if hash(token) not in added_tokens_decoder_hash
+            if hash(repr(token)) not in added_tokens_decoder_hash
         ]
         encoder = list(self.added_tokens_encoder.keys()) + [str(token) for token in tokens_to_add]
         # if some of the special tokens are strings, we check if we don't already have a token

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -172,10 +172,12 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         # allows converting a slow -> fast, non-legacy: if the `tokenizer.json` does not have all the added tokens
         # uses the information stored in `added_tokens_decoder`.
         # this is costly for fast tokenizers as we re-compute the regex again. But not all tokens are added tokens
+        # Use hash to speed up the very slow operation `token not in added_tokens_decoder`.
+        added_tokens_decoder_hash = set(hash(token) for token in self.added_tokens_decoder)
         tokens_to_add = [
             token
             for index, token in sorted(added_tokens_decoder.items(), key=lambda x: x[0])
-            if token not in self.added_tokens_decoder
+            if hash(token) not in added_tokens_decoder_hash
         ]
         encoder = list(self.added_tokens_encoder.keys()) + [str(token) for token in tokens_to_add]
         # if some of the special tokens are strings, we check if we don't already have a token


### PR DESCRIPTION
# What does this PR do?

The condition check

> token not in self.added_tokens_decoder

is very slow, especially when there are more added tokens.


## Loading time (see code snippet below): 2048 added tokens

### before this PR:
3.909789 seconds

### after this PR: 
0.23008 seconds

```
from transformers import AutoProcessor, XLMRobertaTokenizerFast, XLMRobertaTokenizer, AutoTokenizer, PreTrainedTokenizerFast

import datetime

ckpt = "ydshieh/dummy_tok"
s = datetime.datetime.now()
p = XLMRobertaTokenizerFast.from_pretrained("my_p")
e = datetime.datetime.now()
print((e-s).total_seconds())


```