### PR TITLE
[WIP] - Enable speculative decoding with batch size >1

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -204,7 +204,10 @@ class AssistedCandidateGenerator(CandidateGenerator):
             )  # the assistant does not have the token after the last match, hence the -1
 
             if attention_mask is not None:
-                self.assistant_kwargs["attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
+                if self.assistant_model.config.is_encoder_decoder: 
+                    self.assistant_kwargs["decoder_attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
+                else: 
+                    self.assistant_kwargs["attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
             else:
                 self.assistant_kwargs = _prepare_attention_mask(
                     self.assistant_kwargs,

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -168,7 +168,9 @@ class AssistedCandidateGenerator(CandidateGenerator):
                     "Please pass in `min_length` into `.generate()` instead"
                 )
 
-    def get_candidates(self, input_ids: torch.LongTensor, n_matches = None, attention_mask=None) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, n_matches=None, attention_mask=None
+    ) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
         """
         Fetches the candidates to be tried for the current input.
 
@@ -189,25 +191,25 @@ class AssistedCandidateGenerator(CandidateGenerator):
         min_new_tokens = max(min(max_new_tokens, self.main_model_min_length - new_cur_len), 0)
         if max_new_tokens == 0:
             return input_ids, None
-    
 
         # 1. If it is not the first round of candidate generation, prepare the inputs based on the input_ids length
-        # (which implicitly contains the number of accepted candidates from the previous round) 
+        # (which implicitly contains the number of accepted candidates from the previous round)
         has_past_key_values = self.assistant_kwargs.get("past_key_values", None) is not None
 
         if has_past_key_values:
-            
             new_cache_size = new_cur_len - 1
 
             self.assistant_kwargs["past_key_values"] = _crop_past_key_values(
                 self.assistant_model, self.assistant_kwargs["past_key_values"], new_cache_size - 1, n_matches=n_matches
             )  # the assistant does not have the token after the last match, hence the -1
 
-            if attention_mask is not None: 
-                self.assistant_kwargs['attention_mask'] = attention_mask[:,:new_cur_len + self.num_assistant_tokens]
-            else:  
+            if attention_mask is not None:
+                self.assistant_kwargs["attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
+            else:
                 self.assistant_kwargs = _prepare_attention_mask(
-                    self.assistant_kwargs, new_cur_len, self.assistant_model.config.is_encoder_decoder,
+                    self.assistant_kwargs,
+                    new_cur_len,
+                    self.assistant_model.config.is_encoder_decoder,
                 )
             self.assistant_kwargs = _prepare_token_type_ids(self.assistant_kwargs, new_cur_len)
 
@@ -219,7 +221,6 @@ class AssistedCandidateGenerator(CandidateGenerator):
             "generation_config": self.generation_config,
             "logits_processor": self.logits_processor,
         }
-
 
         assistant_output = self.assistant_model.generate(**assistant_generation_kwargs, **self.assistant_kwargs)
 
@@ -255,22 +256,18 @@ class AssistedCandidateGenerator(CandidateGenerator):
                 self.num_assistant_tokens += 2.0
             else:
                 self.num_assistant_tokens = max(1, self.num_assistant_tokens - 1)
-                
-    def update_past_key_values(self, max_length = None, left_cut = None, n_matches = None): 
-        
-        has_past_key_values = self.assistant_kwargs.get("past_key_values", None) is not None
-        
-        if has_past_key_values: 
-            
-            self.assistant_kwargs["past_key_values"] = _crop_past_key_values(
-                self.assistant_model, 
-                self.assistant_kwargs["past_key_values"], 
-                max_length = max_length, 
-                left_cut=left_cut, 
-                n_matches=n_matches
-            )
-            
 
+    def update_past_key_values(self, max_length=None, left_cut=None, n_matches=None):
+        has_past_key_values = self.assistant_kwargs.get("past_key_values", None) is not None
+
+        if has_past_key_values:
+            self.assistant_kwargs["past_key_values"] = _crop_past_key_values(
+                self.assistant_model,
+                self.assistant_kwargs["past_key_values"],
+                max_length=max_length,
+                left_cut=left_cut,
+                n_matches=n_matches,
+            )
 
 
 class PromptLookupCandidateGenerator(CandidateGenerator):

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -168,7 +168,7 @@ class AssistedCandidateGenerator(CandidateGenerator):
                     "Please pass in `min_length` into `.generate()` instead"
                 )
 
-    def get_candidates(self, input_ids: torch.LongTensor, n_matches = None) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
+    def get_candidates(self, input_ids: torch.LongTensor, n_matches = None, attention_mask=None) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
         """
         Fetches the candidates to be tried for the current input.
 
@@ -202,12 +202,13 @@ class AssistedCandidateGenerator(CandidateGenerator):
             self.assistant_kwargs["past_key_values"] = _crop_past_key_values(
                 self.assistant_model, self.assistant_kwargs["past_key_values"], new_cache_size - 1, n_matches=n_matches
             )  # the assistant does not have the token after the last match, hence the -1
-                
-            # self.assistant_kwargs['position_ids'] = position_ids[:, new_cache_size : new_cur_len + self.num_assistant_tokens]
-            # self.assistant_kwargs['attention_mask'] = attention_mask[:,:new_cur_len + self.num_assistant_tokens]
-            self.assistant_kwargs = _prepare_attention_mask(
-                self.assistant_kwargs, new_cur_len, self.assistant_model.config.is_encoder_decoder
-            )
+
+            if attention_mask is not None: 
+                self.assistant_kwargs['attention_mask'] = attention_mask[:,:new_cur_len + self.num_assistant_tokens]
+            else:  
+                self.assistant_kwargs = _prepare_attention_mask(
+                    self.assistant_kwargs, new_cur_len, self.assistant_model.config.is_encoder_decoder,
+                )
             self.assistant_kwargs = _prepare_token_type_ids(self.assistant_kwargs, new_cur_len)
 
         # 2. Forecast next N tokens using the assistant model.
@@ -218,6 +219,7 @@ class AssistedCandidateGenerator(CandidateGenerator):
             "generation_config": self.generation_config,
             "logits_processor": self.logits_processor,
         }
+
 
         assistant_output = self.assistant_model.generate(**assistant_generation_kwargs, **self.assistant_kwargs)
 

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -169,7 +169,11 @@ class AssistedCandidateGenerator(CandidateGenerator):
                 )
 
     def get_candidates(
-        self, input_ids: torch.LongTensor, n_matches=None, attention_mask=None
+        self,
+        input_ids: torch.LongTensor,
+        n_matches=None,
+        attention_mask=None,
+        position_ids=None,
     ) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
         """
         Fetches the candidates to be tried for the current input.
@@ -204,10 +208,14 @@ class AssistedCandidateGenerator(CandidateGenerator):
             )  # the assistant does not have the token after the last match, hence the -1
 
             if attention_mask is not None:
-                if self.assistant_model.config.is_encoder_decoder: 
-                    self.assistant_kwargs["decoder_attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
-                else: 
-                    self.assistant_kwargs["attention_mask"] = attention_mask[:, : new_cur_len + self.num_assistant_tokens]
+                if self.assistant_model.config.is_encoder_decoder:
+                    self.assistant_kwargs["decoder_attention_mask"] = attention_mask[
+                        :, : new_cur_len + self.num_assistant_tokens
+                    ]
+                else:
+                    self.assistant_kwargs["attention_mask"] = attention_mask[
+                        :, : new_cur_len + self.num_assistant_tokens
+                    ]
             else:
                 self.assistant_kwargs = _prepare_attention_mask(
                     self.assistant_kwargs,

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -168,7 +168,7 @@ class AssistedCandidateGenerator(CandidateGenerator):
                     "Please pass in `min_length` into `.generate()` instead"
                 )
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
+    def get_candidates(self, input_ids: torch.LongTensor, position_ids, attention_mask) -> Tuple[torch.LongTensor, Optional[torch.FloatTensor]]:
         """
         Fetches the candidates to be tried for the current input.
 
