### PR TITLE
CI: add torchvision to the consistency image

### DIFF
--- a/docker/consistency.dockerfile
+++ b/docker/consistency.dockerfile
@@ -5,7 +5,7 @@ ARG REF=main
 RUN apt-get update && apt-get install -y time git g++ pkg-config make git-lfs
 ENV UV_PYTHON=/usr/local/bin/python
 RUN pip install uv && uv venv && uv pip install --no-cache-dir -U pip setuptools GitPython
-RUN pip install --no-cache-dir --upgrade 'torch' 'torchaudio' --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir --upgrade 'torch' 'torchaudio' 'torchvision' --index-url https://download.pytorch.org/whl/cpu
 # tensorflow pin matching setup.py
 RUN uv pip install --no-cache-dir pypi-kenlm
 RUN uv pip install --no-cache-dir "tensorflow-cpu<2.16" "tf-keras<2.16"


### PR DESCRIPTION
# What does this PR do?

See title :) 

I'm expanding our doc checker to check the docstrings of methods (in addition to the docstring of the classes) in [this PR](https://github.com/huggingface/transformers/pull/32320). To check whether a documented method exists, the easiest solution is to load a class and check if it has the method. To load the class, we need the dependencies in the docker image.

Currently, the CI in the updated check PR is complaining about the lack of `torchvision`: https://app.circleci.com/pipelines/github/huggingface/transformers/101545/workflows/7939d2ec-284f-4353-81b5-db3fbbc4ed25/jobs/1353577