### PR TITLE
Fix: modeling tests

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2784,9 +2784,9 @@ class ModelTesterMixin:
             model.to(torch_device)
             model.eval()
 
-            model_forward_args = inspect.signature(model.forward).parameters
-            if "inputs_embeds" not in model_forward_args:
-                self.skipTest(reason="This model doesn't use `inputs_embeds`")
+            model_generation_args = inspect.signature(model.prepare_inputs_for_generation).parameters
+            if "inputs_embeds" not in model_generation_args:
+                self.skipTest(reason="This model doesn't use `inputs_embeds` for generation")
 
             inputs = copy.deepcopy(self._prepare_for_class(inputs_dict, model_class))
             pad_token_id = config.pad_token_id if config.pad_token_id is not None else 1


### PR DESCRIPTION
# What does this PR do?

Currently the `test_inputs_embeds_matches_input_ids` is failing for some models that support inputs embeds in forward, but not in generate. This PR skips those tests

We could technically add support to generate from embeds for those models, but since there's no request from users I decided not to spend time on that and better skip tests