### PR TITLE
Support to use adam_mini from installing directly

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -148,6 +148,7 @@ from .utils import (
     can_return_loss,
     find_labels,
     is_accelerate_available,
+    is_adam_mini_torch_available,
     is_apex_available,
     is_bitsandbytes_available,
     is_datasets_available,
@@ -1209,6 +1210,29 @@ class Trainer:
             optimizer_kwargs.update(adam_kwargs)
             if args.optim == OptimizerNames.ADAMW_TORCH_FUSED:
                 optimizer_kwargs.update({"fused": True})
+        elif args.optim == OptimizerNames.ADAMW_MINI:
+            if not is_adam_mini_torch_available():
+                raise ImportError(
+                    "You need to install `adam_mini` in order to use Adam-mini optimizer"
+                    " install it with `pip install adam_mini`"
+                )
+            from adam_mini import Adam_mini
+
+            optimizer_cls = Adam_mini
+
+            hidden_size = getattr(model.config, "hidden_size", None)
+            num_q_head = getattr(model.config, "num_attention_heads", None)
+            num_kv_head = getattr(model.config, "num_key_value_heads", None)
+
+            optimizer_kwargs.update(
+                {
+                    "named_parameters": model.named_parameters(),
+                    "dim": hidden_size,
+                    "n_heads": num_q_head,
+                    "n_kv_heads": num_kv_head,
+                }
+            )
+            optimizer_kwargs.update(adam_kwargs)
         elif args.optim == OptimizerNames.ADAMW_TORCH_XLA:
             try:
                 from torch_xla.amp.syncfree import AdamW

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -148,6 +148,7 @@ class OptimizerNames(ExplicitEnum):
 
     ADAMW_HF = "adamw_hf"
     ADAMW_TORCH = "adamw_torch"
+    ADAMW_MINI = "adamw_mini"
     ADAMW_TORCH_FUSED = "adamw_torch_fused"
     ADAMW_TORCH_XLA = "adamw_torch_xla"
     ADAMW_TORCH_NPU_FUSED = "adamw_torch_npu_fused"

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -112,6 +112,7 @@ from .import_utils import (
     direct_transformers_import,
     get_torch_version,
     is_accelerate_available,
+    is_adam_mini_torch_available,
     is_apex_available,
     is_aqlm_available,
     is_auto_awq_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -101,6 +101,7 @@ _av_available = importlib.util.find_spec("av") is not None
 _bitsandbytes_available = _is_package_available("bitsandbytes")
 _eetq_available = _is_package_available("eetq")
 _fbgemm_gpu_available = _is_package_available("fbgemm_gpu")
+_adam_mini_torch_available = _is_package_available("adam_mini")
 _galore_torch_available = _is_package_available("galore_torch")
 _lomo_available = _is_package_available("lomo_optim")
 _grokadamw_available = _is_package_available("grokadamw")
@@ -352,6 +353,10 @@ def is_torch_sdpa_available():
 
 def is_torchvision_available():
     return _torchvision_available
+
+
+def is_adam_mini_torch_available():
+    return _adam_mini_torch_available
 
 
 def is_galore_torch_available():


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This repo implements the Adam-mini optimizer. 

Paper: https://arxiv.org/abs/2406.16793

Code: https://github.com/zyushun/Adam-mini


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

This pull request was discussed in https://github.com/huggingface/transformers/pull/31933. It is suggested to use the optimizer from the source library.   


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts @muellerzr @Ashwanth369 @chcoliang @zyushun

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
