### PR TITLE
transformers.fx.symbolic_trace supports inputs_embeds

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -995,6 +995,13 @@ class HFTracer(Tracer):
             inputs_dict[input_name] = torch.zeros(
                 *shape, model.config.input_feat_per_channel, dtype=torch.float, device=device
             )
+        elif "inputs_embeds" in input_name:
+            batch_size = shape[0]
+            sequence_length = shape[1]
+
+            inputs_dict[input_name] = torch.zeros(
+                batch_size, sequence_length, model.config.hidden_size, dtype=torch.float, device=device
+            )
         elif "visual_feats" in input_name:
             inputs_dict[input_name] = torch.zeros(
                 shape

--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -997,7 +997,7 @@ class HFTracer(Tracer):
             )
         elif "inputs_embeds" in input_name:
             batch_size = shape[0]
-            sequence_length = shape[1]
+            sequence_length = shape[-1]
 
             inputs_dict[input_name] = torch.zeros(
                 batch_size, sequence_length, model.config.hidden_size, dtype=torch.float, device=device

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1346,10 +1346,7 @@ class ModelTesterMixin:
                 ):
                     model.config.problem_type = "single_label_classification"
 
-                if "past_key_values" in input_names_to_trace:
-                    model.config.use_cache = True
-                else:
-                    model.config.use_cache = False
+                model.config.use_cache = "past_key_values" in input_names_to_trace
 
                 traced_model = symbolic_trace(model, input_names_to_trace)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1332,7 +1332,7 @@ class ModelTesterMixin:
                 inputs_to_test.append(
                     {
                         "inputs_embeds": torch.rand(
-                            3, 5, model.config.hidden_size, dtype=torch.float, device=torch_device
+                            2, 2, model.config.hidden_size, dtype=torch.float, device=torch_device
                         )
                     }
                 )


### PR DESCRIPTION
We should prompt users to use `torch.export.export` instead.

Fixes https://github.com/huggingface/transformers/issues/31414
Fixes https://github.com/huggingface/transformers/issues/31200