### PR TITLE
[docs] add the missing tokenizer when pushing models to huggingface hub

### DIFF
--- a/docs/source/en/tasks/language_modeling.md
+++ b/docs/source/en/tasks/language_modeling.md
@@ -253,6 +253,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
+...     tokenizer=tokenzier,
 ... )
 
 >>> trainer.train()

--- a/docs/source/en/tasks/language_modeling.md
+++ b/docs/source/en/tasks/language_modeling.md
@@ -253,7 +253,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
-...     tokenizer=tokenzier,
+...     tokenizer=tokenizer,
 ... )
 
 >>> trainer.train()

--- a/docs/source/en/tasks/masked_language_modeling.md
+++ b/docs/source/en/tasks/masked_language_modeling.md
@@ -245,6 +245,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
+...     tokenizer=tokenizer,
 ... )
 
 >>> trainer.train()


### PR DESCRIPTION
## What does this PR do?
I tried to run the documentation, but got the following failure that the tokenizer is not to be found in the hf hub. The reason is that we don't pass the `tokenizer` to `Trainer`.  So this PR fixes this issue. 

@stevhliu Pls have a review. Thx!
