### PR TITLE
Fix flash attention speed issue

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -819,6 +819,7 @@ def is_flash_attn_greater_or_equal_2_10():
     return version.parse(importlib.metadata.version("flash_attn")) >= version.parse("2.1.0")
 
 
+@lru_cache()
 def is_flash_attn_greater_or_equal(library_version: str):
     if not _is_package_available("flash_attn"):
         return False


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/31961 inadvertently impacted the performance of the forward with FA2 quite negatively due to the very recurrent call to `is_flash_attn_greater_or_equal("2.4.1")`. This fixes the issue by adding a `lru_cache` to the function for fast lookup, allowing to retain the same performance as before the linked PR was merged.

## Simple benchmark

I ran the snippet on a RTX 4090 card

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
import torch
import numpy as np

model_name = 'meta-llama/Meta-Llama-3-8B'
dtype = torch.bfloat16
model = AutoModelForCausalLM.from_pretrained(model_name, attn_implementation='flash_attention_2',
                                            torch_dtype=dtype, low_cpu_mem_usage=True).cuda()
tokenizer = AutoTokenizer.from_pretrained(model_name)
# Random token sequence
input = torch.randint(0, 1000, (1, 500), device='cuda')

times = []
for _ in range(10):
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    start.record()
    # Generate 200 tokens
    out = model.generate(input, max_new_tokens=200, min_new_tokens=200, do_sample=False)
    end.record()
    torch.cuda.synchronize()
    times.append(start.elapsed_time(end) / 1000)  # time in seconds


print(np.mean(times))
```

This gives:

```python
# Before the fix
>>> 5.863476708984375 s

# After the fix
>>> 4.165076806640625 s
```


## Who can review?

@ArthurZucker  @gante