### PR TITLE
pin gguf 

### DIFF
--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -49,7 +49,7 @@ RUN python3 -m pip install --no-cache-dir aqlm[gpu]==1.0.2
 RUN python3 -m pip install --no-cache-dir hqq
 
 # For GGUF tests
-RUN python3 -m pip install --no-cache-dir gguf
+RUN python3 -m pip install --no-cache-dir gguf<0.9.1
 
 # Add autoawq for quantization testing
 # >=v0.2.3 needed for compatibility with torch 2.2.1


### PR DESCRIPTION
# What does this PR do ? 
This PR pins the gguf packages since it is incompatible with transformers integration of gguf file for now. I will unpin it when it's fixed ! 

cc @Titus-von-Koeller 