### PR TITLE
add staggered linear LR scheduler

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -475,6 +475,10 @@ def get_staggered_schedule_with_linear_modifier(
     Args:
         optimizer ([`~torch.optim.Optimizer`]):
             The optimizer for which to schedule the learning rate.
+        num_training_steps (`int`):
+            The total number of training steps.
+        num_train_epochs (`int`):
+            The total number of training epochs.
         modifier (`float`):
             The modifier to decrease the learning rate at the end of each epoch.
         min_lr (`float`):

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -454,13 +454,21 @@ def get_wsd_schedule(
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
 
-
-def _get_staggered_schedule_with_linear_modifier_lr_lambda(current_step: int, steps_per_stagger: int, modifier: float, min_lr: float):
+def _get_staggered_schedule_with_linear_modifier_lr_lambda(
+    current_step: int, steps_per_stagger: int, modifier: float, min_lr: float
+):
     current_epoch = current_step // steps_per_stagger
     return max(min_lr, 1.0 - (current_epoch * modifier))
 
 
-def get_staggered_schedule_with_linear_modifier(optimizer: Optimizer, num_training_steps: int, num_train_epochs: int, modifier: float, min_lr: float, last_epoch: int = -1):
+def get_staggered_schedule_with_linear_modifier(
+    optimizer: Optimizer,
+    num_training_steps: int,
+    num_train_epochs: int,
+    modifier: float,
+    min_lr: float,
+    last_epoch: int = -1,
+):
     """
     Create a schedule with a staggered learning rate that remains constant throughout the epoch, and decreases linearly by a given modifier at the end of each epoch.
 
@@ -482,10 +490,9 @@ def get_staggered_schedule_with_linear_modifier(optimizer: Optimizer, num_traini
         _get_staggered_schedule_with_linear_modifier_lr_lambda,
         steps_per_stagger=steps_per_stagger,
         modifier=modifier,
-        min_lr=min_lr
+        min_lr=min_lr,
     )
     return LambdaLR(optimizer, lr_lambda, last_epoch=last_epoch)
-
 
 
 TYPE_TO_SCHEDULER_FUNCTION = {
@@ -575,7 +582,12 @@ def get_scheduler(
             raise ValueError(f"{name} requires `num_training_steps`, please provide that argument.")
         if num_train_epochs is None:
             raise ValueError(f"{name} requires `num_train_epochs`, please provide that argument.")
-        return schedule_func(optimizer, num_training_steps=num_training_steps, num_train_epochs=num_train_epochs, **scheduler_specific_kwargs)
+        return schedule_func(
+            optimizer,
+            num_training_steps=num_training_steps,
+            num_train_epochs=num_train_epochs,
+            **scheduler_specific_kwargs,
+        )
 
     # All other schedulers require `num_warmup_steps`
     if num_warmup_steps is None:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1020,7 +1020,7 @@ class Trainer:
         # We use the same batch_size as for eval.
         return self.accelerator.prepare(DataLoader(test_dataset, **dataloader_params))
 
-    def create_optimizer_and_scheduler(self, num_training_steps: int, num_train_epochs: int = 1):
+    def create_optimizer_and_scheduler(self, num_training_steps: int, num_train_epochs: Optional[int] = None):
         """
         Setup the optimizer and the learning rate scheduler.
 
@@ -1436,7 +1436,7 @@ class Trainer:
         return optimizer_cls, optimizer_kwargs
 
     def create_scheduler(
-        self, num_training_steps: int, num_train_epochs: int, optimizer: torch.optim.Optimizer = None
+        self, num_training_steps: int, num_train_epochs: Optional[int] = None, optimizer: torch.optim.Optimizer = None
     ):
         """
         Setup the scheduler. The optimizer of the trainer must have been set up either before this method is called or

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1034,7 +1034,9 @@ class Trainer:
             optimizer = self.optimizer.optimizer
         else:
             optimizer = self.optimizer
-        self.create_scheduler(num_training_steps=num_training_steps, num_train_epochs=num_train_epochs, optimizer=optimizer)
+        self.create_scheduler(
+            num_training_steps=num_training_steps, num_train_epochs=num_train_epochs, optimizer=optimizer
+        )
 
     def get_decay_parameter_names(self, model) -> List[str]:
         """
@@ -1433,7 +1435,9 @@ class Trainer:
             raise ValueError(f"Trainer cannot instantiate unsupported optimizer: {args.optim}")
         return optimizer_cls, optimizer_kwargs
 
-    def create_scheduler(self, num_training_steps: int, num_train_epochs: int, optimizer: torch.optim.Optimizer = None):
+    def create_scheduler(
+        self, num_training_steps: int, num_train_epochs: int, optimizer: torch.optim.Optimizer = None
+    ):
         """
         Setup the scheduler. The optimizer of the trainer must have been set up either before this method is called or
         passed as an argument.

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -416,6 +416,7 @@ class SchedulerType(ExplicitEnum):
     REDUCE_ON_PLATEAU = "reduce_lr_on_plateau"
     COSINE_WITH_MIN_LR = "cosine_with_min_lr"
     WARMUP_STABLE_DECAY = "warmup_stable_decay"
+    STAGGERED_LINEAR = "staggered_linear"
 
 
 class TrainerMemoryTracker:


### PR DESCRIPTION
The staggered linear LR scheduler uses the epoch to successively modify the learning rate, so that it is constant over each epoch, and modified at the start of each new epoch.

# What does this PR do?

This PR adds a new LR scheduler called "staggered linear LR", or "staggered scheduler with linear modifier"* to be exact. 

A lot of users use a constant learning rate with the mindset that they want to give equal weight/importance to every part of the dataset being trained on. However, it is often hit and miss on figuring out which learning rate works the best, and there is no correction happening naturally, as the LR is the exact same value the entire time.

The staggered linear LR scheduler instead keeps a constant learning rate throughout each epoch, and then modifies it (linearly) by a given modifier. For example, running a 10 epoch training run, with lr=0.2 and staggered modifier 0.01, the learning rate would be:

* 0.200 (epoch 1)
* 0.198 (epoch 2)
* 0.196
* 0.194
* 0.192
* 0.190
* 0.188
* 0.186
* 0.184
* 0.182 (epoch 10)

The idea is to train on the entire dataset with the same learning rate, then modify the learning rate and repeat.

(* This is not a scientific paper. If this name offends or confuses, I will change it.)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- trainer: @muellerzr and @SunMarc
