### PR TITLE
Fix Trainer MLU Availability Import For Accelerate < 0.29

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -223,7 +223,6 @@ if is_accelerate_available():
         DistributedDataParallelKwargs,
         DistributedType,
         GradientAccumulationPlugin,
-        is_mlu_available,
         is_mps_available,
         is_npu_available,
         is_torch_version,
@@ -3334,7 +3333,7 @@ class Trainer:
         ):
             if is_xpu_available():
                 torch.xpu.empty_cache()
-            elif is_mlu_available():
+            elif is_torch_mlu_available():
                 torch.mlu.empty_cache()
             elif is_npu_available():
                 torch.npu.empty_cache()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/32461

I checked Accelerate, and the utility for checking if MLU is available was added in the `0.29.0` release, so the accelerate import in the trainer breaks versions `0.21.0 >= x <0.29.0` if accelerate is available at import time (since the minimum version of accelerate transformers is happy with is 0.21.0 [in the deps table](https://github.com/huggingface/transformers/blob/main/src/transformers/dependency_versions_table.py#L6)).

It appears that the `is_mlu_available` check in the Accelerate import utils ([here](https://github.com/huggingface/accelerate/blob/v0.33.0/src/accelerate/utils/imports.py#L349)) is also only used one time and is redundant with the `is_torch_mlu_available ` check in transformers import utils [here](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L630), which is used in other parts of the trainer. 

This PR removes the accelerate util that is breaking the import, and just uses the transformers one in its place.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr and @SunMarc