### PR TITLE
Add include_loss_for_metrics

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3975,7 +3975,7 @@ class Trainer:
 
             if is_torch_xla_available():
                 xm.mark_step()
-            
+
             # Update containers
             if losses is not None:
                 losses = self.gather_function((losses.repeat(batch_size)))
@@ -4590,7 +4590,7 @@ class Trainer:
                     if args.include_inputs_for_metrics or args.include_loss_for_metrics:
                         batch_kwargs = {}
                         batch_kwargs["losses"] = losses_host if  args.include_loss_for_metrics else None
-                        batch_kwargs["inputs"] = inputs_host if  args.include_inputs_for_metrics else None                        
+                        batch_kwargs["inputs"] = inputs_host if  args.include_inputs_for_metrics else None
                         metrics = self.compute_metrics(
                             EvalPrediction(predictions=preds_host, label_ids=labels_host, **batch_kwargs),
                             compute_result=is_last_step,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3971,7 +3971,9 @@ class Trainer:
             # Prediction step
             losses, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
             main_input_name = getattr(self.model, "main_input_name", "input_ids")
-            inputs_decode = self._prepare_input(inputs[main_input_name]) if "inputs" in args.include_for_metrics else None
+            inputs_decode = (
+                self._prepare_input(inputs[main_input_name]) if "inputs" in args.include_for_metrics else None
+            )
 
             if is_torch_xla_available():
                 xm.mark_step()
@@ -4558,7 +4560,9 @@ class Trainer:
         for step, inputs in enumerate(dataloader):
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
             main_input_name = getattr(self.model, "main_input_name", "input_ids")
-            inputs_decode = self._prepare_input(inputs[main_input_name])  if "inputs" in args.include_for_metrics else None
+            inputs_decode = (
+                self._prepare_input(inputs[main_input_name]) if "inputs" in args.include_for_metrics else None
+            )
 
             if loss is not None:
                 losses = loss.repeat(batch_size)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4005,19 +4005,13 @@ class Trainer:
             if self.args.batch_eval_metrics:
                 if self.compute_metrics is not None and logits is not None and labels is not None:
                     is_last_step = self.accelerator.gradient_state.end_of_dataloader
-                    if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                        batch_kwargs = {}
-                        batch_kwargs["losses"] = losses if args.include_loss_for_metrics else None
-                        batch_kwargs["inputs"] = inputs if args.include_inputs_for_metrics else None
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=logits, label_ids=labels, **batch_kwargs),
-                            compute_result=is_last_step,
-                        )
-                    else:
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=logits, label_ids=labels),
-                            compute_result=is_last_step,
-                        )
+                    batch_kwargs = {}
+                    batch_kwargs["losses"] = losses if args.include_loss_for_metrics else None
+                    batch_kwargs["inputs"] = inputs if args.include_inputs_for_metrics else None
+                    metrics = self.compute_metrics(
+                        EvalPrediction(predictions=logits, label_ids=labels, **batch_kwargs),
+                        compute_result=is_last_step,
+                    )
 
                 del losses, logits, labels, inputs
                 torch.cuda.empty_cache()
@@ -4066,14 +4060,11 @@ class Trainer:
             and all_labels is not None
             and not self.args.batch_eval_metrics
         ):
-            if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                eval_set_kwargs["losses"] = all_losses if args.include_loss_for_metrics else None
-                eval_set_kwargs["inputs"] = all_inputs if args.include_inputs_for_metrics else None
-                metrics = self.compute_metrics(
-                    EvalPrediction(predictions=all_preds, label_ids=all_labels, **eval_set_kwargs)
-                )
-            else:
-                metrics = self.compute_metrics(EvalPrediction(predictions=all_preds, label_ids=all_labels))
+            eval_set_kwargs["losses"] = all_losses if args.include_loss_for_metrics else None
+            eval_set_kwargs["inputs"] = all_inputs if args.include_inputs_for_metrics else None
+            metrics = self.compute_metrics(
+                EvalPrediction(predictions=all_preds, label_ids=all_labels, **eval_set_kwargs)
+            )
         elif metrics is None:
             metrics = {}
 
@@ -4587,19 +4578,13 @@ class Trainer:
             if self.args.batch_eval_metrics:
                 if self.compute_metrics is not None and preds_host is not None and labels_host is not None:
                     is_last_step = self.accelerator.gradient_state.end_of_dataloader
