### PR TITLE
unpin `numpy<2.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ _deps = [
     "librosa",
     "nltk",
     "natten>=0.14.6,<0.15.0",
-    "numpy>=1.17,<2.0",
+    "numpy>=1.17",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
     "onnxruntime>=1.4.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "librosa": "librosa",
     "nltk": "nltk",
     "natten": "natten>=0.14.6,<0.15.0",
-    "numpy": "numpy>=1.17,<2.0",
+    "numpy": "numpy>=1.17",
     "onnxconverter-common": "onnxconverter-common",
     "onnxruntime-tools": "onnxruntime-tools>=1.4.2",
     "onnxruntime": "onnxruntime>=1.4.0",


### PR DESCRIPTION
# What does this PR do?

As discussed internally, let's allow the community to run `transformers` with `numpy=2.x`

Fix  #31802