### PR TITLE
Initializes generators in trainer.py with the device specified in sel…

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -916,7 +916,10 @@ class Trainer:
         if self.args.use_legacy_prediction_loop:
             if is_torch_xla_available():
                 return SequentialDistributedSampler(
-                    eval_dataset, num_replicas=xm.xrt_world_size(), rank=xm.get_ordinal(), generator=torch.Generator(device=self.args.device)
+                    eval_dataset,
+                    num_replicas=xm.xrt_world_size(),
+                    rank=xm.get_ordinal(),
+                    generator=torch.Generator(device=self.args.device)
                 )
             elif is_sagemaker_mp_enabled():
                 return SequentialDistributedSampler(
@@ -977,7 +980,7 @@ class Trainer:
             "num_workers": self.args.dataloader_num_workers,
             "pin_memory": self.args.dataloader_pin_memory,
             "persistent_workers": self.args.dataloader_persistent_workers,
-            "generator": torch.Generator(device=self.args.device)
+            "generator": torch.Generator(device=self.args.device),
         }
 
         if not isinstance(eval_dataset, torch.utils.data.IterableDataset):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1020,7 +1020,7 @@ class Trainer:
             "num_workers": self.args.dataloader_num_workers,
             "pin_memory": self.args.dataloader_pin_memory,
             "persistent_workers": self.args.dataloader_persistent_workers,
-            "generator: torch.Generator(device=self.args.device),
+            "generator": torch.Generator(device=self.args.device),
         }
 
         if not isinstance(test_dataset, torch.utils.data.IterableDataset):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -919,7 +919,6 @@ class Trainer:
                     eval_dataset,
                     num_replicas=xm.xrt_world_size(),
                     rank=xm.get_ordinal(),
-                    generator=torch.Generator(device=self.args.device)
                 )
             elif is_sagemaker_mp_enabled():
                 return SequentialDistributedSampler(
@@ -927,13 +926,12 @@ class Trainer:
                     num_replicas=smp.dp_size(),
                     rank=smp.dp_rank(),
                     batch_size=self.args.per_device_eval_batch_size,
-                    generator=torch.Generator(device=self.args.device),
                 )
             else:
-                return SequentialSampler(eval_dataset, generator=torch.Generator(device=self.args.device))
+                return SequentialSampler(eval_dataset)
 
         if self.args.world_size <= 1:
-            return SequentialSampler(eval_dataset, generator=torch.Generator(device=self.args.device))
+            return SequentialSampler(eval_dataset)
         else:
             return None
 


### PR DESCRIPTION
…f.args.device

Initializes generators in Sampler and DataLoader classes with the device specified in TrainingArguments. Currently, the generators are initialized on the CPU by default, leading to errors when running Trainer on a non-CPU device.

Fixes #31897

@muellerzr @SunMarc @amyeroberts 