### PR TITLE
avoid padding for `num_frames` in `AutomaticSpeechRecognitionPipeline`

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -191,7 +191,8 @@ def pad_collate_fn(tokenizer, feature_extractor):
             else:
                 # This is likely another random key maybe even user provided
                 _padding_value = 0
-            padded[key] = _pad(items, key, _padding_value, padding_side)
+            if key not in {"num_frames"}:
+                padded[key] = _pad(items, key, _padding_value, padding_side)
         return padded
 
     return inner


### PR DESCRIPTION
## What does this PR do?
The following example in the batch size part of [this](https://huggingface.co/docs/transformers/en/pipeline_tutorial) tutorial return an error.
```python
from transformers import pipeline

transcriber = pipeline(model="openai/whisper-large-v2", device=0, batch_size=2)
audio_filenames = [f"https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/{i}.flac" for i in range(1, 5)]
texts = transcriber(audio_filenames)
print(texts)
```
```bash
Traceback (most recent call last):
  File "/workspace/DOC/tutorials.py", line 5, in <module>
    texts = transcriber(audio_filenames)
  File "/workspace/transformers/src/transformers/pipelines/automatic_speech_recognition.py", line 284, in __call__
    return super().__call__(inputs, **kwargs)
  File "/workspace/transformers/src/transformers/pipelines/base.py", line 1235, in __call__
    outputs = list(final_iterator)
  File "/workspace/transformers/src/transformers/pipelines/pt_utils.py", line 124, in __next__
    item = next(self.iterator)
  File "/workspace/transformers/src/transformers/pipelines/pt_utils.py", line 269, in __next__
    processed = self.infer(next(self.iterator), **self.params)
  File "/root/miniforge3/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 631, in __next__
    data = self._next_data()
  File "/root/miniforge3/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 675, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/root/miniforge3/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 42, in fetch
    return self.collate_fn(data)
  File "/workspace/transformers/src/transformers/pipelines/base.py", line 194, in inner
    padded[key] = _pad(items, key, _padding_value, padding_side)
  File "/workspace/transformers/src/transformers/pipelines/base.py", line 100, in _pad
    max_length = max(item[key].shape[1] for item in items)
  File "/workspace/transformers/src/transformers/pipelines/base.py", line 100, in <genexpr>
    max_length = max(item[key].shape[1] for item in items)
IndexError: tuple index out of range
```
This PR fixes this error. Below is the results after fix:
```bash
[{'text': ' He hoped there would be stew for dinner, turnips and carrots and bruised potatoes and fat mutton pieces to be ladled out in thick, peppered, flour-fattened sauce.'}, {'text': ' Stuff it into you, his belly counselled him.'}, {'text': ' After early nightfall the yellow lamps would light up here and there the squalid quarter of the brothels.'}, {'text': ' Y en las ramas medio sumergidas revoloteaban algunos pájaros de quimérico y legendario plumaje.'}]
```
