### PR TITLE
Convert new SigLIP checkpoints

### DIFF
--- a/src/transformers/models/siglip/configuration_siglip.py
+++ b/src/transformers/models/siglip/configuration_siglip.py
@@ -62,6 +62,8 @@ class SiglipTextConfig(PretrainedConfig):
             The id of the beginning-of-sequence token in the vocabulary.
         eos_token_id (`int`, *optional*, defaults to 49407):
             The id of the end-of-sequence token in the vocabulary.
+        has_head (`bool`, *optional*, defaults to `True`):
+            If the text model has a head or not.
 
     Example:
 
@@ -96,6 +98,7 @@ class SiglipTextConfig(PretrainedConfig):
         pad_token_id=1,
         bos_token_id=49406,
         eos_token_id=49407,
+        has_head=True,
         **kwargs,
     ):
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
@@ -109,6 +112,7 @@ class SiglipTextConfig(PretrainedConfig):
         self.layer_norm_eps = layer_norm_eps
         self.hidden_act = hidden_act
         self.attention_dropout = attention_dropout
+        self.has_head = has_head
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs) -> "PretrainedConfig":

--- a/src/transformers/models/siglip/configuration_siglip.py
+++ b/src/transformers/models/siglip/configuration_siglip.py
@@ -62,8 +62,6 @@ class SiglipTextConfig(PretrainedConfig):
             The id of the beginning-of-sequence token in the vocabulary.
         eos_token_id (`int`, *optional*, defaults to 49407):
             The id of the end-of-sequence token in the vocabulary.
-        has_head (`bool`, *optional*, defaults to `True`):
-            If the text model has a head or not.
 
     Example:
 
@@ -98,7 +96,6 @@ class SiglipTextConfig(PretrainedConfig):
         pad_token_id=1,
         bos_token_id=49406,
         eos_token_id=49407,
-        has_head=True,
         **kwargs,
     ):
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
@@ -112,7 +109,6 @@ class SiglipTextConfig(PretrainedConfig):
         self.layer_norm_eps = layer_norm_eps
         self.hidden_act = hidden_act
         self.attention_dropout = attention_dropout
-        self.has_head = has_head
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs) -> "PretrainedConfig":

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -103,7 +103,7 @@ def get_siglip_config(model_name):
     if "so400m-patch14-224" in model_name:
         config.text_config.max_position_embeddings = 16
     if model_name == "siglip-so400m-patch16-256-i18n":
-        config.text_config.no_head = True
+        config.text_config.has_head = False
     else:
         raise ValueError("Model not supported")
 
@@ -177,7 +177,7 @@ def create_rename_keys(config):
     rename_keys.append(("params/txt/Encoder_0/encoder_norm/scale", "text_model.final_layer_norm.weight"))
     rename_keys.append(("params/txt/Encoder_0/encoder_norm/bias", "text_model.final_layer_norm.bias"))
 
-    if not config.text_config.no_head:
+    if config.text_config.has_head:
         rename_keys.append(("params/txt/head/kernel", "text_model.head.weight"))
         rename_keys.append(("params/txt/head/bias", "text_model.head.bias"))
 

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -285,7 +285,9 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     data = load(checkpoint)
     state_dict = flatten_nested_dict(data)
 
-    if model_name == "siglip-so400m-patch16-256-i18n":  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
+    if (
+        model_name == "siglip-so400m-patch16-256-i18n"
+    ):  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
         new_state_dict = {}
         for k, v in state_dict.items():
             if "img/Transformer/encoderblock/" in k:

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -102,11 +102,7 @@ def get_siglip_config(model_name):
         config.vision_config.num_attention_heads = 16
     if "so400m-patch14-224" in model_name:
         config.text_config.max_position_embeddings = 16
-    if (
-        config.vision_config.image_size == 256
-        and config.text_config.vocab_size == 250000
-        and config.vision_config.patch_size == 16
-    ):
+    if model_name == "siglip-so400m-patch16-256-i18n":
         config.text_config.no_head = True
     else:
         raise ValueError("Model not supported")
@@ -278,12 +274,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
 
     # get checkpoint
     checkpoint = model_name_to_checkpoint[model_name]
-    if (
-        config.vision_config.image_size == 256
-        and config.text_config.vocab_size == 250000
-        and config.vision_config.patch_size == 16
-    ):
-        siglip_sovit_i18_256 = True
 
     # get vocab file
     if "i18n" in model_name:
@@ -295,9 +285,7 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     data = load(checkpoint)
     state_dict = flatten_nested_dict(data)
 