@@ -198,7 +198,9 @@ class AssistedCandidateGenerator(CandidateGenerator):
             self.assistant_kwargs["past_key_values"] = _crop_past_key_values(
                 self.assistant_model, self.assistant_kwargs["past_key_values"], new_cache_size - 1
             )  # the assistant does not have the token after the last match, hence the -1
-
+                
+            self.assistant_kwargs['position_ids'] = position_ids[:, new_cache_size : new_cur_len + self.num_assistant_tokens]
+            self.assistant_kwargs['attention_mask'] = attention_mask[:,:new_cur_len + self.num_assistant_tokens]
             self.assistant_kwargs = _prepare_attention_mask(
                 self.assistant_kwargs, new_cur_len, self.assistant_model.config.is_encoder_decoder
             )

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -361,7 +361,7 @@ def _crop_past_key_values(model, past_key_values, max_length, n_matches=None, le
             else:
                 k_cache = past_key_values[idx][0][:, :, left_cut:, :]
                 v_cache = past_key_values[idx][1][:, :, left_cut:, :]
-            
+
             if n_matches is not None:
                 for batch_idx in range(len(n_matches)):
                     num_roll_left = n_matches.max() - n_matches[batch_idx]
@@ -371,7 +371,7 @@ def _crop_past_key_values(model, past_key_values, max_length, n_matches=None, le
                         # v_cache[batch_idx].index_copy_(1, torch.arange(num_roll_left, maximum_length, device=v_cache.device), v_cache[batch_idx][:, :-num_roll_left].clone())
                         k_cache[batch_idx][:, num_roll_left:] = k_cache[batch_idx][:, :-num_roll_left].clone()
                         v_cache[batch_idx][:, num_roll_left:] = v_cache[batch_idx][:, :-num_roll_left].clone()
-                
+
             new_past.append(
                 (
                     k_cache,

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -243,10 +243,10 @@ class AssistedCandidateGenerator(CandidateGenerator):
             "heuristic",
             "heuristic_transient",
         }:
-            if num_matches == int(self.num_assistant_tokens):
+            if num_matches.min() == int(self.num_assistant_tokens):
                 self.num_assistant_tokens += 2.0
             else:
-                self.num_assistant_tokens = max(1.0, self.num_assistant_tokens - 1.0)
+                self.num_assistant_tokens = max(1, self.num_assistant_tokens - 1)
 
 
 class PromptLookupCandidateGenerator(CandidateGenerator):
@@ -350,15 +350,32 @@ class PromptLookupCandidateGenerator(CandidateGenerator):
         return
 
 
-def _crop_past_key_values(model, past_key_values, max_length):
+def _crop_past_key_values(model, past_key_values, max_length, n_matches=None, left_cut=None):
     """Crops the past key values up to a certain maximum length."""
     new_past = []
     if model.config.is_encoder_decoder:
         for idx in range(len(past_key_values)):
+            if left_cut is None:
+                k_cache = past_key_values[idx][0][:, :, :max_length, :]
+                v_cache = past_key_values[idx][1][:, :, :max_length, :]
+            else:
+                k_cache = past_key_values[idx][0][:, :, left_cut:, :]
+                v_cache = past_key_values[idx][1][:, :, left_cut:, :]
+            
+            if n_matches is not None:
+                for batch_idx in range(len(n_matches)):
+                    num_roll_left = n_matches.max() - n_matches[batch_idx]
+                    if num_roll_left > 0:
+                        # TODO(PVP) - check mem usage
+                        # k_cache[batch_idx].index_copy_(1, torch.arange(num_roll_left, maximum_length, device=k_cache.device), k_cache[batch_idx][:, :-num_roll_left].clone())
+                        # v_cache[batch_idx].index_copy_(1, torch.arange(num_roll_left, maximum_length, device=v_cache.device), v_cache[batch_idx][:, :-num_roll_left].clone())
+                        k_cache[batch_idx][:, num_roll_left:] = k_cache[batch_idx][:, :-num_roll_left].clone()
+                        v_cache[batch_idx][:, num_roll_left:] = v_cache[batch_idx][:, :-num_roll_left].clone()
+                
             new_past.append(
                 (
-                    past_key_values[idx][0][:, :, :max_length, :],
-                    past_key_values[idx][1][:, :, :max_length, :],
+                    k_cache,
+                    v_cache,
                     past_key_values[idx][2],
                     past_key_values[idx][3],
                 )

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1674,7 +1674,7 @@ class GenerationMixin:
         self._validate_model_class()
         tokenizer = kwargs.pop("tokenizer", None)  # Pull this out first, we only use it for stopping criteria
         generation_config, model_kwargs = self._prepare_generation_config(generation_config, **kwargs)
-        
+
         # position_ids = model_kwargs.pop('position_ids')
         self._validate_model_kwargs(model_kwargs.copy())
         self._validate_assistant(assistant_model)
@@ -3993,7 +3993,9 @@ class GenerationMixin:
             cur_len = input_ids.shape[-1]
 
             #  1. Fetch candidate sequences from a `CandidateGenerator`
-            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids, n_matches, attention_mask)
+            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(
+                input_ids, n_matches, attention_mask
+            )
             candidate_input_ids = candidate_input_ids.to(self.device)
             if candidate_logits is not None:
                 candidate_logits = candidate_logits.to(self.device)
@@ -4108,7 +4110,7 @@ class GenerationMixin:
             # 4.2. Discard past key values relative to unused assistant tokens
             new_cache_size = new_cur_len - 1
             outputs.past_key_values = _crop_past_key_values(self, outputs.past_key_values, new_cache_size, n_matches)
-            
+
             # 5. Update the candidate generation strategy if needed
             candidate_generator.update_candidate_strategy(input_ids, new_logits, n_matches)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3994,7 +3994,7 @@ class GenerationMixin:
 
             #  1. Fetch candidate sequences from a `CandidateGenerator`
             candidate_input_ids, candidate_logits = candidate_generator.get_candidates(
-                input_ids, n_matches, attention_mask
+                input_ids, n_matches, attention_mask, position_ids
             )
             candidate_input_ids = candidate_input_ids.to(self.device)
             if candidate_logits is not None:
@@ -4023,18 +4023,16 @@ class GenerationMixin:
                 )
 
             if self.config.is_encoder_decoder:
-                candidate_kwargs["decoder_position_ids"] = (
-                    position_ids[:, : cur_len + candidate_length] if position_ids is not None else None
-                )
                 candidate_kwargs["decoder_attention_mask"] = (
                     attention_mask[:, : cur_len + candidate_length] if attention_mask is not None else None
                 )
             else:
-                candidate_kwargs["position_ids"] = position_ids[:, : cur_len + candidate_length]
                 candidate_kwargs["attention_mask"] = (
                     attention_mask[:, : cur_len + candidate_length] if attention_mask is not None else None
                 )
 
+            # Remark: we don't need to pass position_ids / decoder_position_ids, they will be inferred in
+            # prepare_inputs_for_generation with the attention masks.
             model_inputs = self.prepare_inputs_for_generation(candidate_input_ids, **candidate_kwargs)
             if "num_logits_to_keep" in model_inputs:
                 model_inputs["num_logits_to_keep"] = candidate_length + 1

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -4031,6 +4031,9 @@ class GenerationMixin:
                 )
             else:
                 candidate_kwargs["position_ids"] = position_ids[:, : cur_len + candidate_length]
+                candidate_kwargs["attention_mask"] = (
+                    attention_mask[:, : cur_len + candidate_length] if attention_mask is not None else None
+                )
 
             model_inputs = self.prepare_inputs_for_generation(candidate_input_ids, **candidate_kwargs)
             if "num_logits_to_keep" in model_inputs:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3993,7 +3993,7 @@ class GenerationMixin:
             cur_len = input_ids.shape[-1]
 
             #  1. Fetch candidate sequences from a `CandidateGenerator`
-            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids, n_matches)
+            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids, n_matches, attention_mask)
             candidate_input_ids = candidate_input_ids.to(self.device)
             if candidate_logits is not None:
                 candidate_logits = candidate_logits.to(self.device)
