### PR TITLE
support copies

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.nn as nn
 from packaging import version
 
 from .configuration_utils import PretrainedConfig
@@ -22,8 +23,6 @@ if is_hqq_available():
 
 logger = logging.get_logger(__name__)
 
-import torch.nn as nn
-
 
 @dataclass
 class Cache(nn.Module):
@@ -32,7 +31,7 @@ class Cache(nn.Module):
     """
 
     def __init__(self):
-        super().__init__(self)
+        super().__init__()
 
     def update(
         self,

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -303,7 +303,7 @@ class DynamicCache(Cache):
     """
 
     def __init__(self) -> None:
-        super().__init__(self)
+        super().__init__()
         self.key_cache: List[torch.Tensor] = []
         self.value_cache: List[torch.Tensor] = []
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -467,6 +467,7 @@ class QuantizedCache(DynamicCache):
     """
 
     def __init__(self, cache_config: QuantizedCacheConfig) -> None:
+        super().__init__()
         self._quantized_key_cache: List[torch.Tensor] = []
         self._quantized_value_cache: List[torch.Tensor] = []
 
@@ -477,8 +478,6 @@ class QuantizedCache(DynamicCache):
         self.axis_value = cache_config.axis_value
         self.compute_dtype = cache_config.compute_dtype
         self.device = cache_config.device
-
-        super().__init__()
 
     def update(
         self,
@@ -640,6 +639,7 @@ class SinkCache(Cache):
     """
 
     def __init__(self, window_length: int, num_sink_tokens: int) -> None:
+        super().__init__()
         self.key_cache: List[torch.Tensor] = []
         self.value_cache: List[torch.Tensor] = []
         self.window_length = window_length
@@ -1009,6 +1009,7 @@ class EncoderDecoderCache(Cache):
     """
 
     def __init__(self, self_attention_cache: Cache, cross_attention_cache: Cache):
+        super().__init__()
         self.self_attention_cache = self_attention_cache
         self.cross_attention_cache = cross_attention_cache
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -22,12 +22,17 @@ if is_hqq_available():
 
 logger = logging.get_logger(__name__)
 
+import torch.nn as nn
+
 
 @dataclass
-class Cache:
+class Cache(nn.Module):
     """
     Base, abstract class for all caches. The actual data structure is specific to each subclass.
     """
+
+    def __init__(self):
+        super().__init__(self)
 
     def update(
         self,
@@ -299,6 +304,7 @@ class DynamicCache(Cache):
     """
 
     def __init__(self) -> None:
+        super().__init__(self)
         self.key_cache: List[torch.Tensor] = []
         self.value_cache: List[torch.Tensor] = []
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen


### PR DESCRIPTION
# What does this PR do?
We can't copy the cache 😢 inheriting from module fixes this easily
This renders us unable to re-use prompts / system prompt like this:
```python 
import os, torch, copy
from transformers import AutoModelForCausalLM, AutoTokenizer, DynamicCache
device = "cuda"
ckpt = "path-to-ckpt"
INITIAL_PROMPT = "From now on, you are going to answer all my questions with historical details. Make sure to always add a bit of french here and there, for style."

model = AutoModelForCausalLM.from_pretrained(ckpt, torch_dtype=torch.float16)
model.to(device)

tokenizer = AutoTokenizer.from_pretrained(ckpt)

prompt_cache = DynamicCache()
inputs = tokenizer(INITIAL_PROMPT, return_tensors="pt").to("cuda")
prompt_cache = model(**inputs, past_key_values = prompt_cache).past_key_values


prompt = "Why are french people obsessed with french?"
new_inputs = tokenizer(INITIAL_PROMPT + prompt, return_tensors="pt").to("cuda")
past_key_values = copy.deepcopy(prompt_cache)
outputs = model.generate(**new_inputs, past_key_values=past_key_values,max_new_tokens=20) 
response = tokenizer.batch_decode(outputs)[0]
print(response)
"""
"""

prompt = "What is the best city to swim in?"
new_inputs = tokenizer(INITIAL_PROMPT + prompt, return_tensors="pt").to("cuda")
outputs = model.generate(**new_inputs, past_key_values=copy.deepcopy(prompt_cache),max_new_tokens=20) 
response = tokenizer.batch_decode(outputs)[0]
print(response)
"""


```