### PR TITLE
Fix the bug with loading DeepSpeed MoE models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -353,6 +353,13 @@ def check_support_param_buffer_assignment(model_to_load, state_dict, start_prefi
     if is_deepspeed_zero3_enabled():
         return False
 
+    try:
+        from deepspeed.moe.utils import has_moe_layers
+        if has_moe_layers(model_to_load)[0]:
+            return False
+    except:
+        pass
+
     # Some models explicitly do not support param buffer assignment
     if not getattr(model_to_load, "_supports_param_buffer_assignment", True):
         logger.debug(


### PR DESCRIPTION
# What does this PR do?

Fix the bug with loading DeepSpeed MoE models with `from_pretrained`


# issue

When specifying the `torch_dtype` in `from_pretrained`, the weights of the MoE layers get overwritten, which causes an exception when using DeepSpeed MoE.

By adding a MoE check, we can determine whether the model contains DeepSpeed MoE layers, and if detected, set `param_buffer_assignment` to `False`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr



