### PR TITLE
Log additional test metrics with the CometCallback

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1129,12 +1129,11 @@ class CometCallback(TrainerCallback):
     def on_predict(self, args, state, control, metrics, **kwargs):
         if not self._initialized:
             self.setup(args, state, model=None)
-        if state.is_world_process_zero:
-            if self._experiment is not None:
-                rewritten_metrics = rewrite_logs(metrics)
-                self._experiment.__internal_api__log_metrics__(
-                    rewritten_metrics, step=state.global_step, epoch=state.epoch, framework="transformers"
-                )
+        if state.is_world_process_zero and self._experiment is not None:
+            rewritten_metrics = rewrite_logs(metrics)
+            self._experiment.__internal_api__log_metrics__(
+                rewritten_metrics, step=state.global_step, epoch=state.epoch, framework="transformers"
+            )
 
 
 class AzureMLCallback(TrainerCallback):


### PR DESCRIPTION
# What does this PR do?

This PR updates the CometCallback to log metrics when checking performance using the test dataset.
It also updates the CometCallback to use the same metric naming convention as WandbCallback and MLflowCallback.

This is a new PR for https://github.com/huggingface/transformers/pull/32683 after I accidentally deleted our internal fork, sorry about the noise.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?