### PR TITLE
Automatically add `transformers` tag to the modelcard

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -454,6 +454,7 @@ class TrainingSummary:
         metric_mapping = infer_metric_tags_from_eval_results(self.eval_results)
 
         metadata = {}
+        metadata = _insert_value(metadata, "library_name", "transformers")
         metadata = _insert_values_as_list(metadata, "language", self.language)
         metadata = _insert_value(metadata, "license", self.license)
         if self.finetuned_from is not None and isinstance(self.finetuned_from, str) and len(self.finetuned_from) > 0:
@@ -603,9 +604,6 @@ class TrainingSummary:
             tags = [tags, "generated_from_trainer"]
         elif "generated_from_trainer" not in tags:
             tags.append("generated_from_trainer")
-
-        if "transformers" not in tags:
-            tags.append("transformers")
 
         _, eval_lines, eval_results = parse_log_history(trainer.state.log_history)
         hyperparameters = extract_hyperparameters_from_trainer(trainer)

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -604,6 +604,9 @@ class TrainingSummary:
         elif "generated_from_trainer" not in tags:
             tags.append("generated_from_trainer")
 
+        if "transformers" not in tags:
+            tags.append("transformers")
+
         _, eval_lines, eval_results = parse_log_history(trainer.state.log_history)
         hyperparameters = extract_hyperparameters_from_trainer(trainer)
 

--- a/tests/utils/test_model_card.py
+++ b/tests/utils/test_model_card.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 import unittest
 
-from transformers.modelcard import ModelCard
+from transformers.modelcard import ModelCard, TrainingSummary
 
 
 class ModelCardTester(unittest.TestCase):
@@ -82,3 +82,8 @@ class ModelCardTester(unittest.TestCase):
             model_card_second = ModelCard.from_pretrained(tmpdirname)
 
         self.assertEqual(model_card_second.to_dict(), model_card_first.to_dict())
+
+    def test_model_summary_modelcard_base_metadata(self):
+        metadata = TrainingSummary("Model name").create_metadata()
+        self.assertTrue("library_name" in metadata)
+        self.assertTrue(metadata["library_name"] == "transformers")


### PR DESCRIPTION
Transformers models on the Hub are not automatically tagged as `transformers` anymore, and this tag should automatically be added to the `metadata`. 