### PR TITLE
Fix tests after `huggingface_hub` 0.24

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -3791,6 +3791,7 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
         max_steps = math.ceil(trainer.args.num_train_epochs * len(trainer.get_train_dataloader()))
         nb_expected_commits = len(range(5, max_steps, 5))
 
+        # '>=' since final commit might be an empty commit as well (not deterministic)
         self.assertGreaterEqual(nb_empty_commits + nb_epoch_commits, nb_expected_commits)
 
     @require_tensorboard

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -3782,7 +3782,9 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
         # Some commits are skipped if nothing has changed
         # We expect 1 commit per 5 epochs + 1 commit at the end
-        nb_empty_commits = len([record for record in logs.records if "Skipping to prevent empty commit." in record.message])
+        nb_empty_commits = len(
+            [record for record in logs.records if "Skipping to prevent empty commit." in record.message]
+        )
         nb_epoch_commits = len([commit for commit in commits if "Training in progress, step" in commit])
 
         # max_steps depend on the number of available GPUs

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -3739,21 +3739,24 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
     def test_push_to_hub_with_saves_each_epoch(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            trainer = get_regression_trainer(
-                output_dir=os.path.join(tmp_dir, "test-trainer-epoch"),
-                push_to_hub=True,
-                hub_token=self._token,
-                # To avoid any flakiness if the training goes faster than the uploads.
-                hub_always_push=True,
-                save_strategy="epoch",
-            )
-            trainer.train()
+            with self.assertLogs(level="WARNING") as logs:
+                trainer = get_regression_trainer(
+                    output_dir=os.path.join(tmp_dir, "test-trainer-epoch"),
+                    push_to_hub=True,
+                    hub_token=self._token,
+                    # To avoid any flakiness if the training goes faster than the uploads.
+                    hub_always_push=True,
+                    save_strategy="epoch",
+                )
+                trainer.train()
 
         commits = list_repo_commits(f"{USER}/test-trainer-epoch", token=self._token)
         commits = [c.title for c in commits]
         self.assertIn("initial commit", commits)
-        for i in range(1, 4):
-            self.assertIn(f"Training in progress, epoch {i}", commits)
+        self.assertIn("Training in progress, epoch 1", commits)
+        self.assertIn("Training in progress, epoch 2", commits)
+        # Epochs 3 and 4 are not guaranteed to be present (empty commits)
+        self.assertTrue(any("Skipping to prevent empty commit." in record.message for record in logs.records))
 
     def test_push_to_hub_with_saves_each_n_steps(self):
         num_gpus = max(1, backend_device_count(torch_device))
@@ -3761,25 +3764,32 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
             self.skipTest(reason="More than 2 GPUs available")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            trainer = get_regression_trainer(
-                output_dir=os.path.join(tmp_dir, "test-trainer-step"),
-                push_to_hub=True,
-                hub_token=self._token,
-                # To avoid any flakiness if the training goes faster than the uploads.
-                hub_always_push=True,
-                save_strategy="steps",
-                save_steps=5,
-            )
-            trainer.train()
+            with self.assertLogs(level="WARNING") as logs:
+                trainer = get_regression_trainer(
+                    output_dir=os.path.join(tmp_dir, "test-trainer-step"),
+                    push_to_hub=True,
+                    hub_token=self._token,
+                    # To avoid any flakiness if the training goes faster than the uploads.
+                    hub_always_push=True,
+                    save_strategy="steps",
+                    save_steps=5,
+                )
+                trainer.train()
 
         commits = list_repo_commits(f"{USER}/test-trainer-step", token=self._token)
         commits = [c.title for c in commits]
         self.assertIn("initial commit", commits)
 
+        # Some commits are skipped if nothing has changed
+        # We expect 1 commit per 5 epochs + 1 commit at the end
+        nb_empty_commits = len([record for record in logs.records if "Skipping to prevent empty commit." in record.message])
+        nb_epoch_commits = len([commit for commit in commits if "Training in progress, step" in commit])
+
         # max_steps depend on the number of available GPUs
         max_steps = math.ceil(trainer.args.num_train_epochs * len(trainer.get_train_dataloader()))
-        for i in range(5, max_steps, 5):
-            self.assertIn(f"Training in progress, step {i}", commits)
+        nb_expected_commits = len(range(5, max_steps, 5))
+
+        self.assertGreaterEqual(nb_empty_commits + nb_epoch_commits, nb_expected_commits)
 
     @require_tensorboard
     def test_push_to_hub_with_tensorboard_logs(self):


### PR DESCRIPTION
See discussion [on slack](https://huggingface.slack.com/archives/C02V5EA0A95/p1721298572212239?thread_ts=1721227457.945549&cid=C02V5EA0A95) (private).

In latest `huggingface_hub` update ([0.24.0!](https://huggingface.co/spaces/Wauplin/huggingface_hub/discussions/7)), some logic has been added to avoid empty commits. This mechanism should prevent bloating git history when no changes have been detected. This change broke 2 tests in `transformers`'s CI which should be fixed by this PR (previously tested on https://github.com/huggingface/transformers/compare/main...ci-test-huggingface-hub-v0.24.0.rc0). **Note:** when an empty commit is prevented, a warning message is logged to the user. This is what we are testing in this PR. 

cc @ydshieh with whom we discussed this


**EDIT:** tests are failing since CI is still running on `huggingface_hub==0.23.5`. I guess rerunning them tomorrow should be good?