### PR TITLE
[Apple Intelligence Foundation Model]

### DIFF
--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -123,6 +123,9 @@ class LlamaConfig(PretrainedConfig):
             The dropout ratio for the attention probabilities.
         mlp_bias (`bool`, *optional*, defaults to `False`):
             Whether to use a bias in up_proj, down_proj and gate_proj layers in the MLP layers.
+        qk_norm (`bool`, *optional*, defaults to `False`):
+            Whether to use QK norm in the Attention layers. For more details checkout [this
+            paper](https://arxiv.org/pdf/2010.04245)
 
     ```python
     >>> from transformers import LlamaModel, LlamaConfig
@@ -163,6 +166,7 @@ class LlamaConfig(PretrainedConfig):
         attention_bias=False,
         attention_dropout=0.0,
         mlp_bias=False,
+        qk_norm=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -187,6 +191,7 @@ class LlamaConfig(PretrainedConfig):
         self.attention_bias = attention_bias
         self.attention_dropout = attention_dropout
         self.mlp_bias = mlp_bias
+        self.qk_norm = qk_norm
 
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, move it to 'rope_type'.


### PR DESCRIPTION
# What does this PR do?

This PR adds minor change in Llama model implementation for Apple Foundation Model architecture used for Apple Intelligence, mentioned in this [paper](https://arxiv.org/pdf/2407.21075), for open research.

```python
from transformers import LlamaModel, LlamaConfig

# Apple Intelligence on device 2.7B model config.
afm_on_device_config = LlamaConfig(
    vocab_size=49152,
    hidden_size=3072,
    intermediate_size=8064,
    num_attention_heads=24,
    num_hidden_layers=26,
    num_key_value_heads=8,
    tie_word_embeddings=True,
    layer_norm_epsilon=1e-05,
    max_position_embeddings=32768,
    rms_norm_eps=1e-05,
    pad_token_id=0,
    bos_token_id=1,
    eos_token_id=1,
    rope_theta=500000.0,
    qk_norm=True,
)

# Initialize the model with the specified configuration.
afm_on_device_model = LlamaModel(config=afm_on_device_config)
```

Notes:
- Weights are not open sourced.
- After adding this change, we will add the parameter converter (from jax to safetensors) into AFM training framework, [axlearn](https://github.com/apple/axlearn/) for internal use cases. [Converter example](https://github.com/apple/axlearn/blob/a962a839130c1e9d63bf0b86b9be2dd6637b547f/axlearn/common/param_converter_test.py#L643)

Open questions:
- Will leave it to huggingface maintainers to decide whether it would be preferred to create a standalone `models/afm/` repo for apple foundation models. We may have future architecture change for research. If so, would appreciate if huggingface team can help add it to avoid duplicate code and tests

Models:
- text models: @ArthurZucker

Contact: gyin@apple.com