-    if (
-        siglip_sovit_i18_256
-    ):  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
+    if model_name == "siglip-so400m-patch16-256-i18n":  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
         new_state_dict = {}
         for k, v in state_dict.items():
             if "img/Transformer/encoderblock/" in k:

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -418,7 +418,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
                 [[-1.9432535, -0.05433846], [0.6222029, 2.2883186]],
             )
         assert torch.allclose(outputs.logits_per_image[:3, :3], expected_slice, atol=1e-4)
-        print("Looks ok!")
 
     if pytorch_dump_folder_path is not None:
         Path(pytorch_dump_folder_path).mkdir(exist_ok=True)

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -100,7 +100,7 @@ def get_siglip_config(model_name):
         config.vision_config.intermediate_size = 4304
         config.vision_config.num_hidden_layers = 27
         config.vision_config.num_attention_heads = 16
-    if "so400m-patch14-224" in model_name:
+    if model_name == "siglip-so400m-patch14-224":
         config.text_config.max_position_embeddings = 16
     if model_name == "siglip-so400m-patch16-256-i18n":
         config.text_config.has_head = False

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -19,6 +19,7 @@ URL: https://github.com/google-research/big_vision/tree/main
 
 import argparse
 import collections
+import re
 from pathlib import Path
 
 import numpy as np
@@ -27,7 +28,6 @@ import torch
 from huggingface_hub import hf_hub_download
 from numpy import load
 from PIL import Image
-import re
 
 from transformers import SiglipConfig, SiglipImageProcessor, SiglipModel, SiglipProcessor, SiglipTokenizer
 from transformers.utils import logging

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -310,7 +310,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     read_in_q_k_v_head(state_dict, config)
     # load HuggingFace model
     model = SiglipModel(config).eval()
-    print("config.text_config", config.text_config)
     model.load_state_dict(state_dict)
     # create processor
     # important: make tokenizer not return attention_mask since original one doesn't require it
