### PR TITLE
[WIP] Sink cache: fix implementation to shift key states

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -980,7 +980,7 @@ class SinkCache(Cache):
             # Growing cache
             self.key_cache[layer_idx] = torch.cat([self.key_cache[layer_idx], key_states], dim=-2)
             self.value_cache[layer_idx] = torch.cat([self.value_cache[layer_idx], value_states], dim=-2)
-        
+
         key_cache_to_return = self.key_cache[layer_idx]
         value_cache_to_return = self.value_cache[layer_idx]
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -967,8 +967,8 @@ class SinkCache(Cache):
                     self._cos_cache = cos[0, ...]
                     self._sin_cache = sin[0, ...]
                 elif self._cos_cache.shape[0] < self.window_length + key_states.shape[-2]:
-                    self._cos_cache = torch.cat([self._cos_cache, cos[0, ...]], dim=0)
-                    self._sin_cache = torch.cat([self._sin_cache, sin[0, ...]], dim=0)
+                    self._cos_cache = torch.cat([self._cos_cache[: self.window_length], cos[0, ...]], dim=0)
+                    self._sin_cache = torch.cat([self._sin_cache[: self.window_length], sin[0, ...]], dim=0)
 
         # [bsz, num_heads, seq_len, head_dim]
         if len(self.key_cache) <= layer_idx:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -986,16 +986,16 @@ class SinkCache(Cache):
 
         # If the cache is full, we need to shift the cache
         if (seq_length := self.get_seq_length(layer_idx)) > self.window_length:
-
             # Shifting cache
-            keys_to_keep = self.key_cache[layer_idx][
-                :, :, -self.window_length + self.num_sink_tokens :
-            ]
+            keys_to_keep = self.key_cache[layer_idx][:, :, -self.window_length + self.num_sink_tokens :]
 
             # On RoPE models, we need to recompute the Key rotation as the tokens are shifted
             if using_rope:
                 rerotation_cos, rerotation_sin = self._get_rerotation_cos_sin(
-                    seq_length - self.window_length, key_states.dtype, self._cos_cache[: seq_length], self._sin_cache[: seq_length]
+                    seq_length - self.window_length,
+                    key_states.dtype,
+                    self._cos_cache[:seq_length],
+                    self._sin_cache[:seq_length],
                 )
                 if partial_rotation_size is not None:
                     keys_to_keep, keys_pass = (
@@ -1011,9 +1011,7 @@ class SinkCache(Cache):
             self.key_cache[layer_idx] = torch.cat([sink_keys, keys_to_keep], dim=-2)
 
             sink_values = self.value_cache[layer_idx][:, :, : self.num_sink_tokens]
-            values_to_keep = self.value_cache[layer_idx][
-                :, :, -self.window_length + self.num_sink_tokens :
-            ]
+            values_to_keep = self.value_cache[layer_idx][:, :, -self.window_length + self.num_sink_tokens :]
             self.value_cache[layer_idx] = torch.cat([sink_values, values_to_keep], dim=-2)
 
         return key_cache_to_return, value_cache_to_return

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -1226,6 +1226,18 @@ class CohereForCausalLM(CoherePreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -1136,6 +1136,18 @@ class GemmaForCausalLM(GemmaPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1261,6 +1261,18 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1137,6 +1137,18 @@ class NemotronForCausalLM(NemotronPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -1179,6 +1179,18 @@ class OlmoForCausalLM(OlmoPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/olmoe/modeling_olmoe.py
+++ b/src/transformers/models/olmoe/modeling_olmoe.py
@@ -1348,6 +1348,18 @@ class OlmoeForCausalLM(OlmoePreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -1004,6 +1004,18 @@ class PersimmonForCausalLM(PersimmonPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -1303,6 +1303,18 @@ class PhiForCausalLM(PhiPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -1235,6 +1235,18 @@ class Qwen2ForCausalLM(Qwen2PreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1433,6 +1433,18 @@ class Qwen2MoeForCausalLM(Qwen2MoePreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1280,6 +1280,18 @@ class StableLmForCausalLM(StableLmPreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -1211,6 +1211,18 @@ class Starcoder2ForCausalLM(Starcoder2PreTrainedModel, GenerationMixin):
             elif input_ids.shape[1] != cache_position.shape[0]:  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
+            # If we have gone beyond the current cache length, we need to crop the input attention mask.
+            total_length = attention_mask.shape[1]
+            # XXX: It seems that Cache.get_seq_length() will be deprecated and replaced by cache_position, but
+            # it is NOT consistent with cache_position
+            cur_cache_length = past_key_values.get_seq_length()
+            if (
+                cur_cache_length is not None
+                and attention_mask is not None
+                and total_length > cur_cache_length + input_ids.shape[1]
+            ):
+                attention_mask = attention_mask[:, -cur_cache_length - input_ids.shape[1] :]
+
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation
             position_ids = attention_mask.long().cumsum(-1) - 1


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #33691

This PR shifts the new key states along with those already in the cache. It could also solve some issues mentioned in #31537, #32315, where the initial input key states are longer than the context window or shorter than the attn sink.

I hope it could better explain the issue in #33691.

It does not solve the issue that the new key states have large positional encodings (See #33691 the last few lines). So it still does not work with `model.generate`. Once this is fixed, the model will be able to generate tokens very well.

Also, it will be better if we can come up with some good tests. E.g. re-design key state so that it takes the actual positional encoding as its attributes in the test?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->

@ArthurZucker @zucchini-nlp @gante
I didn't finish up reading all the previous discussions (it's too long)... But I know you should be very familiar about this.