### PR TITLE
Fix llama gguf converter

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -632,7 +632,27 @@ class GGUFLlamaConverter(LlamaConverter):
         return decoders.Sequence(sequence)
 
     def converted(self):
-        tokenizer = super().converted()
+        # Copied partly from converted method in SpmConverter class
+        tokenizer = self.tokenizer(self.proto)
+
+        # Tokenizer assemble
+        normalizer = self.normalizer(self.proto)
+        if normalizer is not None:
+            tokenizer.normalizer = normalizer
+
+        replacement = "▁"
+        add_prefix_space = True
+        if hasattr(self.original_tokenizer, "add_prefix_space"):
+            add_prefix_space = self.original_tokenizer.add_prefix_space
+
+        pre_tokenizer = self.pre_tokenizer(replacement, add_prefix_space)
+        if pre_tokenizer is not None:
+            tokenizer.pre_tokenizer = pre_tokenizer
+
+        tokenizer.decoder = self.decoder(replacement, add_prefix_space)
+        post_processor = self.post_processor()
+        if post_processor:
+            tokenizer.post_processor = post_processor
 
         # HACK: patch the llama-3 tokenizer to use the correspinding pre-tokenizer
         # and normalizer


### PR DESCRIPTION
# What does this PR do?
This PR fixes the failing gguf tests caused by this [PR](https://github.com/huggingface/transformers/pull/31305). Instead of using the converter methods from `SpmConverter` class for `GGUFLlamaConverter` , we copy it + remove the parts that are using `pieces` and `trainer_spec.control_symbols` attributes from `self.proto` that comes from the sentencepiece (https://github.com/google/sentencepiece/blob/6225e08edb2577757163b3f5dbba4c0b670ef445/src/sentencepiece_model.proto#L299C29-L299C33). `GGUFTokenizerSkeleton`  don't have these attributes and I don't think we should add them.

Fixes https://github.com/huggingface/transformers/issues/31553 