### PR TITLE
fix: Removed `duplicate entries` in a dictionary

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -64,7 +64,6 @@ if is_vision_available():
             PILImageResampling.HAMMING: InterpolationMode.HAMMING,
             PILImageResampling.BICUBIC: InterpolationMode.BICUBIC,
             PILImageResampling.LANCZOS: InterpolationMode.LANCZOS,
-            PILImageResampling.NEAREST: InterpolationMode.NEAREST,
         }
 
 


### PR DESCRIPTION
# What does this PR do?
Just a small fix, the following key-value pairs are repeated in the dictionary.
https://github.com/huggingface/transformers/blob/1c37e8c1a6274e6e87b45c6319eb190757214c2a/src/transformers/image_utils.py#L61
https://github.com/huggingface/transformers/blob/1c37e8c1a6274e6e87b45c6319eb190757214c2a/src/transformers/image_utils.py#L67

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 