### PR TITLE
Fix multi-model training with deepspeed nvme-offloading

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1443,6 +1443,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         torch_dtype = kwargs.pop("torch_dtype", None)
         use_flash_attention_2 = kwargs.pop("use_flash_attention_2", False)
+        disable_zero_init = kwargs.pop("disable_zero_init", False)
 
         # override default dtype if needed
         dtype_orig = None
@@ -1466,7 +1467,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             torch_dtype=torch_dtype,
         )
 
-        if is_deepspeed_zero3_enabled():
+        if is_deepspeed_zero3_enabled() and not disable_zero_init:
             import deepspeed
 
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
@@ -3187,6 +3188,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         adapter_kwargs = kwargs.pop("adapter_kwargs", {})
         adapter_name = kwargs.pop("adapter_name", "default")
         use_flash_attention_2 = kwargs.pop("use_flash_attention_2", False)
+        disable_zero_init = kwargs.pop("disable_zero_init", False)
 
         gguf_file = kwargs.pop("gguf_file", None)
         # Cache path to the GGUF file
@@ -3793,7 +3795,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Instantiate model.
         init_contexts = [no_init_weights(_enable=_fast_init)]
 
-        if is_deepspeed_zero3_enabled() and not is_quantized:
+        if is_deepspeed_zero3_enabled() and not is_quantized and not disable_zero_init:
             import deepspeed
 
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")


### PR DESCRIPTION
# What does this PR do?

This PR fix "multi-model training with deepspeed nvme offloading"



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## To Reproduce 

It gets error `/home/nvme/param/zero_stage_3/float16params/rank0/0_param.tensor.swp: buffer nbytes != file bytes` when multi-model training with deepspeed  nvme offloading

Here is an example deepspeed config
```yaml
# ds_config.json 
    "zero_optimization": {
        "stage": 3,
        "offload_optimizer": {
            "device": "nvme",
            "nvme_path": "/home/nvme/optim",   # different models share single nvme_path, which cause error
        },
        "offload_param": {
            "device": "nvme",
            "nvme_path": "/home/nvme/param",   # different models share single nvme_path, which cause error
        },
    }
```
<!--  
RLHF: actor_model, reference_model, reward_model(一般比较小，不用nvme)。 
DPO: actor_model, reference_ model
 -->
If you are training with multiple models (such as rlhf, dpo, multimodal) like this
```py
# train.py
model_1 = AutoModelForCausalLM.from_pretrained(MODEL_1_DIR)   # it calls deepspeed.zero.Init, then swap_out param to nvme_path 
model_2 = AutoModelForCausalLM.from_pretrained(MODEL_2_DIR)   # it calls deepspeed.zero.Init again
```
Launch deepspeed training with `ds_config.json`
```
deepspeed --hostfile=hostfile train.py --deepspeed --deepspeed_config ds_config.json 
```


`deepspeed.zero.Init` first remove all files in `nvme_path`, which causes the swap files of `model_1` be overwritten by `model_2`. 

<details> 

<summary>details of deepspeed.zero.Init</summary>

```py
# https://github.com/microsoft/DeepSpeed/blob/v0.14.4/deepspeed/runtime/zero/partition_parameters.py#L1010
class Init:   
    def __init__(
        ....
        if self.remote_device == OffloadDeviceEnum.nvme:
            self.param_swapper = param_swapper or AsyncPartitionedParameterSwapper(_ds_config, self.dtype)

# https://github.com/microsoft/DeepSpeed/blob/v0.14.4/deepspeed/runtime/swap_tensor/partitioned_param_swapper.py#L89
class AsyncPartitionedParameterSwapper(object):
    def __init__(self, ds_config, model_dtype):
         ..
        shutil.rmtree(self.swap_folder, ignore_errors=True)    
```
</details>


## After this PR

You can initialize two models with different `nvme_path`
```py
model_1 = AutoModelForCausalLM.from_pretrained(MODEL_1_DIR)   # with default nvme_path
model_2 = AutoModelForCausalLM.from_pretrained(MODEL_2_DIR, disable_zero_init=True)
model_2_engine, *_ = deepspeed.initialize(model=model_2,
                                      config=another_ds_config)  # with a different nvme_path
```

## Who can review?


- deepspeed: HF Trainer/Accelerate: @muellerzr
- trainer: @muellerzr and @SunMarc


