### PR TITLE
Added version constraint on numpy for version <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ _deps = [
     "librosa",
     "nltk",
     "natten>=0.14.6,<0.15.0",
-    "numpy>=1.17",
+    "numpy>=1.17,<2.0",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
     "onnxruntime>=1.4.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6,<0.15.0",
-    "numpy": "numpy>=1.17",
+    "numpy": "numpy>=1.17,<2.0",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",
     "onnxruntime": "onnxruntime>=1.4.0",


### PR DESCRIPTION
# What does this PR do?
This PR fixes the numpy version in `setup.py` to versions below 2.0. At the moment only a lower bound for versions >= 1.17 is specified. The latest major release of numpy that dropped last week causes a bunch of issues with transformers and numpy should be constrained to version 1.xx until API compatibility is restored.

Fixes #31568 

@Narsil 