### PR TITLE
Uniformize model processors (models *with* special arg names) 

### DIFF
--- a/src/transformers/models/clipseg/processing_clipseg.py
+++ b/src/transformers/models/clipseg/processing_clipseg.py
@@ -20,8 +20,8 @@ import sys
 import warnings
 from typing import List, Optional, Union
 
-from ...image_utils import ImageInput
 from ...feature_extraction_utils import BatchFeature
+from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
@@ -109,11 +109,12 @@ class CLIPSegProcessor(ProcessorMixin):
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:
 
-            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None` and `visual_prompt` is `None`.
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
-              `None`).
+              `None`) and `visual_prompt` is `None`.
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **conditional_pixel_values** -- Conditional pixel values to be fed to a model. Returned when `visual_prompt` is not `None`.
         """
 
         output_kwargs = self._merge_kwargs(
@@ -145,7 +146,7 @@ class CLIPSegProcessor(ProcessorMixin):
                 "pixel_values": image_features.pixel_values,
                 "conditional_pixel_values": prompt_features.pixel_values,
             }
-            return encoding
+            return BatchFeature(data=encoding, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
         elif text is not None and images is not None:
             encoding["pixel_values"] = image_features.pixel_values
             return encoding
@@ -155,7 +156,7 @@ class CLIPSegProcessor(ProcessorMixin):
             encoding = {
                 "conditional_pixel_values": prompt_features.pixel_values,
             }
-            return encoding
+            return BatchFeature(data=encoding, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
         else:
             return BatchFeature(
                 data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"].get("return_tensors")

--- a/src/transformers/models/clipseg/processing_clipseg.py
+++ b/src/transformers/models/clipseg/processing_clipseg.py
@@ -21,8 +21,9 @@ import warnings
 from typing import List, Optional, Union
 
 from ...image_utils import ImageInput
+from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
 
 if sys.version_info >= (3, 11):
@@ -106,7 +107,7 @@ class CLIPSegProcessor(ProcessorMixin):
                 (C, H, W), where C is a number of channels, H and W are image height and width.
 
         Returns:
-            [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
 
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
@@ -156,7 +157,7 @@ class CLIPSegProcessor(ProcessorMixin):
             }
             return encoding
         else:
-            return BatchEncoding(
+            return BatchFeature(
                 data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"].get("return_tensors")
             )
 

--- a/src/transformers/models/donut/image_processing_donut.py
+++ b/src/transformers/models/donut/image_processing_donut.py
@@ -183,6 +183,7 @@ class DonutImageProcessor(BaseImageProcessor):
             input_data_format (`ChannelDimension` or `str`, *optional*):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
+        size = get_size_dict(size)
         output_height, output_width = size["height"], size["width"]
         input_height, input_width = get_image_size(image, channel_dim=input_data_format)
 
@@ -232,6 +233,7 @@ class DonutImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         input_height, input_width = get_image_size(image, channel_dim=input_data_format)
+        size = get_size_dict(size)
         output_height, output_width = size["height"], size["width"]
 
         # We always resize to the smallest of either the input or output size.

--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Union
 
 import numpy as np
 
-from ...image_processing_utils import BaseImageProcessor, BatchFeature
+from ...image_processing_utils import BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import (
     pad,
     resize,
@@ -344,6 +344,7 @@ class FuyuImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         image_height, image_width = get_image_size(image, input_data_format)
+        size = get_size_dict(size)
         target_height, target_width = size["height"], size["width"]
         padding_top = 0
         padding_left = 0

--- a/src/transformers/models/nougat/image_processing_nougat.py
+++ b/src/transformers/models/nougat/image_processing_nougat.py
@@ -250,6 +250,7 @@ class NougatImageProcessor(BaseImageProcessor):
             input_data_format (`ChannelDimension` or `str`, *optional*):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
+        size = get_size_dict(size)
         output_height, output_width = size["height"], size["width"]
         input_height, input_width = get_image_size(image, channel_dim=input_data_format)
 
@@ -292,6 +293,7 @@ class NougatImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         input_height, input_width = get_image_size(image, channel_dim=input_data_format)
+        size = get_size_dict(size)
         output_height, output_width = size["height"], size["width"]
 
         # We always resize to the smallest of either the input or output size.

--- a/src/transformers/models/nougat/processing_nougat.py
+++ b/src/transformers/models/nougat/processing_nougat.py
@@ -71,8 +71,8 @@ class NougatProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "tokenizer"]
-    image_processor_class = "AutoImageProcessor"
-    tokenizer_class = "AutoTokenizer"
+    image_processor_class = "NougatImageProcessor"
+    tokenizer_class = "NougatTokenizerFast"
 
     def __init__(self, image_processor, tokenizer):
         super().__init__(image_processor, tokenizer)
@@ -86,6 +86,32 @@ class NougatProcessor(ProcessorMixin):
         videos=None,
         **kwargs: Unpack[NougatProcessorKwargs],
     ):
+        """
+        Main method to prepare for the model one or several text(s) and image(s). This method forwards the `text` and
+        `kwargs` arguments to NougatTokenizerFast's [`~NougatTokenizerFast.__call__`] if `text` is not `None` to encode
+        the text. To prepare the image(s), this method forwards the `images` and `kwrags` arguments to
+        NougatImageProcessor's [`~NougatImageProcessor.__call__`] if `images` is not `None`. Please refer to the doctsring
+        of the above two methods for more information.
+
+        Args:
+            text (`str`, `List[str]`, `List[List[str]]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`,
+            `List[torch.Tensor]`, *optional*):
+                The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
+                tensor. Both channels-first and channels-last formats are supported.
+
+        Returns:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
+              `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
+              `None`).
+            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **labels** -- List of label token ids to be fed to a model. Returned when both `text` and `images` are not `None`.
+        """
         if images is None and text is None:
             raise ValueError("You need to specify either an `images` or `text` input to process.")
 

--- a/src/transformers/models/nougat/processing_nougat.py
+++ b/src/transformers/models/nougat/processing_nougat.py
@@ -103,7 +103,11 @@ class NougatProcessor(ProcessorMixin):
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,
             **kwargs,
         )
+        # Temporary fix for "paddding_side" in init_kwargs
+        _ = output_kwargs["text_kwargs"].pop("padding_side", None)
 
+        # For backwards compatibility, we reuse `audio` as `text_pair`
+        # in case downstream users passed it as a positional argument
         if output_kwargs["text_kwargs"].get("text_pair") is not None and audio is not None:
             raise ValueError(
                 "You cannot provide `text_pair` as a positional argument and as a keyword argument at the same time."
@@ -113,11 +117,11 @@ class NougatProcessor(ProcessorMixin):
             warnings.warn(
                 "No `text_pair` kwarg was detected. The use of `text_pair` as an argument without specifying it explicitely as `text_pair=` will be deprecated in future versions."
             )
-            # For backwards compatibility, we reuse `audio` as `text_pair` in case
-            # downstream users passed it as a positional argument
             if audio is not None:
                 output_kwargs["text_kwargs"]["text_pair"] = audio
 
+        # For backwards compatibility, we reuse `videos` as `text_target`
+        # in case downstream users passed it as a positional argument
         if output_kwargs["text_kwargs"].get("text_target") is not None and videos is not None:
             raise ValueError(
                 "You cannot provide `text_target` as a positional argument and as a keyword argument at the same time."
@@ -127,11 +131,11 @@ class NougatProcessor(ProcessorMixin):
             warnings.warn(
                 "No `text_target` kwarg was detected. The use of `text_target` as an argument without specifying it explicitely as `text_target=` will be deprecated in future versions."
             )
-            # For backwards compatibility, we reuse `videos` as `text_target` in case
-            # downstream users passed it as a positional argument
             if videos is not None:
                 output_kwargs["text_kwargs"]["text_target"] = videos
 
+        # For backwards compatibility, we reuse `backwards_compatibility_placeholder_arg` as `text_pair_target`
+        # in case downstream users passed it as a positional argument
         if (
             output_kwargs["text_kwargs"].get("text_pair_target") is not None
             and backwards_compatibility_placeholder_arg is not None
@@ -144,8 +148,6 @@ class NougatProcessor(ProcessorMixin):
             warnings.warn(
                 "No `text_pair_target` kwarg was detected. The use of `text_pair_target` as an argument without specifying it explicitely as `text_pair_target=` will be deprecated in future versions."
             )
-            # For backwards compatibility, we reuse `backwards_compatibility_placeholder_arg` as `text_pair_target` in case
-            # downstream users passed it as a positional argument
             if backwards_compatibility_placeholder_arg is not None:
                 output_kwargs["text_kwargs"]["text_pair_target"] = backwards_compatibility_placeholder_arg
 

--- a/src/transformers/models/nougat/processing_nougat.py
+++ b/src/transformers/models/nougat/processing_nougat.py
@@ -16,12 +16,52 @@
 Processor class for Nougat.
 """
 
