### PR TITLE
Fix pipeline tests - don't set torch_dtype on non-torch pipelines

### DIFF
--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -126,7 +126,7 @@ class PipelineTesterMixin:
     pipeline_model_mapping = None
     supported_frameworks = ["pt", "tf"]
 
-    def run_task_tests(self, task, torch_dtype="float32"):
+    def run_task_tests(self, task, torch_dtype=None):
         """Run pipeline tests for a specific `task`
 
         Args:
@@ -177,7 +177,7 @@ class PipelineTesterMixin:
             )
 
     def run_model_pipeline_tests(
-        self, task, repo_name, model_architecture, tokenizer_names, processor_names, commit, torch_dtype="float32"
+        self, task, repo_name, model_architecture, tokenizer_names, processor_names, commit, torch_dtype=None
     ):
         """Run pipeline tests for a specific `task` with the give model class and tokenizer/processor class names
 
@@ -221,7 +221,7 @@ class PipelineTesterMixin:
                 )
 
     def run_pipeline_test(
-        self, task, repo_name, model_architecture, tokenizer_name, processor_name, commit, torch_dtype="float32"
+        self, task, repo_name, model_architecture, tokenizer_name, processor_name, commit, torch_dtype=None
     ):
         """Run pipeline tests for a specific `task` with the give model class and tokenizer/processor class name
 


### PR DESCRIPTION
# What does this PR do?

Fixes errors introduced by the merge of #31342 

Example failing run: https://app.circleci.com/pipelines/github/huggingface/transformers/97170/workflows/fd23720b-5884-42d5-8877-e69afcdeda34/jobs/1285703