### PR TITLE
Fix bug about add_special_tokens and so on

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -167,6 +167,8 @@ class TextGenerationPipeline(Pipeline):
             preprocess_params["handle_long_generation"] = handle_long_generation
 
         preprocess_params.update(generate_kwargs)
+        for preprocess_only_key in ["add_special_tokens", "padding"]:
+            generate_kwargs.pop(preprocess_only_key, False)
         forward_params = generate_kwargs
 
         postprocess_params = {}

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -137,11 +137,10 @@ class TextGenerationPipeline(Pipeline):
 
         add_special_tokens = False
         if "add_special_tokens" in generate_kwargs:
-            preprocess_params["add_special_tokens"] = generate_kwargs["add_special_tokens"]
-            add_special_tokens = generate_kwargs["add_special_tokens"]
+            add_special_tokens = preprocess_params["add_special_tokens"] = generate_kwargs.pop("add_special_tokens")
 
         if "padding" in generate_kwargs:
-            preprocess_params["padding"] = generate_kwargs["padding"]
+            preprocess_params["padding"] = generate_kwargs.pop("padding")
 
         if truncation is not None:
             preprocess_params["truncation"] = truncation
@@ -167,8 +166,6 @@ class TextGenerationPipeline(Pipeline):
             preprocess_params["handle_long_generation"] = handle_long_generation
 
         preprocess_params.update(generate_kwargs)
-        for preprocess_only_key in ["add_special_tokens", "padding"]:
-            generate_kwargs.pop(preprocess_only_key, False)
         forward_params = generate_kwargs
 
         postprocess_params = {}

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -107,6 +107,20 @@ class TextGenerationPipelineTests(unittest.TestCase):
         )
         assert output_str != output_str_with_truncation  # results must be different because one had truncation
 
+        ## -- test kwargs for preprocess_params
+        outputs = text_generator("This is a test", do_sample=False, add_special_tokens=False, padding=False)
+        self.assertEqual(
+            outputs,
+            [
+                {
+                    "generated_text": (
+                        "This is a test ☃ ☃ segmental segmental segmental 议议eski eski flutter flutter Lacy oscope."
+                        " oscope. FiliFili@@"
+                    )
+                }
+            ],
+        )
+
         # -- what is the point of this test? padding is hardcoded False in the pipeline anyway
         text_generator.tokenizer.pad_token_id = text_generator.model.config.eos_token_id
         text_generator.tokenizer.pad_token = "<pad>"


### PR DESCRIPTION
# What does this PR do?

When applying add_special_tokens and/or padding arg(s) to `TextGenerationPipeline.__call__()`, we get an exception like:

```
>>> from transformers import pipeline
>>> TARGET = "meta-llama/Llama-2-7b-hf"
>>> pipe = pipeline("text-generation", model=TARGET, max_new_tokens=512, device_map="auto")
>>> pipe("what is 3+4?", add_special_tokens=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/pipelines/text_generation.py", line 263, in __call__
    return super().__call__(text_inputs, **kwargs)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/pipelines/base.py", line 1243, in __call__
    return self.run_single(inputs, preprocess_params, forward_params, postprocess_params)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/pipelines/base.py", line 1250, in run_single
    model_outputs = self.forward(model_inputs, **forward_params)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/pipelines/base.py", line 1150, in forward
    model_outputs = self._forward(model_inputs, **forward_params)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/pipelines/text_generation.py", line 350, in _forward
    generated_sequence = self.model.generate(input_ids=input_ids, attention_mask=attention_mask, **generate_kwargs)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/generation/utils.py", line 1542, in generate
    self._validate_model_kwargs(model_kwargs.copy())
  File "/model/hng88/llm-jp-eval/llm-jp-eval/lib/python3.10/site-packages/transformers/generation/utils.py", line 1157, in _validate_model_kwargs
    raise ValueError(
ValueError: The following `model_kwargs` are not used by the model: ['add_special_tokens'] (note: typos in the generate arguments will also show up in this list)
```
We need to remove both add_special_tokens and padding fields from generate_kwargs in `TextGenerationPipeline.TextGenerationPipeline()`.

Until transformers v4.40.2, these kwargs were used only for preprocess but used for forward_params from v4.41.0.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- pipelines: @Narsil