### PR TITLE
[tests] make `test_sdpa_can_compile_dynamic` device-agnostic

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -79,6 +79,7 @@ from transformers.testing_utils import (
     require_read_token,
     require_safetensors,
     require_torch,
+    require_torch_accelerator,
     require_torch_gpu,
     require_torch_multi_accelerator,
     require_torch_multi_gpu,
@@ -4054,14 +4055,15 @@ class ModelTesterMixin:
                     _ = model(**inputs_dict)
 
     @require_torch_sdpa
-    @require_torch_gpu
+    @require_torch_accelerator
     @slow
     def test_sdpa_can_compile_dynamic(self):
-        if not self.has_attentions:
-            self.skipTest(reason="Model architecture does not support attentions")
+        if "cuda" in torch_device:
+            compute_capability = torch.cuda.get_device_capability()
+            major, _ = compute_capability
 
-        compute_capability = torch.cuda.get_device_capability()
-        major, _ = compute_capability
+            if not torch.version.cuda or major < 8:
+                self.skipTest("This test requires an NVIDIA GPU with compute capability >= 8.0")
 
         if not torch.version.cuda or major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4058,15 +4058,14 @@ class ModelTesterMixin:
     @require_torch_accelerator
     @slow
     def test_sdpa_can_compile_dynamic(self):
+        if not self.has_attentions:
+            self.skipTest(reason="Model architecture does not support attentions")
         if "cuda" in torch_device:
             compute_capability = torch.cuda.get_device_capability()
             major, _ = compute_capability
 
             if not torch.version.cuda or major < 8:
-                self.skipTest("This test requires an NVIDIA GPU with compute capability >= 8.0")
-
-        if not torch.version.cuda or major < 8:
-            self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
+                self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
 
         for model_class in self.all_model_classes:
             if not model_class._supports_sdpa:


### PR DESCRIPTION
## What does this PR do?
`test_sdpa_can_compile_dynamic` should not only work on GPU, it also works on XPU, below is an example:

```bash
PASSED tests/models/hubert/test_modeling_hubert.py::HubertModelTest::test_sdpa_can_compile_dynamic
```

@amyeroberts and @ydshieh 