### PR TITLE
[Backbone] Remove out_features everywhere

### DIFF
--- a/docs/source/en/model_doc/dpt.md
+++ b/docs/source/en/model_doc/dpt.md
@@ -41,7 +41,7 @@ from transformers import Dinov2Config, DPTConfig, DPTForDepthEstimation
 
 # initialize with a Transformer-based backbone such as DINOv2
 # in that case, we also specify `reshape_hidden_states=False` to get feature maps of shape (batch_size, num_channels, height, width)
-backbone_config = Dinov2Config.from_pretrained("facebook/dinov2-base", out_features=["stage1", "stage2", "stage3", "stage4"], reshape_hidden_states=False)
+backbone_config = Dinov2Config.from_pretrained("facebook/dinov2-base", out_indices=[1, 2, 3, 4], reshape_hidden_states=False)
 
 config = DPTConfig(backbone_config=backbone_config)
 model = DPTForDepthEstimation(config=config)

--- a/docs/source/en/model_doc/upernet.md
+++ b/docs/source/en/model_doc/upernet.md
@@ -40,7 +40,7 @@ UPerNet is a general framework for semantic segmentation. It can be used with an
 ```py
 from transformers import SwinConfig, UperNetConfig, UperNetForSemanticSegmentation
 
-backbone_config = SwinConfig(out_features=["stage1", "stage2", "stage3", "stage4"])
+backbone_config = SwinConfig(out_indices=[1, 2, 3, 4])
 
 config = UperNetConfig(backbone_config=backbone_config)
 model = UperNetForSemanticSegmentation(config)
@@ -51,7 +51,7 @@ To use another vision backbone, like [ConvNeXt](convnext), simply instantiate th
 ```py
 from transformers import ConvNextConfig, UperNetConfig, UperNetForSemanticSegmentation
 
-backbone_config = ConvNextConfig(out_features=["stage1", "stage2", "stage3", "stage4"])
+backbone_config = ConvNextConfig(out_indices=[1, 2, 3, 4])
 
 config = UperNetConfig(backbone_config=backbone_config)
 model = UperNetForSemanticSegmentation(config)

