### PR TITLE
Docs: add the ability to manually trigger jobs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -1,6 +1,7 @@
 name: Build documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
# What does this PR do?

Our doc-builder had a bug that was fixed recently (https://github.com/huggingface/doc-builder/pull/516). This bug has an impact on our docs since v4.41 -- we need to manually trigger the job to push the fixed docs.

This PR adds the ability to manually trigger the doc builder :)