### PR TITLE
Fix progress callback deepcopy

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -617,13 +617,16 @@ class ProgressCallback(TrainerCallback):
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         if state.is_world_process_zero and self.training_bar is not None:
-            # avoid modifying the logs object as it is shared between callbacks
-            logs = copy.deepcopy(logs)
-            _ = logs.pop("total_flos", None)
+            # make a shallow copy of logs so we can mutate the fields copied
+            # but avoid doing any value pickling.
+            shallow_logs = {}
+            for k,v in logs.entries():
+                shallow_logs[k] = v
+            _ = shallow_logs.pop("total_flos", None)
             # round numbers so that it looks better in console
-            if "epoch" in logs:
-                logs["epoch"] = round(logs["epoch"], 2)
-            self.training_bar.write(str(logs))
+            if "epoch" in shallow_logs:
+                shallow_logs["epoch"] = round(shallow_logs["epoch"], 2)
+            self.training_bar.write(str(shallow_logs))
 
     def on_train_end(self, args, state, control, **kwargs):
         if state.is_world_process_zero:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -619,7 +619,7 @@ class ProgressCallback(TrainerCallback):
             # make a shallow copy of logs so we can mutate the fields copied
             # but avoid doing any value pickling.
             shallow_logs = {}
-            for k,v in logs.items():
+            for k, v in logs.items():
                 shallow_logs[k] = v
             _ = shallow_logs.pop("total_flos", None)
             # round numbers so that it looks better in console

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -16,7 +16,6 @@
 Callbacks to use with the Trainer class and customize the training loop.
 """
 
-import copy
 import dataclasses
 import json
 from dataclasses import dataclass

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -620,7 +620,7 @@ class ProgressCallback(TrainerCallback):
             # make a shallow copy of logs so we can mutate the fields copied
             # but avoid doing any value pickling.
             shallow_logs = {}
-            for k,v in logs.entries():
+            for k,v in logs.items():
                 shallow_logs[k] = v
             _ = shallow_logs.pop("total_flos", None)
             # round numbers so that it looks better in console


### PR DESCRIPTION
# What does this PR do?

When ProgressCallback runs after the WandbCallback, in some scenarios it currently tries to deepcopy an object that can't be pickled. This makes a shallow copy of the log values to avoid any pickling and safely log everything.

Fixes #32064

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts
@muellerzr and @SunMarc
