### PR TITLE
Update beam_constraints with KMP

### DIFF
--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -139,15 +139,9 @@ class PhrasalConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(token_ids, list) or len(token_ids) == 0:
-            raise ValueError(
-                f"`token_ids` has to be a non-empty list, but is {token_ids}."
-            )
-        if any(
-            (not isinstance(token_id, int) or token_id < 0) for token_id in token_ids
-        ):
-            raise ValueError(
-                f"Each element in `token_ids` has to be a positive integer, but is {token_ids}."
-            )
+            raise ValueError(f"`token_ids` has to be a non-empty list, but is {token_ids}.")
+        if any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids):
+            raise ValueError(f"Each element in `token_ids` has to be a positive integer, but is {token_ids}.")
 
         self.token_ids = token_ids
 
@@ -179,9 +173,7 @@ class PhrasalConstraint(Constraint):
 
     def does_advance(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(
-                f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}"
-            )
+            raise ValueError(f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}")
 
         if self.completed:
             return False
@@ -190,9 +182,7 @@ class PhrasalConstraint(Constraint):
 
     def update(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(
-                f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}"
-            )
+            raise ValueError(f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}")
 
         stepped = False
         completed = False
@@ -207,9 +197,7 @@ class PhrasalConstraint(Constraint):
         else:
             # failed to make progress.
             reset = True
-            new_fulfilled_idx = self.get_qkstart(
-                token_id
-            )  # use KMP to find longest suffix which fulfilled
+            new_fulfilled_idx = self.get_qkstart(token_id)  # use KMP to find longest suffix which fulfilled
             self.fulfilled_idx = new_fulfilled_idx
         return stepped, completed, reset
 
@@ -313,18 +301,11 @@ class DisjunctiveConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(nested_token_ids, list) or len(nested_token_ids) == 0:
-            raise ValueError(
-                f"`nested_token_ids` has to be a non-empty list, but is {nested_token_ids}."
-            )
+            raise ValueError(f"`nested_token_ids` has to be a non-empty list, but is {nested_token_ids}.")
         if any(not isinstance(token_ids, list) for token_ids in nested_token_ids):