@@ -4109,8 +4109,6 @@ class GenerationMixin:
             new_cache_size = new_cur_len - 1
             outputs.past_key_values = _crop_past_key_values(self, outputs.past_key_values, new_cache_size, n_matches)
             
-            # candidate_generator.update_past_key_values(max_lenght = new_cache_size, n_matches = n_matches)
-
             # 5. Update the candidate generation strategy if needed
             candidate_generator.update_candidate_strategy(input_ids, new_logits, n_matches)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1882,8 +1882,6 @@ class GenerationMixin:
                     "num_return_sequences has to be 1 when doing assisted generate, "
                     f"but is {generation_config.num_return_sequences}."
                 )
-            if batch_size > 1:
-                raise ValueError("assisted generate is only supported for batch_size = 1")
             if not model_kwargs["use_cache"]:
                 raise ValueError("assisted generate requires `use_cache=True`")
             if generation_config.cache_implementation == "static":
@@ -3949,7 +3947,40 @@ class GenerationMixin:
                 start_from_empty_dynamic_cache = True
 
         this_peer_finished = False
+        
+        max_len = stopping_criteria[0].max_length
+        position_ids = torch.arange(2 * max_len, device=input_ids.device, dtype=torch.long)[None, :].broadcast_to(batch_size, 2 * max_len) if batch_size > 1 else None
+        attention_mask = torch.ones_like(position_ids) if position_ids is not None else  None        
+        n_matches = None 
+        eos_tokens_mask = None
+
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
+            
+            # Rotate everything for bsz > 1
+            if n_matches is not None and position_ids is not None:
+                shift = unfinished_sequences * (n_matches.max() - n_matches) + (1 - unfinished_sequences) * (eos_tokens_mask.sum(-1) - 1)
+            
+                for i in range(batch_size):
+                    if shift[i] > 0:
+                        input_ids[i][shift[i]:] = input_ids[i][:-shift[i]].clone()
+                        input_ids[i][:shift[i]] = self.config.pad_token_id
+                
+                position_ids = position_ids.add(-shift[:, None]).clamp(min=0)
+                attention_mask[:, :-1] = position_ids[:, 1:] > 0
+                
+                left_cut = (1 - attention_mask).sum(-1).min()
+                
+                if left_cut > 0:
+                    position_ids = position_ids[:, left_cut:]
+                    attention_mask = attention_mask[:, left_cut:]
+                    input_ids = input_ids[:, left_cut:]
+
+                    model_kwargs["past_key_values"] = _crop_past_key_values(self, model_kwargs["past_key_values"], left_cut=left_cut)
+                    model_kwargs["assistant_past_key_values"] = _crop_past_key_values(
+                        candidate_generator.assistant_model, model_kwargs["assistant_past_key_values"], left_cut=left_cut
+                    )  # the assistant does not have the token after the last match, hence the -1
+
+            
             cur_len = input_ids.shape[-1]
 
             #  1. Fetch candidate sequences from a `CandidateGenerator`
