### PR TITLE
Pin datasets<2.20.0 for examples

### DIFF
--- a/examples/flax/_tests_requirements.txt
+++ b/examples/flax/_tests_requirements.txt
@@ -1,4 +1,4 @@
-datasets >= 1.1.3
+datasets >= 1.13.3,<2.20.0 # Temporary upper version
 pytest<8.0.1
 conllu
 nltk

--- a/examples/pytorch/_tests_requirements.txt
+++ b/examples/pytorch/_tests_requirements.txt
@@ -13,7 +13,7 @@ streamlit
 elasticsearch
 nltk
 pandas
-datasets >= 1.13.3
+datasets >= 1.13.3,<2.20.0 # Temporary upper version
 fire
 pytest<8.0.1
 conllu

--- a/examples/tensorflow/_tests_requirements.txt
+++ b/examples/tensorflow/_tests_requirements.txt
@@ -14,7 +14,7 @@ streamlit
 elasticsearch
 nltk
 pandas
-datasets >= 1.13.3
+datasets >= 1.13.3,<2.20.0 # Temporary upper version
 fire
 pytest<8.0.1
 conllu


### PR DESCRIPTION
# What does this PR do?

Temporarily pin datasets upper version until PR merged:

https://github.com/huggingface/transformers/pull/31406

c.f. #31407 


