### PR TITLE
Add `private` to `trainer.push_to_hub`. Add `_update_repo_visibility` to trainer.

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -32,7 +32,15 @@ from typing import Dict, List
 from unittest.mock import Mock, patch
 
 import numpy as np
-from huggingface_hub import HfFolder, ModelCard, create_branch, delete_repo, list_repo_commits, list_repo_files
+from huggingface_hub import (
+    HfFolder,
+    ModelCard,
+    create_branch,
+    delete_repo,
+    list_repo_commits,
+    list_repo_files,
+    model_info,
+)
 from packaging import version
 from parameterized import parameterized
 from requests.exceptions import HTTPError
@@ -4085,6 +4093,26 @@ class TrainerIntegrationWithHubTester(unittest.TestCase):
 
             branch_name = re_search.groups()[0]
             self.assertEqual(branch_name, branch)
+
+    def test_push_to_hub_private(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            trainer = get_regression_trainer(
+                output_dir=os.path.join(tmp_dir, "test-trainer-private"),
+                push_to_hub=True,
+                hub_token=self._token,
+            )
+
+            trainer.push_to_hub(private=True)
+
+            info = model_info(f"{USER}/test-trainer-private", token=self._token)
+
+            self.assertTrue(info.private)
+
+            trainer.push_to_hub(private=False)
+
+            info = model_info(f"{USER}/test-trainer-private", token=self._token)
+
+            self.assertFalse(info.private)
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

Currently setting `hub_private_repo` training argument only allows control over repo visibility at creation.

This PR adds `private` parameter to `trainer.push_to_hub`, this allows control over repo visiblity at creation in case `hub_private_repo` was not set in training arguments, and allows updating visibility of existing repos.

Fixes #33492
Fixes #32909


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

cc @muellerzr