### PR TITLE
CI: separate step to download nltk files

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -129,10 +129,10 @@ class CircleCIJob:
         test_command = ""
         if self.command_timeout:
             test_command = f"timeout {self.command_timeout} "
+        # junit familiy xunit1 is necessary to support splitting on test name or class name with circleci split
+        test_command += f"python3 -m pytest -rsfE -p no:warnings --tb=short -o junit_family=xunit1 --junitxml=test-results/junit.xml -n {self.pytest_num_workers} " + " ".join(pytest_flags)
 
         if self.parallelism == 1:
-            # junit familiy xunit1 is necessary to support splitting on test name or class name with circleci split
-            test_command += f"python3 -m pytest -rsfE -p no:warnings -o junit_family=xunit1 --tb=short --junitxml=test-results/junit.xml -n {self.pytest_num_workers} " + " ".join(pytest_flags)
             if self.tests_to_run is None:
                 test_command += " << pipeline.parameters.tests_to_run >>"
             else:
@@ -190,7 +190,6 @@ class CircleCIJob:
             steps.append({"store_artifacts": {"path": "tests.txt"}})
             steps.append({"store_artifacts": {"path": "splitted_tests.txt"}})
 
-            test_command += f"python3 -m pytest -rsfE -p no:warnings --tb=short  -o junit_family=xunit1 --junitxml=test-results/junit.xml -n {self.pytest_num_workers} " + " ".join(pytest_flags)
             test_command += " $(cat splitted_tests.txt)"
         if self.marker is not None:
             test_command += f" -m {self.marker}"

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -328,7 +328,7 @@ examples_tensorflow_job = CircleCIJob(
     cache_name="tensorflow_examples",
     docker_image=[{"image":"huggingface/transformers-examples-tf"}],
     install_steps=["uv venv && uv pip install . && uv pip install -r examples/tensorflow/_tests_requirements.txt"],
-    parallelism=8,
+    parallelism=8
 )
 
 


### PR DESCRIPTION
# What does this PR do?

Should fix #32667 : NLTK is complaining about parallelism. The parallelism stems from the `pytest` call, so we should get rid of the problem if we download the NLTK data in advance of the `pytest` call 🤗 
