### PR TITLE
Reduce the error log when using core models that need their weights renamed, and provide a step forward

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -699,7 +699,7 @@ def _load_state_dict_into_model(
     found_beta = False
     warning_msg = "This model "
     if pretrained_model_name_or_path is not None:
-        warning_msg += f"({pretrained_model_name_or_path}) "
+        warning_msg += f"(`{pretrained_model_name_or_path}`) "
     warning_msg += "contains parameters that have been renamed internally (a few are listed below but more are present in the model):\n"
     for key in state_dict.keys():
         new_key = None
@@ -866,7 +866,7 @@ def _load_state_dict_into_meta_model(
     found_beta = False
     warning_msg = "This model "
     if pretrained_model_name_or_path is not None:
-        warning_msg += f"({pretrained_model_name_or_path}) "
+        warning_msg += f"(`{pretrained_model_name_or_path}`) "
     warning_msg += "contains parameters that have been renamed internally (a few are listed below but more are present in the model):\n"
     is_quantized = hf_quantizer is not None
     for key in state_dict.keys():
@@ -884,6 +884,11 @@ def _load_state_dict_into_meta_model(
         if new_key:
             old_keys.append(key)
             new_keys.append(new_key)
+    if renamed_keys:
+        for old_key, new_key in renamed_keys.items():
+            warning_msg += f"* `{old_key}` -> `{new_key}`\n"
+        warning_msg += "If you are using a model from the Hub, consider submitting a PR to adjust these weights and help future users."
+        logger.info_once(warning_msg)
     for old_key, new_key in zip(old_keys, new_keys):
         state_dict[new_key] = state_dict.pop(old_key)
 

--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -331,6 +331,21 @@ def warning_once(self, *args, **kwargs):
 logging.Logger.warning_once = warning_once
 
 
+@functools.lru_cache(None)
+def info_once(self, *args, **kwargs):
+    """
+    This method is identical to `logger.info()`, but will emit the info with the same message only once
+
+    Note: The cache is for the function arguments, so 2 different callers using the same arguments will hit the cache.
+    The assumption here is that all warning messages are unique across the code. If they aren't then need to switch to
+    another type of cache that includes the caller frame information in the hashing function.
+    """
+    self.info(*args, **kwargs)
+
+
+logging.Logger.info_once = info_once
+
+
 class EmptyTqdm:
     """Dummy tqdm which doesn't do anything."""
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1640,12 +1640,12 @@ class ModelUtilsTest(TestCasePlus):
 
         logger = logging.get_logger("transformers.modeling_utils")
         config = PretrainedConfig()
-        warning_msg_gamma = "A parameter name that contains `gamma` will be renamed internally"
+        warning_msg_gamma = "`gamma_param` -> `weight_param`"
         model = TestModelGamma(config)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(tmp_dir)
-            with LoggingLevel(logging.WARNING):
+            with LoggingLevel(logging.INFO):
                 with CaptureLogger(logger) as cl1:
                     _, loading_info = TestModelGamma.from_pretrained(tmp_dir, config=config, output_loading_info=True)
 
@@ -1664,12 +1664,12 @@ class ModelUtilsTest(TestCasePlus):
             def forward(self):
                 return self.beta_param.sum()
 
-        warning_msg_beta = "A parameter name that contains `beta` will be renamed internally"
+        warning_msg_beta = "`beta_param` -> `bias_param`"
         model = TestModelBeta(config)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_pretrained(tmp_dir)
-            with LoggingLevel(logging.WARNING):
+            with LoggingLevel(logging.INFO):
                 with CaptureLogger(logger) as cl2:
                     _, loading_info = TestModelBeta.from_pretrained(tmp_dir, config=config, output_loading_info=True)
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1651,6 +1651,7 @@ class ModelUtilsTest(TestCasePlus):
 
         missing_keys = loading_info["missing_keys"]
         unexpected_keys = loading_info["unexpected_keys"]
+        self.assertIn("`TestModelGamma`", cl1.out)
         self.assertIn(warning_msg_gamma, cl1.out)
         self.assertIn("gamma_param", missing_keys)
         self.assertIn("weight_param", unexpected_keys)
@@ -1675,6 +1676,7 @@ class ModelUtilsTest(TestCasePlus):
 
         missing_keys = loading_info["missing_keys"]
         unexpected_keys = loading_info["unexpected_keys"]
+        self.assertIn("`TestModelBeta`", cl2.out)
         self.assertIn(warning_msg_beta, cl2.out)
         self.assertIn("beta_param", missing_keys)
         self.assertIn("bias_param", unexpected_keys)


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/31654 introduced a (good) warning for users when we internally rename certain parameters in a model (`gamma` and `beta`). 

The flag however was extremely verbose and doesn't include a path forward for users who have no control over the model (like `bert-base-cased`).

This PR:
1. Introduces a new `info_once` to the `logger` for when we want something to be at the `INFO` level (since general users don't need this warning)
2. Reduces this warning down to `info`
3. Changes the warning to be more transparent to the user towards a solution

Old warning:
```
A parameter name that contains `beta` will be renamed internally to `bias`. Please use a different name to suppress this warning.
A parameter name that contains `gamma` will be renamed internally to `weight`. Please use a different name to suppress this warning.
A parameter name that contains `beta` will be renamed internally to `bias`. Please use a different name to suppress this warning.
A parameter name that contains `gamma` will be renamed internally to `weight`. Please use a different name to suppress this warning.
...
```

New warning:
```
This model (`bert-base-cased`) contains parameters that have been renamed internally (a few are listed below but more are present in the model):
* `bert.embeddings.LayerNorm.beta` -> `bert.embeddings.LayerNorm.bias`
* `bert.embeddings.LayerNorm.gamma` -> `bert.embeddings.LayerNorm.weight`
If you are using a model from the Hub, consider submitting a PR to adjust these weights and help future users.
```
Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts
