### PR TITLE
Use Self type for PreTrainedModel.from_pretrained

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -22,6 +22,11 @@ import re
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 from packaging import version
 
 from . import __version__
@@ -452,7 +457,7 @@ class PretrainedConfig(PushToHubMixin):
         token: Optional[Union[str, bool]] = None,
         revision: str = "main",
         **kwargs,
-    ) -> "PretrainedConfig":
+    ) -> Self:
         r"""
         Instantiate a [`PretrainedConfig`] (or a derived class) from a pretrained model configuration.
 
@@ -678,7 +683,7 @@ class PretrainedConfig(PushToHubMixin):
         return config_dict, kwargs
 
     @classmethod
-    def from_dict(cls, config_dict: Dict[str, Any], **kwargs) -> "PretrainedConfig":
+    def from_dict(cls, config_dict: Dict[str, Any], **kwargs) -> Self:
         """
         Instantiates a [`PretrainedConfig`] from a Python dictionary of parameters.
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -22,6 +22,7 @@ import re
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+
 try:
     from typing import Self
 except ImportError:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -33,6 +33,7 @@ from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from zipfile import is_zipfile
 
+
 try:
     from typing import Self
 except ImportError:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -33,6 +33,11 @@ from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from zipfile import is_zipfile
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 import torch
 from huggingface_hub import split_torch_state_dict_into_shards
 from packaging import version
@@ -2934,7 +2939,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         revision: str = "main",
         use_safetensors: bool = None,
         **kwargs,
-    ) -> "PreTrainedModel":
+    ) -> Self:
         r"""
         Instantiate a pretrained pytorch model from a pre-trained model configuration.
 

--- a/src/transformers/models/clvp/configuration_clvp.py
+++ b/src/transformers/models/clvp/configuration_clvp.py
@@ -17,6 +17,7 @@
 import os
 from typing import Union
 
+
 try:
     from typing import Self
 except ImportError:

--- a/src/transformers/models/clvp/configuration_clvp.py
+++ b/src/transformers/models/clvp/configuration_clvp.py
@@ -15,11 +15,13 @@
 """CLVP model configuration"""
 
 import os
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
-if TYPE_CHECKING:
-    pass
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import logging
@@ -134,7 +136,7 @@ class ClvpEncoderConfig(PretrainedConfig):
     @classmethod
     def from_pretrained(
         cls, pretrained_model_name_or_path: Union[str, os.PathLike], config_type: str = "text_config", **kwargs
-    ) -> "PretrainedConfig":
+    ) -> Self:
         cls._set_token_in_kwargs(kwargs)
 
         config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)


### PR DESCRIPTION
# What does this PR do?

This type is more precise and more accurately captures the type-signature. Without it, in our codebase we get a bunch of type-checking errors like:

```
from transformers import BertForTokenClassification

# Incompatible attribute type [8]: Variable `model` has type `BertForSequenceClassification` but is used as type `PreTrainedModel`
model: BertForTokenClassification = BertForTokenClassification.from_pretrained(...)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts 
