### PR TITLE
Flash-attn performance: remove cuda sync during inference

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -267,7 +267,8 @@ def _flash_attention_forward(
     # If position_ids is provided and check all examples do not contain only 1 sequence, If tensor in increasing
     # then we probably have one sequence, otherwise it is packed. Additionally check we are in pre-fill/training stage.
     # Use `flash_attn_varlen_func` to prevent cross-example attention and also allow padding free approach
-    elif position_ids is not None and not (torch.diff(position_ids, dim=-1) >= 0).all() and query_length != 1:
+    # Note: the `torch.diff(...)` condition is last to use short-circuit and avoid the cuda synchronization it incurs during inference (query_length == 1 always)
+    elif position_ids is not None and query_length != 1 and not (torch.diff(position_ids, dim=-1) >= 0).all():
         batch_size = query_states.size(0)
         query_states, key_states, value_states, indices_q, cu_seq_lens, max_seq_lens = prepare_fa2_from_position_ids(
             query_states, key_states, value_states, position_ids


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/31629 & https://github.com/huggingface/transformers/pull/32241 introduced a functionality in FA2 intended for training efficiency. However, it adds unnecessary cuda synchronization at inference time in every forward pass due to always checking `(torch.diff(position_ids, dim=-1) >= 0).all()`  in the `elif` condition. This PR fixes the performance issue by simply switching the order of the different checks in the `elif` condition, to make good use of Python's default short-circuit evaluation. Indeed, at inference time, `query_length` will always be 1 except during prefill, thus we will short-circuit torch synchronization all the time.

Performance degradation was not so significant, but this PR allows to win back around 5-10% speed at inference time from the quick tests I ran.
