### PR TITLE
Cast epochs_trained to int when resuming training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2205,6 +2205,10 @@ class Trainer:
             self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
 
         total_batched_samples = 0
+        if type(epochs_trained) != int:
+            epochs_trained = int(epochs_trained)
+        if type(num_train_epochs) != int:
+            num_train_epochs = int(num_train_epochs)
         for epoch in range(epochs_trained, num_train_epochs):
             epoch_iterator = train_dataloader
             if hasattr(epoch_iterator, "set_epoch"):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2155,7 +2155,7 @@ class Trainer:
             self.state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
             self.compare_trainer_and_checkpoint_args(self.args, self.state)
             self._load_callback_state()
-            epochs_trained = self.state.global_step // num_update_steps_per_epoch
+            epochs_trained = int(self.state.global_step // num_update_steps_per_epoch)
             if not args.ignore_data_skip:
                 steps_trained_in_current_epoch = self.state.global_step % (num_update_steps_per_epoch)
                 steps_trained_in_current_epoch *= args.gradient_accumulation_steps
@@ -2205,10 +2205,6 @@ class Trainer:
             self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
 
         total_batched_samples = 0
-        if type(epochs_trained) != int:
-            epochs_trained = int(epochs_trained)
-        if type(num_train_epochs) != int:
-            num_train_epochs = int(num_train_epochs)
         for epoch in range(epochs_trained, num_train_epochs):
             epoch_iterator = train_dataloader
             if hasattr(epoch_iterator, "set_epoch"):


### PR DESCRIPTION
# What does this PR do?

Ensures that `epochs_trained` is an integer when resuming training, so that the loop `for epoch in range(epochs_trained, num_train_epochs):` in `_inner_training_loop` can proceed correctly.

Fixes #27630
