### PR TITLE
Custom beam search scorer argument in generate function

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -136,6 +136,9 @@ class GenerationConfig(PushToHubMixin):
         beam_search_scorer_class: (`class`, *optional*, defaults to `None`):
             Which class to use as a beam search scorer. If `None`, it will use the default `BeamSearchScorer` class.
             The type must inherit from `BeamSearchScorer`.
+        beam_search_scorer_args: (`dict`, *optional*, defaults to `None`)
+            Arguments that will be passed when creating the beam search scorer. When this argument is specified,
+            `beam_search_scorer_class` must not be `None`.
 
         > Parameters for manipulation of the model output logits
 
@@ -357,6 +360,7 @@ class GenerationConfig(PushToHubMixin):
         self.penalty_alpha = kwargs.pop("penalty_alpha", None)
         self.use_cache = kwargs.pop("use_cache", True)
         self.beam_search_scorer_class = kwargs.pop("beam_search_scorer_class", None)
+        self.beam_search_scorer_args = kwargs.pop("beam_search_scorer_args", None)
 
         # Parameters for manipulation of the model output logits
         self.temperature = kwargs.pop("temperature", 1.0)
@@ -650,6 +654,11 @@ class GenerationConfig(PushToHubMixin):
                         flag_name="beam_search_scorer_class", flag_value=self.beam_search_scorer_class
                     ),
                     UserWarning,
+                )
+
+            if self.beam_search_scorer_class is None and self.beam_search_scorer_args is not None:
+                raise ValueError(
+                    "The initialization arguments for the beam search scorer class were provided, but the class was not",
                 )
 
         # 3. detect incorrect paramaterization specific to advanced beam modes

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -133,6 +133,9 @@ class GenerationConfig(PushToHubMixin):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should use the past last key/values attentions (if applicable to the model) to
             speed up decoding.
+        beam_search_scorer_class: (`class`, *optional*, defaults to `None`):
+            Which class to use as a beam search scorer. If `None`, it will use the default `BeamSearchScorer` class.
+            The type must inherit from `BeamSearchScorer`.
 
         > Parameters for manipulation of the model output logits
 
@@ -353,6 +356,7 @@ class GenerationConfig(PushToHubMixin):
         self.num_beam_groups = kwargs.pop("num_beam_groups", 1)
         self.penalty_alpha = kwargs.pop("penalty_alpha", None)
         self.use_cache = kwargs.pop("use_cache", True)
+        self.beam_search_scorer_class = kwargs.pop("beam_search_scorer_class", None)
 
         # Parameters for manipulation of the model output logits
         self.temperature = kwargs.pop("temperature", 1.0)
@@ -640,6 +644,13 @@ class GenerationConfig(PushToHubMixin):
                     single_beam_wrong_parameter_msg.format(flag_name="constraints", flag_value=self.constraints),
                     UserWarning,
                 )
+            if self.beam_search_scorer_class is not None:
+                warnings.warn(
+                    single_beam_wrong_parameter_msg.format(
+                        flag_name="beam_search_scorer_class", flag_value=self.beam_search_scorer_class
+                    ),
+                    UserWarning,
+                )
 
         # 3. detect incorrect paramaterization specific to advanced beam modes
         else:
@@ -658,6 +669,12 @@ class GenerationConfig(PushToHubMixin):
                     raise ValueError(
                         constrained_wrong_parameter_msg.format(
                             flag_name="num_beam_groups", flag_value=self.num_beam_groups
+                        )
+                    )
+                if self.beam_search_scorer_class is not None:
+                    raise ValueError(
+                        constrained_wrong_parameter_msg.format(
+                            flag_name="beam_search_scorer_class", flag_value=self.beam_search_scorer_class
                         )
                     )
             # group beam search

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2006,15 +2006,27 @@ class GenerationMixin:
             )
 
             # 12. prepare beam search scorer