--- a/src/transformers/models/beit/modeling_beit.py
+++ b/src/transformers/models/beit/modeling_beit.py
@@ -1509,7 +1509,7 @@ class BeitBackbone(BeitPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("microsoft/beit-base-patch16-224")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "microsoft/beit-base-patch16-224", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "microsoft/beit-base-patch16-224", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/deprecated/deta/convert_deta_swin_to_pytorch.py
+++ b/src/transformers/models/deprecated/deta/convert_deta_swin_to_pytorch.py
@@ -39,7 +39,7 @@ def get_deta_config(model_name):
         depths=(2, 2, 18, 2),
         num_heads=(6, 12, 24, 48),
         window_size=12,
-        out_features=["stage2", "stage3", "stage4"],
+        out_indices=[2, 3, 4],
     )
 
     config = DetaConfig(

--- a/src/transformers/models/deprecated/nat/modeling_nat.py
+++ b/src/transformers/models/deprecated/nat/modeling_nat.py
@@ -896,7 +896,7 @@ class NatBackbone(NatPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("shi-labs/nat-mini-in1k-224")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "shi-labs/nat-mini-in1k-224", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "shi-labs/nat-mini-in1k-224", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -904,7 +904,7 @@ class DinatBackbone(DinatPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("shi-labs/nat-mini-in1k-224")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "shi-labs/nat-mini-in1k-224", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "shi-labs/nat-mini-in1k-224", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/dpt/convert_dpt_beit_to_hf.py
+++ b/src/transformers/models/dpt/convert_dpt_beit_to_hf.py
@@ -34,14 +34,14 @@ def get_dpt_config(model_name):
     num_hidden_layers = 12
     num_attention_heads = 12
     intermediate_size = 3072
-    out_features = ["stage3", "stage6", "stage9", "stage12"]  # beit-base-384 uses [2, 5, 8, 11]
+    out_indices = [3, 6, 9, 12]  # beit-base-384 uses [2, 5, 8, 11] in original implementation
 
     if "large" in model_name:
         hidden_size = 1024
         num_hidden_layers = 24
         num_attention_heads = 16
         intermediate_size = 4096
-        out_features = ["stage6", "stage12", "stage18", "stage24"]  # beit-large-512 uses [5, 11, 17, 23]
+        out_indices = [6, 12, 18, 24]  # beit-large-512 uses [5, 11, 17, 23] in original implementation
 
     if "512" in model_name:
         image_size = 512
@@ -58,7 +58,7 @@ def get_dpt_config(model_name):
         num_attention_heads=num_attention_heads,
         use_relative_position_bias=True,
         reshape_hidden_states=False,
-        out_features=out_features,
+        out_indices=out_indices,
     )
 
     neck_hidden_sizes = [256, 512, 1024, 1024] if "large" in model_name else [96, 192, 384, 768]

--- a/src/transformers/models/dpt/convert_dpt_swinv2_to_hf.py
+++ b/src/transformers/models/dpt/convert_dpt_swinv2_to_hf.py
@@ -65,7 +65,7 @@ def get_dpt_config(model_name):
         window_size=window_size,
         pretrained_window_sizes=pretrained_window_sizes,
         num_heads=num_heads,
-        out_features=["stage1", "stage2", "stage3", "stage4"],
+        out_indices=[1, 2, 3, 4],
     )
 
     if model_name == "dpt-swinv2-tiny-256":

--- a/src/transformers/models/hiera/modeling_hiera.py
+++ b/src/transformers/models/hiera/modeling_hiera.py
@@ -1515,7 +1515,7 @@ class HieraBackbone(HieraPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("facebook/hiera-tiny-224-hf")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "facebook/hiera-tiny-224-hf", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "facebook/hiera-tiny-224-hf", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/mask2former/configuration_mask2former.py
+++ b/src/transformers/models/mask2former/configuration_mask2former.py
@@ -179,7 +179,7 @@ class Mask2FormerConfig(PretrainedConfig):
                 window_size=7,
                 drop_path_rate=0.3,
                 use_absolute_embeddings=False,
-                out_features=["stage1", "stage2", "stage3", "stage4"],
+                out_indices=[1, 2, 3, 4],
             )
         elif isinstance(backbone_config, dict):
             backbone_model_type = backbone_config.pop("model_type")

--- a/src/transformers/models/mask2former/convert_mask2former_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/mask2former/convert_mask2former_original_pytorch_checkpoint_to_pytorch.py
@@ -136,7 +136,7 @@ class OriginalMask2FormerConfigToOursConverter:
 
         if model.SWIN.EMBED_DIM == 96:
             backbone_config = SwinConfig.from_pretrained(
-                "microsoft/swin-tiny-patch4-window7-224", out_features=["stage1", "stage2", "stage3", "stage4"]
+                "microsoft/swin-tiny-patch4-window7-224", out_indices=[1, 2, 3, 4]
             )
         elif model.SWIN.EMBED_DIM == 128:
             backbone_config = SwinConfig(
@@ -144,12 +144,12 @@ class OriginalMask2FormerConfigToOursConverter:
                 window_size=12,
                 depths=(2, 2, 18, 2),
                 num_heads=(4, 8, 16, 32),
-                out_features=["stage1", "stage2", "stage3", "stage4"],
+                out_indices=[1, 2, 3, 4],
             )
 
         elif model.SWIN.EMBED_DIM == 192:
             backbone_config = SwinConfig.from_pretrained(
-                "microsoft/swin-large-patch4-window12-384", out_features=["stage1", "stage2", "stage3", "stage4"]
+                "microsoft/swin-large-patch4-window12-384", out_indices=[1, 2, 3, 4]
             )
         else:
             raise ValueError(f"embed dim {model.SWIN.EMBED_DIM} not supported for Swin!")

--- a/src/transformers/models/maskformer/configuration_maskformer.py
+++ b/src/transformers/models/maskformer/configuration_maskformer.py
@@ -138,7 +138,7 @@ class MaskFormerConfig(PretrainedConfig):
                 num_heads=[4, 8, 16, 32],
                 window_size=12,
                 drop_path_rate=0.3,
-                out_features=["stage1", "stage2", "stage3", "stage4"],
+                out_indices=[1, 2, 3, 4],
             )
         elif isinstance(backbone_config, dict):
             backbone_model_type = backbone_config.pop("model_type")

--- a/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
@@ -38,13 +38,9 @@ def get_maskformer_config(model_name: str):
         # TODO add support for ResNet-C backbone, which uses a "deeplab" stem
         raise NotImplementedError("To do")
     elif "resnet101" in model_name:
-        backbone_config = ResNetConfig.from_pretrained(
-            "microsoft/resnet-101", out_features=["stage1", "stage2", "stage3", "stage4"]
-        )
+        backbone_config = ResNetConfig.from_pretrained("microsoft/resnet-101", out_indices=[1, 2, 3, 4])
     else:
-        backbone_config = ResNetConfig.from_pretrained(
-            "microsoft/resnet-50", out_features=["stage1", "stage2", "stage3", "stage4"]
-        )
+        backbone_config = ResNetConfig.from_pretrained("microsoft/resnet-50", out_indices=[1, 2, 3, 4])
     config = MaskFormerConfig(backbone_config=backbone_config)
 
     repo_id = "huggingface/label-files"

--- a/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
@@ -34,9 +34,7 @@ logger = logging.get_logger(__name__)
 
 
 def get_maskformer_config(model_name: str):
-    backbone_config = SwinConfig.from_pretrained(
-        "microsoft/swin-tiny-patch4-window7-224", out_features=["stage1", "stage2", "stage3", "stage4"]
-    )
+    backbone_config = SwinConfig.from_pretrained("microsoft/swin-tiny-patch4-window7-224", out_indices=[1, 2, 3, 4])
     config = MaskFormerConfig(backbone_config=backbone_config)
 
     repo_id = "huggingface/label-files"

--- a/src/transformers/models/oneformer/configuration_oneformer.py
+++ b/src/transformers/models/oneformer/configuration_oneformer.py
@@ -209,7 +209,7 @@ class OneFormerConfig(PretrainedConfig):
                 window_size=7,
                 drop_path_rate=0.3,
                 use_absolute_embeddings=False,
