### PR TITLE
Incorrect Whisper long-form decoding timestamps 

### DIFF
--- a/src/transformers/models/clvp/processing_clvp.py
+++ b/src/transformers/models/clvp/processing_clvp.py
@@ -73,7 +73,6 @@ class ClvpProcessor(ProcessorMixin):
             inputs["attention_mask"] = encodings["attention_mask"]
             return inputs
 
-    # Copied from transformers.models.whisper.processing_whisper.WhisperProcessor.batch_decode with Whisper->Clvp
     def batch_decode(self, *args, **kwargs):
         """
         This method forwards all its arguments to ClvpTokenizer's [`~PreTrainedTokenizer.batch_decode`]. Please

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -85,12 +85,12 @@ class WhisperProcessor(ProcessorMixin):
         refer to the docstring of this method for more information.
         """
 
-        if isinstance(args[0], dict) and 'segments' in args[0]:
-            segments = args[0].pop('segments')
+        if isinstance(args[0], dict) and "segments" in args[0]:
+            segments = args[0].pop("segments")
 
             kwargs = {"segments": segments, **kwargs}
 
-            args = tuple(args[0]['sequences'].unsqueeze(0))
+            args = tuple(args[0]["sequences"].unsqueeze(0))
 
         return self.tokenizer.batch_decode(*args, **kwargs)
 

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -86,10 +86,7 @@ class WhisperProcessor(ProcessorMixin):
         """
 
         if isinstance(args[0], dict) and "segments" in args[0]:
-            segments = args[0].pop("segments")
-
-            kwargs = {"segments": segments, **kwargs}
-
+            kwargs["segments"] = args[0].pop("segments")
             args = tuple(args[0]["sequences"].unsqueeze(0))
 
         return self.tokenizer.batch_decode(*args, **kwargs)

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -84,14 +84,14 @@ class WhisperProcessor(ProcessorMixin):
         This method forwards all its arguments to WhisperTokenizer's [`~PreTrainedTokenizer.batch_decode`]. Please
         refer to the docstring of this method for more information.
         """
-        
-        if isinstance(args[0], dict) and 'segments' in args[0]: 
+
+        if isinstance(args[0], dict) and 'segments' in args[0]:
             segments = args[0].pop('segments')
-            
+
             kwargs = {"segments": segments, **kwargs}
-            
+
             args = tuple(args[0]['sequences'].unsqueeze(0))
-        
+
         return self.tokenizer.batch_decode(*args, **kwargs)
 
     def decode(self, *args, **kwargs):

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -84,6 +84,14 @@ class WhisperProcessor(ProcessorMixin):
         This method forwards all its arguments to WhisperTokenizer's [`~PreTrainedTokenizer.batch_decode`]. Please
         refer to the docstring of this method for more information.
         """
+        
+        if isinstance(args[0], dict) and 'segments' in args[0]: 
+            segments = args[0].pop('segments')
+            
+            kwargs = {"segments": segments, **kwargs}
+            
+            args = tuple(args[0]['sequences'].unsqueeze(0))
+        
         return self.tokenizer.batch_decode(*args, **kwargs)
 
     def decode(self, *args, **kwargs):

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -85,6 +85,8 @@ class WhisperProcessor(ProcessorMixin):
         refer to the docstring of this method for more information.
         """
 
+        # If segments are present in args, we are performing long-form generation and need to return long form timestamps.
+        # The long-form timestamps are already present in segments and should be passed as kwargs to batch_decode.
         if isinstance(args[0], dict) and "segments" in args[0]:
             kwargs["segments"] = args[0].pop("segments")
             args = tuple(args[0]["sequences"].unsqueeze(0))

--- a/src/transformers/models/whisper/processing_whisper.py
+++ b/src/transformers/models/whisper/processing_whisper.py
@@ -88,7 +88,7 @@ class WhisperProcessor(ProcessorMixin):
         # If segments are present in args, we are performing long-form generation and need to return long form timestamps.
         # The long-form timestamps are already present in segments and should be passed as kwargs to batch_decode.
         if isinstance(args[0], dict) and "segments" in args[0]:
