### PR TITLE
handle (processor_class, None) returned by ModelPatterns

### DIFF
--- a/src/transformers/commands/add_new_model_like.py
+++ b/src/transformers/commands/add_new_model_like.py
@@ -1628,7 +1628,7 @@ def get_user_input():
     )
 
     old_processing_classes = [
-        c
+        c if not isinstance(c, tuple) else c[0]
         for c in [old_image_processor_class, old_feature_extractor_class, old_tokenizer_class, old_processor_class]
         if c is not None
     ]


### PR DESCRIPTION
`transformers-cli add-new-model-like` seems currently broken for models like `llava` where `ModelPatterns` captures a tuple instead of a processor string descriptor. Adding a special case to handle that.

cc @LysandreJik I suppose?
