### PR TITLE
Added HHCache class implementing H2O Cache

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -349,6 +349,11 @@ class LlamaAttention(nn.Module):
 
         # upcast attention to fp32
         attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+
+        if past_key_value is not None:
+            cache_kwargs = {"attn_weights": attn_weights}
+            past_key_value.post_process(self.layer_idx, cache_kwargs)
+
         attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
         attn_output = torch.matmul(attn_weights, value_states)
 


### PR DESCRIPTION
# What does this PR do?
This PR adds the feature requested in #30758. The HHCache class is almost directly taken from the original H2O paper's authors code found [here](https://github.com/FMInference/H2O). Currently the PR only adds the changes required to Llama model class. As of now I have taken @gante 's suggestion of adding `Cache.post_process()` and calling it within `LlamaAttention.forward`.

# To-Do
1. I'm not sure if the logic for RoPE rerotation is 100% correct. I think the recent tokens are correct, but not the hh tokens after eviction. Would love to have another set of eyes on that.
2. Write tests to ensure that this HHCache class has the same behavior compared to the original code by paper authors.
3. Benchmarking(?)

Feedback and/or help would be appreciated. Thanks!