-            beam_scorer = BeamSearchScorer(
-                batch_size=batch_size,
-                num_beams=generation_config.num_beams,
-                device=inputs_tensor.device,
-                length_penalty=generation_config.length_penalty,
-                do_early_stopping=generation_config.early_stopping,
-                num_beam_hyps_to_keep=generation_config.num_return_sequences,
-                max_length=generation_config.max_length,
-            )
+            if generation_config.beam_search_scorer_class is None:
+                beam_scorer = BeamSearchScorer(
+                    batch_size=batch_size,
+                    num_beams=generation_config.num_beams,
+                    device=inputs_tensor.device,
+                    length_penalty=generation_config.length_penalty,
+                    do_early_stopping=generation_config.early_stopping,
+                    num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                    max_length=generation_config.max_length,
+                )
+            else:
+                beam_scorer = generation_config.beam_search_scorer_class(
+                    batch_size=batch_size,
+                    num_beams=generation_config.num_beams,
+                    device=inputs_tensor.device,
+                    length_penalty=generation_config.length_penalty,
+                    do_early_stopping=generation_config.early_stopping,
+                    num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                    num_beam_groups=generation_config.num_beam_groups,
+                    max_length=generation_config.max_length,
+                )
 
             # 13. interleave input_ids with `num_beams` additional sequences per batch
             input_ids, model_kwargs = self._expand_inputs_for_generation(
@@ -2038,16 +2050,27 @@ class GenerationMixin:
 
         elif generation_mode == GenerationMode.GROUP_BEAM_SEARCH:
             # 11. prepare beam search scorer
-            beam_scorer = BeamSearchScorer(
-                batch_size=batch_size,
-                num_beams=generation_config.num_beams,
-                device=inputs_tensor.device,
-                length_penalty=generation_config.length_penalty,
-                do_early_stopping=generation_config.early_stopping,
-                num_beam_hyps_to_keep=generation_config.num_return_sequences,
-                num_beam_groups=generation_config.num_beam_groups,
-                max_length=generation_config.max_length,
-            )
+            if generation_config.beam_search_scorer_class is None:
+                beam_scorer = BeamSearchScorer(
+                    batch_size=batch_size,
+                    num_beams=generation_config.num_beams,
+                    device=inputs_tensor.device,
+                    length_penalty=generation_config.length_penalty,
+                    do_early_stopping=generation_config.early_stopping,
+                    num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                    max_length=generation_config.max_length,
+                )
+            else:
+                beam_scorer = generation_config.beam_search_scorer_class(
+                    batch_size=batch_size,
+                    num_beams=generation_config.num_beams,
+                    device=inputs_tensor.device,
+                    length_penalty=generation_config.length_penalty,
+                    do_early_stopping=generation_config.early_stopping,
+                    num_beam_hyps_to_keep=generation_config.num_return_sequences,
+                    num_beam_groups=generation_config.num_beam_groups,
+                    max_length=generation_config.max_length,
+                )
             # 12. interleave input_ids with `num_beams` additional sequences per batch
             input_ids, model_kwargs = self._expand_inputs_for_generation(
                 input_ids=input_ids,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2004,7 +2004,6 @@ class GenerationMixin:
                 if generation_config.do_sample
                 else None
             )
-
             # 12. prepare beam search scorer
             if generation_config.beam_search_scorer_class is None:
                 beam_scorer = BeamSearchScorer(
@@ -2017,6 +2016,11 @@ class GenerationMixin:
                     max_length=generation_config.max_length,
                 )
             else:
+                args = (
+                    generation_config.beam_search_scorer_args
+                    if generation_config.beam_search_scorer_args is not None
+                    else {}
+                )
                 beam_scorer = generation_config.beam_search_scorer_class(
                     batch_size=batch_size,
                     num_beams=generation_config.num_beams,
@@ -2026,6 +2030,7 @@ class GenerationMixin:
                     num_beam_hyps_to_keep=generation_config.num_return_sequences,
                     num_beam_groups=generation_config.num_beam_groups,
                     max_length=generation_config.max_length,
+                    **args,
                 )
 
             # 13. interleave input_ids with `num_beams` additional sequences per batch
@@ -2061,6 +2066,11 @@ class GenerationMixin:
                     max_length=generation_config.max_length,
                 )
             else:
+                args = (
+                    generation_config.beam_search_scorer_args
+                    if generation_config.beam_search_scorer_args is not None
+                    else {}
+                )
                 beam_scorer = generation_config.beam_search_scorer_class(
                     batch_size=batch_size,
                     num_beams=generation_config.num_beams,
@@ -2070,6 +2080,7 @@ class GenerationMixin:
                     num_beam_hyps_to_keep=generation_config.num_return_sequences,
                     num_beam_groups=generation_config.num_beam_groups,
                     max_length=generation_config.max_length,
+                    **args,
                 )
             # 12. interleave input_ids with `num_beams` additional sequences per batch
             input_ids, model_kwargs = self._expand_inputs_for_generation(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -65,6 +65,7 @@ if is_torch_available():
         BeamSampleEncoderDecoderOutput,
         BeamSearchDecoderOnlyOutput,
         BeamSearchEncoderDecoderOutput,
+        BeamSearchScorer,
         DisjunctiveConstraint,
         GenerateBeamDecoderOnlyOutput,
         GenerateBeamEncoderDecoderOutput,
@@ -579,6 +580,59 @@ class GenerationTesterMixin:
                 self.assertTrue(output_generate.shape[-1] == self.max_new_tokens + 1)
             else:
                 self.assertTrue(output_generate.shape[-1] == self.max_new_tokens + input_ids.shape[-1])
+
+    def test_custom_beam_search_scorer_generate(self):
+        class CustomBeamSearchScorer(BeamSearchScorer):
+            finalize_called = False
+            process_called = False
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def process(self, *args, **kwargs):
+                results = super().process(*args, **kwargs)
+                CustomBeamSearchScorer.process_called = True
+                return results
+
+            def finalize(self, *args, **kwargs):
+                results = super().finalize(*args, **kwargs)
+                CustomBeamSearchScorer.finalize_called = True
+                return results
+
+        for model_class in self.all_generative_model_classes:
+            CustomBeamSearchScorer.process_called = False
+            CustomBeamSearchScorer.finalize_called = False
+
+            config, input_ids, attention_mask = self._get_input_ids_and_config()
+
+            model = model_class(config).to(torch_device).eval()
+
+            logits_process_kwargs, _ = self._get_logits_processor_and_warper_kwargs(
+                input_ids.shape[-1],
+                config.forced_bos_token_id,
+                config.forced_eos_token_id,
+            )
+            beam_kwargs = self._get_beam_kwargs()
+
+            model_kwargs = {"attention_mask": attention_mask}
+            output_generate = model.generate(
+                input_ids,
+                do_sample=False,
+                max_new_tokens=self.max_new_tokens,
+                beam_search_scorer_class=CustomBeamSearchScorer,
+                output_scores=False,
+                output_logits=False,
+                output_attentions=False,
+                output_hidden_states=False,
+                return_dict_in_generate=False,
+                **beam_kwargs,
+                **logits_process_kwargs,
+                **model_kwargs,
+            )
+
+            self.assertIsNotNone(output_generate)
+            self.assertTrue(CustomBeamSearchScorer.process_called)
+            self.assertTrue(CustomBeamSearchScorer.finalize_called)
 
     def test_beam_search_generate_dict_output(self):
         for model_class in self.all_generative_model_classes:
@@ -2276,6 +2330,60 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
         outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)
 
         self.assertListEqual(outputs, ["Wie alt bist du?"])
+
+    @slow
+    def test_beam_search_custom_scorer(self):
+        tokenizer = AutoTokenizer.from_pretrained("google-t5/t5-base")
+        model = AutoModelForSeq2SeqLM.from_pretrained("google-t5/t5-base")
+
+        encoder_input_str = "translate English to German: How old are you?"
+        encoder_input_ids = tokenizer(encoder_input_str, return_tensors="pt").input_ids
+
+        class CustomBeamSearchScorer(BeamSearchScorer):
+            finalize_called = False
+            process_called = False
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def process(self, *args, **kwargs):
+                results = super().process(*args, **kwargs)
+                CustomBeamSearchScorer.process_called = True
+                return results
+
+            def finalize(self, *args, **kwargs):
+                results = super().finalize(*args, **kwargs)
+                CustomBeamSearchScorer.finalize_called = True
+                return results
+
+        # lets run beam search using 3 beams
+        num_beams = 3
+        # define decoder start token ids
+        input_ids = torch.ones((1, 1), device=model.device, dtype=torch.long)
+        input_ids = input_ids * model.config.decoder_start_token_id
+
+        # add encoder_outputs to model keyword arguments
+        model_kwargs = {"encoder_outputs": model.get_encoder()(encoder_input_ids, return_dict=True)}
+
+        outputs = model.generate(
+            input_ids,
+            num_beams=num_beams,
+            min_length=5,
+            eos_token_id=model.config.eos_token_id,
+            beam_search_scorer_class=CustomBeamSearchScorer,
+            **model_kwargs,
+        )
+        outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+
+        self.assertListEqual(outputs, ["Wie alt bist du?"])
+        self.assertTrue(
+            CustomBeamSearchScorer.process_called,
+            "The `process` function of the custom beam search scorer was not called",
+        )
+        self.assertTrue(
+            CustomBeamSearchScorer.finalize_called,
+            "The `finalize` function of the custom beam search scorer was not called",
+        )
 
     @slow
     def test_constrained_beam_search(self):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -586,8 +586,13 @@ class GenerationTesterMixin:
             finalize_called = False
             process_called = False
 
