### PR TITLE
Install the tensorflow example requirements in docker

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -155,7 +155,7 @@ class CircleCIJob:
                     elif self.name in ["flax","torch","tf"]:
                         name = self.name if self.name != "torch" else ""
                         if self.name == "torch":
-                            all_tests = glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True) 
+                            all_tests = glob.glob(f"tests/models/**/test_modeling_{name}*.py", recursive=True)
                             filtered = [k for k in all_tests if ("_tf_") not in k and "_flax_" not in k]
                             expanded_tests.extend(filtered)
                         else:
@@ -163,7 +163,7 @@ class CircleCIJob:
                     else:
                         expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 elif test == "tests/pipelines":
-                    expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True)) 
+                    expanded_tests.extend(glob.glob("tests/models/**/test_modeling*.py", recursive=True))
                 else:
                     expanded_tests.append(test)
             tests = " ".join(expanded_tests)
@@ -326,7 +326,7 @@ examples_tensorflow_job = CircleCIJob(
     "examples_tensorflow",
     cache_name="tensorflow_examples",
     docker_image=[{"image":"huggingface/transformers-examples-tf"}],
-    install_steps=["uv venv && uv pip install ."],
+    install_steps=["uv venv && uv pip install . && uv pip install -r examples/tensorflow/_tests_requirements.txt"],
     parallelism=8
 )
 


### PR DESCRIPTION
# What does this PR do?

Unlike the pytorch examples [here](https://github.com/huggingface/transformers/blob/c212ac9a0262d47b19675d5d7a9c729ebbdc3ef4/.circleci/create_circleci_config.py#L320) the docker file used to run the tensorflow examples doesn't install the requirements from the [examples requirements file](https://github.com/huggingface/transformers/blob/c212ac9a0262d47b19675d5d7a9c729ebbdc3ef4/examples/tensorflow/_tests_requirements.txt#L4).

Recently, we had to pin the datasets version used for the examples #31417, but this wasn't propogated for tensorflow because of this omisison.  

This means added requirements won't be included, and is currently causing failing tests on main: https://app.circleci.com/pipelines/github/huggingface/transformers/95698/workflows/52a112da-0d84-4569-8f69-ca180f4c7b2a/jobs/1260731