### PR TITLE
fix: Removed a wrong key-word argument in `sigmoid_focal_loss()` function call

### DIFF
--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -2163,7 +2163,7 @@ class RTDetrLoss(nn.Module):
         target_classes[idx] = target_classes_original
 
         target = F.one_hot(target_classes, num_classes=self.num_classes + 1)[..., :-1]
-        loss = sigmoid_focal_loss(src_logits, target, self.alpha, self.gamma, reduction="none")
+        loss = sigmoid_focal_loss(src_logits, target, self.alpha, self.gamma)
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
         return {"loss_focal": loss}
 


### PR DESCRIPTION
# What does this PR do?
The `reduction` argument passed in the following function call is wrong. We can see from the function definition of `sigmoid_focal_loss` there is no parameter named `reduction`:
https://github.com/huggingface/transformers/blob/7f79a97399bb52aad8460e1da2f36577d5dccfed/src/transformers/models/rt_detr/modeling_rt_detr.py#L2166
https://github.com/huggingface/transformers/blob/7f79a97399bb52aad8460e1da2f36577d5dccfed/src/transformers/models/rt_detr/modeling_rt_detr.py#L1933-L1950

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @amyeroberts 