### PR TITLE
Bug report update -- round 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,16 @@
 name: "\U0001F41B Bug Report"
-description: Submit a bug report to help us improve transformers. Be sure to check our [bug report guidelines](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#did-you-find-a-bug) before submitting
+description: Submit a bug report to help us improve transformers
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! 🤗
+
+        Before you submit your bug report:
+
+          - If it is your first time submitting, be sure to check our [bug report guidelines](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#did-you-find-a-bug)
+          - Try our [docs bot](https://huggingface.co/spaces/huggingchat/hf-docs-chat) -- it might be able to help you with your issue
+
   - type: textarea
     id: system-info
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,6 @@
 name: "\U0001F41B Bug Report"
 description: Submit a bug report to help us improve transformers
+labels: [ "bug" ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# What does this PR do?

The previous PR (#31983) had something wrong in its config file, which made the bug report option disappear. 

![Screenshot 2024-07-16 at 17 06 28](https://github.com/user-attachments/assets/fa5a18dd-5578-4eee-9cfb-aeecd1be7f01)

This PR adds a markdown section at the top of the bug report page. The markdown section was inspired by the [example](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) in the GH docs.