### PR TITLE
Fix exception AttributeError for missing attribute is_zero3 from HfDeepSpeedConfig object

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -288,7 +288,10 @@ def unset_hf_deepspeed_config():
 
 def is_deepspeed_zero3_enabled():
     if _hf_deepspeed_config_weak_ref is not None and _hf_deepspeed_config_weak_ref() is not None:
-        return _hf_deepspeed_config_weak_ref().is_zero3()
+        try:
+            return _hf_deepspeed_config_weak_ref().is_zero3()
+        except AttributeError:
+            return False
     else:
         return False
 


### PR DESCRIPTION
Fix exception for missing attribute is_zero3 for stage 2 deepspeed.
This issue was observed on Google Colab with runtime GPU A100, when trying to train a Mistral model using deepspeed acceleration.
In the corresponding config json file, stage 2 optimization was specified.
