### PR TITLE
Fix: fix paligemma generation

### DIFF
--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -574,6 +574,7 @@ class LlavaForConditionalGeneration(LlavaPreTrainedModel):
             cache_position=cache_position,
             **kwargs,
         )
+        model_inputs.pop("num_logits_to_keep", None)
 
         if legacy_processing:
             model_inputs["pixel_values"] = pixel_values

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -356,6 +356,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, PaliGemmaCausalLMOutputWithPast]:
         r"""
         Args:
@@ -458,6 +459,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             cache_position=cache_position,
+            num_logits_to_keep=num_logits_to_keep,
         )
 
         logits = outputs.logits

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -356,7 +356,6 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        num_logits_to_keep: int = 0,
     ) -> Union[Tuple, PaliGemmaCausalLMOutputWithPast]:
         r"""
         Args:
@@ -459,7 +458,6 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             cache_position=cache_position,
-            num_logits_to_keep=num_logits_to_keep,
         )
 
         logits = outputs.logits
@@ -515,7 +513,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel):
             cache_position=cache_position,
             **kwargs,
         )
-
+        model_inputs.pop("num_logits_to_keep", None)
         model_inputs["token_type_ids"] = token_type_ids
 
         # position_ids in Paligemma are 1-indexed


### PR DESCRIPTION
# What does this PR do?

In the latest transformers, Llama and Gemma models introduce `num_logits_to_keep`, whereas the Llava and PaliGemma VLMs do not accept this argument. The program raises exceptions:

https://github.com/huggingface/transformers/blob/c409cd81777fb27aadc043ed3d8339dbc020fb3b/src/transformers/models/gemma/modeling_gemma.py#L1184-L1193

```
TypeError: PaliGemmaForConditionalGeneration.forward() got an unexpected keyword argument 'num_logits_to_keep'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@amyeroberts 