### PR TITLE
Fix Bark logits processors device misplacement

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -991,11 +991,11 @@ class BarkSemanticModel(BarkCausalModel):
             list(range(semantic_generation_config.semantic_pad_token + 1, self.config.output_vocab_size))
         )
 
-        suppress_tokens_logits_processor = SuppressTokensLogitsProcessor(tokens_to_suppress)
+        suppress_tokens_logits_processor = SuppressTokensLogitsProcessor(tokens_to_suppress, device=input_ids.device)
 
         min_eos_p = kwargs.get("min_eos_p", semantic_generation_config.min_eos_p)
         early_stopping_logits_processor = BarkEosPrioritizerLogitsProcessor(
-            eos_token_id=semantic_generation_config.eos_token_id, min_eos_p=min_eos_p
+            eos_token_id=semantic_generation_config.eos_token_id, min_eos_p=min_eos_p, device=input_ids.device
         )
 
         # pass input_ids in order to stay consistent with the transformers generate method even though it is not used


### PR DESCRIPTION
# What does this PR do?
Fix some Bark failing tests where the logits processors' tensors were misplaced on CPU!
It was introduced by #29804 but not flagged because of the Bark custom generation!

Slow tests are now all green on a A100!

cc @ydshieh and @amyeroberts  