### PR TITLE
Fix failing test with race condition

### DIFF
--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -20,7 +20,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from shutil import copyfile
-from time import monotonic_ns
+from uuid import uuid4
 
 from huggingface_hub import HfFolder, Repository, create_repo, delete_repo
 from requests.exceptions import HTTPError
@@ -432,9 +432,7 @@ class ProcessorPushToHubTester(unittest.TestCase):
 
         processor = CustomProcessor(feature_extractor, tokenizer)
 
-        # Use a high-precision clock instead of randint() to get a random ID
-        # in case the test runners synchronize random seeds anywhere
-        random_repo_id = f"{USER}/test-dynamic-processor-{monotonic_ns()}"
+        random_repo_id = f"{USER}/test-dynamic-processor-{uuid4()}"
         with tempfile.TemporaryDirectory() as tmp_dir:
             create_repo(random_repo_id, token=self._token)
             repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from shutil import copyfile
+from random import randint
 
 from huggingface_hub import HfFolder, Repository, create_repo, delete_repo
 from requests.exceptions import HTTPError
@@ -431,9 +432,10 @@ class ProcessorPushToHubTester(unittest.TestCase):
 
         processor = CustomProcessor(feature_extractor, tokenizer)
 
+        random_repo_id = f"{USER}/test-dynamic-processor-{randint(1000, 1000000)}"
         with tempfile.TemporaryDirectory() as tmp_dir:
-            create_repo(f"{USER}/test-dynamic-processor", token=self._token)
-            repo = Repository(tmp_dir, clone_from=f"{USER}/test-dynamic-processor", token=self._token)
+            create_repo(random_repo_id, token=self._token)
+            repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)
             processor.save_pretrained(tmp_dir)
 
             # This has added the proper auto_map field to the feature extractor config
@@ -463,6 +465,6 @@ class ProcessorPushToHubTester(unittest.TestCase):
 
             repo.push_to_hub()
 
-        new_processor = AutoProcessor.from_pretrained(f"{USER}/test-dynamic-processor", trust_remote_code=True)
+        new_processor = AutoProcessor.from_pretrained(random_repo_id, trust_remote_code=True)
         # Can't make an isinstance check because the new_processor is from the CustomProcessor class of a dynamic module
         self.assertEqual(new_processor.__class__.__name__, "CustomProcessor")

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -19,8 +19,8 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from shutil import copyfile
 from random import randint
+from shutil import copyfile
 
 from huggingface_hub import HfFolder, Repository, create_repo, delete_repo
 from requests.exceptions import HTTPError

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -433,38 +433,41 @@ class ProcessorPushToHubTester(unittest.TestCase):
         processor = CustomProcessor(feature_extractor, tokenizer)
 
         random_repo_id = f"{USER}/test-dynamic-processor-{uuid4()}"
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            create_repo(random_repo_id, token=self._token)
-            repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)
-            processor.save_pretrained(tmp_dir)
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                create_repo(random_repo_id, token=self._token)
+                repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)
+                processor.save_pretrained(tmp_dir)
 
-            # This has added the proper auto_map field to the feature extractor config
-            self.assertDictEqual(
-                processor.feature_extractor.auto_map,
-                {
-                    "AutoFeatureExtractor": "custom_feature_extraction.CustomFeatureExtractor",
-                    "AutoProcessor": "custom_processing.CustomProcessor",
-                },
-            )
+                # This has added the proper auto_map field to the feature extractor config
+                self.assertDictEqual(
+                    processor.feature_extractor.auto_map,
+                    {
+                        "AutoFeatureExtractor": "custom_feature_extraction.CustomFeatureExtractor",
+                        "AutoProcessor": "custom_processing.CustomProcessor",
+                    },
+                )
 
-            # This has added the proper auto_map field to the tokenizer config
-            with open(os.path.join(tmp_dir, "tokenizer_config.json")) as f:
-                tokenizer_config = json.load(f)
-            self.assertDictEqual(
-                tokenizer_config["auto_map"],
-                {
-                    "AutoTokenizer": ["custom_tokenization.CustomTokenizer", None],
-                    "AutoProcessor": "custom_processing.CustomProcessor",
-                },
-            )
+                # This has added the proper auto_map field to the tokenizer config
+                with open(os.path.join(tmp_dir, "tokenizer_config.json")) as f:
+                    tokenizer_config = json.load(f)
+                self.assertDictEqual(
+                    tokenizer_config["auto_map"],
+                    {
+                        "AutoTokenizer": ["custom_tokenization.CustomTokenizer", None],
+                        "AutoProcessor": "custom_processing.CustomProcessor",
+                    },
+                )
 
-            # The code has been copied from fixtures
-            self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_feature_extraction.py")))
-            self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_tokenization.py")))
-            self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_processing.py")))
+                # The code has been copied from fixtures
+                self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_feature_extraction.py")))
+                self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_tokenization.py")))
+                self.assertTrue(os.path.isfile(os.path.join(tmp_dir, "custom_processing.py")))
 
-            repo.push_to_hub()
+                repo.push_to_hub()
 
-        new_processor = AutoProcessor.from_pretrained(random_repo_id, trust_remote_code=True)
-        # Can't make an isinstance check because the new_processor is from the CustomProcessor class of a dynamic module
-        self.assertEqual(new_processor.__class__.__name__, "CustomProcessor")
+            new_processor = AutoProcessor.from_pretrained(random_repo_id, trust_remote_code=True)
+            # Can't make an isinstance check because the new_processor is from the CustomProcessor class of a dynamic module
+            self.assertEqual(new_processor.__class__.__name__, "CustomProcessor")
+        finally:
+            delete_repo(repo_id=random_repo_id)

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -19,8 +19,8 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from random import randint
 from shutil import copyfile
+from time import monotonic_ns
 
 from huggingface_hub import HfFolder, Repository, create_repo, delete_repo
 from requests.exceptions import HTTPError
@@ -432,7 +432,9 @@ class ProcessorPushToHubTester(unittest.TestCase):
 
         processor = CustomProcessor(feature_extractor, tokenizer)
 
-        random_repo_id = f"{USER}/test-dynamic-processor-{randint(1000, 1000000)}"
+        # Use a high-precision clock instead of randint() to get a random ID
+        # in case the test runners synchronize random seeds anywhere
+        random_repo_id = f"{USER}/test-dynamic-processor-{monotonic_ns()}"
         with tempfile.TemporaryDirectory() as tmp_dir:
             create_repo(random_repo_id, token=self._token)
             repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)


### PR DESCRIPTION
The `test_push_to_hub_dynamic_processor` calls `create_repo` with a fixed repo name, and often throws an error in the CI. I suspect this happens when multiple test runners try to create the repo at the same time.

I rewrote the test to use a randomized repo name, which should hopefully avoid these collisions - though I don't know how the dummy user works, so I hope these still get cleaned up!