### PR TITLE
change anchor_image_size None for compatibility

### DIFF
--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -118,8 +118,8 @@ class RTDetrConfig(PretrainedConfig):
             Scale or magnitude of noise to be added to the bounding boxes.
         learn_initial_query (`bool`, *optional*, defaults to `False`):
             Indicates whether the initial query embeddings for the decoder should be learned during training
-        anchor_image_size (`Tuple[int, int]`, *optional*, defaults to `[640, 640]`):
-            Height and width of the input image used during evaluation to generate the bounding box anchors.
+        anchor_image_size (`Tuple[int, int]`, *optional*, defaults to `None`):
+            Height and width of the input image used during evaluation to generate the bounding box anchors. If None, automatic generate anchor is applied.
         disable_custom_kernels (`bool`, *optional*, defaults to `True`):
             Whether to disable custom kernels.
         with_box_refine (`bool`, *optional*, defaults to `True`):
@@ -218,7 +218,7 @@ class RTDetrConfig(PretrainedConfig):
         label_noise_ratio=0.5,
         box_noise_scale=1.0,
         learn_initial_query=False,
-        anchor_image_size=[640, 640],
+        anchor_image_size=None,
         disable_custom_kernels=True,
         with_box_refine=True,
         is_encoder_decoder=True,

--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -118,7 +118,7 @@ class RTDetrConfig(PretrainedConfig):
             Scale or magnitude of noise to be added to the bounding boxes.
         learn_initial_query (`bool`, *optional*, defaults to `False`):
             Indicates whether the initial query embeddings for the decoder should be learned during training
-        anchor_image_size (`Tuple[int, int]`, *optional*, defaults to `None`):
+        anchor_image_size (`Tuple[int, int]`, *optional*):
             Height and width of the input image used during evaluation to generate the bounding box anchors. If None, automatic generate anchor is applied.
         disable_custom_kernels (`bool`, *optional*, defaults to `True`):
             Whether to disable custom kernels.

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -89,7 +89,7 @@ class RTDetrModelTester:
         label_noise_ratio=0.5,
         box_noise_scale=1.0,
         learn_initial_query=False,
-        anchor_image_size=[64, 64],
+        anchor_image_size=None,
         image_size=64,
         disable_custom_kernels=True,
         with_box_refine=True,


### PR DESCRIPTION
# What does this PR do?

@qubvel This is the commit that we discussed in earlier for better compatibility!

Currently, RT-DETR can be trained with arbitrary image sizes. However, evaluation will not work if `anchor_image_size` is not properly set. In other words, models behave differently in training and evaluation modes.

```python
import torch
from transformers import RTDetrConfig, RTDetrForObjectDetection

config = RTDetrConfig()
model = RTDetrForObjectDetection(config)

image_size = 320
sample = torch.rand((2, 3, image_size, image_size))

model.train()
model(sample)
print(f"Successfully run model in train mode with image size {image_size}!")

model.eval()
with torch.no_grad():
    try:
        model(sample)
    except Exception as e:
        print(f"Failed to run model in eval mode with image size {image_size}.")

# Fix eval
config = RTDetrConfig(anchor_image_size=[image_size, image_size])
model = RTDetrForObjectDetection(config)
model.eval()
with torch.no_grad():
    model(sample)
    print(f"Successfully run model in eval mode with image size {image_size}!")
```

This issue occurs because anchors are generated dynamically during training but remain static during evaluation. This PR modifies the default behavior, ensuring that anchors are generated dynamically during evaluation, just as they are during the training stage.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc 

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
