### PR TITLE
Modify resize_token_embeddings to ensure output type is same as input

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2135,9 +2135,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         old_embeddings.weight.data = new_embeddings.weight.data
         old_embeddings.num_embeddings = new_embeddings.weight.data.shape[0]
 
-        if old_embeddings.padding_idx is not None:
-            if (new_num_tokens - 1) < old_embeddings.padding_idx:
-                old_embeddings.padding_idx = None
+        # If the new number of tokens is smaller than the original `padding_idx`, the `padding_idx`
+        # will be set to `None` in the resized embeddings.
+        if old_embeddings.padding_idx is not None and (new_num_tokens - 1) < old_embeddings.padding_idx:
+            old_embeddings.padding_idx = None
 
         return old_embeddings
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2129,7 +2129,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         else:
             new_embeddings.weight.data[:n, :] = old_embeddings.weight.data[:n, :]
 
+        # Replace weights in old_embeddings and return to maintain the same embedding type.
+        # This ensures correct functionality when a Custom Embedding class is passed as input.
+        # The input and output embedding types remain consistent. (c.f. https://github.com/huggingface/transformers/pull/31979)
         old_embeddings.weight.data = new_embeddings.weight.data
+        old_embeddings.num_embeddings = new_embeddings.weight.data.shape[0]
+
+        if old_embeddings.padding_idx is not None:
+            if (new_num_tokens - 1) < old_embeddings.padding_idx:
+                old_embeddings.padding_idx = None
+
         return old_embeddings
 
     def _get_resized_lm_head(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2129,7 +2129,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         else:
             new_embeddings.weight.data[:n, :] = old_embeddings.weight.data[:n, :]
 
-        return new_embeddings
+        old_embeddings.weight.data = new_embeddings.weight.data
+        return old_embeddings
 
     def _get_resized_lm_head(
         self, old_lm_head: nn.Linear, new_num_tokens: Optional[int] = None, transposed: Optional[bool] = False

--- a/src/transformers/models/lxmert/modeling_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_lxmert.py
@@ -700,15 +700,6 @@ class LxmertLMPredictionHead(nn.Module):
         self.decoder.weight = lxmert_model_embedding_weights
         self.bias = nn.Parameter(torch.zeros(lxmert_model_embedding_weights.size(0)))
 
-    def _resize_bias(self, new_num_tokens: int) -> None:
-        old_num_tokens = self.bias.shape[0]
-        if new_num_tokens <= old_num_tokens:
-            new_bias = self.bias[:new_num_tokens]
-        else:
-            extra_bias = torch.zeros(new_num_tokens - old_num_tokens, device=self.bias.device)
-            new_bias = torch.cat([self.bias, extra_bias])
-        self.bias = nn.Parameter(new_bias)
-
     def forward(self, hidden_states):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.decoder(hidden_states) + self.bias
@@ -1084,8 +1075,18 @@ class LxmertForPreTraining(LxmertPreTrainedModel):
     def resize_token_embeddings(self, new_num_tokens: int, pad_to_multiple_of: Optional[int] = None) -> nn.Embedding:
         # Adding the following steps to resize bias to match the shape of resized embeddings
         new_embeddings = super().resize_token_embeddings(new_num_tokens, pad_to_multiple_of)
-        self.cls.predictions._resize_bias(new_num_tokens)
+        self.cls.predictions.bias = self._resize_bias(self.cls.predictions.bias, new_num_tokens)
         return new_embeddings
+
+    def _resize_bias(self, bias, new_num_tokens: int):
+        old_num_tokens = bias.shape[0]
+        if new_num_tokens <= old_num_tokens:
+            new_bias = bias[:new_num_tokens]
+        else:
+            extra_bias = torch.zeros(new_num_tokens - old_num_tokens, device=bias.device)
+            new_bias = torch.cat([bias, extra_bias])
+        new_bias = nn.Parameter(new_bias)
+        return new_bias
 
     def resize_num_qa_labels(self, num_labels):
         """

--- a/src/transformers/models/lxmert/modeling_lxmert.py
+++ b/src/transformers/models/lxmert/modeling_lxmert.py
@@ -1082,7 +1082,7 @@ class LxmertForPreTraining(LxmertPreTrainedModel):
         self.visual_losses = visual_losses
 
     def resize_token_embeddings(self, new_num_tokens: int, pad_to_multiple_of: Optional[int] = None) -> nn.Embedding:
-        # Adding the following steps to resize bias term while resizing embeddings
+        # Adding the following steps to resize bias to match the shape of resized embeddings
         new_embeddings = super().resize_token_embeddings(new_num_tokens, pad_to_multiple_of)
         self.cls.predictions._resize_bias(new_num_tokens)
         return new_embeddings

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1755,6 +1755,8 @@ class ModelTesterMixin:
             config = copy.deepcopy(original_config)
             model = model_class(config)
             model.to(torch_device)
+            model_embed_pre_resize = model.get_input_embeddings()
+            type_model_embed_pre_resize = type(model_embed_pre_resize)
 
             if self.model_tester.is_training is False:
                 model.eval()
@@ -1774,6 +1776,9 @@ class ModelTesterMixin:
             self.assertEqual(new_model_vocab_size, model_vocab_size + 10)
             # Check that it actually resizes the embeddings matrix
             self.assertEqual(model_embed.weight.shape[0], cloned_embeddings.shape[0] + 10)
+            # Check to make sure the type of embeddings returned post resizing is same as type of input
+            type_model_embed_post_resize = type(model_embed)
+            self.assertEqual(type_model_embed_pre_resize, type_model_embed_post_resize)
             # Check that the model can still do a forward pass successfully (every parameter should be resized)
             model(**self._prepare_for_class(inputs_dict, model_class))
 


### PR DESCRIPTION
# What does this PR do?

Modified resize_token_embeddings to return the same class that is passed as input to it. Today, even if a custom embedding class is passed, resize_token_embeddings converts it to a nn.Embedding but this commit makes sure that does not happen and the custom embedding class is returned.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (31835)
[](https://github.com/huggingface/transformers/issues/31835)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@zucchini-nlp


<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc 

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
