### PR TITLE
Integrate Liger (Linkedin GPU Efficient Runtime) Kernel to Trainer

### DIFF
--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -382,6 +382,41 @@ trainer.train()
 
 Note layerwise optimization is a bit experimental and does not support DDP (Distributed Data Parallel), thus you can run the training script only on a single GPU. Please see [this appropriate section](https://github.com/jiaweizzhao/GaLore?tab=readme-ov-file#train-7b-model-with-a-single-gpu-with-24gb-memory) for more details. Other features such as gradient clipping, DeepSpeed, etc might not be supported out of the box. Please [raise an issue on GitHub](https://github.com/huggingface/transformers/issues) if you encounter such issue.
 
+## Liger Kernel
+
+[Liger](https://github.com/linkedin/Liger-Kernel) (Linkedin GPU Efficient Runtime) Kernel is a collection of Triton kernels designed specifically for LLM training. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. The kernel works out of the box with flash attention, PyTorch FSDP, and Microsoft DeepSpeed.
+
+<Tip>
+Gain +20% throughput and reduce memory usage by 60% on LLaMA 3-8B model training. Achieve longer context lengths and larger batch sizes. It’s also useful if you want to scale up your model to multi-head training or large vocabulary sizes. Unleash multi-head training (medusa) and more. See details and examples in [Liger](https://github.com/linkedin/Liger-Kernel/tree/main/examples)
+</Tip>
+
+First make sure to install Liger official repository:
+```bash
+pip install liger-kernel
+```
+
+You should pass `use_liger=True` to apply liger kenel on your model, for example:
+
+```py
+from transformers import TrainingArguments
+
+training_args = TrainingArguments(
+    output_dir="your-model",
+    learning_rate=2e-5,
+    per_device_train_batch_size=16,
+    per_device_eval_batch_size=16,
+    num_train_epochs=2,
+    weight_decay=0.01,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    load_best_model_at_end=True,
+    push_to_hub=True,
+    use_liger=True
+)
+```
+
+Currently, the kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. A list of supported models is defined [here](https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/monkey_patch.py#L7). When use_liger is set to True, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
+
 ## LOMO optimizer
 
 The LOMO optimizers have been introduced in [Full Parameter Fine-Tuning for Large Language Models with Limited Resources](https://hf.co/papers/2306.09782) and [AdaLomo: Low-memory Optimization with Adaptive Learning Rate](https://hf.co/papers/2310.10195). 

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -415,7 +415,7 @@ training_args = TrainingArguments(
 )
 ```
 
-Currently, the kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. A list of supported models is defined [here](https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/monkey_patch.py#L7). When use_liger is set to True, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
+Currently, the kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. A list of supported models is defined [here](https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/monkey_patch.py#L7). When `use_liger` is set to `True`, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
 
 ## LOMO optimizer
 

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -384,7 +384,7 @@ Note layerwise optimization is a bit experimental and does not support DDP (Dist
 
 ## Liger Kernel
 
-[Liger](https://github.com/linkedin/Liger-Kernel) Kernel is a collection of Triton kernels developed by Linkedin designed specifically for LLM training. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. The kernel works out of the box with flash attention, PyTorch FSDP, and Microsoft DeepSpeed.
+[Liger-Kernel](https://github.com/linkedin/Liger-Kernel) Kernel is a collection of Triton kernels developed by Linkedin designed specifically for LLM training. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. The kernel works out of the box with flash attention, PyTorch FSDP, and Microsoft DeepSpeed.
 
 <Tip>
 Gain +20% throughput and reduce memory usage by 60% on LLaMA 3-8B model training. Achieve longer context lengths and larger batch sizes. It’s also useful if you want to scale up your model to multi-head training or large vocabulary sizes. Unleash multi-head training (medusa) and more. See details and examples in [Liger](https://github.com/linkedin/Liger-Kernel/tree/main/examples)

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -415,7 +415,7 @@ training_args = TrainingArguments(
 )
 ```
 
-Currently, the kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. A list of supported models is defined [here](https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/monkey_patch.py#L7). When `use_liger` is set to `True`, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
+The kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. The most up-to-date list of supported models can be found [here](https://github.com/linkedin/Liger-Kernel). When `use_liger` is set to `True`, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
 
 ## LOMO optimizer
 

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -384,7 +384,7 @@ Note layerwise optimization is a bit experimental and does not support DDP (Dist
 
 ## Liger Kernel
 
-[Liger](https://github.com/linkedin/Liger-Kernel) (Linkedin GPU Efficient Runtime) Kernel is a collection of Triton kernels designed specifically for LLM training. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. The kernel works out of the box with flash attention, PyTorch FSDP, and Microsoft DeepSpeed.
+[Liger](https://github.com/linkedin/Liger-Kernel) Kernel is a collection of Triton kernels developed by Linkedin designed specifically for LLM training. We have implemented Hugging Face Compatible RMSNorm, RoPE, SwiGLU, CrossEntropy, FusedLinearCrossEntropy, and more to come. It can effectively increase multi-GPU training throughput by 20% and reduces memory usage by 60%. The kernel works out of the box with flash attention, PyTorch FSDP, and Microsoft DeepSpeed.
 
 <Tip>
 Gain +20% throughput and reduce memory usage by 60% on LLaMA 3-8B model training. Achieve longer context lengths and larger batch sizes. It’s also useful if you want to scale up your model to multi-head training or large vocabulary sizes. Unleash multi-head training (medusa) and more. See details and examples in [Liger](https://github.com/linkedin/Liger-Kernel/tree/main/examples)

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -395,7 +395,7 @@ First make sure to install Liger official repository:
 pip install liger-kernel
 ```
 
-You should pass `use_liger=True` to apply liger kenel on your model, for example:
+You should pass `use_liger=True` to apply liger kernel on your model, for example:
 
 ```py
 from transformers import TrainingArguments

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -395,7 +395,7 @@ First make sure to install Liger official repository:
 pip install liger-kernel
 ```
 
-You should pass `use_liger=True` to apply liger kernel on your model, for example:
+You should pass `use_liger_kernel=True` to apply liger kernel on your model, for example:
 
 ```py
 from transformers import TrainingArguments
@@ -411,11 +411,11 @@ training_args = TrainingArguments(
     save_strategy="epoch",
     load_best_model_at_end=True,
     push_to_hub=True,
-    use_liger=True
+    use_liger_kernel=True
 )
 ```
 
-The kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. The most up-to-date list of supported models can be found [here](https://github.com/linkedin/Liger-Kernel). When `use_liger` is set to `True`, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
+The kernel supports the Llama, Gemma, Mistral, and Mixtral model architectures. The most up-to-date list of supported models can be found [here](https://github.com/linkedin/Liger-Kernel). When `use_liger_kernel` is set to `True`, the corresponding layers in the original model will be patched with Liger's efficient implementation, so you don't need to do anything extra other than setting the argument value.
 
 ## LOMO optimizer
 

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -717,9 +717,11 @@ class BigBirdPegasusBlockSparseAttention(nn.Module):
             attention_probs[:, :, -2 * from_block_size : -from_block_size, :to_block_size] = second_last_attn_weights[
                 :, :, :, :to_block_size
             ]  # 1st key block (global)
-            attention_probs[:, :, -2 * from_block_size : -from_block_size, -3 * to_block_size :] = (
-                second_last_attn_weights[:, :, :, to_block_size : 4 * to_block_size]
-            )  # last three blocks (global + sliding)
+            attention_probs[
+                :, :, -2 * from_block_size : -from_block_size, -3 * to_block_size :
+            ] = second_last_attn_weights[
+                :, :, :, to_block_size : 4 * to_block_size
+            ]  # last three blocks (global + sliding)
             # random keys
             for p1, i1, w1 in zip(range(bsz), rand_attn, second_last_attn_weights):
                 # p1, i1, w1 corresponds to batch_dim i.e. following operation is done for each sequence in batch

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -717,11 +717,9 @@ class BigBirdPegasusBlockSparseAttention(nn.Module):
             attention_probs[:, :, -2 * from_block_size : -from_block_size, :to_block_size] = second_last_attn_weights[
                 :, :, :, :to_block_size
             ]  # 1st key block (global)
-            attention_probs[
-                :, :, -2 * from_block_size : -from_block_size, -3 * to_block_size :
-            ] = second_last_attn_weights[
-                :, :, :, to_block_size : 4 * to_block_size
-            ]  # last three blocks (global + sliding)
+            attention_probs[:, :, -2 * from_block_size : -from_block_size, -3 * to_block_size :] = (
+                second_last_attn_weights[:, :, :, to_block_size : 4 * to_block_size]
+            )  # last three blocks (global + sliding)
             # random keys
             for p1, i1, w1 in zip(range(bsz), rand_attn, second_last_attn_weights):
                 # p1, i1, w1 corresponds to batch_dim i.e. following operation is done for each sequence in batch

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -84,6 +84,7 @@ from .utils import (
     is_keras_nlp_available,
     is_levenshtein_available,
     is_librosa_available,
+    is_liger_kernel_available,
     is_lomo_available,
     is_natten_available,
     is_nltk_available,
@@ -1160,6 +1161,13 @@ def require_librosa(test_case):
     Decorator marking a test that requires librosa
     """
     return unittest.skipUnless(is_librosa_available(), "test requires librosa")(test_case)
+
+
+def require_liger_kernel(test_case):
+    """
+    Decorator marking a test that requires liger_kernel
+    """
+    return unittest.skipUnless(is_liger_kernel_available(), "test requires liger_kernel")(test_case)
 
 
 def require_essentia(test_case):

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -35,7 +35,9 @@ import warnings
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+
 from liger_kernel.transformers import MODEL_TO_LIGER_KERNEL_PATCHING_FUNC
+
 
 # Integrations must be imported before ML frameworks:
 # isort: off

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -466,18 +466,18 @@ class Trainer:
 
         if self.args.use_liger:
             if is_liger_kernel_available():
-                from liger_kernel.transformers import MODEL_TO_LIGER_KERNEL_PATCHING_FUNC
-
-                if model.__class__.__name__ not in MODEL_TO_LIGER_KERNEL_PATCHING_FUNC:
-                    raise ValueError(
-                        "The model you have picked ({model.__class__.__name__}) cannot be used with Liger kernels, "
-                        f"a list of supported model classes are: {MODEL_TO_LIGER_KERNEL_PATCHING_FUNC.keys()}"
-                    )
-                # monkey patch the model with liger kernels
-                MODEL_TO_LIGER_KERNEL_PATCHING_FUNC[model.__class__.__name__](model)
+                from liger_kernel.transformers.trainer_integration import _apply_liger_kernel
+                
+                model_type = getattr(model, "config", None) and getattr(model.config, "model_type", None):
+                if model_type:
+                    # Monkey patch the model with liger kernels. Use the default kernel configurations.
+                    _apply_liger_kernel(model_type=model_type)
+                else:
+                    logger.info("The model does not have a valid `model_type` specified.")
             else:
                 raise ImportError(
-                    "You have set `use_liger` to `True` but Liger kernel is not available. Please install Liger kernel"
+                    "You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. "
+                    "Please install it with `pip install liger-kernel`"
                 )
 
         _is_quantized_and_base_model = getattr(model, "is_quantized", False) and not getattr(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -473,7 +473,7 @@ class Trainer:
                     # Monkey patch the model with liger kernels. Use the default kernel configurations.
                     _apply_liger_kernel(model_type=model_type)
                 else:
-                    logger.info("The model does not have a valid `model_type` specified. No liger kernels will be applied.")
+                    logger.warning("The model does not have a valid `model_type` specified. No liger kernels will be applied.")
             else:
                 raise ImportError(
                     "You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -473,7 +473,7 @@ class Trainer:
                     # Monkey patch the model with liger kernels. Use the default kernel configurations.
                     _apply_liger_kernel(model_type=model_type)
                 else:
-                    logger.info("The model does not have a valid `model_type` specified.")
+                    logger.info("The model does not have a valid `model_type` specified. No liger kernels will be applied.")
             else:
                 raise ImportError(
                     "You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. "

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -464,7 +464,7 @@ class Trainer:
                     " to `True` to avoid any unexpected behavior such as device placement mismatching."
                 )
 
-        if self.args.use_liger:
+        if self.args.use_liger_kernel:
             if is_liger_kernel_available():
                 from liger_kernel.transformers.trainer_integration import _apply_liger_kernel
 
@@ -478,7 +478,7 @@ class Trainer:
                     )
             else:
                 raise ImportError(
-                    "You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. "
+                    "You have set `use_liger_kernel` to `True` but liger-kernel >= 0.1.0 is not available. "
                     "Please install it with `pip install liger-kernel`"
                 )
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -467,13 +467,15 @@ class Trainer:
         if self.args.use_liger:
             if is_liger_kernel_available():
                 from liger_kernel.transformers.trainer_integration import _apply_liger_kernel
-                
-                model_type = getattr(model, "config", None) and getattr(model.config, "model_type", None):
+
+                model_type = getattr(model, "config", None) and getattr(model.config, "model_type", None)
                 if model_type:
                     # Monkey patch the model with liger kernels. Use the default kernel configurations.
                     _apply_liger_kernel(model_type=model_type)
                 else:
-                    logger.warning("The model does not have a valid `model_type` specified. No liger kernels will be applied.")
+                    logger.warning(
+                        "The model does not have a valid `model_type` specified. No liger kernels will be applied."
+                    )
             else:
                 raise ImportError(
                     "You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. "

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -791,6 +791,11 @@ class TrainingArguments:
 
         eval_use_gather_object (`bool`, *optional*, defaults to `False`):
             Whether to run recursively gather object in a nested list/tuple/dictionary of objects from all devices. This should only be enabled if users are not just returning tensors, and this is actively discouraged by PyTorch.
+
+        use_liger (`bool`, *optional*, defaults to `False`):
+            Whether enable [Liger](https://github.com/linkedin/Liger-Kernel) (Linkedin GPU Efficient Runtime) Kernel for LLM model training.
+            It can effectively increase multi-GPU training throughput by ~20% and reduces memory usage by ~60%, works out of the box with 
+            flash attention, PyTorch FSDP, and Microsoft DeepSpeed. Currently, it supports llama, mistral, mixtral and gemma models.
     """
 
     framework = "pt"
@@ -1488,6 +1493,13 @@ class TrainingArguments:
         default=False,
         metadata={
             "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
+        },
+    )
+    
+    use_liger: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "Whether or not to enable the Liger (Linkedin GPU Efficient Runtime) Kernel for model training."
         },
     )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -794,7 +794,7 @@ class TrainingArguments:
 
         use_liger (`bool`, *optional*, defaults to `False`):
             Whether enable [Liger](https://github.com/linkedin/Liger-Kernel) (Linkedin GPU Efficient Runtime) Kernel for LLM model training.
-            It can effectively increase multi-GPU training throughput by ~20% and reduces memory usage by ~60%, works out of the box with 
+            It can effectively increase multi-GPU training throughput by ~20% and reduces memory usage by ~60%, works out of the box with
             flash attention, PyTorch FSDP, and Microsoft DeepSpeed. Currently, it supports llama, mistral, mixtral and gemma models.
     """
 
@@ -1495,7 +1495,7 @@ class TrainingArguments:
             "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
         },
     )
-    
+
     use_liger: Optional[bool] = field(
         default=False,
         metadata={

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -793,7 +793,7 @@ class TrainingArguments:
             Whether to run recursively gather object in a nested list/tuple/dictionary of objects from all devices. This should only be enabled if users are not just returning tensors, and this is actively discouraged by PyTorch.
 
         use_liger (`bool`, *optional*, defaults to `False`):
-            Whether enable [Liger](https://github.com/linkedin/Liger-Kernel) (Linkedin GPU Efficient Runtime) Kernel for LLM model training.
+            Whether enable [Liger](https://github.com/linkedin/Liger-Kernel) Kernel for LLM model training.
             It can effectively increase multi-GPU training throughput by ~20% and reduces memory usage by ~60%, works out of the box with
             flash attention, PyTorch FSDP, and Microsoft DeepSpeed. Currently, it supports llama, mistral, mixtral and gemma models.
     """

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -792,7 +792,7 @@ class TrainingArguments:
         eval_use_gather_object (`bool`, *optional*, defaults to `False`):
             Whether to run recursively gather object in a nested list/tuple/dictionary of objects from all devices. This should only be enabled if users are not just returning tensors, and this is actively discouraged by PyTorch.
 
-        use_liger (`bool`, *optional*, defaults to `False`):
+        use_liger_kernel (`bool`, *optional*, defaults to `False`):
             Whether enable [Liger](https://github.com/linkedin/Liger-Kernel) Kernel for LLM model training.
             It can effectively increase multi-GPU training throughput by ~20% and reduces memory usage by ~60%, works out of the box with
             flash attention, PyTorch FSDP, and Microsoft DeepSpeed. Currently, it supports llama, mistral, mixtral and gemma models.
@@ -1496,7 +1496,7 @@ class TrainingArguments:
         },
     )
 
-    use_liger: Optional[bool] = field(
+    use_liger_kernel: Optional[bool] = field(
         default=False,
         metadata={"help": "Whether or not to enable the Liger Kernel for model training."},
     )

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1499,7 +1499,7 @@ class TrainingArguments:
     use_liger: Optional[bool] = field(
         default=False,
         metadata={
-            "help": "Whether or not to enable the Liger (Linkedin GPU Efficient Runtime) Kernel for model training."
+            "help": "Whether or not to enable the Liger Kernel for model training."
         },
     )
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1498,9 +1498,7 @@ class TrainingArguments:
 
     use_liger: Optional[bool] = field(
         default=False,
-        metadata={
-            "help": "Whether or not to enable the Liger Kernel for model training."
-        },
+        metadata={"help": "Whether or not to enable the Liger Kernel for model training."},
     )
 
     eval_use_gather_object: Optional[bool] = field(

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -148,6 +148,7 @@ from .import_utils import (
     is_keras_nlp_available,
     is_levenshtein_available,
     is_librosa_available,
+    is_liger_kernel_avaiable,
     is_lomo_available,
     is_mlx_available,
     is_natten_available,

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -148,7 +148,7 @@ from .import_utils import (
     is_keras_nlp_available,
     is_levenshtein_available,
     is_librosa_available,
-    is_liger_kernel_avaiable,
+    is_liger_kernel_available,
     is_lomo_available,
     is_mlx_available,
     is_natten_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -177,6 +177,7 @@ _torchdistx_available = _is_package_available("torchdistx")
 _torchvision_available = _is_package_available("torchvision")
 _mlx_available = _is_package_available("mlx")
 _hqq_available = _is_package_available("hqq")
+_liger_kernel_available = _is_package_available("liger_kernel")
 
 
 _torch_version = "N/A"
@@ -1162,6 +1163,10 @@ def is_jinja_available():
 
 def is_mlx_available():
     return _mlx_available
+
+
+def is_liger_kernel_avaiable():
+    return _liger_kernel_available
 
 
 # docstyle-ignore

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1168,7 +1168,7 @@ def is_mlx_available():
 def is_liger_kernel_available():
     if not _liger_kernel_available:
         return False
-    
+
     return version.parse(importlib.metadata.version("liger_kernel")) >= version.parse("0.1.0")
 
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1165,8 +1165,11 @@ def is_mlx_available():
     return _mlx_available
 
 
-def is_liger_kernel_avaiable():
-    return _liger_kernel_available
+def is_liger_kernel_available():
+    if not _liger_kernel_available:
+        return False
+    
+    return version.parse(importlib.metadata.version("liger_kernel")) >= version.parse("0.1.0")
 
 
 # docstyle-ignore

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1326,23 +1326,40 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertEqual(second_dataloader, second_dataloader_repeated)
 
     @require_liger_kernel
-    def test_apply_liger_kernel(self):
+    def test_use_liger_kernel_patching(self):
         # Test that the model code actually gets patched with Liger kernel
         from liger_kernel.transformers.rms_norm import LigerRMSNorm
 
         from transformers.models.llama import modeling_llama
 
         config = LlamaConfig(vocab_size=100, hidden_size=32, num_hidden_layers=3, num_attention_heads=4)
-        tiny_model = LlamaForCausalLM(config)
+        tiny_llama = LlamaForCausalLM(config)
 
         args = TrainingArguments(
             "./test",
             use_liger_kernel=True,
         )
-        Trainer(tiny_model, args)
+        Trainer(tiny_llama, args)
 
         # Check that one of the Llama model layers has been correctly patched with Liger kernel
         self.assertEqual(modeling_llama.LlamaRMSNorm, LigerRMSNorm)
+
+    @require_liger_kernel
+    @require_torch_gpu
+    def test_use_liger_kernel_trainer(self):
+        # Check that trainer still works with liger kernel applied
+        config = LlamaConfig(vocab_size=100, hidden_size=32, num_hidden_layers=3, num_attention_heads=4)
+        tiny_llama = LlamaForCausalLM(config)
+
+        x = torch.randint(0, 100, (128,))
+        train_dataset = RepeatDataset(x)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = TrainingArguments(tmpdir, learning_rate=1e-2, logging_steps=5, max_steps=20, use_liger_kernel=True)
+            trainer = Trainer(tiny_llama, args, train_dataset=train_dataset)
+
+            # Check this works
+            _ = trainer.train()
 
     @require_lomo
     @require_torch_gpu

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -64,8 +64,8 @@ from transformers.testing_utils import (
     require_galore_torch,
     require_grokadamw,
     require_intel_extension_for_pytorch,
-    require_lomo,
     require_liger_kernel,
+    require_lomo,
     require_optuna,
     require_peft,
     require_ray,
@@ -1159,7 +1159,6 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
         self.assertTrue(torch.allclose(emb1, emb2), "Neftune noise is still applied!")
 
-
     def test_logging_inf_nan_filter(self):
         config = GPT2Config(vocab_size=100, n_positions=128, n_embd=32, n_layer=3, n_head=4)
         tiny_gpt2 = GPT2LMHeadModel(config)
@@ -1329,8 +1328,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
     @require_liger_kernel
     def test_apply_liger_kernel(self):
         # Test that the model code actually gets patched with Liger kernel
-        from transformers.models.llama import modeling_llama
         from liger_kernel.transformers.rms_norm import LigerRMSNorm
+
+        from transformers.models.llama import modeling_llama
 
         config = LlamaConfig(vocab_size=100, hidden_size=32, num_hidden_layers=3, num_attention_heads=4)
         tiny_model = LlamaForCausalLM(config)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -65,6 +65,7 @@ from transformers.testing_utils import (
     require_grokadamw,
     require_intel_extension_for_pytorch,
     require_lomo,
+    require_liger_kernel,
     require_optuna,
     require_peft,
     require_ray,
@@ -1158,6 +1159,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
         self.assertTrue(torch.allclose(emb1, emb2), "Neftune noise is still applied!")
 
+
     def test_logging_inf_nan_filter(self):
         config = GPT2Config(vocab_size=100, n_positions=128, n_embd=32, n_layer=3, n_head=4)
         tiny_gpt2 = GPT2LMHeadModel(config)
@@ -1323,6 +1325,24 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertEqual(second_dataloader.dataset, second_dataloader_repeated.dataset)
         self.assertEqual(first_dataloader, first_dataloader_repeated)
         self.assertEqual(second_dataloader, second_dataloader_repeated)
+
+    @require_liger_kernel
+    def test_apply_liger_kernel(self):
+        # Test that the model code actually gets patched with Liger kernel
+        from transformers.models.llama import modeling_llama
+        from liger_kernel.transformers.rms_norm import LigerRMSNorm
+
+        config = LlamaConfig(vocab_size=100, hidden_size=32, num_hidden_layers=3, num_attention_heads=4)
+        tiny_model = LlamaForCausalLM(config)
+
+        args = TrainingArguments(
+            "./test",
+            use_liger=True,
+        )
+        Trainer(tiny_model, args)
+
+        # Check that one of the Llama model layers has been correctly patched with Liger kernel
+        self.assertEqual(modeling_llama.LlamaRMSNorm, LigerRMSNorm)
 
     @require_lomo
     @require_torch_gpu

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1337,7 +1337,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
         args = TrainingArguments(
             "./test",
-            use_liger=True,
+            use_liger_kernel=True,
         )
         Trainer(tiny_model, args)
 


### PR DESCRIPTION
# What does this PR do?

Integrate Liger (Linkedin GPU Efficient Runtime) Kernel to HF Trainer with optional flag

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # [(issue) ](https://github.com/huggingface/transformers/issues/32861)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1




 -->

## Tests:

- [x] pytest tests/trainer/test_trainer.py::TrainerIntegrationTest::test_apply_liger_kernel

```
pytest tests/trainer/test_trainer.py::TrainerIntegrationTest::test_use_liger_kernel_patching tests/trainer/test_trainer.py::TrainerIntegrationTest::test_use_liger_kernel_trainer

======================================= test session starts ========================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0
rootdir: /content/transformers-jaszhu
configfile: pyproject.toml
plugins: rich-0.1.1, timeout-2.3.1, xdist-3.6.1
collected 2 items

tests/trainer/test_trainer.py ..                                                             [100%]

======================================== 2 passed in 9.47s =========================================


```
- [x] E2E test 
```
{'loss': 1.6157, 'grad_norm': 32.0, 'learning_rate': 2.4324324324324326e-07, 'epoch': 0.0, 'num_input_tokens_seen': 60416, 'step': 3, 'step_time_sec': 4.87, 'avg_step_time_sec': 6.82, 'time_to_completion_sec': 4970.4, 'estimated_total_time_sec': 4990.85, 'step_peak_memory_allocated_MB': 76728.45, 'total_peak_memory_allocated_MB': 76728.74, 'step_peak_memory_reserved_MB': 79692.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3138.55, 'avg_tokens_per_second': 3158.65}
{'loss': 1.5678, 'grad_norm': 26.875, 'learning_rate': 3.2432432432432436e-07, 'epoch': 0.01, 'num_input_tokens_seen': 84992, 'step': 4, 'step_time_sec': 7.82, 'avg_step_time_sec': 7.15, 'time_to_completion_sec': 5206.53, 'estimated_total_time_sec': 5235.14, 'step_peak_memory_allocated_MB': 76728.67, 'total_peak_memory_allocated_MB': 76728.74, 'step_peak_memory_reserved_MB': 80194.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3142.99, 'avg_tokens_per_second': 3152.94}
{'loss': 1.74, 'grad_norm': 28.875, 'learning_rate': 4.0540540540540546e-07, 'epoch': 0.01, 'num_input_tokens_seen': 103936, 'step': 5, 'step_time_sec': 5.75, 'avg_step_time_sec': 6.8, 'time_to_completion_sec': 4945.07, 'estimated_total_time_sec': 4979.08, 'step_peak_memory_allocated_MB': 76728.54, 'total_peak_memory_allocated_MB': 76728.74, 'step_peak_memory_reserved_MB': 80324.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3293.14, 'avg_tokens_per_second': 3182.59}
{'loss': 1.7297, 'grad_norm': 29.25, 'learning_rate': 4.864864864864865e-07, 'epoch': 0.01, 'num_input_tokens_seen': 124416, 'step': 6, 'step_time_sec': 6.23, 'avg_step_time_sec': 6.69, 'time_to_completion_sec': 4855.78, 'estimated_total_time_sec': 4895.91, 'step_peak_memory_allocated_MB': 76728.57, 'total_peak_memory_allocated_MB': 76728.74, 'step_peak_memory_reserved_MB': 80288.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3285.22, 'avg_tokens_per_second': 3201.72}
{'loss': 1.6393, 'grad_norm': 27.75, 'learning_rate': 5.675675675675676e-07, 'epoch': 0.01, 'num_input_tokens_seen': 153920, 'step': 7, 'step_time_sec': 9.22, 'avg_step_time_sec': 7.11, 'time_to_completion_sec': 5154.73, 'estimated_total_time_sec': 5204.5, 'step_peak_memory_allocated_MB': 76728.78, 'total_peak_memory_allocated_MB': 76728.78, 'step_peak_memory_reserved_MB': 79652.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3200.77, 'avg_tokens_per_second': 3201.51}
{'loss': 1.5642, 'grad_norm': 27.25, 'learning_rate': 6.486486486486487e-07, 'epoch': 0.01, 'num_input_tokens_seen': 170752, 'step': 8, 'step_time_sec': 5.49, 'avg_step_time_sec': 6.88, 'time_to_completion_sec': 4980.15, 'estimated_total_time_sec': 5035.18, 'step_peak_memory_allocated_MB': 76728.49, 'total_peak_memory_allocated_MB': 76728.78, 'step_peak_memory_reserved_MB': 79988.0, 'total_peak_memory_reserved_MB': 80364.0, 'step_tokens_per_second': 3065.48, 'avg_tokens_per_second': 3186.0}

```

- [x] When liger is lower version, the error is thrown `ImportError: You have set `use_liger` to `True` but liger-kernel >= 0.1.0 is not available. Please install it with `pip install liger-kernel`
- [x] Model type is correct extracted as "llama"

![Screenshot 2024-08-20 at 3 13 45 PM](https://github.com/user-attachments/assets/0a033c0e-1b1e-48fd-a040-ff202ea21a4a)

 
  

Test conditions: LLaMA 3-8B, Batch Size = 64, Data Type = bf16, Optimizer = AdamW, Gradient Checkpointing = True, Distributed Strategy = FSDP1 on 4 A100s.


When use_liger=Ture, memory usage and throughput shows improvement compared to use_liger=False, default value

![image (3)](https://github.com/user-attachments/assets/fb47600c-c89b-443f-9ee0-a08b65562c7d)
![image (4)](https://github.com/user-attachments/assets/5e023464-cb7e-4267-b9eb-bbc9205ae8af)

Note: for more detailed benchmark setup and more exciting efficiency for multi-head training (Medusa), please refer to original repo: https://github.com/linkedin/Liger-Kernel (repo will be public soon!!!)




