### PR TITLE
Fix: use `torch.from_numpy()` to create tensors for np.ndarrays

### DIFF
--- a/src/transformers/agents/agent_types.py
+++ b/src/transformers/agents/agent_types.py
@@ -105,7 +105,7 @@ class AgentImage(AgentType, ImageType):
         elif isinstance(value, torch.Tensor):
             self._tensor = value
         elif isinstance(value, np.ndarray):
-            self._tensor = torch.tensor(value)
+            self._tensor = torch.from_numpy(value)
         else:
             raise TypeError(f"Unsupported type for {self.__class__.__name__}: {type(value)}")
 
@@ -192,7 +192,10 @@ class AgentAudio(AgentType, str):
             self._tensor = value
         elif isinstance(value, tuple):
             self.samplerate = value[0]
-            self._tensor = torch.tensor(value[1])
+            if isinstance(value[1], np.ndarray):
+                self._tensor = torch.from_numpy(value[1])
+            else:
+                self._tensor = torch.tensor(value[1])
         else:
             raise ValueError(f"Unsupported audio type: {type(value)}")
 

--- a/src/transformers/agents/document_question_answering.py
+++ b/src/transformers/agents/document_question_answering.py
@@ -60,7 +60,7 @@ class DocumentQuestionAnsweringTool(PipelineTool):
         if isinstance(document, str):
             img = Image.open(document).convert("RGB")
             img_array = np.array(img).transpose(2, 0, 1)
-            document = torch.tensor(img_array)
+            document = torch.from_numpy(img_array)
         pixel_values = self.pre_processor(document, return_tensors="pt").pixel_values
 
         return {"decoder_input_ids": decoder_input_ids, "pixel_values": pixel_values}

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -153,7 +153,7 @@ def torch_default_data_collator(features: List[InputDataClass]) -> Dict[str, Any
             if isinstance(v, torch.Tensor):
                 batch[k] = torch.stack([f[k] for f in features])
             elif isinstance(v, np.ndarray):
-                batch[k] = torch.tensor(np.stack([f[k] for f in features]))
+                batch[k] = torch.from_numpy(np.stack([f[k] for f in features]))
             else:
                 batch[k] = torch.tensor([f[k] for f in features])
 

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -146,7 +146,10 @@ class BatchFeature(UserDict):
                         and isinstance(value[0][0], np.ndarray)
                     ):
                         value = np.array(value)
-                return torch.tensor(value)
+                if isinstance(value, np.ndarray):
+                    return torch.from_numpy(value)
+                else:
+                    return torch.tensor(value)
 
             is_tensor = torch.is_tensor
         elif tensor_type == TensorType.JAX:

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -579,9 +579,15 @@ class ImageFeatureExtractionMixin:
             import torch
 
             if not isinstance(mean, torch.Tensor):
-                mean = torch.tensor(mean)
+                if isinstance(mean, np.ndarray):
+                    mean = torch.from_numpy(mean)
+                else:
+                    mean = torch.tensor(mean)
             if not isinstance(std, torch.Tensor):
-                std = torch.tensor(std)
+                if isinstance(std, np.ndarray):
+                    std = torch.from_numpy(std)
+                else:
+                    std = torch.tensor(std)
 
         if image.ndim == 3 and image.shape[0] in [1, 3]:
             return (image - mean[:, None, None]) / std[:, None, None]

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -721,7 +721,7 @@ class BatchEncoding(UserDict):
 
             def as_tensor(value, dtype=None):
                 if isinstance(value, list) and isinstance(value[0], np.ndarray):
-                    return torch.tensor(np.array(value))
+                    return torch.from_numpy(np.array(value))
                 return torch.tensor(value)
 
         elif tensor_type == TensorType.JAX:


### PR DESCRIPTION
# What does this PR do?

Fixes #33185 by using `torch.from_numpy()` to create tensors for np.ndarrays, instead of `torch.tensor()` which may cause hanging.

I did some rough search in the code and made changes where I thought necessary. Code using `tensor()` with `dtype` specified remains unchanged to prevent potential type errors.

Also, `torch.from_numpy()` would share memory with numpy array, while `torch.tensor()` copies data. If this change would cause potential problems, please let me know.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@qubvel Thanks for your review!