-            kwargs["segments"] = args[0].pop("segments")
+            kwargs["longform_timestamps"] = args[0].pop("segments")
             args = tuple(args[0]["sequences"].unsqueeze(0))
 
         return self.tokenizer.batch_decode(*args, **kwargs)

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -568,7 +568,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
             segments (List[dict], `optional`):
-                Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.   
+                Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []
         # ensure torch tensor of token ids is placed on cpu
@@ -600,13 +600,12 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 text = self._filter_timestamp_ids(text)
 
                 if segments is not None:
-
                     offsets.append(
                         {
                             "text": text,
                             "timestamp": (
-                                segments[0][i]['start'].item(),
-                                segments[0][i]['end'].item(),
+                                segments[0][i]["start"].item(),
+                                segments[0][i]["end"].item(),
                             ),
                         }
                     )
@@ -728,13 +727,12 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
         # retrieve offsets
         if output_offsets:
-
             if "segments" in kwargs:
-                segments = kwargs['segments']
+                segments = kwargs["segments"]
             else:
                 segments = None
 
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments )
+            offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
 
             return {"text": text, "offsets": offsets}
         return text
@@ -874,7 +872,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return batch_encoding["input_ids"]
 
     def _strip_prompt(self, token_ids: List[int], prompt_token_id: int, decoder_start_token_id: int):
-        
         if not isinstance(token_ids, list):
             token_ids = self._convert_to_list(token_ids)
 

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -874,7 +874,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return batch_encoding["input_ids"]
 
     def _strip_prompt(self, token_ids: List[int], prompt_token_id: int, decoder_start_token_id: int):
-        
         if not isinstance(token_ids, list):
             token_ids = self._convert_to_list(token_ids)
 

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -727,8 +727,10 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
         # retrieve offsets
         if output_offsets:
-            segments = kwargs.get("segments")
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision, longform_timestamps=segments)
+            longform_timestamps = kwargs.get("longform_timestamps")
+            offsets = self._compute_offsets(
+                token_ids, time_precision=time_precision, longform_timestamps=longform_timestamps
+            )
 
             return {"text": text, "offsets": offsets}
         return text

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -567,7 +567,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            segments (List[dict], `optional`, defaults to None):
+            segments (List[dict], `optional`):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.   
         """
         offsets = []

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -727,11 +727,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
         # retrieve offsets
         if output_offsets:
-            if "segments" in kwargs:
-                segments = kwargs["segments"]
-            else:
-                segments = None
-
+            segments = kwargs.get("segments")
             offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
 
             return {"text": text, "offsets": offsets}

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -567,7 +567,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            segments (List[dict], `optional`):
+            segments (List[dict], *optional*):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -568,7 +568,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
             segments (List[dict], `optional`, defaults to None):
-                Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.   
+                Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []
         # ensure torch tensor of token ids is placed on cpu
@@ -598,9 +598,9 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 sliced_tokens = self._preprocess_token_ids(sliced_tokens)
                 text = self._decode(sliced_tokens)
                 text = self._filter_timestamp_ids(text)
-                
-                if segments is not None: 
-                
+
+                if segments is not None:
+
                     offsets.append(
                         {
                             "text": text,
@@ -610,7 +610,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
                             ),
                         }
                     )
-                else: 
+                else:
                     offsets.append(
                         {
                             "text": text,
@@ -728,14 +728,14 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
         # retrieve offsets
         if output_offsets:
-            
-            if "segments" in kwargs: 
+
+            if "segments" in kwargs:
                 segments = kwargs['segments']
-            else: 
+            else:
                 segments = None
-            
+
             offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments )
-            
+
             return {"text": text, "offsets": offsets}
         return text
 
@@ -874,7 +874,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         return batch_encoding["input_ids"]
 
     def _strip_prompt(self, token_ids: List[int], prompt_token_id: int, decoder_start_token_id: int):
-        
+
         if not isinstance(token_ids, list):
             token_ids = self._convert_to_list(token_ids)
 

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -728,7 +728,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         # retrieve offsets
         if output_offsets:
             segments = kwargs.get("segments")
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
+            offsets = self._compute_offsets(token_ids, time_precision=time_precision, longform_timestamps=segments)
 
             return {"text": text, "offsets": offsets}
         return text

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -558,7 +558,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         ]
         return "".join(outputs)
 
-    def _compute_offsets(self, token_ids, time_precision=0.02, segments=None):
+    def _compute_offsets(self, token_ids, time_precision=0.02, longform_timestamps=None):
         """
         Compute offsets for a given tokenized input
 
