### PR TITLE
Fix `use_seedable_sampler` when initializing Accelerator

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4544,6 +4544,9 @@ class Trainer:
                 even_batches=accelerator_config.pop("even_batches"),
                 use_seedable_sampler=accelerator_config.pop("use_seedable_sampler"),
             )
+        if not is_accelerate_available("0.26.0"):
+            accelerator_config.pop("use_seedable_sampler")
+
         non_blocking = accelerator_config.pop("non_blocking")
         if not is_accelerate_available("0.30.0"):
             if non_blocking:


### PR DESCRIPTION
# What does this PR do ? 

This PR make sure that we don't pass `use_seedable_sampler` in Accelerator if we don't have the required version. Users are getting initialization error since `AcceleratorConfig` class have the `use_seedable_sampler` arg that was introduced in v0.26 in accelerate. However, the required version of accelerate in transformers is v0.21

However, I'm facing with an issue here. The default value in accelerate is `use_seedable_sampler` is `False` but in transformers, it is `True`. So, for users who have version of accelerate < 0.26, should I log a warning if `use_seedable_sampler` is `True` ? The warning is necessary since the behavior differs but I don't want to add too many warnings. cc @muellerzr @amyeroberts 

Another solution would be to just change the min required version of accelerate to v0.26 when installing transformers. 

Fixes https://github.com/huggingface/transformers/issues/31433