### PR TITLE
Yell at the user if zero-3 init wasn't performed, but expected to have been done

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3802,10 +3802,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model = cls(config, *model_args, **model_kwargs)
 
         # If we init with `zero3`, add an attr to the model so we can check downstream for issues
-        if is_deepspeed_zero3_enabled() and not is_quantized:
-            model.transformers_zero3_init_used = True
-        else:
-            model.transformers_zero3_init_used = False
+        model.transformers_zero3_init_used = is_deepspeed_zero3_enabled() and not is_quantized
 
         # make sure we use the model's config since the __init__ call might have copied it
         config = model.config

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3797,6 +3797,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # Let's make sure we don't run the init function of buffer modules
             model = cls(config, *model_args, **model_kwargs)
 
+        # If we init with `zero3`, add an attr to the model so we can check downstream for issues
+        if is_deepspeed_zero3_enabled():
+            model.transformers_zero3_init_used = True
+
         # make sure we use the model's config since the __init__ call might have copied it
         config = model.config
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1470,7 +1470,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model = cls(config, **kwargs)
 
         # Flag for if we init with `zero3`, add an attr to the model so we can check downstream for issues
-        model.transformers_zero3_init_used = is_deepspeed_zero3_enabled()
+        model._transformers_zero3_init_used = is_deepspeed_zero3_enabled()
 
         # restore default dtype if it was modified
         if dtype_orig is not None:
@@ -3802,7 +3802,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             model = cls(config, *model_args, **model_kwargs)
 
         # If we init with `zero3`, add an attr to the model so we can check downstream for issues
-        model.transformers_zero3_init_used = is_deepspeed_zero3_enabled() and not is_quantized
+        model._transformers_zero3_init_used = is_deepspeed_zero3_enabled() and not is_quantized
 
         # make sure we use the model's config since the __init__ call might have copied it
         config = model.config

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -436,15 +436,14 @@ class Trainer:
                 )
             self.model_init = model_init
 