-                out_features=["stage1", "stage2", "stage3", "stage4"],
+                out_indices=[1, 2, 3, 4],
             )
         elif isinstance(backbone_config, dict):
             backbone_model_type = backbone_config.get("model_type")

--- a/src/transformers/models/oneformer/convert_to_hf_oneformer.py
+++ b/src/transformers/models/oneformer/convert_to_hf_oneformer.py
@@ -130,13 +130,13 @@ class OriginalOneFormerConfigToOursConverter:
                 backbone_config = SwinConfig.from_pretrained(
                     "microsoft/swin-tiny-patch4-window7-224",
                     drop_path_rate=model.SWIN.DROP_PATH_RATE,
-                    out_features=["stage1", "stage2", "stage3", "stage4"],
+                    out_indices=[1, 2, 3, 4],
                 )
             elif model.SWIN.EMBED_DIM == 192:
                 backbone_config = SwinConfig.from_pretrained(
                     "microsoft/swin-large-patch4-window12-384",
                     drop_path_rate=model.SWIN.DROP_PATH_RATE,
-                    out_features=["stage1", "stage2", "stage3", "stage4"],
+                    out_indices=[1, 2, 3, 4],
                 )
             else:
                 raise ValueError(f"embed dim {model.SWIN.EMBED_DIM} not supported for Swin!")
@@ -145,7 +145,7 @@ class OriginalOneFormerConfigToOursConverter:
                 "shi-labs/dinat-large-11x11-in22k-in1k-384",
                 dilations=model.DiNAT.DILATIONS,
                 kernel_size=model.DiNAT.KERNEL_SIZE,
