### PR TITLE
[WIP] [Whisper] Fix generate and tokenizer behavior with added tokens

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -347,7 +347,9 @@ class WhisperGenerationMixin:
             synced_gpus (`bool`, *optional*, defaults to `False`):
                 Whether to continue running the while loop until max_length (needed for ZeRO stage 3)
             return_timestamps (`bool`, *optional*):
-                Whether to return the timestamps with the text. This enables the `WhisperTimestampsLogitsProcessor`.
+                Whether to return the timestamps with the text. This enables the `WhisperTimeStampLogitsProcessor`.
+                By default, Whisper uses 1501 timestamp tokens.  If a custom number of timestamp tokens is needed,
+                it should be specified by setting `generation_config.num_timestamp_tokens`.
             task (`str`, *optional*):
                 Task to use for generation, either "translate" or "transcribe". The `model.config.forced_decoder_ids`
                 will be updated accordingly.

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -517,7 +517,7 @@ class WhisperGenerationMixin:
             logprob_threshold=logprob_threshold,
             generation_config=generation_config,
         )
-        timestamp_begin = self._set_return_timestamps(
+        timestamp_begin, timestamp_end = self._set_return_timestamps(
             return_timestamps=return_timestamps, is_shortform=is_shortform, generation_config=generation_config
         )
         self._set_language_and_task(
@@ -703,6 +703,7 @@ class WhisperGenerationMixin:
                     seek_outputs=seek_outputs,
                     time_offset=time_offset,
                     timestamp_begin=timestamp_begin,
+                    timestamp_end=timestamp_end,
                     seek_num_frames=seek_num_frames,
                     time_precision=time_precision,
                     input_stride=input_stride,
@@ -1209,7 +1210,15 @@ class WhisperGenerationMixin:
             # We set the timestamp begin token larger than the vocab size, such that the timestamp condition is never met in the decoding loop
             timestamp_begin = self.config.vocab_size + 1
 
-        return timestamp_begin
+        if hasattr(generation_config, "number_timestamp_tokens"):
+            number_timestamp_tokens = generation_config.number_timestamp_tokens
+        else:
+            # Whisper uses by default 1501 timestamp tokens, from <|0.00|> to <|30.00|> with a step of 20ms
+            number_timestamp_tokens = 1501
+
+        timestamp_end = timestamp_begin + number_timestamp_tokens - 1
+
+        return timestamp_begin, timestamp_end
 
     @staticmethod
     def _set_language_and_task(language, task, is_multilingual, generation_config):
@@ -1757,6 +1766,7 @@ class WhisperGenerationMixin:
         seek_outputs,
         time_offset,
         timestamp_begin,
+        timestamp_end,
         seek_num_frames,
         time_precision,
         input_stride,
@@ -1766,7 +1776,7 @@ class WhisperGenerationMixin:
     ):
         # find the predicted "end of segment" predictions of Whisper
         # "end of segment" predictions occur whenever Whisper predicts a timestamp token
-        timestamp_tokens: torch.Tensor = seek_sequence.ge(timestamp_begin)
+        timestamp_tokens: torch.Tensor = (timestamp_begin <= seek_sequence) & (seek_sequence <= timestamp_end)
         single_timestamp_ending = timestamp_tokens[-2:].tolist() == [False, True]
         timestamp_segment_indices = torch.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0]
         timestamp_segment_indices.add_(1)

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -891,7 +891,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()
         return token_ids
-    
+
     def _is_timestamp_token(self, token_id) -> bool:
         token = self.convert_ids_to_tokens(int(token_id))
         return self.timestamp_pat.match(token)

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -576,7 +576,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_tokens = self._is_timestamp_token(token_ids)
+        timestamp_tokens = np.array([self._is_timestamp_token(tok) for tok in token_ids])
 
         consecutive = np.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0] + 1
         if consecutive.shape[0] == 0 and timestamp_tokens.sum() <= 1:
@@ -889,7 +889,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
 
     def _is_timestamp_token(self, token_id) -> bool:
         token = self.convert_ids_to_tokens(int(token_id))
