### PR TITLE
[whisper] fix short-form output type

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -732,7 +732,7 @@ class WhisperGenerationMixin:
             else:
                 outputs = sequences
 
-            if generation_config.return_dict_in_generate:
+            if return_dict_in_generate:
                 dict_outputs = self._stack_split_outputs(seek_outputs, model_output_type, sequences.device, kwargs)
 
                 if num_return_sequences > 1:

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -498,7 +498,7 @@ class WhisperGenerationMixin:
 
         # 3. Make sure generation config is correctly set
         # Make sure the generation config is correctly set depending on whether timestamps are to be returned or not
-        self._set_return_outputs(
+        return_dict_in_generate = self._set_return_outputs(
             return_dict_in_generate=return_dict_in_generate,
             return_token_timestamps=return_token_timestamps,
             logprob_threshold=logprob_threshold,
@@ -732,7 +732,7 @@ class WhisperGenerationMixin:
             else:
                 outputs = sequences
 
-            if return_dict_in_generate:
+            if return_dict_in_generate and generation_config.return_dict_in_generate:
                 dict_outputs = self._stack_split_outputs(seek_outputs, model_output_type, sequences.device, kwargs)
 
                 if num_return_sequences > 1:
@@ -1112,15 +1112,15 @@ class WhisperGenerationMixin:
 
         generation_config.return_token_timestamps = return_token_timestamps
         if return_token_timestamps:
-            return_dict_in_generate = True
+            generation_config.return_dict_in_generate = True
             generation_config.output_attentions = True
             generation_config.output_scores = True
 
         if logprob_threshold is not None:
-            return_dict_in_generate = True
+            generation_config.return_dict_in_generate = True
             generation_config.output_scores = True
 
-        generation_config.return_dict_in_generate = return_dict_in_generate
+        return return_dict_in_generate
 
     def _set_return_timestamps(self, return_timestamps, is_shortform, generation_config):
         if not is_shortform:

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1109,6 +1109,8 @@ class WhisperGenerationMixin:
     def _set_return_outputs(return_dict_in_generate, return_token_timestamps, logprob_threshold, generation_config):
         if return_dict_in_generate is None:
             return_dict_in_generate = generation_config.return_dict_in_generate
+        else:
+            generation_config.return_dict_in_generate = return_dict_in_generate
 
         generation_config.return_token_timestamps = return_token_timestamps
         if return_token_timestamps:

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1835,7 +1835,9 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
             # create artificial long-form inputs
             inputs["input_features"] = torch.cat([inputs["input_features"], inputs["input_features"]], dim=-1)
-            inputs["attention_mask"] = torch.ones(inputs["input_features"].shape[:2], dtype=torch.int, device=inputs["input_features"].device)
+            inputs["attention_mask"] = torch.ones(
+                inputs["input_features"].shape[:2], dtype=torch.int, device=inputs["input_features"].device
+            )
             model.generation_config.no_timestamps_token_id = model.generation_config.decoder_start_token_id
 
             # long-form generation without fallback
@@ -1845,6 +1847,7 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
             # short-form generation with fallback
             pred_ids = model.generate(**inputs, logprob_threshold=-1.0, temperature=[0.0, 0.1])
             assert isinstance(pred_ids, torch.Tensor)
+
 
 @require_torch
 @require_torchaudio

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1834,9 +1834,15 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
             assert isinstance(pred_ids, torch.Tensor)
 
             # create artificial long-form inputs
-            inputs["input_features"] = torch.cat([inputs["input_features"], inputs["input_features"]], dim=-1)
+            inputs["input_features"] = torch.randn(
+                [self.model_tester.batch_size, config.num_mel_bins, 4 * config.max_source_positions],
+                dtype=inputs["input_features"].dtype,
+                device=inputs["input_features"].device,
+            )
             inputs["attention_mask"] = torch.ones(
-                inputs["input_features"].shape[:2], dtype=torch.int, device=inputs["input_features"].device
+                [self.model_tester.batch_size, 4 * config.max_source_positions],
+                dtype=torch.int,
+                device=inputs["input_features"].device,
             )
             model.generation_config.no_timestamps_token_id = model.generation_config.decoder_start_token_id
 
@@ -1844,7 +1850,7 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
             pred_ids = model.generate(**inputs)
             assert isinstance(pred_ids, torch.Tensor)
 
-            # short-form generation with fallback
+            # long-form generation with fallback
             pred_ids = model.generate(**inputs, logprob_threshold=-1.0, temperature=[0.0, 0.1])
             assert isinstance(pred_ids, torch.Tensor)
 


### PR DESCRIPTION
# What does this PR do?

Currently, the output type from Whisper short-form generate is inconsistent depending on whether or not we do temperature fallback:
```python
from datasets import load_dataset
from transformers import WhisperForConditionalGeneration, AutoProcessor

# load model + processor
processor = AutoProcessor.from_pretrained("openai/whisper-tiny.en")
model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny.en")

# load dataset
dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
sample = dataset[0]["audio"]

# pre-process inputs
inputs = processor(sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt")

# generation **without** fallback
pred_ids = model.generate(**inputs, max_new_tokens=8)
print(type(pred_ids))

# generation **with** temperature fallback
pred_ids = model.generate(**inputs, max_new_tokens=8, logprob_threshold=-1.0, temperature=[0.0, 0.1])
print(type(pred_ids))
```
**Print Output:**
```
<class 'torch.Tensor'>
<class 'transformers.generation.utils.GenerateEncoderDecoderOutput'>
```
=> we see that generating without fallback gives a torch tensor, whereas generating with fallback gives `GenerateEncoderDecoderOutput`.

This can be fixed by changing one line in the post-processing of the generation outputs, in order to respect the setting `return_dict_in_generate` passed by the user:
```
<class 'torch.Tensor'>
<class 'torch.Tensor'>
```