### PR TITLE
[Bug Fix] fix qa pipeline tensor to numpy

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -118,10 +118,10 @@ def select_starts_ends(
         max_answer_len (`int`): Maximum size of the answer to extract from the model's output.
     """
     # Ensure padded tokens & question tokens cannot belong to the set of candidate answers.
-    undesired_tokens = np.abs(np.array(p_mask) - 1)
+    undesired_tokens = np.abs(p_mask.numpy() - 1)
 
     if attention_mask is not None:
-        undesired_tokens = undesired_tokens.astype(attention_mask.dtype) & attention_mask
+        undesired_tokens = undesired_tokens & attention_mask
 
     # Generate mask
     undesired_tokens_mask = undesired_tokens == 0.0

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -121,7 +121,7 @@ def select_starts_ends(
     undesired_tokens = np.abs(np.array(p_mask) - 1)
 
     if attention_mask is not None:
-        undesired_tokens = undesired_tokens & attention_mask
+        undesired_tokens = undesired_tokens.astype(attention_mask.dtype) & attention_mask
 
     # Generate mask
     undesired_tokens_mask = undesired_tokens == 0.0


### PR DESCRIPTION
Hi @Narsil  @amyeroberts 

This PR fixed the error for question-answering pipeline, the error could be reproduced by
```python
from transformers import pipeline
pipe = pipeline("question-answering", model="hf-internal-testing/tiny-random-bert")
question = "What's my name?"
context = "My Name is Sasha and I live in Lyon."
pipe(question, context)
```

Traceback:
```
Traceback (most recent call last):
  File "test_qa.py", line 5, in <module>
    pipe(question, context)
  File "/home/jiqingfe/miniconda3/envs/ccl/lib/python3.8/site-packages/transformers/pipelines/question_answering.py", line 393, in __call__
    return super().__call__(examples[0], **kwargs)
  File "/home/jiqingfe/miniconda3/envs/ccl/lib/python3.8/site-packages/transformers/pipelines/base.py", line 1235, in __call__
    return next(
  File "/home/jiqingfe/miniconda3/envs/ccl/lib/python3.8/site-packages/transformers/pipelines/pt_utils.py", line 125, in __next__
    processed = self.infer(item, **self.params)
  File "/home/jiqingfe/miniconda3/envs/ccl/lib/python3.8/site-packages/transformers/pipelines/question_answering.py", line 546, in postprocess                                                    starts, ends, scores, min_null_score = select_starts_ends(
  File "/home/jiqingfe/miniconda3/envs/ccl/lib/python3.8/site-packages/transformers/pipelines/question_answering.py", line 124, in select_starts_ends
    undesired_tokens = undesired_tokens & attention_mask
TypeError: ufunc 'bitwise_and' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

```