@@ -3979,6 +4010,12 @@ class GenerationMixin:
                     ),
                     dim=0,
                 )
+                
+            if self.config.is_encoder_decoder:
+                candidate_kwargs["decoder_position_ids"] = position_ids[:, :cur_len + candidate_length] if position_ids is not None else None
+                candidate_kwargs["decoder_attention_mask"] = attention_mask[:, :cur_len + candidate_length] if attention_mask is not None else None
+            else:
+                candidate_kwargs["position_ids"] = position_ids[:, :cur_len + candidate_length]
 
             model_inputs = self.prepare_inputs_for_generation(candidate_input_ids, **candidate_kwargs)
             if "num_logits_to_keep" in model_inputs:
@@ -4024,17 +4061,27 @@ class GenerationMixin:
                     selected_tokens = new_logits.argmax(dim=-1)
 
                 candidate_new_tokens = candidate_input_ids[:, cur_len:]
-                n_matches = ((~(candidate_new_tokens == selected_tokens[:, :-1])).cumsum(dim=-1) < 1).sum()
+                n_matches = ((~(candidate_new_tokens == selected_tokens[:, :-1])).cumsum(dim=-1) < 1).sum(-1)
 
-                # Ensure we don't generate beyond max_len or an EOS token
-                if is_done_candidate and n_matches == candidate_length:
-                    n_matches -= 1
-                valid_tokens = selected_tokens[:, : n_matches + 1]
+                n_matches -= is_done_candidate.int() * (n_matches == candidate_length).int()
+                # make sure than already finished sequences always match until longest "still active" sequence
+                n_matches = torch.clamp(n_matches, max=max_len - cur_len - 1)
+                # make sure that finished sentences cannot slow down valid tokens
+                n_matches = unfinished_sequences * n_matches + (1 - unfinished_sequences) * (unfinished_sequences * n_matches).max()
+                       
+                valid_tokens = selected_tokens[:, : n_matches.max() + 1]
 
             # 4. Update variables according to the number of matching assistant tokens. Remember: the token generated
             # by the model after the last candidate match is also valid, as it is generated from a correct sequence.
             # Because of this last token, assisted generation search reduces to a normal greedy search/sample if there
             # is no match.
