### PR TITLE
Enable multi-GPU in object detection

### DIFF
--- a/examples/pytorch/object-detection/README.md
+++ b/examples/pytorch/object-detection/README.md
@@ -51,8 +51,9 @@ accelerate launch run_object_detection.py \
     --gradient_accumulation_steps 1 \
     --remove_unused_columns false \
     --eval_do_concat_batches false \
+    --eval_use_gather_object true \
     --ignore_mismatched_sizes true \
-    --metric_for_best_model epoch \
+    --metric_for_best_model eval_map \
     --greater_is_better true \
     --load_best_model_at_end true \
     --logging_strategy epoch \
@@ -66,7 +67,7 @@ accelerate launch run_object_detection.py \
 ```
 
 > Note:  
-`--eval_do_concat_batches false` is required for correct evaluation of detection models;  
+`--eval_do_concat_batches false` and `--eval_use_gather_object true` are required for correct evaluation of detection models;
 `--ignore_mismatched_sizes true` is required to load detection model for finetuning with different number of classes.
 
 The resulting model can be seen here: https://huggingface.co/qubvel-hf/qubvel-hf/detr-resnet-50-finetuned-10k-cppe5. The corresponding Weights and Biases report [here](https://api.wandb.ai/links/qubvel-hf-co/bnm0r5ex). Note that it's always advised to check the original paper to know the details regarding training hyperparameters. Hyperparameters for current example were not tuned. To improve model quality you could try:

--- a/examples/pytorch/object-detection/README.md
+++ b/examples/pytorch/object-detection/README.md
@@ -34,7 +34,7 @@ The script leverages the [🤗 Trainer API](https://huggingface.co/docs/transfor
 Here we show how to fine-tune a [DETR](https://huggingface.co/facebook/detr-resnet-50) model on the [CPPE-5](https://huggingface.co/datasets/cppe-5) dataset:
 
 ```bash
-python run_object_detection.py \
+accelerate launch run_object_detection.py \
     --model_name_or_path facebook/detr-resnet-50 \
     --dataset_name cppe-5 \
     --do_train true \
@@ -52,7 +52,7 @@ python run_object_detection.py \
     --remove_unused_columns false \
     --eval_do_concat_batches false \
     --ignore_mismatched_sizes true \
-    --metric_for_best_model eval_map \
+    --metric_for_best_model epoch \
     --greater_is_better true \
     --load_best_model_at_end true \
     --logging_strategy epoch \

--- a/examples/pytorch/object-detection/run_object_detection.py
+++ b/examples/pytorch/object-detection/run_object_detection.py
@@ -16,7 +16,6 @@
 """Finetuning any 🤗 Transformers model supported by AutoModelForObjectDetection for object detection leveraging the Trainer API."""
 
 import logging
-import math
 import os
 import sys
 from dataclasses import dataclass, field
@@ -38,7 +37,6 @@ from transformers import (
     HfArgumentParser,
     Trainer,
     TrainingArguments,
-    get_scheduler,
 )
 from transformers.image_processing_utils import BatchFeature
 from transformers.image_transforms import center_to_corners_format
@@ -180,8 +178,6 @@ def compute_metrics(
     """
 
     predictions, targets = evaluation_results.predictions, evaluation_results.label_ids
-    print('predictions', predictions, targets)
-    print('evaluation_results', evaluation_results)
 
     # For metric computation we need to provide:
     #  - targets in a form of list of dictionaries with keys "boxes", "labels"
@@ -208,8 +204,11 @@ def compute_metrics(
     # Collect predictions in the required format for metric computation,
     # model produce boxes in YOLO format, then image_processor convert them to Pascal VOC format
     for batch, target_sizes in zip(predictions, image_sizes):
-        batch_logits, batch_boxes = batch[1], batch[2]
-        output = ModelOutput(logits=torch.tensor(batch_logits), pred_boxes=torch.tensor(batch_boxes))
+        nested_integer = len(batch) // len(target_sizes)
+        batch_logits, batch_boxes = batch[1::nested_integer], batch[2::nested_integer]
+        output = ModelOutput(
+            logits=torch.tensor(batch_logits).squeeze(1), pred_boxes=torch.tensor(batch_boxes).squeeze(1)
+        )
         post_processed_output = image_processor.post_process_object_detection(
             output, threshold=threshold, target_sizes=target_sizes
         )
@@ -352,7 +351,9 @@ def main():
         accelerator_log_kwargs["log_with"] = training_args.report_to
         accelerator_log_kwargs["project_dir"] = training_args.output_dir
 
-    accelerator = Accelerator(gradient_accumulation_steps=training_args.gradient_accumulation_steps, **accelerator_log_kwargs)
+    accelerator = Accelerator(
+        gradient_accumulation_steps=training_args.gradient_accumulation_steps, **accelerator_log_kwargs
+    )
 
     # Setup logging
     logging.basicConfig(
@@ -487,9 +488,10 @@ def main():
         augment_and_transform_batch, transform=validation_transform, image_processor=image_processor
     )
 
-    dataset["train"] = dataset["train"].with_transform(train_transform_batch)
-    dataset["validation"] = dataset["validation"].with_transform(validation_transform_batch)
-    dataset["test"] = dataset["test"].with_transform(validation_transform_batch)
+    with accelerator.main_process_first():
+        dataset["train"] = dataset["train"].with_transform(train_transform_batch)
+        dataset["validation"] = dataset["validation"].with_transform(validation_transform_batch)
+        dataset["test"] = dataset["test"].with_transform(validation_transform_batch)
 
     # ------------------------------------------------------------------------------------------------
     # Prepare everything with the accelerator
@@ -507,6 +509,7 @@ def main():
     eval_compute_metrics_fn = partial(
         compute_metrics, image_processor=image_processor, id2label=id2label, threshold=0.0
     )
+    training_args.label_names = ["labels"]
 
     trainer = Trainer(
         model=model,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3442,6 +3442,7 @@ class Trainer:
             `torch.Tensor`: The tensor with training loss on this batch.
         """
         model.train()
+
         if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
             self.optimizer.train()
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/33525

This is the concept of the PR that fundamentally fixes the following multi-GPU circumstances error. The reason why I wrote as `concept` is because torchmetrics does not accept multi-gpu problem + also I want to make some code more clean.

Main keypoint is that all the `Trainer` class accept the `prediction` and `labels` as nested tensor (e.g. batch size : 4, num_gpu : 2 -> length of 8). However in order to calculate proper evaluation metric it should be shape as `batch_size`. + We should always encourage to use `accelerate` as default.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
