### PR TITLE
Masking: remove flakiness from test

### DIFF
--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1571,9 +1571,6 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         out_last_tokens = logits[:, -1, :]  # last tokens in each batch line
         out_shared_prefix_last_tokens = logits_shared_prefix[0, -3:, :]  # last three tokens
 
-        # comparing greedily-chosen tokens:
-        assert torch.equal(out_last_tokens.max(axis=1).indices, out_shared_prefix_last_tokens.max(axis=1).indices)
-
         # comparing softmax-normalized logits:
         normalized_0 = torch.nn.functional.softmax(out_last_tokens)
         normalized_1 = torch.nn.functional.softmax(out_shared_prefix_last_tokens)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4486,9 +4486,6 @@ class ModelTesterMixin:
             out_last_tokens = logits[:, -1, :]  # last tokens in each batch line
             out_shared_prefix_last_tokens = logits_shared_prefix[0, -3:, :]  # last three tokens
 
-            # comparing greedily-chosen tokens:
-            assert torch.equal(out_last_tokens.max(axis=1).indices, out_shared_prefix_last_tokens.max(axis=1).indices)
-
             # comparing softmax-normalized logits:
             normalized_0 = F.softmax(out_last_tokens)
             normalized_1 = F.softmax(out_shared_prefix_last_tokens)


### PR DESCRIPTION
# What does this PR do?

`test_custom_4d_attention_mask` was trying to compare the argmax of two sets of logits. The logits should be the same in theory -- one is created through batched inference, the other through properly masked and stacked inputs.

We know from experience that batching introduces tiny fluctuations -- see [this comment](https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535) explaining why.

As such, the argmax of these two tensors can have different values, resulting in a flaky test. This PR removes the flaky part of the test, the equality check of the argmax. We still check that the two tensors are very similar.

Example of a failing test due to flakiness: https://app.circleci.com/pipelines/github/huggingface/transformers/97709/workflows/f407565a-dd9f-423f-9af2-86f0925cf109/jobs/1294534