### PR TITLE
Fix all_special_tokens to have special tokens from added_tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1343,6 +1343,13 @@ class SpecialTokensMixin:
                 tokens_to_add = [value] if str(value) not in seen else []
             seen.update(map(str, tokens_to_add))
             all_tokens.extend(tokens_to_add)
+
+        for _id, token in self.added_tokens_decoder.items():
+            str_token = str(token)
+            if token.special and str_token not in seen:
+                all_tokens.append(token)
+                seen.add(str_token)
+
         return all_tokens
 
     @property

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -301,10 +301,10 @@ class TokenizerUtilsTest(unittest.TestCase):
         tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-cased")
         old_vocab_size = len(tokenizer.all_special_tokens_extended)
 
-        special_tokens_dict = {'cls_token': '<|CLS|>'}
+        special_tokens_dict = {"cls_token": "<|CLS|>"}
         len_add_tokens = len(special_tokens_dict)
 
         tokenizer.add_special_tokens(special_tokens_dict)
         new_vocab_size = len(tokenizer.all_special_tokens_extended)
 
-        self.assertEqual(new_vocab_size, old_vocab_size + len(len_add_tokens))
+        self.assertEqual(new_vocab_size, old_vocab_size + len_add_tokens)

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -296,3 +296,15 @@ class TokenizerUtilsTest(unittest.TestCase):
                 self.assertEqual(len(tokenizer), tokenizer.vocab_size + 1)
                 self.assertEqual(len(tokenizer.added_tokens_decoder), added_tokens_size + 1)
                 self.assertEqual(len(tokenizer.added_tokens_encoder), added_tokens_size + 1)
+
+    def test_add_special_token(self):
+        tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-cased")
+        old_vocab_size = len(tokenizer.all_special_tokens_extended)
+
+        special_tokens_dict = {'cls_token': '<|CLS|>'}
+        len_add_tokens = len(special_tokens_dict)
+
+        tokenizer.add_special_tokens(special_tokens_dict)
+        new_vocab_size = len(tokenizer.all_special_tokens_extended)
+
+        self.assertEqual(new_vocab_size, old_vocab_size + len(len_add_tokens))


### PR DESCRIPTION
# What does this PR do?

for phi-3 models,
![image](https://github.com/user-attachments/assets/0d89f2e5-d8b3-42a9-b33c-5413b72de1d0)

some important special tokens (such as template tokens `<|assistant|>`) are not in Tokenizer.all_special_tokens

but they re in added_vocab
<img width="1222" alt="image" src="https://github.com/user-attachments/assets/9af81b21-8af1-4d23-a8ba-706841b6d959">

 This PR adds those special tokens in added vocab into special tokens.

if I ran correctly, rust tokenizer implementation find special tokens well.

```rust
eprintln!("{:?}", self.special_tokens_set.iter().collect::<Vec<_>>());

> ["<|placeholder15|>", "<|endoftext|>", "<|placeholder13|>", "<|placeholder16|>", "<|placeholder11|>", "<|placeholder10|>", "<|system|>", "<|placeholder18|>", "<|placeholder23|>", "<|placeholder36|>", "<|image|>", "<|placeholder28|>", "<|placeholder29|>", "<|user|>", "<|placeholder3|>", "<|placeholder7|>", "<|placeholder20|>", "<unk>", "<|placeholder24|>", "<|placeholder25|>", "<|placeholder26|>", "<|placeholder1|>", "<|placeholder33|>", "<|placeholder37|>", "<|placeholder12|>", "<|placeholder32|>", "<|placeholder39|>", "<|placeholder27|>", "<|placeholder5|>", "<s>", "<|assistant|>", "<|placeholder38|>", "<|end|>", "<|placeholder14|>", "<|placeholder4|>", "<|placeholder9|>", "<|placeholder2|>", "<|placeholder22|>", "<|placeholder31|>", "<|placeholder34|>", "<|placeholder21|>", "<|placeholder8|>", "<|placeholder6|>", "<|placeholder17|>", "<|placeholder19|>", "<|placeholder30|>", "<|placeholder35|>"]
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