-                    if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                        batch_kwargs = {}
-                        batch_kwargs["losses"] = losses_host if args.include_loss_for_metrics else None
-                        batch_kwargs["inputs"] = inputs_host if args.include_inputs_for_metrics else None
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=preds_host, label_ids=labels_host, **batch_kwargs),
-                            compute_result=is_last_step,
-                        )
-                    else:
-                        metrics = self.compute_metrics(
-                            EvalPrediction(predictions=preds_host, label_ids=labels_host),
-                            compute_result=is_last_step,
-                        )
+                    batch_kwargs = {}
+                    batch_kwargs["losses"] = losses_host if args.include_loss_for_metrics else None
+                    batch_kwargs["inputs"] = inputs_host if args.include_inputs_for_metrics else None
+                    metrics = self.compute_metrics(
+                        EvalPrediction(predictions=preds_host, label_ids=labels_host, **batch_kwargs),
+                        compute_result=is_last_step,
+                    )
 
             if self.args.batch_eval_metrics or (
                 args.eval_accumulation_steps is not None and (step + 1) % args.eval_accumulation_steps == 0
@@ -4638,14 +4623,9 @@ class Trainer:
             and label_ids is not None
             and not self.args.batch_eval_metrics
         ):
-            if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                eval_set_kwargs["losses"] = eval_loss if args.include_loss_for_metrics else None
-                eval_set_kwargs["inputs"] = inputs_ids if args.include_inputs_for_metrics else None
-                metrics = self.compute_metrics(
-                    EvalPrediction(predictions=preds, label_ids=label_ids, **eval_set_kwargs)
-                )
-            else:
-                metrics = self.compute_metrics(EvalPrediction(predictions=preds, label_ids=label_ids))
+            eval_set_kwargs["losses"] = eval_loss if args.include_loss_for_metrics else None
+            eval_set_kwargs["inputs"] = inputs_ids if args.include_inputs_for_metrics else None
+            metrics = self.compute_metrics(EvalPrediction(predictions=preds, label_ids=label_ids, **eval_set_kwargs))
         elif metrics is None:
             metrics = {}
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3953,7 +3953,7 @@ class Trainer:
         all_inputs = EvalLoopContainer(self.args.eval_do_concat_batches, padding_index=-100)
 
         metrics = None
-        eval_set_kwargs =  {}
+        eval_set_kwargs = {}
 
         # Will be useful when we have an iterable dataset so don't know its length.
         observed_num_examples = 0
@@ -4067,8 +4067,8 @@ class Trainer:
             and not self.args.batch_eval_metrics
         ):
             if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                eval_set_kwargs['losses'] = all_losses if args.include_loss_for_metrics else None
-                eval_set_kwargs['inputs'] = all_inputs if args.include_inputs_for_metrics else None
+                eval_set_kwargs["losses"] = all_losses if args.include_loss_for_metrics else None
+                eval_set_kwargs["inputs"] = all_inputs if args.include_inputs_for_metrics else None
                 metrics = self.compute_metrics(
                     EvalPrediction(predictions=all_preds, label_ids=all_labels, **eval_set_kwargs)
                 )
@@ -4589,8 +4589,8 @@ class Trainer:
                     is_last_step = self.accelerator.gradient_state.end_of_dataloader
                     if args.include_inputs_for_metrics or args.include_loss_for_metrics:
                         batch_kwargs = {}
-                        batch_kwargs["losses"] = losses_host if  args.include_loss_for_metrics else None
-                        batch_kwargs["inputs"] = inputs_host if  args.include_inputs_for_metrics else None
+                        batch_kwargs["losses"] = losses_host if args.include_loss_for_metrics else None
+                        batch_kwargs["inputs"] = inputs_host if args.include_inputs_for_metrics else None
                         metrics = self.compute_metrics(
                             EvalPrediction(predictions=preds_host, label_ids=labels_host, **batch_kwargs),
                             compute_result=is_last_step,
@@ -4639,8 +4639,8 @@ class Trainer:
             and not self.args.batch_eval_metrics
         ):
             if args.include_inputs_for_metrics or args.include_loss_for_metrics:
-                eval_set_kwargs['losses'] = eval_loss if args.include_loss_for_metrics else None
-                eval_set_kwargs['inputs'] = inputs_ids if args.include_inputs_for_metrics else None
+                eval_set_kwargs["losses"] = eval_loss if args.include_loss_for_metrics else None
+                eval_set_kwargs["inputs"] = inputs_ids if args.include_inputs_for_metrics else None
                 metrics = self.compute_metrics(
                     EvalPrediction(predictions=preds, label_ids=label_ids, **eval_set_kwargs)
                 )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3971,7 +3971,7 @@ class Trainer:
             # Prediction step
             losses, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
             main_input_name = getattr(self.model, "main_input_name", "input_ids")
