### PR TITLE
Disable quick init for deepspeed

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -344,8 +344,13 @@ def check_support_param_buffer_assignment(model_to_load, state_dict, start_prefi
     as when loading in empty weights) by first checking
     if the model explicitly disables it, then by ensuring that the state dict keys
     are a subset of the model's parameters.
+
+    Note: We fully disable this if we are using `deepspeed`
     """
     if len([key for key in state_dict if key.startswith(start_prefix)]) == 0:
+        return False
+
+    if is_deepspeed_zero3_enabled():
         return False
 
     # Some models explicitly do not support param buffer assignment


### PR DESCRIPTION
# What does this PR do?

As @philschmid tested, this method works for FSDP but not for DS (I think because DS needs their gathered params to not be in this way). So this PR disables it


DS vs FSDP training logs:

DS:
```
{'loss': 2.5297, 'grad_norm': 166.13894215336276, 'learning_rate': 1.9230769230769234e-06, 'epoch': 0.01}                                                                                 
{'loss': 2.3812, 'grad_norm': 7.978569298066882, 'learning_rate': 1.923076923076923e-05, 'epoch': 0.12}                                                                                   
{'loss': 2.1066, 'grad_norm': 3.4303861731711813, 'learning_rate': 3.846153846153846e-05, 'epoch': 0.24}                                                                                  
{'loss': 2.0788, 'grad_norm': 3.1286244034212807, 'learning_rate': 4.99613632163459e-05, 'epoch': 0.36}    
```
FSDP (where this is enabled):
```
{'loss': 2.5297, 'grad_norm': 165.95199584960938, 'learning_rate': 1.9230769230769234e-06, 'epoch': 0.01}                                                                                 
{'loss': 2.3801, 'grad_norm': 7.723988056182861, 'learning_rate': 1.923076923076923e-05, 'epoch': 0.12}                                                                                   
{'loss': 2.1089, 'grad_norm': 3.3734328746795654, 'learning_rate': 3.846153846153846e-05, 'epoch': 0.24}                                                                                  
{'loss': 2.0727, 'grad_norm': 2.6789469718933105, 'learning_rate': 4.99613632163459e-05, 'epoch': 0.36} 
```

FSDP prior to the init PR/without quick load:
```
{'loss': 2.5297, 'grad_norm': 166.12049865722656, 'learning_rate': 1.9230769230769234e-06, 'epoch': 0.01}                                                                                 
{'loss': 2.3754, 'grad_norm': 5.313587665557861, 'learning_rate': 1.923076923076923e-05, 'epoch': 0.12}                                                                                   
{'loss': 2.1038, 'grad_norm': 3.9090209007263184, 'learning_rate': 3.846153846153846e-05, 'epoch': 0.24}                                                                                  
{'loss': 2.0933, 'grad_norm': 3.003643274307251, 'learning_rate': 4.99613632163459e-05, 'epoch': 0.36} 
```

It's close enough that it's reasonable IMO



Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @amyeroberts 