### PR TITLE
pin numpy < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ _deps = [
     "librosa",
     "nltk",
     "natten>=0.14.6,<0.15.0",
-    "numpy>=1.17",
+    "numpy>=1.17,<2.0.0",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
     "onnxruntime>=1.4.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6,<0.15.0",
-    "numpy": "numpy>=1.17",
+    "numpy": "numpy>=1.17,<2.0.0",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",
     "onnxruntime": "onnxruntime>=1.4.0",


### PR DESCRIPTION
# What does this PR do?

Let's pin numpy < 2.0.0 for now. It doesn't work well. See [internal thread](https://huggingface.slack.com/archives/C01NE71C4F7/p1718639652402109): not so bad with torch only env., but not good with tf/flax.

Also see #31569