### PR TITLE
Fix RT-DETR weights initialization

### DIFF
--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -37,6 +37,8 @@ class RTDetrConfig(PretrainedConfig):
     Args:
         initializer_range (`float`, *optional*, defaults to 0.01):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
+        initializer_bias_prior_prob (`float`, *optional*, defaults to 0.01):
+            The prior probability used by the bias initializer to initialize biases for `enc_score_head` and `class_embed`.
         layer_norm_eps (`float`, *optional*, defaults to 1e-05):
             The epsilon used by the layer normalization layers.
         batch_norm_eps (`float`, *optional*, defaults to 1e-05):
@@ -179,6 +181,7 @@ class RTDetrConfig(PretrainedConfig):
     def __init__(
         self,
         initializer_range=0.01,
+        initializer_bias_prior_prob=0.01,
         layer_norm_eps=1e-5,
         batch_norm_eps=1e-5,
         # backbone
@@ -239,6 +242,7 @@ class RTDetrConfig(PretrainedConfig):
         **kwargs,
     ):
         self.initializer_range = initializer_range
+        self.initializer_bias_prior_prob = initializer_bias_prior_prob
         self.layer_norm_eps = layer_norm_eps
         self.batch_norm_eps = batch_norm_eps
         # backbone

--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -37,8 +37,9 @@ class RTDetrConfig(PretrainedConfig):
     Args:
         initializer_range (`float`, *optional*, defaults to 0.01):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
-        initializer_bias_prior_prob (`float`, *optional*, defaults to 0.01):
+        initializer_bias_prior_prob (`float`, *optional*):
             The prior probability used by the bias initializer to initialize biases for `enc_score_head` and `class_embed`.
+            If `None`, `prior_prob` computed as `prior_prob = 1 / (num_labels + 1)` while initializing model weights.
         layer_norm_eps (`float`, *optional*, defaults to 1e-05):
             The epsilon used by the layer normalization layers.
         batch_norm_eps (`float`, *optional*, defaults to 1e-05):
@@ -181,7 +182,7 @@ class RTDetrConfig(PretrainedConfig):
     def __init__(
         self,
         initializer_range=0.01,
-        initializer_bias_prior_prob=0.01,
+        initializer_bias_prior_prob=None,
         layer_norm_eps=1e-5,
         batch_norm_eps=1e-5,
         # backbone

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1156,7 +1156,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
                 nn.init.xavier_uniform_(layer.weight)
                 if hasattr(layer, "bias") and layer.bias is not None:
                     nn.init.constant_(layer.bias, bias)
-        
+
         if isinstance(module, RTDetrModel):
             prior_prob = self.config.initializer_range
             bias = float(-math.log((1 - prior_prob) / prior_prob))

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1148,17 +1148,17 @@ class RTDetrPreTrainedModel(PreTrainedModel):
     def _init_weights(self, module):
         """Initalize the weights"""
 
-        """initialize conv/fc bias value according to a given probability value."""
+        """initialize linear layer bias value according to a given probability value."""
         if isinstance(module, (RTDetrForObjectDetection, RTDetrDecoder)) and module.class_embed is not None:
             for layer in module.class_embed:
-                prior_prob = self.config.initializer_range
+                prior_prob = self.config.initializer_bias_prior_prob
                 bias = float(-math.log((1 - prior_prob) / prior_prob))
                 nn.init.xavier_uniform_(layer.weight)
                 if hasattr(layer, "bias") and layer.bias is not None:
                     nn.init.constant_(layer.bias, bias)
 
         if isinstance(module, RTDetrModel):
-            prior_prob = self.config.initializer_range
+            prior_prob = self.config.initializer_bias_prior_prob
             bias = float(-math.log((1 - prior_prob) / prior_prob))
             nn.init.xavier_uniform_(module.enc_score_head.weight)
             if hasattr(module.enc_score_head, "bias") and module.enc_score_head.bias is not None:

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1152,7 +1152,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
         if isinstance(module, (RTDetrForObjectDetection, RTDetrDecoder)):
             if module.class_embed is not None:
                 for layer in module.class_embed:
-                    prior_prob = self.config.initializer_bias_prior_prob
+                    prior_prob = self.config.initializer_bias_prior_prob or 1 / (self.config.num_labels + 1)
                     bias = float(-math.log((1 - prior_prob) / prior_prob))
                     nn.init.xavier_uniform_(layer.weight)
                     nn.init.constant_(layer.bias, bias)
@@ -1163,7 +1163,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
                     nn.init.constant_(layer.layers[-1].bias, 0)
 
         if isinstance(module, RTDetrModel):
-            prior_prob = self.config.initializer_bias_prior_prob
+            prior_prob = self.config.initializer_bias_prior_prob or 1 / (self.config.num_labels + 1)
             bias = float(-math.log((1 - prior_prob) / prior_prob))
             nn.init.xavier_uniform_(module.enc_score_head.weight)
             nn.init.constant_(module.enc_score_head.bias, bias)

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -626,8 +626,8 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                                 f"Mean is {round_mean}, but should be in [0, 1]"
                             )
 
