### PR TITLE
Uniform kwargs for processors of audio-text models

### DIFF
--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -116,19 +116,14 @@ class AltCLIPProcessor(ProcessorMixin):
             **kwargs,
         )
 
+        data = {}
         if text is not None:
-            encoding = self.tokenizer(text, **output_kwargs["text_kwargs"])
-
+            text_features = self.tokenizer(text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
-
-        return_tensors = output_kwargs["common_kwargs"].get("return_tensors")
-        if text is not None and images is not None:
-            return BatchFeature(data=dict(**encoding, **image_features), tensor_type=return_tensors)
-        elif text is not None:
-            return BatchFeature(data=dict(**encoding), tensor_type=return_tensors)
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            data.update(image_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -76,6 +76,8 @@ class AltCLIPProcessor(ProcessorMixin):
         self,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
         images: Optional[ImageInput] = None,
+        audio=None,
+        videos=None,
         **kwargs: Unpack[AltCLIPProcessingKwargs],
     ):
         """
@@ -86,11 +88,11 @@ class AltCLIPProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
 

--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Union
 
 from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
 
 if sys.version_info >= (3, 11):
@@ -94,16 +94,8 @@ class AltCLIPProcessor(ProcessorMixin):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
 
-            return_tensors (`str` or [`~utils.TensorType`], *optional*):
-                If set, will return tensors of a particular framework. Acceptable values are:
-
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
-
         Returns:
-            [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
 
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
@@ -133,9 +125,7 @@ class AltCLIPProcessor(ProcessorMixin):
         elif text is not None:
             return encoding
         else:
-            return BatchEncoding(
-                data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"]["return_tensors"]
-            )
+            return image_features
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/bridgetower/image_processing_bridgetower.py
+++ b/src/transformers/models/bridgetower/image_processing_bridgetower.py
@@ -115,8 +115,8 @@ def get_resize_output_image_size(
         new_width = scale * new_width
 
     new_height, new_width = int(new_height + 0.5), int(new_width + 0.5)
-    new_height = new_height // size_divisor * size_divisor
-    new_width = new_width // size_divisor * size_divisor
+    new_height = max(1, new_height // size_divisor) * size_divisor
+    new_width = max(1, new_width // size_divisor) * size_divisor
 
     return new_height, new_width
 

--- a/src/transformers/models/bridgetower/image_processing_bridgetower.py
+++ b/src/transformers/models/bridgetower/image_processing_bridgetower.py
@@ -238,9 +238,7 @@ class BridgeTowerImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         size = get_size_dict(size, default_to_square=False)
-        if "shortest_edge" not in size:
-            raise ValueError(f"The `size` dictionary must contain the key `shortest_edge`. Got {size.keys()}")
-        shorter = size["shortest_edge"]
+        shorter = size["shortest_edge"] if "shortest_edge" in size else min(size["height"], size["width"])
         longer = int(1333 / 800 * shorter)
         output_size = get_resize_output_image_size(
             image, shorter=shorter, longer=longer, size_divisor=size_divisor, input_data_format=input_data_format

--- a/src/transformers/models/chameleon/image_processing_chameleon.py
+++ b/src/transformers/models/chameleon/image_processing_chameleon.py
@@ -44,7 +44,8 @@ if is_vision_available():
     import PIL
 
 
-def make_batched_images(images) -> List[List[ImageInput]]:
+# Copied from transformers.models.llava_next.image_processing_llava_next.make_batched_images
+def make_batched_images(images) -> List[ImageInput]:
     """
     Accepts images in list or nested list format, and makes a list of images for preprocessing.
 

--- a/src/transformers/models/chameleon/processing_chameleon.py
+++ b/src/transformers/models/chameleon/processing_chameleon.py
@@ -40,7 +40,6 @@ class ChameleonProcessorKwargs(ProcessingKwargs, total=False):
     _defaults = {
         "text_kwargs": {
             "padding": False,
-            "stride": 0,
             "return_for_text_completion": False,
         },
         "common_kwargs": {

--- a/src/transformers/models/chameleon/processing_chameleon.py
+++ b/src/transformers/models/chameleon/processing_chameleon.py
@@ -24,6 +24,7 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, TextKwargs
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
+
 if sys.version_info >= (3, 11):
     from typing import Unpack
 else:

--- a/src/transformers/models/chameleon/processing_chameleon.py
+++ b/src/transformers/models/chameleon/processing_chameleon.py
@@ -114,7 +114,7 @@ class ChameleonProcessor(ProcessorMixin):
         elif not isinstance(text, list) and not isinstance(text[0], str):
             raise TypeError("Invalid input text. Please provide a string, or a list of strings")
         if text is None and images is None:
-            raise ValueError("You must provide either text or images")
+            raise ValueError("You must provide either text or images as prompt")
 
         output_kwargs = self._merge_kwargs(
             ChameleonProcessorKwargs,
@@ -132,12 +132,10 @@ class ChameleonProcessor(ProcessorMixin):
                 sample += self.tokenizer.sep_token  # special Chameleon treatment to add sep for chat mode
             prompt_strings.append(sample)
 
-        data = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
-
+        features = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
         if images is not None:
-            data["pixel_values"] = self.image_processor(images, **output_kwargs["images_kwargs"])["pixel_values"]
-
-        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"]["return_tensors"])
+            features["pixel_values"] = self.image_processor(images, **output_kwargs["images_kwargs"])["pixel_values"]
+        return features
 
     # Copied from transformers.models.clip.processing_clip.CLIPProcessor.batch_decode with CLIP->Llama
     def batch_decode(self, *args, **kwargs):

--- a/src/transformers/models/chameleon/processing_chameleon.py
+++ b/src/transformers/models/chameleon/processing_chameleon.py
@@ -92,11 +92,11 @@ class ChameleonProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
 

--- a/src/transformers/models/flava/processing_flava.py
+++ b/src/transformers/models/flava/processing_flava.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Union
 
 from ...image_utils import ImageInput
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
 
 if sys.version_info >= (3, 11):
@@ -92,6 +92,8 @@ class FlavaProcessor(ProcessorMixin):
         self,
         images: Optional[ImageInput] = None,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        audio=None,
+        videos=None,
         **kwargs: Unpack[FlavaProcessorKwargs],
     ):
         """
@@ -121,9 +123,7 @@ class FlavaProcessor(ProcessorMixin):
         elif text is not None:
             return encoding
         else:
-            return BatchEncoding(
-                data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"]["return_tensors"]
-            )
+            return image_features
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/flava/processing_flava.py
+++ b/src/transformers/models/flava/processing_flava.py
@@ -100,7 +100,24 @@ class FlavaProcessor(ProcessorMixin):
         This method uses [`FlavaImageProcessor.__call__`] method to prepare image(s) for the model, and
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
-        Please refer to the docstring of the above two methods for more information.
+        Args:
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+            images (`ImageInput`, *optional*):
+                The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
+                tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
+                number of channels, H and W are image height and width.
+
+        Returns:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
+
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
+              `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
+              `None`).
+            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
 
         if text is None and images is None:

--- a/src/transformers/models/flava/processing_flava.py
+++ b/src/transformers/models/flava/processing_flava.py
@@ -102,14 +102,14 @@ class FlavaProcessor(ProcessorMixin):
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
         Args:
-            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
-                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
-                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
-                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
             images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:

--- a/src/transformers/models/flava/processing_flava.py
+++ b/src/transformers/models/flava/processing_flava.py
@@ -130,18 +130,14 @@ class FlavaProcessor(ProcessorMixin):
             **kwargs,
         )
 
+        data = {}
         if text is not None:
-            encoding = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
-
-        return_tensors = output_kwargs["common_kwargs"].get("return_tensors")
-        if text is not None and images is not None:
-            return BatchFeature(data=dict(**encoding, **image_features), tensor_type=return_tensors)
-        elif text is not None:
-            return BatchFeature(data=dict(**encoding), tensor_type=return_tensors)
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            data.update(image_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -56,6 +56,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -58,9 +58,9 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-        if is_valid_image(videos[0]):
+        elif is_valid_image(videos[0]):
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -49,22 +49,17 @@ logger = logging.get_logger(__name__)
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -60,9 +60,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
             return videos
         if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        if is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -47,18 +47,25 @@ if is_vision_available():
 logger = logging.get_logger(__name__)
 
 
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
-            return [videos]
-        elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
+
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        return [videos]
+
+    elif is_valid_image(videos):
+        return [[videos]]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -56,10 +56,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/image_processing_instructblipvideo.py
@@ -50,21 +50,22 @@ logger = logging.get_logger(__name__)
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/instructblipvideo/processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/processing_instructblipvideo.py
@@ -100,14 +100,15 @@ class InstructBlipVideoProcessor(ProcessorMixin):
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
         Args:
-            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
-                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
-                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
-                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
             images (`ImageInput`, *optional*):
+                NOTE: Use `videos` instead. We only left this here for backwards compatibility.
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
             videos (`VideoInput`, *optional*):
                 The image or batch of videos to be prepared. Each video can be a 4D NumPy array or PyTorch
                 tensor, or a nested list of 3D frames. Both channels-first and channels-last formats are supported.

--- a/src/transformers/models/instructblipvideo/processing_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/processing_instructblipvideo.py
@@ -103,7 +103,7 @@ class InstructBlipVideoProcessor(ProcessorMixin):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.
@@ -119,6 +119,7 @@ class InstructBlipVideoProcessor(ProcessorMixin):
             -- **qformer_attention_mask** - List of indices specifying which tokens from the Q-Former tokenizer should be attended to by the model. Returned when `text` is not `None`.
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
+
         output_kwargs = self._merge_kwargs(
             InstructBlipVideoProcessorKwargs,
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,

--- a/src/transformers/models/llava_next/image_processing_llava_next.py
+++ b/src/transformers/models/llava_next/image_processing_llava_next.py
@@ -720,7 +720,11 @@ class LlavaNextImageProcessor(BaseImageProcessor):
             image_patches = self.get_image_patches(
                 image,
                 image_grid_pinpoints,
-                size=(size["shortest_edge"], size["shortest_edge"]),
+                size=(
+                    (size["shortest_edge"], size["shortest_edge"])
+                    if "shortest_edge" in size
+                    else (size["height"], size["width"])
+                ),
                 patch_size=crop_size["height"],
                 resample=resample,
                 data_format=input_data_format,

--- a/src/transformers/models/llava_next/image_processing_llava_next.py
+++ b/src/transformers/models/llava_next/image_processing_llava_next.py
@@ -53,7 +53,7 @@ if is_vision_available():
     from PIL import Image
 
 
-def make_batched_images(images) -> List[List[ImageInput]]:
+def make_batched_images(images) -> List[ImageInput]:
     """
     Accepts images in list or nested list format, and makes a list of images for preprocessing.
 

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -60,9 +60,9 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-        if is_valid_image(videos[0]):
+        elif is_valid_image(videos[0]):
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -46,7 +46,7 @@ logger = logging.get_logger(__name__)
 
 
 if is_vision_available():
-    from PIL import Image
+    import PIL
 
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
@@ -213,7 +213,7 @@ class LlavaNextVideoImageProcessor(BaseImageProcessor):
         do_convert_rgb: bool = None,
         data_format: Optional[ChannelDimension] = ChannelDimension.FIRST,
         input_data_format: Optional[Union[str, ChannelDimension]] = None,
-    ) -> Image.Image:
+    ) -> PIL.Image.Image:
         """
         Preprocess an image or batch of images. Copy of the `preprocess` method from `CLIPImageProcessor`.
 

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -62,9 +62,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
             return videos
         if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        if is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -58,6 +58,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -49,18 +49,25 @@ if is_vision_available():
     from PIL import Image
 
 
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], Image.Image):
-            return [videos]
-        elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
+
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        return [videos]
+
+    elif is_valid_image(videos):
+        return [[videos]]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -51,22 +51,17 @@ if is_vision_available():
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -58,10 +58,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/image_processing_llava_next_video.py
@@ -52,21 +52,22 @@ if is_vision_available():
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -16,19 +16,37 @@
 Processor class for LLaVa-NeXT-Video.
 """
 
+import sys
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput, VideoInput, get_image_size, to_numpy_array
-from ...processing_utils import ProcessorMixin
-from ...tokenization_utils_base import PaddingStrategy, PreTokenizedInput, TextInput, TruncationStrategy
-from ...utils import TensorType, logging
+from ...processing_utils import ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
+from ...utils import logging
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 
 if TYPE_CHECKING:
     pass
 
 logger = logging.get_logger(__name__)
+
+
+class LlavaNextVideoProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+        },
+        "common_kwargs": {
+            "return_tensors": "pt",
+        },
+    }
 
 
 class LlavaNextVideoProcessor(ProcessorMixin):
