### PR TITLE
Push sharded checkpoint to hub when `push_to_hub=True` in `TrainingArguments`

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -22,6 +22,7 @@ import functools
 import glob
 import importlib.metadata
 import inspect
+import json
 import math
 import os
 import random
@@ -4188,6 +4189,15 @@ class Trainer:
         output_dir = self.args.output_dir
         # To avoid a new synchronization of all model weights, we just copy the file from the checkpoint folder
         modeling_files = [CONFIG_NAME, WEIGHTS_NAME, SAFE_WEIGHTS_NAME]
+        #  Add sharded checkpoints if we have an index
+        for index_file in [WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME]:
+            index_path = os.path.join(checkpoint_folder, index_file)
+            if os.path.isfile(index_path):
+                modeling_files.append(index_file)
+                with open(index_path) as f:
+                    index = json.loads(f.read())
+                shard_files = list(set(index["weight_map"].values()))
+                modeling_files.extend(shard_files)
         if is_peft_available():
             modeling_files.extend([ADAPTER_CONFIG_NAME, ADAPTER_WEIGHTS_NAME, ADAPTER_SAFE_WEIGHTS_NAME])
         for modeling_file in modeling_files:


### PR DESCRIPTION
# What does this PR do ?

This PR make sure that sharded checkpoints are pushed to the hub when we set `push_to_hub=True` in `TrainingArguments`. 
Fixes https://github.com/huggingface/transformers/issues/30724. 
Thanks @alvarobartt for the detailed issue !

I didn't add a test as it requires a big model to test it and we can't change the shard size when saving from Trainer. 

## To reproduce: 
I was able to successfully push the checkpoints here : https://huggingface.co/marcsun13/sft_openassistant-guanaco/tree/main

```bash
python trl/examples/scripts/sft.py     --model_name_or_path="mistralai/Mistral-7B-v0.1"     --dataset_text_field="text"     --report_to="wandb"     --learning_rate=1.41e-5     --per_device_train_batch_size=2     --gradient_accumulation_steps=2     --output_dir="sft_openassistant-guanaco"   --torch_dtype="bfloat16"  --optim=adamw_bnb_8bit   --logging_steps=1     --num_train_epochs=3     --hub_strategy="every_save" --save_strategy="steps"  --save_steps=10    --push_to_hub
```