-                out_features=["stage1", "stage2", "stage3", "stage4"],
+                out_indices=[1, 2, 3, 4],
             )
 
         config: OneFormerConfig = OneFormerConfig(

--- a/src/transformers/models/pvt_v2/modeling_pvt_v2.py
+++ b/src/transformers/models/pvt_v2/modeling_pvt_v2.py
@@ -658,7 +658,7 @@ class PvtV2Backbone(PvtV2Model, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("OpenGVLab/pvt_v2_b0")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "OpenGVLab/pvt_v2_b0", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "OpenGVLab/pvt_v2_b0", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -478,7 +478,7 @@ class ResNetBackbone(ResNetPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("microsoft/resnet-50")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "microsoft/resnet-50", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "microsoft/resnet-50", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/swin/modeling_swin.py
+++ b/src/transformers/models/swin/modeling_swin.py
@@ -1350,7 +1350,7 @@ class SwinBackbone(SwinPreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("shi-labs/nat-mini-in1k-224")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "microsoft/swin-tiny-patch4-window7-224", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "microsoft/swin-tiny-patch4-window7-224", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/swinv2/modeling_swinv2.py
+++ b/src/transformers/models/swinv2/modeling_swinv2.py
@@ -1398,7 +1398,7 @@ class Swinv2Backbone(Swinv2PreTrainedModel, BackboneMixin):
 
         >>> processor = AutoImageProcessor.from_pretrained("microsoft/swinv2-tiny-patch4-window8-256")
         >>> model = AutoBackbone.from_pretrained(
-        ...     "microsoft/swinv2-tiny-patch4-window8-256", out_features=["stage1", "stage2", "stage3", "stage4"]
+        ...     "microsoft/swinv2-tiny-patch4-window8-256", out_indices=[1, 2, 3, 4]
         ... )
 
         >>> inputs = processor(image, return_tensors="pt")

--- a/src/transformers/models/table_transformer/convert_table_transformer_to_hf_no_timm.py
+++ b/src/transformers/models/table_transformer/convert_table_transformer_to_hf_no_timm.py
@@ -307,9 +307,7 @@ def convert_table_transformer_checkpoint(checkpoint_url, pytorch_dump_folder_pat
     logger.info("Converting model...")
 
     # create HuggingFace model and load state dict
-    backbone_config = ResNetConfig.from_pretrained(
-        "microsoft/resnet-18", out_features=["stage1", "stage2", "stage3", "stage4"]
-    )
+    backbone_config = ResNetConfig.from_pretrained("microsoft/resnet-18", out_indices=[1, 2, 3, 4])
 
     config = TableTransformerConfig(
         backbone_config=backbone_config,

--- a/src/transformers/models/upernet/configuration_upernet.py
+++ b/src/transformers/models/upernet/configuration_upernet.py
@@ -106,7 +106,7 @@ class UperNetConfig(PretrainedConfig):
         super().__init__(**kwargs)
         if backbone_config is None and backbone is None:
             logger.info("`backbone_config` is `None`. Initializing the config with the default `ResNet` backbone.")
-            backbone_config = CONFIG_MAPPING["resnet"](out_features=["stage1", "stage2", "stage3", "stage4"])
+            backbone_config = CONFIG_MAPPING["resnet"](out_indices=[1, 2, 3, 4])
         elif isinstance(backbone_config, dict):
             backbone_model_type = backbone_config.get("model_type")
             config_class = CONFIG_MAPPING[backbone_model_type]

--- a/src/transformers/models/upernet/convert_convnext_upernet_to_pytorch.py
+++ b/src/transformers/models/upernet/convert_convnext_upernet_to_pytorch.py
@@ -54,9 +54,7 @@ def get_upernet_config(model_name):
     id2label = {int(k): v for k, v in id2label.items()}
     label2id = {v: k for k, v in id2label.items()}
 
-    backbone_config = ConvNextConfig(
-        depths=depths, hidden_sizes=hidden_sizes, out_features=["stage1", "stage2", "stage3", "stage4"]
-    )
+    backbone_config = ConvNextConfig(depths=depths, hidden_sizes=hidden_sizes, out_indices=[1, 2, 3, 4])
     config = UperNetConfig(
         backbone_config=backbone_config,
         auxiliary_in_channels=auxiliary_in_channels,

--- a/src/transformers/models/upernet/convert_swin_upernet_to_pytorch.py
+++ b/src/transformers/models/upernet/convert_swin_upernet_to_pytorch.py
@@ -65,7 +65,7 @@ def get_upernet_config(model_name):
         depths=depths,
         num_heads=num_heads,
         window_size=window_size,
-        out_features=["stage1", "stage2", "stage3", "stage4"],
+        out_indices=[1, 2, 3, 4],
     )
     config = UperNetConfig(
         backbone_config=backbone_config,

--- a/tests/models/beit/test_modeling_beit.py
+++ b/tests/models/beit/test_modeling_beit.py
@@ -73,7 +73,6 @@ class BeitModelTester:
         num_labels=3,
         scope=None,
         out_indices=[1, 2, 3, 4],
-        out_features=["stage1", "stage2", "stage3", "stage4"],
     ):
         self.parent = parent
         self.vocab_size = vocab_size
@@ -94,7 +93,6 @@ class BeitModelTester:
         self.initializer_range = initializer_range
         self.scope = scope
         self.out_indices = out_indices
-        self.out_features = out_features
         self.num_labels = num_labels
 
         # in BeiT, the seq length equals the number of patches + 1 (we add 1 for the [CLS] token)
@@ -130,7 +128,6 @@ class BeitModelTester:
             is_decoder=False,
             initializer_range=self.initializer_range,
             out_indices=self.out_indices,
-            out_features=self.out_features,
         )
 
     def create_and_check_model(self, config, pixel_values, labels, pixel_labels):
@@ -147,17 +144,17 @@ class BeitModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         expected_height = expected_width = self.image_size // config.patch_size
         self.parent.assertListEqual(
             list(result.feature_maps[0].shape), [self.batch_size, self.hidden_size, expected_height, expected_width]
         )
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = BeitBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/bit/test_modeling_bit.py
+++ b/tests/models/bit/test_modeling_bit.py
@@ -52,7 +52,6 @@ class BitModelTester:
         hidden_act="relu",
         num_labels=3,
         scope=None,
-        out_features=["stage2", "stage3", "stage4"],
         out_indices=[2, 3, 4],
         num_groups=1,
     ):
@@ -69,7 +68,6 @@ class BitModelTester:
         self.num_labels = num_labels
         self.scope = scope
         self.num_stages = len(hidden_sizes)
-        self.out_features = out_features
         self.out_indices = out_indices
         self.num_groups = num_groups
 
@@ -92,7 +90,6 @@ class BitModelTester:
             depths=self.depths,
             hidden_act=self.hidden_act,
             num_labels=self.num_labels,
-            out_features=self.out_features,
             out_indices=self.out_indices,
             num_groups=self.num_groups,
         )
@@ -122,15 +119,15 @@ class BitModelTester:
         result = model(pixel_values)
 
         # verify feature maps
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.hidden_sizes[1], 4, 4])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = BitBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/conditional_detr/test_modeling_conditional_detr.py
+++ b/tests/models/conditional_detr/test_modeling_conditional_detr.py
@@ -116,7 +116,6 @@ class ConditionalDetrModelTester:
             depths=[1, 1, 2, 1],
             hidden_act="relu",
             num_labels=3,
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         return ConditionalDetrConfig(

--- a/tests/models/convnext/test_modeling_convnext.py
+++ b/tests/models/convnext/test_modeling_convnext.py
@@ -54,7 +54,6 @@ class ConvNextModelTester:
         hidden_act="gelu",
         num_labels=10,
         initializer_range=0.02,
-        out_features=["stage2", "stage3", "stage4"],
         out_indices=[2, 3, 4],
         scope=None,
     ):
@@ -71,7 +70,6 @@ class ConvNextModelTester:
         self.hidden_act = hidden_act
         self.num_labels = num_labels
         self.initializer_range = initializer_range
-        self.out_features = out_features
         self.out_indices = out_indices
         self.scope = scope
 
@@ -94,7 +92,6 @@ class ConvNextModelTester:
             hidden_act=self.hidden_act,
             is_decoder=False,
             initializer_range=self.initializer_range,
-            out_features=self.out_features,
             out_indices=self.out_indices,
             num_labels=self.num_labels,
         )
