### PR TITLE
ensure tensors in generate_kwargs to be on the same device as input_ids

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -501,6 +501,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                     else:
                         generate_kwargs["num_frames"] = num_frames
 
+            generate_kwargs = self._ensure_tensor_on_device(generate_kwargs, inputs.device)
             tokens = self.model.generate(
                 inputs=inputs,
                 attention_mask=attention_mask,


### PR DESCRIPTION
## What does this PR do?

 mentioned in PR #32316 .