### PR TITLE
Make CI failure summary more useful

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -179,17 +179,17 @@ class CircleCIJob:
             command = f'echo {tests} | tr " " "\\n" >> tests.txt'
             steps.append({"run": {"name": "Get tests", "command": command}})
 
-            command = 'TESTS=$(circleci tests split tests.txt) && echo $TESTS > splitted_tests.txt'
+            command = 'TESTS=$(circleci tests split tests.txt) && echo $TESTS > split_tests.txt'
             steps.append({"run": {"name": "Split tests", "command": command}})
 
             steps.append({"store_artifacts": {"path": "tests.txt"}})
-            steps.append({"store_artifacts": {"path": "splitted_tests.txt"}})
+            steps.append({"store_artifacts": {"path": "split_tests.txt"}})
 
             test_command = ""
             if self.command_timeout:
                 test_command = f"timeout {self.command_timeout} "
             test_command += f"python3 -m pytest -rsfE -p no:warnings --tb=short  -o junit_family=xunit1 --junitxml=test-results/junit.xml -n {self.pytest_num_workers} " + " ".join(pytest_flags)
-            test_command += " $(cat splitted_tests.txt)"
+            test_command += " $(cat split_tests.txt)"
         if self.marker is not None:
             test_command += f" -m {self.marker}"
 

--- a/.circleci/parse_test_outputs.py
+++ b/.circleci/parse_test_outputs.py
@@ -1,5 +1,6 @@
 import re
 import argparse
+from collections import Counter
 
 def parse_pytest_output(file_path):
     skipped_tests = {}
@@ -24,9 +25,17 @@ def parse_pytest_failure_output(file_path):
             if match:
                 failed_count += 1
                 test_name, error, reason = match.groups()
-                failed_tests[test_name] = [reason, error]
+                failed_tests[test_name] = (reason, error)
+
+
+    print("Failures:")
     for test_name, (reason, error) in failed_tests.items():
         print(f"{test_name} failed because `{error}` -> {reason}")
+
+    print("\nSummary:")
+    fail_counts = Counter(failed_tests.values())
+    for (reason, error), count in sorted(fail_counts.items(), key=lambda x:x[1], reverse=True):
+        print(f"{count:4} failed because of `{error}` -> {reason}")
     print("Number of failed tests:", failed_count)
     if failed_count>0:
         exit(1)

--- a/.circleci/parse_test_outputs.py
+++ b/.circleci/parse_test_outputs.py
@@ -23,10 +23,10 @@ def parse_pytest_failure_output(file_path):
             match = re.match(r'^FAILED (tests/.*) - (.*): (.*)$', line)
             if match:
                 failed_count += 1
-                _, error, reason = match.groups()
-                failed_tests[reason] = failed_tests.get(reason, []) + [error]
-    for k,v in sorted(failed_tests.items(), key=lambda x:len(x[1])):
-        print(f"{len(v):4} failed because `{v[0]}` -> {k}")
+                test_name, error, reason = match.groups()
+                failed_tests[test_name] = [reason, error]
+    for test_name, (reason, error) in failed_tests.items():
+        print(f"{test_name} failed because `{error}` -> {reason}")
     print("Number of failed tests:", failed_count)
     if failed_count>0:
         exit(1)


### PR DESCRIPTION
# What does this PR do?


The current 'Failed Tests' summary output of tests isn't useful e.g. here: https://app.circleci.com/pipelines/github/huggingface/transformers/95692/workflows/2c1a2ff4-1182-46f4-b331-33d9fdb0a2c4/jobs/1260625

Output:
```   
1 failed because `AssertionError` -> torch.Size([1, 512, 37890]) != (1, 512, 1026)
2 failed because `AssertionError` -> False is not true
Number of failed tests: 3
```

As: 
* There is no record of the test which have failed. This means, to address failing tests, one still needs to go the main test output and parse yourself
* Without the test name messages like: "`AssertionError` -> False is not true" is not informative (pretty much all tests fail this way) 

Additional nit: "splitted" isn't a word. splitted -> split

Example of an updated output [for this run](https://app.circleci.com/pipelines/github/huggingface/transformers/95689/workflows/106ed803-3f9a-41d4-b6db-709929cc7db9/jobs/1260576): 

```
tests/models/mask2former/test_image_processing_mask2former.py::Mask2FormerImageProcessingTest::test_call_numpy failed because `AssertionError: Tuples differ` -> (1, 3, 32, 91) != (1, 3, 4032, 32)
tests/models/mask2former/test_image_processing_mask2former.py::Mask2FormerImageProcessingTest::test_call_numpy_4_channels failed because `AssertionError: Tuples differ` -> (1, 4, 32, 32) != (1, 4, 1320, 32)
tests/models/swin2sr/test_image_processing_swin2sr.py::Swin2SRImageProcessingTest::test_call_numpy failed because `AssertionError: Tuples differ` -> (1, 3, 136, 384) != (1, 3, 384, 8)
tests/models/swin2sr/test_image_processing_swin2sr.py::Swin2SRImageProcessingTest::test_call_numpy_4_channels failed because `AssertionError: Tuples differ` -> (1, 266, 104, 8) != (1, 4, 104, 8)
tests/models/yolos/test_image_processing_yolos.py::YolosImageProcessingTest::test_call_numpy failed because `AssertionError: Tuples differ` -> (1, 3, 16, 48) != (1, 3, 1376, 0)
tests/models/yolos/test_image_processing_yolos.py::YolosImageProcessingTest::test_call_numpy_4_channels failed because `AssertionError: Tuples differ` -> (1, 4, 48, 16) != (1, 4, 432, 16)
tests/models/vit/test_image_processing_vit.py::ViTImageProcessingTest::test_fast_is_faster_than_slow failed because `AssertionError` -> 0.003969907760620117 not less than or equal to 0.003456274668375651
tests/models/idefics2/test_image_processing_idefics2.py::Idefics2ImageProcessingTest::test_call_numpy_4_channels failed because `TypeError: Cannot handle this data type` -> (1, 1, 157), |u1
```