@@ -124,15 +121,15 @@ class ConvNextModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.hidden_sizes[1], 4, 4])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = ConvNextBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/convnextv2/test_modeling_convnextv2.py
+++ b/tests/models/convnextv2/test_modeling_convnextv2.py
@@ -55,7 +55,6 @@ class ConvNextV2ModelTester:
         hidden_act="gelu",
         num_labels=10,
         initializer_range=0.02,
-        out_features=["stage2", "stage3", "stage4"],
         out_indices=[2, 3, 4],
         scope=None,
     ):
@@ -72,7 +71,6 @@ class ConvNextV2ModelTester:
         self.hidden_act = hidden_act
         self.num_labels = num_labels
         self.initializer_range = initializer_range
-        self.out_features = out_features
         self.out_indices = out_indices
         self.scope = scope
 
@@ -96,7 +94,6 @@ class ConvNextV2ModelTester:
             hidden_act=self.hidden_act,
             is_decoder=False,
             initializer_range=self.initializer_range,
-            out_features=self.out_features,
             out_indices=self.out_indices,
             num_labels=self.num_labels,
         )
@@ -126,15 +123,15 @@ class ConvNextV2ModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.hidden_sizes[1], 4, 4])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = ConvNextV2Backbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/deformable_detr/test_modeling_deformable_detr.py
+++ b/tests/models/deformable_detr/test_modeling_deformable_detr.py
@@ -130,7 +130,6 @@ class DeformableDetrModelTester:
             depths=[1, 1, 2, 1],
             hidden_act="relu",
             num_labels=3,
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         return DeformableDetrConfig(

--- a/tests/models/depth_anything/test_modeling_depth_anything.py
+++ b/tests/models/depth_anything/test_modeling_depth_anything.py
@@ -53,7 +53,7 @@ class DepthAnythingModelTester:
         num_hidden_layers=2,
         num_attention_heads=2,
         intermediate_size=8,
-        out_features=["stage1", "stage2"],
+        out_indices=[1, 2],
         apply_layernorm=False,
         reshape_hidden_states=False,
         neck_hidden_sizes=[2, 2],
@@ -68,7 +68,7 @@ class DepthAnythingModelTester:
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
         self.intermediate_size = intermediate_size
-        self.out_features = out_features
+        self.out_indices = out_indices
         self.apply_layernorm = apply_layernorm
         self.reshape_hidden_states = reshape_hidden_states
         self.use_labels = use_labels
@@ -111,7 +111,7 @@ class DepthAnythingModelTester:
             num_attention_heads=self.num_attention_heads,
             intermediate_size=self.intermediate_size,
             is_training=self.is_training,
-            out_features=self.out_features,
+            out_indices=self.out_indices,
             reshape_hidden_states=self.reshape_hidden_states,
         )
 

--- a/tests/models/detr/test_modeling_detr.py
+++ b/tests/models/detr/test_modeling_detr.py
@@ -112,7 +112,6 @@ class DetrModelTester:
             depths=[1, 1, 2, 1],
             hidden_act="relu",
             num_labels=3,
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         return DetrConfig(

--- a/tests/models/dinat/test_modeling_dinat.py
+++ b/tests/models/dinat/test_modeling_dinat.py
@@ -65,7 +65,6 @@ class DinatModelTester:
         scope=None,
         use_labels=True,
         num_labels=10,
-        out_features=["stage1", "stage2"],
         out_indices=[1, 2],
     ):
         self.parent = parent
@@ -91,7 +90,6 @@ class DinatModelTester:
         self.scope = scope
         self.use_labels = use_labels
         self.num_labels = num_labels
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -125,7 +123,6 @@ class DinatModelTester:
             patch_norm=self.patch_norm,
             layer_norm_eps=self.layer_norm_eps,
             initializer_range=self.initializer_range,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -166,14 +163,14 @@ class DinatModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, model.channels[0], 16, 16])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = DinatBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -129,17 +129,17 @@ class Dinov2ModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         expected_size = self.image_size // config.patch_size
         self.parent.assertListEqual(
             list(result.feature_maps[0].shape), [self.batch_size, model.channels[0], expected_size, expected_size]
         )
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = Dinov2Backbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/dpt/test_modeling_dpt_auto_backbone.py
+++ b/tests/models/dpt/test_modeling_dpt_auto_backbone.py
@@ -53,7 +53,7 @@ class DPTModelTester:
         num_hidden_layers=2,
         num_attention_heads=2,
         intermediate_size=8,
-        out_features=["stage1", "stage2"],
+        out_indices=[1, 2],
         apply_layernorm=False,
         reshape_hidden_states=False,
         neck_hidden_sizes=[2, 2],
@@ -68,7 +68,7 @@ class DPTModelTester:
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
         self.intermediate_size = intermediate_size
-        self.out_features = out_features
+        self.out_indices = out_indices
         self.apply_layernorm = apply_layernorm
         self.reshape_hidden_states = reshape_hidden_states
         self.use_labels = use_labels
@@ -108,7 +108,7 @@ class DPTModelTester:
             num_attention_heads=self.num_attention_heads,
             intermediate_size=self.intermediate_size,
             is_training=self.is_training,
-            out_features=self.out_features,
+            out_indices=self.out_indices,
             reshape_hidden_states=self.reshape_hidden_states,
         )
 

