### PR TITLE
🚨🚨 TextGenerationPipeline: rely on the tokenizer default kwargs

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -273,14 +273,17 @@ class TextGenerationPipeline(Pipeline):
         **generate_kwargs,
     ):
         if isinstance(prompt_text, Chat):
+            # Only set non-None tokenizer kwargs, so as to rely on the tokenizer's defaults
+            tokenizer_kwargs = {}
+            for tokenizer_kwarg_name in ["truncation", "padding", "max_length"]:
+                if locals()[tokenizer_kwarg_name] is not None:
+                    tokenizer_kwargs[tokenizer_kwarg_name] = locals()[tokenizer_kwarg_name]
             inputs = self.tokenizer.apply_chat_template(
                 prompt_text.messages,
-                truncation=truncation,
-                padding=padding,
-                max_length=max_length,
                 add_generation_prompt=True,
                 return_dict=True,
                 return_tensors=self.framework,
+                **tokenizer_kwargs,
             )
         else:
             # Only set non-None tokenizer kwargs, so as to rely on the tokenizer's defaults

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -266,9 +266,9 @@ class TextGenerationPipeline(Pipeline):
         prompt_text,
         prefix="",
         handle_long_generation=None,
-        add_special_tokens=False,
+        add_special_tokens=None,
         truncation=None,
-        padding=False,
+        padding=None,
         max_length=None,
         **generate_kwargs,
     ):
@@ -283,14 +283,13 @@ class TextGenerationPipeline(Pipeline):
                 return_tensors=self.framework,
             )
         else:
-            inputs = self.tokenizer(
-                prefix + prompt_text,
-                truncation=truncation,
-                padding=padding,
-                max_length=max_length,
-                add_special_tokens=add_special_tokens,
-                return_tensors=self.framework,
-            )
+            # Only set non-None tokenizer kwargs, so as to rely on the tokenizer's defaults
+            tokenizer_kwargs = {}
+            for tokenizer_kwarg_name in ["add_special_tokens", "truncation", "padding", "max_length"]:
+                if locals()[tokenizer_kwarg_name] is not None:
+                    tokenizer_kwargs[tokenizer_kwarg_name] = locals()[tokenizer_kwarg_name]
+            inputs = self.tokenizer(prefix + prompt_text, return_tensors=self.framework, **tokenizer_kwargs)
+
         inputs["prompt_text"] = prompt_text
 
         if handle_long_generation == "hole":

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2082,6 +2082,7 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             [1, 18],
         )
 
+    # TODO (joao): replace `stop_sequence` in the pipeline by the more recent `generate` functionality
     def test_stop_sequence_stopping_criteria(self):
         # PT-only test: TF doesn't have StoppingCriteria
         prompt = """Hello I believe in"""
@@ -2089,17 +2090,11 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
         output = generator(prompt)
         self.assertEqual(
             output,
-            [
-                {
-                    "generated_text": (
-                        "Hello I believe in in in number number number number number number number number number"
-                    )
-                }
-            ],
+            [{"generated_text": ("Hello I believe in we we we we we we we we we")}],
         )
 
-        output = generator(prompt, stop_sequence=" number")
-        self.assertEqual(output, [{"generated_text": "Hello I believe in in in number"}])
+        output = generator(prompt, stop_sequence=" we")
+        self.assertEqual(output, [{"generated_text": "Hello I believe in we"}])
 
     def test_generate_non_nlp_input_ids_as_kwarg(self):
         # PT-only test: AFAIK there's no non-NLP model architecture in TF that supports `input_ids` as its only input

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -398,7 +398,7 @@ class TextGenerationPipelineTests(unittest.TestCase):
             self.assertEqual(outputs, [{"generated_text": ANY(str)}])
         else:
             with self.assertRaises((ValueError, AssertionError)):
-                outputs = text_generator("")
+                outputs = text_generator("", add_special_tokens=False)
 
         if text_generator.framework == "tf":
             # TF generation does not support max_new_tokens, and it's impossible


### PR DESCRIPTION
# What does this PR do?

### Issue
`TextGenerationPipeline.preprocess`, where tokenization happens, has defined a few optional kwargs whose default value does not match the tokenizer defaults. This was causing: 
1. A mismatch between the tokens resulting from `tokenizer` calls and the tokens `pipeline` was seeing, using default arguments on both
2. The issue seen in [this thread](https://huggingface.co/google/gemma-2-9b-it/discussions/17#66828e78fcfdfa8c5a514891) -- `add_special_tokens` had to be manually set to `True` in the pipeline, despite it already being the default in the tokenizer.

(2 is a consequence of 1 :) )

### This PR
🚨🚨 This PR changes the code to rely on the tokenizer's defaults when these flags are unset. This means some models using `TextGenerationPipeline` previously did not add a `<bos>` by default, which (negatively) impacted their performance. In practice, this is a breaking change.

Example of a script changed as a result of this PR:
```py
from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
import torch

tokenizer = AutoTokenizer.from_pretrained("google/gemma-2-9b-it")
model = AutoModelForCausalLM.from_pretrained("google/gemma-2-9b-it", torch_dtype=torch.bfloat16, device_map="auto")
pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
print(pipe("Foo bar"))
```