### PR TITLE
fix: Replaced deprecated `mktemp()` function

### DIFF
--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -513,7 +513,7 @@ class LoadImageTester(unittest.TestCase):
 
     def test_load_img_base64_prefix(self):
         try:
-            tmp_file = tempfile.mktemp()
+            tmp_file = tempfile.NamedTemporaryFile(delete=False).name
             with open(tmp_file, "wb") as f:
                 http_get(
                     "https://huggingface.co/datasets/hf-internal-testing/dummy-base64-images/raw/main/image_0.txt", f
@@ -530,7 +530,7 @@ class LoadImageTester(unittest.TestCase):
 
     def test_load_img_base64(self):
         try:
-            tmp_file = tempfile.mktemp()
+            tmp_file = tempfile.NamedTemporaryFile(delete=False).name
             with open(tmp_file, "wb") as f:
                 http_get(
                     "https://huggingface.co/datasets/hf-internal-testing/dummy-base64-images/raw/main/image_1.txt", f
@@ -547,7 +547,7 @@ class LoadImageTester(unittest.TestCase):
 
     def test_load_img_base64_encoded_bytes(self):
         try:
-            tmp_file = tempfile.mktemp()
+            tmp_file = tempfile.NamedTemporaryFile(delete=False).name
             with open(tmp_file, "wb") as f:
                 http_get(
                     "https://huggingface.co/datasets/hf-internal-testing/dummy-base64-images/raw/main/image_2.txt", f

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -84,7 +84,7 @@ class TokenizerUtilTester(unittest.TestCase):
     def test_legacy_load_from_one_file(self):
         # This test is for deprecated behavior and can be removed in v5
         try:
-            tmp_file = tempfile.mktemp()
+            tmp_file = tempfile.NamedTemporaryFile(delete=False).name
             with open(tmp_file, "wb") as f:
                 http_get("https://huggingface.co/albert/albert-base-v1/resolve/main/spiece.model", f)
 


### PR DESCRIPTION
# What does this PR do?
`tempfile.mktemp()` is deprecated. It's usage can be replaced easily with [NamedTemporaryFile()](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile),
Reference: https://docs.python.org/3/library/tempfile.html#tempfile.mktemp

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 