### PR TITLE
Add option for running ffmpeg_microphone_live as a background process

### DIFF
--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -51,7 +51,7 @@ def ffmpeg_microphone(
     chunk_length_s: float,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    background_arg: Optional[str] = None
+    background_arg: Optional[str] = None,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. The default input device will be used unless another
@@ -120,7 +120,7 @@ def ffmpeg_microphone(
         "-loglevel",
         "quiet",
         "pipe:1",
-        stdin_arg
+        stdin_arg,
     ]
     chunk_len = int(round(sampling_rate * chunk_length_s)) * size_of_sample
     iterator = _ffmpeg_stream(ffmpeg_command, chunk_len)
@@ -135,7 +135,7 @@ def ffmpeg_microphone_live(
     stride_length_s: Optional[Union[Tuple[float, float], float]] = None,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    run_in_background: Optional[bool] = False
+    run_in_background: Optional[bool] = False,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. This will output `partial` overlapping chunks starting
@@ -183,16 +183,18 @@ def ffmpeg_microphone_live(
 
     if run_in_background:
         microphone = ffmpeg_microphone(
-            sampling_rate, chunk_s,
+            sampling_rate,
+            chunk_s,
             format_for_conversion=format_for_conversion,
             ffmpeg_input_device=ffmpeg_input_device,
-            background_arg="-nostdin"
+            background_arg="-nostdin",
         )
     else:
         microphone = ffmpeg_microphone(
-            sampling_rate, chunk_s,
+            sampling_rate,
+            chunk_s,
             format_for_conversion=format_for_conversion,
-            ffmpeg_input_device=ffmpeg_input_device
+            ffmpeg_input_device=ffmpeg_input_device,
         )
 
     if format_for_conversion == "s16le":

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -71,7 +71,7 @@ def ffmpeg_microphone(
             The indentifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
             the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
             for how to specify and list input devices.
-        ffmpeg_additional_args (`list`, *optional*):
+        ffmpeg_additional_args (`list[str]`, *optional*):
             Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
             process. For example, to pass -nostdin to the ffmpeg process, pass in ["-nostdin"]. If passing in flags
             with multiple arguments, use the following convention (eg ["flag", "arg1", "arg2]).
@@ -165,7 +165,7 @@ def ffmpeg_microphone_live(
             The identifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
             the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
             for how to specify and list input devices.
-        ffmpeg_additional_args (`list`, *optional*):
+        ffmpeg_additional_args (`list[str]`, *optional*):
             Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
             process. For example, to pass -nostdin to the ffmpeg process, pass in ["-nostdin"]. If passing in flags
             with multiple arguments, use the following convention (eg ["flag", "arg1", "arg2]).

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -51,7 +51,7 @@ def ffmpeg_microphone(
     chunk_length_s: float,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    background_arg: Optional[str] = None,
+    run_in_background: Optional[str] = None,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. The default input device will be used unless another
@@ -71,7 +71,7 @@ def ffmpeg_microphone(
             The indentifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
             the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
             for how to specify and list input devices.
-        background_arg (`str`, *optional*):
+        run_in_background (`str`, *optional*):
             The argument passed to ffmpeg that determines whether or not the process is run in the background
             or not. Default is the empty string and the only other option is -nostdin
 
@@ -118,7 +118,7 @@ def ffmpeg_microphone(
         "-loglevel",
         "quiet",
         "pipe:1",
-        background_arg,
+        run_in_background,
     ]
     chunk_len = int(round(sampling_rate * chunk_length_s)) * size_of_sample
     iterator = _ffmpeg_stream(ffmpeg_command, chunk_len)
@@ -178,14 +178,13 @@ def ffmpeg_microphone_live(
     else:
         chunk_s = chunk_length_s
 
-    if run_in_background:
-        microphone = ffmpeg_microphone(
-            sampling_rate,
-            chunk_s,
-            format_for_conversion=format_for_conversion,
-            ffmpeg_input_device=ffmpeg_input_device,
-            run_in_background="-nostdin" if not run_in_background else "",
-        )
+    microphone = ffmpeg_microphone(
+        sampling_rate,
+        chunk_s,
+        format_for_conversion=format_for_conversion,
+        ffmpeg_input_device=ffmpeg_input_device,
+        run_in_background="-nostdin" if not run_in_background else "",
+    )
 
     if format_for_conversion == "s16le":
         dtype = np.int16

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -100,8 +100,6 @@ def ffmpeg_microphone(
         format_ = "dshow"
         input_ = ffmpeg_input_device or _get_microphone_name()
 
-    stdin_arg = str(background_arg or "")
-
     ffmpeg_command = [
         "ffmpeg",
         "-f",
@@ -120,7 +118,7 @@ def ffmpeg_microphone(
         "-loglevel",
         "quiet",
         "pipe:1",
-        stdin_arg,
+        background_arg,
     ]
     chunk_len = int(round(sampling_rate * chunk_length_s)) * size_of_sample
     iterator = _ffmpeg_stream(ffmpeg_command, chunk_len)
@@ -135,7 +133,7 @@ def ffmpeg_microphone_live(
     stride_length_s: Optional[Union[Tuple[float, float], float]] = None,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    run_in_background: Optional[bool] = False,
+    run_in_background: Optional[str] = None,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. This will output `partial` overlapping chunks starting
@@ -163,9 +161,8 @@ def ffmpeg_microphone_live(
             the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
             for how to specify and list input devices.
         run_in_background (`bool`, *optional*):
-            The boolean to determine whether or not to run the ffmpeg command in the background. If set to true,
-            ffmpeg will not use STDIN as its input (useful for when other processes are using STDIN). If unset,
-            ffmpeg will run using STDIN.
+            The argument passed to ffmpeg that determines whether or not the process is run in the background
+            or not. Default is the empty string (ffmpeg uses STDIN by default) and the only other option is -nostdin.
 
     Return:
         A generator yielding dictionaries of the following form
@@ -187,14 +184,7 @@ def ffmpeg_microphone_live(
             chunk_s,
             format_for_conversion=format_for_conversion,
             ffmpeg_input_device=ffmpeg_input_device,
-            background_arg="-nostdin",
-        )
-    else:
-        microphone = ffmpeg_microphone(
-            sampling_rate,
-            chunk_s,
-            format_for_conversion=format_for_conversion,
-            ffmpeg_input_device=ffmpeg_input_device,
+            run_in_background="-nostdin" if not run_in_background else "",
         )
 
     if format_for_conversion == "s16le":

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -31,10 +31,14 @@ def ffmpeg_read(bpayload: bytes, sampling_rate: int) -> np.array:
     ]
 
     try:
-        with subprocess.Popen(ffmpeg_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as ffmpeg_process:
+        with subprocess.Popen(
+            ffmpeg_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        ) as ffmpeg_process:
             output_stream = ffmpeg_process.communicate(bpayload)
     except FileNotFoundError as error:
-        raise ValueError("ffmpeg was not found but is required to load audio files from filename") from error
+        raise ValueError(
+            "ffmpeg was not found but is required to load audio files from filename"
+        ) from error
     out_bytes = output_stream[0]
     audio = np.frombuffer(out_bytes, np.float32)
     if audio.shape[0] == 0:
@@ -86,7 +90,9 @@ def ffmpeg_microphone(
     elif format_for_conversion == "f32le":
         size_of_sample = 4
     else:
-        raise ValueError(f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`")
+        raise ValueError(
+            f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`"
+        )
 
     system = platform.system()
 
@@ -181,7 +187,7 @@ def ffmpeg_microphone_live(
         chunk_s,
         format_for_conversion=format_for_conversion,
         ffmpeg_input_device=ffmpeg_input_device,
-        ffmpeg_additional_args=ffmpeg_additional_args
+        ffmpeg_additional_args=ffmpeg_additional_args,
     )
 
     if format_for_conversion == "s16le":
@@ -191,7 +197,9 @@ def ffmpeg_microphone_live(
         dtype = np.float32
         size_of_sample = 4
     else:
-        raise ValueError(f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`")
+        raise ValueError(
+            f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`"
+        )
 
     if stride_length_s is None:
         stride_length_s = chunk_length_s / 6
@@ -203,7 +211,9 @@ def ffmpeg_microphone_live(
     stride_right = int(round(sampling_rate * stride_length_s[1])) * size_of_sample
     audio_time = datetime.datetime.now()
     delta = datetime.timedelta(seconds=chunk_s)
-    for item in chunk_bytes_iter(microphone, chunk_len, stride=(stride_left, stride_right), stream=True):
+    for item in chunk_bytes_iter(
+        microphone, chunk_len, stride=(stride_left, stride_right), stream=True
+    ):
         # Put everything back in numpy scale
         item["raw"] = np.frombuffer(item["raw"], dtype=dtype)
         item["stride"] = (
@@ -218,7 +228,9 @@ def ffmpeg_microphone_live(
         yield item
 
 
-def chunk_bytes_iter(iterator, chunk_len: int, stride: Tuple[int, int], stream: bool = False):
+def chunk_bytes_iter(
+    iterator, chunk_len: int, stride: Tuple[int, int], stream: bool = False
+):
     """
     Reads raw bytes from an iterator and does chunks of length `chunk_len`. Optionally adds `stride` to each chunks to
     get overlaps. `stream` is used to return partial results even if a full `chunk_len` is not yet available.
@@ -259,14 +271,18 @@ def _ffmpeg_stream(ffmpeg_command, buflen: int):
     """
     bufsize = 2**24  # 16Mo
     try:
-        with subprocess.Popen(ffmpeg_command, stdout=subprocess.PIPE, bufsize=bufsize) as ffmpeg_process:
+        with subprocess.Popen(
+            ffmpeg_command, stdout=subprocess.PIPE, bufsize=bufsize
+        ) as ffmpeg_process:
             while True:
                 raw = ffmpeg_process.stdout.read(buflen)
                 if raw == b"":
                     break
                 yield raw
     except FileNotFoundError as error:
-        raise ValueError("ffmpeg was not found but is required to stream audio files from filename") from error
+        raise ValueError(
+            "ffmpeg was not found but is required to stream audio files from filename"
+        ) from error
 
 
 def _get_microphone_name():
@@ -276,14 +292,20 @@ def _get_microphone_name():
     command = ["ffmpeg", "-list_devices", "true", "-f", "dshow", "-i", ""]
 
     try:
-        ffmpeg_devices = subprocess.run(command, text=True, stderr=subprocess.PIPE, encoding="utf-8")
-        microphone_lines = [line for line in ffmpeg_devices.stderr.splitlines() if "(audio)" in line]
+        ffmpeg_devices = subprocess.run(
+            command, text=True, stderr=subprocess.PIPE, encoding="utf-8"
+        )
+        microphone_lines = [
+            line for line in ffmpeg_devices.stderr.splitlines() if "(audio)" in line
+        ]
 
         if microphone_lines:
             microphone_name = microphone_lines[0].split('"')[1]
             print(f"Using microphone: {microphone_name}")
             return f"audio={microphone_name}"
     except FileNotFoundError:
-        print("ffmpeg was not found. Please install it or make sure it is in your system PATH.")
+        print(
+            "ffmpeg was not found. Please install it or make sure it is in your system PATH."
+        )
 
     return "default"

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -31,14 +31,10 @@ def ffmpeg_read(bpayload: bytes, sampling_rate: int) -> np.array:
     ]
 
     try:
-        with subprocess.Popen(
-            ffmpeg_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
-        ) as ffmpeg_process:
+        with subprocess.Popen(ffmpeg_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as ffmpeg_process:
             output_stream = ffmpeg_process.communicate(bpayload)
     except FileNotFoundError as error:
-        raise ValueError(
-            "ffmpeg was not found but is required to load audio files from filename"
-        ) from error
+        raise ValueError("ffmpeg was not found but is required to load audio files from filename") from error
     out_bytes = output_stream[0]
     audio = np.frombuffer(out_bytes, np.float32)
     if audio.shape[0] == 0:
@@ -55,7 +51,7 @@ def ffmpeg_microphone(
     chunk_length_s: float,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    ffmpeg_additional_args: Optional[list] = [],
+    ffmpeg_additional_args: Optional[list[str]] = None,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. The default input device will be used unless another
@@ -77,7 +73,8 @@ def ffmpeg_microphone(
             for how to specify and list input devices.
         ffmpeg_additional_args (`list`, *optional*):
             Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
-            process.
+            process. For example, to pass -nostdin to the ffmpeg process, pass in ["-nostdin"]. If passing in flags
+            with multiple arguments, use the following convention (eg ["flag", "arg1", "arg2]).
 
     Returns:
         A generator yielding audio chunks of `chunk_length_s` seconds as `bytes` objects of length
@@ -90,9 +87,7 @@ def ffmpeg_microphone(
     elif format_for_conversion == "f32le":
         size_of_sample = 4
     else:
-        raise ValueError(
-            f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`"
-        )
+        raise ValueError(f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`")
 
     system = platform.system()
 
@@ -105,6 +100,8 @@ def ffmpeg_microphone(
     elif system == "Windows":
         format_ = "dshow"
         input_ = ffmpeg_input_device or _get_microphone_name()
+
+    ffmpeg_additional_args = [] if ffmpeg_additional_args is None else ffmpeg_additional_args
 
     ffmpeg_command = [
         "ffmpeg",
@@ -141,7 +138,7 @@ def ffmpeg_microphone_live(
     stride_length_s: Optional[Union[Tuple[float, float], float]] = None,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    ffmpeg_additional_args: Optional[list] = [],
+    ffmpeg_additional_args: Optional[list[str]] = None,
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. This will output `partial` overlapping chunks starting
@@ -164,9 +161,14 @@ def ffmpeg_microphone_live(
         format_for_conversion (`str`, *optional*, defaults to `f32le`):
             The name of the format of the audio samples to be returned by ffmpeg. The standard is `f32le`, `s16le`
             could also be used.
+        ffmpeg_input_device (`str`, *optional*):
+            The identifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
+            the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
+            for how to specify and list input devices.
         ffmpeg_additional_args (`list`, *optional*):
             Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
-            process.
+            process. For example, to pass -nostdin to the ffmpeg process, pass in ["-nostdin"]. If passing in flags
+            with multiple arguments, use the following convention (eg ["flag", "arg1", "arg2]).
 
     Return:
         A generator yielding dictionaries of the following form
@@ -187,7 +189,7 @@ def ffmpeg_microphone_live(
         chunk_s,
         format_for_conversion=format_for_conversion,
         ffmpeg_input_device=ffmpeg_input_device,
-        ffmpeg_additional_args=ffmpeg_additional_args,
+        ffmpeg_additional_args=[] if ffmpeg_additional_args is None else ffmpeg_additional_args,
     )
 
     if format_for_conversion == "s16le":
@@ -197,9 +199,7 @@ def ffmpeg_microphone_live(
         dtype = np.float32
         size_of_sample = 4
     else:
-        raise ValueError(
-            f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`"
-        )
+        raise ValueError(f"Unhandled format `{format_for_conversion}`. Please use `s16le` or `f32le`")
 
     if stride_length_s is None:
         stride_length_s = chunk_length_s / 6
@@ -211,9 +211,7 @@ def ffmpeg_microphone_live(
     stride_right = int(round(sampling_rate * stride_length_s[1])) * size_of_sample
     audio_time = datetime.datetime.now()
     delta = datetime.timedelta(seconds=chunk_s)
-    for item in chunk_bytes_iter(
-        microphone, chunk_len, stride=(stride_left, stride_right), stream=True
-    ):
+    for item in chunk_bytes_iter(microphone, chunk_len, stride=(stride_left, stride_right), stream=True):
         # Put everything back in numpy scale
         item["raw"] = np.frombuffer(item["raw"], dtype=dtype)
         item["stride"] = (
@@ -228,9 +226,7 @@ def ffmpeg_microphone_live(
         yield item
 
 
-def chunk_bytes_iter(
-    iterator, chunk_len: int, stride: Tuple[int, int], stream: bool = False
-):
+def chunk_bytes_iter(iterator, chunk_len: int, stride: Tuple[int, int], stream: bool = False):
     """
     Reads raw bytes from an iterator and does chunks of length `chunk_len`. Optionally adds `stride` to each chunks to
     get overlaps. `stream` is used to return partial results even if a full `chunk_len` is not yet available.
@@ -271,18 +267,14 @@ def _ffmpeg_stream(ffmpeg_command, buflen: int):
     """
     bufsize = 2**24  # 16Mo
     try:
-        with subprocess.Popen(
-            ffmpeg_command, stdout=subprocess.PIPE, bufsize=bufsize
-        ) as ffmpeg_process:
+        with subprocess.Popen(ffmpeg_command, stdout=subprocess.PIPE, bufsize=bufsize) as ffmpeg_process:
             while True:
                 raw = ffmpeg_process.stdout.read(buflen)
                 if raw == b"":
                     break
                 yield raw
     except FileNotFoundError as error:
-        raise ValueError(
-            "ffmpeg was not found but is required to stream audio files from filename"
-        ) from error
+        raise ValueError("ffmpeg was not found but is required to stream audio files from filename") from error
 
 
 def _get_microphone_name():
@@ -292,20 +284,14 @@ def _get_microphone_name():
     command = ["ffmpeg", "-list_devices", "true", "-f", "dshow", "-i", ""]
 
     try:
-        ffmpeg_devices = subprocess.run(
-            command, text=True, stderr=subprocess.PIPE, encoding="utf-8"
-        )
-        microphone_lines = [
-            line for line in ffmpeg_devices.stderr.splitlines() if "(audio)" in line
-        ]
+        ffmpeg_devices = subprocess.run(command, text=True, stderr=subprocess.PIPE, encoding="utf-8")
+        microphone_lines = [line for line in ffmpeg_devices.stderr.splitlines() if "(audio)" in line]
 
         if microphone_lines:
             microphone_name = microphone_lines[0].split('"')[1]
             print(f"Using microphone: {microphone_name}")
             return f"audio={microphone_name}"
     except FileNotFoundError:
-        print(
-            "ffmpeg was not found. Please install it or make sure it is in your system PATH."
-        )
+        print("ffmpeg was not found. Please install it or make sure it is in your system PATH.")
 
     return "default"

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -51,7 +51,7 @@ def ffmpeg_microphone(
     chunk_length_s: float,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    run_in_background: Optional[str] = None,
+    ffmpeg_additional_args: Optional[list] = [],
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. The default input device will be used unless another
@@ -71,9 +71,9 @@ def ffmpeg_microphone(
             The indentifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
             the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
             for how to specify and list input devices.
-        run_in_background (`str`, *optional*):
-            The argument passed to ffmpeg that determines whether or not the process is run in the background
-            or not. Default is the empty string and the only other option is -nostdin
+        ffmpeg_additional_args (`list`, *optional*):
+            Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
+            process.
 
     Returns:
         A generator yielding audio chunks of `chunk_length_s` seconds as `bytes` objects of length
@@ -118,8 +118,9 @@ def ffmpeg_microphone(
         "-loglevel",
         "quiet",
         "pipe:1",
-        run_in_background,
     ]
+    ffmpeg_command.extend(ffmpeg_additional_args)
+
     chunk_len = int(round(sampling_rate * chunk_length_s)) * size_of_sample
     iterator = _ffmpeg_stream(ffmpeg_command, chunk_len)
     for item in iterator:
@@ -133,7 +134,7 @@ def ffmpeg_microphone_live(
     stride_length_s: Optional[Union[Tuple[float, float], float]] = None,
     format_for_conversion: str = "f32le",
     ffmpeg_input_device: Optional[str] = None,
-    run_in_background: Optional[str] = None,
+    ffmpeg_additional_args: Optional[list] = [],
 ):
     """
     Helper function to read audio from a microphone using ffmpeg. This will output `partial` overlapping chunks starting
@@ -156,13 +157,9 @@ def ffmpeg_microphone_live(
         format_for_conversion (`str`, *optional*, defaults to `f32le`):
             The name of the format of the audio samples to be returned by ffmpeg. The standard is `f32le`, `s16le`
             could also be used.
-        ffmpeg_input_device (`str`, *optional*):
-            The identifier of the input device to be used by ffmpeg (i.e. ffmpeg's '-i' argument). If unset,
-            the default input device will be used. See `https://www.ffmpeg.org/ffmpeg-devices.html#Input-Devices`
-            for how to specify and list input devices.
-        run_in_background (`bool`, *optional*):
-            The argument passed to ffmpeg that determines whether or not the process is run in the background
-            or not. Default is the empty string (ffmpeg uses STDIN by default) and the only other option is -nostdin.
+        ffmpeg_additional_args (`list`, *optional*):
+            Additional arguments to pass to ffmpeg, can include arguments like -nostdin for running as a background
+            process.
 
     Return:
         A generator yielding dictionaries of the following form
@@ -183,7 +180,7 @@ def ffmpeg_microphone_live(
         chunk_s,
         format_for_conversion=format_for_conversion,
         ffmpeg_input_device=ffmpeg_input_device,
-        run_in_background="-nostdin" if not run_in_background else "",
+        ffmpeg_additional_args=ffmpeg_additional_args
     )
 
     if format_for_conversion == "s16le":

--- a/src/transformers/pipelines/audio_utils.py
+++ b/src/transformers/pipelines/audio_utils.py
@@ -119,6 +119,7 @@ def ffmpeg_microphone(
         "quiet",
         "pipe:1",
     ]
+
     ffmpeg_command.extend(ffmpeg_additional_args)
 
     chunk_len = int(round(sampling_rate * chunk_length_s)) * size_of_sample

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -36,7 +36,7 @@ from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
 from transformers.pipelines.audio_utils import chunk_bytes_iter, ffmpeg_microphone_live
 from transformers.pipelines.automatic_speech_recognition import _find_timestamp_sequence, chunk_iter
 from transformers.testing_utils import (
-    # compare_pipeline_output_to_hub_spec,
+    compare_pipeline_output_to_hub_spec,
     is_pipeline_test,
     is_torch_available,
     nested_simplify,
@@ -100,7 +100,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         outputs = speech_recognizer(audio)
         self.assertEqual(outputs, {"text": ANY(str)})
 
-        # compare_pipeline_output_to_hub_spec(outputs, AutomaticSpeechRecognitionOutput)
+        compare_pipeline_output_to_hub_spec(outputs, AutomaticSpeechRecognitionOutput)
 
         # Striding
         audio = {"raw": audio, "stride": (0, 4000), "sampling_rate": speech_recognizer.feature_extractor.sampling_rate}

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -33,10 +33,10 @@ from transformers import (
     WhisperForConditionalGeneration,
 )
 from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
-from transformers.pipelines.audio_utils import chunk_bytes_iter
+from transformers.pipelines.audio_utils import chunk_bytes_iter, ffmpeg_microphone_live
 from transformers.pipelines.automatic_speech_recognition import _find_timestamp_sequence, chunk_iter
 from transformers.testing_utils import (
-    compare_pipeline_output_to_hub_spec,
+    # compare_pipeline_output_to_hub_spec,
     is_pipeline_test,
     is_torch_available,
     nested_simplify,
@@ -100,7 +100,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         outputs = speech_recognizer(audio)
         self.assertEqual(outputs, {"text": ANY(str)})
 
-        compare_pipeline_output_to_hub_spec(outputs, AutomaticSpeechRecognitionOutput)
+        # compare_pipeline_output_to_hub_spec(outputs, AutomaticSpeechRecognitionOutput)
 
         # Striding
         audio = {"raw": audio, "stride": (0, 4000), "sampling_rate": speech_recognizer.feature_extractor.sampling_rate}
@@ -1989,3 +1989,11 @@ class AudioUtilsTest(unittest.TestCase):
         )
         with self.assertRaises(StopIteration):
             next(iter_)
+
+    def test_ffmpeg_no_additional_args(self):
+        mic = ffmpeg_microphone_live(16000, 2.0)
+        mic.close()
+
+    def test_ffmpeg_additional_args(self):
+        mic = ffmpeg_microphone_live(16000, 2.0, ffmpeg_additional_args=["-nostdin"])
+        mic.close()


### PR DESCRIPTION
# What does this PR do?
Gives the options for developers using audio_utils to fun `ffmpeg_microphone_live` as a background process instead of defaulting to STDIN which is the default option for ffmpeg. Useful for cases when running a different process that is using STDIN. The default case behavior is the same and now `ffmpeg_microphone_live` takes a boolean argument that allows the ffmpeg equivalent of passing in `-nostdin`.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #30061 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- pipelines: @Narsil

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
