### PR TITLE
FX symbolic_trace: do not test decoder_inputs_embeds

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1215,7 +1215,7 @@ class ModelTesterMixin:
                             (past_mask, inputs_to_test[1]["attention_mask"]), dim=1
                         )
 
-            if "inputs_embeds" in inspect.signature(model.forward).parameters:
+            if "inputs_embeds" in inspect.signature(model.forward).parameters and not model.config.is_encoder_decoder:
                 inputs_to_test.append(
                     {
                         "inputs_embeds": torch.rand(


### PR DESCRIPTION
As per title, fixes https://github.com/huggingface/transformers/pull/31574#issuecomment-2213827446

https://github.com/huggingface/transformers/pull/31574 was meant to support `inputs_embeds`, not `decoder_inputs_embeds`. As some encoder-decoder models, we hit some errors (`ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds`).