@@ -567,7 +567,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            segments (List[dict], *optional*):
+            longform_timestamps (List[dict], *optional*):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []
@@ -599,13 +599,13 @@ class WhisperTokenizer(PreTrainedTokenizer):
                 text = self._decode(sliced_tokens)
                 text = self._filter_timestamp_ids(text)
 
-                if segments is not None:
+                if longform_timestamps is not None:
                     offsets.append(
                         {
                             "text": text,
                             "timestamp": (
-                                segments[0][i]["start"].item(),
-                                segments[0][i]["end"].item(),
+                                longform_timestamps[0][i]["start"].item(),
+                                longform_timestamps[0][i]["end"].item(),
                             ),
                         }
                     )

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -373,10 +373,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
 
         # retrieve offsets
         if output_offsets:
-            if "segments" in kwargs:
-                segments = kwargs["segments"]
-            else:
-                segments = None
+            segments = kwargs.get("segments")
 
             offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
 

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -200,7 +200,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         return "".join(outputs)
 
     # Copied from transformers.models.whisper.tokenization_whisper.WhisperTokenizer._compute_offsets
-    def _compute_offsets(self, token_ids, time_precision=0.02):
+    def _compute_offsets(self, token_ids, time_precision=0.02, segments=None):
         """
         Compute offsets for a given tokenized input
 
@@ -209,6 +209,8 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
+            segments (List[dict], `optional`):
+                Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []
         # ensure torch tensor of token ids is placed on cpu
@@ -229,7 +231,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
             consecutive = np.append(consecutive, np.where(timestamp_tokens)[0][-1] + 1)
 
         last_slice = np.where(timestamp_tokens)[0][0]
-        for current_slice in consecutive:
+        for i, current_slice in enumerate(consecutive):
             sliced_tokens = token_ids[last_slice:current_slice]
             if len(sliced_tokens) > 1:
                 start_timestamp_position = sliced_tokens[0].item() - timestamp_begin
@@ -238,15 +240,27 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 sliced_tokens = self._preprocess_token_ids(sliced_tokens)
                 text = self._decode(sliced_tokens)
                 text = self._filter_timestamp_ids(text)
-                offsets.append(
-                    {
-                        "text": text,
-                        "timestamp": (
-                            start_timestamp_position * time_precision,
-                            end_timestamp_position * time_precision,
-                        ),
-                    }
-                )
+
+                if segments is not None:
+                    offsets.append(
+                        {
+                            "text": text,
+                            "timestamp": (
+                                segments[0][i]["start"].item(),
+                                segments[0][i]["end"].item(),
+                            ),
+                        }
+                    )
+                else:
+                    offsets.append(
+                        {
+                            "text": text,
+                            "timestamp": (
+                                start_timestamp_position * time_precision,
+                                end_timestamp_position * time_precision,
+                            ),
+                        }
+                    )
             last_slice = current_slice
 
         return offsets
@@ -359,7 +373,13 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
 
         # retrieve offsets
         if output_offsets:
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision)
+            if "segments" in kwargs:
+                segments = kwargs["segments"]
+            else:
+                segments = None
+
+            offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
+
             return {"text": text, "offsets": offsets}
         return text
 

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -374,8 +374,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         # retrieve offsets
         if output_offsets:
             segments = kwargs.get("segments")
-
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision, segments=segments)
+            offsets = self._compute_offsets(token_ids, time_precision=time_precision, longform_timestamps=segments)
 
             return {"text": text, "offsets": offsets}
         return text

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -200,7 +200,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         return "".join(outputs)
 
     # Copied from transformers.models.whisper.tokenization_whisper.WhisperTokenizer._compute_offsets
-    def _compute_offsets(self, token_ids, time_precision=0.02, segments=None):
+    def _compute_offsets(self, token_ids, time_precision=0.02, longform_timestamps=None):
         """
         Compute offsets for a given tokenized input
 
