### PR TITLE
update torch req for 4-bit optimizer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1479,10 +1479,10 @@ class Trainer:
                     "You need to have `torchao>=0.4.0` in order to use torch 4-bit optimizers."
                     "Install it with `pip install torchao` or follow the instructions here: https://github.com/pytorch/ao"
                 )
-            if version.parse(importlib.metadata.version("torch")) < version.parse("2.3"):
+            if version.parse(importlib.metadata.version("torch")) <= version.parse("2.4"):
                 raise ImportError(
-                    "You need to have `torch>=2.3` in order to use torch 4-bit optimizers. "
-                    "Install it with `pip install --upgrade torch`"
+                    "You need to have `torch>2.4` in order to use torch 4-bit optimizers. "
+                    "Install it with `pip install --upgrade torch` it is available on pipy. Otherwise, you need to install torch nightly."
                 )
             from torchao.prototype.low_bit_optim import AdamW4bit
 


### PR DESCRIPTION
# What does this PR do?
This PR updates the torch req in order to use torchao 4-bit optimizer. When I created the PR (using torchao nighlty), it was working with prior version of torch but now with torchao 0.4.0, you need to have torch nighlty to use it. cc @gau-nernst