### PR TITLE
[tests] fix `static` cache implementation is not compatible with `attn_implementation==flash_attention_2`

### DIFF
--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -290,7 +290,7 @@ class CacheIntegrationTest(unittest.TestCase):
         self.assertTrue(decoded[0].endswith(last_output))
 
     @require_torch_gpu
-    @parameterized.expand(["eager", "sdpa", "flash_attention_2"])
+    @parameterized.expand(["eager", "sdpa"])
     def test_static_cache_greedy_decoding_pad_left(self, attn_implementation):
         EXPECTED_GENERATION = [
             "The best color is the one that complements the skin tone of the",
@@ -315,13 +315,12 @@ class CacheIntegrationTest(unittest.TestCase):
         with self.subTest(f"{attn_implementation}, dynamic"):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-        if attn_implementation != "flash_attention_2":
-            set_seed(0)
-            model.generation_config.cache_implementation = "static"
-            gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-            decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-            with self.subTest(f"{attn_implementation}, static, eager"):
-                self.assertListEqual(decoded, EXPECTED_GENERATION)
+        set_seed(0)
+        model.generation_config.cache_implementation = "static"
+        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+        with self.subTest(f"{attn_implementation}, static, eager"):
+            self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         set_seed(0)
         model.forward = torch.compile(model.forward)
@@ -331,7 +330,7 @@ class CacheIntegrationTest(unittest.TestCase):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
     @require_torch_gpu
-    @parameterized.expand(["eager", "sdpa", "flash_attention_2"])
+    @parameterized.expand(["eager", "sdpa"])
     def test_static_cache_greedy_decoding_pad_right(self, attn_implementation):
         EXPECTED_GENERATION = [
             "The best color isЋ the one that complements the skin tone of",
@@ -356,13 +355,13 @@ class CacheIntegrationTest(unittest.TestCase):
         with self.subTest(f"{attn_implementation}, dynamic"):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-        if attn_implementation != "flash_attention_2":
-            set_seed(0)
-            model.generation_config.cache_implementation = "static"
-            gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-            decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-            with self.subTest(f"{attn_implementation}, static, eager"):
-                self.assertListEqual(decoded, EXPECTED_GENERATION)
+
+        set_seed(0)
+        model.generation_config.cache_implementation = "static"
+        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+        with self.subTest(f"{attn_implementation}, static, eager"):
+            self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         set_seed(0)
         model._forward = model.forward

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -355,7 +355,6 @@ class CacheIntegrationTest(unittest.TestCase):
         with self.subTest(f"{attn_implementation}, dynamic"):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-
         set_seed(0)
         model.generation_config.cache_implementation = "static"
         gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -315,12 +315,13 @@ class CacheIntegrationTest(unittest.TestCase):
         with self.subTest(f"{attn_implementation}, dynamic"):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-        set_seed(0)
-        model.generation_config.cache_implementation = "static"
-        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-        with self.subTest(f"{attn_implementation}, static, eager"):
-            self.assertListEqual(decoded, EXPECTED_GENERATION)
+        if attn_implementation != "flash_attention_2":
+            set_seed(0)
+            model.generation_config.cache_implementation = "static"
+            gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+            decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+            with self.subTest(f"{attn_implementation}, static, eager"):
+                self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         set_seed(0)
         model.forward = torch.compile(model.forward)
@@ -355,12 +356,13 @@ class CacheIntegrationTest(unittest.TestCase):
         with self.subTest(f"{attn_implementation}, dynamic"):
             self.assertListEqual(decoded, EXPECTED_GENERATION)
 
-        set_seed(0)
-        model.generation_config.cache_implementation = "static"
-        gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
-        decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
-        with self.subTest(f"{attn_implementation}, static, eager"):
-            self.assertListEqual(decoded, EXPECTED_GENERATION)
+        if attn_implementation != "flash_attention_2":
+            set_seed(0)
+            model.generation_config.cache_implementation = "static"
+            gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=10)
+            decoded = tokenizer.batch_decode(gen_out, skip_special_tokens=True)
+            with self.subTest(f"{attn_implementation}, static, eager"):
+                self.assertListEqual(decoded, EXPECTED_GENERATION)
 
         set_seed(0)
         model._forward = model.forward


### PR DESCRIPTION
## What does this PR do?

```bash
    def forward(
        self,
        hidden_states: torch.Tensor,
        attention_mask: Optional[torch.LongTensor] = None,
        position_ids: Optional[torch.LongTensor] = None,
        past_key_value: Optional[Cache] = None,
        output_attentions: bool = False,
        use_cache: bool = False,
        cache_position: Optional[torch.LongTensor] = None,
    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
        if isinstance(past_key_value, StaticCache):
>           raise ValueError(
                "`static` cache implementation is not compatible with `attn_implementation==flash_attention_2` "
                "make sure to use `sdpa` in the mean time, and open an issue at https://github.com/huggingface/transformers"
            )
E           ValueError: `static` cache implementation is not compatible with `attn_implementation==flash_attention_2` make sure to use `sdpa` in the mean time, and open an issue at https://github.com/huggingface/transformers

src/transformers/models/llama/modeling_llama.py:388: ValueError
```