-        if is_deepspeed_zero3_enabled():
-            # Will reach this branch if the user has
-            # 1. Used `.from_pretrained` or `.from_config` to initialize their model
-            # 2. Did not configure Zero-3 via `TrainingArguments` or `accelerate launch` beforehand
-            # New models init such as `MyModel()` will not hit this step
-            if hasattr(model, "transformers_zero3_init_used") and not model.transformers_zero3_init_used:
-                raise ValueError(
-                    "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `***Model.from_pretrained(...)` or `***Model.from_config(...)` after creating your `TrainingArguments`!"
-                )
+        # Will reach this branch if the user has
+        # 1. Used `.from_pretrained` or `.from_config` to initialize their model
+        # 2. Did not configure Zero-3 via `TrainingArguments` or `accelerate launch` beforehand
+        # New models init such as `MyModel()` will not hit this step
+        if is_deepspeed_zero3_enabled() and not getattr(model, "transformers_zero3_init_used", True):
+            raise ValueError(
+                "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `***Model.from_pretrained(...)` or `***Model.from_config(...)` after creating your `TrainingArguments`!"
+            )
 
         if model.__class__.__name__ in MODEL_MAPPING_NAMES:
             raise ValueError(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -442,7 +442,7 @@ class Trainer:
         # New models init such as `MyModel()` will not hit this step
         if is_deepspeed_zero3_enabled() and not getattr(model, "transformers_zero3_init_used", True):
             raise ValueError(
-                "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `***Model.from_pretrained(...)` or `***Model.from_config(...)` after creating your `TrainingArguments`!"
+                "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `Model.from_pretrained(...)` or `Model.from_config(...)` after creating your `TrainingArguments`!"
             )
 
         if model.__class__.__name__ in MODEL_MAPPING_NAMES:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -440,7 +440,7 @@ class Trainer:
         # 1. Used `.from_pretrained` or `.from_config` to initialize their model
         # 2. Did not configure Zero-3 via `TrainingArguments` or `accelerate launch` beforehand
         # New models init such as `MyModel()` will not hit this step
-        if is_deepspeed_zero3_enabled() and not getattr(model, "transformers_zero3_init_used", True):
+        if is_deepspeed_zero3_enabled() and not getattr(model, "_transformers_zero3_init_used", True):
             raise ValueError(
                 "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `Model.from_pretrained(...)` or `Model.from_config(...)` after creating your `TrainingArguments`!"
             )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4678,6 +4678,10 @@ class Trainer:
         if self.is_deepspeed_enabled and getattr(self.args, "hf_deepspeed_config", None) is None:
             self.propagate_args_to_deepspeed()
 
+        if self.is_deepspeed_enabled and is_deepspeed_zero3_enabled():
+            if not getattr(self.model, "transformers_zero3_init_used", False):
+                raise ValueError("Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via AutoModel.from_pretrained(...) after creating your `TrainingArguments`!")
+
         # `save_only_model` can't be used with DeepSpeed/FSDP along with `load_best_model_at_end`
         if (
             self.args.save_only_model

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -442,7 +442,7 @@ class Trainer:
         # New models init such as `MyModel()` will not hit this step
         if is_deepspeed_zero3_enabled() and not getattr(model, "_transformers_zero3_init_used", True):
             raise ValueError(
-                "Model was not initialized with `Zero-3` despite being configured. Please re-initialize your model via `Model.from_pretrained(...)` or `Model.from_config(...)` after creating your `TrainingArguments`!"
+                "Model was not initialized with `Zero-3` despite being configured for DeepSpeed Zero-3. Please re-initialize your model via `Model.from_pretrained(...)` or `Model.from_config(...)` after creating your `TrainingArguments`!"
             )
 
         if model.__class__.__name__ in MODEL_MAPPING_NAMES:

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -725,7 +725,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
                     model=model,
                     args=training_args,
                 )
-            # Now do it proper, triggered from our `TrainingArguments` earlier
+            # Now do it properly, triggered from our `TrainingArguments` earlier
             model = AutoModel.from_pretrained(T5_TINY)
             trainer = Trainer(
                 model=model,

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -732,7 +732,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
                 args=training_args,
             )
             assert trainer.is_deepspeed_enabled
-            assert model.transformers_zero3_init_used
+            assert model._transformers_zero3_init_used
 
     def check_saved_checkpoints_deepspeed(self, output_dir, freq, total, stage, dtype):
         # adapted from TrainerIntegrationCommon.check_saved_checkpoints

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -434,6 +434,12 @@ if is_torch_available():
         train_dataset = RegressionDataset(length=train_len, label_names=label_names)
         eval_dataset = RegressionDataset(length=eval_len, label_names=label_names)
 
+        compute_metrics = kwargs.pop("compute_metrics", None)
+        data_collator = kwargs.pop("data_collator", None)
+        optimizers = kwargs.pop("optimizers", (None, None))
+        output_dir = kwargs.pop("output_dir", "./regression")
+        preprocess_logits_for_metrics = kwargs.pop("preprocess_logits_for_metrics", None)
+
         model_init = kwargs.pop("model_init", None)
         if model_init is not None:
             model = None
@@ -449,12 +455,6 @@ if is_torch_available():
                 model = target_cls(config)
             else:
                 model = RegressionModel(a=a, b=b, double_output=double_output)
-
-        compute_metrics = kwargs.pop("compute_metrics", None)
-        data_collator = kwargs.pop("data_collator", None)
-        optimizers = kwargs.pop("optimizers", (None, None))
-        output_dir = kwargs.pop("output_dir", "./regression")
-        preprocess_logits_for_metrics = kwargs.pop("preprocess_logits_for_metrics", None)
 
         args = RegressionTrainingArguments(output_dir, a=a, b=b, keep_report_to=keep_report_to, **kwargs)
         return Trainer(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -434,12 +434,6 @@ if is_torch_available():
         train_dataset = RegressionDataset(length=train_len, label_names=label_names)
         eval_dataset = RegressionDataset(length=eval_len, label_names=label_names)
 
-        compute_metrics = kwargs.pop("compute_metrics", None)
-        data_collator = kwargs.pop("data_collator", None)
-        optimizers = kwargs.pop("optimizers", (None, None))
-        output_dir = kwargs.pop("output_dir", "./regression")
-        preprocess_logits_for_metrics = kwargs.pop("preprocess_logits_for_metrics", None)
-
         model_init = kwargs.pop("model_init", None)
         if model_init is not None:
             model = None
@@ -455,6 +449,12 @@ if is_torch_available():
                 model = target_cls(config)
             else:
                 model = RegressionModel(a=a, b=b, double_output=double_output)
+
+        compute_metrics = kwargs.pop("compute_metrics", None)
+        data_collator = kwargs.pop("data_collator", None)
+        optimizers = kwargs.pop("optimizers", (None, None))
+        output_dir = kwargs.pop("output_dir", "./regression")
+        preprocess_logits_for_metrics = kwargs.pop("preprocess_logits_for_metrics", None)
 
         args = RegressionTrainingArguments(output_dir, a=a, b=b, keep_report_to=keep_report_to, **kwargs)
         return Trainer(


### PR DESCRIPTION
# What does this PR do?

This PR adds a guard if the user has selected Zero-3 but the init was *not* called. This can easily happen when a user does not instantiate their `TrainingArguments()` before calling the model init. Will now raise a very helpful error message telling them to instantiate their `TrainingArguments` prior to init if we've found this has happened

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @philschmid @LysandreJik 