### PR TITLE
Add warning for stop string edge case

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -252,7 +252,6 @@ class StopStringCriteria(StoppingCriteria):
         self.num_stop_strings = len(self.stop_strings)
         self.target_lens = torch.tensor([len(stop_string) for stop_string in stop_strings], dtype=torch.int32)
 
-
     def clean_and_embed_tokens_with_cache(self, token_list, token_indices, stop_strings, tokenizer):
         # We don't use the tokenizer in the cache key, because I don't trust it to have well-behaved equality
         if (token_list, token_indices, stop_strings) in STOP_STRING_EMBEDDING_CACHE:
@@ -351,9 +350,11 @@ class StopStringCriteria(StoppingCriteria):
         # There should always be at least one valid end_len, however, so no fallback needed here
         valid_end_lens = [len(val) for positions in token_end_overlaps.values() for val in positions.values()]
         if not valid_end_lens:
-            raise ValueError("Stop string preprocessing was unable to identify tokens matching one or more of the "
-                             "supplied stop string(s). This is most often caused by the stop "
-                             "strings containing unusual characters that are not in the tokenizer vocabulary.")
+            raise ValueError(
+                "Stop string preprocessing was unable to identify tokens matching one or more of the "
+                "supplied stop string(s). This is most often caused by the stop "
+                "strings containing unusual characters that are not in the tokenizer vocabulary."
+            )
         max_valid_end_lens = max(valid_end_lens)
         vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
         gather_vec = np.full((len(token_list), vec_size), dtype=np.int32, fill_value=-1)

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -252,6 +252,7 @@ class StopStringCriteria(StoppingCriteria):
         self.num_stop_strings = len(self.stop_strings)
         self.target_lens = torch.tensor([len(stop_string) for stop_string in stop_strings], dtype=torch.int32)
 
+
     def clean_and_embed_tokens_with_cache(self, token_list, token_indices, stop_strings, tokenizer):
         # We don't use the tokenizer in the cache key, because I don't trust it to have well-behaved equality
         if (token_list, token_indices, stop_strings) in STOP_STRING_EMBEDDING_CACHE:
@@ -348,7 +349,12 @@ class StopStringCriteria(StoppingCriteria):
         # we need a fallback to handle this case
         max_valid_positions = max(all_valid_positions) if all_valid_positions else 1
         # There should always be at least one valid end_len, however, so no fallback needed here
-        max_valid_end_lens = max(len(val) for positions in token_end_overlaps.values() for val in positions.values())
+        valid_end_lens = [len(val) for positions in token_end_overlaps.values() for val in positions.values()]
+        if not valid_end_lens:
+            raise ValueError("Stop string preprocessing was unable to identify tokens matching one or more of the "
+                             "supplied stop string(s). This is most often caused by the stop "
+                             "strings containing unusual characters that are not in the tokenizer vocabulary.")
+        max_valid_end_lens = max(valid_end_lens)
         vec_size = len(stop_strings) * (max_valid_positions + max_valid_end_lens) + 1
         gather_vec = np.full((len(token_list), vec_size), dtype=np.int32, fill_value=-1)
 


### PR DESCRIPTION
In #31435 @murray-z mentions that the stop string code can throw an error with an unusual stop string: "✿RESULT✿"

The underlying cause is that the ✿ token doesn't exist in the tokenizer vocabulary anywhere. The tokenizer in question has a special-case fallback for unknown characters where it builds them out of other tokens, but the tokens it uses to compose unknown characters have different meanings when considered alone. This means that the stop string code can't figure out how to build the stop string out of the tokenizer vocabulary, because it doesn't have access to the internal special-casing logic.

I can't really see a general solution here without completely rewriting the stop string code to run `tokenizer.decode()` at each generation step, which would break the ability to compile generation or export it to non-Python environments. Since it's a fairly rare edge case, though, I'm just going to add a proper error message instead!

cc @LysandreJik 