### PR TITLE
Remove deprecated config attribute in VLMs

### DIFF
--- a/src/transformers/models/llava/configuration_llava.py
+++ b/src/transformers/models/llava/configuration_llava.py
@@ -131,23 +131,5 @@ class LlavaConfig(PretrainedConfig):
             text_config = CONFIG_MAPPING["llama"]()
 
         self.text_config = text_config
-        self._vocab_size = self.text_config.vocab_size
 
         super().__init__(**kwargs)
-
-    @property
-    def vocab_size(self):
-        warnings.warn(
-            "The `vocab_size` attribute is deprecated and will be removed in v4.42, Please use `text_config.vocab_size` instead.",
-            FutureWarning,
-        )
-        return self._vocab_size
-
-    @vocab_size.setter
-    def vocab_size(self, value):
-        self._vocab_size = value
-
-    def to_dict(self):
-        output = super().to_dict()
-        output.pop("_vocab_size", None)
-        return output

--- a/src/transformers/models/vipllava/configuration_vipllava.py
+++ b/src/transformers/models/vipllava/configuration_vipllava.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """VipLlava model configuration"""
 
-import warnings
-
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
 from ..auto import CONFIG_MAPPING
@@ -90,13 +88,6 @@ class VipLlavaConfig(PretrainedConfig):
         self.projector_hidden_act = projector_hidden_act
         self.projector_layernorm_eps = projector_layernorm_eps
         self.vision_feature_layers = vision_feature_layers
-
-        if "vocab_size" in kwargs:
-            warnings.warn(
-                "The `vocab_size` argument is deprecated and will be removed in v4.42, since it can be inferred from the `text_config`. Passing this argument has no effect",
-                FutureWarning,
-            )
-
         self.vision_config = vision_config
 
         if isinstance(self.vision_config, dict):
@@ -123,19 +114,5 @@ class VipLlavaConfig(PretrainedConfig):
             text_config = CONFIG_MAPPING["llama"]()
 
         self.text_config = text_config
-        self._vocab_size = self.text_config.vocab_size
 
         super().__init__(**kwargs)
-
-        @property
-        def vocab_size(self):
-            warnings.warn(
-                "The `vocab_size` attribute is deprecated and will be removed in v4.42, Please use `text_config.vocab_size` instead.",
-                FutureWarning,
-            )
-            return self._vocab_size
-
-        def to_dict(self):
-            output = super().to_dict()
-            output.pop("_vocab_size", None)
-            return output


### PR DESCRIPTION
# What does this PR do?

This PR removes the deprecated 'vocab_size' in llava and vipllava. One moment to note is that I didn't notice Paligemma added 'vocab_size' to its config, not `text_config`. Since it did not have a deprecation cycle, I am not sure if we can remove it now, so leaving as-is. cc @molbap 

The resize_embedding tests are passing for both models, because we've fixed that in prev PRs to work with "text_config"