### PR TITLE
Fix Megatron-LM tokenizer path

### DIFF
--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -18,7 +18,7 @@ import os
 import re
 import sys
 import types
-
+import importlib.util
 import torch
 
 from transformers import AutoTokenizer, GPT2Config
@@ -606,7 +606,8 @@ def convert_checkpoint_from_transformers_to_megatron(args):
     if args.megatron_path is not None:
         sys.path.insert(0, args.megatron_path)
 
-    try:
+    megatron_exists = importlib.util.find_spec("megatron") is not None
+    if megatron_exists:
         from megatron.core import package_info
 
         version = package_info.__version__
@@ -615,7 +616,7 @@ def convert_checkpoint_from_transformers_to_megatron(args):
             from megatron.tokenizer.tokenizer import _vocab_size_with_padding
         else:
             from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
-    except ModuleNotFoundError:
+    else:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         exit(1)
 

--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import argparse
+import importlib.util
 import json
 import os
 import re
 import sys
 import types
-import importlib.util
+
 import torch
 
 from transformers import AutoTokenizer, GPT2Config

--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -607,7 +607,13 @@ def convert_checkpoint_from_transformers_to_megatron(args):
         sys.path.insert(0, args.megatron_path)
 
     try:
-        from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+        from megatron.core import package_info
+        version = package_info.__version__
+        version = tuple(map(int, version.split('.')))
+        if version < (0, 6):
+            from megatron.tokenizer.tokenizer import _vocab_size_with_padding
+        else:
+            from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         exit(1)

--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -608,8 +608,9 @@ def convert_checkpoint_from_transformers_to_megatron(args):
 
     try:
         from megatron.core import package_info
+
         version = package_info.__version__
-        version = tuple(map(int, version.split('.')))
+        version = tuple(map(int, version.split(".")))
         if version < (0, 6):
             from megatron.tokenizer.tokenizer import _vocab_size_with_padding
         else:

--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -21,6 +21,7 @@ import sys
 import types
 
 import torch
+from packaging import version
 
 from transformers import AutoTokenizer, GPT2Config
 from transformers.modeling_utils import WEIGHTS_INDEX_NAME, WEIGHTS_NAME, shard_checkpoint
@@ -611,12 +612,11 @@ def convert_checkpoint_from_transformers_to_megatron(args):
     if megatron_exists:
         from megatron.core import package_info
 
-        version = package_info.__version__
-        version = tuple(map(int, version.split(".")))
-        if version < (0, 6):
-            from megatron.tokenizer.tokenizer import _vocab_size_with_padding
-        else:
+        if version.parse(package_info.__version__) >= version.parse("0.6.0"):
             from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
+        else:
+            from megatron.tokenizer.tokenizer import _vocab_size_with_padding
+
     else:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         exit(1)

--- a/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
+++ b/src/transformers/models/megatron_gpt2/checkpoint_reshaping_and_interoperability.py
@@ -607,7 +607,7 @@ def convert_checkpoint_from_transformers_to_megatron(args):
         sys.path.insert(0, args.megatron_path)
 
     try:
-        from megatron.tokenizer.tokenizer import _vocab_size_with_padding
+        from megatron.training.tokenizer.tokenizer import _vocab_size_with_padding
     except ModuleNotFoundError:
         print("Unable to import Megatron, please specify the path to Megatron using --megatron-path. Exiting.")
         exit(1)


### PR DESCRIPTION
# What does this PR do?
This PR addresses an issue with the Megatron-LM checkpoint conversion script introduced in the [documentation](https://huggingface.co/docs/accelerate/usage_guides/megatron_lm#utility-for-checkpoint-reshaping-and-interoperability). The path to the Megatron-LM tokenizer was outdated and did not match the current path. I have updated the script to reflect the correct path to the tokenizer.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@muellerzr @ArthurZucker 
