### PR TITLE
Fix: Mamba2 `norm_before_gate` usage

### DIFF
--- a/src/transformers/models/mamba2/configuration_mamba2.py
+++ b/src/transformers/models/mamba2/configuration_mamba2.py
@@ -83,7 +83,7 @@ class Mamba2Config(PretrainedConfig):
             Whether or not to rescale `out_proj` weights when initializing.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the cache should be used.
-        norm_before_gate (`bool`, *optional*, defaults to `True`):
+        norm_before_gate (`bool`, *optional*, defaults to `False`):
             Option of cuda kernels -whether to normalize before the gate or not.
         rms_norm (`bool`, *optional*, defaults to `True`):
             Whether to use RMS norm or not.
@@ -137,7 +137,7 @@ class Mamba2Config(PretrainedConfig):
         time_step_limit=(0.0, float("inf")),
         rescale_prenorm_residual=False,
         use_cache=True,
-        norm_before_gate=True,
+        norm_before_gate=False,
         rms_norm=True,
         chunk_size=256,
         tie_word_embeddings=False,

--- a/src/transformers/models/mamba2/configuration_mamba2.py
+++ b/src/transformers/models/mamba2/configuration_mamba2.py
@@ -83,8 +83,6 @@ class Mamba2Config(PretrainedConfig):
             Whether or not to rescale `out_proj` weights when initializing.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the cache should be used.
-        norm_before_gate (`bool`, *optional*, defaults to `False`):
-            Option of cuda kernels -whether to normalize before the gate or not.
         rms_norm (`bool`, *optional*, defaults to `True`):
             Whether to use RMS norm or not.
         chunk_size (`int`, *optional*, defaults to 256):
@@ -137,7 +135,6 @@ class Mamba2Config(PretrainedConfig):
         time_step_limit=(0.0, float("inf")),
         rescale_prenorm_residual=False,
         use_cache=True,
-        norm_before_gate=False,
         rms_norm=True,
         chunk_size=256,
         tie_word_embeddings=False,
@@ -168,7 +165,6 @@ class Mamba2Config(PretrainedConfig):
         self.n_groups = n_groups
         self.num_heads = num_heads
         self.head_dim = head_dim
-        self.norm_before_gate = norm_before_gate
         self.rms_norm = rms_norm
         self.state_size = state_size
         self.chunk_size = chunk_size

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -255,7 +255,7 @@ class Mamba2Mixer(nn.Module):
         self.A_log = nn.Parameter(torch.log(A))
         self.A_log._no_weight_decay = True
         self.norm = MambaRMSNormGated(
-            self.intermediate_size, eps=self.layer_norm_epsilon, norm_before_gate=config.norm_before_gate
+            self.intermediate_size, eps=self.layer_norm_epsilon, norm_before_gate=self.norm_before_gate
         )
         self.D = nn.Parameter(torch.ones(self.num_heads))
         self.D._no_weight_decay = True

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -170,27 +170,21 @@ class Mamba2Cache:
 
 
 class MambaRMSNormGated(torch.nn.Module):
-    def __init__(self, hidden_size, eps=1e-6, norm_before_gate=False):
+    def __init__(self, hidden_size, eps=1e-6):
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
-        self.norm_before_gate = norm_before_gate
 
     def forward(self, hidden_states, gate=None):
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)
 
-        if gate is not None and not self.norm_before_gate:
+        if gate is not None:
             hidden_states = hidden_states * nn.functional.silu(gate.to(torch.float32))
-
         variance = hidden_states.pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        hidden_states = self.weight * hidden_states
 
-        if gate is not None and self.norm_before_gate:
-            hidden_states = hidden_states * nn.functional.silu(gate.to(torch.float32))
-
-        return hidden_states.to(input_dtype)
+        return self.weight * hidden_states.to(input_dtype)
 
 
 class Mamba2Mixer(nn.Module):
@@ -214,7 +208,6 @@ class Mamba2Mixer(nn.Module):
         self.activation = config.hidden_act
         self.act = ACT2FN[config.hidden_act]
 
-        self.norm_before_gate = config.norm_before_gate
         self.layer_norm_epsilon = config.layer_norm_epsilon
         self.rms_norm = config.rms_norm
 
@@ -254,9 +247,7 @@ class Mamba2Mixer(nn.Module):
         A = torch.arange(1, self.num_heads + 1)
         self.A_log = nn.Parameter(torch.log(A))
         self.A_log._no_weight_decay = True
-        self.norm = MambaRMSNormGated(
-            self.intermediate_size, eps=self.layer_norm_epsilon, norm_before_gate=self.norm_before_gate
-        )
+        self.norm = MambaRMSNormGated(self.intermediate_size, eps=self.layer_norm_epsilon)
         self.D = nn.Parameter(torch.ones(self.num_heads))
         self.D._no_weight_decay = True
 
@@ -355,7 +346,7 @@ class Mamba2Mixer(nn.Module):
                     outproj_bias=self.out_proj.bias,
                     headdim=self.head_dim,
                     ngroups=self.n_groups,
-                    norm_before_gate=self.norm_before_gate,
+                    norm_before_gate=False,
                     return_final_states=True,
                     **dt_limit_kwargs,
                 )


### PR DESCRIPTION
# What does this PR do?
Fixes the default value for norm_before_gate (False) in the default config of mamba2. Additionally, implemented the other variation with norm_before_gate = True. Currently, this only affects continuous training from codestral on the fast path with the fused kernel: https://github.com/huggingface/transformers/blob/20a04497a86dc79adb8a93e31325f25255d317e1/src/transformers/models/mamba2/modeling_mamba2.py#L334-L353 
Discovered in https://github.com/huggingface/transformers/pull/32580#discussion_r1712661960

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
@molbap @ArthurZucker 