### PR TITLE
[Idefics2] - Fix FA2 call for Perceiver layer

### DIFF
--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -894,7 +894,7 @@ class Idefics2PerceiverFlashAttention2(Idefics2PerceiverAttention):
             attention_mask,
             q_len,
             dropout=dropout_rate,
-            sliding_window=False,
+            sliding_window=None,
             is_causal=self.is_causal,
             use_top_left_mask=self._flash_attn_uses_top_left_mask,
         )

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -498,6 +498,7 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
         torch.cuda.empty_cache()
 
     @slow
+    @unittest.skip("Test hits OOM on CI - https://github.com/huggingface/transformers/issues/32288")
     def test_integration_test(self):
         model = Idefics2ForConditionalGeneration.from_pretrained(
             "HuggingFaceM4/idefics2-8b-base",

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -560,6 +560,8 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
         generated_ids_flash_attention_2 = model_flash_attention_2.generate(**inputs, max_new_tokens=10)
-        generated_texts_flash_attention_2 = self.processor.batch_decode(generated_ids_flash_attention_2, skip_special_tokens=True)
+        generated_texts_flash_attention_2 = self.processor.batch_decode(
+            generated_ids_flash_attention_2, skip_special_tokens=True
+        )
 
         self.assertEqual(generated_texts_eager[0], generated_texts_flash_attention_2[0])

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -29,7 +29,7 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
-from transformers.testing_utils import require_bitsandbytes, require_torch, slow, torch_device
+from transformers.testing_utils import require_bitsandbytes, require_torch, slow, torch_device, require_torch_gpu, require_flash_attn
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -497,7 +497,6 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
             torch_dtype=torch.bfloat16,
             device_map="auto",
         )
-        model.to(torch_device)
 
         # Create inputs
         text = "<image>In this image, we see"
@@ -517,7 +516,7 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
     def test_integration_test_4bit(self):
         # Let' s make sure we test the preprocessing to replace what is used
         model = Idefics2ForConditionalGeneration.from_pretrained(
-            "HuggingFaceM4/idefics2-8b-base", load_in_4bit=True, device_map="auto"
+            "HuggingFaceM4/idefics2-8b-base", load_in_4bit=True,
         )
 
         # Create pixel inputs
@@ -531,7 +530,8 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
         expected_generated_text = "In this image, we see the Statue of Liberty, the Hudson River,"
         self.assertEqual(generated_texts[0], expected_generated_text)
 
-    @slow
+    @require_flash_attn
+    @require_torch_gpu
     @require_bitsandbytes
     def test_flash_attn_2_eager_equivalence(self):
         # Create inputs

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -29,7 +29,14 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
-from transformers.testing_utils import require_bitsandbytes, require_torch, slow, torch_device, require_torch_gpu, require_flash_attn
+from transformers.testing_utils import (
+    require_bitsandbytes,
+    require_flash_attn,
+    require_torch,
+    require_torch_gpu,
+    slow,
+    torch_device,
+)
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -516,7 +523,8 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
     def test_integration_test_4bit(self):
         # Let' s make sure we test the preprocessing to replace what is used
         model = Idefics2ForConditionalGeneration.from_pretrained(
-            "HuggingFaceM4/idefics2-8b-base", load_in_4bit=True,
+            "HuggingFaceM4/idefics2-8b-base",
+            load_in_4bit=True,
         )
 
         # Create pixel inputs

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -555,7 +555,6 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
             attn_implementation="eager",
             load_in_4bit=True,
         )
-
         generated_ids_eager = model_eager.generate(**inputs, max_new_tokens=10)
         generated_texts_eager = self.processor.batch_decode(generated_ids_eager, skip_special_tokens=True)
 
@@ -567,7 +566,6 @@ class Idefics2ForConditionalGenerationIntegrationTest(unittest.TestCase):
             attn_implementation="flash_attention_2",
             load_in_4bit=True,
         )
-
         generated_ids_flash_attention_2 = model_flash_attention_2.generate(**inputs, max_new_tokens=10)
         generated_texts_flash_attention_2 = self.processor.batch_decode(
             generated_ids_flash_attention_2, skip_special_tokens=True


### PR DESCRIPTION
# What does this PR do?

The generation for IDEFICS2 was broken by https://github.com/huggingface/transformers/pull/31446

The previous logic controlled the sliding window using a boolean flag, whereas the refactored `flash_attn_forward` assumes `None` is for no `sliding_window`, and passing in `False` will propagate `flash_kwargs` of `{"window_size": (False, False)}` 

Adds a test so this will be caught in future

Fixes #32271