### PR TITLE
Sequence Length Invariant Text Models

### DIFF
--- a/src/transformers/models/blip/modeling_blip.py
+++ b/src/transformers/models/blip/modeling_blip.py
@@ -284,10 +284,10 @@ class BlipVisionEmbeddings(nn.Module):
 class BlipTextEmbeddings(nn.Module):
     def __init__(self, config: BlipTextConfig):
         super().__init__()
-        embed_dim = config.hidden_size
-
-        self.token_embedding = nn.Embedding(config.vocab_size, embed_dim)
-        self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
+        self.embed_dim = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+        self.token_embedding = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.position_embedding = nn.Embedding(self.max_position_embeddings, self.embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
         self.register_buffer(
@@ -303,12 +303,21 @@ class BlipTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :seq_length]
+            position_ids = self.position_ids[:, : min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
+        # Shape: BATCH x MAX POSITION EMBEDDING X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
+
+        # Bi-Linear Interpolation
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        if seq_length > self.max_position_embeddings:
+            position_embeddings = nn.functional.interpolate(
+                position_embeddings.unsqueeze(0), size=(seq_length, self.embed_dim), mode="bilinear"
+            ).squeeze(0)
+
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -217,7 +217,7 @@ class CLIPTextEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
-        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        # Shape: BATCH x MAX POSITION EMBEDDING X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
 
         # Bi-Linear Interpolation

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -212,7 +212,7 @@ class CLIPTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :min(seq_length, self.max_position_embeddings)]
+            position_ids = self.position_ids[:, : min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -193,10 +193,10 @@ class CLIPVisionEmbeddings(nn.Module):
 class CLIPTextEmbeddings(nn.Module):
     def __init__(self, config: CLIPTextConfig):
         super().__init__()
-        embed_dim = config.hidden_size
-
-        self.token_embedding = nn.Embedding(config.vocab_size, embed_dim)
-        self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
+        self.embed_dim = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+        self.token_embedding = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.position_embedding = nn.Embedding(self.max_position_embeddings, self.embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
         self.register_buffer(
@@ -212,12 +212,21 @@ class CLIPTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :seq_length]
+            position_ids = self.position_ids[:, :min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
+
+        # Bi-Linear Interpolation
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        if seq_length > self.max_position_embeddings:
+            position_embeddings = nn.functional.interpolate(
+                position_embeddings.unsqueeze(0), size=(seq_length, self.embed_dim), mode="bilinear"
+            ).squeeze(0)
+
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings

--- a/src/transformers/models/groupvit/modeling_groupvit.py
+++ b/src/transformers/models/groupvit/modeling_groupvit.py
@@ -424,10 +424,10 @@ class GroupViTVisionEmbeddings(nn.Module):
 class GroupViTTextEmbeddings(nn.Module):
     def __init__(self, config: GroupViTTextConfig):
         super().__init__()
-        embed_dim = config.hidden_size
-
-        self.token_embedding = nn.Embedding(config.vocab_size, embed_dim)
-        self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
+        self.embed_dim = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+        self.token_embedding = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.position_embedding = nn.Embedding(self.max_position_embeddings, self.embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
         self.register_buffer(
@@ -443,12 +443,21 @@ class GroupViTTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :seq_length]
+            position_ids = self.position_ids[:, : min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
+        # Shape: BATCH x MAX POSITION EMBEDDING X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
+
+        # Bi-Linear Interpolation
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        if seq_length > self.max_position_embeddings:
+            position_embeddings = nn.functional.interpolate(
+                position_embeddings.unsqueeze(0), size=(seq_length, self.embed_dim), mode="bilinear"
+            ).squeeze(0)
+
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -315,10 +315,10 @@ class SiglipVisionEmbeddings(nn.Module):
 class SiglipTextEmbeddings(nn.Module):
     def __init__(self, config: SiglipTextConfig):
         super().__init__()
-        embed_dim = config.hidden_size
-
-        self.token_embedding = nn.Embedding(config.vocab_size, embed_dim)
-        self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
+        self.embed_dim = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+        self.token_embedding = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.position_embedding = nn.Embedding(self.max_position_embeddings, self.embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
         self.register_buffer(
@@ -334,12 +334,21 @@ class SiglipTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :seq_length]
+            position_ids = self.position_ids[:, : min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
+        # Shape: BATCH x MAX POSITION EMBEDDING X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
+
+        # Bi-Linear Interpolation
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        if seq_length > self.max_position_embeddings:
+            position_embeddings = nn.functional.interpolate(
+                position_embeddings.unsqueeze(0), size=(seq_length, self.embed_dim), mode="bilinear"
+            ).squeeze(0)
+
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings

--- a/src/transformers/models/x_clip/modeling_x_clip.py
+++ b/src/transformers/models/x_clip/modeling_x_clip.py
@@ -137,10 +137,10 @@ class XCLIPVisionEmbeddings(nn.Module):
 class XCLIPTextEmbeddings(nn.Module):
     def __init__(self, config: XCLIPTextConfig):
         super().__init__()
-        embed_dim = config.hidden_size
-
-        self.token_embedding = nn.Embedding(config.vocab_size, embed_dim)
-        self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
+        self.embed_dim = config.hidden_size
+        self.max_position_embeddings = config.max_position_embeddings
+        self.token_embedding = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.position_embedding = nn.Embedding(self.max_position_embeddings, self.embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
         self.register_buffer(
@@ -156,12 +156,21 @@ class XCLIPTextEmbeddings(nn.Module):
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = self.position_ids[:, :seq_length]
+            position_ids = self.position_ids[:, : min(seq_length, self.max_position_embeddings)]
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
+        # Shape: BATCH x MAX POSITION EMBEDDING X EMBEDDING DIMENSION
         position_embeddings = self.position_embedding(position_ids)
+
+        # Bi-Linear Interpolation
+        # Shape: BATCH x SEQUENCE LENGTH X EMBEDDING DIMENSION
+        if seq_length > self.max_position_embeddings:
+            position_embeddings = nn.functional.interpolate(
+                position_embeddings.unsqueeze(0), size=(seq_length, self.embed_dim), mode="bilinear"
+            ).squeeze(0)
+
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings


### PR DESCRIPTION
### What does this PR do?
This PR introduces changes to the `huggingface/transformers` repository aimed at making models like CLIP and similar ones invariant to sequence length. The primary modification involves applying Bi-Linear interpolation to the embeddings generated by the `position_embedding` layer. This allows the embeddings to be interpolated to the required sequence length, enabling the models to handle sequences of varying lengths effectively.

#### Motivation and Context
The motivation behind this change is to improve the flexibility and robustness of models when processing inputs of different lengths. The `max_position_embedding` for pre-trained models like CLIP is very limiting. By ensuring sequence length invariance, the models can maintain performance and consistency regardless of input sequence variations. Also to enable the use of these models with StableDiffusion Pipelines in `huggingface/diffusers` for long prompt generation, enhancing their applicability and integration in more complex workflows.

#### Fixes
Fixes: https://github.com/huggingface/diffusers/issues/2136

#### Dependencies
There are no additional dependencies required for this change.

#### Checklist
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


@ArthurZucker, @amyeroberts, @qubvel  and @younesbelkada

