### PR TITLE
Dependencies: fix typo

### DIFF
--- a/docker/consistency.dockerfile
+++ b/docker/consistency.dockerfile
@@ -8,7 +8,7 @@ RUN pip install uv && uv venv && uv pip install --no-cache-dir -U pip setuptools
 RUN uv pip install --no-cache-dir --upgrade 'torch' --index-url https://download.pytorch.org/whl/cpu
 # tensorflow pin matching setup.py
 RUN uv pip install --no-cache-dir "tensorflow-cpu<2.16" "tf-keras<2.16"
-RUN uv pip install --no-cache-dir "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[flax,quality,speech,vision,testing]"
+RUN uv pip install --no-cache-dir "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[flax,quality,torch-speech,vision,testing]"
 RUN git lfs install
 
 RUN pip uninstall -y transformers


### PR DESCRIPTION
# What does this PR do?

#32374: `speech` is not a known dependency, `torch-speech` is ([source](https://github.com/huggingface/transformers/blob/083e13b7c47f674b11c74d1b7c7ee7cd1241b406/setup.py#L303)) 🙃 

Note: CI is not broken, but the [daily build for this specific image](https://github.com/huggingface/transformers/actions/runs/10207817526/job/28243277190) is. The fact that this CI update is either manual or prone to errors is a great example of the need to update it :)