-            inputs_decode = self._prepare_input(inputs[main_input_name]) if args.include_inputs_for_metrics else None
+            inputs_decode = self._prepare_input(inputs[main_input_name]) if "inputs" in args.include_for_metrics else None
 
             if is_torch_xla_available():
                 xm.mark_step()
@@ -4006,8 +4006,8 @@ class Trainer:
                 if self.compute_metrics is not None and logits is not None and labels is not None:
                     is_last_step = self.accelerator.gradient_state.end_of_dataloader
                     batch_kwargs = {}
-                    batch_kwargs["losses"] = losses if args.include_loss_for_metrics else None
-                    batch_kwargs["inputs"] = inputs if args.include_inputs_for_metrics else None
+                    batch_kwargs["losses"] = losses if "loss" in args.include_for_metrics else None
+                    batch_kwargs["inputs"] = inputs if "inputs" in args.include_for_metrics else None
                     metrics = self.compute_metrics(
                         EvalPrediction(predictions=logits, label_ids=labels, **batch_kwargs),
                         compute_result=is_last_step,
@@ -4060,8 +4060,8 @@ class Trainer:
             and all_labels is not None
             and not self.args.batch_eval_metrics
         ):
-            eval_set_kwargs["losses"] = all_losses if args.include_loss_for_metrics else None
-            eval_set_kwargs["inputs"] = all_inputs if args.include_inputs_for_metrics else None
+            eval_set_kwargs["losses"] = all_losses if "loss" in args.include_for_metrics else None
+            eval_set_kwargs["inputs"] = all_inputs if "inputs" in args.include_for_metrics else None
             metrics = self.compute_metrics(
                 EvalPrediction(predictions=all_preds, label_ids=all_labels, **eval_set_kwargs)
             )
@@ -4558,7 +4558,7 @@ class Trainer:
         for step, inputs in enumerate(dataloader):
             loss, logits, labels = self.prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
             main_input_name = getattr(self.model, "main_input_name", "input_ids")
-            inputs_decode = self._prepare_input(inputs[main_input_name]) if args.include_inputs_for_metrics else None
+            inputs_decode = self._prepare_input(inputs[main_input_name])  if "inputs" in args.include_for_metrics else None
 
             if loss is not None:
                 losses = loss.repeat(batch_size)
@@ -4579,8 +4579,8 @@ class Trainer:
                 if self.compute_metrics is not None and preds_host is not None and labels_host is not None:
                     is_last_step = self.accelerator.gradient_state.end_of_dataloader
                     batch_kwargs = {}
-                    batch_kwargs["losses"] = losses_host if args.include_loss_for_metrics else None
-                    batch_kwargs["inputs"] = inputs_host if args.include_inputs_for_metrics else None
+                    batch_kwargs["losses"] = losses_host if "loss" in args.include_for_metrics else None
+                    batch_kwargs["inputs"] = inputs_host if "inputs" in args.include_for_metrics else None
                     metrics = self.compute_metrics(
                         EvalPrediction(predictions=preds_host, label_ids=labels_host, **batch_kwargs),
                         compute_result=is_last_step,
@@ -4623,8 +4623,8 @@ class Trainer:
             and label_ids is not None
             and not self.args.batch_eval_metrics
         ):
-            eval_set_kwargs["losses"] = eval_loss if args.include_loss_for_metrics else None
-            eval_set_kwargs["inputs"] = inputs_ids if args.include_inputs_for_metrics else None
+            eval_set_kwargs["losses"] = eval_loss if "loss" in args.include_for_metrics else None
+            eval_set_kwargs["inputs"] = inputs_ids if "inputs" in args.include_for_metrics else None
             metrics = self.compute_metrics(EvalPrediction(predictions=preds, label_ids=label_ids, **eval_set_kwargs))
         elif metrics is None:
             metrics = {}

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -156,22 +156,21 @@ class EvalPrediction:
     Parameters:
         predictions (`np.ndarray`): Predictions of the model.
         label_ids (`np.ndarray`): Targets to be matched.
