### PR TITLE
[pipeline] fix padding for 1-d tensors

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -90,6 +90,9 @@ def _pad(items, key, padding_value, padding_side):
         # Others include `attention_mask` etc...
         shape = items[0][key].shape
         dim = len(shape)
+        if dim == 1:
+            # We have a list of 1-dim torch tensors, which can be stacked without padding
+            return torch.cat([item[key] for item in items], dim=0)
         if key in ["pixel_values", "image"]:
             # This is probable image so padding shouldn't be necessary
             # B, C, H, W

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -549,7 +549,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer([filename], chunk_length_s=5, batch_size=4)
         self.assertEqual(output, [{"text": " A man said to the universe, Sir, I exist."}])
 
-
     @require_torch
     @slow
     def test_torch_whisper_batched(self):
@@ -562,8 +561,8 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         sample = ds[:2]["audio"]
 
         EXPECTED_OUTPUT = [
-            {'text': ' Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.'},
-            {'text': " Nor is Mr. Quilters' manner less interesting than his matter."},
+            {"text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."},
+            {"text": " Nor is Mr. Quilters' manner less interesting than his matter."},
         ]
 
         output = speech_recognizer(sample, batch_size=2)

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -549,6 +549,26 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer([filename], chunk_length_s=5, batch_size=4)
         self.assertEqual(output, [{"text": " A man said to the universe, Sir, I exist."}])
 
+
+    @require_torch
+    @slow
+    def test_torch_whisper_batched(self):
+        speech_recognizer = pipeline(
+            task="automatic-speech-recognition",
+            model="openai/whisper-tiny",
+            framework="pt",
+        )
+        ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+        sample = ds[:2]["audio"]
+
+        EXPECTED_OUTPUT = [
+            {'text': ' Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.'},
+            {'text': " Nor is Mr. Quilters' manner less interesting than his matter."},
+        ]
+
+        output = speech_recognizer(sample, batch_size=2)
+        self.assertEqual(output, EXPECTED_OUTPUT)
+
     @slow
     def test_find_longest_common_subsequence(self):
         max_source_positions = 1500

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -557,7 +557,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             model="openai/whisper-tiny",
             framework="pt",
         )
-        ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+        ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation[:2]")
         sample = ds[:2]["audio"]
 
         EXPECTED_OUTPUT = [

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -558,14 +558,12 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             framework="pt",
         )
         ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation[:2]")
-        sample = ds[:2]["audio"]
-
         EXPECTED_OUTPUT = [
             {"text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel."},
             {"text": " Nor is Mr. Quilters' manner less interesting than his matter."},
         ]
 
-        output = speech_recognizer(sample, batch_size=2)
+        output = speech_recognizer(ds["audio"], batch_size=2)
         self.assertEqual(output, EXPECTED_OUTPUT)
 
     @slow


### PR DESCRIPTION
# What does this PR do?

Currently on main, batched inference using the ASR pipeline fails:

```python
from transformers import pipeline, AutoProcessor, WhisperForConditionalGeneration
from transformers.utils import is_accelerate_available
from datasets import load_dataset

processor = AutoProcessor.from_pretrained("openai/whisper-tiny.en")
model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny.en", low_cpu_mem_usage=is_accelerate_available())

pipe = pipeline("automatic-speech-recognition", model=model, feature_extractor=processor.feature_extractor, tokenizer=processor.tokenizer)

dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
sample = dataset[:2]["audio"]

pipe(sample, batch_size=2)
```

<details>

<summary> Traceback </summary>

```python
  File "/home/sanchit/transformers/src/transformers/pipelines/base.py", line 194, in inner                              
    padded[key] = _pad(items, key, _padding_value, padding_side)                                                        
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                        
  File "/home/sanchit/transformers/src/transformers/pipelines/base.py", line 100, in _pad                               
    max_length = max(item[key].shape[1] for item in items)                                                              
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                              
  File "/home/sanchit/transformers/src/transformers/pipelines/base.py", line 100, in <genexpr>                          
    max_length = max(item[key].shape[1] for item in items)                                                              
                     ~~~~~~~~~~~~~~~^^^                                                                                 
IndexError: tuple index out of range    
```

</details>

This is because the pipeline class attempts to pad the 1-d tensor of `num_frames`, which we added in https://github.com/huggingface/transformers/pull/30637 to correctly compute word-level timestamps:

https://github.com/huggingface/transformers/blob/048f599f3506e57e0a595b455d9d2834c8d45023/src/transformers/pipelines/automatic_speech_recognition.py#L452

The simple fix is to handle padding of 1-d tensors explicitly in the private `_pad` method, which we implement here. We also add a slow test to confirm batched generation works following the fix.