### PR TITLE
Hub test: avoid repo creation deadlocks

### DIFF
--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -435,7 +435,8 @@ class ProcessorPushToHubTester(unittest.TestCase):
         random_repo_id = f"{USER}/test-dynamic-processor-{uuid4()}"
         try:
             with tempfile.TemporaryDirectory() as tmp_dir:
-                create_repo(random_repo_id, token=self._token)
+                # exist_ok=True to avoid unlikely deadlocks
+                create_repo(random_repo_id, token=self._token, exist_ok=True)
                 repo = Repository(tmp_dir, clone_from=random_repo_id, token=self._token)
                 processor.save_pretrained(tmp_dir)
 


### PR DESCRIPTION
# What does this PR do?

see title :)

- Fixed test: `tests/models/auto/test_processor_auto.py::ProcessorPushToHubTester::test_push_to_hub_dynamic_processor`
  - before:
![Screenshot 2024-07-23 at 09 26 38](https://github.com/user-attachments/assets/1fb8db21-2907-4be9-a659-9261aa83676c)
  - this PR:
![Screenshot 2024-07-23 at 09 26 59](https://github.com/user-attachments/assets/11b815ed-75fa-4049-affc-45d849d9d6fa)