-        if failed_cases:
-            raise AssertionError("\n" + "\n".join(failed_cases))
+        message = "\n" + "\n".join(failed_cases)
+        self.assertTrue(not failed_cases, message)
 
     @parameterized.expand(["float32", "float16", "bfloat16"])
     @require_torch_gpu

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -583,6 +583,11 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         configs_no_init = _config_zero_init(config)
+        configs_no_init.initializer_bias_prior_prob = 0.2
+        bias_value = -1.3863  # log_e ((1 - 0.2) / 0.2)
+
+        failed_cases = []
+
         for model_class in self.all_model_classes:
             model = model_class(config=configs_no_init)
             # Skip the check for the backbone
@@ -593,20 +598,36 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
             for name, param in model.named_parameters():
                 if param.requires_grad:
-                    if (
+                    if ("class_embed" in name and "bias" in name) or "enc_score_head.bias" in name:
+                        bias_tensor = torch.full_like(param.data, bias_value)
+                        if not torch.allclose(param.data, bias_tensor, atol=1e-4):
+                            failed_cases.append(
+                                f"Parameter {name} of model {model_class} seems not properly initialized. "
+                                f"Biases should be initialized to {bias_value}, got {param.data}"
+                            )
+                    elif (
                         "level_embed" in name
                         or "sampling_offsets.bias" in name
                         or "value_proj" in name
                         or "output_proj" in name
                         or "reference_points" in name
+                        or "enc_score_head.weight" in name
+                        or ("class_embed" in name and "weight" in name)
                         or name in backbone_params
                     ):
                         continue
-                    self.assertIn(
-                        ((param.data.mean() * 1e9).round() / 1e9).item(),
-                        [0.0, 1.0],
-                        msg=f"Parameter {name} of model {model_class} seems not properly initialized",
-                    )
+                    else:
+                        mean = param.data.mean()
+                        round_mean = (mean * 1e9).round() / 1e9
+                        round_mean = round_mean.item()
+                        if round_mean not in [0.0, 1.0]:
+                            failed_cases.append(
+                                f"Parameter {name} of model {model_class} seems not properly initialized. "
+                                f"Mean is {round_mean}, but should be in [0, 1]"
+                            )
+
+        if failed_cases:
+            raise AssertionError("\n" + "\n".join(failed_cases))
 
     @parameterized.expand(["float32", "float16", "bfloat16"])
     @require_torch_gpu


### PR DESCRIPTION
# What does this PR do?

Fix RT-DETR bbox and class head weight initialization.

1. In`_init_weight` method bbox and class heads are not reachable for initialization. This sometimes leads to unstable training and lower results (see experiments below).
2. Added config parameter for bias initialization, in the [original code](https://github.com/lyuwenyu/RT-DETR/blob/5b628eaa0a2fc25bdafec7e6148d5296b144af85/rtdetr_paddle/ppdet/modeling/transformers/rtdetr_transformer.py#L325) biases of the head are initialized with `prior_prob=0.01` which is OK for training with 80 classes, however, while fine-tuning this value should be adjusted.

Results of the fine-tuning on `main` vs `fix` branches on CPPE-5 dataset (averaged for 6 runs each):

 - better convergence: +0.1-0.15 mAP50 on average on eval and test sets
 - lower dispersion of results

<img width="680" alt="Screenshot 2024-07-01 at 09 42 12" src="https://github.com/huggingface/transformers/assets/31920396/e2410381-e836-4d7c-b722-ae3575731f69">

<img width="662" alt="Screenshot 2024-07-01 at 09 43 00" src="https://github.com/huggingface/transformers/assets/31920396/a630bf42-4bfb-4afe-9e4c-1ea3b98983fd">


## Who can review?
@amyeroberts 

cc @SangbumChoi @NielsRogge 