+            
+            # if eos_token was found in one sentence, set sentence to finished
+            eos_token_id_tensor = stopping_criteria[1].eos_token_id
+            eos_tokens = valid_tokens.eq(stopping_criteria[1].eos_token_id)
+            finished_seq_mask = ~(unfinished_sequences.bool()[:, None].broadcast_to(valid_tokens.shape))
+            eos_tokens_mask = torch.logical_or(eos_tokens.cumsum(-1).bool(), finished_seq_mask)
+            valid_tokens = torch.where(eos_tokens_mask, eos_token_id_tensor, valid_tokens)
 
             # 4.1. Get the valid continuation, after the matching tokens
             input_ids = torch.cat((input_ids, valid_tokens), dim=-1)
@@ -4044,7 +4091,7 @@ class GenerationMixin:
 
             # 4.2. Discard past key values relative to unused assistant tokens
             new_cache_size = new_cur_len - 1
-            outputs.past_key_values = _crop_past_key_values(self, outputs.past_key_values, new_cache_size)
+            outputs.past_key_values = _crop_past_key_values(self, outputs.past_key_values, new_cache_size, n_matches)
 
             # 5. Update the candidate generation strategy if needed
             candidate_generator.update_candidate_strategy(input_ids, new_logits, n_matches)
@@ -4056,7 +4103,7 @@ class GenerationMixin:
             # Assistant: modified to append one tuple element per token, as in the other generation methods.
             if return_dict_in_generate:
                 if output_scores:
