### PR TITLE
Add device in Bark Logits Processors

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -991,11 +991,13 @@ class BarkSemanticModel(BarkCausalModel):
             list(range(semantic_generation_config.semantic_pad_token + 1, self.config.output_vocab_size))
         )
 
-        suppress_tokens_logits_processor = SuppressTokensLogitsProcessor(tokens_to_suppress)
+        suppress_tokens_logits_processor = SuppressTokensLogitsProcessor(
+            tokens_to_suppress, device=input_embeds.device
+        )
 
         min_eos_p = kwargs.get("min_eos_p", semantic_generation_config.min_eos_p)
         early_stopping_logits_processor = BarkEosPrioritizerLogitsProcessor(
-            eos_token_id=semantic_generation_config.eos_token_id, min_eos_p=min_eos_p
+            eos_token_id=semantic_generation_config.eos_token_id, min_eos_p=min_eos_p, device=input_embeds.device
         )
 
         # pass input_ids in order to stay consistent with the transformers generate method even though it is not used


### PR DESCRIPTION
# What does this PR do?

As per title, cuda generation on Bark throws an error currently after we added 'device' argument in LogitsProcessors. This PR propagates the changes to Bark's custom generate