### PR TITLE
Fix bnb dequantization 

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -437,6 +437,7 @@ def _dequantize_and_replace(
 
                 new_module.to(device)
                 model._modules[name] = new_module
+                has_been_replaced = True
         if len(list(module.children())) > 0:
             _, has_been_replaced = _dequantize_and_replace(
                 module,


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a small error on how dequantization is handled in bnb. We need to set `has_been_replaced` to `True` if the dequantization happens. 

Fixes an issue raised by @sayakpaul 