### PR TITLE
docs: typo in tf qa example

### DIFF
--- a/examples/tensorflow/question-answering/README.md
+++ b/examples/tensorflow/question-answering/README.md
@@ -18,11 +18,12 @@ limitations under the License.
 
 This folder contains the `run_qa.py` script, demonstrating *question answering* with the 🤗 Transformers library.
 For straightforward use-cases you may be able to use this script without modification, although we have also
-included comments in the code to indicate areas that you may need to adapt to your own projects. 
+included comments in the code to indicate areas that you may need to adapt to your own projects.
 
 ### Usage notes
+
 Note that when contexts are long they may be split into multiple training cases, not all of which may contain
-the answer span. 
+the answer span.
 
 As-is, the example script will train on SQuAD or any other question-answering dataset formatted the same way, and can handle user
 inputs as well.
@@ -32,7 +33,7 @@ inputs as well.
 By default, the script uses a `MirroredStrategy` and will use multiple GPUs effectively if they are available. TPUs
 can also be used by passing the name of the TPU resource with the `--tpu` argument. There are some issues surrounding
 these strategies and our models right now, which are most likely to appear in the evaluation/prediction steps. We're
-actively working on better support for multi-GPU and TPU training in TF, but if you encounter problems a quick 
+actively working on better support for multi-GPU and TPU training in TF, but if you encounter problems a quick
 workaround is to train in the multi-GPU or TPU context and then perform predictions outside of it.
 
 ### Memory usage and data loading
@@ -40,16 +41,17 @@ workaround is to train in the multi-GPU or TPU context and then perform predicti
 One thing to note is that all data is loaded into memory in this script. Most question answering datasets are small
 enough that this is not an issue, but if you have a very large dataset you will need to modify the script to handle
 data streaming. This is particularly challenging for TPUs, given the stricter requirements and the sheer volume of data
