### PR TITLE
[Zero-shot image classification pipeline] Remove tokenizer_kwargs

### DIFF
--- a/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
+++ b/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
@@ -150,12 +150,12 @@ def convert_blip2_checkpoint(
     if "opt" in model_name:
         tokenizer = AutoTokenizer.from_pretrained("facebook/opt-2.7b")
     elif "itm" in model_name:
-        tokenizer = BertTokenizer.from_pretrained("bert-base-uncased", truncation_side="right")
+        tokenizer = BertTokenizer.from_pretrained(
+            "bert-base-uncased", truncation_side="right", model_input_names=["input_ids", "attention_mask"]
+        )
         tokenizer.add_special_tokens({"bos_token": "[DEC]"})
     else:
         tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-xl")
-
-    tokenizer.model_input_names = ["input_ids", "attention_mask"]
 
     if "itm" in model_name:
         eos_token_id = None

--- a/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
+++ b/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
@@ -155,6 +155,8 @@ def convert_blip2_checkpoint(
     else:
         tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-xl")
 
+    tokenizer.model_input_names = ["input_ids", "attention_mask"]
+
     if "itm" in model_name:
         eos_token_id = None
     else:

--- a/tests/pipelines/test_pipelines_zero_shot_image_classification.py
+++ b/tests/pipelines/test_pipelines_zero_shot_image_classification.py
@@ -292,7 +292,6 @@ class ZeroShotImageClassificationPipelineTests(unittest.TestCase):
         output = image_classifier(
             image,
             candidate_labels=["2 cats", "a plane", "a remote"],
-            tokenizer_kwargs={"return_token_type_ids": False},
         )
 
         self.assertEqual(
@@ -308,7 +307,6 @@ class ZeroShotImageClassificationPipelineTests(unittest.TestCase):
             [image] * 5,
             candidate_labels=["2 cats", "a plane", "a remote"],
             batch_size=2,
-            tokenizer_kwargs={"return_token_type_ids": False},
         )
 
         self.assertEqual(


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up of #29261, namely the `tokenizer_kwargs` argument is unnecessary, one can just update the `model_input_names` attribute of the tokenizer.