### PR TITLE
Fix RT-DETR cache for generate_anchors

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1657,7 +1657,6 @@ class RTDetrModel(RTDetrPreTrainedModel):
 
     @lru_cache(maxsize=32)
     def generate_anchors(self, spatial_shapes=None, grid_size=0.05):
-
         # We always generate anchors in float32 to preserve original model code
         dtype = torch.float32
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1657,7 +1657,8 @@ class RTDetrModel(RTDetrPreTrainedModel):
 
     @lru_cache(maxsize=32)
     def generate_anchors(self, spatial_shapes=None, grid_size=0.05):
-        # We always generate anchors in float32 to preserve original model code
+        # We always generate anchors in float32 to preserve equivalence between
+        # dynamic and static anchor inference
         dtype = torch.float32
 
         if spatial_shapes is None:

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -649,7 +649,7 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             if tensor.dtype == torch.float32:
                 inputs_dict[key] = tensor.to(torch_dtype)
 
-        for model_class in self.all_model_classes[1:]:
+        for model_class in self.all_model_classes:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model_class(config).save_pretrained(tmpdirname)
                 model_static = model_class.from_pretrained(

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -671,7 +671,6 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                     outputs_static.last_hidden_state, outputs_dynamic.last_hidden_state, rtol=1e-4, atol=1e-4
                 ),
                 f"Max diff: {(outputs_static.last_hidden_state - outputs_dynamic.last_hidden_state).abs().max()}"
-                f"Max logit value: {outputs_static.logits.abs().max()}",
             )
 
 

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -670,7 +670,7 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 torch.allclose(
                     outputs_static.last_hidden_state, outputs_dynamic.last_hidden_state, rtol=1e-4, atol=1e-4
                 ),
-                f"Max diff: {(outputs_static.last_hidden_state - outputs_dynamic.last_hidden_state).abs().max()}"
+                f"Max diff: {(outputs_static.last_hidden_state - outputs_dynamic.last_hidden_state).abs().max()}",
             )
 
 


### PR DESCRIPTION
# What does this PR do?

For RT-DETR model:

1. Fix lru_cache for the `generate_anchors` method, so even if we go with dynamic anchors generation we only generate it once per image of the same size.
2. Fix anchors dtype: make anchors generated always in float32, and then convert to the desired type. Otherwise, a difference might be observed between dynamic and static anchors inference in float16/bfloat16 (test is added).

## Who can review?
cc @SangbumChoi 
