### PR TITLE
fix: Fixed an if condition that is always evaluating to true

### DIFF
--- a/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
+++ b/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py
@@ -43,7 +43,7 @@ def get_dpt_config(checkpoint_url):
         config.neck_hidden_sizes = [256, 512, 1024, 1024]
         expected_shape = (1, 384, 384)
 
-    if "nyu" or "midas" in checkpoint_url:
+    if "nyu" in checkpoint_url or "midas" in checkpoint_url:
         config.hidden_size = 768
         config.reassemble_factors = [1, 1, 1, 0.5]
         config.neck_hidden_sizes = [256, 512, 768, 768]


### PR DESCRIPTION
# What does this PR do?
This `if condition` will always evaluate to true.
https://github.com/huggingface/transformers/blob/9cf4f2aa9a9cecbb22e813931ef3bb72fc773540/src/transformers/models/dpt/convert_dpt_hybrid_to_pytorch.py#L46

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 