### PR TITLE
Fix Input Handling Error in Floating Point Operations

### DIFF
--- a/examples/pytorch/instance-segmentation/run_instance_segmentation.py
+++ b/examples/pytorch/instance-segmentation/run_instance_segmentation.py
@@ -15,9 +15,6 @@
 
 """Finetuning 🤗 Transformers model for instance segmentation leveraging the Trainer API."""
 
-import os
-os.environ["CUDA_VISIBLE_DEVICES"]="0"
-
 import logging
 import os
 import sys
@@ -37,16 +34,13 @@ from transformers import (
     AutoModelForUniversalSegmentation,
     HfArgumentParser,
     Trainer,
-    OneFormerForUniversalSegmentation,
     TrainingArguments,
-    AutoProcessor,
 )
 from transformers.image_processing_utils import BatchFeature
 from transformers.trainer import EvalPrediction
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
-from transformers.models.oneformer import OneFormerProcessor
 
 
 logger = logging.getLogger(__name__)
@@ -115,14 +109,8 @@ def augment_and_transform_batch(
         "class_labels": [],
     }
 
-    if isinstance(image_processor, OneFormerProcessor):
-        batch["text_inputs"] = []
-        batch["task_inputs"] = []
-
     for pil_image, pil_annotation in zip(examples["image"], examples["annotation"]):
         image = np.array(pil_image)
-        # NOTE: in the instance annotation masks,
-        # R(ed) channel encodes category ID, and the G(reen) channel encodes instance ID.
         semantic_and_instance_masks = np.array(pil_annotation)[..., :2]
 
         # Apply augmentations
@@ -132,11 +120,6 @@ def augment_and_transform_batch(
         aug_semantic_and_instance_masks = output["mask"]
         aug_instance_mask = aug_semantic_and_instance_masks[..., 1]
 
-        # NOTE: current image processor limitation
-        # due to the limitation of the current implementation of the image processor,
-        # we need to create a mapping from instance id to semantic id.
-        # and we can only have 255 object instances in the image.
-
         # Create mapping from instance id to semantic id
         unique_semantic_id_instance_id_pairs = np.unique(aug_semantic_and_instance_masks.reshape(-1, 2), axis=0)
         instance_id_to_semantic_id = {
@@ -144,28 +127,16 @@ def augment_and_transform_batch(
         }
 
         # Apply the image processor transformations: resizing, rescaling, normalization
-        if isinstance(image_processor, OneFormerProcessor):
-            model_inputs = image_processor(
-                images=[aug_image],
-                task_inputs=["panoptic"],
-                segmentation_maps=[aug_instance_mask],
-                instance_id_to_semantic_id=instance_id_to_semantic_id,
-                return_tensors="pt",
-            )
-        else:
-            model_inputs = image_processor(
-                images=[aug_image],
-                segmentation_maps=[aug_instance_mask],
-                instance_id_to_semantic_id=instance_id_to_semantic_id,
-                return_tensors="pt",
-            )
+        model_inputs = image_processor(
+            images=[aug_image],
+            segmentation_maps=[aug_instance_mask],
+            instance_id_to_semantic_id=instance_id_to_semantic_id,
+            return_tensors="pt",
+        )
 
         batch["pixel_values"].append(model_inputs.pixel_values[0])
         batch["mask_labels"].append(model_inputs.mask_labels[0])
         batch["class_labels"].append(model_inputs.class_labels[0])
-        if "text_inputs" in model_inputs:
-            batch["text_inputs"].append(model_inputs.text_inputs[0])
-            batch["task_inputs"].append(model_inputs.task_inputs[0])
 
     return batch
 
@@ -175,16 +146,8 @@ def collate_fn(examples):
     batch["pixel_values"] = torch.stack([example["pixel_values"] for example in examples])
     batch["class_labels"] = [example["class_labels"] for example in examples]
     batch["mask_labels"] = [example["mask_labels"] for example in examples]
-
     if "pixel_mask" in examples[0]:
         batch["pixel_mask"] = torch.stack([example["pixel_mask"] for example in examples])
-
-    if "text_inputs" in examples[0]:
-        batch["text_inputs"] = torch.stack([example["text_inputs"] for example in examples])
-
-    if "task_inputs" in examples[0]:
-        batch["task_inputs"] = torch.stack([example["task_inputs"] for example in examples])
-
     return batch
 
 
@@ -435,30 +398,16 @@ def main():
         id2label=id2label,
         ignore_mismatched_sizes=True,
         token=args.token,
-        # NOTE: you need to set is_training = True in order to randomly initialize a text encoder
-        is_training=True,
     )
 
-    if isinstance(model, OneFormerForUniversalSegmentation):
-        image_processor = AutoProcessor.from_pretrained(
-            args.model_name_or_path,
-            do_resize=True,
-            size={"height": args.image_height, "width": args.image_width},
-            token=args.token,
-            # NOTE: you need to set is_training = True in order to randomly initialize a text encoder
-            is_training=True,
-        )
-        image_processor.image_processor.num_text = model.config.num_queries - model.config.text_encoder_n_ctx
-    else:
-        image_processor = AutoImageProcessor.from_pretrained(
-            args.model_name_or_path,
-            do_resize=True,
-            size={"height": args.image_height, "width": args.image_width},
-            do_reduce_labels=args.do_reduce_labels,
-            reduce_labels=args.do_reduce_labels,  # TODO: remove when mask2former support `do_reduce_labels`
-            token=args.token,
-            is_training=True,
-        )
+    image_processor = AutoImageProcessor.from_pretrained(
+        args.model_name_or_path,
+        do_resize=True,
+        size={"height": args.image_height, "width": args.image_width},
+        do_reduce_labels=args.do_reduce_labels,
+        reduce_labels=args.do_reduce_labels,  # TODO: remove when mask2former support `do_reduce_labels`
+        token=args.token,
+    )
 
     # ------------------------------------------------------------------------------------------------
     # Define image augmentations and dataset transforms

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1233,14 +1233,18 @@ class ModuleUtilsMixin:
         """
         if not hasattr(self, "warnings_issued"):
             self.warnings_issued = {}
-        if self.main_input_name in input_dict:
-            return input_dict[self.main_input_name].numel()
+        num_tokens = 0
+        if isinstance(self.main_input_name, str):
+            self.main_input_name = [self.main_input_name]
+            for input_name in self.main_input_name:
+                if input_name in input_dict:
+                    num_tokens += input_dict[input_name].numel() 
         elif "estimate_tokens" not in self.warnings_issued:
             logger.warning(
                 "Could not estimate the number of tokens of the input, floating-point operations will not be computed"
             )
             self.warnings_issued["estimate_tokens"] = True
-        return 0
+        return num_tokens
 
     def floating_point_ops(
         self, input_dict: Dict[str, Union[torch.Tensor, Any]], exclude_embeddings: bool = True

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -3236,6 +3236,8 @@ class OneFormerForUniversalSegmentation(OneFormerPreTrainedModel):
             )
             loss = self.get_loss(loss_dict)
 
+        loss = loss.squeeze()
+
         output_auxiliary_logits = (
             self.config.output_auxiliary_logits if output_auxiliary_logits is None else output_auxiliary_logits
         )


### PR DESCRIPTION
# What does this PR do?

Fixes `OneFormerModel` has a list of inputs i.e  `main_input_name = ["pixel_values", "task_inputs"]` , `estimate_tokens` called in `floating_point_ops` can't process list of inputs thus raised an error:

```python
if self.main_input_name in input_dict:
Exception has occurred: TypeError       (note: full exception trace is shown but execution is paused at: _run_module_as_main)
unhashable type: 'list'
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
