### PR TITLE
fixed Mask2Former image processor segmentation maps handling

### DIFF
--- a/src/transformers/models/mask2former/image_processing_mask2former.py
+++ b/src/transformers/models/mask2former/image_processing_mask2former.py
@@ -935,7 +935,7 @@ class Mask2FormerImageProcessor(BaseImageProcessor):
         if segmentation_maps is not None:
             mask_labels = []
             class_labels = []
-            pad_size = get_max_height_width(pixel_values_list)
+            pad_size = get_max_height_width(pixel_values_list, input_data_format=input_data_format)
             # Convert to list of binary masks and labels
             for idx, segmentation_map in enumerate(segmentation_maps):
                 segmentation_map = to_numpy_array(segmentation_map)

--- a/tests/models/mask2former/test_image_processing_mask2former.py
+++ b/tests/models/mask2former/test_image_processing_mask2former.py
@@ -51,8 +51,8 @@ class Mask2FormerImageProcessingTester(unittest.TestCase):
         size=None,
         do_resize=True,
         do_normalize=True,
-        image_mean=0.5,
-        image_std=0.5,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
         num_labels=10,
         do_reduce_labels=True,
         ignore_index=255,
@@ -244,6 +244,8 @@ class Mask2FormerImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase
         ):
             self.image_processor_tester.num_channels = num_channels
             self.image_processor_tester.do_resize = do_resize
+            self.image_processor_tester.image_mean = [0.5] * num_channels
+            self.image_processor_tester.image_std = [0.5] * num_channels
 
             inputs = self.comm_get_image_processing_inputs(
                 with_segmentation_maps=True,


### PR DESCRIPTION
Fixes segmentation maps padding size calculation when handling multichannel images using previously inferred `input_data_format`. 

Fixes #33295

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case -> #33295.
- [x] Did you write any new necessary tests?

## Who can review?
Anyone