### PR TITLE
Fix float out of range in owlvit and owlv2 when using FP16 or lower precision

### DIFF
--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -1276,7 +1276,7 @@ class Owlv2ClassPredictionHead(nn.Module):
             if query_mask.ndim > 1:
                 query_mask = torch.unsqueeze(query_mask, dim=-2)
 
-            pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
+            pred_logits = torch.where(query_mask == 0, torch.finfo(pred_logits.dtype).min, pred_logits)
             pred_logits = pred_logits.to(torch.float32)
 
         return (pred_logits, image_class_embeds)

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1257,7 +1257,7 @@ class OwlViTClassPredictionHead(nn.Module):
             if query_mask.ndim > 1:
                 query_mask = torch.unsqueeze(query_mask, dim=-2)
 
-            pred_logits = torch.where(query_mask == 0, -1e6, pred_logits)
+            pred_logits = torch.where(query_mask == 0, torch.finfo(pred_logits.dtype).min, pred_logits)
             pred_logits = pred_logits.to(torch.float32)
 
         return (pred_logits, image_class_embeds)


### PR DESCRIPTION
# What does this PR do?
As discussed in https://github.com/huggingface/transformers/pull/31342#issuecomment-2192011957

The hard coded `-1e6` value used to mask logits is not in range for FP16 which causes a `value cannot be converted to type at::Half without overflow` error. We replace that with the min value of whichever dtype the logits are in.

Did a search and only the `owlvit` and `owlv2` models are using this, however, we should take note if any future model implementation hardcodes a similar value. There exists a couple more models using -1e7, -1e8, -1e9 and -1e10, but most of them are TensorFlow models, and the rest are either deprecated or language models. Since there has been no issue reports on this so far, I think it is properly handled somewhere so I won't change them.

Tests on FP32 showed no numerical difference in logits up to 1e-4 (what the test uses).

The reason of not using `float('-inf')` is that it can be 20% (RTX 3080Ti) to 3x (H100 SXM5) slower than using a predefined value for some reason.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 
