### PR TITLE
use diff internal model in tests

### DIFF
--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -838,8 +838,8 @@ class CommonSpmIntegrationTests(unittest.TestCase):
         self.assertEqual(tokens, ["▁No", "<s>", "▁He"])  # spaces are eaten by rstrip / lstrip
 
 
-# @require_tiktoken
-# @require_read_token
+@require_tiktoken
+@require_read_token
 class TikTokenIntegrationTests(unittest.TestCase):
     """
     A class that regroups important test to make sure that we properly handle the special tokens.

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -838,15 +838,16 @@ class CommonSpmIntegrationTests(unittest.TestCase):
         self.assertEqual(tokens, ["▁No", "<s>", "▁He"])  # spaces are eaten by rstrip / lstrip
 
 
-@require_tiktoken
-@require_read_token
+# @require_tiktoken
+# @require_read_token
 class TikTokenIntegrationTests(unittest.TestCase):
     """
     A class that regroups important test to make sure that we properly handle the special tokens.
     """
 
     def test_tiktoken_llama(self):
-        model_path = "hf-internal-testing/Llama3-Instruct-Internal"
+        model_path = "hf-internal-testing/llama-3-8b-internal"
+        subfolder = "original"
         test_text = "This is a test sentence."
         test_tokens = [128000, 2028, 374, 264, 1296, 11914, 13, 128001]
         num_reserved_special_tokens = 256
@@ -866,6 +867,7 @@ class TikTokenIntegrationTests(unittest.TestCase):
 
         tiktoken_tokenizer = PreTrainedTokenizerFast.from_pretrained(
             model_path,
+            subfolder=subfolder,
             additional_special_tokens=special_tokens,
             bos_token="<|begin_of_text|>",
             eos_token="<|end_of_text|>",
@@ -874,7 +876,14 @@ class TikTokenIntegrationTests(unittest.TestCase):
         self.assertEqual(tokens[0], "<|begin_of_text|>")
 
         tiktoken_tokenizer = AutoTokenizer.from_pretrained(
-            model_path, legacy=False, additional_special_tokens=special_tokens, add_bos_token=True, add_eos_token=True
+            model_path,
+            subfolder=subfolder,
+            legacy=False,
+            additional_special_tokens=special_tokens,
+            bos_token="<|begin_of_text|>",
+            eos_token="<|end_of_text|>",
+            add_bos_token=True,
+            add_eos_token=True,
         )
         self.assertTrue(isinstance(tiktoken_tokenizer, PreTrainedTokenizerFast))
 
@@ -892,7 +901,10 @@ class TikTokenIntegrationTests(unittest.TestCase):
 
         tiktoken_tokenizer = AutoTokenizer.from_pretrained(
             model_path,
+            subfolder=subfolder,
             additional_special_tokens=special_tokens,
+            bos_token="<|begin_of_text|>",
+            eos_token="<|end_of_text|>",
             from_slow=True,
             add_bos_token=True,
             add_eos_token=True,


### PR DESCRIPTION
Update to use internal model - @require_read_token only works for internal

other changes:
- need to pass `bos_token` and `eos_token` because renaming the internal repo to "llama-3" from "llama3" resulted in the AutoTokenizer instantiating with LlamaTokenizerFast as opposed to PreTrainedTokenizerFast. This is good but needs to have `bos_token` and `eos_token` updated to the `Llama-3` values instead of the default `<s>` and `</s> ` cc @ydshieh 
(related to tiktoken support PR #31656)

@ArthurZucker 