### PR TITLE
FIX / Hub: Also catch for `exceptions.ConnectionError`

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -686,7 +686,7 @@ def has_file(
         ) from e
     except EntryNotFoundError:
         return False  # File does not exist
-    except requests.HTTPError:
+    except (requests.HTTPError, requests.exceptions.ConnectionError):
         # Any authentication/authorization error will be caught here => default to cache
         return has_file_in_cache
 


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/transformers/issues/30920 

Please see the detailed issue description for more details, it seems in transformers we hit a corner case when using HF offline mode + loading a non-safetensors model offline 

cc @Wauplin as I am not 100% sure about this and why this is not catched within `hf_raise_for_status` in `huggingface_hub`

