### PR TITLE
Update modeling_longformer.py so it can be converted to onnx format using Pytorch.

### DIFF
--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -528,7 +528,7 @@ class LongformerSelfAttention(nn.Module):
         layer_head_mask=None,
         is_index_masked=None,
         is_index_global_attn=None,
-        is_global_attn=None,
+        is_global_attn=False,
         output_attentions=False,
     ):
         """
@@ -589,7 +589,7 @@ class LongformerSelfAttention(nn.Module):
         )
 
         # compute local attention probs from global attention keys and contact over window dim
-        if is_global_attn:
+        if is_global_attn == True:
             # compute global attn indices required through out forward fn
             (
                 max_num_global_attn_indices,
@@ -637,7 +637,7 @@ class LongformerSelfAttention(nn.Module):
         value_vectors = value_vectors.view(seq_len, batch_size, self.num_heads, self.head_dim).transpose(0, 1)
 
         # compute local attention output with global attention value and add
-        if is_global_attn:
+        if is_global_attn == True:
             # compute sum of global and local attn
             attn_output = self._compute_attn_output_with_global_indices(
                 value_vectors=value_vectors,
@@ -657,7 +657,7 @@ class LongformerSelfAttention(nn.Module):
 
         # compute value for global attention and overwrite to attention output
         # TODO: remove the redundant computation
-        if is_global_attn:
+        if is_global_attn == True:
             global_attn_output, global_attn_probs = self._compute_global_attn_output_from_hidden(
                 hidden_states=hidden_states,
                 max_num_global_attn_indices=max_num_global_attn_indices,
@@ -687,7 +687,7 @@ class LongformerSelfAttention(nn.Module):
         if output_attentions:
             outputs += (attn_probs,)
 
-        return outputs + (global_attn_probs,) if (is_global_attn and output_attentions) else outputs
+        return outputs + (global_attn_probs,) if (is_global_attn == True and output_attentions) else outputs
 
     @staticmethod
     def _pad_and_transpose_last_two_dims(hidden_states_padded, padding):

--- a/src/transformers/models/longformer/modeling_longformer.py
+++ b/src/transformers/models/longformer/modeling_longformer.py
@@ -589,7 +589,7 @@ class LongformerSelfAttention(nn.Module):
         )
 
         # compute local attention probs from global attention keys and contact over window dim
-        if is_global_attn == True:
+        if is_global_attn is not None and is_global_attn:
             # compute global attn indices required through out forward fn
             (
                 max_num_global_attn_indices,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In longformer model,  the original 'is_global_attn=None' can works, but when using torch.onnx.export() it will be failed when meet the below line `if is_global_attn:` 
So I need to change it to explicitly checking like 'if is_global_attn == True:', also set the default value as False in signature 'is_global_attn=False'.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
      No, it is tiny code fix.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
      No related issue. I try to convert the model to onnx but failed, so make some tiny change.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
  It don't need to change document.
- [ ] Did you write any new necessary tests?
 No necessary test need because it is a tiny fix.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
