### PR TITLE
Add RobustSAM model documentation

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -846,6 +846,8 @@
         title: Perceiver
       - local: model_doc/pix2struct
         title: Pix2Struct
+      - local: model_doc/robustsam
+        title: RobustSAM
       - local: model_doc/sam
         title: Segment Anything
       - local: model_doc/siglip

--- a/docs/source/en/model_doc/robustsam.md
+++ b/docs/source/en/model_doc/robustsam.md
@@ -1,0 +1,57 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# RobustSAM
+
+## Overview
+
+The RobustSAM model was proposed in [<INSERT PAPER NAME HERE>](<INSERT PAPER LINK HERE>) by <INSERT AUTHORS HERE>.
+<INSERT SHORT SUMMARY HERE>
+
+The abstract from the paper is the following:
+
+*<INSERT PAPER ABSTRACT HERE>*
+
+Tips:
+
+<INSERT TIPS ABOUT MODEL HERE>
+
+This model was contributed by [INSERT YOUR HF USERNAME HERE](https://huggingface.co/<INSERT YOUR HF USERNAME HERE>).
+The original code can be found [here](<INSERT LINK TO GITHUB REPO HERE>).
+
+
+## RobustSAMConfig
+
+[[autodoc]] RobustSAMConfig
+
+## RobustSAMVisionConfig
+
+[[autodoc]] RobustSAMVisionConfig
+
+## RobustSAMMaskDecoderConfig
+
+[[autodoc]] RobustSAMMaskDecoderConfig
+
+## RobustSAMPromptEncoderConfig
+
+[[autodoc]] RobustSAMPromptEncoderConfig
+
+
+## RobustSAMModel
+
+[[autodoc]] RobustSAMModel
+    - forward
+


### PR DESCRIPTION

# What does this PR do?

- Added RobustSAM model documentation under docs/source/en/model_doc/
- Modified toc file to include the new model documentation

<!-- Remove if not applicable -->

Fixes # (issue)

None.


## Motivation

The addition of the `RobustSAM` model documentation is intended to help users understand how to use the model within the Transformers library. This documentation provides detailed information on the model's capabilities, usage examples, and integration within the existing framework.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?[#32874](https://github.com/huggingface/transformers/issues/32874)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
Feedback on the current implementation and documentation structure is welcome. Tagging the following for review once ready:
- Author: @robustsam
- Documentation: @stevhliu
- Vision models: @amyeroberts

