### PR TITLE
fix: Replaced deprecated `unittest method` with the correct one

### DIFF
--- a/tests/models/llava/test_processor_llava.py
+++ b/tests/models/llava/test_processor_llava.py
@@ -44,4 +44,4 @@ class LlavaProcessorTest(unittest.TestCase):
         ]
 
         formatted_prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
-        self.assertEquals(expected_prompt, formatted_prompt)
+        self.assertEqual(expected_prompt, formatted_prompt)

--- a/tests/models/llava_next/test_processor_llava_next.py
+++ b/tests/models/llava_next/test_processor_llava_next.py
@@ -38,4 +38,4 @@ class LlavaProcessorTest(unittest.TestCase):
         ]
 
         formatted_prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
-        self.assertEquals(expected_prompt, formatted_prompt)
+        self.assertEqual(expected_prompt, formatted_prompt)

--- a/tests/models/vipllava/test_processor_vipllava.py
+++ b/tests/models/vipllava/test_processor_vipllava.py
@@ -38,4 +38,4 @@ class LlavaProcessorTest(unittest.TestCase):
         ]
 
         formatted_prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
-        self.assertEquals(expected_prompt, formatted_prompt)
+        self.assertEqual(expected_prompt, formatted_prompt)


### PR DESCRIPTION
# What does this PR do?
Small fix, `assertEquals(a, b)` is deprecated and replaced with `assertEqual(a, b)`
Reference: https://docs.python.org/3/library/2to3.html#to3fixer-asserts

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@amyeroberts 