### PR TITLE
Fix module initialization for root module under Zero3

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -608,7 +608,8 @@ def set_initialized_submodules(model, state_dict_keys):
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
         loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
-        if module_name == '': loaded_keys = set(state_dict_keys)
+        if module_name == "":
+            loaded_keys = set(state_dict_keys)
         if loaded_keys.issuperset(module.state_dict()):
             module._is_hf_initialized = True
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -608,7 +608,7 @@ def set_initialized_submodules(model, state_dict_keys):
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
         loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
-        # When checking if the root module is loaded use all state_dict_keys
+        # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":
             loaded_keys = set(state_dict_keys)
         if loaded_keys.issuperset(module.state_dict()):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -608,6 +608,7 @@ def set_initialized_submodules(model, state_dict_keys):
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
         loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
+        if module_name == '': loaded_keys = set(state_dict_keys)
         if loaded_keys.issuperset(module.state_dict()):
             module._is_hf_initialized = True
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -608,6 +608,7 @@ def set_initialized_submodules(model, state_dict_keys):
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
         loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
+        # When checking if the root module is loaded use all state_dict_keys
         if module_name == "":
             loaded_keys = set(state_dict_keys)
         if loaded_keys.issuperset(module.state_dict()):


### PR DESCRIPTION
# What does this PR do?
Fixes #28808

Behaviour:  
```loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}``` in ```Trainer.py``` misses the case where the module_name is the empty string (the root module), as its looking for state_dict_keys that start with ```"."```. This causes the root module (CLIPModel, AlignModel, etc.) to always have ```model.apply(model._initialize_weights)``` called on it. Which leads to initialization of an empty parameter tensor when running zero3 (that doesn't need to be initialized as it will be replaced later) in ```modeling_align.py```. The reason this causes a crash in ```modeling_align.py``` and not other models like CLIP is because ALIGN uses ```xavier_uniform_``` which asserts the tensor must be 2d whereas CLIP uses ```nn.init.normal_``` which just returns another empty tensor.

Fix:  
Use the whole state_dict as the root module's set of load_keys.

Please let me know if there is anything I should revise / this should be fixed in another way.😄 
@ArthurZucker @muellerzr

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?