### PR TITLE
Fix mistral ONNX export

### DIFF
--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1089,8 +1089,9 @@ class MistralModel(MistralPreTrainedModel):
             exclude_mask = torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
             if self.config.sliding_window is not None:
                 if not using_sliding_window_cache or sequence_length > self.config.sliding_window:
-                    exclude_mask |= torch.arange(target_length, device=device) <= (
-                        cache_position.reshape(-1, 1) - self.config.sliding_window
+                    exclude_mask.bitwise_or_(
+                        torch.arange(target_length, device=device)
+                        <= (cache_position.reshape(-1, 1) - self.config.sliding_window)
                     )
             causal_mask *= exclude_mask
             causal_mask = causal_mask[None, None, :, :].expand(input_tensor.shape[0], 1, -1, -1)


### PR DESCRIPTION
The ONNX torchscript export fails after https://github.com/huggingface/transformers/pull/30642 as `exclude_mask |= ...` gets mapped to `aten::__ior_` which is not exportable. `aten::bitwise_or` is.

Using `torch.bitwise_or(exclude_mask, second_mask, out=exclude_mask)` breaks as well the ONNX export so using the inplace version of the operator instead.