### PR TITLE
Cleanup tool calling documentation and rename doc

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -120,7 +120,7 @@
   - local: custom_models
     title: Share a custom model
   - local: chat_templating
-    title: Templates for chat models
+    title: Chat templates
   - local: trainer
     title: Trainer
   - local: sagemaker

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Templates for Chat Models
+# Chat Templates
 
 ## Introduction
 

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -235,6 +235,7 @@ The sun.</s>
 From here, just continue training like you would with a standard language modelling task, using the `formatted_chat` column.
 
 <Tip>
+
 If you format text with `apply_chat_template(tokenize=False)` and then tokenize it in a separate step, you should set the argument
 `add_special_tokens=False`. If you use `apply_chat_template(tokenize=True)`, you don't need to worry about this!
 
@@ -242,6 +243,7 @@ By default, some tokenizers add special tokens like `<bos>` and `<eos>` to text 
 always include all of the special tokens they need, and so adding extra special tokens with
 the default `add_special_tokens=True` can result in incorrect or duplicated special tokens, which will hurt model
 performance.
+
 </Tip>
 
 ## Advanced: Extra inputs to chat templates

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -867,3 +867,24 @@ all implementations of Jinja:
 - Replace `True`, `False` and `None`, which are Python-specific, with `true`, `false` and `none`.
 - Directly rendering a dict or list may give different results in other implementations (for example, string entries
   might change from single-quoted to double-quoted). Adding the `tojson` filter can help to ensure consistency here.
+
+### Writing and debugging larger templates
+
+When this feature was introduced, most templates were quite small, the Jinja equivalent of a "one-liner" script. 
+However, with new models and features like tool-use and RAG, some templates can be 100 lines long or more. When
+writing templates like these, it's a good idea to write them in a separate file, using a text editor. You can easily 
+extract a chat template to a file:
+
+```python
+open("template.jinja", "w").write(tokenizer.chat_template)
+```
+
+Or load the edited template back into the tokenizer:
+
+```python
+tokenizer.chat_template = open("template.jinja").read()
+```
+
+As an added bonus, when you write a long, multi-line template in a separate file, line numbers in that file will
+exactly correspond to line numbers in template parsing or execution errors. This will make it much easier to
+identify the source of issues.

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -240,7 +240,7 @@ By default, some tokenizers add special tokens like `<bos>` and `<eos>` to text 
 already include all the special tokens they need, and so additional special tokens will often be incorrect or 
 duplicated, which will hurt model performance.
 
-Therefore, if you format text with `apply_chat_template(tokenize=False)` , you should set the argument
+Therefore, if you format text with `apply_chat_template(tokenize=False)`, you should set the argument
 `add_special_tokens=False` when you tokenize that text later. If you use `apply_chat_template(tokenize=True)`, you don't need to worry about this!
 
 </Tip>

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -236,13 +236,12 @@ From here, just continue training like you would with a standard language modell
 
 <Tip>
 
-If you format text with `apply_chat_template(tokenize=False)` and then tokenize it in a separate step, you should set the argument
-`add_special_tokens=False`. If you use `apply_chat_template(tokenize=True)`, you don't need to worry about this!
-
 By default, some tokenizers add special tokens like `<bos>` and `<eos>` to text they tokenize. Chat templates should 
-always include all of the special tokens they need, and so adding extra special tokens with
-the default `add_special_tokens=True` can result in incorrect or duplicated special tokens, which will hurt model
-performance.
+already include all the special tokens they need, and so additional special tokens will often be incorrect or 
+duplicated, which will hurt model performance.
+
+Therefore, if you format text with `apply_chat_template(tokenize=False)` , you should set the argument
+`add_special_tokens=False` when you tokenize that text later. If you use `apply_chat_template(tokenize=True)`, you don't need to worry about this!
 
 </Tip>
 

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -326,7 +326,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 checkpoint = "NousResearch/Hermes-2-Pro-Llama-3-8B"
 
-tokenizer = AutoTokenizer.from_pretrained(checkpoint, revision="pr/13")
+tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 model = AutoModelForCausalLM.from_pretrained(checkpoint, torch_dtype=torch.bfloat16, device_map="auto")
 ```
 

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -391,15 +391,6 @@ the temperature in France should certainly be displayed in Celsius.
 
 Next, let's append the model's tool call to the conversation.
 
-<Tip>
-
-Some model architectures, notably Mistral/Mixtral, also require a `tool_call_id` here, which should be
-9 randomly-generated alphanumeric characters, and assigned to the `tool_call_id` key of the tool call
-dictionary. The same key should also be assigned to the `id` key of the tool response dictionary below, so 
-that tool calls can be matched to tool responses.
-
-</Tip>
-
 ```python
 tool_call = {"name": "get_current_temperature", "arguments": {"location": "Paris, France", "unit": "celsius"}}
 messages.append({"role": "assistant", "tool_calls": [{"type": "function", "function": tool_call}]})
@@ -413,6 +404,27 @@ that result directly.
 ```python
 messages.append({"role": "tool", "name": "get_current_temperature", "content": "22.0"})
 ```
+
+<Tip>
+
+Some model architectures, notably Mistral/Mixtral, also require a `tool_call_id` here, which should be
+9 randomly-generated alphanumeric characters, and assigned to the `id` key of the tool call
+dictionary. The same key should also be assigned to the `tool_call_id` key of the tool response dictionary below, so 
+that tool calls can be matched to tool responses. So, for Mistral/Mixtral models, the code above would be:
+
+```python
+tool_call_id = "9Ae3bDc2F"  # Random ID, 9 alphanumeric characters
+tool_call = {"name": "get_current_temperature", "arguments": {"location": "Paris, France", "unit": "celsius"}}
+messages.append({"role": "assistant", "tool_calls": [{"type": "function", "id": tool_call_id, "function": tool_call}]})
+```
+
+and
+
+```python
+messages.append({"role": "tool", "tool_call_id": tool_call_id, "name": "get_current_temperature", "content": "22.0"})
+```
+
+</Tip>
 
 Finally, let's let the assistant read the function outputs and continue chatting with the user:
 

--- a/docs/source/ja/chat_templating.md
+++ b/docs/source/ja/chat_templating.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Templates for Chat Models
+# Chat Templates
 
 ## Introduction
 


### PR DESCRIPTION
This is a nit, but the chat templates doc has the title "Templates for Chat Models". This is annoying - it makes it harder to find if you search for 'chat templates'. Calling the doc "Chat Templates" is much cleaner, and almost certainly better SEO.

This PR makes that change, and also simplifies our tool calling documentation a little. Now that it's a little more mature, we've found that relatively few developers are using `tool_call_id`, so I'm taking that out of the core examples and putting it in a `Tip` block instead.