### PR TITLE
prepare_fa2_from_position_ids function bugfix

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -163,8 +163,8 @@ def prepare_fa2_from_position_ids(query, key, value, position_ids):
             Maximum sequence length in batch (`max_seqlen_in_batch_q` for the target sequence i.e. query, `max_seqlen_in_batch_k` for the source sequence i.e. key/value).
     """
     query = query.view(-1, query.size(-2), query.size(-1))
-    key = key.view(-1, key.size(-2), key.size(-1))
-    value = value.view(-1, value.size(-2), value.size(-1))
+    key = key.contiguous().view(-1, key.size(-2), key.size(-1))
+    value = value.contiguous().view(-1, value.size(-2), value.size(-1))
     position_ids = position_ids.flatten()
     indices_q = torch.arange(position_ids.size(0), device=position_ids.device, dtype=torch.int32)
 


### PR DESCRIPTION
# What does this PR do?
It resolves the bug reported in [issue 33268](https://github.com/huggingface/transformers/issues/33268) by calling contiguous() before view() for key and value within **prepare_fa2_from_position_ids** function.
Related error stems from that the tensor is not contiguous in the memory, hence is fixed by simply calling contiguous() function.

The same error is encountered and discussed in:
[PyTorch forum](https://discuss.pytorch.org/t/view-size-is-not-compatible-with-input-tensors-size-and-stride/121488/2)
[Huggingface forum](https://discuss.huggingface.co/t/albertformaskedlm-error-view-size-is-not-compatible/1261)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@RhuiDih
@ArthurZucker