### PR TITLE
Repo checks: skip docstring checks if not in the diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
             - run: python utils/custom_init_isort.py --check_only
             - run: python utils/sort_auto_mappings.py --check_only
             - run: python utils/check_doc_toc.py
+            - run: python utils/check_docstrings.py --check_all
 
     check_repository_consistency:
         working_directory: ~/transformers

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ quality:
 	python utils/custom_init_isort.py --check_only
 	python utils/sort_auto_mappings.py --check_only
 	python utils/check_doc_toc.py
+	python utils/check_docstrings.py --check_all
 
 
 # Format source code automatically and check is there are any problems left that need manual fixing

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -112,6 +112,7 @@ class CacheConfig:
         Args:
             config_dict (Dict[str, Any]): Dictionary containing configuration parameters.
             **kwargs: Additional keyword arguments to override dictionary values.
+
         Returns:
             CacheConfig: Instance of CacheConfig constructed from the dictionary.
         """

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -964,7 +964,7 @@ def check_docstrings(overwrite: bool = False, check_all: bool = False):
             if modified_file_diff.a_path.startswith("src/transformers"):
                 module_diff_files.add(modified_file_diff.a_path)
         # Diff from index to `main`
-        for modified_file_diff in repo.index.diff("origin/main"):
+        for modified_file_diff in repo.index.diff(repo.refs.main.commit):
             if modified_file_diff.a_path.startswith("src/transformers"):
                 module_diff_files.add(modified_file_diff.a_path)
         # quick escape route: if there are no module files in the diff, skip this check

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -957,11 +957,16 @@ def check_docstrings(overwrite: bool = False, check_all: bool = False):
     """
     module_diff_files = None
     if not check_all:
-        module_diff_files = []
+        module_diff_files = set()
         repo = Repo(PATH_TO_REPO)
+        # Diff from index to unstaged files
         for modified_file_diff in repo.index.diff(None):
             if modified_file_diff.a_path.startswith("src/transformers"):
-                module_diff_files += [modified_file_diff.a_path]
+                module_diff_files.add(modified_file_diff.a_path)
+        # Diff from index to `main`
+        for modified_file_diff in repo.index.diff("origin/main"):
+            if modified_file_diff.a_path.startswith("src/transformers"):
+                module_diff_files.add(modified_file_diff.a_path)
         # quick escape route: if there are no module files in the diff, skip this check
         if len(module_diff_files) == 0:
             return


### PR DESCRIPTION
# What does this PR do?

See title. A flag was added to optionally check all files.

Timed examples:
- No `src` files in the diff: ~30s -> ~3s
- Two `src` files in the diff: ~30s -> ~7s

Notes:
- After these changes, the majority of the time is spent on imports.
- ⚠️ Because we now exclusively check on the diff, complex patterns (e.g. a docstring built from an f-string using a variable from a different file) may deceive our checks. Added the ability to do a full run to `make quality`, so we can check on it once in a while.