### PR TITLE
Docker: add `speech` dep to the consistency docker image

### DIFF
--- a/docker/consistency.dockerfile
+++ b/docker/consistency.dockerfile
@@ -8,7 +8,7 @@ RUN pip install uv && uv venv && uv pip install --no-cache-dir -U pip setuptools
 RUN uv pip install --no-cache-dir --upgrade 'torch' --index-url https://download.pytorch.org/whl/cpu
 # tensorflow pin matching setup.py
 RUN uv pip install --no-cache-dir "tensorflow-cpu<2.16" "tf-keras<2.16"
-RUN uv pip install --no-cache-dir "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[flax,quality,vision,testing]"
+RUN uv pip install --no-cache-dir "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[flax,quality,speech,vision,testing]"
 RUN git lfs install
 
 RUN pip uninstall -y transformers


### PR DESCRIPTION
# What does this PR do?

See title :)

### Why is this being added?
1. I'm working on adding more repository checks
2. A missing check is whether methods we explicitly request to document in the `*.mdx` files have a docstring (we have this check for the documented classes, but not for the documented methods).
3. This check requires inspecting objects
4. Inspecting an object requires loading it, realizing the lazy imports

I've opened a preliminary PR with this check [here](https://github.com/huggingface/transformers/pull/32320), but [CI complaining about missing audio dependencies](https://app.circleci.com/pipelines/github/huggingface/transformers/99261/workflows/a82b7613-4563-4011-9667-f73a02fd881f/jobs/1319765).

My plan is to:
1. Merge this extra dependency
2. Wait a day for the new CI images to be built
3. Reopen https://github.com/huggingface/transformers/pull/32320, which adds the check described above.
4. After this check is merged, work on a check over the contents of the explicitly documented methods (`check_docstring.py` currently only checks/fixes non-empty class docstrings) 👉 better quality docs with no manual work