### PR TITLE
Fix: Suppressed 'use_reentrant=False' warning

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2118,12 +2118,7 @@ class Trainer:
 
         # Activate gradient checkpointing if needed
         if args.gradient_checkpointing:
-            if args.gradient_checkpointing_kwargs is None:
-                gradient_checkpointing_kwargs = {}
-            else:
-                gradient_checkpointing_kwargs = args.gradient_checkpointing_kwargs
-
-            self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gradient_checkpointing_kwargs)
+            self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=args.gradient_checkpointing_kwargs)
 
         model = self._wrap_model(self.model_wrapped)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #28536 Resolving 'use_reentrant=False' warning due to empty dict in gradient_checkpointing_kwargs.

Referenced prior issue where `gradient_checkpointing_kwargs` was initialized as an empty dict in the Trainer. This led to the `gradient_checkpointing_enable` function not handling it as `None`, causing a 'use_reentrant=False' warning. The issue was resolved by removing the unnecessary initialization, ensuring proper handling of gradient checkpointing parameters. 

For more information, see: https://github.com/huggingface/transformers/issues/28536#issuecomment-2312997910

@ArthurZucker