### PR TITLE
Llava: add checkpoint doc

### DIFF
--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -39,6 +39,9 @@ logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "LlavaConfig"
 
+# Base docstring
+_CHECKPOINT_FOR_DOC = "llava-hf/llava-1.5-7b-hf"
+
 
 @dataclass
 # Copied from transformers.models.idefics.modeling_idefics.IdeficsCausalLMOutputWithPast with Idefics->Llava


### PR DESCRIPTION
# What does this PR do?
`transformers-cli add-new-model-like` throws out following error when llava like model init scripts are created. This PR fixes that by providing `_CHECKPOINT_FOR_DOC` for the model.

```
warnings.warn("Can't initialize NVML")
2024-08-05 21:52:43.951612: I tensorflow/core/util/port.cc:113] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2024-08-05 21:52:44.096990: E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2024-08-05 21:52:44.097061: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:607] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2024-08-05 21:52:44.116129: E external/local_xla/xla/stream_executor/cuda/cuda_blas.cc:1515] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2024-08-05 21:52:44.157408: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2024-08-05 21:52:45.293269: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
What is the model you would like to duplicate? Please provide the lowercase `model_type` (e.g. roberta): llava
We couldn't find the name of the base checkpoint for that model, please enter it here. 
What is the name (with no special casing) for your new model in the paper (e.g. RoBERTa)? dummy
What identifier would you like to use for the `model_type` of this model?  [dummy] dummy
What lowercase name would you like to use for the module (folder) of this model?  [dummy] dummy
What prefix (camel-cased) would you like to use for the model classes of this model (e.g. Roberta)?  [Dummy] Dummy
What prefix (upper-cased) would you like to use for the constants relative to this model?  [DUMMY] DUMMY
What will be the name of the config class for this model?  [DummyConfig] DummyConfig
Please give a checkpoint identifier (on the model Hub) for this new model (e.g. facebook/FacebookAI/roberta-base): dummy/dummy
Will your new model use the same processing class as llava (CLIPImageProcessor, LlamaTokenizer, LlavaProcessor) (yes/no)? yes
Should we add # Copied from statements when creating the new modeling file (yes/no)?  [yes] yes
Should we add a version of your new model in all the frameworks implemented by llava (['pt']) (yes/no)?  [yes] no
Please enter the list of framworks you want (pt, tf, flax) separated by spaces pt
Traceback (most recent call last):
  File "/home/ruffy-369/HuggingFace/iris/.iristransformers/bin/transformers-cli", line 8, in <module>
    sys.exit(main())
  File "/home/ruffy-369/HuggingFace/transformers/src/transformers/commands/transformers_cli.py", line 53, in main
    service.run()
  File "/home/ruffy-369/HuggingFace/transformers/src/transformers/commands/add_new_model_like.py", line 1495, in run
    create_new_model_like(
  File "/home/ruffy-369/HuggingFace/transformers/src/transformers/commands/add_new_model_like.py", line 1301, in create_new_model_like
    raise ValueError(
ValueError: The old model checkpoint could not be recovered from the model type. Please pass it to the `old_checkpoint` argument.
```

## Who can review?
 Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.
@amyeroberts @ArthurZucker @younesbelkada 
