### PR TITLE
Generate: fix `SlidingWindowCache.reset()`

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -971,13 +971,14 @@ class SlidingWindowCache(StaticCache):
         return k_out, v_out
 
     def get_max_length(self) -> Optional[int]:
-        # in theory there is no limit because the sliding window size is fixed
-        # no matter how long the sentence is
+        # in theory there is no limit because the sliding window size is fixed no matter how long the sentence is
         return None
 
     def reset(self):
-        self.key_cache.zero_()
-        self.value_cache.zero_()
+        for layer_idx in range(len(self.key_cache)):
+            # In-place ops prevent breaking the static address
+            self.key_cache[layer_idx].zero_()
+            self.value_cache[layer_idx].zero_()
 
 
 class EncoderDecoderCache(Cache):


### PR DESCRIPTION
# What does this PR do?

`RUN_SLOW=1 py.test tests/models/mistral/test_modeling_mistral.py::MistralIntegrationTest::test_compile_static_cache` is failing due to the `reset` function in the sliding window cache, which is incorrect 

(possibly the result of a bad merge conflict? this used to be the old code)