### PR TITLE
Respect the config's attn_implementation if set

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1449,7 +1449,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             dtype_orig = cls._set_default_torch_dtype(torch_dtype)
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in _from_config.
-        config._attn_implementation = kwargs.pop("attn_implementation", None)
+
+        if config._attn_implementation_internal is not None:
+            # In this case, the config has been created with the attn_implementation set by the user, which we
+            # should respect.
+            attn_implementation = config._attn_implementation_internal
+        else:
+            attn_implementation = kwargs.pop("attn_implementation", None)
+
+        config._attn_implementation = attn_implementation
         config = cls._autoset_attn_implementation(
             config,
             use_flash_attention_2=use_flash_attention_2,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1455,9 +1455,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # should respect.
             attn_implementation = config._attn_implementation_internal
         else:
-            attn_implementation = kwargs.pop("attn_implementation", None)
+            attn_implementation = None
 
-        config._attn_implementation = attn_implementation
+        config._attn_implementation = kwargs.pop("attn_implementation", attn_implementation)
         config = cls._autoset_attn_implementation(
             config,
             use_flash_attention_2=use_flash_attention_2,

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -576,8 +576,9 @@ class ModelUtilsTest(TestCasePlus):
 
     def test_model_from_config_attn_implementation(self):
         # test that the model can be instantiated with attn_implementation of either
-        # 1. explicit from_config's attn_implementation argument
+        # 1. config created with explicit attn_implementatation and from_config
         # 2. explicit from_config's attn_implementation argument with a config argument
+        # 3. config created with explicit attn_implementatation and from_config overriding with explicit attn_implementation argument
         attn_implementation_available = ["eager"]
         if is_torch_sdpa_available():
             attn_implementation_available.append("sdpa")
@@ -592,6 +593,9 @@ class ModelUtilsTest(TestCasePlus):
         }
         for requested_attn_implementation in attn_implementation_available:
             config = AutoConfig.from_pretrained(TINY_MISTRAL, attn_implementation=requested_attn_implementation)
+            # Ensure the config was set correctly
+            self.assertEqual(config._attn_implementation, requested_attn_implementation)
+            self.assertEqual(config._attn_implementation_internal, requested_attn_implementation)
             model = AutoModelForCausalLM.from_config(config)
             self.assertEqual(model.config._attn_implementation, requested_attn_implementation)
             for module in model.modules():
@@ -601,6 +605,21 @@ class ModelUtilsTest(TestCasePlus):
                     )
 
             config = AutoConfig.from_pretrained(TINY_MISTRAL)
+            # When the config is not set, the default is "eager"
+            self.assertEqual(config._attn_implementation, "eager")
+            self.assertEqual(config._attn_implementation_internal, None)
+            model = AutoModelForCausalLM.from_config(config=config, attn_implementation=requested_attn_implementation)
+            self.assertEqual(model.config._attn_implementation, requested_attn_implementation)
+            for module in model.modules():
+                if "Attention" in module.__class__.__name__:
+                    self.assertEqual(
+                        module.__class__.__name__, mistral_attention_classes[requested_attn_implementation]
+                    )
+
+            # Set a nonsense attn_implementation in the config, which should be overridden by the explicit argument
+            config = AutoConfig.from_pretrained(TINY_MISTRAL, attn_implementation="foo-bar-baz")
+            self.assertEqual(config._attn_implementation, "foo-bar-baz")
+            self.assertEqual(config._attn_implementation_internal, "foo-bar-baz")
             model = AutoModelForCausalLM.from_config(config=config, attn_implementation=requested_attn_implementation)
             self.assertEqual(model.config._attn_implementation, requested_attn_implementation)
             for module in model.modules():

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -574,6 +574,41 @@ class ModelUtilsTest(TestCasePlus):
                         module.__class__.__name__, mistral_attention_classes[requested_attn_implementation]
                     )
 
+    def test_model_from_config_attn_implementation(self):
+        # test that the model can be instantiated with attn_implementation of either
+        # 1. explicit from_config's attn_implementation argument
+        # 2. explicit from_config's attn_implementation argument with a config argument
+        attn_implementation_available = ["eager"]
+        if is_torch_sdpa_available():
+            attn_implementation_available.append("sdpa")
+
+        if is_flash_attn_2_available():
+            attn_implementation_available.append("flash_attention_2")
+
+        mistral_attention_classes = {
+            "eager": "MistralAttention",
+            "sdpa": "MistralSdpaAttention",
+            "flash_attention_2": "MistralFlashAttention2",
+        }
+        for requested_attn_implementation in attn_implementation_available:
+            config = AutoConfig.from_pretrained(TINY_MISTRAL, attn_implementation=requested_attn_implementation)
+            model = AutoModelForCausalLM.from_config(config)
+            self.assertEqual(model.config._attn_implementation, requested_attn_implementation)
+            for module in model.modules():
+                if "Attention" in module.__class__.__name__:
+                    self.assertEqual(
+                        module.__class__.__name__, mistral_attention_classes[requested_attn_implementation]
+                    )
+
+            config = AutoConfig.from_pretrained(TINY_MISTRAL)
+            model = AutoModelForCausalLM.from_config(config=config, attn_implementation=requested_attn_implementation)
+            self.assertEqual(model.config._attn_implementation, requested_attn_implementation)
+            for module in model.modules():
+                if "Attention" in module.__class__.__name__:
+                    self.assertEqual(
+                        module.__class__.__name__, mistral_attention_classes[requested_attn_implementation]
+                    )
+
     def test_torch_dtype_byte_sizes(self):
         torch_dtypes_and_bytes = [
             (torch.double, 8),


### PR DESCRIPTION
# What does this PR do?

At the moment - if a user sets the attn_implementatation within a config, and then creates a model using `from_config`, the attention implementation isn't respected. 

For example, in the following, SDPA would be selected for the model: 

```py
from transformers import AutoConfig, AutoModel

checkpoint = "bert-base-uncased"
config = AutoConfig.from_pretrained(checkpoint, attn_implementation="eager")
model = AutoModel.from_config(config)
print(model.config._attn_implementation)
```

This PR:
* Ensures `attn_implementation` is respected if set in the config
* Ensures `attn_implementation` can be overridden in the `from_config` call
* Ensures previous `attn_implementation` setting in `from_config` remains if not set in config intially
* Adds test for the above

We have to use `_attn_implementation_internal` as this tells us if this has actually been set by the user. Otherwise `_attn_implementation` will return `"eager"` both if this has been specified by the user and if nothing is set

Fixes #32082