--- a/tests/models/focalnet/test_modeling_focalnet.py
+++ b/tests/models/focalnet/test_modeling_focalnet.py
@@ -72,7 +72,6 @@ class FocalNetModelTester:
         use_labels=True,
         type_sequence_label_size=10,
         encoder_stride=8,
-        out_features=["stage1", "stage2"],
         out_indices=[1, 2],
     ):
         self.parent = parent
@@ -100,7 +99,6 @@ class FocalNetModelTester:
         self.use_labels = use_labels
         self.type_sequence_label_size = type_sequence_label_size
         self.encoder_stride = encoder_stride
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -135,7 +133,6 @@ class FocalNetModelTester:
             layer_norm_eps=self.layer_norm_eps,
             initializer_range=self.initializer_range,
             encoder_stride=self.encoder_stride,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -157,15 +154,15 @@ class FocalNetModelTester:
         result = model(pixel_values)
 
         # verify feature maps
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.image_size, 8, 8])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[:-1])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = FocalNetBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/grounding_dino/test_modeling_grounding_dino.py
+++ b/tests/models/grounding_dino/test_modeling_grounding_dino.py
@@ -140,7 +140,6 @@ class GroundingDinoModelTester:
             depths=[1, 1, 1, 1],
             num_heads=[1, 1, 1, 1],
             image_size=self.image_size,
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         text_backbone = {

--- a/tests/models/hiera/test_modeling_hiera.py
+++ b/tests/models/hiera/test_modeling_hiera.py
@@ -148,17 +148,17 @@ class HieraModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         num_patches = config.image_size[0] // config.patch_stride[0] // config.masked_unit_size[0]
         self.parent.assertListEqual(
             list(result.feature_maps[0].shape), [self.batch_size, model.channels[0], num_patches, num_patches]
         )
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = HieraBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/maskformer/test_modeling_maskformer_swin.py
+++ b/tests/models/maskformer/test_modeling_maskformer_swin.py
@@ -150,6 +150,11 @@ class MaskFormerSwinModelTester:
         self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, [16, 32, 64])
 
+        # verify ValueError
+        with self.parent.assertRaises(ValueError):
+            config.out_indices = [0]
+            model = MaskFormerSwinBackbone(config=config)
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         config, pixel_values, labels = config_and_inputs

--- a/tests/models/maskformer/test_modeling_maskformer_swin.py
+++ b/tests/models/maskformer/test_modeling_maskformer_swin.py
@@ -63,7 +63,6 @@ class MaskFormerSwinModelTester:
         use_labels=True,
         type_sequence_label_size=10,
         encoder_stride=8,
-        out_features=["stage1", "stage2", "stage3"],
         out_indices=[1, 2, 3],
     ):
         self.parent = parent
@@ -90,7 +89,6 @@ class MaskFormerSwinModelTester:
         self.use_labels = use_labels
         self.type_sequence_label_size = type_sequence_label_size
         self.encoder_stride = encoder_stride
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -124,7 +122,6 @@ class MaskFormerSwinModelTester:
             layer_norm_eps=self.layer_norm_eps,
             initializer_range=self.initializer_range,
             encoder_stride=self.encoder_stride,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -146,17 +143,12 @@ class MaskFormerSwinModelTester:
         result = model(pixel_values)
 
         # verify feature maps
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [13, 16, 16, 16])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, [16, 32, 64])
-
-        # verify ValueError
-        with self.parent.assertRaises(ValueError):
-            config.out_features = ["stem"]
-            model = MaskFormerSwinBackbone(config=config)
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()

--- a/tests/models/pvt_v2/test_modeling_pvt_v2.py
+++ b/tests/models/pvt_v2/test_modeling_pvt_v2.py
@@ -142,8 +142,8 @@ class PvtV2ModelTester(ModelTesterMixin):
         self.parent.assertEqual(len(model.channels), len(config.out_features))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = PvtV2Backbone(config=config)
         model.to(torch_device)
         model.eval()
@@ -397,32 +397,11 @@ class PvtV2BackboneTest(BackboneTesterMixin, unittest.TestCase):
         num_stages = len(config.depths) if hasattr(config, "depths") else config.num_hidden_layers
         expected_stage_names = [f"stage{idx}" for idx in range(1, num_stages + 1)]
         self.assertEqual(config.stage_names, expected_stage_names)
-        self.assertTrue(set(config.out_features).issubset(set(config.stage_names)))
 
-        # Test out_features and out_indices are correctly set
-        # out_features and out_indices both None
-        config = config_class(out_features=None, out_indices=None)
-        self.assertEqual(config.out_features, [config.stage_names[-1]])
+        # Test out_indices are correctly set
+        # out_indices set to None
+        config = config_class(out_indices=None)
         self.assertEqual(config.out_indices, [len(config.stage_names) - 1])
