### PR TITLE
Generate using exported model and enable gemma2-2b in ExecuTorch

### DIFF
--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -114,6 +114,56 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
         )
         return outs.logits
 
+    @staticmethod
+    def generate(
+        exported_program: torch.export.ExportedProgram, prompt_token_ids: torch.Tensor, max_new_tokens: int
+    ) -> torch.Tensor:
+        """
+        Generate a sequence of tokens using an exported program.
+
+        This util function is designed to test exported models by simulating the generation process.
+        It processes the input prompt tokens sequentially (no parallel prefill).
+        This generate function is not intended to replace the original `generate` method, and the support
+        for leveraging the original `generate` is potentially planed!
+
+        Args:
+            exported_program (`torch.export.ExportedProgram`): The exported program generated via `torch.export`.
+            prompt_token_ids (`torch.Tensor`): Tensor representing the input prompt token IDs.
+            max_new_tokens (`int`): Maximum number of new tokens to generate. Note that the total generation
+                length is limited by both `max_new_tokens` and the model's cache size.
+
+        Returns:
+            torch.Tensor: A tensor containing the generated sequence of token IDs, including the original prompt tokens.
+        """
+        prompt_token_len = prompt_token_ids.shape[-1]
+        max_generation_length = prompt_token_len + max_new_tokens
+        for buffer_name, buffer in exported_program.named_buffers():
+            if buffer_name.startswith("static_cache.key_cache"):
+                max_cache_len = buffer.shape[2]
+                max_generation_length = min(max_generation_length, max_cache_len)
+                break
+
+        response_tokens = []
+        for input_pos in range(min(max_generation_length, prompt_token_len)):
+            result = exported_program.module().forward(
+                input_ids=prompt_token_ids[:, input_pos : input_pos + 1],
+                cache_position=torch.tensor([input_pos], dtype=torch.long),
+            )
+            response_tokens.append(prompt_token_ids[0][input_pos].item())
+
+        current_token = torch.argmax(result[:, -1, :], dim=-1).item()
+        response_tokens.append(current_token)
+
+        while len(response_tokens) < max_generation_length:
+            result = exported_program.module().forward(
+                input_ids=torch.tensor([[current_token]], dtype=torch.long),
+                cache_position=torch.tensor([len(response_tokens)], dtype=torch.long),
+            )
+            current_token = torch.argmax(result[:, -1, :], dim=-1).item()
+            response_tokens.append(current_token)
+
+        return torch.tensor([response_tokens], dtype=torch.long)
+
 
 def convert_and_export_with_cache(
     model: PreTrainedModel,

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -845,7 +845,7 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained("google/gemma-2b", pad_token="</s>", padding_side="right")
         EXPECTED_TEXT_COMPLETION = [
-            "Hello I am doing a project on the 1990s and I need to know what the most popular music was in the 1990s. I have looked on the internet and I have found a few things but I need more. I have found that the most popular music was rap",
+            "Hello I am doing a project on the 1990s and I need to know what the most popular music was in the 1990s. I have looked on the internet and I have found",
         ]
         max_generation_length = tokenizer(EXPECTED_TEXT_COMPLETION, return_tensors="pt", padding=True)[
             "input_ids"

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -21,6 +21,7 @@ import pytest
 from packaging import version
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, GemmaConfig, is_torch_available
+from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     is_flaky,
     require_bitsandbytes,
@@ -830,6 +831,67 @@ class GemmaIntegrationTest(unittest.TestCase):
         )
         static_compiled_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, static_compiled_text)
