### PR TITLE
Fix quantization w/ DeepSpeed not working

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -436,8 +436,13 @@ class Trainer:
         # Will reach this branch if the user has
         # 1. Used `.from_pretrained` or `.from_config` to initialize their model
         # 2. Did not configure Zero-3 via `TrainingArguments` or `accelerate launch` beforehand
+        # 3. Also not using quantization
         # New models init such as `MyModel()` will not hit this step
-        if is_deepspeed_zero3_enabled() and not getattr(model, "_transformers_zero3_init_used", True):
+        if (
+            not (hasattr(model, "hf_quantizer") and model.hf_quantizer.is_trainable)
+            and is_deepspeed_zero3_enabled()
+            and not getattr(model, "_transformers_zero3_init_used", True)
+        ):
             raise ValueError(
                 "Model was not initialized with `Zero-3` despite being configured for DeepSpeed Zero-3. Please re-initialize your model via `Model.from_pretrained(...)` or `Model.from_config(...)` after creating your `TrainingArguments`!"
             )

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -747,9 +747,7 @@ class TrainerIntegrationDeepSpeed(TrainerIntegrationDeepSpeedWithCustomConfig, T
                 output_dir="./test_missed_zero3_init",
                 deepspeed=self.get_config_dict(ZERO3),
             )
-            # with self.assertRaises(
-            #     ValueError, msg="Model was not initialized with `Zero-3` despite being configured."
-            # ):
+            # Shouldn't raise an error in this case
             _ = Trainer(
                 model=model,
                 args=training_args,


### PR DESCRIPTION
# What does this PR do?

This PR tweaks the logic check introduced in https://github.com/huggingface/transformers/pull/32299 to specifically exclude when Zero-3 is enabled and we're using a quantization method (which skips this chunk of the zero3 init use)

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc can you check if what I've done here makes sense given the comment we're trying to fix?

https://github.com/huggingface/transformers/pull/32299#issuecomment-2284975360

I believe so and I think the test makes sense, but you're quant eyes would be appreciated :) 

