### PR TITLE
[Whisper] Fix generate and tokenizer behavior with added tokens

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1908,6 +1908,14 @@ class WhisperTimeStampLogitsProcessor(LogitsProcessor):
     ):  # support for the kwargs
         self.no_timestamps_token_id = generate_config.no_timestamps_token_id
         self.timestamp_begin = generate_config.no_timestamps_token_id + 1
+
+        if hasattr(generate_config, "number_timestamp_tokens"):
+            number_timestamp_tokens = generate_config.number_timestamp_tokens
+        else:
+            # Whisper uses by default 1501 timestamp tokens, from <|0.00|> to <|30.00|> with a step of 20ms
+            number_timestamp_tokens = 1501 
+
+        self.timestamp_end = self.timestamp_begin + number_timestamp_tokens - 1
         self.eos_token_id = generate_config.eos_token_id or generate_config.bos_token_id
 
         # this variable is mostly just used for testing

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1913,7 +1913,7 @@ class WhisperTimeStampLogitsProcessor(LogitsProcessor):
             number_timestamp_tokens = generate_config.number_timestamp_tokens
         else:
             # Whisper uses by default 1501 timestamp tokens, from <|0.00|> to <|30.00|> with a step of 20ms
-            number_timestamp_tokens = 1501 
+            number_timestamp_tokens = 1501
 
         self.timestamp_end = self.timestamp_begin + number_timestamp_tokens - 1
         self.eos_token_id = generate_config.eos_token_id or generate_config.bos_token_id

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1209,12 +1209,12 @@ class WhisperGenerationMixin:
             # BC for models missing the `no_timestamps_token_id` in the generation config when generating short-form with no timestamps
             # We set the timestamp begin token larger than the vocab size, such that the timestamp condition is never met in the decoding loop
             timestamp_begin = self.config.vocab_size + 1
-        
+
         if hasattr(generation_config, "number_timestamp_tokens"):
             number_timestamp_tokens = generation_config.number_timestamp_tokens
         else:
             # Whisper uses by default 1501 timestamp tokens, from <|0.00|> to <|30.00|> with a step of 20ms
-            number_timestamp_tokens = 1501 
+            number_timestamp_tokens = 1501
 
         timestamp_end = timestamp_begin + number_timestamp_tokens - 1
 

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -348,6 +348,8 @@ class WhisperGenerationMixin:
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             return_timestamps (`bool`, *optional*):
                 Whether to return the timestamps with the text. This enables the `WhisperTimeStampLogitsProcessor`.
+                By default, Whisper uses 1501 timestamp tokens.  If a custom number of timestamp tokens is needed,
+                it should be specified by setting `generation_config.num_timestamp_tokens`.
             task (`str`, *optional*):
                 Task to use for generation, either "translate" or "transcribe". The `model.config.forced_decoder_ids`
                 will be updated accordingly.

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -517,7 +517,7 @@ class WhisperGenerationMixin:
             logprob_threshold=logprob_threshold,
             generation_config=generation_config,
         )