-from typing import Dict, List, Optional, Union
+import sys
+import warnings
+from typing import List, Optional, Union
 
-from transformers.tokenization_utils_base import PreTokenizedInput, TextInput, TruncationStrategy
+from ...image_utils import ImageInput
+from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin, TextKwargs
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
-from ...processing_utils import ProcessorMixin
-from ...utils import PaddingStrategy, TensorType
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class NougatTextKwargs(TextKwargs, total=False):
+    text_pair: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]]
+    text_target: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]]
+    text_pair_target: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]]
+
+
+class NougatImagesKwargs(ImagesKwargs, total=False):
+    do_crop_margin: Optional[bool]
+    do_thumbnail: Optional[bool]
+    do_align_long_axis: Optional[bool]
+
+
+class NougatProcessorKwargs(ProcessingKwargs, total=False):
+    text_kwargs: NougatTextKwargs
+    images_kwargs: NougatImagesKwargs
+    _defaults = {
+        "text_kwargs": {
+            "add_special_tokens": True,
+            "padding": False,
+            "stride": 0,
+            "is_split_into_words": False,
+            "return_overflowing_tokens": False,
+            "return_special_tokens_mask": False,
+            "return_offsets_mapping": False,
+            "return_length": False,
+            "verbose": True,
+        },
+        "images_kwargs": {
+            "data_format": "channels_first",
+        },
+    }
 
 
 class NougatProcessor(ProcessorMixin):
@@ -48,86 +88,80 @@ class NougatProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        images=None,
-        text=None,
-        do_crop_margin: bool = None,
-        do_resize: bool = None,
-        size: Dict[str, int] = None,
-        resample: "PILImageResampling" = None,  # noqa: F821
-        do_thumbnail: bool = None,
-        do_align_long_axis: bool = None,
-        do_pad: bool = None,
-        do_rescale: bool = None,
-        rescale_factor: Union[int, float] = None,
-        do_normalize: bool = None,
-        image_mean: Optional[Union[float, List[float]]] = None,
-        image_std: Optional[Union[float, List[float]]] = None,
-        data_format: Optional["ChannelDimension"] = "channels_first",  # noqa: F821
-        input_data_format: Optional[Union[str, "ChannelDimension"]] = None,  # noqa: F821
-        text_pair: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
-        text_target: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
-        text_pair_target: Optional[
-            Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]
-        ] = None,
-        add_special_tokens: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy] = None,
-        max_length: Optional[int] = None,
-        stride: int = 0,
-        is_split_into_words: bool = False,
-        pad_to_multiple_of: Optional[int] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
-        return_overflowing_tokens: bool = False,
-        return_special_tokens_mask: bool = False,
-        return_offsets_mapping: bool = False,
-        return_length: bool = False,
-        verbose: bool = True,
+        images: Optional[ImageInput] = None,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        audio=None,
+        videos=None,
+        backwards_compatibility_placeholder_arg=None,
+        **kwargs: Unpack[NougatProcessorKwargs],
     ):
         if images is None and text is None:
             raise ValueError("You need to specify either an `images` or `text` input to process.")
 
