### PR TITLE
Test fetcher: missing return on filtered tests; don't write empty files

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -346,7 +346,13 @@ def create_circleci_config(folder=None):
     if folder is None:
         folder = os.getcwd()
     os.environ["test_preparation_dir"] = folder
-    jobs = [k for k in ALL_TESTS if os.path.isfile(os.path.join("test_preparation" , f"{k.job_name}_test_list.txt") )]
+
+    def has_file_with_contents(file_path):
+        return os.path.isfile(file_path) and os.path.getsize(file_path) > 0
+
+    jobs = [
+        k for k in ALL_TESTS if has_file_with_contents(os.path.join("test_preparation", f"{k.job_name}_test_list.txt"))
+    ]
     print("The following jobs will be run ", jobs)
 
     if len(jobs) == 0:

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -346,13 +346,7 @@ def create_circleci_config(folder=None):
     if folder is None:
         folder = os.getcwd()
     os.environ["test_preparation_dir"] = folder
-
-    def has_file_with_contents(file_path):
-        return os.path.isfile(file_path) and os.path.getsize(file_path) > 0
-
-    jobs = [
-        k for k in ALL_TESTS if has_file_with_contents(os.path.join("test_preparation", f"{k.job_name}_test_list.txt"))
-    ]
+    jobs = [k for k in ALL_TESTS if os.path.isfile(os.path.join("test_preparation" , f"{k.job_name}_test_list.txt") )]
     print("The following jobs will be run ", jobs)
 
     if len(jobs) == 0:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -979,6 +979,7 @@ def create_module_to_test_map(
                 or "/".join(Path(t).parts[1:3]) in module
             ):
                 filtered_tests += [t]
+        return filtered_tests
 
     return {
         module: (filter_tests(tests, module=module) if has_many_models(tests) else tests)

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1153,6 +1153,7 @@ JOB_TO_TEST_FILE = {
 
 def create_test_list_from_filter(full_test_list, out_path):
     all_test_files = "\n".join(full_test_list)
+    breakpoint()
     for job_name, _filter in JOB_TO_TEST_FILE.items():
         file_name = os.path.join(out_path, f"{job_name}_test_list.txt")
         if job_name == "tests_hub":

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1160,8 +1160,9 @@ def create_test_list_from_filter(full_test_list, out_path):
         else:
             files_to_test = list(re.findall(_filter, all_test_files))
         print(job_name, file_name)
-        # with open(file_name, "w") as f:
-        #     f.write("\n".join(files_to_test))
+        if len(files_to_test) > 0:  # No tests -> no file with test list
+            with open(file_name, "w") as f:
+                f.write("\n".join(files_to_test))
 
 
 if __name__ == "__main__":

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1153,7 +1153,6 @@ JOB_TO_TEST_FILE = {
 
 def create_test_list_from_filter(full_test_list, out_path):
     all_test_files = "\n".join(full_test_list)
-    breakpoint()
     for job_name, _filter in JOB_TO_TEST_FILE.items():
         file_name = os.path.join(out_path, f"{job_name}_test_list.txt")
         if job_name == "tests_hub":
@@ -1161,8 +1160,8 @@ def create_test_list_from_filter(full_test_list, out_path):
         else:
             files_to_test = list(re.findall(_filter, all_test_files))
         print(job_name, file_name)
-        with open(file_name, "w") as f:
-            f.write("\n".join(files_to_test))
+        # with open(file_name, "w") as f:
+        #     f.write("\n".join(files_to_test))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

See title :)

This PR addresses two problems:
- missing return
- writing empty files

# missing return

The `filter_tests(tests, module=module)` call always returned `None`, because it is missing a `return`. This `None` would then cause the fetcher to fail: https://app.circleci.com/pipelines/github/huggingface/transformers/102546/workflows/5e358605-da6b-4c2f-886f-84c9e455a211/jobs/1365782

With this return, the failing job above no longer happens, and CI runs as expected :) (see [this PR](https://github.com/huggingface/transformers/pull/33219))

# writing empty files

The test fetcher can write empty files for a given job (e.g. `test_preparation/tests_torch_and_tf_test_list.txt`). This caused a downstream error because:
- CircleCI skips uploads of empty files (see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/102551/workflows/263f91e9-aff9-41fe-ab51-d48440ac4cec/jobs/1365844), in `Uploading artifacts`)
- We trigger a job when there is a file (before upload)
- The job tried to download a file that didn't exist, causing a failure in the `curl` step (see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/102551/workflows/aa0f93e6-30b6-412a-887c-322edc56e81a/jobs/1365855))

As such, this PR changes our test fetcher to skip writing a test file if the file is empty 🤗 No file -> no job -> no problem