+
+    @slow
+    @require_read_token
+    def test_export_static_cache(self):
+        if version.parse(torch.__version__) < version.parse("2.3.0"):
+            self.skipTest(reason="This test requires torch >= 2.3 to run.")
+
+        from transformers.integrations.executorch import (
+            TorchExportableModuleWithStaticCache,
+            convert_and_export_with_cache,
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained("google/gemma-2b", pad_token="</s>", padding_side="right")
+        EXPECTED_TEXT_COMPLETION = [
+            "Hello I am doing a project on the 1990s and I need to know what the most popular music was in the 1990s. I have looked on the internet and I have found a few things but I need more. I have found that the most popular music was rap",
+        ]
+        max_generation_length = tokenizer(EXPECTED_TEXT_COMPLETION, return_tensors="pt", padding=True)[
+            "input_ids"
+        ].shape[-1]
+
+        # Load model
+        device = "cpu"
+        dtype = torch.bfloat16
+        cache_implementation = "static"
+        attn_implementation = "sdpa"
+        batch_size = 1
+        model = GemmaForCausalLM.from_pretrained(
+            "google/gemma-2b",
+            device_map=device,
+            torch_dtype=dtype,
+            attn_implementation=attn_implementation,
+            generation_config=GenerationConfig(
+                use_cache=True,
+                cache_implementation=cache_implementation,
+                max_length=max_generation_length,
+                cache_config={
+                    "batch_size": batch_size,
+                    "max_cache_len": max_generation_length,
+                },
+            ),
+        )
+
+        prompts = ["Hello I am doing"]
+        prompt_tokens = tokenizer(prompts, return_tensors="pt", padding=True).to(model.device)
+        prompt_token_ids = prompt_tokens["input_ids"]
+        max_new_tokens = max_generation_length - prompt_token_ids.shape[-1]
+
+        # Static Cache + eager
+        eager_generated_ids = model.generate(
+            **prompt_tokens, max_new_tokens=max_new_tokens, do_sample=False, cache_implementation=cache_implementation
+        )
+        eager_generated_text = tokenizer.batch_decode(eager_generated_ids, skip_special_tokens=True)
+        self.assertEqual(EXPECTED_TEXT_COMPLETION, eager_generated_text)
+
+        # Static Cache + export
+        exported_program = convert_and_export_with_cache(model)
+        ep_generated_ids = TorchExportableModuleWithStaticCache.generate(
+            exported_program=exported_program, prompt_token_ids=prompt_token_ids, max_new_tokens=max_new_tokens
+        )
+        ep_generated_text = tokenizer.batch_decode(ep_generated_ids, skip_special_tokens=True)
+        self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
     def test_model_2b_bf16_dola(self):
         model_id = "google/gemma-2b"

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -312,8 +312,8 @@ class Gemma2IntegrationTest(unittest.TestCase):
     @slow
     @require_read_token
     def test_export_static_cache(self):
-        if version.parse(torch.__version__) < version.parse("2.3.0"):
-            self.skipTest(reason="This test requires torch >= 2.3 to run.")
+        if version.parse(torch.__version__) < version.parse("2.5.0"):
+            self.skipTest(reason="This test requires torch >= 2.5 to run.")
 
         from transformers.integrations.executorch import (
             TorchExportableModuleWithStaticCache,

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -16,10 +16,12 @@
 
 import unittest
 
+from packaging import version
 from parameterized import parameterized
 from pytest import mark
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, Gemma2Config, HybridCache, is_torch_available, pipeline
+from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     require_flash_attn,
     require_read_token,
@@ -306,3 +308,57 @@ class Gemma2IntegrationTest(unittest.TestCase):
         output_text = tokenizer.batch_decode(output, skip_special_tokens=False)
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
+
+    @slow
+    @require_read_token
+    def test_export_static_cache(self):
+        if version.parse(torch.__version__) < version.parse("2.3.0"):
+            self.skipTest(reason="This test requires torch >= 2.3 to run.")
+
+        from transformers.integrations.executorch import (
+            TorchExportableModuleWithStaticCache,
+            convert_and_export_with_cache,
+        )
+
+        tokenizer = AutoTokenizer.from_pretrained("google/gemma-2-2b", pad_token="</s>", padding_side="right")
+        EXPECTED_TEXT_COMPLETION = [
+            "Hello I am doing a project for my school and I need to know how to make a program that will take a number",
+        ]
+        max_generation_length = tokenizer(EXPECTED_TEXT_COMPLETION, return_tensors="pt", padding=True)[
+            "input_ids"
+        ].shape[-1]
+
+        # Load model
+        device = "cpu"
+        dtype = torch.bfloat16
+        cache_implementation = "static"
+        attn_implementation = "sdpa"
+        batch_size = 1
+        model = AutoModelForCausalLM.from_pretrained(
+            "google/gemma-2-2b",
+            device_map=device,
+            torch_dtype=dtype,
+            attn_implementation=attn_implementation,
+            generation_config=GenerationConfig(
+                use_cache=True,
+                cache_implementation=cache_implementation,
+                max_length=max_generation_length,
+                cache_config={
+                    "batch_size": batch_size,
+                    "max_cache_len": max_generation_length,
+                },
+            ),
+        )
+
+        prompts = ["Hello I am doing"]
+        prompt_tokens = tokenizer(prompts, return_tensors="pt", padding=True).to(model.device)
+        prompt_token_ids = prompt_tokens["input_ids"]
+        max_new_tokens = max_generation_length - prompt_token_ids.shape[-1]
+
+        # Static Cache + export
+        exported_program = convert_and_export_with_cache(model)
+        ep_generated_ids = TorchExportableModuleWithStaticCache.generate(
+            exported_program=exported_program, prompt_token_ids=prompt_token_ids, max_new_tokens=max_new_tokens
+        )
+        ep_generated_text = tokenizer.batch_decode(ep_generated_ids, skip_special_tokens=True)
+        self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)


### PR DESCRIPTION
# What does this PR do?

Adding `generate` support for exported model.
Adding `gemma2-2b` to `ExecuTorch` with tests.
Adding an integration test for `gemma-2b` that we've enabled already. 

### Additional Test in `ExecuTorch`
Running `gemma2-2b` E2E:
```
cmake-out/examples/models/llama2/llama_main --tokenizer_path=tokenizer_gemma2.bin --model_path=gemma2.pte --prompt="My name is"
I 00:00:00.001356 executorch:cpuinfo_utils.cpp:62] Reading file /sys/devices/soc0/image_version
I 00:00:00.001425 executorch:cpuinfo_utils.cpp:78] Failed to open midr file /sys/devices/soc0/image_version
I 00:00:00.001431 executorch:cpuinfo_utils.cpp:158] Number of efficient cores 4
I 00:00:00.001434 executorch:main.cpp:65] Resetting threadpool with num threads = 6
I 00:00:00.005564 executorch:runner.cpp:65] Creating LLaMa runner: model_path=gemma2.pte, tokenizer_path=tokenizer_gemma2.bin
E 00:00:03.701808 executorch:tiktoken.cpp:79] invalid tiktoken line:
I 00:00:03.701845 executorch:runner.cpp:88] Failed to load tokenizer_gemma2.bin as a Tiktoken artifact, trying BPE tokenizer
I 00:00:03.767485 executorch:runner.cpp:94] Reading metadata from model
I 00:00:03.767512 executorch:runner.cpp:119] Metadata: get_vocab_size = 256000
I 00:00:03.767515 executorch:runner.cpp:119] Metadata: get_bos_id = 2
I 00:00:03.767517 executorch:runner.cpp:117] Methond use_sdpa_with_kv_cache not found, using the default value 0
I 00:00:03.767518 executorch:runner.cpp:119] Metadata: use_sdpa_with_kv_cache = 0
I 00:00:03.767520 executorch:runner.cpp:119] Metadata: get_n_eos = 1
I 00:00:03.767521 executorch:runner.cpp:117] Methond append_eos_to_prompt not found, using the default value 0
I 00:00:03.767522 executorch:runner.cpp:119] Metadata: append_eos_to_prompt = 0
I 00:00:03.767524 executorch:runner.cpp:119] Metadata: get_max_seq_len = 123
I 00:00:03.767525 executorch:runner.cpp:117] Methond enable_dynamic_shape not found, using the default value 0
I 00:00:03.767527 executorch:runner.cpp:119] Metadata: enable_dynamic_shape = 0
I 00:00:03.767529 executorch:runner.cpp:119] Metadata: use_kv_cache = 1
I 00:00:03.767575 executorch:runner.cpp:119] Metadata: get_n_bos = 1
I 00:00:03.767604 executorch:runner.cpp:167] RSS after loading model: 0.000000 MiB (0 if unsupported)
I 00:00:04.408489 executorch:runner.cpp:234] RSS after prompt prefill: 0.000000 MiB (0 if unsupported)
My name is Lale and I love to play with my dolls. I started to play with dolls at the age of two years old. My favorite activity is dancing. I would like to help people. I would like to travel to Spain. I like to be a vet. I love to help people. I would like to travel. I would like to be. I love to travel. I would like to be. I like to travel. I would like to be. I love to travel. I would like to be. I love to travel. I would like to be. I love to travel
I 00:00:23.188418 executorch:runner.cpp:246] RSS after finishing text generation: 0.000000 MiB (0 if unsupported)
PyTorchObserver {"prompt_tokens":4,"generated_tokens":118,"model_load_start_ms":1727310065089,"model_load_end_ms":1727310068851,"inference_start_ms":1727310068851,"inference_end_ms":1727310088272,"prompt_eval_end_ms":1727310069492,"first_token_ms":1727310069492,"aggregate_sampling_time_ms":180,"SCALING_FACTOR_UNITS_PER_SECOND":1000}
I 00:00:23.188436 executorch:stats.h:84] 	Prompt Tokens: 4    Generated Tokens: 118
I 00:00:23.188438 executorch:stats.h:90] 	Model Load Time:		3.762000 (seconds)
I 00:00:23.188440 executorch:stats.h:100] 	Total inference time:		19.421000 (seconds)		 Rate: 	6.075897 (tokens/second)
I 00:00:23.188442 executorch:stats.h:108] 		Prompt evaluation:	0.641000 (seconds)		 Rate: 	6.240250 (tokens/second)
I 00:00:23.188444 executorch:stats.h:119] 		Generated 118 tokens:	18.780000 (seconds)		 Rate: 	6.283280 (tokens/second)
I 00:00:23.188446 executorch:stats.h:127] 	Time to first generated token:	0.641000 (seconds)
I 00:00:23.188480 executorch:stats.h:134] 	Sampling time over 122 tokens:	0.180000 (seconds)
```


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #33709
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker
@gante
@amyeroberts
@qubvel 