@@ -209,7 +209,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            segments (List[dict], `optional`):
+            longform_timestamps (List[dict], *optional*):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []
@@ -241,13 +241,13 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 text = self._decode(sliced_tokens)
                 text = self._filter_timestamp_ids(text)
 
-                if segments is not None:
+                if longform_timestamps is not None:
                     offsets.append(
                         {
                             "text": text,
                             "timestamp": (
-                                segments[0][i]["start"].item(),
-                                segments[0][i]["end"].item(),
+                                longform_timestamps[0][i]["start"].item(),
+                                longform_timestamps[0][i]["end"].item(),
                             ),
                         }
                     )

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -373,8 +373,10 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
 
         # retrieve offsets
         if output_offsets:
-            segments = kwargs.get("segments")
-            offsets = self._compute_offsets(token_ids, time_precision=time_precision, longform_timestamps=segments)
+            longform_timestamps = kwargs.get("longform_timestamps")
+            offsets = self._compute_offsets(
+                token_ids, time_precision=time_precision, longform_timestamps=longform_timestamps
+            )
 
             return {"text": text, "offsets": offsets}
         return text

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -209,7 +209,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            longform_timestamps (List[dict], *optional*):
+            longform_timestamps (`List[dict]`, *optional*):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -209,7 +209,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
                 List of tokenized input ids. Can be obtained using the `__call__` method.
             time_precision (`float`, `optional`, defaults to 0.02):
                 The time ratio to convert from token to time.