@@ -407,6 +406,11 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
         elif model_name == "siglip-so400m-patch14-224":
             expected_slice = torch.tensor(
                 [[-1.0864916 ,  1.1704235 ], [-0.71784306,  1.4354687 ]],
+            )
+        
+        elif model_name == "siglip-so400m-patch16-256-i18n":
+            expected_slice = torch.tensor(
+                [[-1.9432535 ,  -0.05433846 ], [0.6222029,  2.2883186 ]],
             )
 
         assert torch.allclose(outputs.logits_per_image[:3, :3], expected_slice, atol=1e-4)

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -39,19 +39,19 @@ logger = logging.get_logger(__name__)
 
 model_name_to_checkpoint = {
     # base checkpoints
-    "siglip-base-patch16-224": "/Users/nielsrogge/Documents/SigLIP/webli_en_b16_224_63724782.npz",
-    "siglip-base-patch16-256": "/Users/nielsrogge/Documents/SigLIP/webli_en_b16_256_60500360.npz",
-    "siglip-base-patch16-384": "/Users/nielsrogge/Documents/SigLIP/webli_en_b16_384_68578854.npz",
-    "siglip-base-patch16-512": "/Users/nielsrogge/Documents/SigLIP/webli_en_b16_512_68580893.npz",
+    "siglip-base-patch16-224": "webli_en_b16_224_63724782.npz",
+    "siglip-base-patch16-256": "webli_en_b16_256_60500360.npz",
+    "siglip-base-patch16-384": "webli_en_b16_384_68578854.npz",
+    "siglip-base-patch16-512": "webli_en_b16_512_68580893.npz",
     # large checkpoints
-    "siglip-large-patch16-256": "/Users/nielsrogge/Documents/SigLIP/webli_en_l16_256_60552751.npz",
-    "siglip-large-patch16-384": "/Users/nielsrogge/Documents/SigLIP/webli_en_l16_384_63634585.npz",
+    "siglip-large-patch16-256": "webli_en_l16_256_60552751.npz",
+    "siglip-large-patch16-384": "webli_en_l16_384_63634585.npz",
     # multilingual checkpoint
-    "siglip-base-patch16-256-i18n": "/Users/nielsrogge/Documents/SigLIP/webli_i18n_b16_256_66117334.npz",
+    "siglip-base-patch16-256-i18n": "webli_i18n_b16_256_66117334.npz",
     # so400m checkpoints
-    "siglip-so400m-patch14-384": "/Users/nielsrogge/Documents/SigLIP/webli_en_so400m_384_58765454.npz",
-    "siglip-so400m-patch14-224": "/Users/mervenoyan/Desktop/siglips/webli_en_so400m_224_57633886.npz",
-    "siglip-so400m-patch16-256-i18n": "/Users/mervenoyan/Desktop/siglip/webli_i18n_so400m_16_256_78061115.npz",
+    "siglip-so400m-patch14-384": "webli_en_so400m_384_58765454.npz",
+    "siglip-so400m-patch14-224": "webli_en_so400m_224_57633886.npz",
+    "siglip-so400m-patch16-256-i18n": "webli_i18n_so400m_16_256_78061115.npz",
 }
 
 model_name_to_image_size = {
@@ -79,7 +79,8 @@ def get_siglip_config(model_name):
     config.vision_config.image_size = image_size
     config.vision_config.patch_size = patch_size
     config.text_config.vocab_size = vocab_size
-
+    if model_name == "siglip-so400m-patch14-224":
+        config.text_config.max_position_embeddings = 16
     if "base" in model_name:
         pass
     elif "large" in model_name:
@@ -100,10 +101,6 @@ def get_siglip_config(model_name):
         config.vision_config.intermediate_size = 4304
         config.vision_config.num_hidden_layers = 27
         config.vision_config.num_attention_heads = 16
-    if model_name == "siglip-so400m-patch14-224":
-        config.text_config.max_position_embeddings = 16
-    if model_name == "siglip-so400m-patch16-256-i18n":
-        config.text_config.has_head = False
     else:
         raise ValueError("Model not supported")
 
@@ -116,74 +113,74 @@ def create_rename_keys(config):
 
     # vision encoder
 
-    rename_keys.append(("params/img/embedding/kernel", "vision_model.embeddings.patch_embedding.weight"))
-    rename_keys.append(("params/img/embedding/bias", "vision_model.embeddings.patch_embedding.bias"))
-    rename_keys.append(("params/img/pos_embedding", "vision_model.embeddings.position_embedding.weight"))
+    rename_keys.append(("img/embedding/kernel", "vision_model.embeddings.patch_embedding.weight"))
+    rename_keys.append(("img/embedding/bias", "vision_model.embeddings.patch_embedding.bias"))
+    rename_keys.append(("img/pos_embedding", "vision_model.embeddings.position_embedding.weight"))
 
     for i in range(config.vision_config.num_hidden_layers):
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/LayerNorm_0/scale", f"vision_model.encoder.layers.{i}.layer_norm1.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/LayerNorm_0/bias", f"vision_model.encoder.layers.{i}.layer_norm1.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/LayerNorm_1/scale", f"vision_model.encoder.layers.{i}.layer_norm2.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/LayerNorm_1/bias", f"vision_model.encoder.layers.{i}.layer_norm2.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_0/kernel", f"vision_model.encoder.layers.{i}.mlp.fc1.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_0/bias", f"vision_model.encoder.layers.{i}.mlp.fc1.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_1/kernel", f"vision_model.encoder.layers.{i}.mlp.fc2.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_1/bias", f"vision_model.encoder.layers.{i}.mlp.fc2.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/key/kernel", f"vision_model.encoder.layers.{i}.self_attn.k_proj.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/key/bias", f"vision_model.encoder.layers.{i}.self_attn.k_proj.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/value/kernel", f"vision_model.encoder.layers.{i}.self_attn.v_proj.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/value/bias", f"vision_model.encoder.layers.{i}.self_attn.v_proj.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/query/kernel", f"vision_model.encoder.layers.{i}.self_attn.q_proj.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/query/bias", f"vision_model.encoder.layers.{i}.self_attn.q_proj.bias"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/out/kernel", f"vision_model.encoder.layers.{i}.self_attn.out_proj.weight"))
-        rename_keys.append((f"params/img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/out/bias", f"vision_model.encoder.layers.{i}.self_attn.out_proj.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/LayerNorm_0/scale", f"vision_model.encoder.layers.{i}.layer_norm1.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/LayerNorm_0/bias", f"vision_model.encoder.layers.{i}.layer_norm1.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/LayerNorm_1/scale", f"vision_model.encoder.layers.{i}.layer_norm2.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/LayerNorm_1/bias", f"vision_model.encoder.layers.{i}.layer_norm2.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_0/kernel", f"vision_model.encoder.layers.{i}.mlp.fc1.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_0/bias", f"vision_model.encoder.layers.{i}.mlp.fc1.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_1/kernel", f"vision_model.encoder.layers.{i}.mlp.fc2.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MlpBlock_0/Dense_1/bias", f"vision_model.encoder.layers.{i}.mlp.fc2.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/key/kernel", f"vision_model.encoder.layers.{i}.self_attn.k_proj.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/key/bias", f"vision_model.encoder.layers.{i}.self_attn.k_proj.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/value/kernel", f"vision_model.encoder.layers.{i}.self_attn.v_proj.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/value/bias", f"vision_model.encoder.layers.{i}.self_attn.v_proj.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/query/kernel", f"vision_model.encoder.layers.{i}.self_attn.q_proj.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/query/bias", f"vision_model.encoder.layers.{i}.self_attn.q_proj.bias"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/out/kernel", f"vision_model.encoder.layers.{i}.self_attn.out_proj.weight"))
+        rename_keys.append((f"img/Transformer/encoderblock_{i}/MultiHeadDotProductAttention_0/out/bias", f"vision_model.encoder.layers.{i}.self_attn.out_proj.bias"))
 
-    rename_keys.append(("params/img/Transformer/encoder_norm/scale", "vision_model.post_layernorm.weight"))
-    rename_keys.append(("params/img/Transformer/encoder_norm/bias", "vision_model.post_layernorm.bias"))
+    rename_keys.append(("img/Transformer/encoder_norm/scale", "vision_model.post_layernorm.weight"))
+    rename_keys.append(("img/Transformer/encoder_norm/bias", "vision_model.post_layernorm.bias"))
 
-    rename_keys.append(("params/img/MAPHead_0/probe", "vision_model.head.probe"))
-    rename_keys.append(("params/img/MAPHead_0/LayerNorm_0/scale", "vision_model.head.layernorm.weight"))
-    rename_keys.append(("params/img/MAPHead_0/LayerNorm_0/bias", "vision_model.head.layernorm.bias"))
-    rename_keys.append(("params/img/MAPHead_0/MlpBlock_0/Dense_0/kernel", "vision_model.head.mlp.fc1.weight"))
-    rename_keys.append(("params/img/MAPHead_0/MlpBlock_0/Dense_0/bias", "vision_model.head.mlp.fc1.bias"))
-    rename_keys.append(("params/img/MAPHead_0/MlpBlock_0/Dense_1/kernel", "vision_model.head.mlp.fc2.weight"))
-    rename_keys.append(("params/img/MAPHead_0/MlpBlock_0/Dense_1/bias", "vision_model.head.mlp.fc2.bias"))
-    rename_keys.append(("params/img/MAPHead_0/MultiHeadDotProductAttention_0/out/kernel", "vision_model.head.attention.out_proj.weight"))
-    rename_keys.append(("params/img/MAPHead_0/MultiHeadDotProductAttention_0/out/bias", "vision_model.head.attention.out_proj.bias"))
+    rename_keys.append(("img/MAPHead_0/probe", "vision_model.head.probe"))
+    rename_keys.append(("img/MAPHead_0/LayerNorm_0/scale", "vision_model.head.layernorm.weight"))
+    rename_keys.append(("img/MAPHead_0/LayerNorm_0/bias", "vision_model.head.layernorm.bias"))
+    rename_keys.append(("img/MAPHead_0/MlpBlock_0/Dense_0/kernel", "vision_model.head.mlp.fc1.weight"))
+    rename_keys.append(("img/MAPHead_0/MlpBlock_0/Dense_0/bias", "vision_model.head.mlp.fc1.bias"))
+    rename_keys.append(("img/MAPHead_0/MlpBlock_0/Dense_1/kernel", "vision_model.head.mlp.fc2.weight"))
+    rename_keys.append(("img/MAPHead_0/MlpBlock_0/Dense_1/bias", "vision_model.head.mlp.fc2.bias"))
+    rename_keys.append(("img/MAPHead_0/MultiHeadDotProductAttention_0/out/kernel", "vision_model.head.attention.out_proj.weight"))
+    rename_keys.append(("img/MAPHead_0/MultiHeadDotProductAttention_0/out/bias", "vision_model.head.attention.out_proj.bias"))
 
     # text encoder
 
-    rename_keys.append(("params/txt/Embed_0/embedding", "text_model.embeddings.token_embedding.weight"))
-    rename_keys.append(("params/txt/pos_embedding", "text_model.embeddings.position_embedding.weight"))
+    rename_keys.append(("txt/Embed_0/embedding", "text_model.embeddings.token_embedding.weight"))
+    rename_keys.append(("txt/pos_embedding", "text_model.embeddings.position_embedding.weight"))
 
     for i in range(config.text_config.num_hidden_layers):
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/LayerNorm_0/scale", f"text_model.encoder.layers.{i}.layer_norm1.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/LayerNorm_0/bias", f"text_model.encoder.layers.{i}.layer_norm1.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/LayerNorm_1/scale", f"text_model.encoder.layers.{i}.layer_norm2.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/LayerNorm_1/bias", f"text_model.encoder.layers.{i}.layer_norm2.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_0/kernel", f"text_model.encoder.layers.{i}.mlp.fc1.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_0/bias", f"text_model.encoder.layers.{i}.mlp.fc1.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_1/kernel", f"text_model.encoder.layers.{i}.mlp.fc2.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_1/bias", f"text_model.encoder.layers.{i}.mlp.fc2.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/key/kernel", f"text_model.encoder.layers.{i}.self_attn.k_proj.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/key/bias", f"text_model.encoder.layers.{i}.self_attn.k_proj.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/value/kernel", f"text_model.encoder.layers.{i}.self_attn.v_proj.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/value/bias", f"text_model.encoder.layers.{i}.self_attn.v_proj.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/query/kernel", f"text_model.encoder.layers.{i}.self_attn.q_proj.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/query/bias", f"text_model.encoder.layers.{i}.self_attn.q_proj.bias"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/out/kernel", f"text_model.encoder.layers.{i}.self_attn.out_proj.weight"))
-        rename_keys.append((f"params/txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/out/bias", f"text_model.encoder.layers.{i}.self_attn.out_proj.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/LayerNorm_0/scale", f"text_model.encoder.layers.{i}.layer_norm1.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/LayerNorm_0/bias", f"text_model.encoder.layers.{i}.layer_norm1.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/LayerNorm_1/scale", f"text_model.encoder.layers.{i}.layer_norm2.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/LayerNorm_1/bias", f"text_model.encoder.layers.{i}.layer_norm2.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_0/kernel", f"text_model.encoder.layers.{i}.mlp.fc1.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_0/bias", f"text_model.encoder.layers.{i}.mlp.fc1.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_1/kernel", f"text_model.encoder.layers.{i}.mlp.fc2.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MlpBlock_0/Dense_1/bias", f"text_model.encoder.layers.{i}.mlp.fc2.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/key/kernel", f"text_model.encoder.layers.{i}.self_attn.k_proj.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/key/bias", f"text_model.encoder.layers.{i}.self_attn.k_proj.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/value/kernel", f"text_model.encoder.layers.{i}.self_attn.v_proj.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/value/bias", f"text_model.encoder.layers.{i}.self_attn.v_proj.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/query/kernel", f"text_model.encoder.layers.{i}.self_attn.q_proj.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/query/bias", f"text_model.encoder.layers.{i}.self_attn.q_proj.bias"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/out/kernel", f"text_model.encoder.layers.{i}.self_attn.out_proj.weight"))
+        rename_keys.append((f"txt/Encoder_0/encoderblock_{i}/MultiHeadDotProductAttention_0/out/bias", f"text_model.encoder.layers.{i}.self_attn.out_proj.bias"))
 
-    rename_keys.append(("params/txt/Encoder_0/encoder_norm/scale", "text_model.final_layer_norm.weight"))
-    rename_keys.append(("params/txt/Encoder_0/encoder_norm/bias", "text_model.final_layer_norm.bias"))
+    rename_keys.append(("txt/Encoder_0/encoder_norm/scale", "text_model.final_layer_norm.weight"))
+    rename_keys.append(("txt/Encoder_0/encoder_norm/bias", "text_model.final_layer_norm.bias"))
 
-    if config.text_config.has_head:
-        rename_keys.append(("params/txt/head/kernel", "text_model.head.weight"))
-        rename_keys.append(("params/txt/head/bias", "text_model.head.bias"))
+    if not (config.vision_config.image_size==256 and config.text_config.vocab_size==250000 and config.vision_config.patch_size==16):
+        rename_keys.append(("txt/head/kernel", "text_model.head.weight"))
+        rename_keys.append(("txt/head/bias", "text_model.head.bias"))
 
     # learned temperature and bias
-    rename_keys.append(("params/t", "logit_scale"))
-    rename_keys.append(("params/b", "logit_bias"))
+    rename_keys.append(("t", "logit_scale"))
+    rename_keys.append(("b", "logit_bias"))
 
     # fmt: on
     return rename_keys
@@ -191,7 +188,6 @@ def create_rename_keys(config):
 
 def rename_key(dct, old, new, config):
     val = dct.pop(old)
-
     if ("out_proj" in new or "v_proj" in new or "k_proj" in new or "q_proj" in new) and "vision" in new:
         val = val.reshape(-1, config.vision_config.hidden_size)
     if ("out_proj" in new or "v_proj" in new or "k_proj" in new or "q_proj" in new) and "text" in new:
@@ -209,6 +205,17 @@ def rename_key(dct, old, new, config):
 
     if new.endswith("bias"):
         val = val.reshape(-1)
+    if (
+        config.vision_config.image_size == 256
+        and config.text_config.vocab_size == 250000
+        and config.vision_config.patch_size == 16
+    ) or (
+        config.vision_config.image_size == 256
+        and config.text_config.vocab_size == 250000
+        and config.vision_config.patch_size == 16
+    ):
+        dct["text_model.head.weight"] = torch.eye(config.text_config.hidden_size)
+        dct["text_model.head.bias"] = torch.zeros(config.text_config.hidden_size)
 
     dct[new] = torch.from_numpy(val)
 
@@ -216,23 +223,23 @@ def rename_key(dct, old, new, config):
 def read_in_q_k_v_head(state_dict, config):
     # read in individual input projection layers
     key_proj_weight = (
-        state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/key/kernel")
+        state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/key/kernel")
         .reshape(-1, config.vision_config.hidden_size)
         .T
     )
-    key_proj_bias = state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/key/bias").reshape(-1)
+    key_proj_bias = state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/key/bias").reshape(-1)
     value_proj_weight = (
-        state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/value/kernel")
+        state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/value/kernel")
         .reshape(-1, config.vision_config.hidden_size)
         .T
     )
-    value_proj_bias = state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/value/bias").reshape(-1)
+    value_proj_bias = state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/value/bias").reshape(-1)
     query_proj_weight = (
-        state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/query/kernel")
+        state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/query/kernel")
         .reshape(-1, config.vision_config.hidden_size)
         .T
     )
-    query_proj_bias = state_dict.pop("params/img/MAPHead_0/MultiHeadDotProductAttention_0/query/bias").reshape(-1)
+    query_proj_bias = state_dict.pop("img/MAPHead_0/MultiHeadDotProductAttention_0/query/bias").reshape(-1)
 
     # next, add them to the state dict as a single matrix + vector
     state_dict["vision_model.head.attention.in_proj_weight"] = torch.from_numpy(
@@ -268,26 +275,28 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     """
     Copy/paste/tweak model's weights to our SigLIP structure.
     """
-
     # define default SigLIP configuration
     config = get_siglip_config(model_name)
 
     # get checkpoint
-    checkpoint = model_name_to_checkpoint[model_name]
-
+    filename = model_name_to_checkpoint[model_name]
+    checkpoint = hf_hub_download(repo_id="merve/google-ckpts", filename=filename, repo_type="model")
     # get vocab file
     if "i18n" in model_name:
-        vocab_file = "/Users/mervenoyan/Desktop/siglips/mc4/sentencepiece.model"
+        filename = "mc4/sentencepiece.model"
+        vocab_file = hf_hub_download(repo_id="merve/google-tokenizers", filename=filename, repo_type="model")
     else:
-        vocab_file = "/Users/mervenoyan/Desktop/siglips/c4_en/sentencepiece.model"
+        filename = "c4_en/sentencepiece.model"
+        vocab_file = hf_hub_download(repo_id="merve/google-tokenizers", filename=filename, repo_type="model")
 
     # load original state dict
     data = load(checkpoint)
     state_dict = flatten_nested_dict(data)
-
-    if (
-        model_name == "siglip-so400m-patch16-256-i18n"
-    ):  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
+    if model_name in [
+        "siglip-so400m-patch16-256-i18n",
+        "siglip-so400m-patch14-224",
+        "siglip-base-patch16-512",
+    ]:  # make state dict compatible with rest of the SiglIPs, add param/ prefix and encoderblock index
         new_state_dict = {}
         for k, v in state_dict.items():
             if "img/Transformer/encoderblock/" in k:
@@ -295,11 +304,10 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
                 split_arrays = np.array_split(original_array, config.vision_config.num_hidden_layers, axis=0)  # 27
                 for i in range(config.vision_config.num_hidden_layers):
                     new_key = re.sub(r"(encoderblock)/", rf"\1_{i}/", k)
-                    new_state_dict[f"params/{new_key}"] = split_arrays[i].squeeze()
+                    new_state_dict[f"{new_key}"] = split_arrays[i].squeeze()
             else:
-                new_state_dict[f"params/{k}"] = v
-
-    state_dict = new_state_dict
+                new_state_dict[f"{k}"] = v
+        state_dict = new_state_dict
     rename_keys = create_rename_keys(config)
 
     for src, dest in rename_keys:

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -342,7 +342,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
         filename = "siglip_pixel_values_512.pt"
     else:
         raise ValueError("Image size not supported")
-
     filepath = hf_hub_download(repo_id="nielsr/test-image", filename=filename, repo_type="dataset")
     original_pixel_values = torch.load(filepath)
     filepath = hf_hub_download(repo_id="nielsr/test-image", filename="siglip_input_ids.pt", repo_type="dataset")
@@ -365,7 +364,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
 
     # with torch.no_grad():
     #     outputs = model(input_ids=inputs.input_ids, pixel_values=inputs.pixel_values)
-
     probs = torch.sigmoid(outputs.logits_per_image)  # these are the probabilities
     print(f"{probs[0][0]:.1%} that image 0 is '{texts[0]}'")
     print(f"{probs[0][1]:.1%} that image 0 is '{texts[1]}'")
@@ -411,7 +409,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
             expected_slice = torch.tensor(
                 [[-1.9432535, -0.05433846], [0.6222029, 2.2883186]],
             )
-
         assert torch.allclose(outputs.logits_per_image[:3, :3], expected_slice, atol=1e-4)
         print("Looks ok!")
 

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -292,7 +292,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     # load HuggingFace model
     model = SiglipModel(config).eval()
     model.load_state_dict(state_dict)
-
     # create processor
     # important: make tokenizer not return attention_mask since original one doesn't require it
     image_size = config.vision_config.image_size
@@ -349,8 +348,6 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
     # with torch.no_grad():
     #     outputs = model(input_ids=inputs.input_ids, pixel_values=inputs.pixel_values)
 
-    print(outputs.logits_per_image[:3, :3])
-
     probs = torch.sigmoid(outputs.logits_per_image)  # these are the probabilities
     print(f"{probs[0][0]:.1%} that image 0 is '{texts[0]}'")
     print(f"{probs[0][1]:.1%} that image 0 is '{texts[1]}'")
@@ -389,11 +386,9 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
             )
         elif model_name == "siglip-so400m-patch14-224":
             expected_slice = torch.tensor(
-                [[-1.0836973,  1.1742821], [-0.7195749,  1.4370537]],
+                [[-1.0864916 ,  1.1704235 ], [-0.71784306,  1.4354687 ]],
             )
 
-        print("outputs.logits_per_image[:3, :3]:", outputs.logits_per_image[:3, :3])
-        print("expected_slice:", expected_slice)
         assert torch.allclose(outputs.logits_per_image[:3, :3], expected_slice, atol=1e-4)
         print("Looks ok!")
 

--- a/src/transformers/models/siglip/convert_siglip_to_hf.py
+++ b/src/transformers/models/siglip/convert_siglip_to_hf.py
@@ -49,6 +49,8 @@ model_name_to_checkpoint = {
     "siglip-base-patch16-256-i18n": "/Users/nielsrogge/Documents/SigLIP/webli_i18n_b16_256_66117334.npz",
     # so400m checkpoints
     "siglip-so400m-patch14-384": "/Users/nielsrogge/Documents/SigLIP/webli_en_so400m_384_58765454.npz",
+    "siglip-so400m-patch14-224": "/Users/mervenoyan/Desktop/siglips/webli_en_so400m_224_57633886.npz",
+#    "siglip-so400m-patch16-256": "/Users/mervenoyan/Desktop/siglips/webli_i18n_so400m_16_256_78061115.npz",
 }
 
 model_name_to_image_size = {
@@ -60,6 +62,8 @@ model_name_to_image_size = {
     "siglip-large-patch16-384": 384,
     "siglip-base-patch16-256-i18n": 256,
     "siglip-so400m-patch14-384": 384,
+    "siglip-so400m-patch14-224": 224,
+    "siglip-so400m-patch16-256": 256,
 }
 
 
@@ -366,9 +370,14 @@ def convert_siglip_checkpoint(model_name, pytorch_dump_folder_path, verify_logit
             )
         elif model_name == "siglip-so400m-patch14-384":
             expected_slice = torch.tensor([[-1.2441, -0.6649], [-0.7060, 0.7374]])
+
         elif model_name == "siglip-base-patch16-256-i18n":
             expected_slice = torch.tensor(
                 [[-0.9064, 0.1073], [-0.0299, 0.5304]],
+            )
+        elif model_name == "siglip-so400m-patch14-224-i18n":
+            expected_slice = torch.tensor(
+                [[-1.0836973,  1.1742821], [-0.7195749,  1.4370537]],
             )
 
         assert torch.allclose(outputs.logits_per_image[:3, :3], expected_slice, atol=1e-4)

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,8 +926,8 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        #if not (config.vision_config.image_size==256 and config.text_config.vocab_size==250000 and config.vision_config.patch_size==16):
-        self.head = nn.Linear(embed_dim, embed_dim)
+        if not hasattr(self.config, "no_head"):
+            self.head = nn.Linear(embed_dim, embed_dim)
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
     @add_start_docstrings_to_model_forward(SIGLIP_TEXT_INPUTS_DOCSTRING)
@@ -978,7 +978,8 @@ class SiglipTextTransformer(nn.Module):
 
         # Assuming "sticky" EOS tokenization, last token is always EOS.
         pooled_output = last_hidden_state[:, -1, :]
-        pooled_output = self.head(pooled_output)
+        if not hasattr(self.config, "no_head"):
+            pooled_output = self.head(pooled_output)
 
         if not return_dict:
             return (last_hidden_state, pooled_output) + encoder_outputs[1:]

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,8 +926,7 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        if self.config.has_head:
-            self.head = nn.Linear(embed_dim, embed_dim)
+        self.head = nn.Linear(embed_dim, embed_dim) if config.has_head else None
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
     @add_start_docstrings_to_model_forward(SIGLIP_TEXT_INPUTS_DOCSTRING)

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,7 +926,7 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        if not hasattr(self.config, "no_head"):
+        if self.config.has_head:
             self.head = nn.Linear(embed_dim, embed_dim)
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
@@ -978,7 +978,7 @@ class SiglipTextTransformer(nn.Module):
 
         # Assuming "sticky" EOS tokenization, last token is always EOS.
         pooled_output = last_hidden_state[:, -1, :]
-        if not hasattr(self.config, "no_head"):
+        if self.config.has_head:
             pooled_output = self.head(pooled_output)
 
         if not return_dict:

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,7 +926,7 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        self.head = nn.Linear(embed_dim, embed_dim) if config.has_head else None
+        self.head = nn.Linear(embed_dim, embed_dim, bias=False) if config.has_head else lambda x: x @ torch.eye(embed_dim, device=x.device)
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
     @add_start_docstrings_to_model_forward(SIGLIP_TEXT_INPUTS_DOCSTRING)
@@ -977,8 +977,7 @@ class SiglipTextTransformer(nn.Module):
 
         # Assuming "sticky" EOS tokenization, last token is always EOS.
         pooled_output = last_hidden_state[:, -1, :]
-        if self.head is not None:
-            pooled_output = self.head(pooled_output)
+        pooled_output = self.head(pooled_output)
 
         if not return_dict:
             return (last_hidden_state, pooled_output) + encoder_outputs[1:]

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,11 +926,7 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        self.head = (
-            nn.Linear(embed_dim, embed_dim, bias=False)
-            if config.has_head
-            else lambda x: x @ torch.eye(embed_dim, device=x.device)
-        )
+        self.head = nn.Linear(embed_dim, embed_dim)
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
     @add_start_docstrings_to_model_forward(SIGLIP_TEXT_INPUTS_DOCSTRING)

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -926,7 +926,11 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-        self.head = nn.Linear(embed_dim, embed_dim, bias=False) if config.has_head else lambda x: x @ torch.eye(embed_dim, device=x.device)
+        self.head = (
+            nn.Linear(embed_dim, embed_dim, bias=False)
+            if config.has_head
+            else lambda x: x @ torch.eye(embed_dim, device=x.device)
+        )
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 
     @add_start_docstrings_to_model_forward(SIGLIP_TEXT_INPUTS_DOCSTRING)

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -338,7 +338,7 @@ class SiglipTextEmbeddings(nn.Module):
         inputs_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
-        
+
         if position_ids is None:
             position_ids = self.position_ids[:, :seq_length]
 
@@ -926,7 +926,7 @@ class SiglipTextTransformer(nn.Module):
         self.embeddings = SiglipTextEmbeddings(config)
         self.encoder = SiglipEncoder(config)
         self.final_layer_norm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-
+        #if not (config.vision_config.image_size==256 and config.text_config.vocab_size==250000 and config.vision_config.patch_size==16):
         self.head = nn.Linear(embed_dim, embed_dim)
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
 

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -978,7 +978,7 @@ class SiglipTextTransformer(nn.Module):
 
         # Assuming "sticky" EOS tokenization, last token is always EOS.
         pooled_output = last_hidden_state[:, -1, :]
-        if self.config.has_head:
+        if self.head is not None:
             pooled_output = self.head(pooled_output)
 
         if not return_dict:

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -338,6 +338,7 @@ class SiglipTextEmbeddings(nn.Module):
         inputs_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
+        
         if position_ids is None:
             position_ids = self.position_ids[:, :seq_length]
 

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -338,7 +338,6 @@ class SiglipTextEmbeddings(nn.Module):
         inputs_embeds: Optional[torch.FloatTensor] = None,
     ) -> torch.Tensor:
         seq_length = input_ids.shape[-1] if input_ids is not None else inputs_embeds.shape[-2]
-
         if position_ids is None:
             position_ids = self.position_ids[:, :seq_length]
 


### PR DESCRIPTION
@NielsRogge as requested, I have modified the conversion script to convert new SigLIP ckpts.

I have modified model max length and pos embed shape because normally it was 64 and for the so-400m-patch14-224 it is now 16. 
My problem is that the expected output and the converted model outputs aren't close enough, see below. Did you come across the same issue?

```
outputs.logits_per_image[:3, :3]: tensor([[-1.0865,  1.1704],
        [-0.7178,  1.4354]])
expected_slice: tensor([[-1.0837,  1.1743],
        [-0.7196,  1.4371]])
```

Skipping the other model for now, the vocab dim of text embeddings is a bit of an issue, it is said to be 250k but is 256k, waiting for response from google folks (I think they used a different tokenizer, the demo notebook of big-vision also doesn't work for this reason)

Update: I confirmed with folks that there seems to be a mistake with tokenizer.