### PR TITLE
PyTorch XLA wrong device assignment with ellipsis 

### DIFF
--- a/src/transformers/models/sew/modeling_sew.py
+++ b/src/transformers/models/sew/modeling_sew.py
@@ -911,7 +911,7 @@ class SEWEncoder(nn.Module):
         position_embeddings = self.pos_conv_embed(hidden_states)
         pooled_hidden_states = self.pool(hidden_states)
         min_length = min(position_embeddings.size(-1), pooled_hidden_states.size(-1))
-        hidden_states = pooled_hidden_states[..., :min_length] + position_embeddings[..., :min_length]
+        hidden_states = pooled_hidden_states[:, :min_length] + position_embeddings[:, :min_length]
         hidden_states = hidden_states.transpose(1, 2)
 
         hidden_states = self.layer_norm(hidden_states)

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -1204,7 +1204,7 @@ class SEWDEncoder(nn.Module):
         position_embeddings = self.pos_conv_embed(hidden_states)
         pooled_hidden_states = self.pool(hidden_states)
         min_length = min(position_embeddings.size(-1), pooled_hidden_states.size(-1))
-        hidden_states = pooled_hidden_states[..., :min_length] + position_embeddings[..., :min_length]
+        hidden_states = pooled_hidden_states[:, :min_length] + position_embeddings[:, :min_length]
         hidden_states = hidden_states.transpose(1, 2)
 
         encoder_outputs = self.encoder(hidden_states, attention_mask, output_hidden_states, output_attentions)

--- a/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
@@ -560,13 +560,13 @@ class Wav2Vec2BertSelfAttention(nn.Module):
         batch_size, sequence_length, hidden_size = hidden_states.size()
         hidden_states = hidden_states.view(batch_size, sequence_length, self.num_heads, self.head_size)
 
-        cos = relative_position_embeddings[0, :sequence_length, ...]
-        sin = relative_position_embeddings[1, :sequence_length, ...]
+        cos = relative_position_embeddings[0, :sequence_length, :]
+        sin = relative_position_embeddings[1, :sequence_length, :]
 
         # rotate hidden_states with rotary embeddings
         hidden_states = hidden_states.transpose(0, 1)
-        rotated_states_begin = hidden_states[..., : self.head_size // 2]
-        rotated_states_end = hidden_states[..., self.head_size // 2 :]
+        rotated_states_begin = hidden_states[:, : self.head_size // 2]
+        rotated_states_end = hidden_states[:, self.head_size // 2 :]
         rotated_states = torch.cat((-rotated_states_end, rotated_states_begin), dim=rotated_states_begin.ndim - 1)
         hidden_states = (hidden_states * cos) + (rotated_states * sin)
         hidden_states = hidden_states.transpose(0, 1)

--- a/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
@@ -724,13 +724,13 @@ class Wav2Vec2ConformerSelfAttention(nn.Module):
         batch_size, sequence_length, hidden_size = hidden_states.size()
         hidden_states = hidden_states.view(batch_size, sequence_length, self.num_heads, self.head_size)
 
-        cos = relative_position_embeddings[0, :sequence_length, ...]
-        sin = relative_position_embeddings[1, :sequence_length, ...]
+        cos = relative_position_embeddings[0, :sequence_length, :]
+        sin = relative_position_embeddings[1, :sequence_length, :]
 
         # rotate hidden_states with rotary embeddings
         hidden_states = hidden_states.transpose(0, 1)
-        rotated_states_begin = hidden_states[..., : self.head_size // 2]
-        rotated_states_end = hidden_states[..., self.head_size // 2 :]
+        rotated_states_begin = hidden_states[:, : self.head_size // 2]
+        rotated_states_end = hidden_states[:, self.head_size // 2 :]
         rotated_states = torch.cat((-rotated_states_end, rotated_states_begin), dim=rotated_states_begin.ndim - 1)
         hidden_states = (hidden_states * cos) + (rotated_states * sin)
         hidden_states = hidden_states.transpose(0, 1)


### PR DESCRIPTION
# What does this PR do?

Hi team, when trying to support some audio models in Optimum Neuron, I got some compilation failures due to a bug in PyTorch XLA: https://github.com/pytorch/xla/issues/6398.

[TL;DR] XLA will assign incorrect device (`lazy` instead of `xla`) when there is ellipsis (...), a swift workaround would be replacing all `...` with `:` to extract part of the tensor. Wonder if it's ok for transformers, so that Optimum Neuron can unblock audio tasks support without waiting for the fix in PyTorch XLA. Thanks! 

<details close>
<summary>Error log</summary>
<br>

```
E   AssertionError: sew, feature-extraction -> torch_xla/csrc/tensor.cpp:57 : Check failed: tensor.device().type() == at::kCPU (lazy vs. cpu)
E   *** Begin stack trace ***
E       tsl::CurrentStackTrace()
E       torch_xla::XLATensor::Create(at::Tensor const&, torch::lazy::BackendDevice const&)
E       torch_xla::bridge::GetOrCreateXlaTensor(at::Tensor const&, torch::lazy::BackendDevice const&)
E   
E       torch_xla::XLANativeFunctions::add(at::Tensor const&, at::Tensor const&, c10::Scalar const&)
E   
E       at::_ops::add_Tensor::redispatch(c10::DispatchKeySet, at::Tensor const&, at::Tensor const&, c10::Scalar const&)
E   
E   
E       at::_ops::add_Tensor::call(at::Tensor const&, at::Tensor const&, c10::Scalar const&)
E   
E   
E   
E   
E       _PyObject_FastCall_Prepend
E   
E   
E       PyNumber_Add
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       _PyObject_MakeTpCall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E   
E       _PyEval_EvalFrameDefault
E       _PyFunction_Vectorcall
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E   
E       _PyEval_EvalFrameDefault
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       _PyObject_MakeTpCall
E       _PyEval_EvalFrameDefault
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyFunction_Vectorcall
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E   
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E   
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E   
E       _PyEval_EvalFrameDefault
E       _PyEval_EvalCodeWithName
E       _PyFunction_Vectorcall
E       PyObject_Call
E       _PyEval_EvalFrameDefault
E   *** End stack trace ***
```

</details>


## Who can review?

Gently pinging @ArthurZucker and @amyeroberts