### PR TITLE
Set position_embeddings in BertEmbeddings for absolute position type only, to avoid unused parameters

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -161,7 +161,8 @@ class BertEmbeddings(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id)
-        self.position_embeddings = nn.Embedding(config.max_position_embeddings, config.hidden_size)
+        if self.position_embedding_type == "absolute":
+            self.position_embeddings = nn.Embedding(config.max_position_embeddings, config.hidden_size)
         self.token_type_embeddings = nn.Embedding(config.type_vocab_size, config.hidden_size)
 
         # self.LayerNorm is not snake-cased to stick with TensorFlow model variable name and be able to load

--- a/src/transformers/models/bert/modeling_tf_bert.py
+++ b/src/transformers/models/bert/modeling_tf_bert.py
@@ -1246,6 +1246,7 @@ class TFBertForPreTraining(TFBertPreTrainedModel, TFBertPreTrainingLoss):
         r"position_ids",
         r"cls.predictions.decoder.weight",
         r"cls.predictions.decoder.bias",
+        r"embeddings.position_embeddings",
     ]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):
@@ -1366,6 +1367,7 @@ class TFBertForMaskedLM(TFBertPreTrainedModel, TFMaskedLanguageModelingLoss):
         r"pooler",
         r"cls.seq_relationship",
         r"cls.predictions.decoder.weight",
+        r"embeddings.position_embeddings",
         r"nsp___cls",
     ]
 
@@ -1462,6 +1464,7 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
         r"pooler",
         r"cls.seq_relationship",
         r"cls.predictions.decoder.weight",
+        r"embeddings.position_embeddings",
         r"nsp___cls",
     ]
 
@@ -1598,7 +1601,7 @@ class TFBertLMHeadModel(TFBertPreTrainedModel, TFCausalLanguageModelingLoss):
 )
 class TFBertForNextSentencePrediction(TFBertPreTrainedModel, TFNextSentencePredictionLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
-    _keys_to_ignore_on_load_unexpected = [r"mlm___cls", r"cls.predictions"]
+    _keys_to_ignore_on_load_unexpected = [r"mlm___cls", r"cls.predictions", r"embeddings.position_embeddings"]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):
         super().__init__(config, *inputs, **kwargs)
@@ -1694,7 +1697,13 @@ class TFBertForNextSentencePrediction(TFBertPreTrainedModel, TFNextSentencePredi
 )
 class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassificationLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
-    _keys_to_ignore_on_load_unexpected = [r"mlm___cls", r"nsp___cls", r"cls.predictions", r"cls.seq_relationship"]
+    _keys_to_ignore_on_load_unexpected = [
+        r"mlm___cls",
+        r"nsp___cls",
+        r"cls.predictions",
+        r"cls.seq_relationship",
+        r"embeddings.position_embeddings",
+    ]
     _keys_to_ignore_on_load_missing = [r"dropout"]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):
@@ -1792,7 +1801,13 @@ class TFBertForSequenceClassification(TFBertPreTrainedModel, TFSequenceClassific
 )
 class TFBertForMultipleChoice(TFBertPreTrainedModel, TFMultipleChoiceLoss):
     # names with a '.' represents the authorized unexpected/missing layers when a TF model is loaded from a PT model
-    _keys_to_ignore_on_load_unexpected = [r"mlm___cls", r"nsp___cls", r"cls.predictions", r"cls.seq_relationship"]
+    _keys_to_ignore_on_load_unexpected = [
+        r"mlm___cls",
+        r"nsp___cls",
+        r"cls.predictions",
+        r"cls.seq_relationship",
+        r"embeddings.position_embeddings",
+    ]
     _keys_to_ignore_on_load_missing = [r"dropout"]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):
@@ -1909,6 +1924,7 @@ class TFBertForTokenClassification(TFBertPreTrainedModel, TFTokenClassificationL
         r"nsp___cls",
         r"cls.predictions",
         r"cls.seq_relationship",
+        r"embeddings.position_embeddings",
     ]
     _keys_to_ignore_on_load_missing = [r"dropout"]
 
@@ -2011,6 +2027,7 @@ class TFBertForQuestionAnswering(TFBertPreTrainedModel, TFQuestionAnsweringLoss)
         r"nsp___cls",
         r"cls.predictions",
         r"cls.seq_relationship",
+        r"embeddings.position_embeddings",
     ]
 
     def __init__(self, config: BertConfig, *inputs, **kwargs):


### PR DESCRIPTION
The position_embeddings are only used for the "absolute" position type. For other position types, they are unused, causing DDP training to fail due to unused parameters. Instead, we should only add this module if it will be used in the forward pass.

Tagging @ArthurZucker, because this is a text model, but feel free to tag others instead.

This is my first contribution, so please let me know if I've missed a step (or worse)!