### PR TITLE
Add warm up in evaluation_loop to get more accurate performance data

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3800,6 +3800,9 @@ class Trainer:
                 if self.is_deepspeed_enabled
                 else self.accelerator.prepare_model(model, evaluation_mode=True)
             )
+            example_inputs = dict(next(iter(dataloader)))
+            with torch.no_grad():
+                model(**example_inputs)
             self.model_preparation_time = round(time.time() - start_time, 4)
 
             if self.is_fsdp_enabled:


### PR DESCRIPTION
Add warm up in evaluation_loop, this will make performance metrics more accurate when using torch_compile, take `text-classification+albert-base-v1` as example:
`python -u ./transformers/examples/pytorch/text-classification/run_glue.py --model_name_or_path albert-base-v1 --task_name MRPC --do_eval --max_seq_length 16 --learning_rate 2e-5 --overwrite_output_dir --output_dir /tmp/tmp_huggingface/ --torch_compile --report_to=none`
before this PR:
```
***** Running Evaluation *****
[INFO|trainer.py:3831] 2024-08-12 07:22:17,390 >>   Num examples = 408
[INFO|trainer.py:3834] 2024-08-12 07:22:17,390 >>   Batch size = 8
100%|████████████████████████████████████████████████████████████████████████| 51/51 [00:00<00:00, 69.95it/s]
***** eval metrics *****
  eval_accuracy               =     0.5637
  eval_combined_score         =     0.6024
  eval_f1                     =     0.6411
  eval_loss                   =     0.6855
  eval_model_preparation_time =     0.6604
  eval_runtime                = 0:00:06.56
  eval_samples                =        408
  eval_samples_per_second     =     62.169
  eval_steps_per_second       =      7.771
```
after this PR:
```
***** Running Evaluation *****
[INFO|trainer.py:3831] 2024-08-12 07:11:18,818 >>   Num examples = 408
[INFO|trainer.py:3834] 2024-08-12 07:11:18,818 >>   Batch size = 8
100%|██████████| 51/51 [00:00<00:00, 68.18it/s]
***** eval metrics *****
  eval_accuracy               =     0.5637
  eval_combined_score         =     0.6024
  eval_f1                     =     0.6411
  eval_loss                   =     0.6855
  eval_model_preparation_time =     6.4489
  eval_runtime                = 0:00:00.76
  eval_samples                =        408
  eval_samples_per_second     =    533.526
  eval_steps_per_second       =     66.691
```