### PR TITLE
make length an integer value before comparison

### DIFF
--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -136,7 +136,7 @@ class EncodecConv1d(nn.Module):
         """Tiny wrapper around torch.nn.functional.pad, just to allow for reflect padding on small input.
         If this is the case, we insert extra 0 padding to the right before the reflection happens.
         """
-        length = hidden_states.shape[-1]
+        length = int(hidden_states.shape[-1])
         padding_left, padding_right = paddings
         if not mode == "reflect":
             return nn.functional.pad(hidden_states, paddings, mode, value)


### PR DESCRIPTION
## What does this PR do?
I am not really sure why `hidden_states.shape[-1]` returns a torch.Tensor value, e.g. tensor(40) on XPU in the following test:

```bash
pytest -rA tests/models/encodec/test_modeling_encodec.py::EncodecModelTest::test_torchscript_simple
```

But I think it doesn't have any downside if we make sure that length is an integer value, since max_pad is an integer for sure. 
The test passes after the fix 
```bash
====================================================== short test summary info =======================================================
PASSED tests/models/encodec/test_modeling_encodec.py::EncodecModelTest::test_torchscript_simple
========================================= 1 passed, 60120 deselected, 17 warnings in 14.22s ==========================================
```

@amyeroberts 