### PR TITLE
[BigBird Pegasus] set _supports_param_buffer_assignment to False

### DIFF
--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -1569,6 +1569,7 @@ class BigBirdPegasusPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["BigBirdPegasusEncoderLayer", "BigBirdPegasusDecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
+    _supports_param_buffer_assignment = False
 
     def _init_weights(self, module):
         std = self.config.init_std


### PR DESCRIPTION
# What does this PR do?

sets the `_supports_param_buffer_assignment` to `False` to fix the model loading error.

similar to https://github.com/huggingface/transformers/pull/32149