### PR TITLE
Fix typo in classification function selection logic to improve code consistency

### DIFF
--- a/src/transformers/pipelines/image_classification.py
+++ b/src/transformers/pipelines/image_classification.py
@@ -171,9 +171,9 @@ class ImageClassificationPipeline(Pipeline):
 
     def postprocess(self, model_outputs, function_to_apply=None, top_k=5):
         if function_to_apply is None:
-            if self.model.config.problem_type == "multi_label_classification" or self.model.config.num_labels == 1:
+            if self.model.config.problem_type == "single_label_classification" or self.model.config.num_labels == 1:
                 function_to_apply = ClassificationFunction.SIGMOID
-            elif self.model.config.problem_type == "single_label_classification" or self.model.config.num_labels > 1:
+            elif self.model.config.problem_type == "multi_label_classification" or self.model.config.num_labels > 1:
                 function_to_apply = ClassificationFunction.SOFTMAX
             elif hasattr(self.model.config, "function_to_apply") and function_to_apply is None:
                 function_to_apply = self.model.config.function_to_apply


### PR DESCRIPTION
Fixes https://github.com/huggingface/transformers/issues/32030 
(previously tagged ~#32013~ )

The existing logic has a typo in it, where, for example, it selects a sigmoid classification function if the problem type is "multi_label_classification" or num_labels is 1. The num_labels condition overrides the problem_type condition, so in practice, I don't think this error will cause a bug, but it's confusing.

This fix corrects the problem type conditions.

Please review at your convenience @Narsil 