-        return self.timestamp_pat.match(token)
+        return bool(self.timestamp_pat.match(token))
 
 
 def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language, time_precision):

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -539,14 +539,13 @@ class WhisperTokenizer(PreTrainedTokenizer):
         given tokens with timestamps tokens annotated, e.g. "<|1.08|>".
         """
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_end = self.timestamp_end
         outputs = [[]]
 
         cur_max_timestamp = 0.0
         prev_segments_len = 0.0
 
         for token in token_ids:
-            if timestamp_begin <= token <= timestamp_end:
+            if self._is_timestamp_token(token):
                 timestamp = float((token - timestamp_begin) * time_precision)
 
                 if timestamp < cur_max_timestamp:
@@ -582,8 +581,7 @@ class WhisperTokenizer(PreTrainedTokenizer):
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_end = self.timestamp_end
-        timestamp_tokens = (timestamp_begin <= token_ids) & (token_ids <= timestamp_end)
+        timestamp_tokens = self._is_timestamp_token(token_ids)
 
         consecutive = np.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0] + 1
         if consecutive.shape[0] == 0 and timestamp_tokens.sum() <= 1:
@@ -893,6 +891,10 @@ class WhisperTokenizer(PreTrainedTokenizer):
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()
         return token_ids
+    
+    def _is_timestamp_token(self, token_id) -> bool:
+        token = self.convert_ids_to_tokens(int(token_id))
+        return self.timestamp_pat.match(token)
 
 
 def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language, time_precision):
@@ -923,7 +925,6 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
     chunk = new_chunk()
     time_offset = 0.0
     timestamp_begin = tokenizer.convert_tokens_to_ids("<|notimestamps|>") + 1
-    timestamp_end = tokenizer.timestamp_end
     previous_tokens = []
     previous_token_timestamps = []
     skip = False
@@ -962,7 +963,7 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
                 first_timestamp = stride_left / time_precision + timestamp_begin
             if stride_right:
                 for token in reversed(token_ids):
-                    if timestamp_begin <= token <= timestamp_end:
+                    if tokenizer._is_timestamp_token(token):
                         # There can be several token in the right stride
                         # But the last one is ALWAYS going to be skipped
                         if (
@@ -1008,7 +1009,7 @@ def _decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language,
                 else:
                     # 2/ This is a regular special token, ignoring it
                     pass
-            elif timestamp_begin <= token <= timestamp_end:
+            elif tokenizer._is_timestamp_token(token):
                 # 3/ Timestamp token
                 time = (token - timestamp_begin) * time_precision + time_offset
                 time = round(time, 2)

--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -329,11 +329,6 @@ class WhisperTokenizer(PreTrainedTokenizer):
     def vocab_size(self) -> int:
         return len(self.encoder)
 
-    @property
-    def timestamp_end(self) -> int:
-        timestamp_ids = [value for key, value in self.added_tokens_encoder.items() if self.timestamp_pat.match(key)]
-        return max(timestamp_ids)
-
     def get_vocab(self):
         vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
         vocab.update(self.added_tokens_encoder)

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -218,7 +218,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_tokens = self._is_timestamp_token(token_ids)
+        timestamp_tokens = np.array([self._is_timestamp_token(tok) for tok in token_ids])
 
         consecutive = np.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0] + 1
         if consecutive.shape[0] == 0 and timestamp_tokens.sum() <= 1:
@@ -622,4 +622,4 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
 
     def _is_timestamp_token(self, token_id) -> bool:
         token = self.convert_ids_to_tokens(int(token_id))
-        return self.timestamp_pat.match(token)
+        return bool(self.timestamp_pat.match(token))

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -147,7 +147,6 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         self.task = task
         self.predict_timestamps = predict_timestamps
 
-
     # Copied from transformers.models.gpt2.tokenization_gpt2_fast.GPT2TokenizerFast._batch_encode_plus
     def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:
         is_split_into_words = kwargs.get("is_split_into_words", False)
@@ -620,7 +619,7 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         if isinstance(token_ids, np.ndarray):
             token_ids = token_ids.tolist()
         return token_ids
-    
+
     def _is_timestamp_token(self, token_id) -> bool:
         token = self.convert_ids_to_tokens(int(token_id))
         return self.timestamp_pat.match(token)

--- a/src/transformers/models/whisper/tokenization_whisper_fast.py
+++ b/src/transformers/models/whisper/tokenization_whisper_fast.py
@@ -147,6 +147,11 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         self.task = task
         self.predict_timestamps = predict_timestamps
 
+    @property
+    def timestamp_end(self) -> int:
+        timestamp_ids = [value for key, value in self.added_tokens_encoder.items() if self.timestamp_pat.match(key)]
+        return max(timestamp_ids)
+
     # Copied from transformers.models.gpt2.tokenization_gpt2_fast.GPT2TokenizerFast._batch_encode_plus
     def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:
         is_split_into_words = kwargs.get("is_split_into_words", False)
@@ -175,13 +180,14 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         given tokens with timestamps tokens annotated, e.g. "<|1.08|>".
         """
         timestamp_begin = self.all_special_ids[-1] + 1
