### PR TITLE
Improve Error Messaging for Flash Attention 2 on CPU

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1698,6 +1698,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     raise ImportError(
                         f"{preface} you need flash_attn package version to be greater or equal than 2.1.0. Detected version {flash_attention_version}. {install_message}"
                     )
+                elif not torch.cuda.is_available():
+                    raise ValueError(
+                        f"{preface} Flash Attention 2 is not available on CPU. Please make sure torch can access a CUDA device."
+                    )
                 else:
                     raise ImportError(f"{preface} Flash Attention 2 is not available. {install_message}")
             elif torch.version.hip:


### PR DESCRIPTION
## Before submitting
- [x] This PR adds a better better error message on CPU for flash attention
Sometimes torch.version.cuda is available but due to CUDA_VISIBLE_DEVICES being empty, the current error message raised is unhelpful

Previously the message used to be 
```
FlashAttention2 has been toggled on, but it cannot be used due to the following error: Flash Attention 2 is not available.
```

Now the error message will be 
```
FlashAttention2 has been toggled on, but it cannot be used due to the following error: Flash Attention 2 is not available on CPU. Please make sure torch can access a CUDA device."
```


## Who can review?

@stevhliu