-        if images is not None:
-            inputs = self.image_processor(
-                images,
-                do_crop_margin=do_crop_margin,
-                do_resize=do_resize,
-                size=size,
-                resample=resample,
-                do_thumbnail=do_thumbnail,
-                do_align_long_axis=do_align_long_axis,
-                do_pad=do_pad,
-                do_rescale=do_rescale,
-                rescale_factor=rescale_factor,
-                do_normalize=do_normalize,
-                image_mean=image_mean,
-                image_std=image_std,
-                return_tensors=return_tensors,
-                data_format=data_format,
-                input_data_format=input_data_format,
+        output_kwargs = self._merge_kwargs(
+            NougatProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        if output_kwargs["text_kwargs"].get("text_pair") is not None and audio is not None:
+            raise ValueError(
+                "You cannot provide `text_pair` as a positional argument and as a keyword argument at the same time."
+                "Please provide it only as a keyword argument (i.e. `text_pair=...`)."
             )
+        if "text_pair" not in output_kwargs["text_kwargs"]:
+            warnings.warn(
+                "No `text_pair` kwarg was detected. The use of `text_pair` as an argument without specifying it explicitely as `text_pair=` will be deprecated in future versions."
+            )
+            # For backwards compatibility, we reuse `audio` as `text_pair` in case
+            # downstream users passed it as a positional argument
+            if audio is not None:
+                output_kwargs["text_kwargs"]["text_pair"] = audio
+
+        if output_kwargs["text_kwargs"].get("text_target") is not None and videos is not None:
+            raise ValueError(
+                "You cannot provide `text_target` as a positional argument and as a keyword argument at the same time."
+                "Please provide it only as a keyword argument (i.e. `text_target=...`)."
+            )
+        if "text_target" not in output_kwargs["text_kwargs"]:
+            warnings.warn(
+                "No `text_target` kwarg was detected. The use of `text_target` as an argument without specifying it explicitely as `text_target=` will be deprecated in future versions."
+            )
+            # For backwards compatibility, we reuse `videos` as `text_target` in case
+            # downstream users passed it as a positional argument
+            if videos is not None:
+                output_kwargs["text_kwargs"]["text_target"] = videos
+
+        if (
+            output_kwargs["text_kwargs"].get("text_pair_target") is not None
+            and backwards_compatibility_placeholder_arg is not None
+        ):
+            raise ValueError(
+                "You cannot provide `text_pair_target` as a positional argument and as a keyword argument at the same time."
+                "Please provide it only as a keyword argument (i.e. `text_pair_target=...`)."
+            )
+        if "text_pair_target" not in output_kwargs["text_kwargs"]:
+            warnings.warn(
+                "No `text_pair_target` kwarg was detected. The use of `text_pair_target` as an argument without specifying it explicitely as `text_pair_target=` will be deprecated in future versions."
+            )
+            # For backwards compatibility, we reuse `backwards_compatibility_placeholder_arg` as `text_pair_target` in case
+            # downstream users passed it as a positional argument
+            if backwards_compatibility_placeholder_arg is not None:
+                output_kwargs["text_kwargs"]["text_pair_target"] = backwards_compatibility_placeholder_arg
+
+        text_pair = output_kwargs["text_kwargs"].pop("text_pair", None)
+        text_target = output_kwargs["text_kwargs"].pop("text_target", None)
+        text_pair_target = output_kwargs["text_kwargs"].pop("text_pair_target", None)
+
+        if images is not None:
+            inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
         if text is not None:
             encodings = self.tokenizer(
                 text,
                 text_pair=text_pair,
                 text_target=text_target,
                 text_pair_target=text_pair_target,
-                add_special_tokens=add_special_tokens,
-                padding=padding,
-                truncation=truncation,
-                max_length=max_length,
-                stride=stride,
-                is_split_into_words=is_split_into_words,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_tensors=return_tensors,
-                return_token_type_ids=return_token_type_ids,
-                return_attention_mask=return_attention_mask,
-                return_overflowing_tokens=return_overflowing_tokens,
-                return_special_tokens_mask=return_special_tokens_mask,
-                return_offsets_mapping=return_offsets_mapping,
-                return_length=return_length,
-                verbose=verbose,
+                **output_kwargs["text_kwargs"],
             )
 
         if text is None:

--- a/src/transformers/models/nougat/processing_nougat.py
+++ b/src/transformers/models/nougat/processing_nougat.py
@@ -94,14 +94,14 @@ class NougatProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`, *optional*):
-                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
-                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
-                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
             images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`,
             `List[torch.Tensor]`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
+            text (`str`, `List[str]`, `List[List[str]]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:

--- a/src/transformers/models/owlv2/image_processing_owlv2.py
+++ b/src/transformers/models/owlv2/image_processing_owlv2.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from ...image_processing_utils import BaseImageProcessor, BatchFeature
+from ...image_processing_utils import BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import (
     center_to_corners_format,
     pad,
@@ -296,6 +296,7 @@ class Owlv2ImageProcessor(BaseImageProcessor):
         """
         requires_backends(self, "scipy")
 
+        size = get_size_dict(size)
         output_shape = (size["height"], size["width"])
         image = to_channel_dimension_format(image, ChannelDimension.LAST)
         image, output_shape = _preprocess_resize_output_shape(image, output_shape)

--- a/src/transformers/models/owlv2/processing_owlv2.py
+++ b/src/transformers/models/owlv2/processing_owlv2.py
@@ -22,8 +22,9 @@ from typing import List, Optional, Union
 import numpy as np
 
 from ...image_utils import ImageInput
+from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
 
 
@@ -105,7 +106,7 @@ class Owlv2Processor(ProcessorMixin):
                 should be of shape (C, H, W), where C is a number of channels, H and W are image height and width.
 
         Returns:
-            [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
@@ -172,12 +173,12 @@ class Owlv2Processor(ProcessorMixin):
             else:
                 raise ValueError("Target return tensor type could not be returned")
 
-            encoding = BatchEncoding()
+            encoding = BatchFeature()
             encoding["input_ids"] = input_ids
             encoding["attention_mask"] = attention_mask
 
         if query_images is not None:
-            encoding = BatchEncoding()
+            encoding = BatchFeature()
             query_pixel_values = self.image_processor(query_images, **output_kwargs["images_kwargs"]).pixel_values
             encoding["query_pixel_values"] = query_pixel_values
 
@@ -193,7 +194,7 @@ class Owlv2Processor(ProcessorMixin):
         elif text is not None or query_images is not None:
             return encoding
         else:
-            return BatchEncoding(data=dict(**image_features), tensor_type=return_tensors)
+            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
 
     # Copied from transformers.models.owlvit.processing_owlvit.OwlViTProcessor.post_process_object_detection with OWLViT->OWLv2
     def post_process_object_detection(self, *args, **kwargs):

--- a/src/transformers/models/owlv2/processing_owlv2.py
+++ b/src/transformers/models/owlv2/processing_owlv2.py
@@ -16,13 +16,38 @@
 Image/Text processor class for OWLv2
 """
 
-from typing import List
+import sys
+import warnings
+from typing import List, Optional, Union
 
 import numpy as np
 
-from ...processing_utils import ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding
+from ...image_utils import ImageInput
+from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class Owlv2ImagesKwargs(ImagesKwargs, total=False):
+    query_images: Optional[ImageInput]
+
+
+class Owlv2ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Owlv2ImagesKwargs
+    _defaults = {
+        "text_kwargs": {
+            "padding": "max_length",
+        },
+        "common_kwargs": {
+            "return_tensors": "np",
+        },
+    }
 
 
 class Owlv2Processor(ProcessorMixin):
@@ -45,8 +70,14 @@ class Owlv2Processor(ProcessorMixin):
     def __init__(self, image_processor, tokenizer, **kwargs):
         super().__init__(image_processor, tokenizer)
 
-    # Copied from transformers.models.owlvit.processing_owlvit.OwlViTProcessor.__call__ with OWLViT->OWLv2
-    def __call__(self, text=None, images=None, query_images=None, padding="max_length", return_tensors="np", **kwargs):
+    def __call__(
+        self,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        images: Optional[ImageInput] = None,
+        audio=None,
+        videos=None,
+        **kwargs: Unpack[Owlv2ProcessorKwargs],
+    ):
         """
         Main method to prepare for the model one or several text(s) and image(s). This method forwards the `text` and
         `kwargs` arguments to CLIPTokenizerFast's [`~CLIPTokenizerFast.__call__`] if `text` is not `None` to encode:
@@ -67,12 +98,7 @@ class Owlv2Processor(ProcessorMixin):
                 The query image to be prepared, one query image is expected per target image to be queried. Each image
                 can be a PIL image, NumPy array or PyTorch tensor. In case of a NumPy array/PyTorch tensor, each image
                 should be of shape (C, H, W), where C is a number of channels, H and W are image height and width.
-            return_tensors (`str` or [`~utils.TensorType`], *optional*):
-                If set, will return tensors of a particular framework. Acceptable values are:
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
+
         Returns:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
@@ -81,6 +107,28 @@ class Owlv2Processor(ProcessorMixin):
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
+        output_kwargs = self._merge_kwargs(
+            Owlv2ProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        if output_kwargs["images_kwargs"].get("query_images") is not None and audio is not None:
+            raise ValueError(
+                "You cannot provide `query_images` as a positional argument and as a keyword argument at the same time."
+                "Please provide it only as a keyword argument (i.e. `query_images=...`)."
+            )
+        if "query_images" not in output_kwargs["images_kwargs"]:
+            warnings.warn(
+                "No `query_images` kwarg was detected. The use of `query_images` as an argument without specifying it explicitely as `query_images=` will be deprecated in future versions."
+            )
+            # For backwards compatibility, we reuse `audio` as `query_images` in case
+            # downstream users passed it as a positional argument
+            if audio is not None:
+                output_kwargs["images_kwargs"]["query_images"] = audio
+
+        query_images = output_kwargs["images_kwargs"].pop("query_images", None)
+        return_tensors = output_kwargs["common_kwargs"]["return_tensors"]
 
         if text is None and query_images is None and images is None:
             raise ValueError(
@@ -89,7 +137,7 @@ class Owlv2Processor(ProcessorMixin):
 
         if text is not None:
             if isinstance(text, str) or (isinstance(text, List) and not isinstance(text[0], List)):
-                encodings = [self.tokenizer(text, padding=padding, return_tensors=return_tensors, **kwargs)]
+                encodings = [self.tokenizer(text, **output_kwargs["text_kwargs"])]
 
             elif isinstance(text, List) and isinstance(text[0], List):
                 encodings = []
@@ -102,7 +150,7 @@ class Owlv2Processor(ProcessorMixin):
                     if len(t) != max_num_queries:
                         t = t + [" "] * (max_num_queries - len(t))
 
-                    encoding = self.tokenizer(t, padding=padding, return_tensors=return_tensors, **kwargs)
+                    encoding = self.tokenizer(t, **output_kwargs["text_kwargs"])
                     encodings.append(encoding)
             else:
                 raise TypeError("Input text should be a string, a list of strings or a nested list of strings")
@@ -138,13 +186,11 @@ class Owlv2Processor(ProcessorMixin):
 
         if query_images is not None:
             encoding = BatchEncoding()
-            query_pixel_values = self.image_processor(
-                query_images, return_tensors=return_tensors, **kwargs
-            ).pixel_values
+            query_pixel_values = self.image_processor(query_images, **output_kwargs["images_kwargs"]).pixel_values
             encoding["query_pixel_values"] = query_pixel_values
 
         if images is not None:
-            image_features = self.image_processor(images, return_tensors=return_tensors, **kwargs)
+            image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
 
         if text is not None and images is not None:
             encoding["pixel_values"] = image_features.pixel_values

--- a/src/transformers/models/owlv2/processing_owlv2.py
+++ b/src/transformers/models/owlv2/processing_owlv2.py
@@ -21,8 +21,8 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from ...image_utils import ImageInput
 from ...feature_extraction_utils import BatchFeature
+from ...image_utils import ImageInput
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
@@ -112,6 +112,7 @@ class Owlv2Processor(ProcessorMixin):
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **query_pixel_values** -- Pixel values of the query images to be fed to a model. Returned when `query_images` is not `None`.
         """
         output_kwargs = self._merge_kwargs(
             Owlv2ProcessorKwargs,

--- a/src/transformers/models/owlvit/processing_owlvit.py
+++ b/src/transformers/models/owlvit/processing_owlvit.py
@@ -23,8 +23,9 @@ from typing import List, Optional, Union
 import numpy as np
 
 from ...image_utils import ImageInput
+from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
 
 
@@ -121,7 +122,7 @@ class OwlViTProcessor(ProcessorMixin):
                 should be of shape (C, H, W), where C is a number of channels, H and W are image height and width.
 
         Returns:
-            [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
@@ -189,12 +190,12 @@ class OwlViTProcessor(ProcessorMixin):
             else:
                 raise ValueError("Target return tensor type could not be returned")
 
-            encoding = BatchEncoding()
+            encoding = BatchFeature()
             encoding["input_ids"] = input_ids
             encoding["attention_mask"] = attention_mask
 
         if query_images is not None:
-            encoding = BatchEncoding()
+            encoding = BatchFeature()
             query_pixel_values = self.image_processor(query_images, **output_kwargs["images_kwargs"]).pixel_values
             encoding["query_pixel_values"] = query_pixel_values
 
@@ -210,7 +211,7 @@ class OwlViTProcessor(ProcessorMixin):
         elif text is not None or query_images is not None:
             return encoding
         else:
-            return BatchEncoding(data=dict(**image_features), tensor_type=return_tensors)
+            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
 
     def post_process(self, *args, **kwargs):
         """

--- a/src/transformers/models/owlvit/processing_owlvit.py
+++ b/src/transformers/models/owlvit/processing_owlvit.py
@@ -99,7 +99,7 @@ class OwlViTProcessor(ProcessorMixin):
         audio=None,
         videos=None,
         **kwargs: Unpack[OwlViTProcessorKwargs],
-    ):
+    ) -> BatchFeature:
         """
         Main method to prepare for the model one or several text(s) and image(s). This method forwards the `text` and
         `kwargs` arguments to CLIPTokenizerFast's [`~CLIPTokenizerFast.__call__`] if `text` is not `None` to encode:
@@ -145,6 +145,12 @@ class OwlViTProcessor(ProcessorMixin):
             raise ValueError(
                 "You have to specify at least one text or query image or image. All three cannot be none."
             )
+        if text is not None and query_images is not None:
+            warnings.warn(
+                "Query images will override the text prompt. In the future, this will raise an error.", FutureWarning
+            )
+
+        data = {}
 
         if text is not None:
             if isinstance(text, str) or (isinstance(text, List) and not isinstance(text[0], List)):
@@ -191,28 +197,19 @@ class OwlViTProcessor(ProcessorMixin):
             else:
                 raise ValueError("Target return tensor type could not be returned")
 
-            encoding = BatchFeature()
-            encoding["input_ids"] = input_ids
-            encoding["attention_mask"] = attention_mask
+            data["input_ids"] = input_ids
+            data["attention_mask"] = attention_mask
 
         if query_images is not None:
-            encoding = BatchFeature()
             query_pixel_values = self.image_processor(query_images, **output_kwargs["images_kwargs"]).pixel_values
-            encoding["query_pixel_values"] = query_pixel_values
+            # Query images always override the text prompt
+            data = {"query_pixel_values": query_pixel_values}
 
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
+            data["pixel_values"] = image_features.pixel_values
 
-        if text is not None and images is not None:
-            encoding["pixel_values"] = image_features.pixel_values
-            return encoding
-        elif query_images is not None and images is not None:
-            encoding["pixel_values"] = image_features.pixel_values
-            return encoding
-        elif text is not None or query_images is not None:
-            return encoding
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+        return BatchFeature(data=data, tensor_type=return_tensors)
 
     def post_process(self, *args, **kwargs):
         """

--- a/src/transformers/models/owlvit/processing_owlvit.py
+++ b/src/transformers/models/owlvit/processing_owlvit.py
@@ -22,8 +22,8 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from ...image_utils import ImageInput
 from ...feature_extraction_utils import BatchFeature
+from ...image_utils import ImageInput
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
@@ -128,6 +128,7 @@ class OwlViTProcessor(ProcessorMixin):
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **query_pixel_values** -- Pixel values of the query images to be fed to a model. Returned when `query_images` is not `None`.
         """
 
         output_kwargs = self._merge_kwargs(

--- a/src/transformers/models/owlvit/processing_owlvit.py
+++ b/src/transformers/models/owlvit/processing_owlvit.py
@@ -66,6 +66,8 @@ class OwlViTProcessor(ProcessorMixin):
     attributes = ["image_processor", "tokenizer"]
     image_processor_class = "OwlViTImageProcessor"
     tokenizer_class = ("CLIPTokenizer", "CLIPTokenizerFast")
+    # For backward compatibility. See transformers.processing_utils.ProcessorMixin.prepare_and_validate_optional_call_args for more details.
+    optional_call_args = ["query_images"]
 
     def __init__(self, image_processor=None, tokenizer=None, **kwargs):
         feature_extractor = None
@@ -89,6 +91,10 @@ class OwlViTProcessor(ProcessorMixin):
         self,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
         images: Optional[ImageInput] = None,
+        # The following is to capture `visual_prompt` argument that may be passed as a positional argument.
+        # See transformers.processing_utils.ProcessorMixin.prepare_and_validate_optional_call_args for more details.
+        # This behavior is only needed for backward compatibility and will be removed in future versions.
+        *args,
         audio=None,
         videos=None,
         **kwargs: Unpack[OwlViTProcessorKwargs],
@@ -101,15 +107,15 @@ class OwlViTProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
+            text (`str`, `List[str]`, `List[List[str]]`, *optional*):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
             images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`,
-            `List[torch.Tensor]`):
+            `List[torch.Tensor]`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
-            query_images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            query_images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`, *optional*):
                 The query image to be prepared, one query image is expected per target image to be queried. Each image
                 can be a PIL image, NumPy array or PyTorch tensor. In case of a NumPy array/PyTorch tensor, each image
                 should be of shape (C, H, W), where C is a number of channels, H and W are image height and width.
@@ -127,21 +133,8 @@ class OwlViTProcessor(ProcessorMixin):
             OwlViTProcessorKwargs,
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,
             **kwargs,
+            **self.prepare_and_validate_optional_call_args(*args),
         )
-
-        if output_kwargs["images_kwargs"].get("query_images") is not None and audio is not None:
-            raise ValueError(
-                "You cannot provide `query_images` as a positional argument and as a keyword argument at the same time."
-                "Please provide it only as a keyword argument (i.e. `query_images=...`)."
-            )
-        if "query_images" not in output_kwargs["images_kwargs"]:
-            warnings.warn(
-                "No `query_images` kwarg was detected. The use of `query_images` as an argument without specifying it explicitely as `query_images=` will be deprecated in future versions."
-            )
-            # For backwards compatibility, we reuse `audio` as `query_images` in case
-            # downstream users passed it as a positional argument
-            if audio is not None:
-                output_kwargs["images_kwargs"]["query_images"] = audio
 
         query_images = output_kwargs["images_kwargs"].pop("query_images", None)
         return_tensors = output_kwargs["common_kwargs"]["return_tensors"]

--- a/src/transformers/models/owlvit/processing_owlvit.py
+++ b/src/transformers/models/owlvit/processing_owlvit.py
@@ -16,14 +16,38 @@
 Image/Text processor class for OWL-ViT
 """
 
+import sys
 import warnings
-from typing import List
+from typing import List, Optional, Union
 
 import numpy as np
 
-from ...processing_utils import ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding
+from ...image_utils import ImageInput
+from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
 from ...utils import is_flax_available, is_tf_available, is_torch_available
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class OwlViTImagesKwargs(ImagesKwargs, total=False):
+    query_images: Optional[ImageInput]
+
+
+class OwlViTProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: OwlViTImagesKwargs
+    _defaults = {
+        "text_kwargs": {
+            "padding": "max_length",
+        },
+        "common_kwargs": {
+            "return_tensors": "np",
+        },
+    }
 
 
 class OwlViTProcessor(ProcessorMixin):
@@ -61,7 +85,14 @@ class OwlViTProcessor(ProcessorMixin):
 
         super().__init__(image_processor, tokenizer)
 
-    def __call__(self, text=None, images=None, query_images=None, padding="max_length", return_tensors="np", **kwargs):
+    def __call__(
+        self,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        images: Optional[ImageInput] = None,
+        audio=None,
+        videos=None,
+        **kwargs: Unpack[OwlViTProcessorKwargs],
+    ):
         """
         Main method to prepare for the model one or several text(s) and image(s). This method forwards the `text` and
         `kwargs` arguments to CLIPTokenizerFast's [`~CLIPTokenizerFast.__call__`] if `text` is not `None` to encode:
@@ -82,12 +113,7 @@ class OwlViTProcessor(ProcessorMixin):
                 The query image to be prepared, one query image is expected per target image to be queried. Each image
                 can be a PIL image, NumPy array or PyTorch tensor. In case of a NumPy array/PyTorch tensor, each image
                 should be of shape (C, H, W), where C is a number of channels, H and W are image height and width.
-            return_tensors (`str` or [`~utils.TensorType`], *optional*):
-                If set, will return tensors of a particular framework. Acceptable values are:
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
+
         Returns:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
@@ -97,6 +123,29 @@ class OwlViTProcessor(ProcessorMixin):
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
 
+        output_kwargs = self._merge_kwargs(
+            OwlViTProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        if output_kwargs["images_kwargs"].get("query_images") is not None and audio is not None:
+            raise ValueError(
+                "You cannot provide `query_images` as a positional argument and as a keyword argument at the same time."
+                "Please provide it only as a keyword argument (i.e. `query_images=...`)."
+            )
+        if "query_images" not in output_kwargs["images_kwargs"]:
+            warnings.warn(
+                "No `query_images` kwarg was detected. The use of `query_images` as an argument without specifying it explicitely as `query_images=` will be deprecated in future versions."
+            )
+            # For backwards compatibility, we reuse `audio` as `query_images` in case
+            # downstream users passed it as a positional argument
+            if audio is not None:
+                output_kwargs["images_kwargs"]["query_images"] = audio
+
+        query_images = output_kwargs["images_kwargs"].pop("query_images", None)
+        return_tensors = output_kwargs["common_kwargs"]["return_tensors"]
+
         if text is None and query_images is None and images is None:
             raise ValueError(
                 "You have to specify at least one text or query image or image. All three cannot be none."
@@ -104,7 +153,7 @@ class OwlViTProcessor(ProcessorMixin):
 
         if text is not None:
             if isinstance(text, str) or (isinstance(text, List) and not isinstance(text[0], List)):
-                encodings = [self.tokenizer(text, padding=padding, return_tensors=return_tensors, **kwargs)]
+                encodings = [self.tokenizer(text, **output_kwargs["text_kwargs"])]
 
             elif isinstance(text, List) and isinstance(text[0], List):
                 encodings = []
@@ -117,7 +166,7 @@ class OwlViTProcessor(ProcessorMixin):
                     if len(t) != max_num_queries:
                         t = t + [" "] * (max_num_queries - len(t))
 
-                    encoding = self.tokenizer(t, padding=padding, return_tensors=return_tensors, **kwargs)
+                    encoding = self.tokenizer(t, **output_kwargs["text_kwargs"])
                     encodings.append(encoding)
             else:
                 raise TypeError("Input text should be a string, a list of strings or a nested list of strings")
@@ -153,13 +202,11 @@ class OwlViTProcessor(ProcessorMixin):
 
         if query_images is not None:
             encoding = BatchEncoding()
-            query_pixel_values = self.image_processor(
-                query_images, return_tensors=return_tensors, **kwargs
-            ).pixel_values
+            query_pixel_values = self.image_processor(query_images, **output_kwargs["images_kwargs"]).pixel_values
             encoding["query_pixel_values"] = query_pixel_values
 
         if images is not None:
-            image_features = self.image_processor(images, return_tensors=return_tensors, **kwargs)
+            image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
 
         if text is not None and images is not None:
             encoding["pixel_values"] = image_features.pixel_values

--- a/src/transformers/models/sam/image_processing_sam.py
+++ b/src/transformers/models/sam/image_processing_sam.py
@@ -185,6 +185,7 @@ class SamImageProcessor(BaseImageProcessor):
             input_data_format (`str` or `ChannelDimension`, *optional*):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
+        pad_size = get_size_dict(pad_size)
         output_height, output_width = pad_size["height"], pad_size["width"]
         input_height, input_width = get_image_size(image, channel_dim=input_data_format)
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -244,6 +244,7 @@ class TvpImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         height, width = get_image_size(image, channel_dim=input_data_format)
+        pad_size = get_size_dict(pad_size)
         max_height = pad_size.get("height", height)
         max_width = pad_size.get("width", width)
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1013,8 +1013,10 @@ class ProcessorMixin(PushToHubMixin):
             )
         if len(args) > len(self.optional_call_args):
             raise ValueError(
-                f"Expected *at most* {len(self.optional_call_args)} optional positional arguments in processor call but received {len(args)}."
-                "Passing positional arguments to the processor call is not recommended"
+                f"Expected *at most* {len(self.optional_call_args)} optional positional arguments in processor call"
+                f"which will be matched with {' '.join(self.optional_call_args)} in the order they are passed."
+                f"However, got {len(args)} positional arguments instead."
+                "Please pass all arguments as keyword arguments instead (e.g. `processor(arg_name_1=..., arg_name_2=...))`."
             )
         return {arg_name: arg_value for arg_value, arg_name in zip(args, self.optional_call_args)}
 

--- a/tests/models/clipseg/test_processor_clipseg.py
+++ b/tests/models/clipseg/test_processor_clipseg.py
@@ -193,6 +193,23 @@ class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         with pytest.raises(ValueError):
             processor()
 
+    def test_processor_visual_prompt_positional(self):
+        image_processor = self.get_image_processor()
+        tokenizer = self.get_tokenizer()
+
+        processor = CLIPSegProcessor(tokenizer=tokenizer, image_processor=image_processor)
+
+        image_input = self.prepare_image_inputs()
+        visual_prompt_input = self.prepare_image_inputs()
+
+        inputs = processor(None, image_input, visual_prompt_input)
+
+        self.assertListEqual(list(inputs.keys()), ["pixel_values", "conditional_pixel_values"])
+
+        # test if it raises when no input is passed
+        with pytest.raises(ValueError):
+            processor()
+
     def test_tokenizer_decode(self):
         image_processor = self.get_image_processor()
         tokenizer = self.get_tokenizer()

--- a/tests/models/clipseg/test_processor_clipseg.py
+++ b/tests/models/clipseg/test_processor_clipseg.py
@@ -187,7 +187,7 @@ class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         inputs = processor(images=image_input, visual_prompt=visual_prompt_input)
 
-        self.assertListEqual(list(inputs.keys()), ["pixel_values", "conditional_pixel_values"])
+        self.assertListEqual(list(inputs.keys()), ["conditional_pixel_values", "pixel_values"])
 
         # test if it raises when no input is passed
         with pytest.raises(ValueError):

--- a/tests/models/clipseg/test_processor_clipseg.py
+++ b/tests/models/clipseg/test_processor_clipseg.py
@@ -204,7 +204,7 @@ class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         inputs = processor(None, image_input, visual_prompt_input)
 
-        self.assertListEqual(list(inputs.keys()), ["pixel_values", "conditional_pixel_values"])
+        self.assertListEqual(list(inputs.keys()), ["conditional_pixel_values", "pixel_values"])
 
         # test if it raises when no input is passed
         with pytest.raises(ValueError):

--- a/tests/models/clipseg/test_processor_clipseg.py
+++ b/tests/models/clipseg/test_processor_clipseg.py
@@ -21,20 +21,24 @@ import unittest
 import numpy as np
 import pytest
 
-from transformers import CLIPTokenizer, CLIPTokenizerFast
+from transformers import CLIPSegProcessor, CLIPTokenizer, CLIPTokenizerFast
 from transformers.models.clip.tokenization_clip import VOCAB_FILES_NAMES
 from transformers.testing_utils import require_vision
 from transformers.utils import IMAGE_PROCESSOR_NAME, is_vision_available
+
+from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_vision_available():
     from PIL import Image
 
-    from transformers import CLIPSegProcessor, ViTImageProcessor
+    from transformers import ViTImageProcessor
 
 
 @require_vision
-class CLIPSegProcessorTest(unittest.TestCase):
+class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = CLIPSegProcessor
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
 

--- a/tests/models/nougat/test_processor_nougat.py
+++ b/tests/models/nougat/test_processor_nougat.py
@@ -1,0 +1,17 @@
+import tempfile
+import unittest
+
+from transformers import NougatProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class NougatProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "facebook/nougat-base"
+    text_data_arg_name = "labels"
+    processor_class = NougatProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/owlv2/test_processor_owlv2.py
+++ b/tests/models/owlv2/test_processor_owlv2.py
@@ -1,0 +1,18 @@
+import tempfile
+import unittest
+
+from transformers import Owlv2Processor
+from transformers.testing_utils import require_scipy
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+@require_scipy
+class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "google/owlv2-base-patch16-ensemble"
+    processor_class = Owlv2Processor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/owlv2/test_processor_owlv2.py
+++ b/tests/models/owlv2/test_processor_owlv2.py
@@ -1,6 +1,8 @@
 import tempfile
 import unittest
 
+import pytest
+
 from transformers import Owlv2Processor
 from transformers.testing_utils import require_scipy
 
@@ -16,3 +18,18 @@ class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.tmpdirname = tempfile.mkdtemp()
         processor = self.processor_class.from_pretrained(self.from_pretrained_id)
         processor.save_pretrained(self.tmpdirname)
+
+    def test_processor_query_images_positional(self):
+        processor_components = self.prepare_components()
+        processor = Owlv2Processor(**processor_components)
+
+        image_input = self.prepare_image_inputs()
+        query_images = self.prepare_image_inputs()
+
+        inputs = processor(None, image_input, query_images)
+
+        self.assertListEqual(list(inputs.keys()), ["query_pixel_values", "pixel_values"])
+
+        # test if it raises when no input is passed
+        with pytest.raises(ValueError):
+            processor()

--- a/tests/models/owlvit/test_processor_owlvit.py
+++ b/tests/models/owlvit/test_processor_owlvit.py
@@ -21,20 +21,24 @@ import unittest
 import numpy as np
 import pytest
 
-from transformers import CLIPTokenizer, CLIPTokenizerFast
+from transformers import CLIPTokenizer, CLIPTokenizerFast, OwlViTProcessor
 from transformers.models.clip.tokenization_clip import VOCAB_FILES_NAMES
 from transformers.testing_utils import require_vision
 from transformers.utils import IMAGE_PROCESSOR_NAME, is_vision_available
+
+from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_vision_available():
     from PIL import Image
 
-    from transformers import OwlViTImageProcessor, OwlViTProcessor
+    from transformers import OwlViTImageProcessor
 
 
 @require_vision
-class OwlViTProcessorTest(unittest.TestCase):
+class OwlViTProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = OwlViTProcessor
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
 

--- a/tests/models/owlvit/test_processor_owlvit.py
+++ b/tests/models/owlvit/test_processor_owlvit.py
@@ -258,3 +258,18 @@ class OwlViTProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         decoded_tok = tokenizer.batch_decode(predicted_ids)
 
         self.assertListEqual(decoded_tok, decoded_processor)
+
+    def test_processor_query_images_positional(self):
+        processor_components = self.prepare_components()
+        processor = OwlViTProcessor(**processor_components)
+
+        image_input = self.prepare_image_inputs()
+        query_images = self.prepare_image_inputs()
+
+        inputs = processor(None, image_input, query_images)
+
+        self.assertListEqual(list(inputs.keys()), ["query_pixel_values", "pixel_values"])
+
+        # test if it raises when no input is passed
+        with pytest.raises(ValueError):
+            processor()

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -48,6 +48,8 @@ if is_vision_available():
 @require_vision
 @require_torch
 class ProcessorTesterMixin:
+    image_data_arg_name = "pixel_values"
+    text_data_arg_name = "input_ids"
     processor_class = None
 
     def prepare_processor_dict(self):
@@ -136,7 +138,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input, return_tensors="pt")
-        self.assertEqual(len(inputs["input_ids"][0]), 117)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 117)
 
     @require_torch
     @require_vision
@@ -153,7 +155,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input)
-        self.assertEqual(len(inputs["pixel_values"][0][0]), 234)
+        self.assertEqual(len(inputs[self.image_data_arg_name][0][0]), 234)
 
     @require_vision
     @require_torch
@@ -171,7 +173,7 @@ class ProcessorTesterMixin:
         inputs = processor(
             text=input_str, images=image_input, return_tensors="pt", max_length=112, padding="max_length"
         )
-        self.assertEqual(len(inputs["input_ids"][0]), 112)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 112)
 
     @require_torch
     @require_vision
@@ -188,7 +190,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input, size=[224, 224])
-        self.assertEqual(len(inputs["pixel_values"][0][0]), 224)
+        self.assertEqual(len(inputs[self.image_data_arg_name][0][0]), 224)
 
     @require_torch
     @require_vision
@@ -212,8 +214,8 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(inputs[self.image_data_arg_name].shape[2], 214)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
     @require_torch
     @require_vision
@@ -237,9 +239,9 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.image_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 6)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 6)
 
     @require_torch
     @require_vision
@@ -286,9 +288,9 @@ class ProcessorTesterMixin:
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
         self.skip_processor_without_typed_kwargs(processor)
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.image_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
     @require_torch
     @require_vision
@@ -312,9 +314,9 @@ class ProcessorTesterMixin:
         }
 
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.image_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
 
 class MyProcessor(ProcessorMixin):


### PR DESCRIPTION
# What does this PR do?

- Uniformizes kwargs for processors of ClipSeq, Nougat, Owlv2, OwlVIT as discussed in https://github.com/huggingface/transformers/issues/31911
- Adds backward compatibility for special call arguments passed as positional arguments. Special call args are arguments that carry data (e.g. negative prompt, segmentation images, etc.), but aren't `[text, images, audio, videos]` and not config values for the tokenizer, image processor, etc.

 (arguments that carry data 

TODO:

- [x] add tests
  - [x] ClipSeg
  - [x] Nougat
  - [x] OwlV2
  - [x] OwlVIT

Fixes # (issue)

- https://github.com/huggingface/transformers/issues/31911

## Who can review?

@zucchini-nlp @molbap @NielsRogge 