-            raise ValueError(
-                f"`nested_token_ids` has to be a list of lists, but is {nested_token_ids}."
-            )
+            raise ValueError(f"`nested_token_ids` has to be a list of lists, but is {nested_token_ids}.")
         if any(
-            any(
-                (not isinstance(token_id, int) or token_id < 0)
-                for token_id in token_ids
-            )
+            any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids)
             for token_ids in nested_token_ids
         ):
             raise ValueError(
@@ -348,9 +329,7 @@ class DisjunctiveConstraint(Constraint):
 
     def does_advance(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(
-                f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}"
-            )
+            raise ValueError(f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}")
 
         next_tokens = self.trie.next_tokens(self.current_seq)
 
@@ -358,9 +337,7 @@ class DisjunctiveConstraint(Constraint):
 
     def update(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(
-                f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}"
-            )
+            raise ValueError(f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}")
 
         stepped = False
         completed = False
@@ -422,9 +399,7 @@ class ConstraintListState:
     def init_state(self):
         self.complete_constraints = []
         self.inprogress_constraint = None
-        self.pending_constraints = [
-            constraint.copy(stateful=False) for constraint in self.constraints
-        ]
+        self.pending_constraints = [constraint.copy(stateful=False) for constraint in self.constraints]
 
     def get_bank(self):
         add = 0
@@ -451,9 +426,7 @@ class ConstraintListState:
         """
         token_list = []
         if self.inprogress_constraint is None:
-            for (
-                constraint
-            ) in self.pending_constraints:  # "pending" == "unfulfilled yet"
+            for constraint in self.pending_constraints:  # "pending" == "unfulfilled yet"
                 advance = constraint.advance()
                 if isinstance(advance, int):
                     token_list.append(advance)
@@ -509,9 +482,7 @@ class ConstraintListState:
                 #     But that doesn't mean we self.init_state(), since we only reset the state for this particular
                 #     constraint, not the full list of constraints.
 
-                self.pending_constraints.append(
-                    self.inprogress_constraint.copy(stateful=False)
-                )
+                self.pending_constraints.append(self.inprogress_constraint.copy(stateful=False))
                 self.inprogress_constraint = None
 
             if complete:
@@ -551,14 +522,10 @@ class ConstraintListState:
                         # If we made any progress at all, then it's at least not a "pending constraint".
 
                         self.pending_constraints = (
-                            self.pending_constraints[:cidx]
-                            + self.pending_constraints[cidx + 1 :]
+                            self.pending_constraints[:cidx] + self.pending_constraints[cidx + 1 :]
                         )
 
-                        if (
-                            len(self.pending_constraints) == 0
-                            and self.inprogress_constraint is None
-                        ):
+                        if len(self.pending_constraints) == 0 and self.inprogress_constraint is None:
                             # If there's no longer any pending after this and no inprogress either, then we must be
                             # complete.
 
@@ -569,22 +536,15 @@ class ConstraintListState:
         return complete, stepped
 
     def copy(self, stateful=True):
-        new_state = ConstraintListState(
-            self.constraints
-        )  # we actually never though self.constraints objects
+        new_state = ConstraintListState(self.constraints)  # we actually never though self.constraints objects
         # throughout this process. So it's at initialization state.
 
         if stateful:
             new_state.complete_constraints = [
-                constraint.copy(stateful=True)
-                for constraint in self.complete_constraints
+                constraint.copy(stateful=True) for constraint in self.complete_constraints
             ]
             if self.inprogress_constraint is not None:
-                new_state.inprogress_constraint = self.inprogress_constraint.copy(
-                    stateful=True
-                )
-            new_state.pending_constraints = [
-                constraint.copy() for constraint in self.pending_constraints
-            ]
+                new_state.inprogress_constraint = self.inprogress_constraint.copy(stateful=True)
+            new_state.pending_constraints = [constraint.copy() for constraint in self.pending_constraints]
 
         return new_state

--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -139,9 +139,15 @@ class PhrasalConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(token_ids, list) or len(token_ids) == 0:
-            raise ValueError(f"`token_ids` has to be a non-empty list, but is {token_ids}.")
-        if any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids):
-            raise ValueError(f"Each element in `token_ids` has to be a positive integer, but is {token_ids}.")
+            raise ValueError(
+                f"`token_ids` has to be a non-empty list, but is {token_ids}."
+            )
+        if any(
+            (not isinstance(token_id, int) or token_id < 0) for token_id in token_ids
+        ):
+            raise ValueError(
+                f"Each element in `token_ids` has to be a positive integer, but is {token_ids}."
+            )
 
         self.token_ids = token_ids
 
@@ -149,7 +155,7 @@ class PhrasalConstraint(Constraint):
         self.fulfilled_idx = -1  # the index of the currently fulfilled step
         self.completed = False
 
-        self.match_table = self.build_kmp_table() # Build the KMP partial match table
+        self.match_table = self.build_kmp_table()  # Build the KMP partial match table
 
     def build_kmp_table(self):
         """
@@ -159,7 +165,7 @@ class PhrasalConstraint(Constraint):
         match_table = [-1] * len(pattern)
         j = -1
         for i in range(1, len(pattern)):
-            while j !=-1 and pattern[i] != pattern[j + 1]:
+            while j != -1 and pattern[i] != pattern[j + 1]:
                 j = match_table[j]
             if pattern[i] == pattern[j + 1]:
                 j = j + 1
@@ -173,7 +179,9 @@ class PhrasalConstraint(Constraint):
 
     def does_advance(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}")
+            raise ValueError(
+                f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}"
+            )
 
         if self.completed:
             return False
@@ -182,7 +190,9 @@ class PhrasalConstraint(Constraint):
 
     def update(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}")
+            raise ValueError(
+                f"`token_id` has to be an `int`, but is {token_id} of type {type(token_id)}"
+            )
 
         stepped = False
         completed = False
@@ -197,7 +207,9 @@ class PhrasalConstraint(Constraint):
         else:
             # failed to make progress.
             reset = True
-            new_fulfilled_idx = self.get_qkstart(token_id) # use KMP to find longest suffix which fulfilled
+            new_fulfilled_idx = self.get_qkstart(
+                token_id
+            )  # use KMP to find longest suffix which fulfilled
             self.fulfilled_idx = new_fulfilled_idx
         return stepped, completed, reset
 
@@ -209,7 +221,7 @@ class PhrasalConstraint(Constraint):
         while now_idx > 0 and token_id != self.token_ids[now_idx + 1]:
             now_idx = self.match_table[now_idx]
         if token_id == self.token_ids[now_idx + 1]:
-            now_idx = now_idx +1
+            now_idx = now_idx + 1
         return now_idx
 
     def reset(self):
@@ -301,11 +313,18 @@ class DisjunctiveConstraint(Constraint):
         super(Constraint, self).__init__()
 
         if not isinstance(nested_token_ids, list) or len(nested_token_ids) == 0:
-            raise ValueError(f"`nested_token_ids` has to be a non-empty list, but is {nested_token_ids}.")
+            raise ValueError(
+                f"`nested_token_ids` has to be a non-empty list, but is {nested_token_ids}."
+            )
         if any(not isinstance(token_ids, list) for token_ids in nested_token_ids):
-            raise ValueError(f"`nested_token_ids` has to be a list of lists, but is {nested_token_ids}.")
+            raise ValueError(
+                f"`nested_token_ids` has to be a list of lists, but is {nested_token_ids}."
+            )
         if any(
-            any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids)
+            any(
+                (not isinstance(token_id, int) or token_id < 0)
+                for token_id in token_ids
+            )
             for token_ids in nested_token_ids
         ):
             raise ValueError(
@@ -329,7 +348,9 @@ class DisjunctiveConstraint(Constraint):
 
     def does_advance(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}")
+            raise ValueError(
+                f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}"
+            )
 
         next_tokens = self.trie.next_tokens(self.current_seq)
 
@@ -337,7 +358,9 @@ class DisjunctiveConstraint(Constraint):
 
     def update(self, token_id: int):
         if not isinstance(token_id, int):
-            raise ValueError(f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}")
+            raise ValueError(
+                f"`token_id` is supposed to be type `int`, but is {token_id} of type {type(token_id)}"
+            )
 
         stepped = False
         completed = False
@@ -399,7 +422,9 @@ class ConstraintListState:
     def init_state(self):
         self.complete_constraints = []
         self.inprogress_constraint = None
-        self.pending_constraints = [constraint.copy(stateful=False) for constraint in self.constraints]
+        self.pending_constraints = [
+            constraint.copy(stateful=False) for constraint in self.constraints
+        ]
 
     def get_bank(self):
         add = 0
