### PR TITLE
Fix doc typo in `TrainingArguments`

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2742,7 +2742,7 @@ class TrainingArguments:
 
         Calling this method will set `self.push_to_hub` to `True`, which means the `output_dir` will begin a git
         directory synced with the repo (determined by `model_id`) and the content will be pushed each time a save is
-        triggered (depending on`self.save_strategy`). Calling [`~Trainer.save_model`] will also trigger a push.
+        triggered (depending on your `self.save_strategy`). Calling [`~Trainer.save_model`] will also trigger a push.
 
         </Tip>
 


### PR DESCRIPTION
# What does this PR do?

Minor typo fix
 
@stevhliu and @MKhalusova
