### PR TITLE
add scaling_factor to GemmaRotaryEmbedding for fix error in GemmaLine…

### DIFF
--- a/src/transformers/models/gemma/diff_gemma.py
+++ b/src/transformers/models/gemma/diff_gemma.py
@@ -185,9 +185,9 @@ ALL_LAYERNORM_LAYERS.append(GemmaRMSNorm)
 
 
 class GemmaRotaryEmbedding(nn.Module):
-    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):
         super().__init__()
-
+        self.scaling_factor = scaling_factor
         self.dim = dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base


### PR DESCRIPTION
In generated code, there are GemmaLinearScalingRotaryEmbedding and GemmaDynamicNTKScalingRotaryEmbedding which use scaling_factor need to declare it in base class, or remove generation of: GemmaLinearScalingRotaryEmbedding and GemmaDynamicNTKScalingRotaryEmbedding