### PR TITLE
Fix: multigpu training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1926,7 +1926,7 @@ class Trainer:
 
         # do_train is not a reliable argument, as it might not be set and .train() still called, so
         # the following is a workaround:
-        if (args.fp16_full_eval or args.bf16_full_eval) and not args.do_train:
+        if (args.fp16_full_eval or args.bf16_full_eval) and not args.do_train and not self.is_model_parallel:
             self._move_model_to_device(self.model, args.device)
 
         if "model_path" in kwargs:


### PR DESCRIPTION
# What does this PR do?

Addresses issues in https://github.com/LLaVA-VL/LLaVA-NeXT/issues/79#issuecomment-2298261869 and https://github.com/huggingface/trl/issues/1785#issuecomment-2316330482. 

I could trace the issue to the line where we move the model to `args.device` which apparently moved the model from multigpu to a  single device. That caused device mismatch errors where the kwargs are moved to device from `hf-device-map` while the weights are all in `args.device`. I am not 100% sure this is the right fix, as I am not a Trainer master so pls let me know if there's a better way to check that

I guess @SunMarc for multigpu related issues