### PR TITLE
Set seed for M4T retain grad test

### DIFF
--- a/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
@@ -612,11 +612,11 @@ class SeamlessM4TModelWithSpeechInputTest(ModelTesterMixin, unittest.TestCase):
                 [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
             )
 
-    @unittest.skip(
-        reason="In training model, the first speech encoder layer is sometimes skipped. Training is not supported yet, so the test is ignored."
-    )
     def test_retain_grad_hidden_states_attentions(self):
-        pass
+        # When training the model, the first speech encoder layer is sometimes skipped.
+        # Setting the seed to always have the first layer.
+        set_seed(0)
+        super().test_retain_grad_hidden_states_attentions()
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

The speech encoder attentions of M4T can be None with a non-zero probability when training=True. Instead of skipping the test, this PR fixes the seed so that the first layer is never skipped: `test_retain_grad_hidden_states_attentions`.

I've ran it multiple times and it passed every time. 

cc @amyeroberts 

Fixes #28036