### PR TITLE
Test loading generation config with safetensor weights

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1424,20 +1424,15 @@ class ModelUtilsTest(TestCasePlus):
             self.assertEqual(model.__class__.__name__, model_ref.__class__.__name__)
 
     def test_generation_config_is_loaded_with_model(self):
-        # Note: `joaogante/tiny-random-gpt2-with-generation-config` has a `generation_config.json` containing a dummy
-        # `transformers_version` field set to `foo`. If loading the file fails, this test also fails.
+        # Note: `TinyLlama/TinyLlama-1.1B-Chat-v1.0` has a `generation_config.json` containing `max_length: 2048`
 
         # 1. Load without further parameters
-        model = AutoModelForCausalLM.from_pretrained(
-            "joaogante/tiny-random-gpt2-with-generation-config", use_safetensors=False
-        )
-        self.assertEqual(model.generation_config.transformers_version, "foo")
+        model = AutoModelForCausalLM.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+        self.assertEqual(model.generation_config.max_length, 2048)
 
         # 2. Load with `device_map`
-        model = AutoModelForCausalLM.from_pretrained(
-            "joaogante/tiny-random-gpt2-with-generation-config", device_map="auto", use_safetensors=False
-        )
-        self.assertEqual(model.generation_config.transformers_version, "foo")
+        model = AutoModelForCausalLM.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0", device_map="auto")
+        self.assertEqual(model.generation_config.max_length, 2048)
 
     @require_safetensors
     def test_safetensors_torch_from_torch(self):


### PR DESCRIPTION
# What does this PR do?

Fix #29522

This PR changes the model used in a generation config loading test to a model that a) is used on other tests b) has a generation config. The purpose of the test is to check that the generation config is loaded correctly with the model (which broke in the past)

The model used for the test is a dummy model, and it has empty weights that break when we load the model with `device_map="auto"` (because we can call `.to` with empty weights when the source is a `meta` device).

