### PR TITLE
adds: extra_repr() to MambaRMSNorm to include hidden size / size of weights in the layer

### DIFF
--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -330,6 +330,7 @@ class MambaRMSNorm(nn.Module):
     def extra_repr(self):
         return f"{self.weight.shape[0]}, eps={self.variance_epsilon}"
 
+
 class MambaBlock(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -327,6 +327,8 @@ class MambaRMSNorm(nn.Module):
         hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
         return self.weight * hidden_states.to(input_dtype)
 
+    def extra_repr(self):
+        return f"{self.weight.shape[0]}, eps={self.variance_epsilon}"
 
 class MambaBlock(nn.Module):
     def __init__(self, config, layer_idx):


### PR DESCRIPTION
# What does this PR do?
Printing out a MAMBA model right now looks something like this:

```
> model = MambaForCausalLM.from_pretrained("state-spaces/mamba-130m-hf")
> print(model)
MambaForCausalLM(
  (backbone): MambaModel(
    (embeddings): Embedding(50280, 768)
    (layers): ModuleList(
      (0-23): 24 x MambaBlock(
        (norm): MambaRMSNorm()
        (mixer): MambaMixer(
          (conv1d): Conv1d(1536, 1536, kernel_size=(4,), stride=(1,), padding=(3,), groups=1536)
          (act): SiLU()
          (in_proj): Linear(in_features=768, out_features=3072, bias=False)
          (x_proj): Linear(in_features=1536, out_features=80, bias=False)
          (dt_proj): Linear(in_features=48, out_features=1536, bias=True)
          (out_proj): Linear(in_features=1536, out_features=768, bias=False)
        )
      )
    )
    (norm_f): MambaRMSNorm()
  )
  (lm_head): Linear(in_features=768, out_features=50280, bias=False)
)
```

All of the other layers (e.g. `Linear`, `Conv1d`, `Embedding`), when printed as a string show the size of the hidden states within the paranthesis. The `MambaRMSNorm`, when printed, does not include the `hidden_size` (or the `eps`) it was initialized with - this change would change the way this layer is printed from `MambaRMSNorm()` to `MambaRMSNorm(768, eps=1e-05)`. This format matches the convention that other normalization layers in PyTorch (e.g. `torch.nn.LayerNorm`) use when being printed. 

For example,

```python3
> from torch.nn import LayerNorm
> l = LayerNorm(10)
> print(l)
LayerNorm((10,), eps=1e-05, elementwise_affine=True)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker