### PR TITLE
🚨🚨🚨 [SuperPoint] Fix keypoint coordinate output and add post processing

### DIFF
--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -95,9 +95,10 @@ for output in outputs:
     descriptors = output["descriptors"]
 ```
 
-You can then print the keypoints on the image of your choice to visualize the result :
+You can then print the keypoints on the image of your choice to visualize the result:
 ```python
 import matplotlib.pyplot as plt
+
 plt.axis("off")
 plt.imshow(image)
 plt.scatter(

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -104,7 +104,8 @@ plt.scatter(
     keypoints[:, 0],
     keypoints[:, 1],
     c=scores * 100,
-    s=scores * 20
+    s=scores * 50,
+    alpha=0.8
 )
 plt.savefig(f"output_image.png")
 ```

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -86,7 +86,7 @@ model = SuperPointForKeypointDetection.from_pretrained("magic-leap-community/sup
 
 inputs = processor(images, return_tensors="pt")
 outputs = model(**inputs)
-image_sizes = [(image[1], image[0]) for image in images]
+image_sizes = [(image.size[1], image.size[0]) for image in images]
 outputs = processor.post_process_keypoint_detection(outputs, image_sizes)
 
 for output in outputs:

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -86,7 +86,7 @@ model = SuperPointForKeypointDetection.from_pretrained("magic-leap-community/sup
 
 inputs = processor(images, return_tensors="pt")
 outputs = model(**inputs)
-image_sizes = torch.tensor([image.size for image in images]).flip(1)
+image_sizes = [(image[1], image[0]) for image in images]
 outputs = processor.post_process_keypoint_detection(outputs, image_sizes)
 
 for output in outputs:

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -123,6 +123,7 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 [[autodoc]] SuperPointImageProcessor
 
 - preprocess
+- post_process_keypoint_detection
 
 ## SuperPointForKeypointDetection
 

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -90,9 +90,10 @@ image_sizes = [(image.height, image.width) for image in images]
 outputs = processor.post_process_keypoint_detection(outputs, image_sizes)
 
 for output in outputs:
-    keypoints = output["keypoints"]
-    scores = output["scores"]
-    descriptors = output["descriptors"]
+    for keypoints, scores, descriptors in zip(output["keypoints"], output["scores"], output["descriptors"]):
+        print(f"Keypoints: {keypoints}")
+        print(f"Scores: {scores}")
+        print(f"Descriptors: {descriptors}")
 ```
 
 You can then print the keypoints on the image of your choice to visualize the result:

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -86,7 +86,7 @@ model = SuperPointForKeypointDetection.from_pretrained("magic-leap-community/sup
 
 inputs = processor(images, return_tensors="pt")
 outputs = model(**inputs)
-image_sizes = [(image.size[1], image.size[0]) for image in images]
+image_sizes = [(image.height, image.width) for image in images]
 outputs = processor.post_process_keypoint_detection(outputs, image_sizes)
 
 for output in outputs:

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -101,12 +101,12 @@ You can then print the keypoints on the image of your choice to visualize the re
 import matplotlib.pyplot as plt
 
 plt.axis("off")
-plt.imshow(image)
+plt.imshow(image_1)
 plt.scatter(
-    keypoints[:, 0],
-    keypoints[:, 1],
-    c=scores * 100,
-    s=scores * 50,
+    outputs[0]["keypoints"][:, 0],
+    outputs[0]["keypoints"][:, 1],
+    c=outputs[0]["scores"] * 100,
+    s=outputs[0]["scores"] * 50,
     alpha=0.8
 )
 plt.savefig(f"output_image.png")

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -110,6 +110,7 @@ plt.scatter(
 )
 plt.savefig(f"output_image.png")
 ```
+![image/png](https://cdn-uploads.huggingface.co/production/uploads/632885ba1558dac67c440aa8/ZtFmphEhx8tcbEQqOolyE.png)
 
 This model was contributed by [stevenbucaille](https://huggingface.co/stevenbucaille).
 The original code can be found [here](https://github.com/magicleap/SuperPointPretrainedNetwork).

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -293,7 +293,7 @@ class SuperPointImageProcessor(BaseImageProcessor):
             an image in the batch as predicted by the model.
         """
         if len(outputs.mask) != len(target_sizes):
-            raise ValueError("Make sure that you pass in as many target sizes as the batch dimension of the logits")
+            raise ValueError("Make sure that you pass in as many target sizes as the batch dimension of the mask")
         if target_sizes.shape[1] != 2:
             raise ValueError("Each element of target_sizes must contain the size (h, w) of each image of the batch")
 

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 
-from ... import is_vision_available
+from ... import is_torch_available, is_vision_available
 from ...image_processing_utils import BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import resize, to_channel_dimension_format
 from ...image_utils import (
@@ -31,6 +31,9 @@ from ...image_utils import (
 )
 from ...utils import TensorType, logging, requires_backends
 
+
+if is_torch_available():
+    import torch
 
 if is_vision_available():
     import PIL
@@ -270,3 +273,28 @@ class SuperPointImageProcessor(BaseImageProcessor):
         data = {"pixel_values": images}
 
         return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def post_process_keypoint_detection(self, outputs, target_sizes, unwrap_batch_dim=True):
+        if len(outputs.mask) != len(target_sizes):
+            raise ValueError("Make sure that you pass in as many target sizes as the batch dimension of the logits")
+        if target_sizes.shape[1] != 2:
+            raise ValueError("Each element of target_sizes must contain the size (h, w) of each image of the batch")
+
+        for keypoints, target_size in zip(outputs.keypoints, target_sizes):
+            keypoints[:, 0] = keypoints[:, 0] * target_size[1]
+            keypoints[:, 1] = keypoints[:, 1] * target_size[0]
+
+        # Convert masked_keypoints to int
+        masked_keypoints = outputs.keypoints.to(torch.int32)
+
+        outputs.keypoints = masked_keypoints
+
+        results = []
+        for i, image_mask in enumerate(outputs.mask):
+            indices = torch.nonzero(image_mask).squeeze(1)
+            keypoints = outputs.keypoints[i][indices]
+            scores = outputs.scores[i][indices]
+            descriptors = outputs.descriptors[i][indices]
+            results.append({"keypoints": keypoints, "scores": scores, "descriptors": descriptors})
+
+        return results

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -35,11 +35,12 @@ from ...utils import TensorType, logging, requires_backends
 if is_torch_available():
     import torch
 
+    from .modeling_superpoint import SuperPointKeypointDescriptionOutput
+
 
 if is_vision_available():
     import PIL
 
-    from .modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -279,7 +279,7 @@ class SuperPointImageProcessor(BaseImageProcessor):
         return BatchFeature(data=data, tensor_type=return_tensors)
 
     def post_process_keypoint_detection(
-        self, outputs: 'SuperPointKeypointDescriptionOutput', target_sizes: Union[TensorType, List[Tuple]]
+        self, outputs: "SuperPointKeypointDescriptionOutput", target_sizes: Union[TensorType, List[Tuple]]
     ):
         """
         Converts the raw output of [`SuperPointForKeypointDetection`] into lists of keypoints, scores and descriptors

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -279,7 +279,7 @@ class SuperPointImageProcessor(BaseImageProcessor):
         return BatchFeature(data=data, tensor_type=return_tensors)
 
     def post_process_keypoint_detection(
-        self, outputs: SuperPointKeypointDescriptionOutput, target_sizes: Union[TensorType, List[Tuple]]
+        self, outputs: 'SuperPointKeypointDescriptionOutput', target_sizes: Union[TensorType, List[Tuple]]
     ):
         """
         Converts the raw output of [`SuperPointForKeypointDetection`] into lists of keypoints, scores and descriptors

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -30,14 +30,16 @@ from ...image_utils import (
     valid_images,
 )
 from ...utils import TensorType, logging, requires_backends
-from .modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 
 if is_torch_available():
     import torch
 
+
 if is_vision_available():
     import PIL
+
+    from .modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Image processor class for SuperPoint."""
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -35,12 +35,11 @@ from ...utils import TensorType, logging, requires_backends
 if is_torch_available():
     import torch
 
+if TYPE_CHECKING:
     from .modeling_superpoint import SuperPointKeypointDescriptionOutput
-
 
 if is_vision_available():
     import PIL
-
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -279,21 +279,21 @@ class SuperPointImageProcessor(BaseImageProcessor):
 
     def post_process_keypoint_detection(
         self, outputs: "SuperPointKeypointDescriptionOutput", target_sizes: Union[TensorType, List[Tuple]]
-    ):
+    ) -> List[Dict[str, torch.Tensor]]:
         """
         Converts the raw output of [`SuperPointForKeypointDetection`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
 
         Args:
             outputs ([`SuperPointKeypointDescriptionOutput`]):
-                Raw outputs of the model.
-            target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`, *optional*):
+                Raw outputs of the model containing keypoints in a relative (x, y) format, with scores and descriptors.
+            target_sizes (`torch.Tensor` or `List[Tuple[int, int]]`):
                 Tensor of shape `(batch_size, 2)` or list of tuples (`Tuple[int, int]`) containing the target size
                 `(height, width)` of each image in the batch. This must be the original
                 image size (before any processing).
         Returns:
-            `List[Dict]`: A list of dictionaries, each dictionary containing the keypoints, scores and descriptors for
-            an image in the batch as predicted by the model.
+            `List[Dict]`: A list of dictionaries, each dictionary containing the keypoints in absolute format according
+            to target_sizes, scores and descriptors for an image in the batch as predicted by the model.
         """
         if len(outputs.mask) != len(target_sizes):
             raise ValueError("Make sure that you pass in as many target sizes as the batch dimension of the mask")

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -279,7 +279,7 @@ class SuperPointImageProcessor(BaseImageProcessor):
 
     def post_process_keypoint_detection(
         self, outputs: "SuperPointKeypointDescriptionOutput", target_sizes: Union[TensorType, List[Tuple]]
-    ) -> List[Dict[str, torch.Tensor]]:
+    ) -> List[Dict[str, "torch.Tensor"]]:
         """
         Converts the raw output of [`SuperPointForKeypointDetection`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.

--- a/src/transformers/models/superpoint/image_processing_superpoint.py
+++ b/src/transformers/models/superpoint/image_processing_superpoint.py
@@ -307,11 +307,9 @@ class SuperPointImageProcessor(BaseImageProcessor):
                 )
             image_sizes = target_sizes
 
-        masked_keypoints = outputs.keypoints.clone()
-
-        for keypoints, image_size in zip(masked_keypoints, image_sizes):
-            keypoints[:, 0] = keypoints[:, 0] * image_size[1]
-            keypoints[:, 1] = keypoints[:, 1] * image_size[0]
+        # Flip the image sizes to (width, height) and convert keypoints to absolute coordinates
+        image_sizes = torch.flip(image_sizes, [1])
+        masked_keypoints = outputs.keypoints * image_sizes[:, None]
 
         # Convert masked_keypoints to int
         masked_keypoints = masked_keypoints.to(torch.int32)

--- a/src/transformers/models/superpoint/modeling_superpoint.py
+++ b/src/transformers/models/superpoint/modeling_superpoint.py
@@ -258,6 +258,9 @@ class SuperPointInterestPointDecoder(nn.Module):
         # Convert (y, x) to (x, y)
         keypoints = torch.flip(keypoints, [1]).float()
 
+        # Convert to relative coordinates
+        keypoints = keypoints / torch.tensor([width, height], device=keypoints.device)
+
         return keypoints, scores
 
 

--- a/src/transformers/models/superpoint/modeling_superpoint.py
+++ b/src/transformers/models/superpoint/modeling_superpoint.py
@@ -258,9 +258,6 @@ class SuperPointInterestPointDecoder(nn.Module):
         # Convert (y, x) to (x, y)
         keypoints = torch.flip(keypoints, [1]).float()
 
-        # Convert to relative coordinates
-        keypoints = keypoints / torch.tensor([width, height], device=keypoints.device)
-
         return keypoints, scores
 
 
@@ -450,7 +447,7 @@ class SuperPointForKeypointDetection(SuperPointPreTrainedModel):
 
         pixel_values = self.extract_one_channel_pixel_values(pixel_values)
 
-        batch_size = pixel_values.shape[0]
+        batch_size, _, height, width = pixel_values.shape
 
         encoder_outputs = self.encoder(
             pixel_values,
@@ -487,6 +484,9 @@ class SuperPointForKeypointDetection(SuperPointPreTrainedModel):
             scores[i, : _scores.shape[0]] = _scores
             descriptors[i, : _descriptors.shape[0]] = _descriptors
             mask[i, : _scores.shape[0]] = 1
+
+        # Convert to relative coordinates
+        keypoints[:, :] = keypoints[:, :] / torch.tensor([width, height], device=keypoints.device)
 
         hidden_states = encoder_outputs[1] if output_hidden_states else None
         if not return_dict:

--- a/src/transformers/models/superpoint/modeling_superpoint.py
+++ b/src/transformers/models/superpoint/modeling_superpoint.py
@@ -192,7 +192,7 @@ class SuperPointEncoder(nn.Module):
         )
 
 
-class SuperPointInterestPointDecoder(nn.Module):
+class SuperPointKeypointDecoder(nn.Module):
     """
     The SuperPointInterestPointDecoder uses the output of the SuperPointEncoder to compute the keypoint with scores.
     The scores are first computed by a convolutional layer, then a softmax is applied to get a probability distribution
@@ -239,7 +239,10 @@ class SuperPointInterestPointDecoder(nn.Module):
         return scores
 
     def _extract_keypoints(self, scores: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Based on their scores, extract the pixels that represent the keypoints that will be used for descriptors computation"""
+        """
+        Based on their scores, extract the pixels that represent the keypoints that will be used for descriptors computation.
+        The keypoints are in the form of relative (x, y) coordinates.
+        """
         _, height, width = scores.shape
 
         # Threshold keypoints by score value
@@ -405,7 +408,7 @@ class SuperPointForKeypointDetection(SuperPointPreTrainedModel):
         self.config = config
 
         self.encoder = SuperPointEncoder(config)
-        self.keypoint_decoder = SuperPointInterestPointDecoder(config)
+        self.keypoint_decoder = SuperPointKeypointDecoder(config)
         self.descriptor_decoder = SuperPointDescriptorDecoder(config)
 
         self.post_init()

--- a/src/transformers/models/superpoint/modeling_superpoint.py
+++ b/src/transformers/models/superpoint/modeling_superpoint.py
@@ -489,7 +489,7 @@ class SuperPointForKeypointDetection(SuperPointPreTrainedModel):
             mask[i, : _scores.shape[0]] = 1
 
         # Convert to relative coordinates
-        keypoints[:, :] = keypoints[:, :] / torch.tensor([width, height], device=keypoints.device)
+        keypoints = keypoints / torch.tensor([width, height], device=keypoints.device)
 
         hidden_states = encoder_outputs[1] if output_hidden_states else None
         if not return_dict:

--- a/src/transformers/models/superpoint/modeling_superpoint.py
+++ b/src/transformers/models/superpoint/modeling_superpoint.py
@@ -192,7 +192,7 @@ class SuperPointEncoder(nn.Module):
         )
 
 