-                    scores += tuple(new_logits[:, i, :] for i in range(n_matches + 1))
+                    scores += tuple(new_logits[:, i, :] for i in range(n_matches.max() + 1))
                 if output_logits:
                     raw_logits += (next_token_logits,)
 
@@ -4101,7 +4148,7 @@ class GenerationMixin:
                 outputs,
                 model_kwargs,
                 is_encoder_decoder=self.config.is_encoder_decoder,
-                num_new_tokens=n_matches + 1,
+                num_new_tokens=n_matches.max() + 1,
             )
 
             unfinished_sequences = unfinished_sequences & ~stopping_criteria(input_ids, scores)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1674,6 +1674,8 @@ class GenerationMixin:
         self._validate_model_class()
         tokenizer = kwargs.pop("tokenizer", None)  # Pull this out first, we only use it for stopping criteria
         generation_config, model_kwargs = self._prepare_generation_config(generation_config, **kwargs)
+        
+        position_ids = model_kwargs.pop('position_ids')
         self._validate_model_kwargs(model_kwargs.copy())
         self._validate_assistant(assistant_model)
 
@@ -3994,7 +3996,7 @@ class GenerationMixin:
             cur_len = input_ids.shape[-1]
 
             #  1. Fetch candidate sequences from a `CandidateGenerator`
-            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids)
+            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids, position_ids, attention_mask)
             candidate_input_ids = candidate_input_ids.to(self.device)
             if candidate_logits is not None:
                 candidate_logits = candidate_logits.to(self.device)
@@ -4129,7 +4131,7 @@ class GenerationMixin:
                     # set it to false for other iterations
                     start_from_empty_dynamic_cache = False
                 else:
-                    added_len = n_matches + 1
+                    added_len = n_matches.max() + 1
 
                 if output_attentions:
                     if self.config.is_encoder_decoder:

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1766,12 +1766,11 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         use_cache=None,
         encoder_outputs=None,
         attention_mask=None,
-        decoder_position_ids=None, 
+        decoder_position_ids=None,
         decoder_attention_mask=None,
         cache_position=None,
         **kwargs,
     ):
