### PR TITLE
Added support for bfloat16 to zero-shot classification pipeline

### DIFF
--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -240,7 +240,10 @@ class ZeroShotClassificationPipeline(ChunkPipeline):
     def postprocess(self, model_outputs, multi_label=False):
         candidate_labels = [outputs["candidate_label"] for outputs in model_outputs]
         sequences = [outputs["sequence"] for outputs in model_outputs]
-        logits = np.concatenate([output["logits"].astype(torch.float32).numpy() for output in model_outputs])
+        if self.framework == "pt":
+            logits = np.concatenate([output["logits"].float().numpy() for output in model_outputs])
+        else:
+            logits = np.concatenate([output["logits"].numpy() for output in model_outputs])
         N = logits.shape[0]
         n = len(candidate_labels)
         num_sequences = N // n

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -1,7 +1,6 @@
 import inspect
 from typing import List, Union
 
-import torch
 import numpy as np
 
 from ..tokenization_utils import TruncationStrategy

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import List, Union
 
+import torch
 import numpy as np
 
 from ..tokenization_utils import TruncationStrategy
@@ -239,7 +240,7 @@ class ZeroShotClassificationPipeline(ChunkPipeline):
     def postprocess(self, model_outputs, multi_label=False):
         candidate_labels = [outputs["candidate_label"] for outputs in model_outputs]
         sequences = [outputs["sequence"] for outputs in model_outputs]
-        logits = np.concatenate([output["logits"].numpy() for output in model_outputs])
+        logits = np.concatenate([output["logits"].astype(torch.float32).numpy() for output in model_outputs])
         N = logits.shape[0]
         n = len(candidate_labels)
         num_sequences = N // n


### PR DESCRIPTION
This PR fixes #33386 and adds support for models that output logits in `torch.bfloat16` in the zero-shot classification pipeline by casting logits to `torch.float32` before they are converted to `numpy` floats (instead of attempting a direct conversion, which is currently not possible and raises `TypeError: Got unsupported ScalarType BFloat16`).

@Rocketknight1