### PR TITLE
Fix RT-DETR inference with float16 and bfloat16

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1357,12 +1357,9 @@ class RTDetrHybridEncoder(nn.Module):
                 # flatten [batch, channel, height, width] to [batch, height*width, channel]
                 src_flatten = hidden_states[enc_ind].flatten(2).permute(0, 2, 1)
                 if self.training or self.eval_size is None:
-                    pos_embed = (
-                        self.build_2d_sincos_position_embedding(
-                            width, height, self.encoder_hidden_dim, self.positional_encoding_temperature
-                        )
-                        .to(src_flatten.device, src_flatten.dtype)
-                    )
+                    pos_embed = self.build_2d_sincos_position_embedding(
+                        width, height, self.encoder_hidden_dim, self.positional_encoding_temperature
+                    ).to(src_flatten.device, src_flatten.dtype)
                 else:
                     pos_embed = None
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1357,9 +1357,13 @@ class RTDetrHybridEncoder(nn.Module):
                 # flatten [batch, channel, height, width] to [batch, height*width, channel]
                 src_flatten = hidden_states[enc_ind].flatten(2).permute(0, 2, 1)
                 if self.training or self.eval_size is None:
-                    pos_embed = self.build_2d_sincos_position_embedding(
-                        width, height, self.encoder_hidden_dim, self.positional_encoding_temperature
-                    ).to(src_flatten.device)
+                    pos_embed = (
+                        self.build_2d_sincos_position_embedding(
+                            width, height, self.encoder_hidden_dim, self.positional_encoding_temperature
+                        )
+                        .to(src_flatten.device)
+                        .to(src_flatten.dtype)
+                    )
                 else:
                     pos_embed = None
 
@@ -1801,12 +1805,13 @@ class RTDetrModel(RTDetrPreTrainedModel):
 
         batch_size = len(source_flatten)
         device = source_flatten.device
+        dtype = source_flatten.dtype
 
         # prepare input for decoder
         if self.training or self.config.anchor_image_size is None:
-            anchors, valid_mask = self.generate_anchors(spatial_shapes, device=device)
+            anchors, valid_mask = self.generate_anchors(spatial_shapes, device=device, dtype=dtype)
         else:
-            anchors, valid_mask = self.anchors.to(device), self.valid_mask.to(device)
+            anchors, valid_mask = self.anchors.to(device).to(dtype), self.valid_mask.to(device).to(dtype)
 
         # use the valid_mask to selectively retain values in the feature map where the mask is `True`
         memory = valid_mask.to(source_flatten.dtype) * source_flatten

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1361,8 +1361,7 @@ class RTDetrHybridEncoder(nn.Module):
                         self.build_2d_sincos_position_embedding(
                             width, height, self.encoder_hidden_dim, self.positional_encoding_temperature
                         )
-                        .to(src_flatten.device)
-                        .to(src_flatten.dtype)
+                        .to(src_flatten.device, src_flatten.dtype)
                     )
                 else:
                     pos_embed = None
@@ -1811,7 +1810,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         if self.training or self.config.anchor_image_size is None:
             anchors, valid_mask = self.generate_anchors(spatial_shapes, device=device, dtype=dtype)
         else:
-            anchors, valid_mask = self.anchors.to(device).to(dtype), self.valid_mask.to(device).to(dtype)
+            anchors, valid_mask = self.anchors.to(device, dtype), self.valid_mask.to(device, dtype)
 
         # use the valid_mask to selectively retain values in the feature map where the mask is `True`
         memory = valid_mask.to(source_flatten.dtype) * source_flatten

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -18,6 +18,8 @@ import inspect
 import math
 import unittest
 
+from parameterized import parameterized
+
 from transformers import (
     RTDetrConfig,
     RTDetrImageProcessor,
@@ -25,7 +27,7 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
-from transformers.testing_utils import require_torch, require_vision, torch_device
+from transformers.testing_utils import require_torch, require_torch_gpu, require_vision, slow, torch_device
 from transformers.utils import cached_property
 
 from ...test_configuration_common import ConfigTester
@@ -605,6 +607,28 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                         [0.0, 1.0],
                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                     )
+
+    @parameterized.expand(["float32", "float16", "bfloat16"])
+    @require_torch_gpu
+    @slow
+    def test_inference_with_different_dtypes(self, torch_dtype_str):
+        torch_dtype = {
+            "float32": torch.float32,
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+        }[torch_dtype_str]
+
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+            model.to(torch_device).to(torch_dtype)
+            model.eval()
+            for key, tensor in inputs_dict.items():
+                if tensor.dtype == torch.float32:
+                    inputs_dict[key] = tensor.to(torch_dtype)
+            with torch.no_grad():
+                _ = model(**self._prepare_for_class(inputs_dict, model_class))
 
 
 TOLERANCE = 1e-4


### PR DESCRIPTION
# What does this PR do?

Fix positional embeddings and anchor data types for RT-DETR.

Running the model in `float16` or `bfloat16` with the following code crashes with the error:

```python
import torch
import requests

from PIL import Image
from transformers import RTDetrForObjectDetection, RTDetrImageProcessor

device = "cuda"
dtype = torch.float16

url = 'http://images.cocodataset.org/val2017/000000039769.jpg' 
image = Image.open(requests.get(url, stream=True).raw)

image_processor = RTDetrImageProcessor.from_pretrained("PekingU/rtdetr_r50vd")
model = RTDetrForObjectDetection.from_pretrained("PekingU/rtdetr_r50vd", attn_implementation="eager", torch_dtype=dtype, device_map=device)

inputs = image_processor(images=image, return_tensors="pt").to(device)
pixel_values = inputs.pixel_values.to(device).to(dtype)

with torch.no_grad():
    outputs = model(pixel_values)

assert outputs.logits.dtype == dtype

results = image_processor.post_process_object_detection(outputs, target_sizes=torch.tensor([image.size[::-1]]), threshold=0.3)

for result in results:
    for score, label_id, box in zip(result["scores"], result["labels"], result["boxes"]):
        score, label = score.item(), label_id.item()
        box = [round(i, 2) for i in box.tolist()]
        print(f"{model.config.id2label[label]}: {score:.2f} {box}")

```
Error:
```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::Half
```

One approach to fix is to use `torch.autocast()`, but it could also be fixed with proper dtypes in the modeling file.

Steps:

1. Add test that fails with float16/bfloat16 dtypes
2. Add fix

## Before submitting
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc 

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