@@ -88,12 +106,10 @@ class LlavaNextVideoProcessor(ProcessorMixin):
     def __call__(
         self,
         text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]],
-        images: ImageInput = None,
-        videos: VideoInput = None,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy] = None,
-        max_length: int = None,
-        return_tensors: Optional[Union[str, TensorType]] = TensorType.PYTORCH,
+        images: Optional[ImageInput] = None,
+        videos: Optional[VideoInput] = None,
+        audio=None,
+        **kwargs: Unpack[LlavaNextVideoProcessorKwargs],
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
@@ -115,26 +131,6 @@ class LlavaNextVideoProcessor(ProcessorMixin):
             videos (`np.ndarray`, `torch.Tensor`, `List[np.ndarray]`, `List[torch.Tensor]`):
                 The image or batch of videos to be prepared. Each video can be a 4D NumPy array or PyTorch
                 tensor, or a nested list of 3D frames. Both channels-first and channels-last formats are supported.
-            padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*, defaults to `False`):
-                Select a strategy to pad the returned sequences (according to the model's padding side and padding
-                index) among:
-                - `True` or `'longest'`: Pad to the longest sequence in the batch (or no padding if only a single
-                  sequence if provided).
-                - `'max_length'`: Pad to a maximum length specified with the argument `max_length` or to the maximum
-                  acceptable input length for the model if that argument is not provided.
-                - `False` or `'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of different
-                  lengths).
-            max_length (`int`, *optional*):
-                Maximum length of the returned list and optionally padding length (see above).
-            truncation (`bool`, *optional*):
-                Activates truncation to cut input sequences longer than `max_length` to `max_length`.
-            return_tensors (`str` or [`~utils.TensorType`], *optional*):
-                If set, will return tensors of a particular framework. Acceptable values are:
-
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:
@@ -145,13 +141,19 @@ class LlavaNextVideoProcessor(ProcessorMixin):
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
+        output_kwargs = self._merge_kwargs(
+            LlavaNextVideoProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
         if images is not None:
-            image_inputs = self.image_processor(images, return_tensors=return_tensors)
+            image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
         else:
             image_inputs = {}
 
         if videos is not None:
-            videos_inputs = self.video_processor(videos, return_tensors=return_tensors)
+            videos_inputs = self.video_processor(videos, **output_kwargs["videos_kwargs"])
         else:
             videos_inputs = {}
 
@@ -203,14 +205,7 @@ class LlavaNextVideoProcessor(ProcessorMixin):
                     sample = sample.replace(self.video_token, self.video_token * num_video_tokens)
                     prompt_strings.append(sample)
 
-        text_inputs = self.tokenizer(
-            prompt_strings,
-            return_tensors=return_tensors,
-            padding=padding,
-            truncation=truncation,
-            max_length=max_length,
-        )
-        print(text_inputs.keys())
+        text_inputs = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs})
 

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -139,7 +139,8 @@ class LlavaNextVideoProcessor(ProcessorMixin):
             - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
               `None`).
-            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **pixel_values_images** -- Pixel values of images to be fed to a model. Returned when `images` is not `None`.
+            - **pixel_values_videos** -- Pixel values of videos to be fed to a model. Returned when `videos` is not `None`.
         """
         output_kwargs = self._merge_kwargs(
             LlavaNextVideoProcessorKwargs,
@@ -161,8 +162,6 @@ class LlavaNextVideoProcessor(ProcessorMixin):
             text = [text]
         elif not isinstance(text, list) and not isinstance(text[0], str):
             raise ValueError("Invalid input text. Please provide a string, or a list of strings")
-
-        print(self.patch_size, self.vision_feature_select_strategy, image_inputs, videos_inputs.keys())
 
         if self.patch_size is None or self.vision_feature_select_strategy is None:
             prompt_strings = text
@@ -207,7 +206,10 @@ class LlavaNextVideoProcessor(ProcessorMixin):
 
         text_inputs = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
 
-        return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs})
+        return BatchFeature(
+            data={**text_inputs, **image_inputs, **videos_inputs},
+            tensor_type=output_kwargs["common_kwargs"].get("return_tensors"),
+        )
 
     # Copied from transformers.models.clip.processing_clip.CLIPProcessor.batch_decode with CLIP->Llama
     def batch_decode(self, *args, **kwargs):

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -121,14 +121,14 @@ class LlavaNextVideoProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
-            videos (`np.ndarray`, `torch.Tensor`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            videos (`VideoInput`, *optional*):
                 The image or batch of videos to be prepared. Each video can be a 4D NumPy array or PyTorch
                 tensor, or a nested list of 3D frames. Both channels-first and channels-last formats are supported.
 

--- a/src/transformers/models/mgp_str/processing_mgp_str.py
+++ b/src/transformers/models/mgp_str/processing_mgp_str.py
@@ -139,6 +139,7 @@ class MgpstrProcessor(ProcessorMixin):
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
+
         if images is None and text is None:
             raise ValueError("You need to specify either an `images` or `text` input to process.")
 
@@ -148,18 +149,14 @@ class MgpstrProcessor(ProcessorMixin):
             **kwargs,
         )
 
+        data = {}
+        if text is not None:
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
-        if text is not None:
-            encodings = self.tokenizer(text, **output_kwargs["text_kwargs"])
-
-        return_tensors = output_kwargs["common_kwargs"].get("return_tensors")
-        if text is not None and images is not None:
-            return BatchFeature(data=dict(**image_features, labels=encodings["input_ids"]), tensor_type=return_tensors)
-        elif text is not None:
-            return BatchFeature(data=dict(**encodings), tensor_type=return_tensors)
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            data.update(image_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, sequences):
         """

--- a/src/transformers/models/mgp_str/processing_mgp_str.py
+++ b/src/transformers/models/mgp_str/processing_mgp_str.py
@@ -156,6 +156,10 @@ class MgpstrProcessor(ProcessorMixin):
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
             data.update(image_features)
+            # TODO: remove this after standardizing the outputs of vision-language processors
+            if "input_ids" in data:
+                data["labels"] = data["input_ids"]
+                data.pop("input_ids")
         return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, sequences):

--- a/src/transformers/models/mgp_str/processing_mgp_str.py
+++ b/src/transformers/models/mgp_str/processing_mgp_str.py
@@ -78,27 +78,34 @@ class MgpstrProcessor(ProcessorMixin):
                 FutureWarning,
             )
             feature_extractor = kwargs.pop("feature_extractor")
-        if "char_tokenizer" in kwargs:
-            warnings.warn(
-                "The `char_tokenizer` argument is deprecated and will be removed in future versions, use `tokenizer`"
-                " instead.",
-                FutureWarning,
-            )
-            char_tokenizer = kwargs.pop("char_tokenizer")
 
         image_processor = image_processor if image_processor is not None else feature_extractor
-        tokenizer = tokenizer if tokenizer is not None else char_tokenizer
         if image_processor is None:
             raise ValueError("You need to specify an `image_processor`.")
         if tokenizer is None:
             raise ValueError("You need to specify a `tokenizer`.")
 
         self.tokenizer = tokenizer
-        self.char_tokenizer = tokenizer  # For backwards compatibility
         self.bpe_tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
         self.wp_tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-uncased")
 
         super().__init__(image_processor, tokenizer)
+
+    @property
+    def char_tokenizer(self):
+        warnings.warn(
+            "The `char_tokenizer` attribute is deprecated and will be removed in future versions, use `tokenizer` instead.",
+            FutureWarning,
+        )
+        return self.tokenizer
+
+    @char_tokenizer.setter
+    def char_tokenizer(self, value):
+        warnings.warn(
+            "The `char_tokenizer` attribute is deprecated and will be removed in future versions, use `tokenizer` instead.",
+            FutureWarning,
+        )
+        self.tokenizer = value
 
     def __call__(
         self,

--- a/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
@@ -53,8 +53,8 @@ class Qwen2AudioProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
-        audios: Union[np.ndarray, List[np.ndarray]] = None,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        audios: Optional[Union[np.ndarray, List[np.ndarray]]] = None,
         padding: Union[bool, str, PaddingStrategy] = False,
         sampling_rate: Optional[int] = None,
         **kwargs,

--- a/src/transformers/models/siglip/processing_siglip.py
+++ b/src/transformers/models/siglip/processing_siglip.py
@@ -16,13 +16,30 @@
 Image/Text processor class for SigLIP.
 """
 
+import sys
 from typing import List, Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
-from ...processing_utils import ProcessorMixin
-from ...tokenization_utils_base import PaddingStrategy, PreTokenizedInput, TextInput, TruncationStrategy
-from ...utils import TensorType
+from ...processing_utils import ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class SiglipProcessingKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+        },
+        "common_kwargs": {
+            "return_tensors": "pt",
+        },
+    }
 
 
 class SiglipProcessor(ProcessorMixin):
@@ -48,12 +65,9 @@ class SiglipProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
-        images: ImageInput = None,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy] = None,
-        max_length: int = None,
-        return_tensors: Optional[Union[str, TensorType]] = TensorType.PYTORCH,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        images: Optional[ImageInput] = None,
+        **kwargs: Unpack[SiglipProcessingKwargs],
     ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
@@ -70,26 +84,6 @@ class SiglipProcessor(ProcessorMixin):
             images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
-            padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*, defaults to `False`):
-                Select a strategy to pad the returned sequences (according to the model's padding side and padding
-                index) among:
-                - `True` or `'longest'`: Pad to the longest sequence in the batch (or no padding if only a single
-                  sequence if provided).
-                - `'max_length'`: Pad to a maximum length specified with the argument `max_length` or to the maximum
-                  acceptable input length for the model if that argument is not provided.
-                - `False` or `'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of different
-                  lengths).
-            max_length (`int`, *optional*):
-                Maximum length of the returned list and optionally padding length (see above).
-            truncation (`bool`, *optional*):
-                Activates truncation to cut input sequences longer than `max_length` to `max_length`.
-            return_tensors (`str` or [`~utils.TensorType`], *optional*):
-                If set, will return tensors of a particular framework. Acceptable values are:
-
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:
@@ -104,13 +98,17 @@ class SiglipProcessor(ProcessorMixin):
         if text is None and images is None:
             raise ValueError("You have to specify either text or images. Both cannot be none.")
 
