### PR TITLE
Generate: assistant should sample when the main model samples

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -160,12 +160,6 @@ class AssistedCandidateGenerator(CandidateGenerator):
         self.generation_config.output_scores = True
         self.generation_config.assistant_confidence_threshold = self.assistant_confidence_threshold
 
-        # Disable sampling -- this implementation of assisted generation/speculative decoding uses the assistant
-        # greedily to maximize matches. Disables sampling-related flags to prevent warnings
-        self.generation_config.do_sample = False
-        for attr in ("temperature", "top_p", "min_p", "typical_p", "top_k", "epsilon_cutoff", "eta_cutoff"):
-            setattr(self.generation_config, attr, None)
-
         # avoid unnecessary warnings that min_length is larger than max_new_tokens
         # remove the `MinLengthLogitsProcessor` if exists (NOTE: no need to check for `MinNewTokensLogitsProcessor`)
         self.main_model_min_length = self.generation_config.min_length


### PR DESCRIPTION
# What does this PR do?

Fixes #32867 

TL;DR in assisted generation, the assistant model must sample when the main model is sampling. Otherwise, mathematical properties in the corresponding code path do not hold (see speculative decoding paper).

This reverts #30778, where I forced the assistant model to always run greedy decoding for speed purposes (more matched candidate tokens = faster).