### PR TITLE
gguf conversion add_prefix_space=None for llama3

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -609,7 +609,7 @@ class GGUFLlamaConverter(LlamaConverter):
         self.additional_kwargs["bos_token"] = eos_token
 
         if self.is_llama_3_tokenizer:
-            self.additional_kwargs["add_prefix_space"] = False
+            self.additional_kwargs["add_prefix_space"] = None
             self.additional_kwargs["clean_up_tokenization_spaces"] = True
 
             self.additional_kwargs["legacy"] = False

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -174,10 +174,14 @@ class GgufIntegrationTests(unittest.TestCase):
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
     def test_llama3_q4_0_tokenizer(self):
-        tokenizer_gguf = AutoTokenizer.from_pretrained(self.llama3_model_id, gguf_file=self.q4_llama3_model_id)
-        special_sentence = "สวัสดี"
-        predicted_text = tokenizer_gguf.decode(tokenizer_gguf.encode(special_sentence, return_tensors="pt")[0])
-        self.assertEqual(predicted_text, "<|begin_of_text|>" + special_sentence)
+        tokenizer = AutoTokenizer.from_pretrained(self.llama3_model_id, gguf_file=self.q4_llama3_model_id)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpdirname = "quant_test_3"
+            tokenizer.save_pretrained(tmpdirname)
+            tokenizer = AutoTokenizer.from_pretrained(tmpdirname)
+            special_sentence = "สวัสดี"
+            predicted_text = tokenizer.decode(tokenizer_gguf.encode(special_sentence, return_tensors="pt")[0])
+            self.assertEqual(predicted_text, "<|begin_of_text|>" + special_sentence)
 
     def test_llama3_q4_0(self):
         tokenizer = AutoTokenizer.from_pretrained(self.llama3_model_id, gguf_file=self.q4_llama3_model_id)

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -180,7 +180,7 @@ class GgufIntegrationTests(unittest.TestCase):
             tokenizer.save_pretrained(tmpdirname)
             tokenizer = AutoTokenizer.from_pretrained(tmpdirname)
             special_sentence = "สวัสดี"
-            predicted_text = tokenizer.decode(tokenizer_gguf.encode(special_sentence, return_tensors="pt")[0])
+            predicted_text = tokenizer.decode(tokenizer.encode(special_sentence, return_tensors="pt")[0])
             self.assertEqual(predicted_text, "<|begin_of_text|>" + special_sentence)
 
     def test_llama3_q4_0(self):

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -176,7 +176,6 @@ class GgufIntegrationTests(unittest.TestCase):
     def test_llama3_q4_0_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained(self.llama3_model_id, gguf_file=self.q4_llama3_model_id)
         with tempfile.TemporaryDirectory() as tmpdirname:
-            tmpdirname = "quant_test_3"
             tokenizer.save_pretrained(tmpdirname)
             tokenizer = AutoTokenizer.from_pretrained(tmpdirname)
             special_sentence = "สวัสดี"


### PR DESCRIPTION
fixes #31630 

gguf conversion forces add_prefix_space=False for llama3, this is not required and forces from_slow, which fails. changing to None + test

@ArthurZucker 