### PR TITLE
Fix single letter stop strings

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -372,9 +372,9 @@ class StopStringCriteria(StoppingCriteria):
         token_valid_positions, token_end_overlaps = StopStringCriteria._stop_string_get_matching_positions(
             token_list, token_indices, stop_strings
         )
-
+        # Insert a 0 to catch the case where there are no valid internal positions for any stop string
         max_valid_positions = max(
-            len(val) for positions in token_valid_positions.values() for val in positions.values()
+            [len(val) for positions in token_valid_positions.values() for val in positions.values()] + [0]
         )
         max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
         vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -372,9 +372,9 @@ class StopStringCriteria(StoppingCriteria):
         token_valid_positions, token_end_overlaps = StopStringCriteria._stop_string_get_matching_positions(
             token_list, token_indices, stop_strings
         )
-        # Insert a 0 to catch the case where there are no valid internal positions for any stop string
+        # Insert a dummy 1 to catch the case where there are no valid internal positions for any stop string
         max_valid_positions = max(
-            [len(val) for positions in token_valid_positions.values() for val in positions.values()] + [0]
+            [len(val) for positions in token_valid_positions.values() for val in positions.values()] + [1]
         )
         max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
         vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -372,10 +372,11 @@ class StopStringCriteria(StoppingCriteria):
         token_valid_positions, token_end_overlaps = StopStringCriteria._stop_string_get_matching_positions(
             token_list, token_indices, stop_strings
         )
-        # Insert a dummy 1 to catch the case where there are no valid internal positions for any stop string
-        max_valid_positions = max(
-            [len(val) for positions in token_valid_positions.values() for val in positions.values()] + [1]
-        )
+        all_valid_positions = [len(val) for positions in token_valid_positions.values() for val in positions.values()]
+        # In some cases, tokens may have no valid internal positions (such as single-character stop strings), so
+        # we need a fallback to handle this case
+        max_valid_positions = max(all_valid_positions) if all_valid_positions else 1
+        # There should always be at least one valid end_len, however, so no fallback needed here
         max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
         vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
         gather_vec = np.full((len(token_list), vec_size), dtype=np.int32, fill_value=-1)

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -209,8 +209,8 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         self.assertEqual(token_lengths, [len(token) for token in token_list])
 
     def test_single_letter_stop_string(self):
-        true_strings = ["a", "baa", "abc"]
-        false_strings = ["abbbbbbb", "b"]
+        true_strings = ["a", "baa", "abc"]  # "abc" is a single token
+        false_strings = ["abbbbbbb", "b"]  # "abbbbbbb" is split into multiple tokens
         stop_strings = ["a"]
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
         tokenizer.pad_token_id = tokenizer.eos_token_id

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -208,6 +208,24 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         token_lengths = embedding_vec[:, 2].tolist()
         self.assertEqual(token_lengths, [len(token) for token in token_list])
 
+    def test_single_letter_stop_string(self):
+        true_strings = ["a", "baa", "abc"]
+        false_strings = ["abbbbbbb", "b"]
+        stop_strings = ["a"]
+        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+        tokenizer.padding_side = "left"
+
+        true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
+        false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
+
+        scores = None
+        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
+        for i in range(len(true_strings)):
+            self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
+        for i in range(len(false_strings)):
+            self.assertFalse(criteria(false_input_ids["input_ids"][i : i + 1], scores))
+
     def test_criterias_per_row(self):
         text = "They completed the challenging puzzle, revealing the hidden image at the end"
         stop_strings = ["end"]

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -221,10 +221,10 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
-        for i in range(len(true_strings)):
-            self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
-        for i in range(len(false_strings)):
-            self.assertFalse(criteria(false_input_ids["input_ids"][i : i + 1], scores))
+        for input_ids in true_input_ids["input_ids"]:
+            self.assertTrue(criteria(input_ids, scores))
+        for input_ids in false_input_ids["input_ids"]:
+            self.assertFalse(criteria(input_ids, scores))
 
     def test_criterias_per_row(self):
         text = "They completed the challenging puzzle, revealing the hidden image at the end"

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -222,9 +222,9 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         scores = None
         criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
         for input_ids in true_input_ids["input_ids"]:
-            self.assertTrue(criteria(input_ids, scores))
+            self.assertTrue(criteria(input_ids.unsqueeze(0), scores))
         for input_ids in false_input_ids["input_ids"]:
-            self.assertFalse(criteria(input_ids, scores))
+            self.assertFalse(criteria(input_ids.unsqueeze(0), scores))
 
     def test_criterias_per_row(self):
         text = "They completed the challenging puzzle, revealing the hidden image at the end"


### PR DESCRIPTION
Our `StopStringCriteria` has a bug when all stop strings are one letter long. This results in a case where no stop strings have any `valid_positions`, as this variable only tracks internal positions, and this causes a `max()` to fail later.

This code fixes the issue by ensuring that `max()` takes a minimum value of `1`. It also adds a test for single-letter stop strings!

Fixes #31435

cc @amyeroberts @zucchini-nlp @gante 