-            def __init__(self, *args, **kwargs):
+            def __init__(inside_self, test_args, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+                inside_self.test_args = test_args
+                self.assertTrue(
+                    inside_self.test_args,
+                    "The argument `test_args` should " "have been passed to the beam search scorer init function",
+                )
 
             def process(self, *args, **kwargs):
                 results = super().process(*args, **kwargs)
@@ -620,6 +625,7 @@ class GenerationTesterMixin:
                 do_sample=False,
                 max_new_tokens=self.max_new_tokens,
                 beam_search_scorer_class=CustomBeamSearchScorer,
+                beam_search_scorer_args={"test_args": True},
                 output_scores=False,
                 output_logits=False,
                 output_attentions=False,
@@ -2343,8 +2349,13 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             finalize_called = False
             process_called = False
 
-            def __init__(self, *args, **kwargs):
+            def __init__(inside_self, test_args, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+                inside_self.test_args = test_args
+                self.assertTrue(
+                    inside_self.test_args,
+                    ("The argument `test_args` should " "have been passed to the beam search scorer init function"),
+                )
 
             def process(self, *args, **kwargs):
                 results = super().process(*args, **kwargs)
@@ -2371,6 +2382,7 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             min_length=5,
             eos_token_id=model.config.eos_token_id,
             beam_search_scorer_class=CustomBeamSearchScorer,
+            beam_search_scorer_args={"test_args": True},
             **model_kwargs,
         )
         outputs = tokenizer.batch_decode(outputs, skip_special_tokens=True)


### PR DESCRIPTION
# What does this PR do?

Added an argument `beam_search_scorer_class` in `generate()` function to allow users to use beam search and grouped beam search using a custom beam search scorer.

Before that, the internal methods `_beam_search()` and `_group_beam_search()` had to be used to pass in a custom beam search scorer. However, this caused a lot of problems since the `generate()` function does a lot of preprocessing on the input (interleave the input_ids for example in the case of beam search). All that preprocessing had to be done manually Right now, this can be set directly in the `generate()` function by passing the type of the beam search scorer in the following way :

```python
tokenizer = AutoTokenizer.from_pretrained("google-t5/t5-base")
model = AutoModelForSeq2SeqLM.from_pretrained("google-t5/t5-base")

encoder_input_str = "translate English to German: How old are you?"
encoder_input_ids = tokenizer(encoder_input_str, return_tensors="pt").input_ids

class CustomBeamSearchScorer(BeamSearchScorer):
    finalize_called = False
    process_called = False

    def __init__(self, test_args, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.test_args = test_args

    def process(self, *args, **kwargs):
        results = super().process(*args, **kwargs)
        # Do stuff
        return results

    def finalize(self, *args, **kwargs):
        results = super().finalize(*args, **kwargs)
        # Do stuff
        return results

# lets run beam search using 3 beams
num_beams = 3
# define decoder start token ids
input_ids = torch.ones((1, 1), device=model.device, dtype=torch.long)
input_ids = input_ids * model.config.decoder_start_token_id

# add encoder_outputs to model keyword arguments
model_kwargs = {"encoder_outputs": model.get_encoder()(encoder_input_ids, return_dict=True)}

outputs = model.generate(
    input_ids,
    num_beams=num_beams,
    min_length=5,
    eos_token_id=model.config.eos_token_id,
    beam_search_scorer_class=CustomBeamSearchScorer,
    beam_search_scorer_args={"test_args": True},
    **model_kwargs,
)
``` 

# Why was this done that way
Initially, the beam_search_scorer was simply an object instead of the type. However, this could lead to inconsistencies between the parameters of the generation config and the beam search scorer. For example, the number of beams could have been set to 2 in the generate() method, but set to 4 when creating the scorer. By passing the type only, this allows the scorer to be created with the generation config inside the method (like before) and preventing any inconsistencies between the two objects.


<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@gante 
@ArthurZucker 