-        timestamp_begin = self._set_return_timestamps(
+        timestamp_begin, timestamp_end = self._set_return_timestamps(
             return_timestamps=return_timestamps, is_shortform=is_shortform, generation_config=generation_config
         )
         self._set_language_and_task(
@@ -703,6 +703,7 @@ class WhisperGenerationMixin:
                     seek_outputs=seek_outputs,
                     time_offset=time_offset,
                     timestamp_begin=timestamp_begin,
+                    timestamp_end=timestamp_end,
                     seek_num_frames=seek_num_frames,
                     time_precision=time_precision,
                     input_stride=input_stride,
@@ -1206,8 +1207,16 @@ class WhisperGenerationMixin:
             # BC for models missing the `no_timestamps_token_id` in the generation config when generating short-form with no timestamps
             # We set the timestamp begin token larger than the vocab size, such that the timestamp condition is never met in the decoding loop
             timestamp_begin = self.config.vocab_size + 1
+        
+        if hasattr(generation_config, "number_timestamp_tokens"):
+            number_timestamp_tokens = generation_config.number_timestamp_tokens
+        else:
+            # Whisper uses by default 1501 timestamp tokens, from <|0.00|> to <|30.00|> with a step of 20ms
+            number_timestamp_tokens = 1501 
 
-        return timestamp_begin
+        timestamp_end = timestamp_begin + number_timestamp_tokens - 1
+
+        return timestamp_begin, timestamp_end
 
     @staticmethod
     def _set_language_and_task(language, task, is_multilingual, generation_config):
@@ -1755,6 +1764,7 @@ class WhisperGenerationMixin:
         seek_outputs,
         time_offset,
         timestamp_begin,
+        timestamp_end,
         seek_num_frames,
         time_precision,
         input_stride,
@@ -1764,7 +1774,7 @@ class WhisperGenerationMixin:
     ):
         # find the predicted "end of segment" predictions of Whisper
         # "end of segment" predictions occur whenever Whisper predicts a timestamp token
-        timestamp_tokens: torch.Tensor = seek_sequence.ge(timestamp_begin)
+        timestamp_tokens: torch.Tensor = (timestamp_begin <= seek_sequence) & (seek_sequence <= timestamp_end)
         single_timestamp_ending = timestamp_tokens[-2:].tolist() == [False, True]
         timestamp_segment_indices = torch.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0]
         timestamp_segment_indices.add_(1)

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -347,7 +347,7 @@ class WhisperGenerationMixin:
             synced_gpus (`bool`, *optional*, defaults to `False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             return_timestamps (`bool`, *optional*):
-                Whether to return the timestamps with the text. This enables the `WhisperTimestampsLogitsProcessor`.
+                Whether to return the timestamps with the text. This enables the `WhisperTimeStampLogitsProcessor`.
             task (`str`, *optional*):
                 Task to use for generation, either "translate" or "transcribe". The `model.config.forced_decoder_ids`
                 will be updated accordingly.

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -923,6 +923,7 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
     chunk = new_chunk()
     time_offset = 0.0
     timestamp_begin = tokenizer.convert_tokens_to_ids("<|notimestamps|>") + 1
+    timestamp_end = tokenizer.timestamp_end
     previous_tokens = []
     previous_token_timestamps = []
     skip = False
@@ -961,7 +962,7 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
                 first_timestamp = stride_left / time_precision + timestamp_begin
             if stride_right:
                 for token in reversed(token_ids):
-                    if token >= timestamp_begin:
+                    if timestamp_begin <= token <= timestamp_end:
                         # There can be several token in the right stride
                         # But the last one is ALWAYS going to be skipped
                         if (
@@ -1007,7 +1008,7 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
                 else:
                     # 2/ This is a regular special token, ignoring it
                     pass
-            elif token >= timestamp_begin:
+            elif timestamp_begin <= token <= timestamp_end:
                 # 3/ Timestamp token
                 time = (token - timestamp_begin) * time_precision + time_offset
                 time = round(time, 2)

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -328,12 +328,12 @@ class WhisperTokenizer(PreTrainedTokenizer):
     @property
     def vocab_size(self) -> int:
         return len(self.encoder)
-    
-    @property 
+
+    @property
     def timestamp_end(self) -> int:
         timestamp_ids = [value for key, value in self.added_tokens_encoder.items() if self.timestamp_pat.match(key)]
         return max(timestamp_ids)
-        
+
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
         vocab.update(self.added_tokens_encoder)

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -147,6 +147,11 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         self.task = task
         self.predict_timestamps = predict_timestamps
 
+    @property 
+    def timestamp_end(self) -> int:
+        timestamp_ids = [value for key, value in self.added_tokens_encoder.items() if self.timestamp_pat.match(key)]
+        return max(timestamp_ids)
+    
     # Copied from transformers.models.gpt2.tokenization_gpt2_fast.GPT2TokenizerFast._batch_encode_plus
     def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:
         is_split_into_words = kwargs.get("is_split_into_words", False)
@@ -175,13 +180,14 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         given tokens with timestamps tokens annotated, e.g. "<|1.08|>".
         """
         timestamp_begin = self.all_special_ids[-1] + 1
+        timestamp_end = self.timestamp_end
         outputs = [[]]
 
         cur_max_timestamp = 0.0
         prev_segments_len = 0.0
 
         for token in token_ids:
-            if token >= timestamp_begin:
+            if timestamp_begin <= token <= timestamp_end:
                 timestamp = float((token - timestamp_begin) * time_precision)
 
                 if timestamp < cur_max_timestamp:
@@ -218,7 +224,8 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_tokens = token_ids >= timestamp_begin
+        timestamp_end = self.timestamp_end
+        timestamp_tokens = (timestamp_begin <= token_ids) & (token_ids <= timestamp_end)
 
         consecutive = np.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0] + 1
         if consecutive.shape[0] == 0 and timestamp_tokens.sum() <= 1:

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -147,11 +147,11 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         self.task = task
         self.predict_timestamps = predict_timestamps
 
-    @property 
+    @property
     def timestamp_end(self) -> int:
         timestamp_ids = [value for key, value in self.added_tokens_encoder.items() if self.timestamp_pat.match(key)]
         return max(timestamp_ids)
-    
+
     # Copied from transformers.models.gpt2.tokenization_gpt2_fast.GPT2TokenizerFast._batch_encode_plus
     def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:
         is_split_into_words = kwargs.get("is_split_into_words", False)


### PR DESCRIPTION
# What does this PR do?

Fixes #33082. 

### Description of the issue

Transformers' `PretTrainedTokenizer` [`_add_tokens`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/tokenization_utils.py#L510) add tokens at the end of the vocabulary. Likewise, `PreTrainedModel`'s [`_get_resized_embeddings`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/modeling_utils.py#L2080) will add newly initialized tensors at the end. This behavior is not compatible with Whisper's timestamp token identification. Indeed, official implementation as well as Transformer's one identifies timestamp tokens as the ones that have an id > `timestamp_begin`. For this reason, the newly added tokens are falsely considered timestamps and this poses decoding issues. 

###  Implementation choices

Two possibilities here: 
1. change Whisper's decoding logic using a `timestamp_end`
2. overwrite  [`_add_tokens`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/tokenization_utils.py#L510)  and [`_get_resized_embeddings`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/modeling_utils.py#L2080) in order to add new tokens before the first timestamp token (and not at the end as current implementation)

I chose option 1 to avoid overwriting the default methods, focusing instead on modifying the Whisper-specific generation method and tokenizer logic.

## Who can review?

@ylacombe 