-
-        # out_features and out_indices both set
-        config = config_class(out_features=["stage1", "stage2"], out_indices=[0, 1])
-        self.assertEqual(config.out_features, ["stage1", "stage2"])
-        self.assertEqual(config.out_indices, [0, 1])
-
-        # Only out_features set
-        config = config_class(out_features=["stage2", "stage4"])
-        self.assertEqual(config.out_features, ["stage2", "stage4"])
-        self.assertEqual(config.out_indices, [1, 3])
-
-        # Only out_indices set
-        config = config_class(out_indices=[0, 2])
-        self.assertEqual(config.out_features, [config.stage_names[0], config.stage_names[2]])
-        self.assertEqual(config.out_indices, [0, 2])
-
-        # Error raised when out_indices do not correspond to out_features
-        with self.assertRaises(ValueError):
-            config = config_class(out_features=["stage1", "stage2"], out_indices=[0, 2])
 
     def test_config_save_pretrained(self):
         config_class = self.config_class

--- a/tests/models/resnet/test_modeling_resnet.py
+++ b/tests/models/resnet/test_modeling_resnet.py
@@ -54,7 +54,6 @@ class ResNetModelTester:
         hidden_act="relu",
         num_labels=3,
         scope=None,
-        out_features=["stage2", "stage3", "stage4"],
         out_indices=[2, 3, 4],
     ):
         self.parent = parent
@@ -70,7 +69,6 @@ class ResNetModelTester:
         self.num_labels = num_labels
         self.scope = scope
         self.num_stages = len(hidden_sizes)
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -92,7 +90,6 @@ class ResNetModelTester:
             depths=self.depths,
             hidden_act=self.hidden_act,
             num_labels=self.num_labels,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -122,15 +119,15 @@ class ResNetModelTester:
         result = model(pixel_values)
 
         # verify feature maps
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.hidden_sizes[1], 4, 4])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = ResNetBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -170,7 +170,6 @@ class RTDetrModelTester:
             embeddings_size=10,
             hidden_sizes=hidden_sizes,
             depths=[1, 1, 2, 1],
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         return RTDetrConfig.from_backbone_configs(

--- a/tests/models/rt_detr/test_modeling_rt_detr_resnet.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr_resnet.py
@@ -42,7 +42,6 @@ class RTDetrResNetModelTester:
         hidden_act="relu",
         num_labels=3,
         scope=None,
-        out_features=["stage2", "stage3", "stage4"],
         out_indices=[2, 3, 4],
     ):
         self.parent = parent
@@ -58,7 +57,6 @@ class RTDetrResNetModelTester:
         self.num_labels = num_labels
         self.scope = scope
         self.num_stages = len(hidden_sizes)
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -80,7 +78,6 @@ class RTDetrResNetModelTester:
             depths=self.depths,
             hidden_act=self.hidden_act,
             num_labels=self.num_labels,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -91,15 +88,15 @@ class RTDetrResNetModelTester:
         result = model(pixel_values)
 
         # verify feature maps
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, self.hidden_sizes[1], 4, 4])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, config.hidden_sizes[1:])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = RTDetrResNetBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/swin/test_modeling_swin.py
+++ b/tests/models/swin/test_modeling_swin.py
@@ -67,7 +67,6 @@ class SwinModelTester:
         use_labels=True,
         type_sequence_label_size=10,
         encoder_stride=8,
-        out_features=["stage1", "stage2"],
         out_indices=[1, 2],
     ):
         self.parent = parent
@@ -94,7 +93,6 @@ class SwinModelTester:
         self.use_labels = use_labels
         self.type_sequence_label_size = type_sequence_label_size
         self.encoder_stride = encoder_stride
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -128,7 +126,6 @@ class SwinModelTester:
             layer_norm_eps=self.layer_norm_eps,
             initializer_range=self.initializer_range,
             encoder_stride=self.encoder_stride,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -150,14 +147,14 @@ class SwinModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, model.channels[0], 16, 16])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = SwinBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/swinv2/test_modeling_swinv2.py
+++ b/tests/models/swinv2/test_modeling_swinv2.py
@@ -67,7 +67,6 @@ class Swinv2ModelTester:
         use_labels=True,
         type_sequence_label_size=10,
         encoder_stride=8,
-        out_features=["stage1", "stage2"],
         out_indices=[1, 2],
     ):
         self.parent = parent
@@ -94,7 +93,6 @@ class Swinv2ModelTester:
         self.use_labels = use_labels
         self.type_sequence_label_size = type_sequence_label_size
         self.encoder_stride = encoder_stride
-        self.out_features = out_features
         self.out_indices = out_indices
 
     def prepare_config_and_inputs(self):
@@ -128,7 +126,6 @@ class Swinv2ModelTester:
             layer_norm_eps=self.layer_norm_eps,
             initializer_range=self.initializer_range,
             encoder_stride=self.encoder_stride,
-            out_features=self.out_features,
             out_indices=self.out_indices,
         )
 
@@ -150,14 +147,14 @@ class Swinv2ModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(list(result.feature_maps[0].shape), [self.batch_size, model.channels[0], 16, 16])
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = Swinv2Backbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/table_transformer/test_modeling_table_transformer.py
+++ b/tests/models/table_transformer/test_modeling_table_transformer.py
@@ -113,7 +113,6 @@ class TableTransformerModelTester:
             depths=[1, 1, 2, 1],
             hidden_act="relu",
             num_labels=3,