-        kwargs (`Dict[str, Any]`, *optional*): Additional keyword arguments passed to EvalPrediction to include inputs and/or losses.
+        inputs (`np.ndarray`, *optional*): Input data passed to the model.
+        losses (`np.ndarray`, *optional*): Loss values computed during evaluation.
     """
 
     def __init__(
         self,
         predictions: Union[np.ndarray, Tuple[np.ndarray]],
         label_ids: Union[np.ndarray, Tuple[np.ndarray]],
-        kwargs: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Union[np.ndarray, Tuple[np.ndarray]]] = None,
+        losses: Optional[Union[np.ndarray, Tuple[np.ndarray]]] = None,
     ):
         self.predictions = predictions
         self.label_ids = label_ids
-        self.inputs = None
-        self.losses = None
-        if kwargs is not None:
-            self.inputs = kwargs.pop("inputs", None)
-            self.losses = kwargs.pop("losses", None)
+        self.inputs = inputs
+        self.losses = losses
         self.items = (self.predictions, self.label_ids)
         if self.inputs is not None:
             self.items += (self.inputs,)

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -170,8 +170,8 @@ class EvalPrediction:
         self.inputs = None
         self.losses = None
         if kwargs is not None:
-            self.inputs =  kwargs.pop("inputs", None)
-            self.losses =  kwargs.pop("losses", None)
+            self.inputs = kwargs.pop("inputs", None)
+            self.losses = kwargs.pop("losses", None)
         self.items = (self.predictions, self.label_ids)
         if self.inputs is not None:
             self.items += (self.inputs,)

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -167,6 +167,8 @@ class EvalPrediction:
     ):
         self.predictions = predictions
         self.label_ids = label_ids
+        self.inputs = None
+        self.losses = None
         if kwargs is not None:
             self.inputs =  kwargs.pop("inputs", None)
             self.losses =  kwargs.pop("losses", None)

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -171,19 +171,19 @@ class EvalPrediction:
         self.label_ids = label_ids
         self.inputs = inputs
         self.losses = losses
-        self.items = (self.predictions, self.label_ids)
+        self.elements = (self.predictions, self.label_ids)
         if self.inputs is not None:
-            self.items += (self.inputs,)
+            self.elements += (self.inputs,)
         if self.losses is not None:
-            self.items += (self.losses,)
+            self.elements += (self.losses,)
 
     def __iter__(self):
-        return iter(self.items)
+        return iter(self.elements)
 
     def __getitem__(self, idx):
-        if idx < 0 or idx >= len(self.items):
+        if idx < 0 or idx >= len(self.elements):
             raise IndexError("tuple index out of range")
-        return self.items[idx]
+        return self.elements[idx]
 
 
 class EvalLoopOutput(NamedTuple):

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1354,7 +1354,7 @@ class TrainingArguments:
         },
     )
     include_inputs_for_metrics: bool = field(
-        default=False, 
+        default=False,
         metadata={
             "help": "Whether or not the inputs will be passed to the `compute_metrics` function."
         },

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1357,7 +1357,7 @@ class TrainingArguments:
     include_inputs_for_metrics: bool = field(
         default=False,
         metadata={
-            "help": "This argument is deprecated and will be removed in version 5 of 🤗 Transformers. Use `include_for_metrics` instead"
+            "help": "This argument is deprecated and will be removed in version 5 of 🤗 Transformers. Use `include_for_metrics` instead."
         },
     )
     include_for_metrics: List[str] = field(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -703,6 +703,9 @@ class TrainingArguments:
         include_inputs_for_metrics (`bool`, *optional*, defaults to `False`):
             Whether or not the inputs will be passed to the `compute_metrics` function. This is intended for metrics
             that need inputs, predictions and references for scoring calculation in Metric class.
+        include_loss_for_metrics (`bool`, *optional*, defaults to `False`):
+            Whether or not the loss values will be passed to the `compute_metrics` function. This is intended for calculating
+            loss dependent metrics.
         eval_do_concat_batches (`bool`, *optional*, defaults to `True`):
             Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`,
             will instead store them as lists, with each batch kept separate.
@@ -1351,7 +1354,15 @@ class TrainingArguments:
         },
     )
     include_inputs_for_metrics: bool = field(
-        default=False, metadata={"help": "Whether or not the inputs will be passed to the `compute_metrics` function."}
+        default=False, 
+        metadata={
+            "help": "Whether or not the inputs will be passed to the `compute_metrics` function."
+        },
+    )
+    include_loss_for_metrics: bool = field(
+        default=False,
+        metadata={"help": "Whether or not the loss will be passed to the `compute_metrics` function."
+        },
     )
     eval_do_concat_batches: bool = field(
         default=True,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2063,9 +2063,8 @@ class TrainingArguments:
             )
 
         if self.include_inputs_for_metrics:
-            warnings.warn(
-                "Using `include_inputs_for_metrics` is deprecated and will be removed in version 5 of 🤗 Transformers. Please use `include_for_metrics` list argument instead.",
-                FutureWarning,
+            logger.warning(
+                "Using `include_inputs_for_metrics` is deprecated and will be removed in version 5 of 🤗 Transformers. Please use `include_for_metrics` list argument instead."
             )
             self.include_for_metrics.append("inputs")
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1355,14 +1355,11 @@ class TrainingArguments:
     )
     include_inputs_for_metrics: bool = field(
         default=False,
-        metadata={
-            "help": "Whether or not the inputs will be passed to the `compute_metrics` function."
-        },
+        metadata={"help": "Whether or not the inputs will be passed to the `compute_metrics` function."},
     )
     include_loss_for_metrics: bool = field(
         default=False,
-        metadata={"help": "Whether or not the loss will be passed to the `compute_metrics` function."
-        },
+        metadata={"help": "Whether or not the loss will be passed to the `compute_metrics` function."},
     )
     eval_do_concat_batches: bool = field(
         default=True,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -701,11 +701,12 @@ class TrainingArguments:
         gradient_checkpointing_kwargs (`dict`, *optional*, defaults to `None`):
             Key word arguments to be passed to the `gradient_checkpointing_enable` method.
         include_inputs_for_metrics (`bool`, *optional*, defaults to `False`):
-            Whether or not the inputs will be passed to the `compute_metrics` function. This is intended for metrics
-            that need inputs, predictions and references for scoring calculation in Metric class.
-        include_loss_for_metrics (`bool`, *optional*, defaults to `False`):
-            Whether or not the loss values will be passed to the `compute_metrics` function. This is intended for calculating
-            loss dependent metrics.
+            This argument is deprecated. Use `include_for_metrics` instead, e.g, `include_for_metrics = ["inputs"]`.
+        include_for_metrics (`List[str]`, *optional*, defaults to `[]`):
+            Include additional data in the `compute_metrics` function if needed for metrics computation.
+            Possible options to add to `include_for_metrics` list:
+            - `"inputs"`: Input data passed to the model, intended for calculating input dependent metrics.
+            - `"loss"`: Loss values computed during evaluation, intended for calculating loss dependent metrics.
         eval_do_concat_batches (`bool`, *optional*, defaults to `True`):
             Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`,
             will instead store them as lists, with each batch kept separate.
@@ -1355,11 +1356,16 @@ class TrainingArguments:
     )
     include_inputs_for_metrics: bool = field(
         default=False,
-        metadata={"help": "Whether or not the inputs will be passed to the `compute_metrics` function."},
+        metadata={
+            "help": "This argument is deprecated and will be removed in version 5 of 🤗 Transformers. Use `include_for_metrics` instead"
+        },
     )
-    include_loss_for_metrics: bool = field(
-        default=False,
-        metadata={"help": "Whether or not the loss will be passed to the `compute_metrics` function."},
+    include_for_metrics: List[str] = field(
+        default_factory=list,
+        metadata={
+            "help": "List of strings to specify additional data to include in the `compute_metrics` function."
+            "Options: 'inputs', 'loss'."
+        },
     )
     eval_do_concat_batches: bool = field(
         default=True,
@@ -2055,6 +2061,13 @@ class TrainingArguments:
                 "--eval_use_gather_object requires Accelerate to be version of `accelerate` > 0.30.0."
                 "This is not supported and we recommend you to update your version."
             )
+
+        if self.include_inputs_for_metrics:
+            warnings.warn(
+                "Using `include_inputs_for_metrics` is deprecated and will be removed in version 5 of 🤗 Transformers. Please use `include_for_metrics` list argument instead.",
+                FutureWarning,
+            )
+            self.include_for_metrics.append("inputs")
 
     def __str__(self):
         self_as_dict = asdict(self)


### PR DESCRIPTION
# What does this PR do?
Fixes #32307

This PR includes loss in the `compute_metrics` function via the `include_loss_for_metrics` training argument flag, this is particularly useful for calculating loss dependent metrics, the `EvalPrediction` class now handles optional inputs and losses.

## Before submitting

- [ ]  This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x]  Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),Pull Request section?
- [x]  Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ]  Did you make sure to update the documentation with your changes? Here are the[documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ]  Did you write any new necessary tests?

## Who can review?

@muellerzr @SunMarc