-            longform_timestamps (`List[dict]`, *optional*):
+            longform_timestamps (List[dict], *optional*):
                 Timestamps obtained using long form generation in Whisper, to be used to replace predicted timestamps in token_ids.
         """
         offsets = []

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -2001,6 +2001,103 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         transcript = processor.batch_decode(generated_ids, skip_special_tokens=True, output_offsets=True)
         self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
 
+
+    @slow
+    def test_tiny_longform_timestamps_generation(self):
+        set_seed(0)
+        processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
+        model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
+        model.to(torch_device)
+
+        sample = self._load_datasamples(1)
+        input_speech = np.concatenate(sample * 10)
+
+        input_features = processor(input_speech, return_tensors="pt", truncation=False, sampling_rate=16_000)
+        input_features = input_features.to(torch_device)
+
+        generated_ids = model.generate(**input_features, return_timestamps=True, return_segments = True)
+
+        EXPECTED_TRANSCRIPT = [
+            {
+                "text": ' Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.',
+                "offsets": [
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            0.0,
+                            6.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            6.0,
+                            12.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            12.0,
+                            18.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            18.0,
+                            24.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            24.0,
+                            29.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            29.0,
+                            35.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            35.0,
+                            41.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            41.0,
+                            47.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            47.0,
+                            53.0
+                        )
+                    },
+                    {
+                        "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
+                        "timestamp": (
+                            53.0,
+                            58.20000076293945
+                        )
+                    }
+                ]
+            }
+        ]
+
+        transcript = processor.batch_decode(generated_ids, skip_special_tokens=True, output_offsets=True)
+        self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
+
     @slow
     def test_large_timestamp_generation(self):
         set_seed(0)

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -2001,7 +2001,6 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         transcript = processor.batch_decode(generated_ids, skip_special_tokens=True, output_offsets=True)
         self.assertEqual(transcript, EXPECTED_TRANSCRIPT)
 
-
     @slow
     def test_tiny_longform_timestamps_generation(self):
         set_seed(0)
@@ -2015,83 +2014,53 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         input_features = processor(input_speech, return_tensors="pt", truncation=False, sampling_rate=16_000)
         input_features = input_features.to(torch_device)
 
-        generated_ids = model.generate(**input_features, return_timestamps=True, return_segments = True)
+        generated_ids = model.generate(**input_features, return_timestamps=True, return_segments=True)
 
         EXPECTED_TRANSCRIPT = [
             {
-                "text": ' Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.',
+                "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel. Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
                 "offsets": [
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            0.0,
-                            6.0
-                        )
+                        "timestamp": (0.0, 6.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            6.0,
-                            12.0
-                        )
+                        "timestamp": (6.0, 12.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            12.0,
-                            18.0
-                        )
+                        "timestamp": (12.0, 18.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            18.0,
-                            24.0
-                        )
+                        "timestamp": (18.0, 24.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            24.0,
-                            29.0
-                        )
+                        "timestamp": (24.0, 29.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            29.0,
-                            35.0
-                        )
+                        "timestamp": (29.0, 35.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            35.0,
-                            41.0
-                        )
+                        "timestamp": (35.0, 41.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            41.0,
-                            47.0
-                        )
+                        "timestamp": (41.0, 47.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            47.0,
-                            53.0
-                        )
+                        "timestamp": (47.0, 53.0),
                     },
                     {
                         "text": " Mr. Quilter is the apostle of the middle classes and we are glad to welcome his gospel.",
-                        "timestamp": (
-                            53.0,
-                            58.20000076293945
-                        )
-                    }
-                ]
+                        "timestamp": (53.0, 58.20000076293945),
+                    },
+                ],
             }
         ]
 


### PR DESCRIPTION
# What does this PR do?

As mentionned in issue #31942,  when performing long form generation, timestamps are currently reset to zero after 30 seconds of audio. 

This error occurs both with AutomaticSpeechRecognitionPipeline and WhisperForConditionalGeneration. 

Here, I propose a solution to make it work with `WhisperForConditionalGeneration`. With this PR, the following code snippet should give the right output: 

```
import numpy as np
import json
from transformers import AutoProcessor, WhisperForConditionalGeneration
import torch
from datasets import load_dataset

device = "cuda"
torch_dtype = torch.bfloat16

processor = AutoProcessor.from_pretrained("distil-whisper/distil-large-v3")
model = WhisperForConditionalGeneration.from_pretrained("distil-whisper/distil-large-v3", torch_dtype=torch.float16)
model = model.to("cuda")

dataset = load_dataset(
    "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
)
sample = dataset[0]["audio"]
sample = np.concatenate([sample["array"]] * 10)

inputs = processor(sample, return_tensors="pt", truncation=False, sampling_rate=16_000)
inputs = inputs.to("cuda", torch.float16)

output = model.generate(**inputs, return_timestamps=True, return_segments = True)

result = processor.batch_decode(output, skip_special_tokens=True, output_offsets = True)
```

## Explanation of the solution: 

When performing long form generation with Whisper, the utterance level timestamps are returned as output to generate when we specify `return_segments = True` and `return_timestamps=True`.

The problem arise at the decoding level: `batch_decode` currently doesn't support long form generation (can't take as input `segments`). When specifying output_offsets, it outputs the wrong timestamps. 

Solution: we can update `batch_decode` to use the timestamps returned by the generate method. 

# Who can review: 

@sanchit-gandhi @ylacombe 