### PR TITLE
Add Slow CI reminder bot

### DIFF
--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -49,6 +49,7 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: | 
+          Hey! 🤗 Thanks for your contribution to the `transformers` library!
           Before merging this pull request, slow tests CI should be triggered. To enable this:
           - Add the `run-slow` label to the PR
           - When your PR is ready for merge and all reviewers' comments have been addressed, push an empty commit with the command `[run-slow]` followed by a comma separated list of all the models to be tested, i.e. `[run_slow] model_to_test_1, model_to_test_2`

--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -48,8 +48,9 @@ jobs:
     - name: Add comment
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: | 
+        message: |
           Hey! 🤗 Thanks for your contribution to the `transformers` library!
+
           Before merging this pull request, slow tests CI should be triggered. To enable this:
           - Add the `run-slow` label to the PR
           - When your PR is ready for merge and all reviewers' comments have been addressed, push an empty commit with the command `[run-slow]` followed by a comma separated list of all the models to be tested, i.e. `[run_slow] model_to_test_1, model_to_test_2`

--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -3,6 +3,8 @@ name: Slow CI Reminder
 # For security reason, don't use `pull_request` but `pull_request_target`!
 on:
   pull_request_target:
+    paths:
+      - '**.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,7 +22,7 @@ jobs:
       id: find_comment
       with:
         issue-number: ${{ github.event.number }}
-        body-includes: Please trigger Slow CI and make sure all tests are passing before merging this pull request.
+        body-includes: Before merging this pull request, slow tests CI should be triggered. To enable this
 
     - run: |
         echo ${{ steps.find_comment.outputs.comment-id }}
@@ -41,6 +43,13 @@ jobs:
     - name: Add comment
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: 'Please trigger Slow CI and make sure all tests are passing before merging this pull request.'
+        message: | 
+          Before merging this pull request, slow tests CI should be triggered. To enable this:
+          - Add the `run-slow` label to the PR
+          - When your PR is ready for merge and all reviewers' comments have been addressed, push an empty commit with the command `[run-slow]` followed by a comma separated list of all the models to be tested, i.e. `[run_slow] model_to_test_1, model_to_test_2`
+          - A `transformers` maintainer will then approve the workflow to start the tests
+          
+          (For maintainers) The documentation for slow tests CI on PRs is [here](https://www.notion.so/huggingface2/CI-for-pull-requests-8335bd9217d24d1e8ed1d3a016f39804).
+
         pr_number: ${{ github.event.number }}
         GITHUB_TOKEN: ${{ secrets.comment_bot_token }}

--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -53,6 +53,7 @@ jobs:
           Before merging this pull request, slow tests CI should be triggered. To enable this:
           - Add the `run-slow` label to the PR
           - When your PR is ready for merge and all reviewers' comments have been addressed, push an empty commit with the command `[run-slow]` followed by a comma separated list of all the models to be tested, i.e. `[run_slow] model_to_test_1, model_to_test_2`
+            - If the pull request affects a lot of models, put at most 10 models in the commit message
           - A `transformers` maintainer will then approve the workflow to start the tests
           
           (For maintainers) The documentation for slow tests CI on PRs is [here](https://www.notion.so/huggingface2/CI-for-pull-requests-8335bd9217d24d1e8ed1d3a016f39804).

--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -4,7 +4,12 @@ name: Slow CI Reminder
 on:
   pull_request_target:
     paths:
-      - '**.py'
+      - "src/transformers/models/*/*.py"
+      - "src/transformers/generation/*.py"
+      - "src/transformers/pipelines/*.py"
+      - "tests/models/*/*.py"
+      - "tests/generation/*/*.py"
+      - "tests/pipelines/*/*.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/slow_ci_remainder.yml
+++ b/.github/workflows/slow_ci_remainder.yml
@@ -1,0 +1,46 @@
+name: Slow CI Reminder
+
+# For security reason, don't use `pull_request` but `pull_request_target`!
+on:
+  pull_request_target:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  remind:
+    name: remind
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - name: Find comment
+      uses: peter-evans/find-comment@v2
+      id: find_comment
+      with:
+        issue-number: ${{ github.event.number }}
+        body-includes: Please trigger Slow CI and make sure all tests are passing before merging this pull request.
+
+    - run: |
+        echo ${{ steps.find_comment.outputs.comment-id }}
+
+    - name: Delete previous comment (if found)
+      if: steps.find_comment.outputs.comment-id != ''
+      uses: actions/github-script@v6
+      with:
+        result-encoding: string
+        github-token: ${{ secrets.comment_bot_token }}
+        script: |
+          github.rest.issues.deleteComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: ${{ steps.find_comment.outputs.comment-id }},
+          })
+
+    - name: Add comment
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: 'Please trigger Slow CI and make sure all tests are passing before merging this pull request.'
+        pr_number: ${{ github.event.number }}
+        GITHUB_TOKEN: ${{ secrets.comment_bot_token }}


### PR DESCRIPTION
# What does this PR do?

@amyeroberts and @gante both mentioned that it would be helpful if we have such a reminder (so we won't forget to trigger whenever necessary)

p.s. 

- I am using `comment_bot_token` whose owner is [HuggingFaceDocBuilderDev](https://github.com/HuggingFaceDocBuilderDev), which might seems a bit strange. But I think it's fine (and not to create a new member with a new token again)


<img width="627" alt="Screenshot 2024-09-16 115318" src="https://github.com/user-attachments/assets/d8a5d4c0-a96e-4577-ad8e-a0d1fbe988a8">
