### PR TITLE
Docs: alert for the possibility of manipulating logits

### DIFF
--- a/docs/source/en/generation_strategies.md
+++ b/docs/source/en/generation_strategies.md
@@ -225,9 +225,20 @@ array([True, True])
 ## Decoding strategies
 
 Certain combinations of the `generate()` parameters, and ultimately `generation_config`, can be used to enable specific
-decoding strategies. If you are new to this concept, we recommend reading [this blog post that illustrates how common decoding strategies work](https://huggingface.co/blog/how-to-generate).
+decoding strategies. If you are new to this concept, we recommend reading
+[this blog post that illustrates how common decoding strategies work](https://huggingface.co/blog/how-to-generate).
 
 Here, we'll show some of the parameters that control the decoding strategies and illustrate how you can use them.
+
+<Tip>
+
+Selecting a given decoding strategy is not the only way you can influence the outcome of `generate()` with your model.
+The decoding strategies act based (mostly) on the logits, the distribution of probabilities for the next token, and
+thus selecting a good logit manipulation can go a long way! In other words, manipulating the logits is another
+dimension you can act upon. Common logit manipulation strategies include `top_p`, `min_p`, and `repetition_penalty` --
+you can check the full list in the [`GenerationConfig`] class.
+
+</Tip>
 
 ### Greedy Search
 

--- a/docs/source/en/generation_strategies.md
+++ b/docs/source/en/generation_strategies.md
@@ -234,9 +234,9 @@ Here, we'll show some of the parameters that control the decoding strategies and
 
 Selecting a given decoding strategy is not the only way you can influence the outcome of `generate()` with your model.
 The decoding strategies act based (mostly) on the logits, the distribution of probabilities for the next token, and
-thus selecting a good logit manipulation can go a long way! In other words, manipulating the logits is another
-dimension you can act upon. Common logit manipulation strategies include `top_p`, `min_p`, and `repetition_penalty` --
-you can check the full list in the [`GenerationConfig`] class.
+thus selecting a good logits manipulation strategy can go a long way! In other words, manipulating the logits is another
+dimension you can act upon, in addition to selecting a decoding strategy. Popular logits manipulation strategies include
+`top_p`, `min_p`, and `repetition_penalty` -- you can check the full list in the [`GenerationConfig`] class.
 
 </Tip>
 


### PR DESCRIPTION
# What does this PR do?

As @osanseviero told me on slack, popular logit manipulation strategies like `min_p` are a bit obscure in our docs.

A proper fix will come with the [`generate` refactor](https://github.com/huggingface/transformers/issues/30810), where a diagram of what `generate` does will be added. In that diagram, there will be a dedicated section for logits processors.

Meanwhile, a quick patch: this PR adds a tip in the decoding strategies section alerting for the existence and importance of logit manipulation.