### PR TITLE
disable scheduled daily CI temporarily

### DIFF
--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -2,9 +2,6 @@ name: Self-hosted runner (scheduled)
 
 
 on:
-  repository_dispatch:
-  schedule:
-    - cron: "17 2 * * *"
   push:
     branches:
       - run_scheduled_ci*


### PR DESCRIPTION
# What does this PR do?

We have trouble with daily CI runs. 

It seems our daily CI run is not able to finish in 24 hours, and once the next day's run is triggered, things get worse.
It's not very clear what happens, but I see

- qwen2_moe --> can't finish in 6 hours
- gemma2 --> finished in 3 hours

In order to see what would a run go  (especially if it could even finish and/or how long) **without a next run being triggered**, let's disable the scheduled daily CI on `main`  for  1 or 2 days, and manually a run.