### PR TITLE
Whisper: move to tensor cpu before converting to np array at decode time

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -872,8 +872,11 @@ class WhisperTokenizer(PreTrainedTokenizer):
     @staticmethod
     def _convert_to_list(token_ids):
         # convert type to ndarray if necessary
-        if "torch" in str(type(token_ids)) or "tensorflow" in str(type(token_ids)) and hasattr(token_ids, "numpy"):
-            token_ids = token_ids.numpy()
+        if hasattr(token_ids, "numpy"):
+            if "torch" in str(type(token_ids)):
+                token_ids = token_ids.cpu().numpy()
+            elif "tensorflow" in str(type(token_ids)):
+                token_ids = token_ids.cpu().numpy()
         # now the token ids are either a numpy array, or a list of lists
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -876,7 +876,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
             if "torch" in str(type(token_ids)):
                 token_ids = token_ids.cpu().numpy()
             elif "tensorflow" in str(type(token_ids)):
-                token_ids = token_ids.cpu().numpy()
+                token_ids = token_ids.numpy()
         # now the token ids are either a numpy array, or a list of lists
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -605,8 +605,11 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
     # Copied from transformers.models.whisper.tokenization_whisper.WhisperTokenizer._convert_to_list
     def _convert_to_list(token_ids):
         # convert type to ndarray if necessary
-        if "torch" in str(type(token_ids)) or "tensorflow" in str(type(token_ids)) and hasattr(token_ids, "numpy"):
-            token_ids = token_ids.numpy()
+        if hasattr(token_ids, "numpy"):
+            if "torch" in str(type(token_ids)):
+                token_ids = token_ids.cpu().numpy()
+            elif "tensorflow" in str(type(token_ids)):
+                token_ids = token_ids.numpy()
         # now the token ids are either a numpy array, or a list of lists
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()


### PR DESCRIPTION
# What does this PR do?

Follow up to #27818 

`pytest --doctest-modules src/transformers/models/whisper/generation_whisper.py -vv` started failing on `main` due to the PR above. 

In a nutshell, if Whisper was running on GPU, the generated tensors would also be on GPU. The new decoding code called `token_ids.numpy()`, which failed if the `token_ids` tensor was on GPU. This PR moves it to the CPU before the numpy conversion :)

cc @sanchit-gandhi 