-class SuperPointKeypointDecoder(nn.Module):
+class SuperPointInterestPointDecoder(nn.Module):
     """
     The SuperPointInterestPointDecoder uses the output of the SuperPointEncoder to compute the keypoint with scores.
     The scores are first computed by a convolutional layer, then a softmax is applied to get a probability distribution
@@ -408,7 +408,7 @@ class SuperPointForKeypointDetection(SuperPointPreTrainedModel):
         self.config = config
 
         self.encoder = SuperPointEncoder(config)
-        self.keypoint_decoder = SuperPointKeypointDecoder(config)
+        self.keypoint_decoder = SuperPointInterestPointDecoder(config)
         self.descriptor_decoder = SuperPointDescriptorDecoder(config)
 
         self.post_init()

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -27,9 +27,10 @@ from ...test_image_processing_common import (
 if is_torch_available():
     import torch
 
+    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
+
 if is_vision_available():
     from transformers import SuperPointImageProcessor
-    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 
 class SuperPointImageProcessingTester(unittest.TestCase):

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -27,11 +27,9 @@ from ...test_image_processing_common import (
 if is_torch_available():
     import torch
 
-    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
-
 if is_vision_available():
     from transformers import SuperPointImageProcessor
-
+    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 
 class SuperPointImageProcessingTester(unittest.TestCase):

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -25,6 +25,9 @@ from ...test_image_processing_common import (
 )
 
 
+if is_torch_available():
+    import torch
+
 if is_vision_available():
     from transformers import SuperPointImageProcessor
 
@@ -72,7 +75,6 @@ class SuperPointImageProcessingTester(unittest.TestCase):
         )
 
     def prepare_keypoint_detection_output(self, pixel_values):
-        import torch
         max_number_keypoints = 50
         batch_size = len(pixel_values)
         mask = torch.zeros((batch_size, max_number_keypoints))

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -25,9 +25,6 @@ from ...test_image_processing_common import (
 )
 
 
-if is_torch_available():
-    import torch
-
 if is_vision_available():
     from transformers import SuperPointImageProcessor
 
@@ -75,6 +72,7 @@ class SuperPointImageProcessingTester(unittest.TestCase):
         )
 
     def prepare_keypoint_detection_output(self, pixel_values):
+        import torch
         max_number_keypoints = 50
         batch_size = len(pixel_values)
         mask = torch.zeros((batch_size, max_number_keypoints))

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -133,6 +133,7 @@ class SuperPointImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
             self.assertTrue(np.all(image[0, ...] == image[1, ...]) and np.all(image[1, ...] == image[2, ...]))
 
     @slow
+    @require_torch
     def test_post_processing_keypoint_detection(self):
         image_processor = self.image_processing_class.from_dict(self.image_processor_dict)
         image_inputs = self.image_processor_tester.prepare_image_inputs()

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -15,7 +15,6 @@ import unittest
 
 import numpy as np
 
-from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
 from transformers.testing_utils import require_torch, require_vision, slow
 from transformers.utils import is_torch_available, is_vision_available
 
@@ -30,6 +29,7 @@ if is_torch_available():
 
 if is_vision_available():
     from transformers import SuperPointImageProcessor
+    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
 
 
 class SuperPointImageProcessingTester(unittest.TestCase):

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -27,9 +27,11 @@ from ...test_image_processing_common import (
 if is_torch_available():
     import torch
 
+    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
+
 if is_vision_available():
     from transformers import SuperPointImageProcessor
-    from transformers.models.superpoint.modeling_superpoint import SuperPointKeypointDescriptionOutput
+
 
 
 class SuperPointImageProcessingTester(unittest.TestCase):

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 
 from transformers.testing_utils import require_torch, require_vision, slow
-from transformers.utils import is_vision_available
+from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_image_processing_common import (
     ImageProcessingTestMixin,
@@ -24,11 +24,11 @@ from ...test_image_processing_common import (
 )
 
 
-if is_vision_available():
-    from transformers import SuperPointForKeypointDetection, SuperPointImageProcessor, is_torch_available
-
 if is_torch_available():
     import torch
+
+if is_vision_available():
+    from transformers import SuperPointForKeypointDetection, SuperPointImageProcessor
 
 
 class SuperPointImageProcessingTester(unittest.TestCase):
@@ -121,7 +121,7 @@ class SuperPointImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
         image_inputs = self.image_processor_tester.prepare_image_inputs()
         pre_processed_images = image_processor.preprocess(image_inputs, return_tensors="pt")
         outputs = model(**pre_processed_images)
-        image_sizes = torch.tensor([image.size for image in image_inputs])
+        image_sizes = torch.tensor([image.size for image in image_inputs]).flip(1)
         post_processed_outputs = image_processor.post_process_keypoint_detection(outputs, image_sizes)
 
         self.assertTrue(len(post_processed_outputs) == self.image_processor_tester.batch_size)

--- a/tests/models/superpoint/test_image_processing_superpoint.py
+++ b/tests/models/superpoint/test_image_processing_superpoint.py
@@ -15,7 +15,7 @@ import unittest
 
 import numpy as np
 
-from transformers.testing_utils import require_torch, require_vision, slow
+from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_image_processing_common import (
@@ -133,7 +133,6 @@ class SuperPointImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
         for image in pre_processed_images["pixel_values"]:
             self.assertTrue(np.all(image[0, ...] == image[1, ...]) and np.all(image[1, ...] == image[2, ...]))
 
-    @slow
     @require_torch
     def test_post_processing_keypoint_detection(self):
         image_processor = self.image_processing_class.from_dict(self.image_processor_dict)
@@ -151,7 +150,8 @@ class SuperPointImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
                     keypoints[:, 1] <= image_size[0]
                 )
                 all_above_zero = torch.all(keypoints[:, 0] >= 0) and torch.all(keypoints[:, 1] >= 0)
-                self.assertTrue(all_below_image_size and all_above_zero)
+                self.assertTrue(all_below_image_size)
+                self.assertTrue(all_above_zero)
 
         tuple_image_sizes = [(image.size[0], image.size[1]) for image in image_inputs]
         tuple_post_processed_outputs = image_processor.post_process_keypoint_detection(outputs, tuple_image_sizes)

--- a/tests/models/superpoint/test_modeling_superpoint.py
+++ b/tests/models/superpoint/test_modeling_superpoint.py
@@ -275,7 +275,9 @@ class SuperPointModelIntegrationTest(unittest.TestCase):
         self.assertEqual(outputs.keypoints.shape, expected_keypoints_shape)
         self.assertEqual(outputs.scores.shape, expected_scores_shape)
         self.assertEqual(outputs.descriptors.shape, expected_descriptors_shape)
-        expected_keypoints_image0_values = torch.tensor([[0.75, 0.0188],[0.7719, 0.0188], [0.7641, 0.0333]]).to(torch_device)
+        expected_keypoints_image0_values = torch.tensor([[0.75, 0.0188], [0.7719, 0.0188], [0.7641, 0.0333]]).to(
+            torch_device
+        )
         expected_scores_image0_values = torch.tensor(
             [0.0064, 0.0139, 0.0591, 0.0727, 0.5170, 0.0175, 0.1526, 0.2057, 0.0335]
         ).to(torch_device)

--- a/tests/models/superpoint/test_modeling_superpoint.py
+++ b/tests/models/superpoint/test_modeling_superpoint.py
@@ -281,7 +281,7 @@ class SuperPointModelIntegrationTest(unittest.TestCase):
         expected_scores_image0_values = torch.tensor(
             [0.0064, 0.0139, 0.0591, 0.0727, 0.5170, 0.0175, 0.1526, 0.2057, 0.0335]
         ).to(torch_device)
-        expected_descriptors_image0_value = torch.tensor(0.0449).to(torch_device)
+        expected_descriptors_image0_value = torch.tensor(-0.1095).to(torch_device)
         predicted_keypoints_image0_values = outputs.keypoints[0, :3]
         predicted_scores_image0_values = outputs.scores[0, :9]
         predicted_descriptors_image0_value = outputs.descriptors[0, 0, 0]

--- a/tests/models/superpoint/test_modeling_superpoint.py
+++ b/tests/models/superpoint/test_modeling_superpoint.py
@@ -260,7 +260,7 @@ class SuperPointModelIntegrationTest(unittest.TestCase):
         inputs = preprocessor(images=images, return_tensors="pt").to(torch_device)
         with torch.no_grad():
             outputs = model(**inputs)
-        expected_number_keypoints_image0 = 567
+        expected_number_keypoints_image0 = 568
         expected_number_keypoints_image1 = 830
         expected_max_number_keypoints = max(expected_number_keypoints_image0, expected_number_keypoints_image1)
         expected_keypoints_shape = torch.Size((len(images), expected_max_number_keypoints, 2))
@@ -275,11 +275,11 @@ class SuperPointModelIntegrationTest(unittest.TestCase):
         self.assertEqual(outputs.keypoints.shape, expected_keypoints_shape)
         self.assertEqual(outputs.scores.shape, expected_scores_shape)
         self.assertEqual(outputs.descriptors.shape, expected_descriptors_shape)
-        expected_keypoints_image0_values = torch.tensor([[480.0, 9.0], [494.0, 9.0], [489.0, 16.0]]).to(torch_device)
+        expected_keypoints_image0_values = torch.tensor([[0.75, 0.0188],[0.7719, 0.0188], [0.7641, 0.0333]]).to(torch_device)
         expected_scores_image0_values = torch.tensor(
-            [0.0064, 0.0137, 0.0589, 0.0723, 0.5166, 0.0174, 0.1515, 0.2054, 0.0334]
+            [0.0064, 0.0139, 0.0591, 0.0727, 0.5170, 0.0175, 0.1526, 0.2057, 0.0335]
         ).to(torch_device)
-        expected_descriptors_image0_value = torch.tensor(-0.1096).to(torch_device)
+        expected_descriptors_image0_value = torch.tensor(0.0449).to(torch_device)
         predicted_keypoints_image0_values = outputs.keypoints[0, :3]
         predicted_scores_image0_values = outputs.scores[0, :9]
         predicted_descriptors_image0_value = outputs.descriptors[0, 0, 0]


### PR DESCRIPTION
# What does this PR do?

There is a bug highlighted by @merveenoyan where SuperPoint returns absolute keypoint coordinates at a wrong scale.
For example, an image of size (1000, 1000) will first be resized into (640, 480) by the image processor but SuperPoint will output keypoint coordinates between 0 and 640 for x and 0 and 480 for y.
This PR fixes this bug by returning keypoints in relative coordinates out of the SuperPoint forward method.
An additional ``post_process_keypoint_detection`` is added to the ``SuperPointImageProcessor`` to cast the keypoint coordinates into the original image sizes.
I also added an "unwrapping" logic where the output will be a list of ``keypoints, scores, descriptors`` for each image so that the user don't have to deal with the current mask mechanism. This is conditionned by a boolean argument in the signature.

I have not finished all the details but most of the implementation is there and I will add tests tomorrow but at least the PR is open as I promised Merve ☺️

Fixes #33825


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. 
-> On Slack
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@amyeroberts @NielsRogge @merveenoyan 