### PR TITLE
Fix error when streaming to gradio with non-string tool arguments

### DIFF
--- a/src/transformers/agents/monitoring.py
+++ b/src/transformers/agents/monitoring.py
@@ -34,7 +34,7 @@ def pull_message(step_log: dict):
         yield ChatMessage(
             role="assistant",
             metadata={"title": f"🛠️ Used tool {step_log['tool_call']['tool_name']}"},
-            content=content,
+            content=str(content),
         )
     if step_log.get("observation"):
         yield ChatMessage(role="assistant", content=f"```\n{step_log['observation']}\n```")
@@ -72,4 +72,4 @@ def stream_to_gradio(agent: ReactAgent, task: str, **kwargs):
             content={"path": step_log.to_string(), "mime_type": "audio/wav"},
         )
     else:
-        yield ChatMessage(role="assistant", content=step_log)
+        yield ChatMessage(role="assistant", content=str(step_log))


### PR DESCRIPTION
# What does this PR do?

Follow-up on [this question on Discord](https://discord.com/channels/879548962464493619/1267867376272150652/1267867376272150652).

Fixes an error raised in gradio when some non-string tool arguments were passed as the `content` attribute of a `gradio.ChatMessage`.

cc @freddyaboulton 