### PR TITLE
Enable customized optimizer for DeepSpeed

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -603,7 +603,7 @@ class Trainer:
             self.optimizer is not None or self.lr_scheduler is not None
         ):
             raise RuntimeError(
-                "Passing `optimizers` is not allowed if Deepspeed or PyTorch FSDP is enabled. "
+                "Passing `optimizers` is not allowed if PyTorch FSDP is enabled. "
                 "You should subclass `Trainer` and override the `create_optimizer_and_scheduler` method."
             )
         default_callbacks = DEFAULT_CALLBACKS + get_reporting_integration_callbacks(self.args.report_to)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -599,7 +599,7 @@ class Trainer:
                     " `Trainer`. Make sure the lines `import torch_xla.core.xla_model as xm` and"
                     " `model.to(xm.xla_device())` is performed before the optimizer creation in your script."
                 )
-        if (self.is_deepspeed_enabled or self.is_fsdp_xla_enabled or self.is_fsdp_enabled) and (
+        if (self.is_fsdp_xla_enabled or self.is_fsdp_enabled) and (
             self.optimizer is not None or self.lr_scheduler is not None
         ):
             raise RuntimeError(


### PR DESCRIPTION
# What does this PR do?

Dear maintainers,

I am using Trainer for continual pre-training thanks to your dedicated efforts.

Recently, I discovered a bug when using DeepSpeed thorugh HuggingFace Trainer.

It is common to implement custom optimizers while using DeepSpeed with Trainer.
However, as pointed out in issue #15784, even though DeepSpeed can be used in conjunction with custom optimizers, it is implemented to raise a RuntimeError as in PR #16786.

Because of this, the workaround has been to override ``create_optimizer_and_scheduler`` to bypass the aforementioned bug and make things work, but I think there can be a more fundamental solution.

Upon analyzing the current Trainer implementation, I have found that the bug occurs due to the unnecessary branch during the Trainer instantiation at the time of writing, and I have fixed this issue.

Therefore, after bug fix, I have confirmed that using custom optimizers with DeepSpeed through Trainer works as expected, as shown in the below comparison.

- Before:

```sh
Using Default config for accelerate: cfg/accelerate/default_config.yaml                                                                                                                           
...
INFO:__main__:Model is loaded on 0
Counting items of /data/sample_text: 0it [00:00, ?it/s]INFO:__main__:Model is loaded on 1
Counting items of /data/sample_text: 100it [00:00, 1960.49it/s]
Counting items of /data/sample_text: 0it [00:00, ?it/s]INFO:__main__:Dataset is loaded on 0
WARNING:accelerate.utils.other:Detected kernel version 5.4.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
Counting items of /data/sample_text: 100it [00:00, 2147.84it/s]                                                                                                           
INFO:__main__:Dataset is loaded on 1                                                                                                                                                              
[rank1]: Traceback (most recent call last):                                                                                                                                                       
[rank1]:   File "/train_gpt.py", line 244, in <module>                                                                                                                    
[rank1]:     main()                                                                                                                                                                               
[rank1]:   File "/train_gpt.py", line 95, in main                                                                                                                         
[rank1]:     trainer = Seq2SeqTrainer(                                                                                                                                                            
[rank1]:               ^^^^^^^^^^^^^^^                                                                                                                                                            
[rank1]:   File "/opt/conda/envs/lib/python3.12/site-packages/transformers/trainer_seq2seq.py", line 57, in __init__                                                                          
[rank1]:     super().__init__(                                                                                                                                                                    
[rank1]:   File "/opt/conda/envs/lib/python3.12/site-packages/transformers/trainer.py", line 568, in __init__                                                                                 
[rank1]:     raise RuntimeError(                                                                                                                                                                  
[rank1]: RuntimeError: Passing `optimizers` is not allowed if Deepspeed or PyTorch FSDP is enabled. You should subclass `Trainer` and override the `create_optimizer_and_scheduler` method.       
...
```

- After:

```sh
Using Default config for accelerate: cfg/accelerate/default_config.yaml                                                                                                                           
[2024-07-18 08:51:38,334] [INFO] [real_accelerator.py:191:get_accelerator] Setting ds_accelerator to cuda (auto detect)                                                                           
[2024-07-18 08:51:38,355] [INFO] [real_accelerator.py:191:get_accelerator] Setting ds_accelerator to cuda (auto detect)                                                                           
INFO:__main__:Enabling full determinism with train_cfg.seed=777. It may slow down the training especially depending on multi-node settings. Set seed=null if reproducibility can be ignored in that case.                                                                                                                                                                                           
INFO:__main__:Enabling full determinism with train_cfg.seed=777. It may slow down the training especially depending on multi-node settings. Set seed=null if reproducibility can be ignored in that case.                                                                                                                                                                                           
```

Thank you for your attention to this matter.

Regards,

---

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).

---

Dear @muellerzr, I kindly ask you to review this PR.