### PR TITLE
Allow infer_framework_load_model to use the originally specified config.

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -280,7 +280,7 @@ def infer_framework_load_model(
                 )
 
             try:
-                model = model_class.from_pretrained(model, **kwargs)
+                model = model_class.from_pretrained(model, config=config, **kwargs)
                 if hasattr(model, "eval"):
                     model = model.eval()
                 # Stop loading on the first successful load.

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -26,6 +26,7 @@ from huggingface_hub import HfFolder, delete_repo
 from requests.exceptions import HTTPError
 
 from transformers import (
+    AutoConfig,
     AutoModelForSequenceClassification,
     AutoTokenizer,
     DistilBertForSequenceClassification,
@@ -519,6 +520,14 @@ class PipelineUtilsTest(unittest.TestCase):
         expected_output = [{"generated_text": ANY(str)}]
         actual_output = classifier("Test input.")
         self.assertEqual(expected_output, actual_output)
+
+    @require_torch
+    def test_config_object_with_named_repo(self):
+        checkpoint = "hf-internal-testing/tiny-random-distilbert"
+        config = AutoConfig.from_pretrained(checkpoint)
+        config.dropout = 0.5  # Changed from default
+        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert", config=config)
+        self.assertEqual(pipe.model.config.dropout, 0.5)
 
     @require_torch_accelerator
     def test_pipeline_no_device(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -526,7 +526,7 @@ class PipelineUtilsTest(unittest.TestCase):
         checkpoint = "hf-internal-testing/tiny-random-distilbert"
         config = AutoConfig.from_pretrained(checkpoint)
         config.dropout = 0.5  # Changed from default
-        pipe = pipeline(model="hf-internal-testing/tiny-random-distilbert", config=config)
+        pipe = pipeline(model=checkpoint, config=config)
         self.assertEqual(pipe.model.config.dropout, 0.5)
 
     @require_torch_accelerator


### PR DESCRIPTION
# What does this PR do?

Allows infer_framework_load_model to use the originally specified config, currently if you specify config in the model_kwargs, you get a duplicate key error.

I don't have time to test this, but want to point out where there's a problem/inconsistency. Just check the diff, it's one line!

Fixes # (issue)
Currently if you specify config in the model_kwargs, you get a duplicate key error.

## Before submitting
- [n ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [y ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [n/a ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [n/a ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [n/a ] Did you write any new necessary tests?

Models:

- text models: @ArthurZucker

Library:

- pipelines: @Narsil