+        output_kwargs = self._merge_kwargs(
+            SiglipProcessingKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
         if text is not None:
-            encoding = self.tokenizer(
-                text, return_tensors=return_tensors, padding=padding, truncation=truncation, max_length=max_length
-            )
+            encoding = self.tokenizer(text, **output_kwargs["text_kwargs"])
 
         if images is not None:
-            image_features = self.image_processor(images, return_tensors=return_tensors)
+            image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
 
         if text is not None and images is not None:
             encoding["pixel_values"] = image_features.pixel_values
@@ -118,7 +116,9 @@ class SiglipProcessor(ProcessorMixin):
         elif text is not None:
             return encoding
         else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            return BatchFeature(
+                data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"]["return_tensors"]
+            )
 
     def decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/siglip/processing_siglip.py
+++ b/src/transformers/models/siglip/processing_siglip.py
@@ -79,11 +79,11 @@ class SiglipProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. Both channels-first and channels-last formats are supported.
 

--- a/src/transformers/models/siglip/processing_siglip.py
+++ b/src/transformers/models/siglip/processing_siglip.py
@@ -67,6 +67,8 @@ class SiglipProcessor(ProcessorMixin):
         self,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
         images: Optional[ImageInput] = None,
+        audio=None,
+        videos=None,
         **kwargs: Unpack[SiglipProcessingKwargs],
     ) -> BatchFeature:
         """
@@ -116,9 +118,7 @@ class SiglipProcessor(ProcessorMixin):
         elif text is not None:
             return encoding
         else:
-            return BatchFeature(
-                data=dict(**image_features), tensor_type=output_kwargs["common_kwargs"]["return_tensors"]
-            )
+            return image_features
 
     def decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/siglip/processing_siglip.py
+++ b/src/transformers/models/siglip/processing_siglip.py
@@ -106,21 +106,14 @@ class SiglipProcessor(ProcessorMixin):
             **kwargs,
         )
 
+        data = {}
         if text is not None:
-            encoding = self.tokenizer(text, **output_kwargs["text_kwargs"])
-
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if images is not None:
             image_features = self.image_processor(images, **output_kwargs["images_kwargs"])
-
-        return_tensors = output_kwargs["common_kwargs"].get("return_tensors")
-        if text is not None and images is not None:
-            return BatchFeature(
-                data=dict(**encoding, pixel_values=image_features.pixel_values), tensor_type=return_tensors
-            )
-        elif text is not None:
-            return BatchFeature(data=dict(**encoding), tensor_type=return_tensors)
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            data.update(image_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/speecht5/processing_speecht5.py
+++ b/src/transformers/models/speecht5/processing_speecht5.py
@@ -60,6 +60,9 @@ class SpeechT5Processor(ProcessorMixin):
     feature_extractor_class = "SpeechT5FeatureExtractor"
     tokenizer_class = "SpeechT5Tokenizer"
 
+    def __init__(self, feature_extractor, tokenizer):
+        super().__init__(feature_extractor, tokenizer)
+
     def __call__(
         self,
         audio: Optional[AudioInput] = None,

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -60,9 +60,9 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-        if is_valid_image(videos[0]):
+        elif is_valid_image(videos[0]):
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -50,7 +50,13 @@ logger = logging.get_logger(__name__)
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched
 def make_batched(videos) -> List[List[ImageInput]]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+        return videos
+
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
+
+    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
@@ -305,29 +311,19 @@ class TvpImageProcessor(BaseImageProcessor):
         # All transformations expect numpy arrays.
         image = to_numpy_array(image)
 
-        print(f"{image.shape = }")
-
         if do_resize:
             image = self.resize(image=image, size=size, resample=resample, input_data_format=input_data_format)
-
-        print(f"{image.shape = }")
 
         if do_center_crop:
             image = self.center_crop(image, size=crop_size, input_data_format=input_data_format)
 
-        print(f"{image.shape = }")
-
         if do_rescale:
             image = self.rescale(image=image, scale=rescale_factor, input_data_format=input_data_format)
-
-        print(f"{image.shape = }")
 
         if do_normalize:
             image = self.normalize(
                 image=image.astype(np.float32), mean=image_mean, std=image_std, input_data_format=input_data_format
             )
-
-        print(f"{image.shape = }")
 
         if do_pad:
             image = self.pad_image(
@@ -338,17 +334,11 @@ class TvpImageProcessor(BaseImageProcessor):
                 input_data_format=input_data_format,
             )
 
-        print(f"{image.shape = }")
-
         # the pretrained checkpoints assume images are BGR, not RGB
         if do_flip_channel_order:
             image = flip_channel_order(image=image, input_data_format=input_data_format)
 
-        print(f"{image.shape = }")
-
         image = to_channel_dimension_format(image, data_format, input_channel_dim=input_data_format)
-
-        print(f"{image.shape = }")
 
         return image
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -32,6 +32,7 @@ from ...image_utils import (
     ChannelDimension,
     ImageInput,
     PILImageResampling,
+    VideoInput,
     get_image_size,
     is_valid_image,
     to_numpy_array,
@@ -48,16 +49,19 @@ if is_vision_available():
 logger = logging.get_logger(__name__)
 
 
-# Copied from transformers.models.vivit.image_processing_vivit.make_batched
-def make_batched(videos) -> List[List[ImageInput]]:
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
+def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
     elif isinstance(videos, np.ndarray) and videos.ndim == 4:
         return [videos]
 
-    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
         return [videos]
@@ -449,7 +453,7 @@ class TvpImageProcessor(BaseImageProcessor):
                 "torch.Tensor, tf.Tensor or jax.ndarray."
             )
 
-        videos = make_batched(videos)
+        videos = make_batched_videos(videos)
 
         videos = [
             np.array(

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -62,9 +62,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
             return videos
         if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        if is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -58,6 +58,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -51,22 +51,17 @@ logger = logging.get_logger(__name__)
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -52,21 +52,22 @@ logger = logging.get_logger(__name__)
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -58,10 +58,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/tvp/image_processing_tvp.py
+++ b/src/transformers/models/tvp/image_processing_tvp.py
@@ -305,19 +305,29 @@ class TvpImageProcessor(BaseImageProcessor):
         # All transformations expect numpy arrays.
         image = to_numpy_array(image)
 
+        print(f"{image.shape = }")
+
         if do_resize:
             image = self.resize(image=image, size=size, resample=resample, input_data_format=input_data_format)
+
+        print(f"{image.shape = }")
 
         if do_center_crop:
             image = self.center_crop(image, size=crop_size, input_data_format=input_data_format)
 
+        print(f"{image.shape = }")
+
         if do_rescale:
             image = self.rescale(image=image, scale=rescale_factor, input_data_format=input_data_format)
+
+        print(f"{image.shape = }")
 
         if do_normalize:
             image = self.normalize(
                 image=image.astype(np.float32), mean=image_mean, std=image_std, input_data_format=input_data_format
             )
+
+        print(f"{image.shape = }")
 
         if do_pad:
             image = self.pad_image(
@@ -328,11 +338,17 @@ class TvpImageProcessor(BaseImageProcessor):
                 input_data_format=input_data_format,
             )
 
+        print(f"{image.shape = }")
+
         # the pretrained checkpoints assume images are BGR, not RGB
         if do_flip_channel_order:
             image = flip_channel_order(image=image, input_data_format=input_data_format)
 
+        print(f"{image.shape = }")
+
         image = to_channel_dimension_format(image, data_format, input_channel_dim=input_data_format)
+
+        print(f"{image.shape = }")
 
         return image
 

--- a/src/transformers/models/tvp/processing_tvp.py
+++ b/src/transformers/models/tvp/processing_tvp.py
@@ -121,16 +121,14 @@ class TvpProcessor(ProcessorMixin):
             **kwargs,
         )
 
-        encoding = {}
+        data = {}
         if text is not None:
-            textual_input = self.tokenizer(text, **output_kwargs["text_kwargs"])
-            encoding.update(textual_input)
-
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if videos is not None:
-            image_features = self.image_processor(videos, **output_kwargs["videos_kwargs"])
-            encoding.update(image_features)
-
-        return BatchFeature(data=encoding, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
+            video_features = self.image_processor(videos, **output_kwargs["videos_kwargs"])
+            data.update(video_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -59,6 +59,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -63,9 +63,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
             return videos
         if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        if is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -34,6 +34,7 @@ from ...image_utils import (
     VideoInput,
     infer_channel_dimension_format,
     is_scaled_image,
+    is_valid_image,
     make_list_of_images,
     to_numpy_array,
     valid_images,

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -59,10 +59,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -50,18 +50,25 @@ if is_vision_available():
     import PIL
 
 
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
-            return [videos]
-        elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
+
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        return [videos]
+
+    elif is_valid_image(videos):
+        return [[videos]]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -34,7 +34,6 @@ from ...image_utils import (
     VideoInput,
     infer_channel_dimension_format,
     is_scaled_image,
-    is_valid_image,
     make_list_of_images,
     to_numpy_array,
     valid_images,
@@ -52,22 +51,17 @@ if is_vision_available():
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -53,21 +53,22 @@ if is_vision_available():
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/video_llava/image_processing_video_llava.py
+++ b/src/transformers/models/video_llava/image_processing_video_llava.py
@@ -61,9 +61,9 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-        if is_valid_image(videos[0]):
+        elif is_valid_image(videos[0]):
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/video_llava/processing_video_llava.py
+++ b/src/transformers/models/video_llava/processing_video_llava.py
@@ -109,15 +109,15 @@ class VideoLlavaProcessor(ProcessorMixin):
         of the above two methods for more information.
 
         Args:
-            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.
-            videos (`np.ndarray`, `torch.Tensor`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            videos (`VideoInput`, *optional*):
                 Video frames to preprocess. Expects a single or batch of video frames in NumPy array or PyTorch
                 tensor. Each video should be of shape (T, C, H, W), where T is number of frames, C is
                 number of channels, H and W are image height and width.

--- a/src/transformers/models/video_llava/processing_video_llava.py
+++ b/src/transformers/models/video_llava/processing_video_llava.py
@@ -20,7 +20,7 @@ import sys
 from typing import List, Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
-from ...image_utils import ImageInput, get_image_size, to_numpy_array
+from ...image_utils import ImageInput, VideoInput, get_image_size, to_numpy_array
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import logging
@@ -97,7 +97,7 @@ class VideoLlavaProcessor(ProcessorMixin):
         self,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
         images: Optional[ImageInput] = None,
-        videos: Optional[ImageInput] = None,
+        videos: Optional[VideoInput] = None,
         audio=None,
         **kwargs: Unpack[VideoLlavaProcessorKwargs],
     ) -> BatchFeature:
@@ -181,7 +181,7 @@ class VideoLlavaProcessor(ProcessorMixin):
         text_inputs = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"])
         data.update(text_inputs)
 
-        return BatchFeature(data=data)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     # Copied from transformers.models.clip.processing_clip.CLIPProcessor.batch_decode with CLIP->Llama
     def batch_decode(self, *args, **kwargs):

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -59,9 +59,9 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-        if is_valid_image(videos[0]):
+        elif is_valid_image(videos[0]):
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -30,6 +30,7 @@ from ...image_utils import (
     ChannelDimension,
     ImageInput,
     PILImageResampling,
+    VideoInput,
     infer_channel_dimension_format,
     is_scaled_image,
     is_valid_image,
@@ -47,16 +48,19 @@ if is_vision_available():
 logger = logging.get_logger(__name__)
 
 
-# Copied from transformers.models.vivit.image_processing_vivit.make_batched
-def make_batched(videos) -> List[List[ImageInput]]:
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
+def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
     elif isinstance(videos, np.ndarray) and videos.ndim == 4:
         return [videos]
 
-    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
         return [videos]
@@ -324,7 +328,7 @@ class VideoMAEImageProcessor(BaseImageProcessor):
                 "torch.Tensor, tf.Tensor or jax.ndarray."
             )
 
-        videos = make_batched(videos)
+        videos = make_batched_videos(videos)
 
         videos = [
             [

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -47,8 +47,15 @@ if is_vision_available():
 logger = logging.get_logger(__name__)
 
 
+# Copied from transformers.models.vivit.image_processing_vivit.make_batched
 def make_batched(videos) -> List[List[ImageInput]]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+        return videos
+
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
+
+    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -57,10 +57,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -50,22 +50,17 @@ logger = logging.get_logger(__name__)
 
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -61,9 +61,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
             return videos
         if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        if is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -57,6 +57,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/videomae/image_processing_videomae.py
+++ b/src/transformers/models/videomae/image_processing_videomae.py
@@ -51,21 +51,22 @@ logger = logging.get_logger(__name__)
 # Copied from transformers.models.vivit.image_processing_vivit.make_batched_videos
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/vilt/image_processing_vilt.py
+++ b/src/transformers/models/vilt/image_processing_vilt.py
@@ -112,8 +112,8 @@ def get_resize_output_image_size(
         new_width = scale * new_width
 
     new_height, new_width = int(new_height + 0.5), int(new_width + 0.5)
-    new_height = new_height // size_divisor * size_divisor
-    new_width = new_width // size_divisor * size_divisor
+    new_height = max(1, new_height // size_divisor) * size_divisor
+    new_width = max(1, new_width // size_divisor) * size_divisor
 
     return new_height, new_width
 
@@ -236,9 +236,7 @@ class ViltImageProcessor(BaseImageProcessor):
                 The channel dimension format of the input image. If not provided, it will be inferred.
         """
         size = get_size_dict(size, default_to_square=False)
