### PR TITLE
Make tool JSON schemas consistent

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -80,7 +80,7 @@ def _parse_type_hint(hint: str) -> Dict:
             return_dict = subtypes[0]
         elif all(isinstance(subtype["type"], str) for subtype in subtypes):
             # A union of basic types can be expressed as a list in the schema
-            return_dict = {"type": [subtype["type"] for subtype in subtypes]}
+            return_dict = {"type": sorted([subtype["type"] for subtype in subtypes])}
         else:
             # A union of more complex types requires "anyOf"
             return_dict = {"anyOf": subtypes}

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -137,7 +137,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                 "properties": {
                     "x": {
                         "type": "array",
-                        "items": {"type": "array", "items": {"type": ["string", "integer"]}},
+                        "items": {"type": "array", "items": {"type": ["integer", "string"]}},
                         "description": "The input",
                     }
                 },
@@ -455,13 +455,13 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                     },
                     "y": {
                         "type": "array",
-                        "items": {"type": ["string", "integer"]},
+                        "items": {"type": ["integer", "string"]},
                         "nullable": True,
                         "description": "The second input. It's a big list with a single-line description.",
                     },
                     "z": {
                         "type": "array",
-                        "prefixItems": [{"type": ["string", "integer"]}, {"type": "string"}],
+                        "prefixItems": [{"type": ["integer", "string"]}, {"type": "string"}],
                         "description": "The third input. It's some kind of tuple with a default arg.",
                     },
                 },


### PR DESCRIPTION
Our helper for generating JSON schemas from functions had an inconsistency, because the order of types inside a `Union` is not well-defined (I suspect internally it gets converted to a set somewhere).

As a result, they came out in somewhat arbitrary order, and this caused the CI to break when we changed some random aspect of the test runner that flipped the order to the other one. This PR fixes that by using `sorted()` to ensure a consistent ordering for a union of types.