-required to keep them fed. A full explanation of all the possible pitfalls is a bit beyond this example script and 
-README, but for more information you can see the 'Input Datasets' section of 
+required to keep them fed. A full explanation of all the possible pitfalls is a bit beyond this example script and
+README, but for more information you can see the 'Input Datasets' section of
 [this document](https://www.tensorflow.org/guide/tpu).
 
 ### Example command
+
 ```bash
 python run_qa.py \
 --model_name_or_path distilbert/distilbert-base-cased \
 --output_dir output \
 --dataset_name squad \
 --do_train \
---do_eval \
+--do_eval
 ```


### PR DESCRIPTION
# What does this PR do?
fix type in tf qa docs to avoid the following error
```
python run_qa.py \
--model_name_or_path distilbert/distilbert-base-cased \
--output_dir output \
--dataset_name squad \
--do_train \
--do_eval \
usage: run_qa.py [-h] --model_name_or_path MODEL_NAME_OR_PATH [--config_name CONFIG_NAME] [--tokenizer_name TOKENIZER_NAME]
                 [--cache_dir CACHE_DIR] [--model_revision MODEL_REVISION] [--token TOKEN]
                 [--trust_remote_code [TRUST_REMOTE_CODE]] [--dataset_name DATASET_NAME]
                 [--dataset_config_name DATASET_CONFIG_NAME] [--train_file TRAIN_FILE] [--validation_file VALIDATION_FILE]
                 [--test_file TEST_FILE] [--overwrite_cache [OVERWRITE_CACHE]]
                 [--preprocessing_num_workers PREPROCESSING_NUM_WORKERS] [--max_seq_length MAX_SEQ_LENGTH]
                 [--pad_to_max_length [PAD_TO_MAX_LENGTH]] [--max_train_samples MAX_TRAIN_SAMPLES]
                 [--max_eval_samples MAX_EVAL_SAMPLES] [--max_predict_samples MAX_PREDICT_SAMPLES]
                 [--version_2_with_negative [VERSION_2_WITH_NEGATIVE]] [--null_score_diff_threshold NULL_SCORE_DIFF_THRESHOLD]
                 [--doc_stride DOC_STRIDE] [--n_best_size N_BEST_SIZE] [--max_answer_length MAX_ANSWER_LENGTH] --output_dir
                 OUTPUT_DIR [--overwrite_output_dir [OVERWRITE_OUTPUT_DIR]] [--do_train [DO_TRAIN]] [--do_eval [DO_EVAL]]
                 [--do_predict [DO_PREDICT]] [--eval_strategy {no,steps,epoch}] [--prediction_loss_only [PREDICTION_LOSS_ONLY]]
                 [--per_device_train_batch_size PER_DEVICE_TRAIN_BATCH_SIZE]
                 [--per_device_eval_batch_size PER_DEVICE_EVAL_BATCH_SIZE] [--per_gpu_train_batch_size PER_GPU_TRAIN_BATCH_SIZE]
                 [--per_gpu_eval_batch_size PER_GPU_EVAL_BATCH_SIZE] [--gradient_accumulation_steps GRADIENT_ACCUMULATION_STEPS]
                 [--eval_accumulation_steps EVAL_ACCUMULATION_STEPS] [--eval_delay EVAL_DELAY]
                 [--torch_empty_cache_steps TORCH_EMPTY_CACHE_STEPS] [--learning_rate LEARNING_RATE] [--weight_decay WEIGHT_DECAY]
                 [--adam_beta1 ADAM_BETA1] [--adam_beta2 ADAM_BETA2] [--adam_epsilon ADAM_EPSILON] [--max_grad_norm MAX_GRAD_NORM]
                 [--num_train_epochs NUM_TRAIN_EPOCHS] [--max_steps MAX_STEPS]
                 [--lr_scheduler_type {linear,cosine,cosine_with_restarts,polynomial,constant,constant_with_warmup,inverse_sqrt,reduce_lr_on_plateau,cosine_with_min_lr,warmup_stable_decay}]
                 [--lr_scheduler_kwargs LR_SCHEDULER_KWARGS] [--warmup_ratio WARMUP_RATIO] [--warmup_steps WARMUP_STEPS]
                 [--log_level {detail,debug,info,warning,error,critical,passive}]
                 [--log_level_replica {detail,debug,info,warning,error,critical,passive}] [--log_on_each_node [LOG_ON_EACH_NODE]]
                 [--no_log_on_each_node] [--logging_dir LOGGING_DIR] [--logging_strategy {no,steps,epoch}]
                 [--logging_first_step [LOGGING_FIRST_STEP]] [--logging_steps LOGGING_STEPS]
                 [--logging_nan_inf_filter [LOGGING_NAN_INF_FILTER]] [--no_logging_nan_inf_filter]
                 [--save_strategy {no,steps,epoch}] [--save_steps SAVE_STEPS] [--save_total_limit SAVE_TOTAL_LIMIT]
                 [--save_safetensors [SAVE_SAFETENSORS]] [--no_save_safetensors] [--save_on_each_node [SAVE_ON_EACH_NODE]]
                 [--save_only_model [SAVE_ONLY_MODEL]]
                 [--restore_callback_states_from_checkpoint [RESTORE_CALLBACK_STATES_FROM_CHECKPOINT]] [--no_cuda [NO_CUDA]]
                 [--use_cpu [USE_CPU]] [--use_mps_device [USE_MPS_DEVICE]] [--seed SEED] [--data_seed DATA_SEED]
                 [--jit_mode_eval [JIT_MODE_EVAL]] [--use_ipex [USE_IPEX]] [--bf16 [BF16]] [--fp16 [FP16]]
                 [--fp16_opt_level FP16_OPT_LEVEL] [--half_precision_backend {auto,apex,cpu_amp}]
                 [--bf16_full_eval [BF16_FULL_EVAL]] [--fp16_full_eval [FP16_FULL_EVAL]] [--tf32 TF32] [--local_rank LOCAL_RANK]
                 [--ddp_backend {nccl,gloo,mpi,ccl,hccl,cncl}] [--tpu_num_cores TPU_NUM_CORES]
                 [--tpu_metrics_debug [TPU_METRICS_DEBUG]] [--debug DEBUG [DEBUG ...]]
                 [--dataloader_drop_last [DATALOADER_DROP_LAST]] [--eval_steps EVAL_STEPS]
                 [--dataloader_num_workers DATALOADER_NUM_WORKERS] [--dataloader_prefetch_factor DATALOADER_PREFETCH_FACTOR]
                 [--past_index PAST_INDEX] [--run_name RUN_NAME] [--disable_tqdm DISABLE_TQDM]
                 [--remove_unused_columns [REMOVE_UNUSED_COLUMNS]] [--no_remove_unused_columns]
                 [--label_names LABEL_NAMES [LABEL_NAMES ...]] [--load_best_model_at_end [LOAD_BEST_MODEL_AT_END]]
                 [--metric_for_best_model METRIC_FOR_BEST_MODEL] [--greater_is_better GREATER_IS_BETTER]
                 [--ignore_data_skip [IGNORE_DATA_SKIP]] [--fsdp FSDP] [--fsdp_min_num_params FSDP_MIN_NUM_PARAMS]
                 [--fsdp_config FSDP_CONFIG] [--fsdp_transformer_layer_cls_to_wrap FSDP_TRANSFORMER_LAYER_CLS_TO_WRAP]
                 [--accelerator_config ACCELERATOR_CONFIG] [--deepspeed DEEPSPEED]
                 [--label_smoothing_factor LABEL_SMOOTHING_FACTOR]
                 [--optim {adamw_hf,adamw_torch,adamw_torch_fused,adamw_torch_xla,adamw_torch_npu_fused,adamw_apex_fused,adafactor,adamw_anyprecision,sgd,adagrad,adamw_bnb_8bit,adamw_8bit,lion_8bit,lion_32bit,paged_adamw_32bit,paged_adamw_8bit,paged_lion_32bit,paged_lion_8bit,rmsprop,rmsprop_bnb,rmsprop_bnb_8bit,rmsprop_bnb_32bit,galore_adamw,galore_adamw_8bit,galore_adafactor,galore_adamw_layerwise,galore_adamw_8bit_layerwise,galore_adafactor_layerwise,lomo,adalomo}]
                 [--optim_args OPTIM_ARGS] [--adafactor [ADAFACTOR]] [--group_by_length [GROUP_BY_LENGTH]]
                 [--length_column_name LENGTH_COLUMN_NAME] [--report_to REPORT_TO]
                 [--ddp_find_unused_parameters DDP_FIND_UNUSED_PARAMETERS] [--ddp_bucket_cap_mb DDP_BUCKET_CAP_MB]
                 [--ddp_broadcast_buffers DDP_BROADCAST_BUFFERS] [--dataloader_pin_memory [DATALOADER_PIN_MEMORY]]
                 [--no_dataloader_pin_memory] [--dataloader_persistent_workers [DATALOADER_PERSISTENT_WORKERS]]
                 [--skip_memory_metrics [SKIP_MEMORY_METRICS]] [--no_skip_memory_metrics]
                 [--use_legacy_prediction_loop [USE_LEGACY_PREDICTION_LOOP]] [--push_to_hub [PUSH_TO_HUB]]
                 [--resume_from_checkpoint RESUME_FROM_CHECKPOINT] [--hub_model_id HUB_MODEL_ID]
                 [--hub_strategy {end,every_save,checkpoint,all_checkpoints}] [--hub_token HUB_TOKEN]
                 [--hub_private_repo [HUB_PRIVATE_REPO]] [--hub_always_push [HUB_ALWAYS_PUSH]]
                 [--gradient_checkpointing [GRADIENT_CHECKPOINTING]]
                 [--gradient_checkpointing_kwargs GRADIENT_CHECKPOINTING_KWARGS]
                 [--include_inputs_for_metrics [INCLUDE_INPUTS_FOR_METRICS]] [--eval_do_concat_batches [EVAL_DO_CONCAT_BATCHES]]
                 [--no_eval_do_concat_batches] [--fp16_backend {auto,apex,cpu_amp}] [--evaluation_strategy {no,steps,epoch}]
                 [--push_to_hub_model_id PUSH_TO_HUB_MODEL_ID] [--push_to_hub_organization PUSH_TO_HUB_ORGANIZATION]
                 [--push_to_hub_token PUSH_TO_HUB_TOKEN] [--mp_parameters MP_PARAMETERS]
                 [--auto_find_batch_size [AUTO_FIND_BATCH_SIZE]] [--full_determinism [FULL_DETERMINISM]]
                 [--torchdynamo TORCHDYNAMO] [--ray_scope RAY_SCOPE] [--ddp_timeout DDP_TIMEOUT] [--torch_compile [TORCH_COMPILE]]
                 [--torch_compile_backend TORCH_COMPILE_BACKEND] [--torch_compile_mode TORCH_COMPILE_MODE]
                 [--dispatch_batches DISPATCH_BATCHES] [--split_batches SPLIT_BATCHES]
                 [--include_tokens_per_second [INCLUDE_TOKENS_PER_SECOND]]
                 [--include_num_input_tokens_seen [INCLUDE_NUM_INPUT_TOKENS_SEEN]] [--neftune_noise_alpha NEFTUNE_NOISE_ALPHA]
                 [--optim_target_modules OPTIM_TARGET_MODULES] [--batch_eval_metrics [BATCH_EVAL_METRICS]]
                 [--eval_on_start [EVAL_ON_START]] [--eval_use_gather_object [EVAL_USE_GATHER_OBJECT]] [--tpu_name TPU_NAME]
                 [--tpu_zone TPU_ZONE] [--gcp_project GCP_PROJECT] [--poly_power POLY_POWER] [--xla [XLA]]
run_qa.py: error: argument --do_eval: Truthy value expected: got   but expected one of yes/no, true/false, t/f, y/n, 1/0 (case insensitive).
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
 -->
