### PR TITLE
Update stateful_callbacks state before saving checkpoint

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2960,8 +2960,10 @@ class Trainer:
 
         # Save the Trainer state
         if self.args.should_save:
-            # Update the `TrainerControl` state to where we are currently
-            self.state.stateful_callbacks["TrainerControl"] = self.control.state()
+            # Update `ExportableState` callbacks and `TrainerControl` state to where we are currently
+            for cb in [cb for cb in self.callback_handler.callbacks + [self.control] if
+                       isinstance(cb, ExportableState)]:
+                self.state.stateful_callbacks[cb.__class__.__name__] = cb.state()
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 
         if self.args.push_to_hub:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2961,8 +2961,9 @@ class Trainer:
         # Save the Trainer state
         if self.args.should_save:
             # Update `ExportableState` callbacks and `TrainerControl` state to where we are currently
-            for cb in [cb for cb in self.callback_handler.callbacks + [self.control] if
-                       isinstance(cb, ExportableState)]:
+            for cb in [
+                cb for cb in self.callback_handler.callbacks + [self.control] if isinstance(cb, ExportableState)
+            ]:
                 self.state.stateful_callbacks[cb.__class__.__name__] = cb.state()
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2964,7 +2964,12 @@ class Trainer:
             for cb in [
                 cb for cb in self.callback_handler.callbacks + [self.control] if isinstance(cb, ExportableState)
             ]:
-                self.state.stateful_callbacks[cb.__class__.__name__] = cb.state()
+                cb_name = cb.__class__.__name__
+                cb_state = cb.state()
+                if isinstance(self.state.stateful_callbacks[cb_name], list):
+                    self.state.stateful_callbacks[cb_name].append(cb_state)
+                else:
+                    self.state.stateful_callbacks[cb_name] = cb_state
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 
         if self.args.push_to_hub:


### PR DESCRIPTION
### Fixes
This PR addresses an issue where stateful callbacks, such as EarlyStoppingCallback, were not being updated before saving checkpoints. As a result, resuming training would not have access to the latest state of these callbacks.

### Description
Updated the state of stateful callbacks before saving checkpoints to ensure that their state is preserved and correctly restored when resuming training.

### Suggested Reviewers
@muellerz  @amyeroberts  @SunMarc
