### PR TITLE
fix: multilingual midel convert to tflite get wrong token

### DIFF
--- a/src/transformers/generation/tf_logits_process.py
+++ b/src/transformers/generation/tf_logits_process.py
@@ -581,7 +581,7 @@ class TFForceTokensLogitsProcessor(TFLogitsProcessor):
             batch_size = scores.shape[0]
             current_token = self.force_token_array[generation_idx]
 
-            new_scores = tf.ones_like(scores, dtype=scores.dtype) * -float("inf")
+            new_scores = tf.zeros_like(scores, dtype=scores.dtype) + tf.constant([scores.dtype.min])
             indices = tf.stack((tf.range(batch_size), tf.tile([current_token], [batch_size])), axis=1)
             updates = tf.zeros((batch_size,), dtype=scores.dtype)
             new_scores = tf.tensor_scatter_nd_update(new_scores, indices, updates)

--- a/tests/generation/test_tf_logits_process.py
+++ b/tests/generation/test_tf_logits_process.py
@@ -406,7 +406,12 @@ class TFLogitsProcessorTest(unittest.TestCase):
 
         non_forced_inds = [i for i in range(vocab_size) if i != force_token_map[cur_len]]
         self.assertTrue(
-            tf.math.reduce_all(tf.math.is_inf(tf.gather(scores, [non_forced_inds], axis=1))),
+            tf.math.reduce_all(
+                tf.experimental.numpy.isclose(
+                    tf.gather(scores, [non_forced_inds], axis=1),
+                    tf.constant(scores.dtype.min),
+                )
+            )
         )
 
         # check that if the cur_len is not contained in the force_token_map, the logits are not modified


### PR DESCRIPTION
# What does this PR do?
when using multilingual whisper model and covert to tflite for end device use, always get wrong token.
Like this: this sample is voice transcription to chinese(zh)
```
ds = ds: {'audio': {'path': '/root/.cache/huggingface/datasets/downloads/extracted/81aac54528c46189de3348c82aaf37cfa33d9b1d3110a
f647d92b9e97280889d/zh-TW_dev_0/common_voice_zh-TW_17383559.mp3', 'sampling_rate': 16000}, 'sentence': '二話不說拉住她的手往回走',  'locale': 'zh-TW'}

before convert that  is work!
Tensorflow Transcription: 而話不說拉住他的手往回憶住

but after convert to tflite get wrong->
tflite transcription: : !!!

get token : generated_ids: [[50258 50260     0     0     0 50257 50257 ...... 50257 50257 ]]

```

It seem like ``TFForceTokensLogitsProcessor`` _force_token this function may happen overflow when converted
```
            new_scores = tf.ones_like(scores, dtype=scores.dtype) * -float("inf")
```
So change the way that new_scores retains the most negative values to avoid it
```
            new_scores = tf.zeros_like(scores, dtype=scores.dtype) + tf.constant([scores.dtype.min])
```

result:
```
# after fixed result
tflite transcription: 而話不說拉住她的手往回頭
```

convert model sample code can ref [this](https://github.com/Ayaa17/transformers/tree/fix_TFLogitsProcessor_demo_code/src/example)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@gante   @Rocketknight1

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
