### PR TITLE
Fix is_torch_xpu_available for torch < 2.3

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -754,10 +754,13 @@ def is_torch_xpu_available(check_device=False):
     if not is_torch_available():
         return False
 
-    import torch
-
+    torch_version = version.parse(_torch_version)
     if is_ipex_available():
         import intel_extension_for_pytorch  # noqa: F401
+    elif torch_version.major < 2 or (torch_version.major == 2 and torch_version.minor < 4):
+        return False
+
+    import torch
 
     if check_device:
         try:


### PR DESCRIPTION
# What does this PR do?

A recent PR #31238 updated the `is_torch_xpu_available` check to reflect XPU support from Pytorch >= 2.4. However, this broke backwards compatibility with versions of pytorch < 2.4 when `is_ipex_available` is `False` and `check_device=True`. 

Technically, this fails if the installed torch in the environment is <= 2.2, and 2.3 will still pass, as torch 2.3 has the `torch.xpu` module. However, as the intended logic is to default to the pytorch available logic for >= 2.4 and previously this evaluated to False for 2.3, this is more backwards compatible. 

Fixes #31563