### PR TITLE
Fix Wav2Vec2 Fairseq conversion (weight norm state dict keys)

### DIFF
--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
@@ -104,7 +104,7 @@ def set_recursively(key, value, full_name, weight_type, hf_pointer):
         elif weight_type == "weight_v" and not hasattr(hf_pointer, "weight_v"):
             hf_shape = hf_pointer.parametrizations.weight.original1.shape
         else:
-            hf_shape = getattr(hf_pointer, weight_type).shape    
+            hf_shape = getattr(hf_pointer, weight_type).shape
     elif weight_type is not None and weight_type == "param":
         shape_pointer = hf_pointer
         for attribute in hf_param_name.split("."):

--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
@@ -94,8 +94,17 @@ def set_recursively(key, value, full_name, weight_type, hf_pointer):
             hf_param_name = PARAM_MAPPING[full_name.split(".")[-1]]
             weight_type = "param"
 
+    # fairseq uses nn.utils.weight_norm() while transformers switches to nn.utils.parametrizations.weight_norm()
+    # the mapping between two versions:
+    # https://github.com/pytorch/pytorch/blob/56935684c3dfad7841c83c719eeebecb560fe466/torch/nn/utils/parametrizations.py#L389-L395
+
     if weight_type is not None and weight_type != "param":
-        hf_shape = getattr(hf_pointer, weight_type).shape
+        if weight_type == "weight_g" and not hasattr(hf_pointer, "weight_g"):
+            hf_shape = hf_pointer.parametrizations.weight.original0.shape
+        elif weight_type == "weight_v" and not hasattr(hf_pointer, "weight_v"):
+            hf_shape = hf_pointer.parametrizations.weight.original1.shape
+        else:
+            hf_shape = getattr(hf_pointer, weight_type).shape    
     elif weight_type is not None and weight_type == "param":
         shape_pointer = hf_pointer
         for attribute in hf_param_name.split("."):
@@ -116,9 +125,15 @@ def set_recursively(key, value, full_name, weight_type, hf_pointer):
     if weight_type == "weight":
         hf_pointer.weight.data = value
     elif weight_type == "weight_g":
-        hf_pointer.weight_g.data = value
+        if hasattr(hf_pointer, "weight_g"):
+            hf_pointer.weight_g.data = value
+        else:
+            hf_pointer.parametrizations.weight.original0 = value
     elif weight_type == "weight_v":
-        hf_pointer.weight_v.data = value
+        if hasattr(hf_pointer, "weight_v"):
+            hf_pointer.weight_v.data = value
+        else:
+            hf_pointer.parametrizations.weight.original1 = value
     elif weight_type == "bias":
         hf_pointer.bias.data = value
     elif weight_type == "param":

--- a/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py
@@ -128,12 +128,12 @@ def set_recursively(key, value, full_name, weight_type, hf_pointer):
         if hasattr(hf_pointer, "weight_g"):
             hf_pointer.weight_g.data = value
         else:
-            hf_pointer.parametrizations.weight.original0 = value
+            hf_pointer.parametrizations.weight.original0.data = value
     elif weight_type == "weight_v":
         if hasattr(hf_pointer, "weight_v"):
             hf_pointer.weight_v.data = value
         else:
-            hf_pointer.parametrizations.weight.original1 = value
+            hf_pointer.parametrizations.weight.original1.data = value
     elif weight_type == "bias":
         hf_pointer.bias.data = value
     elif weight_type == "param":


### PR DESCRIPTION
# What does this PR do?

Close #31633

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sanchit-gandhi @amyeroberts

## To test

```bash
wget https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_small.pt  # wav2vec2-base checkpoint from facebook
pip install git+https://github.com/facebookresearch/fairseq.git  # install fairseq

python src/transformers/models/wav2vec2/convert_wav2vec2_original_pytorch_checkpoint_to_pytorch.py \
    --pytorch_dump_folder wav2vec2-base \
    --checkpoint_path wav2vec_small.pt \
    --config_path facebook/wav2vec2-base \
    --not_finetuned
```

I only checked for Wav2Vec2 base. Other checkpoints should work too. See other checkpoints from fairseq here: https://github.com/facebookresearch/fairseq/tree/main/examples/wav2vec

e.g. https://dl.fbaipublicfiles.com/fairseq/wav2vec/libri960_big.pt corresponds to https://huggingface.co/facebook/wav2vec2-large