### PR TITLE
Test: add higher `atol` in `test_forward_with_num_logits_to_keep`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4842,8 +4842,8 @@ class ModelTesterMixin:
             self.assertEqual(tuple(all_logits.shape), (batch_size, sequence_length, vocab_size))
             self.assertEqual(tuple(last_token_logits.shape), (batch_size, 1, vocab_size))
 
-            # Assert the last tokens are actually the same
-            self.assertTrue(torch.allclose(all_logits[:, -1:, :], last_token_logits))
+            # Assert the last tokens are actually the same (except for the natural fluctuation due to order of FP ops)
+            self.assertTrue(torch.allclose(all_logits[:, -1:, :], last_token_logits, atol=1e-5))
 
 
 global_rng = random.Random()


### PR DESCRIPTION
# What does this PR do?

#31292 added `test_forward_with_num_logits_to_keep`. The test needs a higher atol at least for modern CUDA devices, it was failing locally on my end.

[Forward pass in the lm head with different shape due to `num_logits_to_keep` -> different order of FP operations (maybe different optimal kernels too) -> slightly different output. See [this comment](https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535) for more info.]

FYI @Cyrilvallez 