-        if "shortest_edge" not in size:
-            raise ValueError(f"The `size` dictionary must contain the key `shortest_edge`. Got {size.keys()}")
-        shorter = size["shortest_edge"]
+        shorter = size["shortest_edge"] if "shortest_edge" in size else min(size["height"], size["width"])
         longer = int(1333 / 800 * shorter)
         output_size = get_resize_output_image_size(
             image, shorter=shorter, longer=longer, size_divisor=size_divisor, input_data_format=input_data_format

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -16,12 +16,34 @@
 Processor class for ViLT.
 """
 
+import sys
 import warnings
 from typing import List, Optional, Union
 
-from ...processing_utils import ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PaddingStrategy, PreTokenizedInput, TextInput, TruncationStrategy
-from ...utils import TensorType
+from ...image_utils import ImageInput
+from ...processing_utils import ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class ViltProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "add_special_tokens": True,
+            "padding": False,
+            "stride": 0,
+            "return_overflowing_tokens": False,
+            "return_special_tokens_mask": False,
+            "return_offsets_mapping": False,
+            "return_length": False,
+            "verbose": True,
+        },
+    }
 
 
 class ViltProcessor(ProcessorMixin):
@@ -63,23 +85,9 @@ class ViltProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        images,
-        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
-        add_special_tokens: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy] = None,
-        max_length: Optional[int] = None,
-        stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
-        return_overflowing_tokens: bool = False,
-        return_special_tokens_mask: bool = False,
-        return_offsets_mapping: bool = False,
-        return_length: bool = False,
-        verbose: bool = True,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        **kwargs,
+        images: ImageInput,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        **kwargs: Unpack[ViltProcessorKwargs],
     ) -> BatchEncoding:
         """
         This method uses [`ViltImageProcessor.__call__`] method to prepare image(s) for the model, and
@@ -87,26 +95,15 @@ class ViltProcessor(ProcessorMixin):
 
         Please refer to the docstring of the above two methods for more information.
         """
-        encoding = self.tokenizer(
-            text=text,
-            add_special_tokens=add_special_tokens,
-            padding=padding,
-            truncation=truncation,
-            max_length=max_length,
-            stride=stride,
-            pad_to_multiple_of=pad_to_multiple_of,
-            return_token_type_ids=return_token_type_ids,
-            return_attention_mask=return_attention_mask,
-            return_overflowing_tokens=return_overflowing_tokens,
-            return_special_tokens_mask=return_special_tokens_mask,
-            return_offsets_mapping=return_offsets_mapping,
-            return_length=return_length,
-            verbose=verbose,
-            return_tensors=return_tensors,
+        output_kwargs = self._merge_kwargs(
+            ViltProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
             **kwargs,
         )
+
+        encoding = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
         # add pixel_values + pixel_mask
-        encoding_image_processor = self.image_processor(images, return_tensors=return_tensors)
+        encoding_image_processor = self.image_processor(images, **output_kwargs["images_kwargs"])
         encoding.update(encoding_image_processor)
 
         return encoding

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -97,14 +97,14 @@ class ViltProcessor(ProcessorMixin):
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
         Args:
-            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
-                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
-                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
-                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`ImageInput`, *optional*):
+            images (`ImageInput`):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -114,6 +114,7 @@ class ViltProcessor(ProcessorMixin):
               `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
               `None`).
             - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+            - **pixel_mask** -- Mask for the pixel values. Returned when `images` is not `None`.
         """
         output_kwargs = self._merge_kwargs(
             ViltProcessorKwargs,
@@ -126,7 +127,7 @@ class ViltProcessor(ProcessorMixin):
         encoding_image_processor = self.image_processor(images, **output_kwargs["images_kwargs"])
         encoding.update(encoding_image_processor)
 
-        return encoding
+        return BatchFeature(data=dict(**encoding), tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -20,9 +20,10 @@ import sys
 import warnings
 from typing import List, Optional, Union
 
+from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
-from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
+from ...tokenization_utils_base import PreTokenizedInput, TextInput
 
 
 if sys.version_info >= (3, 11):
@@ -87,13 +88,32 @@ class ViltProcessor(ProcessorMixin):
         self,
         images: ImageInput,
         text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        audio=None,
+        videos=None,
         **kwargs: Unpack[ViltProcessorKwargs],
-    ) -> BatchEncoding:
+    ) -> BatchFeature:
         """
         This method uses [`ViltImageProcessor.__call__`] method to prepare image(s) for the model, and
         [`BertTokenizerFast.__call__`] to prepare text for the model.
 
-        Please refer to the docstring of the above two methods for more information.
+        Args:
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+                The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
+                tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
+                number of channels, H and W are image height and width.
+
+        Returns:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
+
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
+              `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
+              `None`).
+            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
         """
         output_kwargs = self._merge_kwargs(
             ViltProcessorKwargs,

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -122,12 +122,14 @@ class ViltProcessor(ProcessorMixin):
             **kwargs,
         )
 
-        encoding = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
-        # add pixel_values + pixel_mask
-        encoding_image_processor = self.image_processor(images, **output_kwargs["images_kwargs"])
-        encoding.update(encoding_image_processor)
-
-        return BatchFeature(data=dict(**encoding), tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
+        data = {}
+        if text is not None:
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
+        if images is not None:
+            images_features = self.image_processor(images, **output_kwargs["images_kwargs"])
+            data.update(images_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -101,7 +101,7 @@ class ViltProcessor(ProcessorMixin):
                 The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
                 (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
                 `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            images (`ImageInput`, *optional*):
                 The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
                 tensor. In case of a NumPy array/PyTorch tensor, each image should be of shape (C, H, W), where C is a
                 number of channels, H and W are image height and width.

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -59,6 +59,8 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
+            return videos
+        elif len(videos[0].shape) == 3:
             return [videos]
 
     elif is_valid_image(videos):

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -52,22 +52,17 @@ logger = logging.get_logger(__name__)
 
 
 def make_batched_videos(videos) -> List[VideoInput]:
-    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
-    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
-        return [videos]
-
-    elif isinstance(videos, (list, tuple)):
-        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-            return videos
-        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
-            return videos
-        elif is_valid_image(videos[0]):
+    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
+        if isinstance(videos[0], PIL.Image.Image):
             return [videos]
+        elif len(videos[0].shape) == 4:
+            return [list(video) for video in videos]
 
-    elif is_valid_image(videos):
-        return [[videos]]
+    elif is_valid_image(videos) and len(videos.shape) == 4:
+        return [list(videos)]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -51,7 +51,13 @@ logger = logging.get_logger(__name__)
 
 
 def make_batched(videos) -> List[List[ImageInput]]:
-    if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+    if isinstance(videos, np.ndarray) and videos.ndim == 5:
+        return videos
+
+    elif isinstance(videos, np.ndarray) and videos.ndim == 4:
+        return [videos]
+
+    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
         return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -61,11 +61,10 @@ def make_batched_videos(videos) -> List[VideoInput]:
     elif isinstance(videos, (list, tuple)):
         if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
             return videos
-        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+        elif isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
             return videos
-
-    elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        return [videos]
+        elif is_valid_image(videos[0]):
+            return [videos]
 
     elif is_valid_image(videos):
         return [[videos]]

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -59,10 +59,13 @@ def make_batched_videos(videos) -> List[VideoInput]:
         if isinstance(videos[0], PIL.Image.Image):
             return [videos]
         elif len(videos[0].shape) == 4:
-            return [list(video) for video in videos]
+            return [videos]
 
-    elif is_valid_image(videos) and len(videos.shape) == 4:
-        return [list(videos)]
+    elif is_valid_image(videos):
+        if len(videos.shape) == 5:
+            return videos
+        elif len(videos.shape) == 4:
+            return [videos]
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -53,21 +53,22 @@ logger = logging.get_logger(__name__)
 
 def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+        if isinstance(videos[0][0], PIL.Image.Image) or len(videos[0][0].shape) == 3:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
-        if isinstance(videos[0], PIL.Image.Image):
+        if isinstance(videos[0], PIL.Image.Image) or len(videos[0].shape) == 3:
             return [videos]
         elif len(videos[0].shape) == 4:
             return videos
-        elif len(videos[0].shape) == 3:
-            return [videos]
 
     elif is_valid_image(videos):
-        if len(videos.shape) == 5:
-            return videos
+        if isinstance(videos, PIL.Image.Image) or len(videos.shape) == 3:
+            return [[videos]]
         elif len(videos.shape) == 4:
             return [videos]
+        elif len(videos.shape) == 5:
+            return videos
 
     raise ValueError(f"Could not make batched video from {videos}")
 

--- a/src/transformers/models/vivit/image_processing_vivit.py
+++ b/src/transformers/models/vivit/image_processing_vivit.py
@@ -34,6 +34,7 @@ from ...image_utils import (
     ChannelDimension,
     ImageInput,
     PILImageResampling,
+    VideoInput,
     infer_channel_dimension_format,
     is_scaled_image,
     is_valid_image,
@@ -50,15 +51,18 @@ if is_vision_available():
 logger = logging.get_logger(__name__)
 
 
-def make_batched(videos) -> List[List[ImageInput]]:
+def make_batched_videos(videos) -> List[VideoInput]:
     if isinstance(videos, np.ndarray) and videos.ndim == 5:
         return videos
 
     elif isinstance(videos, np.ndarray) and videos.ndim == 4:
         return [videos]
 
-    elif isinstance(videos, (list, tuple)) and isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
-        return videos
+    elif isinstance(videos, (list, tuple)):
+        if isinstance(videos[0], (list, tuple)) and is_valid_image(videos[0][0]):
+            return videos
+        if isinstance(videos[0], np.ndarray) and videos[0].ndim == 4:
+            return videos
 
     elif isinstance(videos, (list, tuple)) and is_valid_image(videos[0]):
         return [videos]
@@ -381,7 +385,7 @@ class VivitImageProcessor(BaseImageProcessor):
                 "torch.Tensor, tf.Tensor or jax.ndarray."
             )
 
-        videos = make_batched(videos)
+        videos = make_batched_videos(videos)
 
         videos = [
             [

--- a/src/transformers/models/wav2vec2_bert/processing_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/processing_wav2vec2_bert.py
@@ -16,11 +16,25 @@
 Speech processor class for Wav2Vec2-BERT
 """
 
+import sys
 import warnings
+from typing import List, Optional, Union
 
-from ...processing_utils import ProcessorMixin
+from ...feature_extraction_utils import BatchFeature
+from ...processing_utils import ProcessingKwargs, ProcessorMixin
+from ...tokenization_utils_base import AudioInput, PreTokenizedInput, TextInput
 from ..seamless_m4t.feature_extraction_seamless_m4t import SeamlessM4TFeatureExtractor
 from ..wav2vec2.tokenization_wav2vec2 import Wav2Vec2CTCTokenizer
+
+
+if sys.version_info >= (3, 11):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
+
+
+class Wav2Vec2BertProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {}
 
 
 class Wav2Vec2BertProcessor(ProcessorMixin):
@@ -38,11 +52,9 @@ class Wav2Vec2BertProcessor(ProcessorMixin):
             An instance of [`PreTrainedTokenizer`]. The tokenizer is a required input.
     """
 
+    attributes = ["feature_extractor", "tokenizer"]
     feature_extractor_class = "SeamlessM4TFeatureExtractor"
     tokenizer_class = "AutoTokenizer"
-
-    def __init__(self, feature_extractor, tokenizer):
-        super().__init__(feature_extractor, tokenizer)
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
@@ -63,7 +75,14 @@ class Wav2Vec2BertProcessor(ProcessorMixin):
 
             return cls(feature_extractor=feature_extractor, tokenizer=tokenizer)
 
-    def __call__(self, audio=None, text=None, **kwargs):
+    def __call__(
+        self,
+        audio: Optional[AudioInput] = None,
+        text: Optional[Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]]] = None,
+        images=None,
+        videos=None,
+        **kwargs: Unpack[Wav2Vec2BertProcessorKwargs],
+    ) -> BatchFeature:
         """
         Main method to prepare for the model one or several sequences(s) and audio(s). This method forwards the `audio`
         and `kwargs` arguments to SeamlessM4TFeatureExtractor's [`~SeamlessM4TFeatureExtractor.__call__`] if `audio` is not
@@ -71,17 +90,15 @@ class Wav2Vec2BertProcessor(ProcessorMixin):
         PreTrainedTokenizer's [`~PreTrainedTokenizer.__call__`] if `text` is not `None`. Please refer to the doctsring of the above two methods for more information.
 
         Args:
-            text (`str`, `List[str]`, `List[List[str]]`):
-                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
-                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
-                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
-            audio (`np.ndarray`, `torch.Tensor`, `List[np.ndarray]`, `List[torch.Tensor]`):
+            audio (`AudioInput`, *optional*):
                 The audio or batch of audios to be prepared. Each audio can be NumPy array or PyTorch tensor. In case
                 of a NumPy array/PyTorch tensor, each audio should be of shape (C, T), where C is a number of channels,
                 and T the sample length of the audio.
-            kwargs (*optional*):
-                Remaining dictionary of keyword arguments that will be passed to the feature extractor and/or the
-                tokenizer.
+            text (`TextInput`, `PreTokenizedInput`, `List[TextInput]`, `List[PreTokenizedInput]`, *optional*):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+
         Returns:
             [`BatchEncoding`]: A [`BatchEncoding`] with the following fields:
             - **input_features** -- Audio input features to be fed to a model. Returned when `audio` is not `None`.
@@ -91,23 +108,26 @@ class Wav2Vec2BertProcessor(ProcessorMixin):
             - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None` and `audio` is `None`.
         """
 
-        sampling_rate = kwargs.pop("sampling_rate", None)
-
         if audio is None and text is None:
             raise ValueError("You need to specify either an `audio` or `text` input to process.")
 
-        if audio is not None:
-            inputs = self.feature_extractor(audio, sampling_rate=sampling_rate, **kwargs)
-        if text is not None:
-            encodings = self.tokenizer(text, **kwargs)
+        output_kwargs = self._merge_kwargs(
+            Wav2Vec2BertProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
 
-        if text is None:
-            return inputs
-        elif audio is None:
-            return encodings
-        else:
-            inputs["labels"] = encodings["input_ids"]
-            return inputs
+        data = {}
+        if audio is not None:
+            audio_features = self.feature_extractor(audio, **output_kwargs["audio_kwargs"])
+            data.update(audio_features)
+        if text is not None:
+            text_features = self.tokenizer(text, **output_kwargs["text_kwargs"])
+            if audio is not None:
+                data["labels"] = text_features["input_ids"]
+            else:
+                data.update(text_features)
+        return BatchFeature(data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def pad(self, input_features=None, labels=None, **kwargs):
         """

--- a/src/transformers/models/wav2vec2_bert/processing_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/processing_wav2vec2_bert.py
@@ -56,6 +56,9 @@ class Wav2Vec2BertProcessor(ProcessorMixin):
     feature_extractor_class = "SeamlessM4TFeatureExtractor"
     tokenizer_class = "AutoTokenizer"
 
+    def __init__(self, feature_extractor, tokenizer):
+        super().__init__(feature_extractor, tokenizer)
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
         try:

--- a/src/transformers/models/x_clip/processing_x_clip.py
+++ b/src/transformers/models/x_clip/processing_x_clip.py
@@ -118,19 +118,14 @@ class XCLIPProcessor(ProcessorMixin):
             **kwargs,
         )
 
+        data = {}
         if text is not None:
-            encoding = self.tokenizer(text, **output_kwargs["text_kwargs"])
-
+            text_features = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+            data.update(text_features)
         if videos is not None:
-            image_features = self.image_processor(videos, **output_kwargs["videos_kwargs"])
-
-        return_tensors = output_kwargs["common_kwargs"].get("return_tensors")
-        if text is not None and videos is not None:
-            return BatchFeature(data=dict(**encoding, **image_features), tensor_type=return_tensors)
-        elif text is not None:
-            return BatchFeature(data=dict(**encoding), tensor_type=return_tensors)
-        else:
-            return BatchFeature(data=dict(**image_features), tensor_type=return_tensors)
+            video_features = self.image_processor(videos, **output_kwargs["images_kwargs"])
+            data.update(video_features)
+        return BatchFeature(data=data, tensor_type=output_kwargs["common_kwargs"].get("return_tensors"))
 
     def batch_decode(self, *args, **kwargs):
         """

--- a/tests/models/altclip/test_processor_altclip.py
+++ b/tests/models/altclip/test_processor_altclip.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+
+from transformers import AltCLIPProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class AltCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "BAAI/AltCLIP"
+    processor_class = AltCLIPProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/chameleon/test_processor_chameleon.py
+++ b/tests/models/chameleon/test_processor_chameleon.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+
+from transformers import ChameleonProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class ChameleonProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "leloy/Anole-7b-v0.1-hf"
+    processor_class = ChameleonProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/chameleon/test_processor_chameleon.py
+++ b/tests/models/chameleon/test_processor_chameleon.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 
 from transformers import ChameleonProcessor
+from transformers.models.auto.processing_auto import processor_class_from_name
 
 from ...test_processing_common import ProcessorTesterMixin
 
@@ -9,6 +10,22 @@ from ...test_processing_common import ProcessorTesterMixin
 class ChameleonProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     from_pretrained_id = "leloy/Anole-7b-v0.1-hf"
     processor_class = ChameleonProcessor
+
+    def get_component(self, attribute, **kwargs):
+        assert attribute in self.processor_class.attributes
+        component_class_name = getattr(self.processor_class, f"{attribute}_class")
+        if isinstance(component_class_name, tuple):
+            if "_fast" in component_class_name[0]:
+                component_class_name = component_class_name[0]
+            else:
+                component_class_name = component_class_name[1]
+
+        component_class = processor_class_from_name(component_class_name)
+        component = component_class.from_pretrained(self.tmpdirname, **kwargs)  # noqa
+        if attribute == "tokenizer" and not component.pad_token:
+            component.pad_token = "[TEST_PAD]"
+
+        return component
 
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()

--- a/tests/models/clap/test_processor_clap.py
+++ b/tests/models/clap/test_processor_clap.py
@@ -19,21 +19,32 @@ import unittest
 from transformers import ClapFeatureExtractor, ClapProcessor, RobertaTokenizer, RobertaTokenizerFast
 from transformers.testing_utils import require_sentencepiece, require_torchaudio
 
+from ...test_processing_common import ProcessorTesterMixin
 from .test_feature_extraction_clap import floats_list
 
 
 @require_torchaudio
 @require_sentencepiece
-class ClapProcessorTest(unittest.TestCase):
+class ClapProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "laion/clap-htsat-unfused"
+    processor_class = ClapProcessor
+
     def setUp(self):
-        self.checkpoint = "laion/clap-htsat-unfused"
         self.tmpdirname = tempfile.mkdtemp()
+        processor = ClapProcessor.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
+
+    def get_component(self, attribute, **kwargs):
+        assert attribute in self.processor_class.attributes
+        if attribute == "tokenizer":
+            return self.get_tokenizer(**kwargs)
+        return super().get_component(attribute, **kwargs)
 
     def get_tokenizer(self, **kwargs):
-        return RobertaTokenizer.from_pretrained(self.checkpoint, **kwargs)
+        return RobertaTokenizer.from_pretrained(self.from_pretrained_id, **kwargs)
 
     def get_feature_extractor(self, **kwargs):
-        return ClapFeatureExtractor.from_pretrained(self.checkpoint, **kwargs)
+        return ClapFeatureExtractor.from_pretrained(self.from_pretrained_id, **kwargs)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/clvp/test_processor_clvp.py
+++ b/tests/models/clvp/test_processor_clvp.py
@@ -21,14 +21,19 @@ import unittest
 from transformers import ClvpFeatureExtractor, ClvpProcessor, ClvpTokenizer
 from transformers.testing_utils import require_torch
 
+from ...test_processing_common import ProcessorTesterMixin
 from .test_feature_extraction_clvp import floats_list
 
 
 @require_torch
-class ClvpProcessorTest(unittest.TestCase):
+class ClvpProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "susnato/clvp_dev"
+    processor_class = ClvpProcessor
+
     def setUp(self):
-        self.checkpoint = "susnato/clvp_dev"
         self.tmpdirname = tempfile.mkdtemp()
+        processor = ClvpProcessor.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
 
     def tearDown(self):
         super().tearDown()
@@ -37,11 +42,11 @@ class ClvpProcessorTest(unittest.TestCase):
 
     # Copied from transformers.tests.models.whisper.test_processor_whisper.WhisperProcessorTest.get_tokenizer with Whisper->Clvp
     def get_tokenizer(self, **kwargs):
-        return ClvpTokenizer.from_pretrained(self.checkpoint, **kwargs)
+        return ClvpTokenizer.from_pretrained(self.from_pretrained_id, **kwargs)
 
     # Copied from transformers.tests.models.whisper.test_processor_whisper.WhisperProcessorTest.get_feature_extractor with Whisper->Clvp
     def get_feature_extractor(self, **kwargs):
-        return ClvpFeatureExtractor.from_pretrained(self.checkpoint, **kwargs)
+        return ClvpFeatureExtractor.from_pretrained(self.from_pretrained_id, **kwargs)
 
     # Copied from transformers.tests.models.whisper.test_processor_whisper.WhisperProcessorTest.test_save_load_pretrained_default with Whisper->Clvp
     def test_save_load_pretrained_default(self):

--- a/tests/models/flava/test_processor_flava.py
+++ b/tests/models/flava/test_processor_flava.py
@@ -22,16 +22,18 @@ import unittest
 import numpy as np
 import pytest
 
-from transformers import BertTokenizer, BertTokenizerFast
+from transformers import BertTokenizer, BertTokenizerFast, FlavaProcessor
 from transformers.models.bert.tokenization_bert import VOCAB_FILES_NAMES
 from transformers.testing_utils import require_vision
 from transformers.utils import IMAGE_PROCESSOR_NAME, is_vision_available
+
+from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_vision_available():
     from PIL import Image
 
-    from transformers import FlavaImageProcessor, FlavaProcessor
+    from transformers import FlavaImageProcessor
     from transformers.models.flava.image_processing_flava import (
         FLAVA_CODEBOOK_MEAN,
         FLAVA_CODEBOOK_STD,
@@ -41,7 +43,9 @@ if is_vision_available():
 
 
 @require_vision
-class FlavaProcessorTest(unittest.TestCase):
+class FlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = FlavaProcessor
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
 

--- a/tests/models/git/test_processor_git.py
+++ b/tests/models/git/test_processor_git.py
@@ -21,6 +21,8 @@ import pytest
 from transformers.testing_utils import require_vision
 from transformers.utils import is_vision_available
 
+from ...test_processing_common import ProcessorTesterMixin
+
 
 if is_vision_available():
     from PIL import Image
@@ -29,7 +31,9 @@ if is_vision_available():
 
 
 @require_vision
-class GitProcessorTest(unittest.TestCase):
+class GitProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = GitProcessor
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
 

--- a/tests/models/instructblipvideo/test_processor_instructblipvideo.py
+++ b/tests/models/instructblipvideo/test_processor_instructblipvideo.py
@@ -1,0 +1,21 @@
+import tempfile
+import unittest
+
+from transformers import InstructBlipVideoProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class InstructBlipVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "Salesforce/instructblip-vicuna-7b"
+    processor_class = InstructBlipVideoProcessor
+
+    def prepare_components(self):
+        components = super().prepare_components()
+        components["qformer_tokenizer"] = components["tokenizer"]
+        return components
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/instructblipvideo/test_processor_instructblipvideo.py
+++ b/tests/models/instructblipvideo/test_processor_instructblipvideo.py
@@ -9,6 +9,7 @@ from ...test_processing_common import ProcessorTesterMixin
 class InstructBlipVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     from_pretrained_id = "Salesforce/instructblip-vicuna-7b"
     processor_class = InstructBlipVideoProcessor
+    videos_data_arg_name = "pixel_values"
 
     def prepare_components(self):
         components = super().prepare_components()

--- a/tests/models/llava_next_video/test_processor_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processor_llava_next_video.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+
+from transformers import LlavaNextVideoProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "llava-hf/LLaVA-NeXT-Video-7B-hf"
+    processor_class = LlavaNextVideoProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/mgp_str/test_processor_mgp_str.py
+++ b/tests/models/mgp_str/test_processor_mgp_str.py
@@ -20,13 +20,14 @@ import shutil
 import tempfile
 import unittest
 
-import numpy as np
 import pytest
 
-from transformers import MgpstrTokenizer
+from transformers import MgpstrProcessor, MgpstrTokenizer
 from transformers.models.mgp_str.tokenization_mgp_str import VOCAB_FILES_NAMES
 from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import IMAGE_PROCESSOR_NAME, is_torch_available, is_vision_available
+
+from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_torch_available():
@@ -34,15 +35,15 @@ if is_torch_available():
 
 
 if is_vision_available():
-    from PIL import Image
-
-    from transformers import MgpstrProcessor, ViTImageProcessor
+    from transformers import ViTImageProcessor
 
 
 @require_torch
 @require_vision
-class MgpstrProcessorTest(unittest.TestCase):
+class MgpstrProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = MgpstrProcessor
     image_processing_class = ViTImageProcessor if is_vision_available() else None
+    text_data_arg_name = "labels"
 
     @property
     def image_processor_dict(self):
@@ -78,15 +79,6 @@ class MgpstrProcessorTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)
-
-    def prepare_image_inputs(self):
-        """This function prepares a list of PIL images."""
-
-        image_input = np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)
-
-        image_input = Image.fromarray(np.moveaxis(image_input, 0, -1))
-
-        return image_input
 
     def test_save_load_pretrained_default(self):
         tokenizer = self.get_tokenizer()

--- a/tests/models/musicgen_melody/test_processor_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_processor_musicgen_melody.py
@@ -20,13 +20,15 @@ import unittest
 
 import numpy as np
 
-from transformers import T5Tokenizer, T5TokenizerFast
+from transformers import MusicgenMelodyProcessor, T5Tokenizer, T5TokenizerFast
 from transformers.testing_utils import require_sentencepiece, require_torch, require_torchaudio
 from transformers.utils.import_utils import is_torchaudio_available
 
+from ...test_processing_common import ProcessorTesterMixin
+
 
 if is_torchaudio_available():
-    from transformers import MusicgenMelodyFeatureExtractor, MusicgenMelodyProcessor
+    from transformers import MusicgenMelodyFeatureExtractor
 
 
 global_rng = random.Random()
@@ -51,17 +53,20 @@ def floats_list(shape, scale=1.0, rng=None, name=None):
 @require_sentencepiece
 @require_torchaudio
 # Copied from tests.models.musicgen.test_processing_musicgen.MusicgenProcessorTest with Musicgen->MusicgenMelody, Encodec->MusicgenMelody, padding_mask->attention_mask, input_values->input_features
-class MusicgenMelodyProcessorTest(unittest.TestCase):
+class MusicgenMelodyProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "facebook/musicgen-melody"
+    processor_class = MusicgenMelodyProcessor
+
     def setUp(self):
-        # Ignore copy
-        self.checkpoint = "facebook/musicgen-melody"
         self.tmpdirname = tempfile.mkdtemp()
+        processor = MusicgenMelodyProcessor.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
-        return T5Tokenizer.from_pretrained(self.checkpoint, **kwargs)
+        return T5Tokenizer.from_pretrained(self.from_pretrained_id, **kwargs)
 
     def get_feature_extractor(self, **kwargs):
-        return MusicgenMelodyFeatureExtractor.from_pretrained(self.checkpoint, **kwargs)
+        return MusicgenMelodyFeatureExtractor.from_pretrained(self.from_pretrained_id, **kwargs)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/siglip/test_processor_siglip.py
+++ b/tests/models/siglip/test_processor_siglip.py
@@ -1,0 +1,16 @@
+import tempfile
+import unittest
+
+from transformers import SiglipProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class SiglipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "google/siglip-base-patch16-224"
+    processor_class = SiglipProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/speecht5/test_processor_speecht5.py
+++ b/tests/models/speecht5/test_processor_speecht5.py
@@ -19,14 +19,16 @@ import shutil
 import tempfile
 import unittest
 
-from transformers import is_speech_available, is_torch_available
+from transformers import SpeechT5Processor, is_speech_available, is_torch_available
 from transformers.models.speecht5 import SpeechT5Tokenizer
-from transformers.testing_utils import get_tests_dir, require_torch
+from transformers.testing_utils import get_tests_dir, require_torch, require_torchaudio
 from transformers.utils import FEATURE_EXTRACTOR_NAME
+
+from ...test_processing_common import ProcessorTesterMixin
 
 
 if is_speech_available() and is_torch_available():
-    from transformers import SpeechT5FeatureExtractor, SpeechT5Processor
+    from transformers import SpeechT5FeatureExtractor
 
     from .test_feature_extraction_speecht5 import floats_list
 
@@ -35,7 +37,10 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece_bpe_char.model")
 
 
 @require_torch
-class SpeechT5ProcessorTest(unittest.TestCase):
+@require_torchaudio
+class SpeechT5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = SpeechT5Processor
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
 

--- a/tests/models/tvp/test_processor_tvp.py
+++ b/tests/models/tvp/test_processor_tvp.py
@@ -1,0 +1,81 @@
+import inspect
+import tempfile
+import unittest
+
+import numpy as np
+
+from transformers import TvpProcessor
+from transformers.testing_utils import require_torch, require_vision
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class TvpProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "Jiqing/tiny-random-tvp"
+    processor_class = TvpProcessor
+    videos_data_arg_name = "pixel_values"
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
+
+    @require_vision
+    def prepare_video_inputs(self):
+        return [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)]
+
+    @require_torch
+    @require_vision
+    def test_video_processor_defaults_preserved_by_kwargs(self):
+        if "video_processor" not in self.processor_class.attributes and (
+            "videos" not in inspect.signature(self.processor_class.__call__).parameters
+            or inspect.signature(self.processor_class.__call__).parameters["videos"].annotation == inspect._empty
+        ):
+            self.skipTest(f"video_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor_components["image_processor"] = self.get_component(
+            "image_processor", size=(234, 234), crop_size=(234, 234), do_pad=False
+        )
+        if "video_processor" in self.processor_class.attributes:
+            processor_components["video_processor"] = self.get_component(
+                "video_processor", size=(234, 234), crop_size=(234, 234), do_pad=False
+            )
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        input_str = "lower newer"
+        video_input = self.prepare_video_inputs()
+
+        inputs = processor(text=input_str, videos=video_input, return_tensors="pt")
+        self.assertEqual(inputs[self.videos_data_arg_name].shape[-1], 234)
+
+    @require_torch
+    @require_vision
+    def test_image_processor_defaults_preserved_by_image_kwargs(self):
+        self.skipTest("TVP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_kwargs_overrides_default_image_processor_kwargs(self):
+        self.skipTest("TVP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs(self):
+        self.skipTest("TVP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs_batched(self):
+        self.skipTest("TVP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested(self):
+        self.skipTest("TVP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested_from_dict(self):
+        self.skipTest("TVP does not process images")

--- a/tests/models/tvp/test_processor_tvp.py
+++ b/tests/models/tvp/test_processor_tvp.py
@@ -2,8 +2,6 @@ import inspect
 import tempfile
 import unittest
 
-import numpy as np
-
 from transformers import TvpProcessor
 from transformers.testing_utils import require_torch, require_vision
 
@@ -19,10 +17,6 @@ class TvpProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.tmpdirname = tempfile.mkdtemp()
         processor = self.processor_class.from_pretrained(self.from_pretrained_id)
         processor.save_pretrained(self.tmpdirname)
-
-    @require_vision
-    def prepare_video_inputs(self):
-        return [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)]
 
     @require_torch
     @require_vision

--- a/tests/models/video_llava/test_processor_video_llava.py
+++ b/tests/models/video_llava/test_processor_video_llava.py
@@ -1,0 +1,17 @@
+import tempfile
+import unittest
+
+from transformers.models.video_llava.processing_video_llava import VideoLlavaProcessor
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class VideoLlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "LanguageBind/Video-LLaVA-7B-hf"
+    processor_class = VideoLlavaProcessor
+    images_data_arg_name = "pixel_values_images"
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)

--- a/tests/models/vilt/test_processor_vilt.py
+++ b/tests/models/vilt/test_processor_vilt.py
@@ -1,0 +1,178 @@
+import tempfile
+import unittest
+
+from transformers import ViltProcessor
+from transformers.testing_utils import require_torch, require_vision
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class ViltProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "dandelin/vilt-b32-mlm"
+    processor_class = ViltProcessor
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
+
+    @require_torch
+    @require_vision
+    def test_image_processor_defaults_preserved_by_image_kwargs(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor_components["image_processor"] = self.get_component(
+            "image_processor", size=(234, 234), crop_size=(234, 234), size_divisor=32
+        )
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
+
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 384)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+
+        inputs = processor(text=input_str, images=image_input, return_tensors="pt")
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+
+    @require_torch
+    @require_vision
+    def test_kwargs_overrides_default_image_processor_kwargs(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor_components["image_processor"] = self.get_component("image_processor", size=(234, 234))
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
+
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 352)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+
+        inputs = processor(
+            text=input_str, images=image_input, size=[224, 224], crop_size=(224, 224), return_tensors="pt"
+        )
+
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 352)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+
+        # Define the kwargs for each modality
+        all_kwargs = {
+            "common_kwargs": {"return_tensors": "pt"},
+            "images_kwargs": {
+                "size": {"height": 214, "width": 214},
+                "crop_size": {"height": 214, "width": 214},
+            },
+            "text_kwargs": {"padding": "max_length", "max_length": 76},
+        }
+
+        inputs = processor(text=input_str, images=image_input, **all_kwargs)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested_from_dict(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 352)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+
+        # Define the kwargs for each modality
+        all_kwargs = {
+            "common_kwargs": {"return_tensors": "pt"},
+            "images_kwargs": {
+                "size": {"height": 214, "width": 214},
+                "crop_size": {"height": 214, "width": 214},
+            },
+            "text_kwargs": {"padding": "max_length", "max_length": 76},
+        }
+
+        inputs = processor(text=input_str, images=image_input, **all_kwargs)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 352)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+        inputs = processor(
+            text=input_str,
+            images=image_input,
+            return_tensors="pt",
+            size={"height": 214, "width": 214},
+            crop_size={"height": 214, "width": 214},
+            padding="max_length",
+            max_length=76,
+        )
+
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs_batched(self):
+        if "image_processor" not in self.processor_class.attributes:
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
+        self.skip_processor_without_typed_kwargs(processor)
+
+        # VILT resizes images to dims divisible by size_divisor
+        vilt_compatible_image_size = (32, 352)
+
+        input_str = ["lower newer", "upper older longer string"]
+        image_input = self.prepare_image_inputs() * 2
+        inputs = processor(
+            text=input_str,
+            images=image_input,
+            return_tensors="pt",
+            size={"height": 214, "width": 214},
+            crop_size={"height": 214, "width": 214},
+            padding="longest",
+            max_length=76,
+        )
+
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], vilt_compatible_image_size[-1])
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), len(inputs[self.text_data_arg_name][1]))

--- a/tests/models/wav2vec2_bert/test_processor_wav2vec2_bert.py
+++ b/tests/models/wav2vec2_bert/test_processor_wav2vec2_bert.py
@@ -24,11 +24,14 @@ from transformers.models.wav2vec2.tokenization_wav2vec2 import VOCAB_FILES_NAMES
 from transformers.models.wav2vec2_bert import Wav2Vec2BertProcessor
 from transformers.utils import FEATURE_EXTRACTOR_NAME
 
+from ...test_processing_common import ProcessorTesterMixin
 from ..wav2vec2.test_feature_extraction_wav2vec2 import floats_list
 
 
 # Copied from tests.models.wav2vec2.test_processor_wav2vec2.Wav2Vec2ProcessorTest with Wav2Vec2FeatureExtractor->SeamlessM4TFeatureExtractor, Wav2Vec2Processor->Wav2Vec2BertProcessor
-class Wav2Vec2BertProcessorTest(unittest.TestCase):
+class Wav2Vec2BertProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = Wav2Vec2BertProcessor
+
     def setUp(self):
         vocab = "<pad> <s> </s> <unk> | E T A O N I H S R D L U M W C F G Y P B V K ' X J Q Z".split(" ")
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
@@ -55,6 +58,12 @@ class Wav2Vec2BertProcessorTest(unittest.TestCase):
 
         with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
+
+    def get_component(self, attribute, **kwargs):
+        assert attribute in self.processor_class.attributes
+        if attribute == "tokenizer":
+            return self.get_tokenizer(**kwargs)
+        return super().get_component(attribute, **kwargs)
 
     def get_tokenizer(self, **kwargs_init):
         kwargs = self.add_kwargs_tokens_map.copy()

--- a/tests/models/x_clip/test_processor_x_clip.py
+++ b/tests/models/x_clip/test_processor_x_clip.py
@@ -1,0 +1,54 @@
+import tempfile
+import unittest
+
+import numpy as np
+
+from transformers import XCLIPProcessor
+from transformers.testing_utils import require_torch, require_vision
+
+from ...test_processing_common import ProcessorTesterMixin
+
+
+class XCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    from_pretrained_id = "microsoft/xclip-base-patch32"
+    processor_class = XCLIPProcessor
+    videos_data_arg_name = "pixel_values"
+
+    def setUp(self):
+        self.tmpdirname = tempfile.mkdtemp()
+        processor = self.processor_class.from_pretrained(self.from_pretrained_id)
+        processor.save_pretrained(self.tmpdirname)
+
+    @require_vision
+    def prepare_video_inputs(self):
+        return [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)]
+
+    @require_torch
+    @require_vision
+    def test_image_processor_defaults_preserved_by_image_kwargs(self):
+        self.skipTest("XCLIP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_kwargs_overrides_default_image_processor_kwargs(self):
+        self.skipTest("XCLIP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs(self):
+        self.skipTest("XCLIP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_unstructured_kwargs_batched(self):
+        self.skipTest("XCLIP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested(self):
+        self.skipTest("XCLIP does not process images")
+
+    @require_torch
+    @require_vision
+    def test_structured_kwargs_nested_from_dict(self):
+        self.skipTest("XCLIP does not process images")

--- a/tests/models/x_clip/test_processor_x_clip.py
+++ b/tests/models/x_clip/test_processor_x_clip.py
@@ -1,8 +1,6 @@
 import tempfile
 import unittest
 
-import numpy as np
-
 from transformers import XCLIPProcessor
 from transformers.testing_utils import require_torch, require_vision
 
@@ -18,10 +16,6 @@ class XCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.tmpdirname = tempfile.mkdtemp()
         processor = self.processor_class.from_pretrained(self.from_pretrained_id)
         processor.save_pretrained(self.tmpdirname)
-
-    @require_vision
-    def prepare_video_inputs(self):
-        return [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)]
 
     @require_torch
     @require_vision

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -49,6 +49,8 @@ if is_vision_available():
 @require_torch
 class ProcessorTesterMixin:
     processor_class = None
+    text_data_arg_name = "input_ids"
+    images_data_arg_name = "pixel_values"
 
     def prepare_processor_dict(self):
         return {}
@@ -136,7 +138,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input, return_tensors="pt")
-        self.assertEqual(len(inputs["input_ids"][0]), 117)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 117)
 
     @require_torch
     @require_vision
@@ -153,7 +155,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input)
-        self.assertEqual(len(inputs["pixel_values"][0][0]), 234)
+        self.assertEqual(len(inputs[self.images_data_arg_name][0][0]), 234)
 
     @require_vision
     @require_torch
@@ -171,7 +173,7 @@ class ProcessorTesterMixin:
         inputs = processor(
             text=input_str, images=image_input, return_tensors="pt", max_length=112, padding="max_length"
         )
-        self.assertEqual(len(inputs["input_ids"][0]), 112)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 112)
 
     @require_torch
     @require_vision
@@ -188,7 +190,7 @@ class ProcessorTesterMixin:
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input, size=[224, 224], crop_size=(224, 224))
-        self.assertEqual(len(inputs["pixel_values"][0][0]), 224)
+        self.assertEqual(len(inputs[self.images_data_arg_name][0][0]), 224)
 
     @require_torch
     @require_vision
@@ -213,8 +215,8 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
     @require_torch
     @require_vision
@@ -239,9 +241,9 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 6)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 6)
 
     @require_torch
     @require_vision
@@ -292,9 +294,9 @@ class ProcessorTesterMixin:
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
         self.skip_processor_without_typed_kwargs(processor)
 
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
     @require_torch
     @require_vision
@@ -321,9 +323,9 @@ class ProcessorTesterMixin:
         }
 
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
-        self.assertEqual(inputs["pixel_values"].shape[2], 214)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
 
-        self.assertEqual(len(inputs["input_ids"][0]), 76)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
 
 
 class MyProcessor(ProcessorMixin):

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -282,7 +282,10 @@ class ProcessorTesterMixin:
         # Define the kwargs for each modality
         all_kwargs = {
             "common_kwargs": {"return_tensors": "pt"},
-            "images_kwargs": {"size": {"height": 214, "width": 214}},
+            "images_kwargs": {
+                "size": {"height": 214, "width": 214},
+                "crop_size": {"height": 214, "width": 214},
+            },
             "text_kwargs": {"padding": "max_length", "max_length": 76},
         }
 
@@ -310,7 +313,10 @@ class ProcessorTesterMixin:
         # Define the kwargs for each modality
         all_kwargs = {
             "common_kwargs": {"return_tensors": "pt"},
-            "images_kwargs": {"size": {"height": 214, "width": 214}},
+            "images_kwargs": {
+                "size": {"height": 214, "width": 214},
+                "crop_size": {"height": 214, "width": 214},
+            },
             "text_kwargs": {"padding": "max_length", "max_length": 76},
         }
 

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -143,7 +143,7 @@ class ProcessorTesterMixin:
     def test_image_processor_defaults_preserved_by_image_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor", size=(234, 234))
+        image_processor = self.get_component("image_processor", size=(234, 234), crop_size=(234, 234))
         tokenizer = self.get_component("tokenizer", max_length=117, padding="max_length")
 
         processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
@@ -187,7 +187,7 @@ class ProcessorTesterMixin:
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
 
-        inputs = processor(text=input_str, images=image_input, size=[224, 224])
+        inputs = processor(text=input_str, images=image_input, size=[224, 224], crop_size=(224, 224))
         self.assertEqual(len(inputs["pixel_values"][0][0]), 224)
 
     @require_torch
@@ -208,6 +208,7 @@ class ProcessorTesterMixin:
             images=image_input,
             return_tensors="pt",
             size={"height": 214, "width": 214},
+            crop_size={"height": 214, "width": 214},
             padding="max_length",
             max_length=76,
         )
@@ -233,6 +234,7 @@ class ProcessorTesterMixin:
             images=image_input,
             return_tensors="pt",
             size={"height": 214, "width": 214},
+            crop_size={"height": 214, "width": 214},
             padding="longest",
             max_length=76,
         )
@@ -260,6 +262,7 @@ class ProcessorTesterMixin:
                 images=image_input,
                 images_kwargs={"size": {"height": 222, "width": 222}},
                 size={"height": 214, "width": 214},
+                crop_size={"height": 214, "width": 214},
             )
 
     @require_torch

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -26,7 +26,6 @@ except ImportError:
 import unittest
 
 import numpy as np
-from huggingface_hub import hf_hub_download
 
 from transformers import CLIPTokenizerFast, ProcessorMixin
 from transformers.models.auto.processing_auto import processor_class_from_name
@@ -94,10 +93,7 @@ class ProcessorTesterMixin:
 
     @require_vision
     def prepare_video_inputs(self):
-        video_file = hf_hub_download(
-            repo_id="raushan-testing-hf/videos-test", filename="video_demo.npy", repo_type="dataset"
-        )
-        return [np.load(video_file)]
+        return [np.random.randint(255, size=(4, 3, 30, 400), dtype=np.uint8)]
 
     def test_processor_to_json_string(self):
         processor = self.get_processor()

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -132,17 +132,16 @@ class ProcessorTesterMixin:
     @require_vision
     @require_torch
     def test_tokenizer_defaults_preserved_by_kwargs(self):
-        if "image_processor" not in self.processor_class.attributes:
-            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        if "tokenizer" not in self.processor_class.attributes:
+            self.skipTest(f"tokenizer attribute not present in {self.processor_class}")
         processor_components = self.prepare_components()
         processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
 
         processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
-        image_input = self.prepare_image_inputs()
 
-        inputs = processor(text=input_str, images=image_input, return_tensors="pt")
+        inputs = processor(text=input_str, return_tensors="pt")
         self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 117)
 
     @require_torch
@@ -194,19 +193,16 @@ class ProcessorTesterMixin:
     @require_vision
     @require_torch
     def test_kwargs_overrides_default_tokenizer_kwargs(self):
-        if "image_processor" not in self.processor_class.attributes:
-            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+        if "tokenizer" not in self.processor_class.attributes:
+            self.skipTest(f"tokenizer attribute not present in {self.processor_class}")
         processor_components = self.prepare_components()
         processor_components["tokenizer"] = self.get_component("tokenizer", padding="longest")
 
         processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
-        image_input = self.prepare_image_inputs()
 
-        inputs = processor(
-            text=input_str, images=image_input, return_tensors="pt", max_length=112, padding="max_length"
-        )
+        inputs = processor(text=input_str, return_tensors="pt", max_length=112, padding="max_length")
         self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 112)
 
     @require_torch

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -93,7 +93,7 @@ class ProcessorTesterMixin:
 
     @require_vision
     def prepare_video_inputs(self):
-        return [np.random.randint(255, size=(4, 3, 30, 400), dtype=np.uint8)]
+        return np.random.randint(255, size=(1, 4, 3, 30, 400), dtype=np.uint8)
 
     def test_processor_to_json_string(self):
         processor = self.get_processor()

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -26,6 +26,7 @@ except ImportError:
 import unittest
 
 import numpy as np
+from huggingface_hub import hf_hub_download
 
 from transformers import CLIPTokenizerFast, ProcessorMixin
 from transformers.models.auto.processing_auto import processor_class_from_name
@@ -51,6 +52,7 @@ class ProcessorTesterMixin:
     processor_class = None
     text_data_arg_name = "input_ids"
     images_data_arg_name = "pixel_values"
+    videos_data_arg_name = "pixel_values_videos"
 
     def prepare_processor_dict(self):
         return {}
@@ -89,6 +91,13 @@ class ProcessorTesterMixin:
         image_inputs = [np.random.randint(255, size=(3, 30, 400), dtype=np.uint8)]
         image_inputs = [Image.fromarray(np.moveaxis(x, 0, -1)) for x in image_inputs]
         return image_inputs
+
+    @require_vision
+    def prepare_video_inputs(self):
+        video_file = hf_hub_download(
+            repo_id="raushan-testing-hf/videos-test", filename="video_demo.npy", repo_type="dataset"
+        )
+        return [np.load(video_file)]
 
     def test_processor_to_json_string(self):
         processor = self.get_processor()
@@ -129,43 +138,69 @@ class ProcessorTesterMixin:
     def test_tokenizer_defaults_preserved_by_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer", max_length=117, padding="max_length")
+        processor_components = self.prepare_components()
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
 
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
 
         inputs = processor(text=input_str, images=image_input, return_tensors="pt")
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 117)
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 117)
 
     @require_torch
     @require_vision
     def test_image_processor_defaults_preserved_by_image_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor", size=(234, 234), crop_size=(234, 234))
-        tokenizer = self.get_component("tokenizer", max_length=117, padding="max_length")
+        processor_components = self.prepare_components()
+        processor_components["image_processor"] = self.get_component(
+            "image_processor", size=(234, 234), crop_size=(234, 234)
+        )
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
 
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
 
-        inputs = processor(text=input_str, images=image_input)
-        self.assertEqual(len(inputs[self.images_data_arg_name][0][0]), 234)
+        inputs = processor(text=input_str, images=image_input, return_tensors="pt")
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 234)
+
+    @require_torch
+    @require_vision
+    def test_video_processor_defaults_preserved_by_kwargs(self):
+        if "video_processor" not in self.processor_class.attributes:
+            self.skipTest(f"video_processor attribute not present in {self.processor_class}")
+        image_processor = self.get_component("image_processor", size=(234, 234), crop_size=(234, 234))
+        video_processor = self.get_component("video_processor", size=(234, 234), crop_size=(234, 234))
+        tokenizer = self.get_component("tokenizer", max_length=117, padding="max_length")
+
+        processor = self.processor_class(
+            tokenizer=tokenizer,
+            image_processor=image_processor,
+            video_processor=video_processor,
+        )
+        self.skip_processor_without_typed_kwargs(processor)
+
+        input_str = "lower newer"
+        image_input = self.prepare_image_inputs()
+        video_input = self.prepare_video_inputs()
+
+        inputs = processor(text=input_str, images=image_input, videos=video_input, return_tensors="pt")
+        self.assertEqual(inputs[self.videos_data_arg_name].shape[-1], 234)
 
     @require_vision
     @require_torch
     def test_kwargs_overrides_default_tokenizer_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer", padding="longest")
+        processor_components = self.prepare_components()
+        processor_components["tokenizer"] = self.get_component("tokenizer", padding="longest")
 
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
@@ -173,34 +208,35 @@ class ProcessorTesterMixin:
         inputs = processor(
             text=input_str, images=image_input, return_tensors="pt", max_length=112, padding="max_length"
         )
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 112)
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 112)
 
     @require_torch
     @require_vision
     def test_kwargs_overrides_default_image_processor_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor", size=(234, 234))
-        tokenizer = self.get_component("tokenizer", max_length=117, padding="max_length")
+        processor_components = self.prepare_components()
+        processor_components["image_processor"] = self.get_component("image_processor", size=(234, 234))
+        processor_components["tokenizer"] = self.get_component("tokenizer", max_length=117, padding="max_length")
 
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
 
-        inputs = processor(text=input_str, images=image_input, size=[224, 224], crop_size=(224, 224))
-        self.assertEqual(len(inputs[self.images_data_arg_name][0][0]), 224)
+        inputs = processor(
+            text=input_str, images=image_input, size=[224, 224], crop_size=(224, 224), return_tensors="pt"
+        )
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 224)
 
     @require_torch
     @require_vision
     def test_unstructured_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer")
-
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = "lower newer"
@@ -215,18 +251,16 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 214)
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
 
     @require_torch
     @require_vision
     def test_unstructured_kwargs_batched(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer")
-
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = ["lower newer", "upper older longer string"]
@@ -241,19 +275,16 @@ class ProcessorTesterMixin:
             max_length=76,
         )
 
-        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
-
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 6)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 214)
+        self.assertEqual(len(inputs[self.text_data_arg_name][0]), len(inputs[self.text_data_arg_name][1]))
 
     @require_torch
     @require_vision
     def test_doubly_passed_kwargs(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer")
-
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = ["lower newer"]
@@ -265,6 +296,7 @@ class ProcessorTesterMixin:
                 images_kwargs={"size": {"height": 222, "width": 222}},
                 size={"height": 214, "width": 214},
                 crop_size={"height": 214, "width": 214},
+                return_tensors="pt",
             )
 
     @require_torch
@@ -272,10 +304,8 @@ class ProcessorTesterMixin:
     def test_structured_kwargs_nested(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer")
-
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
 
         input_str = "lower newer"
@@ -294,21 +324,18 @@ class ProcessorTesterMixin:
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
         self.skip_processor_without_typed_kwargs(processor)
 
-        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
-
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 214)
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
 
     @require_torch
     @require_vision
     def test_structured_kwargs_nested_from_dict(self):
         if "image_processor" not in self.processor_class.attributes:
             self.skipTest(f"image_processor attribute not present in {self.processor_class}")
-
-        image_processor = self.get_component("image_processor")
-        tokenizer = self.get_component("tokenizer")
-
-        processor = self.processor_class(tokenizer=tokenizer, image_processor=image_processor)
+        processor_components = self.prepare_components()
+        processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
+
         input_str = "lower newer"
         image_input = self.prepare_image_inputs()
 
@@ -323,9 +350,8 @@ class ProcessorTesterMixin:
         }
 
         inputs = processor(text=input_str, images=image_input, **all_kwargs)
-        self.assertEqual(inputs[self.images_data_arg_name].shape[2], 214)
-
-        self.assertEqual(len(inputs[self.text_data_arg_name][0]), 76)
+        self.assertEqual(inputs[self.images_data_arg_name].shape[-1], 214)
+        self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 76)
 
 
 class MyProcessor(ProcessorMixin):

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -140,8 +140,9 @@ class ProcessorTesterMixin:
         processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
+        image_input = self.prepare_image_inputs() if "image_processor" in self.processor_class.attributes else None
 
-        inputs = processor(text=input_str, return_tensors="pt")
+        inputs = processor(text=input_str, images=image_input, return_tensors="pt")
         self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 117)
 
     @require_torch
@@ -201,8 +202,11 @@ class ProcessorTesterMixin:
         processor = self.processor_class(**processor_components)
         self.skip_processor_without_typed_kwargs(processor)
         input_str = "lower newer"
+        image_input = self.prepare_image_inputs() if "image_processor" in self.processor_class.attributes else None
 
-        inputs = processor(text=input_str, return_tensors="pt", max_length=112, padding="max_length")
+        inputs = processor(
+            text=input_str, images=image_input, return_tensors="pt", max_length=112, padding="max_length"
+        )
         self.assertEqual(inputs[self.text_data_arg_name].shape[-1], 112)
 
     @require_torch


### PR DESCRIPTION
# What does this PR do?

- Uniformizes kwargs for processors of audio-text models.
- An extension of https://github.com/huggingface/transformers/issues/31911
- NOTE: don't review nor merge until this PR is complete: https://github.com/huggingface/transformers/pull/32841

TODO Models:
- [x] Clap
- [x] CLVP
- [x] MusicGen Melody
- [ ] Qwen2 Audio
- [x] Seamless M4T
- [x] SpeechT5
- [x] Wav2Vec2 Bert

TODO tests
- [ ] Add audio-text-specific processor tests
- [ ] Remove unnecessary/duplicated tests

Models with special args (will not be done in this PR):
- PopPiano

Models with weird `_in_target_context_manager` logic (will not be done in this PR):
- MusicGen
- SpeechToText
- Wav2Vec2
- Wav2Vec2 w/ LM
- Whisper

Fixes # (issue)

- https://github.com/huggingface/transformers/issues/31911

## Who can review?

@zucchini-nlp @molbap @yonigozlan
