### PR TITLE
[enc-dec cache] fix bug in indexing

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1034,7 +1034,7 @@ class EncoderDecoderCache(Cache):
                 self.self_attention_cache.key_cache[layer_idx],
                 self.self_attention_cache.value_cache[layer_idx],
                 self.cross_attention_cache.key_cache[layer_idx],
-                self.cross_attention_cache.key_cache[layer_idx],
+                self.cross_attention_cache.value_cache[layer_idx],
             )
         else:
             raise KeyError(f"Cache only has {len(self)} layers, attempted to access layer with index {layer_idx}")


### PR DESCRIPTION
# What does this PR do?

Fixes #32366. Assisted generation was incredibly slow since we were passing incorrect past key-values between decoding steps. 

Benchmarking using this toy script, inspired from the Whisper [Speculative Decoding Colab](https://colab.research.google.com/github/sanchit-gandhi/notebooks/blob/main/speculative_decoding.ipynb), we get the expected results:
```python
import torch
from transformers import AutoModelForSpeechSeq2Seq, AutoModelForCausalLM, AutoProcessor
from datasets import load_dataset
import time
from tqdm import tqdm

device = "cuda:0" if torch.cuda.is_available() else "cpu"
torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32

# load main model
model_id = "openai/whisper-large-v3"
model = AutoModelForSpeechSeq2Seq.from_pretrained(
    model_id,
    torch_dtype=torch_dtype,
    low_cpu_mem_usage=True,
    use_safetensors=True,
    attn_implementation="sdpa",
)
model.to(device)

# load assistant model
assistant_model = AutoModelForCausalLM.from_pretrained(
    "distil-whisper/distil-large-v3",
    torch_dtype=torch_dtype,
    low_cpu_mem_usage=True,
    use_safetensors=True,
    attn_implementation="sdpa",
)
assistant_model.to(device)

model.generation_config.forced_decoder_ids = None
assistant_model.generation_config.forced_decoder_ids = None

model.config.forced_decoder_ids = None
assistant_model.config.forced_decoder_ids = None

# load processor
processor = AutoProcessor.from_pretrained(model_id)

# benchmarking dataset - 73 samples from LibriSpeech
dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")

# define benchmarking fn
def generate_with_time(model, inputs, **kwargs):
    start_time = time.time()
    outputs = model.generate(**inputs, **kwargs)
    generation_time = time.time() - start_time
    return outputs, generation_time

all_time = 0
predictions = []
references = []

for sample in tqdm(dataset, desc="Benchmarking baseline..."):
    audio = sample["audio"]
    inputs = processor(audio["array"], sampling_rate=audio["sampling_rate"], return_tensors="pt")
    inputs = inputs.to(device=device, dtype=torch.float16)
    output, gen_time = generate_with_time(model, inputs)
    all_time += gen_time
    predictions.append(processor.batch_decode(output, skip_special_tokens=True, normalize=True)[0])
    references.append(processor.tokenizer._normalize(sample["text"]))

print("Whisper:", all_time)

def assisted_generate_with_time(model, inputs, **kwargs):
    start_time = time.time()
    outputs = model.generate(**inputs, assistant_model=assistant_model, **kwargs)
    generation_time = time.time() - start_time
    return outputs, generation_time

all_time = 0
predictions = []
references = []

for sample in tqdm(dataset, desc="Benchmarking assisted..."):
    audio = sample["audio"]
    inputs = processor(audio["array"], sampling_rate=audio["sampling_rate"], return_tensors="pt")
    inputs = inputs.to(device=device, dtype=torch.float16)

    output, gen_time = assisted_generate_with_time(model, inputs, language="en", task="transcribe", num_assistant_tokens=20)
    all_time += gen_time
    predictions.append(processor.batch_decode(output, skip_special_tokens=True, normalize=True)[0])
    references.append(processor.tokenizer._normalize(sample["text"]))

print("Whisper + Distil-Whisper: ", all_time)
```
**Print Output:**
```
Benchmarking baseline...: 100%|█████████████████████████████████████████████████████████| 73/73 [00:47<00:00,  1.53it/s]
Whisper: 45.20792293548584
Benchmarking assisted...: 100%|█████████████████████████████████████████████████████████| 73/73 [00:16<00:00,  4.37it/s]
Whisper + Distil-Whisper:  15.34307336807251
```

=> approx 3x speed-up using Whisper + Distil-Whisper. Note: not a 100% fair benchmark, since we don't do warm-up steps, but sufficient for the purpose of demonstrating that the issue is fixed.