### PR TITLE
Avoid race condition

### DIFF
--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -256,7 +256,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-generation-config")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -284,7 +284,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-generation-config-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -253,8 +253,11 @@ class ConfigPushToHubTester(unittest.TestCase):
             if k != "transformers_version":
                 self.assertEqual(v, getattr(new_config, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-generation-config")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-generation-config")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -278,8 +281,11 @@ class ConfigPushToHubTester(unittest.TestCase):
             if k != "transformers_version":
                 self.assertEqual(v, getattr(new_config, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-generation-config-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-generation-config-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -256,7 +256,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-generation-config")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -284,7 +284,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-generation-config-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -126,8 +126,11 @@ class ConfigPushToHubTester(unittest.TestCase):
             if k != "transformers_version":
                 self.assertEqual(v, getattr(new_config, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-config")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-config")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -149,8 +152,11 @@ class ConfigPushToHubTester(unittest.TestCase):
             if k != "transformers_version":
                 self.assertEqual(v, getattr(new_config, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-config-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-config-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -129,7 +129,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-config")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -155,7 +155,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-config-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -129,7 +129,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-config")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -155,7 +155,7 @@ class ConfigPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-config-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_feature_extraction_utils.py
+++ b/tests/utils/test_feature_extraction_utils.py
@@ -88,7 +88,7 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-feature-extractor")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -112,7 +112,7 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-feature-extractor")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_feature_extraction_utils.py
+++ b/tests/utils/test_feature_extraction_utils.py
@@ -88,7 +88,7 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-feature-extractor")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -112,7 +112,7 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-feature-extractor")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_feature_extraction_utils.py
+++ b/tests/utils/test_feature_extraction_utils.py
@@ -85,8 +85,11 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         for k, v in feature_extractor.__dict__.items():
             self.assertEqual(v, getattr(new_feature_extractor, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-feature-extractor")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-feature-extractor")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -106,8 +109,11 @@ class FeatureExtractorPushToHubTester(unittest.TestCase):
         for k, v in feature_extractor.__dict__.items():
             self.assertEqual(v, getattr(new_feature_extractor, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-feature-extractor")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-feature-extractor")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -96,8 +96,11 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         for k, v in image_processor.__dict__.items():
             self.assertEqual(v, getattr(new_image_processor, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-image-processor")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-image-processor")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -117,8 +120,11 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         for k, v in image_processor.__dict__.items():
             self.assertEqual(v, getattr(new_image_processor, k))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -78,6 +78,16 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         except HTTPError:
             pass
 
+        try:
+            delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
+        except HTTPError:
+            pass
+
+        try:
+            delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
+        except HTTPError:
+            pass
+
     def test_push_to_hub(self):
         image_processor = ViTImageProcessor.from_pretrained(SAMPLE_IMAGE_PROCESSING_CONFIG_DIR)
         image_processor.push_to_hub("test-image-processor", token=self._token)

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -99,7 +99,7 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-image-processor")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -123,7 +123,7 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -71,22 +71,22 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         cls._token = TOKEN
         HfFolder.save_token(TOKEN)
 
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            delete_repo(token=cls._token, repo_id="test-image-processor")
-        except HTTPError:
-            pass
-
-        try:
-            delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
-        except HTTPError:
-            pass
-
-        try:
-            delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
-        except HTTPError:
-            pass
+    # @classmethod
+    # def tearDownClass(cls):
+    #     try:
+    #         delete_repo(token=cls._token, repo_id="test-image-processor")
+    #     except HTTPError:
+    #         pass
+    #
+    #     try:
+    #         delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
+    #     except HTTPError:
+    #         pass
+    #
+    #     try:
+    #         delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
+    #     except HTTPError:
+    #         pass
 
     def test_push_to_hub(self):
         image_processor = ViTImageProcessor.from_pretrained(SAMPLE_IMAGE_PROCESSING_CONFIG_DIR)

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -71,22 +71,9 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         cls._token = TOKEN
         HfFolder.save_token(TOKEN)
 
-    # @classmethod
-    # def tearDownClass(cls):
-    #     try:
-    #         delete_repo(token=cls._token, repo_id="test-image-processor")
-    #     except HTTPError:
-    #         pass
-    #
-    #     try:
-    #         delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
-    #     except HTTPError:
-    #         pass
-    #
-    #     try:
-    #         delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
-    #     except HTTPError:
-    #         pass
+    @classmethod
+    def tearDownClass(cls):
+        pass
 
     def test_push_to_hub(self):
         image_processor = ViTImageProcessor.from_pretrained(SAMPLE_IMAGE_PROCESSING_CONFIG_DIR)

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -78,16 +78,6 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         except HTTPError:
             pass
 
-        try:
-            delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
-        except HTTPError:
-            pass
-
-        try:
-            delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
-        except HTTPError:
-            pass
-
     def test_push_to_hub(self):
         image_processor = ViTImageProcessor.from_pretrained(SAMPLE_IMAGE_PROCESSING_CONFIG_DIR)
         image_processor.push_to_hub("test-image-processor", token=self._token)

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -96,11 +96,8 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         for k, v in image_processor.__dict__.items():
             self.assertEqual(v, getattr(new_image_processor, k))
 
-        try:
-            # Reset repo
-            delete_repo(token=self._token, repo_id="test-image-processor")
-        except:
-            pass
+        # Reset repo
+        delete_repo(token=self._token, repo_id="test-image-processor")
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -120,11 +117,8 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         for k, v in image_processor.__dict__.items():
             self.assertEqual(v, getattr(new_image_processor, k))
 
-        try:
-            # Reset repo
-            delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
-        except:
-            pass
+        # Reset repo
+        delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -99,7 +99,7 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-image-processor")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -123,7 +123,7 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-image-processor")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -73,7 +73,20 @@ class ImageProcessorPushToHubTester(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        pass
+        try:
+            delete_repo(token=cls._token, repo_id="test-image-processor")
+        except HTTPError:
+            pass
+
+        try:
+            delete_repo(token=cls._token, repo_id="valid_org/test-image-processor-org")
+        except HTTPError:
+            pass
+
+        try:
+            delete_repo(token=cls._token, repo_id="test-dynamic-image-processor")
+        except HTTPError:
+            pass
 
     def test_push_to_hub(self):
         image_processor = ViTImageProcessor.from_pretrained(SAMPLE_IMAGE_PROCESSING_CONFIG_DIR)

--- a/tests/utils/test_modeling_flax_utils.py
+++ b/tests/utils/test_modeling_flax_utils.py
@@ -86,7 +86,7 @@ class FlaxModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model-flax")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -121,7 +121,7 @@ class FlaxModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-flax-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_modeling_flax_utils.py
+++ b/tests/utils/test_modeling_flax_utils.py
@@ -86,7 +86,7 @@ class FlaxModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model-flax")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -121,7 +121,7 @@ class FlaxModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-flax-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_modeling_flax_utils.py
+++ b/tests/utils/test_modeling_flax_utils.py
@@ -83,8 +83,11 @@ class FlaxModelPushToHubTester(unittest.TestCase):
             max_diff = (base_params[key] - new_params[key]).sum().item()
             self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-model-flax")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-model-flax")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -115,8 +118,11 @@ class FlaxModelPushToHubTester(unittest.TestCase):
             max_diff = (base_params[key] - new_params[key]).sum().item()
             self.assertLessEqual(max_diff, 1e-3, msg=f"{key} not identical")
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-model-flax-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-model-flax-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_modeling_tf_utils.py
+++ b/tests/utils/test_modeling_tf_utils.py
@@ -723,8 +723,11 @@ class TFModelPushToHubTester(unittest.TestCase):
                 break
         self.assertTrue(models_equal)
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-model-tf")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-model-tf")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -786,8 +789,11 @@ class TFModelPushToHubTester(unittest.TestCase):
                 break
         self.assertTrue(models_equal)
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-model-tf-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-model-tf-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_modeling_tf_utils.py
+++ b/tests/utils/test_modeling_tf_utils.py
@@ -726,7 +726,7 @@ class TFModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model-tf")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -792,7 +792,7 @@ class TFModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-tf-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_modeling_tf_utils.py
+++ b/tests/utils/test_modeling_tf_utils.py
@@ -726,7 +726,7 @@ class TFModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model-tf")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -792,7 +792,7 @@ class TFModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-tf-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1847,8 +1847,11 @@ class ModelPushToHubTester(unittest.TestCase):
         for p1, p2 in zip(model.parameters(), new_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-model")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-model")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1887,8 +1890,11 @@ The commit description supports markdown synthax see:
         for p1, p2 in zip(model.parameters(), new_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-model-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-model-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1850,7 +1850,7 @@ class ModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -1893,7 +1893,7 @@ The commit description supports markdown synthax see:
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1850,7 +1850,7 @@ class ModelPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-model")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -1893,7 +1893,7 @@ The commit description supports markdown synthax see:
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-model-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -146,8 +146,11 @@ class TokenizerPushToHubTester(unittest.TestCase):
         new_tokenizer = BertTokenizer.from_pretrained(f"{USER}/test-tokenizer")
         self.assertDictEqual(new_tokenizer.vocab, tokenizer.vocab)
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="test-tokenizer")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="test-tokenizer")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -167,8 +170,11 @@ class TokenizerPushToHubTester(unittest.TestCase):
         new_tokenizer = BertTokenizer.from_pretrained("valid_org/test-tokenizer-org")
         self.assertDictEqual(new_tokenizer.vocab, tokenizer.vocab)
 
-        # Reset repo
-        delete_repo(token=self._token, repo_id="valid_org/test-tokenizer-org")
+        try:
+            # Reset repo
+            delete_repo(token=self._token, repo_id="valid_org/test-tokenizer-org")
+        except:
+            pass
 
         # Push to hub via save_pretrained
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -149,7 +149,7 @@ class TokenizerPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-tokenizer")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -173,7 +173,7 @@ class TokenizerPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-tokenizer-org")
-        except:
+        except: # noqa E722
             pass
 
         # Push to hub via save_pretrained

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -149,7 +149,7 @@ class TokenizerPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="test-tokenizer")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained
@@ -173,7 +173,7 @@ class TokenizerPushToHubTester(unittest.TestCase):
         try:
             # Reset repo
             delete_repo(token=self._token, repo_id="valid_org/test-tokenizer-org")
-        except: # noqa E722
+        except:  # noqa E722
             pass
 
         # Push to hub via save_pretrained


### PR DESCRIPTION
# What does this PR do?

We have some hub tests failing from time to time.

https://app.circleci.com/pipelines/github/huggingface/transformers/97781/workflows/d3365fb8-a6b4-489a-912e-6d142409f848/jobs/1295791

This is due to the race condition of deleting the repo. 

This PR avoid it by using `try ... except ...` just as in some `def tearDownClass(cls):`.

(Might be better to catch specific error code)