### PR TITLE
Update chat template docs and bump Jinja version

### DIFF
--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -593,7 +593,7 @@ isn't printing extra spaces where it shouldn't be!
 ```
 
 <Tip>
-A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use `{{-` and `{%` instead
+A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use `{{-` and `{%-` instead
 of `{{` and `{%`. This will strip any whitespace or newlines that come before the block or statement. If you use these,
 you can actually write your template with proper indentation and newlines and still have it render correctly!
 </Tip>

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -767,7 +767,7 @@ write a short Python script that formats messages the way you want, and then con
 
 Remember that the template handler will receive the conversation history as a variable called `messages`.  
 You will be able to access `messages` in your template just like you can in Python, which means you can loop over 
-it with `{% for message in messages %}` or access  individual messages with, for example, `{{ messages[0] }}`.
+it with `{% for message in messages %}` or access individual messages with `{{ messages[0] }}`, for example.
 
 You can also use the following tips to convert your code to Jinja:
 

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -842,3 +842,5 @@ all implementations of Jinja:
   See the [list of built-in filters](https://jinja.palletsprojects.com/en/3.1.x/templates/#builtin-filters)
   in the Jinja documentation for more.
 - Replace `True`, `False` and `None`, which are Python-specific, with `true`, `false` and `none`.
+- Directly rendering a dict or list may give different results in other implementations (for example, string entries
+  might change from single-quoted to double-quoted). Adding the `tojson` filter can help to ensure consistency here.

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -593,7 +593,7 @@ isn't printing extra spaces where it shouldn't be!
 ```
 
 <Tip>
-A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use `{{-` and `{%-` instead
+A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use **{{-** and **{%-** instead
 of `{{` and `{%`. This will strip any whitespace or newlines that come before the block or statement. If you use these,
 you can write your template with proper indentation and newlines and still have it render correctly!
 </Tip>

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -594,7 +594,7 @@ isn't printing extra spaces where it shouldn't be!
 
 <Tip>
 A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use **{{-** and **{%-** instead
-of `{{` and `{%`. This will strip any whitespace or newlines that come before the block or statement. If you use these,
+of **{{** and **{%**. This will strip any whitespace or newlines that come before the block or statement. If you use these,
 you can write your template with proper indentation and newlines and still have it render correctly!
 </Tip>
 

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -775,7 +775,7 @@ You can also use the following tips to convert your code to Jinja:
 
 By default, Jinja will print any whitespace that comes before or after a block. This can be a problem for chat
 templates, which generally want to be very precise with whitespace! To avoid this, we strongly recommend writing
-your templates with `{{-` and `{%-` blocks instead of `{{` and `{%`. This will strip any whitespace that comes
+your templates with **{{-** and **{%-** blocks instead of **{{** and **{%**. This will strip any whitespace that comes
 before the block, ensuring that your template doesn't print extra spaces where it shouldn't.
 
 ### For loops

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -595,7 +595,7 @@ isn't printing extra spaces where it shouldn't be!
 <Tip>
 A good way to ensure that your template isn't printing unwanted whitespaces or newlines is to use `{{-` and `{%-` instead
 of `{{` and `{%`. This will strip any whitespace or newlines that come before the block or statement. If you use these,
-you can actually write your template with proper indentation and newlines and still have it render correctly!
+you can write your template with proper indentation and newlines and still have it render correctly!
 </Tip>
 
 

--- a/src/transformers/agents/tools.py
+++ b/src/transformers/agents/tools.py
@@ -441,8 +441,8 @@ def compile_jinja_template(template):
     except ImportError:
         raise ImportError("template requires jinja2 to be installed.")
 
-    if version.parse(jinja2.__version__) <= version.parse("3.0.0"):
-        raise ImportError("template requires jinja2>=3.0.0 to be installed. Your version is " f"{jinja2.__version__}.")
+    if version.parse(jinja2.__version__) <= version.parse("3.1.0"):
+        raise ImportError("template requires jinja2>=3.1.0 to be installed. Your version is " f"{jinja2.__version__}.")
 
     def raise_exception(message):
         raise TemplateError(message)

--- a/src/transformers/agents/tools.py
+++ b/src/transformers/agents/tools.py
@@ -441,7 +441,7 @@ def compile_jinja_template(template):
     except ImportError:
         raise ImportError("template requires jinja2 to be installed.")
 
-    if version.parse(jinja2.__version__) <= version.parse("3.1.0"):
+    if version.parse(jinja2.__version__) < version.parse("3.1.0"):
         raise ImportError("template requires jinja2>=3.1.0 to be installed. Your version is " f"{jinja2.__version__}.")
 
     def raise_exception(message):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1886,9 +1886,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         except ImportError:
             raise ImportError("apply_chat_template requires jinja2 to be installed.")
 
-        if version.parse(jinja2.__version__) < version.parse("3.0.0"):
+        if version.parse(jinja2.__version__) < version.parse("3.1.0"):
             raise ImportError(
-                "apply_chat_template requires jinja2>=3.0.0 to be installed. Your version is " f"{jinja2.__version__}."
+                "apply_chat_template requires jinja2>=3.1.0 to be installed. Your version is " f"{jinja2.__version__}."
             )
 
         def raise_exception(message):


### PR DESCRIPTION
This PR makes some updates to the chat template docs. Specifically, I put much more emphasis on using trimming blocks like `{{-` and `{%-` to let you write neater, indented code, and I also add a section on making your template compatible with non-Python implementations of Jinja. This PR also bumps the minimum Jinja version to 3.1, which is the earliest version that supports the filters we recommend in these docs (and have started to use in our templates), such as `|items`.