### PR TITLE
Add Jinja as a requirement with the right version cutoff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ _deps = [
     "jax>=0.4.1,<=0.4.13",
     "jaxlib>=0.4.1,<=0.4.13",
     "jieba",
+    "jinja>=3.1.0",
     "kenlm",
     # Keras pin - this is to make sure Keras 3 doesn't destroy us. Remove or change when we have proper support.
     "keras>2.9,<2.16",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ _deps = [
     "jax>=0.4.1,<=0.4.13",
     "jaxlib>=0.4.1,<=0.4.13",
     "jieba",
-    "jinja>=3.1.0",
+    "jinja2>=3.1.0",
     "kenlm",
     # Keras pin - this is to make sure Keras 3 doesn't destroy us. Remove or change when we have proper support.
     "keras>2.9,<2.16",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -31,7 +31,7 @@ deps = {
     "jax": "jax>=0.4.1,<=0.4.13",
     "jaxlib": "jaxlib>=0.4.1,<=0.4.13",
     "jieba": "jieba",
-    "jinja": "jinja>=3.1.0",
+    "jinja2": "jinja2>=3.1.0",
     "kenlm": "kenlm",
     "keras": "keras>2.9,<2.16",
     "keras-nlp": "keras-nlp>=0.3.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -31,6 +31,7 @@ deps = {
     "jax": "jax>=0.4.1,<=0.4.13",
     "jaxlib": "jaxlib>=0.4.1,<=0.4.13",
     "jieba": "jieba",
+    "jinja": "jinja>=3.1.0",
     "kenlm": "kenlm",
     "keras": "keras>2.9,<2.16",
     "keras-nlp": "keras-nlp>=0.3.1",


### PR DESCRIPTION
We (I) were lazy and didn't add Jinja as a requirement because it was already a requirement of `torch`. This PR finally makes it a requirement of `transformers` as well, and lets us set the right version cutoff so we can ensure we have the filters we need to render templates properly.