### PR TITLE
fix: Fixed the `1st argument` name in classmethods

### DIFF
--- a/src/transformers/models/layoutlmv2/configuration_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/configuration_layoutlmv2.py
@@ -177,7 +177,7 @@ class LayoutLMv2Config(PretrainedConfig):
         )
 
     @classmethod
-    def get_default_detectron2_config(self):
+    def get_default_detectron2_config(cls):
         return {
             "MODEL.MASK_ON": True,
             "MODEL.PIXEL_STD": [57.375, 57.120, 58.395],

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -209,5 +209,5 @@ class LambdaScheduleWrapper:
         return self.fn(*args, **kwargs)
 
     @classmethod
-    def wrap_scheduler(self, scheduler):
-        scheduler.lr_lambdas = list(map(self, scheduler.lr_lambdas))
+    def wrap_scheduler(cls, scheduler):
+        scheduler.lr_lambdas = list(map(cls, scheduler.lr_lambdas))


### PR DESCRIPTION
# What does this PR do?
Updated the first argument of classmethods to `cls` as per the recommended naming convention of PEP8


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts