### PR TITLE
[tests] fix deepspeed zero3 config for `test_stage3_nvme_offload`

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -545,6 +545,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
             ds_config_zero3_dict = self.get_config_dict(ZERO3)
             ds_config_zero3_dict["zero_optimization"]["offload_optimizer"] = nvme_config
             ds_config_zero3_dict["zero_optimization"]["offload_param"] = nvme_config
+            ds_config_zero3_dict["zero_optimization"]["stage3_gather_16bit_weights_on_model_save"] = True
             trainer = get_regression_trainer(local_rank=0, fp16=True, deepspeed=ds_config_zero3_dict)
             with CaptureLogger(deepspeed_logger) as cl:
                 trainer.train()


### PR DESCRIPTION
## What does this PR do?
Since we manually modified the original zero3 config value [here](https://github.com/huggingface/transformers/blob/main/tests/deepspeed/test_deepspeed.py#L402), we will end up with a ValueError in accelerate ([code](https://github.com/huggingface/accelerate/blob/main/src/accelerate/accelerator.py#L3269)). 

For Zero3 Checkpointing, we need to turn this value to True. 

 @amyeroberts and @ydshieh 