### PR TITLE
Generate: throw warning when `return_dict_in_generate` is False but should be True

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -289,8 +289,8 @@ class GenerationConfig(PushToHubMixin):
             more details.
         return_dict_in_generate (`bool`, *optional*, defaults to `False`):
             Whether or not to return a [`~utils.ModelOutput`], as opposed to returning exclusively the generated
-            sequence. This flag must be set to return the generation cache or other optional outputs (see flags
-            starting with `output_`)
+            sequence. This flag must be set to `True` to return the generation cache (when `use_cache` is `True`)
+            or optional outputs (see flags starting with `output_`)
 
         > Special tokens that can be used at generation time
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -737,7 +737,7 @@ class GenerationConfig(PushToHubMixin):
                 if getattr(self, extra_output_flag) is True:
                     warnings.warn(
                         f"`return_dict_in_generate` is NOT set to `True`, but `{extra_output_flag}` is. When "
-                        f"`return_dict_in_generate` is not `True`, `{extra_output_flag}` will not be respected.",
+                        f"`return_dict_in_generate` is not `True`, `{extra_output_flag}` is ignored.",
                         UserWarning,
                     )
 

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -136,6 +136,10 @@ class GenerationConfigTest(unittest.TestCase):
             GenerationConfig(do_sample=False, temperature=0.5)
         self.assertEqual(len(captured_warnings), 1)
 
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            GenerationConfig(return_dict_in_generate=False, output_scores=True)
+        self.assertEqual(len(captured_warnings), 1)
+
         # Expanding on the case above, we can update a bad configuration to get rid of the warning. Ideally,
         # that is done by unsetting the parameter (i.e. setting it to None)
         generation_config_bad_temperature = GenerationConfig(do_sample=False, temperature=0.5)


### PR DESCRIPTION
# What does this PR do?

See title. 

I've fallen victim to this one a few times, so it probably means users have fallen too :)