### PR TITLE
fix bug in modeling_qwen2_vl

### DIFF
--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -275,6 +275,7 @@ class VisionAttention(nn.Module):
     def __init__(self, dim: int, num_heads: int = 16) -> None:
         super().__init__()
         self.num_heads = num_heads
+        self.head_dim = dim // num_heads
         self.qkv = nn.Linear(dim, dim * 3, bias=True)
         self.proj = nn.Linear(dim, dim)
 


### PR DESCRIPTION
# What does this PR do?

See title :)

Fixes bug in modeling_qwen2_vl.
AttributeError  raise AttributeError("'{}' object has no attribute '{}'".format(^: ^'VisionAttention' object has no attribute 'head_dim' 

the [location](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L296) of this bug