### PR TITLE
fix: wandb artifact throws error if user sets wandb runtime name with "/"

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -839,6 +839,7 @@ class WandbCallback(TrainerCallback):
                     if (args.run_name is None or args.run_name == args.output_dir)
                     else f"model-{self._wandb.run.name}"
                 )
+                model_name = model_name.replace("/", "-")
                 model_artifact = self._wandb.Artifact(
                     name=model_name,
                     type="model",


### PR DESCRIPTION
# What does this PR do?

Wandb artifact throws error when the user names the wandb runtime with string that contains "/".

For example, if the user sets the wandb runtime name with the "mistralai/Mistral-Nemo-Instruct-2407", which is the exact name of the model in the huggingface hub, the wandb artifact throws exceptions.

Since most of the models in the huggingface-hub contain "/" in its name, might be better to replace the "/" by "-" automatically.
