### PR TITLE
Update chameleon.md — fix runtime type error

### DIFF
--- a/docs/source/en/model_doc/chameleon.md
+++ b/docs/source/en/model_doc/chameleon.md
@@ -78,7 +78,7 @@ url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
 image = Image.open(requests.get(url, stream=True).raw)
 prompt = "What do you see in this image?<image>"
 
-inputs = processor(prompt, image, return_tensors="pt").to(model.device)
+inputs = processor(prompt, image, return_tensors="pt").to(model.device, dtype=torch.bfloat16)
 
 # autoregressively complete prompt
 output = model.generate(**inputs, max_new_tokens=50)


### PR DESCRIPTION
# What does this PR do?
Fix runtime type error when following the Chameleon documentation

```
RuntimeError: Input type (float) and bias type (c10::BFloat16) should be the same
```


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).