### PR TITLE
Make beam_constraints.Constraint.advance() docstring more accurate

### DIFF
--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -51,7 +51,7 @@ class Constraint(ABC):
         When called, returns the token(s) that would take this constraint one step closer to being fulfilled.
 
         Return:
-            token_ids (Union[int, List[int], None]): 
+            token_ids (Union[int, List[int], None]):
                 - A single token ID (int) that advances the constraint, or
                 - A list of token IDs that could advance the constraint
                 - None if the constraint is completed or cannot be advanced

--- a/src/transformers/generation/beam_constraints.py
+++ b/src/transformers/generation/beam_constraints.py
@@ -48,10 +48,13 @@ class Constraint(ABC):
     @abstractmethod
     def advance(self):
         """
-        When called, returns the token that would take this constraint one step closer to being fulfilled.
+        When called, returns the token(s) that would take this constraint one step closer to being fulfilled.
 
         Return:
-            token_ids(`torch.tensor`): Must be a tensor of a list of indexable tokens, not some integer.
+            token_ids (Union[int, List[int], None]): 
+                - A single token ID (int) that advances the constraint, or
+                - A list of token IDs that could advance the constraint
+                - None if the constraint is completed or cannot be advanced
         """
         raise NotImplementedError(
             f"{self.__class__} is an abstract class. Only classes inheriting this class can be called."


### PR DESCRIPTION
# What does this PR do?
The abstract base class Constraint.advance() docstring indicated that it could only return an integer token_id, when in fact it can return a list of token_ids.


Fixes #32668
https://github.com/huggingface/transformers/issues/32668


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@gante @stevhliu 
