### PR TITLE
Removed torch.cuda.empty_cache from train loop.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3307,7 +3307,6 @@ class Trainer:
             loss = self.compute_loss(model, inputs)
 
         del inputs
-        torch.cuda.empty_cache()
 
         kwargs = {}
 


### PR DESCRIPTION
# What does this PR do?

Removes the addition of torch.cuda.empty_cache from the training loop (introduced in https://github.com/huggingface/transformers/pull/28769).

This line caused training slowdowns observed in issue https://github.com/huggingface/transformers/issues/31372

While [this thread](https://discuss.pytorch.org/t/about-torch-cuda-empty-cache/34232/27) in the PyTorch forums recommends not to use this function because it is slow, it appears many in the comments there still find it necessary to save them from OOMs on their training jobs, so it might be nice to have the option, but users can just add it on their own if they're in a jam.

Fixes [# 31372](https://github.com/huggingface/transformers/issues/31372)

@muellerz @SunMarc 
