### PR TITLE
Cleanup return_text and return_full_text options in TextGenerationPipeline

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -173,17 +173,17 @@ class TextGenerationPipeline(Pipeline):
         forward_params = generate_kwargs
 
         postprocess_params = {}
-        if return_full_text is not None and return_type is None:
-            if return_tensors is not None:
-                raise ValueError("`return_full_text` is mutually exclusive with `return_tensors`")
-            return_type = ReturnType.FULL_TEXT
-        elif return_text is not None and return_type is None:
-            if return_tensors is not None:
-                raise ValueError("`return_text` is mutually exclusive with `return_tensors`")
-            return_type = ReturnType.NEW_TEXT
-        if return_tensors is not None and return_type is None:
-            # No incompatibility error needed here because it should already be caught above
+        if return_type is not None and (return_text is not None or return_full_text is not None or return_tensors is not None):
+            raise ValueError("`return_type` is mutually exclusive with `return_text`, `return_full_text`, and `return_tensors`")
+        if return_tensors is not None:
+            if return_text or return_full_text:
+                raise ValueError("`return_text` and `return_full_text` are mutually exclusive with `return_tensors`")
             return_type = ReturnType.TENSORS
+        elif return_full_text and return_type is None:
+            return_type = ReturnType.FULL_TEXT
+        elif (return_text or return_full_text == False) and return_type is None:
+            return_type = ReturnType.NEW_TEXT
+
         if return_type is not None:
             postprocess_params["return_type"] = return_type
         if clean_up_tokenization_spaces is not None:

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -174,14 +174,15 @@ class TextGenerationPipeline(Pipeline):
 
         postprocess_params = {}
         if return_full_text is not None and return_type is None:
-            if return_text is not None:
-                raise ValueError("`return_text` is mutually exclusive with `return_full_text`")
             if return_tensors is not None:
                 raise ValueError("`return_full_text` is mutually exclusive with `return_tensors`")
-            return_type = ReturnType.FULL_TEXT if return_full_text else ReturnType.NEW_TEXT
-        if return_tensors is not None and return_type is None:
-            if return_text is not None:
+            return_type = ReturnType.FULL_TEXT
+        elif return_text is not None and return_type is None:
+            if return_tensors is not None:
                 raise ValueError("`return_text` is mutually exclusive with `return_tensors`")
+            return_type = ReturnType.NEW_TEXT
+        if return_tensors is not None and return_type is None:
+            # No incompatibility error needed here because it should already be caught above
             return_type = ReturnType.TENSORS
         if return_type is not None:
             postprocess_params["return_type"] = return_type
@@ -223,13 +224,13 @@ class TextGenerationPipeline(Pipeline):
                 of dicts with "role" and "content" keys, can be passed, or a list of such chats. When chats are passed,
                 the model's chat template will be used to format them before passing them to the model.
             return_tensors (`bool`, *optional*, defaults to `False`):
-                Whether or not to return the tensors of predictions (as token indices) in the outputs. If set to
+                Returns the tensors of predictions (as token indices) in the outputs. If set to
                 `True`, the decoded text is not returned.
             return_text (`bool`, *optional*, defaults to `True`):
-                Whether or not to return the decoded texts in the outputs.
+                Returns the decoded texts in the outputs.
             return_full_text (`bool`, *optional*, defaults to `True`):
-                If set to `False` only added text is returned, otherwise the full text is returned. Only meaningful if
-                *return_text* is set to True.
+                Returns the full text, including the prompt and the decoded output. This option
+                overrides `return_text`.
             clean_up_tokenization_spaces (`bool`, *optional*, defaults to `True`):
                 Whether or not to clean up the potential extra spaces in the text output.
             continue_final_message( `bool`, *optional*): This indicates that you want the model to continue the

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -173,17 +173,21 @@ class TextGenerationPipeline(Pipeline):
         forward_params = generate_kwargs
 
         postprocess_params = {}
-        if return_type is not None and (return_text is not None or return_full_text is not None or return_tensors is not None):
-            raise ValueError("`return_type` is mutually exclusive with `return_text`, `return_full_text`, and `return_tensors`")
+        if return_type is not None and (
+            return_text is not None or return_full_text is not None or return_tensors is not None
+        ):
+            raise ValueError(
+                "`return_type` is mutually exclusive with `return_text`, `return_full_text`, and `return_tensors`"
+            )
         if return_tensors is not None:
             if return_text or return_full_text:
                 raise ValueError("`return_text` and `return_full_text` are mutually exclusive with `return_tensors`")
             return_type = ReturnType.TENSORS
         elif return_full_text and return_type is None:
             return_type = ReturnType.FULL_TEXT
-        elif (return_text or return_full_text == False) and return_type is None:
+        elif (return_text or return_full_text is not None) and return_type is None:
+            # Explicitly setting return_full_text = False is caught here, and results in ReturnType.NEW_TEXT
             return_type = ReturnType.NEW_TEXT
-
         if return_type is not None:
             postprocess_params["return_type"] = return_type
         if clean_up_tokenization_spaces is not None:

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -436,6 +436,8 @@ class TextGenerationPipelineTests(unittest.TestCase):
             )
 
         with self.assertRaises(ValueError):
+            outputs = text_generator("test", return_full_text=True, return_text=True)
+        with self.assertRaises(ValueError):
             outputs = text_generator("test", return_full_text=True, return_tensors=True)
         with self.assertRaises(ValueError):
             outputs = text_generator("test", return_text=True, return_tensors=True)

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -436,8 +436,6 @@ class TextGenerationPipelineTests(unittest.TestCase):
             )
 
         with self.assertRaises(ValueError):
-            outputs = text_generator("test", return_full_text=True, return_text=True)
-        with self.assertRaises(ValueError):
             outputs = text_generator("test", return_full_text=True, return_tensors=True)
         with self.assertRaises(ValueError):
             outputs = text_generator("test", return_text=True, return_tensors=True)


### PR DESCRIPTION
The extra options in `TextGenerationPipeline` right now are confusing and poorly documented. This PR refactors things so that the documentation is clearer. It also creates a proper hierarchy of options (`return_full_text` overrides and ignores `return_text`, and `return_tensors` is incompatible with both)

Before this PR, the documentation was incorrect, as it claimed that `return_full_text` required `return_text`, whereas actually these options were not compatible with each other!

Behaviour after the change should be mostly unchanged, with the exception that `return_full_text` overrides `return_text` if both are set, rather than raising an error. The test that checked for those two options being incompatible has been removed.

Fixes #33535