### PR TITLE
Mitigate a conflict when using sentencepiece

### DIFF
--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -36,6 +36,7 @@ logger = logging.get_logger(__name__)
 def import_protobuf(error_message=""):
     if is_sentencepiece_available():
         from sentencepiece import sentencepiece_model_pb2
+
         return sentencepiece_model_pb2
     if is_protobuf_available():
         import google.protobuf

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -26,7 +26,7 @@ from packaging import version
 from tokenizers import AddedToken, Regex, Tokenizer, decoders, normalizers, pre_tokenizers, processors
 from tokenizers.models import BPE, Unigram, WordPiece
 
-from .utils import is_protobuf_available, logging, requires_backends
+from .utils import is_protobuf_available, is_sentencepiece_available, logging, requires_backends
 from .utils.import_utils import PROTOBUF_IMPORT_ERROR
 
 
@@ -34,6 +34,9 @@ logger = logging.get_logger(__name__)
 
 
 def import_protobuf(error_message=""):
+    if is_sentencepiece_available():
+        from sentencepiece import sentencepiece_model_pb2
+        return sentencepiece_model_pb2
     if is_protobuf_available():
         import google.protobuf
 

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -35,7 +35,15 @@ from transformers import (
     is_tokenizers_available,
 )
 from transformers.models.gpt2.tokenization_gpt2 import GPT2Tokenizer
-from transformers.testing_utils import CaptureStderr, require_flax, require_tf, require_tokenizers, require_torch, slow
+from transformers.testing_utils import (
+    CaptureStderr,
+    require_flax,
+    require_sentencepiece,
+    require_tf,
+    require_tokenizers,
+    require_torch,
+    slow,
+)
 
 
 if is_tokenizers_available():
@@ -296,3 +304,13 @@ class TokenizerUtilsTest(unittest.TestCase):
                 self.assertEqual(len(tokenizer), tokenizer.vocab_size + 1)
                 self.assertEqual(len(tokenizer.added_tokens_decoder), added_tokens_size + 1)
                 self.assertEqual(len(tokenizer.added_tokens_encoder), added_tokens_size + 1)
+
+    @require_sentencepiece
+    @unittest.expectedFailure
+    def test_sentencepiece_cohabitation(self):
+        from sentencepiece import sentencepiece_model_pb2 as _original_protobuf  # noqa: F401
+
+        from transformers.convert_slow_tokenizer import import_protobuf  # noqa: F401
+
+        # Now this will try to import sentencepiece_model_pb2_new.py and fail due to a conflict with the protobuf file
+        import_protobuf()

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -306,11 +306,11 @@ class TokenizerUtilsTest(unittest.TestCase):
                 self.assertEqual(len(tokenizer.added_tokens_encoder), added_tokens_size + 1)
 
     @require_sentencepiece
-    @unittest.expectedFailure
     def test_sentencepiece_cohabitation(self):
         from sentencepiece import sentencepiece_model_pb2 as _original_protobuf  # noqa: F401
 
         from transformers.convert_slow_tokenizer import import_protobuf  # noqa: F401
 
-        # Now this will try to import sentencepiece_model_pb2_new.py and fail due to a conflict with the protobuf file
+        # Now this will try to import sentencepiece_model_pb2_new.py. This should not fail even if the protobuf
+        # was already imported.
         import_protobuf()


### PR DESCRIPTION
# What does this PR do?

This is a fix to a conflict between the fast tokenizers usage and sentencepiece module.
This is due to the fact that protobuf C implementation uses a global pool for all added descriptors, so if two different files add descriptors, they will end up conflicting.

I added a test showing the problem and a guard when loading the proto file to mitigate the problem. Note that the problem is not completly removed: if for any obscure reason an invalid sentencepiece proto file was loaded before, it will keep on using that. Also, if sentencepiece was loaded _after_ the tokenizers load the proto file, the error will occur again (but at least there will be a way to avoid it).


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Original discussion in internal slack: https://huggingface.slack.com/archives/C014N4749J9/p1725371896664959
- [x] Did you write any new necessary tests?


## Who can review?

@ydshieh 