### PR TITLE
fix: resolve bug with `use_mps_device` setting not taking effect

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2186,7 +2186,7 @@ class TrainingArguments:
                         "Either you do not have an MPS-enabled device on this machine or MacOS version is not 12.3+ "
                         "or current PyTorch install was not built with MPS enabled."
                     )
-            if self.use_cpu:
+            elif self.use_cpu:
                 device = torch.device("cpu")
             elif is_torch_mps_available():
                 device = torch.device("mps")


### PR DESCRIPTION
# Fixes the bug with `use_mps_device` setting not taking effect.
In training_args.py,, even when `use_mps_device` is set, the current implementation overrides it with `device=cuda/cpu`, causing `use_mps_device` to not take effect.

It's a minor code typo, so I didn't open an issue for it. 

<img width="982" alt="image" src="https://github.com/user-attachments/assets/68b84763-7b67-4064-aa00-34f77bd8f453">


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.pytorch.org/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/pytorch/pytorch/tree/master/docs), and [here are tips on formatting docstrings](https://github.com/pytorch/pytorch/tree/master/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
