### PR TITLE
dependencies: `keras-nlp<0.14` pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ _deps = [
     "kenlm",
     # Keras pin - this is to make sure Keras 3 doesn't destroy us. Remove or change when we have proper support.
     "keras>2.9,<2.16",
-    "keras-nlp>=0.3.1",
+    "keras-nlp>=0.3.1,<0.14.0",  # keras-nlp 0.14 doesn't support keras 2, see pin on keras.
     "librosa",
     "nltk",
     "natten>=0.14.6,<0.15.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -34,7 +34,7 @@ deps = {
     "jinja2": "jinja2>=3.1.0",
     "kenlm": "kenlm",
     "keras": "keras>2.9,<2.16",
-    "keras-nlp": "keras-nlp>=0.3.1",
+    "keras-nlp": "keras-nlp>=0.3.1,<0.14.0",
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6,<0.15.0",


### PR DESCRIPTION
# What does this PR do?

On the latest `keras-nlp` [release](https://github.com/keras-team/keras-nlp/releases/tag/v0.14.0) -- "KerasNLP no longer supports Keras 2.". This means we don't support this version, as we only support Keras 2