### PR TITLE
Requires for torch.tensor before casting

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -762,7 +762,7 @@ def torch_int(x):
 
     import torch
 
-    return x.to(torch.int64) if torch.jit.is_tracing() else int(x)
+    return x.to(torch.int64) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
 def torch_float(x):
@@ -774,7 +774,7 @@ def torch_float(x):
 
     import torch
 
-    return x.to(torch.float32) if torch.jit.is_tracing() else int(x)
+    return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
 def filter_out_non_signature_kwargs(extra: Optional[list] = None):


### PR DESCRIPTION
Fixes ONNX export for swin, swin-donut and clap models

https://github.com/huggingface/transformers/blob/82486e5995ed0a65520b10ce1ea938214a199231/src/transformers/models/swin/modeling_swin.py#L643

coming from : 

```
self.shift_size = torch_int(0)
```

introduced in https://github.com/huggingface/transformers/pull/31311

as `torch_int` is expecting a `torch.Tensor` : https://github.com/huggingface/transformers/blob/82486e5995ed0a65520b10ce1ea938214a199231/src/transformers/utils/generic.py#L765


also I think we should be able to have here 
```
self.shift_size = 0
```

cc @merveenoyan @xenova 



