### PR TITLE
[tests] enable GemmaIntegrationTest on XPU 

### DIFF
--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -528,7 +528,7 @@ class GemmaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
 
 @slow
-@require_torch_gpu
+@require_torch_accelerator
 class GemmaIntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
     # This variable is used to determine which CUDA device are we using for our runners (A10 or T4)
@@ -748,7 +748,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-
         self.assertEqual(output_text, EXPECTED_TEXTS[self.cuda_compute_capability_major_version])
 
     @require_read_token
@@ -770,10 +769,8 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(torch_device)
-
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_bitsandbytes


### PR DESCRIPTION
## What does this PR do?
Below are the test results on XPU. There are some tests failed, because the generated text don't exactly match the expected tests due to precision issues. We will take a look into it, but I think `GemmaIntegrationTest` should also run on non-cuda devices. 

```bash
================================================= short test summary info =================================================
PASSED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_bf16
PASSED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_fp16
PASSED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_sdpa
SKIPPED [1] tests/models/gemma/test_modeling_gemma.py:794: test requires CUDA
SKIPPED [1] tests/models/gemma/test_modeling_gemma.py:655: test requires bitsandbytes and torch
SKIPPED [1] tests/models/gemma/test_modeling_gemma.py:632: test requires Flash Attention
SKIPPED [1] tests/models/gemma/test_modeling_gemma.py:776: test requires bitsandbytes and torch
SKIPPED [1] tests/models/gemma/test_modeling_gemma.py:674: The test will not fit our CI runners
FAILED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_bf16_dola - AssertionError: Lists differ: ['Hel[64 chars] The only tool we have is a scale', 'Hi today [58 chars] of'] != ['Hel[64...
FAILED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_2b_eager - AssertionError: Lists differ: ['Hel[117 chars]ith you a very easy and simple recipe of <strong><em>Kaju Kat'] != ['Hel...
FAILED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_7b_bf16 - KeyError: None
FAILED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_7b_fp16 - AssertionError: Lists differ: ['Hel[27 chars]a 1995 4.0L 4x4. I', 'Hi today I am going to s[51 chars] 3D'] != ['Hel[27...
FAILED tests/models/gemma/test_modeling_gemma.py::GemmaIntegrationTest::test_model_7b_fp16_static_cache - AssertionError: Lists differ: ['Hel[27 chars]a 1995 4.0L 4x4. I', 'Hi today I am going to s[51 chars] 3D'] != ['Hel[27...
============================= 5 failed, 3 passed, 5 skipped, 2 warnings in 126.64s (0:02:06) ==============================
```