### PR TITLE
Donut: fix `generate` call from local path

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -577,6 +577,7 @@ class GenerationMixin:
             decoder_input_ids = decoder_start_token_id
         # exception: Donut checkpoints have task-specific decoder starts and don't expect a BOS token. Note that the
         # original checkpoints can't be detected through `self.__class__.__name__.lower()`, needing custom logic.
+        # See: https://github.com/huggingface/transformers/pull/31470
         elif "donut" in self.__class__.__name__.lower() or (
             self.config.model_type == "vision-encoder-decoder" and "donut" in self.config.encoder.model_type.lower()
         ):

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -576,7 +576,7 @@ class GenerationMixin:
         if decoder_input_ids is None:
             decoder_input_ids = decoder_start_token_id
         # exception: Donut checkpoints have task-specific decoder starts and don't expect a BOS token. Note that the
-        # original checkpoints can't be detected through `self.__class__.__name__.lower()`, neededing custom logic.
+        # original checkpoints can't be detected through `self.__class__.__name__.lower()`, needing custom logic.
         elif "donut" in self.__class__.__name__.lower() or (
             self.config.model_type == "vision-encoder-decoder" and "donut" in self.config.encoder.model_type.lower()
         ):

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -575,8 +575,11 @@ class GenerationMixin:
         # no user input -> use decoder_start_token_id as decoder_input_ids
         if decoder_input_ids is None:
             decoder_input_ids = decoder_start_token_id
-        # exception: Donut checkpoints have task-specific decoder starts and don't expect a BOS token
-        elif self.config.model_type == "vision-encoder-decoder" and "donut" in self.name_or_path.lower():
+        # exception: Donut checkpoints have task-specific decoder starts and don't expect a BOS token. Note that the
+        # original checkpoints can't be detected through `self.__class__.__name__.lower()`, neededing custom logic.
+        elif "donut" in self.__class__.__name__.lower() or (
+            self.config.model_type == "vision-encoder-decoder" and "donut" in self.config.encoder.model_type.lower()
+        ):
             pass
         elif self.config.model_type in ["whisper"]:
             pass


### PR DESCRIPTION
# What does this PR do?

Donut has custom logic in `generate`. Typically, we can detect certain architectures through `self.__class__.__name__`, to then trigger custom logic. However, to detect donut's original checkpoints, whose `model_type` and `architectures` is incorrectly defined (e.g. [here](https://huggingface.co/naver-clova-ix/donut-base/blob/a959cf33c20e09215873e338299c900f57047c61/config.json#L3)), we can't rely on `self.__class__.__name__`.

The custom logic that was in place relied on the hub path, but that doesn't work for local file paths. This PR fixes it by clawing at the [only piece of text saying "donut" in the original config](https://huggingface.co/naver-clova-ix/donut-base/blob/a959cf33c20e09215873e338299c900f57047c61/config.json#L138) 👀 

cc @nbroad1881 