### PR TITLE
Only set max_length if max_new_tokens is None for TextGenerationPipeline

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -147,7 +147,8 @@ class TextGenerationPipeline(Pipeline):
 
         if max_length is not None:
             preprocess_params["max_length"] = max_length
-            generate_kwargs["max_length"] = max_length
+            if "max_new_tokens" not in generate_kwargs:
+                generate_kwargs["max_length"] = max_length
 
         if prefix is not None:
             preprocess_params["prefix"] = prefix


### PR DESCRIPTION
# What does this PR do?

Get rid of the `Both max_new_tokens (=512) and max_length (=512) seem to have been set. max_new_tokens will take precedence. Please refer to the documentation for more information.` warning for `TextGenerationPipeline`. There is no change in behaviour, just makes it a bit clearer to the user what is going on.

No added tests or changes to documentation
