### PR TITLE
Only disallow DeepSpeed Zero-3 for auto bs finder

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4829,7 +4829,7 @@ class Trainer:
 
         # `auto_find_batch_size` isn't yet supported with DeepSpeed
         if self.is_deepspeed_enabled and self.args.auto_find_batch_size:
-            raise NotImplementedError(f"`DeepSpeed` doesn't support `auto_find_batch_size`.")
+            raise NotImplementedError("`DeepSpeed` doesn't support `auto_find_batch_size`.")
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4827,10 +4827,9 @@ class Trainer:
             wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
             raise ValueError(f"{wrapper} can't be used with `save_only_model` along with `load_best_model_at_end`.")
 
-        # `auto_find_batch_size` isn't yet supported with DeepSpeed/FSDP
-        if (self.is_deepspeed_enabled or self.is_fsdp_enabled) and self.args.auto_find_batch_size:
-            wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
-            raise NotImplementedError(f"`{wrapper}` doesn't support `auto_find_batch_size`.")
+        # `auto_find_batch_size` isn't yet supported with DeepSpeed
+        if self.is_deepspeed_enabled and self.args.auto_find_batch_size:
+            raise NotImplementedError(f"`DeepSpeed` doesn't support `auto_find_batch_size`.")
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4827,9 +4827,15 @@ class Trainer:
             wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
             raise ValueError(f"{wrapper} can't be used with `save_only_model` along with `load_best_model_at_end`.")
 
-        # `auto_find_batch_size` isn't yet supported with DeepSpeed
-        if self.is_deepspeed_enabled and self.args.auto_find_batch_size:
-            raise NotImplementedError("`DeepSpeed` doesn't support `auto_find_batch_size`.")
+        # `auto_find_batch_size` isn't supported yet with DeepSpeed Zero-3
+        if (
+            self.is_deepspeed_enabled
+            and self.accelerator.state.deepspeed_plugin.zero_stage == 3
+            and self.args.auto_find_batch_size
+        ):
+            raise ValueError(
+                "`auto_find_batch_size` isn't supported yet with DeepSpeed Zero-3. Please consider using Zero-2, Zero-1, or FSDP"
+            )
 
     def propagate_args_to_deepspeed(self, auto_find_batch_size=False):
         """


### PR DESCRIPTION
# What does this PR do?

Looking into re-enabling the auto bs finder for FSDP and DeepSpeed. Did a small scale test with FSDP and found that training works fine. Will move onto DeepSpeed soon but here is an interim.

At the *worst* users can raise an issue here (a new one) with what specifically breaks with FSDP. But my attempts to break it based on FSDP have yet to fail (as FSDP doesn't care about batch sizes actually!)

I don't enjoy not having a test here, in my tests I was using `tinyllama` on 48GB (2x4090). What's the general guidelines for using non-custom models in this case? Do we make test models of size N? `tinyllama` is a 1.1B Llama model, so I can probably write a chunk test with a model that size if we need to/should. Just curious if we have any methods of dynamically creating models of `n` size for testing purposes (I know we do so in accelerate)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @SunMarc 