+        timestamp_end = self.timestamp_end
         outputs = [[]]
 
         cur_max_timestamp = 0.0
         prev_segments_len = 0.0
 
         for token in token_ids:
-            if token >= timestamp_begin:
+            if timestamp_begin <= token <= timestamp_end:
                 timestamp = float((token - timestamp_begin) * time_precision)
 
                 if timestamp < cur_max_timestamp:
@@ -218,7 +224,8 @@ class WhisperTokenizerFast(PreTrainedTokenizerFast):
         if token_ids.shape[0] > 1 and len(token_ids.shape) > 1:
             raise ValueError("Can only process a single input at a time")
         timestamp_begin = self.all_special_ids[-1] + 1
-        timestamp_tokens = token_ids >= timestamp_begin
+        timestamp_end = self.timestamp_end
+        timestamp_tokens = (timestamp_begin <= token_ids) & (token_ids <= timestamp_end)
 
         consecutive = np.where(timestamp_tokens[:-1] & timestamp_tokens[1:])[0] + 1
         if consecutive.shape[0] == 0 and timestamp_tokens.sum() <= 1:


### PR DESCRIPTION
# What does this PR do?

Fixes #33082 #35330.

### Description of the issue

Transformers' `PretTrainedTokenizer` [`_add_tokens`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/tokenization_utils.py#L510) add tokens at the end of the vocabulary. Likewise, `PreTrainedModel`'s [`_get_resized_embeddings`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/modeling_utils.py#L2080) will add newly initialized tokens at the end. This behavior is not compatible with Whisper's timestamp token identification. Indeed, official implementation as well as Transformer's one identifies timestamp tokens as the ones that have an id > `timestamp_begin`. For this reason, the newly added tokens are falsely considered timestamps and this poses decoding issues. 

###  Implementation possibilities

Two possibilities here: 
1. change Whisper's decoding logic using a timestamp_end
2. overwrite  [`_add_tokens`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/tokenization_utils.py#L510)  and [`_get_resized_embeddings`](https://github.com/huggingface/transformers/blob/ce62a41880b5b70a304d068eb58f55894a5a7af8/src/transformers/modeling_utils.py#L2080) in order to add new tokens before the first timestamp token (and not at the end as current implementation)

I chose option 1 to avoid overwriting the default methods of the Transformers library, focusing instead on modifying the Whisper-specific generation method and tokenizer logic.

## Implementation decision (see below discussion for details)

In the updated implementation, Whisper will now use both `timestamp_begin` and `timestamp_end`, instead of just `timestamp_begin` as in OpenAI’s original version.

**→  Justification:**

**what is the best for the users (least amount of work for them)**

We have two scenarios:

1.	Adding text tokens.
2.	Adding timestamp tokens.

These cases overlap, as both types of tokens must be added via the add_tokens method. For the system to work seamlessly:

- Text tokens should be inserted before the first timestamp token (Case 1).
- Timestamp tokens should be added at the end of the vocabulary (Case 2).

To handle Case 1, modifying the `add_tokens` method would also require changes to the `resize_token_embedding`. From a simplicity perspective, deviating from the standard implementation of these methods complicates things unnecessarily.

Since Case 1 is more common, we should prioritize simplifying it for the user. Hardcoding a default number of timestamp tokens achieves this, and the `number_timestamp_tokens` config option easily accommodates Case 2 for the few users who need it.

As for the tokenizer, the regex pattern currently used to detect timestamps prevents the use of custom timestamp tokens (meaning with a custom syntax not matching the pattern). However, since this is a rare use case and the current implementation already depends on regex, it’s best to keep things simple and do it this way.

## Who can review?

@ylacombe 

# TODO 

- [x] discuss different implementations and choose 
- [ ] add tests before merging