### PR TITLE
[Quickfix] Update deprecated method `_register_pytree_node` to `register_pytree_node`.

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -336,7 +336,7 @@ class ModelOutput(OrderedDict):
                     serialized_type_name=f"{cls.__module__}.{cls.__name__}",
                 )
             else:
-                _torch_pytree._register_pytree_node(
+                _torch_pytree.register_pytree_node(
                     cls,
                     _model_output_flatten,
                     partial(_model_output_unflatten, output_type=cls),
@@ -479,7 +479,7 @@ if is_torch_available():
             serialized_type_name=f"{ModelOutput.__module__}.{ModelOutput.__name__}",
         )
     else:
-        _torch_pytree._register_pytree_node(
+        _torch_pytree.register_pytree_node(
             ModelOutput,
             _model_output_flatten,
             partial(_model_output_unflatten, output_type=ModelOutput),


### PR DESCRIPTION
# What does this PR do?
Nothing too big, this PR aims at updating the deprecated method `_register_pytree_node` to `register_pytree_node`.

Fixes #31903


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts, @muellerzr and @SunMarc