### PR TITLE
add Gemma2 for causal LM to test classes

### DIFF
--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -59,7 +59,7 @@ class Gemma2ModelTest(GemmaModelTest, unittest.TestCase):
         if is_torch_available()
         else ()
     )
-    all_generative_model_classes = ()
+    all_generative_model_classes = (Gemma2ForCausalLM,) if is_torch_available else ()
     pipeline_model_mapping = (
         {
             "feature-extraction": Gemma2Model,

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -59,7 +59,7 @@ class Gemma2ModelTest(GemmaModelTest, unittest.TestCase):
         if is_torch_available()
         else ()
     )
-    all_generative_model_classes = (Gemma2ForCausalLM,) if is_torch_available else ()
+    all_generative_model_classes = (Gemma2ForCausalLM,) if is_torch_available() else ()
     pipeline_model_mapping = (
         {
             "feature-extraction": Gemma2Model,


### PR DESCRIPTION
# What does this PR do?

Generate tests depend on the attribute `all_generative_model_classes`, which was empty for Gemma2, causing all generate tests to be skipped. 
Q additional maybe @gante : do you think it'd be useful to use the lists in `modeling_auto.py` instead?
