### PR TITLE
wait 15m before SSH into runner workflow stops

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -61,3 +61,4 @@ jobs:
           slackChannel: ${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}
           slackToken: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           waitForSSH: true
+          sshTimeout: 15m


### PR DESCRIPTION
# What does this PR do?

Let's make it wait a bit longer (instead of the current 5m) - to reduce the chance we have to re-trigger it if we forget to connect within 5m.