@@ -426,7 +451,9 @@ class ConstraintListState:
         """
         token_list = []
         if self.inprogress_constraint is None:
-            for constraint in self.pending_constraints:  # "pending" == "unfulfilled yet"
+            for (
+                constraint
+            ) in self.pending_constraints:  # "pending" == "unfulfilled yet"
                 advance = constraint.advance()
                 if isinstance(advance, int):
                     token_list.append(advance)
@@ -482,7 +509,9 @@ class ConstraintListState:
                 #     But that doesn't mean we self.init_state(), since we only reset the state for this particular
                 #     constraint, not the full list of constraints.
 
-                self.pending_constraints.append(self.inprogress_constraint.copy(stateful=False))
+                self.pending_constraints.append(
+                    self.inprogress_constraint.copy(stateful=False)
+                )
                 self.inprogress_constraint = None
 
             if complete:
@@ -522,10 +551,14 @@ class ConstraintListState:
                         # If we made any progress at all, then it's at least not a "pending constraint".
 
                         self.pending_constraints = (
-                            self.pending_constraints[:cidx] + self.pending_constraints[cidx + 1 :]
+                            self.pending_constraints[:cidx]
+                            + self.pending_constraints[cidx + 1 :]
                         )
 
-                        if len(self.pending_constraints) == 0 and self.inprogress_constraint is None:
+                        if (
+                            len(self.pending_constraints) == 0
+                            and self.inprogress_constraint is None
+                        ):
                             # If there's no longer any pending after this and no inprogress either, then we must be
                             # complete.
 
@@ -536,15 +569,22 @@ class ConstraintListState:
         return complete, stepped
 
     def copy(self, stateful=True):
-        new_state = ConstraintListState(self.constraints)  # we actually never though self.constraints objects
+        new_state = ConstraintListState(
+            self.constraints
+        )  # we actually never though self.constraints objects
         # throughout this process. So it's at initialization state.
 
         if stateful:
             new_state.complete_constraints = [
-                constraint.copy(stateful=True) for constraint in self.complete_constraints
+                constraint.copy(stateful=True)
+                for constraint in self.complete_constraints
             ]
             if self.inprogress_constraint is not None:
-                new_state.inprogress_constraint = self.inprogress_constraint.copy(stateful=True)
-            new_state.pending_constraints = [constraint.copy() for constraint in self.pending_constraints]
+                new_state.inprogress_constraint = self.inprogress_constraint.copy(
+                    stateful=True
+                )
+            new_state.pending_constraints = [
+                constraint.copy() for constraint in self.pending_constraints
+            ]
 
         return new_state

--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -196,9 +196,14 @@ class PhrasalConstraint(Constraint):
             self.completed = completed
         else:
             # failed to make progress.
-            reset = True
+
             new_fulfilled_idx = self.get_qkstart(token_id)  # use KMP to find longest suffix which fulfilled
-            self.fulfilled_idx = new_fulfilled_idx
+            if new_fulfilled_idx == -1:
+                reset = True
+                self.reset()
+            else:
+                self.fulfilled_idx = new_fulfilled_idx
+
         return stepped, completed, reset
 
     def get_qkstart(self, token_id: int):

--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -141,13 +141,30 @@ class PhrasalConstraint(Constraint):
         if not isinstance(token_ids, list) or len(token_ids) == 0:
             raise ValueError(f"`token_ids` has to be a non-empty list, but is {token_ids}.")
         if any((not isinstance(token_id, int) or token_id < 0) for token_id in token_ids):
-            raise ValueError(f"Each list in `token_ids` has to be a list of positive integers, but is {token_ids}.")
+            raise ValueError(f"Each element in `token_ids` has to be a positive integer, but is {token_ids}.")
 
         self.token_ids = token_ids
 
         self.seqlen = len(self.token_ids)
         self.fulfilled_idx = -1  # the index of the currently fulfilled step
         self.completed = False
+
+        self.match_table = self.build_kmp_table() # Build the KMP partial match table
+
+    def build_kmp_table(self):
+        """
+        Builds the KMP partial match table for the token_ids pattern.
+        """
+        pattern = self.token_ids
+        match_table = [-1] * len(pattern)
+        j = -1
+        for i in range(1, len(pattern)):
+            while j !=-1 and pattern[i] != pattern[j + 1]:
+                j = match_table[j]
+            if pattern[i] == pattern[j + 1]:
+                j = j + 1
+            match_table[i] = j
+        return match_table
 
     def advance(self):
         if self.completed:
@@ -180,12 +197,24 @@ class PhrasalConstraint(Constraint):
         else:
             # failed to make progress.
             reset = True
-            self.reset()
+            new_fulfilled_idx = self.get_qkstart(token_id) # use KMP to find longest suffix which fulfilled
+            self.fulfilled_idx = new_fulfilled_idx
         return stepped, completed, reset
+
+    def get_qkstart(self, token_id: int):
+        """
+        Implements the KMP search algorithm. Returns the start index of the pattern in the text or -1 if not found.
+        """
+        now_idx = self.fulfilled_idx
+        while now_idx > 0 and token_id != self.token_ids[now_idx + 1]:
+            now_idx = self.match_table[now_idx]
+        if token_id == self.token_ids[now_idx + 1]:
+            now_idx = now_idx +1
+        return now_idx
 
     def reset(self):
         self.completed = False
-        self.fulfilled_idx = 0
+        self.fulfilled_idx = -1
 
     def remaining(self):
         return self.seqlen - (self.fulfilled_idx + 1)


### PR DESCRIPTION
# What does this PR do?

This PR enhances the `PhrasalConstraint` class with the Knuth-Morris-Pratt (KMP) algorithm. This allows the constraint to restart quickly rather than start from the beginning when a match fails, improving efficiency.

Here is test:
```
from transformers import AutoTokenizer
import beam_constant


def test():
    tokenize = AutoTokenizer.from_pretrained("Qwen-7B-Chat", trust_remote_code=True)
    force_word = " love cat, love dog"
    force_word_id = tokenize.encode(force_word, add_special_tokens=False)
    constraint = beam_constant.PhrasalConstraint(force_word_id)
    generate_contest = "I love cat, love cat, love dog"
    generate_tokens = tokenize.encode(generate_contest, add_special_tokens=False)
    print(force_word_id)
    print(constraint.match_table)
    for token_id in generate_tokens:
        step, complete, reset = constraint.update(token_id)
        print(f"token_id:{token_id} {constraint.fulfilled_idx} {step} {complete} {reset}")

if __name__ == "__main__":
    test()
```

test result

![image](https://github.com/huggingface/transformers/assets/124332948/9d83ad73-5087-49b3-a93d-a5802c198b1d)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
## Who can review?

@gante