-            out_features=["stage2", "stage3", "stage4"],
             out_indices=[2, 3, 4],
         )
         return TableTransformerConfig(

--- a/tests/models/tvp/test_modeling_tvp.py
+++ b/tests/models/tvp/test_modeling_tvp.py
@@ -118,7 +118,6 @@ class TVPModelTester:
             hidden_sizes=[64, 128],
             depths=[2, 2],
             hidden_act="relu",
-            out_features=["stage2"],
             out_indices=[2],
         )
         return TvpConfig(

--- a/tests/models/upernet/test_modeling_upernet.py
+++ b/tests/models/upernet/test_modeling_upernet.py
@@ -62,7 +62,7 @@ class UperNetModelTester:
         hidden_act="gelu",
         type_sequence_label_size=10,
         initializer_range=0.02,
-        out_features=["stage2", "stage3", "stage4"],
+        out_indices=[2, 3, 4],
         num_labels=3,
         scope=None,
     ):
@@ -79,7 +79,7 @@ class UperNetModelTester:
         self.hidden_act = hidden_act
         self.type_sequence_label_size = type_sequence_label_size
         self.initializer_range = initializer_range
-        self.out_features = out_features
+        self.out_indices = out_indices
         self.num_labels = num_labels
         self.scope = scope
         self.num_hidden_layers = num_stages
@@ -104,7 +104,7 @@ class UperNetModelTester:
             is_training=self.is_training,
             intermediate_size=self.intermediate_size,
             hidden_act=self.hidden_act,
-            out_features=self.out_features,
+            out_indices=self.out_indices,
         )
 
     def get_config(self):

--- a/tests/models/vitdet/test_modeling_vitdet.py
+++ b/tests/models/vitdet/test_modeling_vitdet.py
@@ -120,18 +120,18 @@ class VitDetModelTester:
         result = model(pixel_values)
 
         # verify hidden states
-        self.parent.assertEqual(len(result.feature_maps), len(config.out_features))
+        self.parent.assertEqual(len(result.feature_maps), len(config.out_indices))
         self.parent.assertListEqual(
             list(result.feature_maps[0].shape),
             [self.batch_size, self.hidden_size, self.num_patches_one_direction, self.num_patches_one_direction],
         )
 
         # verify channels
-        self.parent.assertEqual(len(model.channels), len(config.out_features))
+        self.parent.assertEqual(len(model.channels), len(config.out_indices))
         self.parent.assertListEqual(model.channels, [config.hidden_size])
 
-        # verify backbone works with out_features=None
-        config.out_features = None
+        # verify backbone works with out_indices=None
+        config.out_indices = None
         model = VitDetBackbone(config=config)
         model.to(torch_device)
         model.eval()

--- a/tests/models/vitmatte/test_modeling_vitmatte.py
+++ b/tests/models/vitmatte/test_modeling_vitmatte.py
@@ -61,7 +61,7 @@ class VitMatteModelTester:
         type_sequence_label_size=10,
         initializer_range=0.02,
         scope=None,
-        out_features=["stage1"],
+        out_indices=[1],
         fusion_hidden_sizes=[128, 64, 32, 16],
     ):
         self.parent = parent
@@ -78,7 +78,7 @@ class VitMatteModelTester:
         self.type_sequence_label_size = type_sequence_label_size
         self.initializer_range = initializer_range
         self.scope = scope
-        self.out_features = out_features
+        self.out_indices = out_indices
         self.fusion_hidden_sizes = fusion_hidden_sizes
 
         self.seq_length = (self.image_size // self.patch_size) ** 2
@@ -104,7 +104,7 @@ class VitMatteModelTester:
             hidden_size=self.hidden_size,
             is_training=self.is_training,
             hidden_act=self.hidden_act,
-            out_features=self.out_features,
+            out_indices=self.out_indices,
         )
 
     def get_config(self):

--- a/tests/models/zoedepth/test_modeling_zoedepth.py
+++ b/tests/models/zoedepth/test_modeling_zoedepth.py
@@ -52,7 +52,7 @@ class ZoeDepthModelTester:
         num_hidden_layers=2,
         num_attention_heads=2,
         intermediate_size=8,
-        out_features=["stage1", "stage2"],
+        out_indices=[1, 2],
         apply_layernorm=False,
         reshape_hidden_states=False,
         neck_hidden_sizes=[2, 2],
@@ -69,7 +69,7 @@ class ZoeDepthModelTester:
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
         self.intermediate_size = intermediate_size
-        self.out_features = out_features
+        self.out_indices = out_indices
         self.apply_layernorm = apply_layernorm
         self.reshape_hidden_states = reshape_hidden_states
         self.use_labels = use_labels
@@ -113,7 +113,7 @@ class ZoeDepthModelTester:
             num_attention_heads=self.num_attention_heads,
             intermediate_size=self.intermediate_size,
             is_training=self.is_training,
-            out_features=self.out_features,
+            out_indices=self.out_indices,
             reshape_hidden_states=self.reshape_hidden_states,
         )
 


### PR DESCRIPTION
# What does this PR do?

As `out_features` is deprecated in favor of `out_indices` for the `xxxBackbone` classes, this PR removes a first batch of `out_features` mentions in favor of `out_indices`.