-
         decoder_position_ids = None
 
         if decoder_attention_mask is not None:

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1888,6 +1888,7 @@ class WhisperForCausalLM(WhisperPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        position_ids = None, 
     ) -> Union[Tuple, CausalLMOutputWithCrossAttentions]:
         r"""
         Args:
@@ -1997,6 +1998,7 @@ class WhisperForCausalLM(WhisperPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             cache_position=cache_position,
+            position_ids = position_ids
         )
 
         logits = self.proj_out(outputs[0])
@@ -2030,6 +2032,12 @@ class WhisperForCausalLM(WhisperPreTrainedModel):
         cache_position=None,
         **kwargs,
     ):
+        
+        position_ids = None 
+        
+        if attention_mask is not None: 
+            position_ids = (attention_mask.cumsum(-1) - 1).clamp(min=0)
+        
         past_length = 0
         if past_key_values is not None:
             if isinstance(past_key_values, (Cache, EncoderDecoderCache)):
@@ -2057,6 +2065,7 @@ class WhisperForCausalLM(WhisperPreTrainedModel):
             "input_ids": input_ids,
             "use_cache": use_cache,
             "attention_mask": attention_mask,
+            "position_ids": position_ids, 
             "cache_position": cache_position,
         }
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1772,6 +1772,8 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         **kwargs,
     ):
 
+        decoder_position_ids = None
+
         if decoder_attention_mask is not None:
             decoder_position_ids = (decoder_attention_mask.cumsum(-1) - 1).clamp(min=0)
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1766,11 +1766,12 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         use_cache=None,
         encoder_outputs=None,
         attention_mask=None,
+        decoder_position_ids=None, 
         decoder_attention_mask=None,
         cache_position=None,
         **kwargs,
     ):
-        decoder_position_ids = None
+
         if decoder_attention_mask is not None:
             decoder_position_ids = (decoder_attention_mask.cumsum(-1) - 1).clamp(min=0)
 


### PR DESCRIPTION
# What does this PR do?

This PR aims at solving issue #32165. 

I've started adapting code to enable speculative decoding with batch_size >1. I've reused some of the work in former PR #26875. 

# Main steps of the solution:  

When batch size > 1: 

1. Compute the number of similar tokens between candidate tokens and tokens obtained after doing a forward pass with the main model. This results in a tensor `n_matches` with the number of matches for each sequence in the batch. 

2. We keep the matching tokens. For that, we keep all tokens from the output to the main model with a sequence position inferior to `n_matches.max() + 1`. In doing so, we also retain some potential mismatched tokens, which we will deal with in the next steps using padding tokens. The resulting tensor, `input_ids`,  is thus in the form (`batch_size`, `n_matches` + 1).

3. We shift each sequence `i` in `input_ids` by `n_matches.max() - n_matches[i]`. The matching tokens are displaced to the right of `input_ids` and `n_matches.max() - n_matches[i]` padding tokens are added to the left.

5. Left cut: We cut all columns that contain only padding tokens. By design, these columns are to the left of the `input_ids`. In this way we keep the smallest possible `input_ids' that contain all the information needed to continue assisted generation. 

Steps 1 to 4 are the main addition to the the original speculative decoding loop described in detail in [this blog](https://huggingface.co/blog/assisted-generation) to enable assisted generation with BS > 1.

To make this work, we also need to adapt the computation of  the `attention_masks`, `past_key_values` and `position_ids` to take into account the shifted positions of the generated tokens. 

# To do: 

For now, I want to make this work with Whisper using this [snippet](https://github.com/huggingface/transformers/issues/32165). 

I've implemented steps 1 to 4 and adapted the computation of the `attention_masks` and `past_key_values` to handle the new padding tokens. 

I still need to make some adaptations with the `position_ids` to make this work properly. From what I can see: 

- For the main model (here `WhisperForConditionalGeneration`), `position_ids` are inferred directly from the attention_mask as we can see [here](https://github.com/huggingface/transformers/blob/7f5d644e69068825bb5b6e84cdc56b3d3a9bd04f/src/transformers/models/whisper/modeling_whisper.py#L1774). So if we pass the right attention mask to `generate` we should be good. 

- For the assistant model (`WhisperForCausalLM` in our example), `position_ids` are currently not computed nor passed to [prepare_inputs_for_generation](https://github.com/huggingface/transformers/blob/7f5d644e69068825bb5b6e84cdc56b3d3a9bd04f/src/transformers/models/whisper/modeling_whisper.py#L2052), which I'm not sure exactly why. I've done a first attempt at solving this with no success so far. 


cc @sanchit-gandhi @gante 