### PR TITLE
Generate: fix `tokenizer` being popped twice

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1640,8 +1640,6 @@ class GenerationMixin:
             else:
                 synced_gpus = False
 
-        tokenizer = kwargs.pop("tokenizer", None)
-
         logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
         stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
 


### PR DESCRIPTION
# What does this PR do?

See title :) Because the tokenizer was popped twice from `kwargs` in `generate`, the example [here](https://huggingface.co/docs/transformers/internal/generation_utils#transformers.StopStringCriteria) was failing -- `tokenizer` was `None` even when it was passed.

Found while replying to https://github.com/huggingface/transformers/issues/26959