### PR TITLE
Avoid failure `TFBlipModelTest::test_pipeline_image_to_text`

### DIFF
--- a/tests/models/efficientnet/test_modeling_efficientnet.py
+++ b/tests/models/efficientnet/test_modeling_efficientnet.py
@@ -218,6 +218,12 @@ class EfficientNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     @is_pipeline_test
     @require_vision
     @slow
+    def test_pipeline_image_feature_extraction_fp16(self):
+        super().test_pipeline_image_feature_extraction_fp16()
+
+    @is_pipeline_test
+    @require_vision
+    @slow
     def test_pipeline_image_classification(self):
         super().test_pipeline_image_classification()
 

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -181,6 +181,10 @@ class VitsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     def test_pipeline_feature_extraction(self):
         super().test_pipeline_feature_extraction()
 
+    @is_flaky(description="torch 2.2.0 gives `Timeout >120.0s`")
+    def test_pipeline_feature_extraction_fp16(self):
+        super().test_pipeline_feature_extraction_fp16()
+
     @unittest.skip(reason="Need to fix this after #26538")
     def test_model_forward(self):
         set_seed(12345)

--- a/tests/pipelines/test_pipelines_image_to_text.py
+++ b/tests/pipelines/test_pipelines_image_to_text.py
@@ -17,7 +17,7 @@ import unittest
 import requests
 
 from transformers import MODEL_FOR_VISION_2_SEQ_MAPPING, TF_MODEL_FOR_VISION_2_SEQ_MAPPING, is_vision_available
-from transformers.pipelines import pipeline
+from transformers.pipelines import ImageToTextPipeline, pipeline
 from transformers.testing_utils import (
     is_pipeline_test,
     require_tf,
@@ -46,8 +46,8 @@ class ImageToTextPipelineTests(unittest.TestCase):
     tf_model_mapping = TF_MODEL_FOR_VISION_2_SEQ_MAPPING
 
     def get_test_pipeline(self, model, tokenizer, processor, torch_dtype="float32"):
-        pipe = pipeline(
-            "image-to-text", model=model, tokenizer=tokenizer, image_processor=processor, torch_dtype=torch_dtype
+        pipe = ImageToTextPipeline(
+            model=model, tokenizer=tokenizer, image_processor=processor, torch_dtype=torch_dtype
         )
         examples = [
             Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png"),


### PR DESCRIPTION
# What does this PR do?

Currently,

> FAILED tests/models/blip/test_modeling_tf_blip.py::TFBlipModelTest::test_pipeline_image_to_text - NameError: name 'torch' is not defined

is failing on `main` after (#31342)

See https://app.circleci.com/pipelines/github/huggingface/transformers/97187/workflows/81b63940-fd42-4a6a-aafe-404301fafc1d/jobs/1285954

There is a slight difference between `Pipeline.__init__` and `pipeline`: the later one has 

>         if isinstance(torch_dtype, str) and hasattr(torch, torch_dtype):
>            torch_dtype = getattr(torch, torch_dtype)

which we should have a check on if `torch` is available. I will open another PR for that.

----------------------------------------------
Also for 2 `Failed: Timeout >120.0s`: the fix for them is the same as their **non** `_fp16` versions.

FAILED tests/models/vits/test_modeling_vits.py::VitsModelTest::test_pipeline_feature_extraction_fp16 - Failed: Timeout >120.0s

FAILED tests/models/efficientnet/test_modeling_efficientnet.py::EfficientNetModelTest::test_pipeline_image_feature_extraction_fp16 - Failed: Timeout >120.0s