### PR TITLE
Generate: `can_generate()` recursive check

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1639,12 +1639,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
-        # Directly inherits `GenerationMixin` -> can generate
+        # Directly inherits `GenerationMixin`-> can generate
         if "GenerationMixin" in str(cls.__bases__):
             return True
         # Model class overwrites `generate` (e.g. time series models) -> can generate
         if str(cls.__name__) in str(cls.generate):
             return True
+        # The class inherits from a class that can generate (recursive check) -> can generate
+        for base in cls.__bases__:
+            if "PreTrainedModel" not in str(base) and base.can_generate():
+                return True
         # BC: Detects whether `prepare_inputs_for_generation` has been overwritten in the model. Prior to v4.45, this
         # was how we detected whether a model could generate.
         if "GenerationMixin" not in str(cls.prepare_inputs_for_generation):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1647,6 +1647,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             return True
         # The class inherits from a class that can generate (recursive check) -> can generate
         for base in cls.__bases__:
+            if not hasattr(base, "can_generate"):
+                continue
             if "PreTrainedModel" not in str(base) and base.can_generate():
                 return True
         # BC: Detects whether `prepare_inputs_for_generation` has been overwritten in the model. Prior to v4.45, this

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1639,7 +1639,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """
-        # Directly inherits `GenerationMixin`-> can generate
+        # Directly inherits `GenerationMixin` -> can generate
         if "GenerationMixin" in str(cls.__bases__):
             return True
         # Model class overwrites `generate` (e.g. time series models) -> can generate

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1718,29 +1718,51 @@ class ModelUtilsTest(TestCasePlus):
 
     def test_can_generate(self):
         """Tests the behavior of `PreTrainedModel.can_generate` method."""
+        logger = logging.get_logger("transformers.modeling_utils")
+        logger.warning_once.cache_clear()
+
         # 1 - By default, a model CAN'T generate
-        self.assertFalse(BertModel.can_generate())
+        can_generate = BertModel.can_generate()
+        self.assertFalse(can_generate)
 
         # 2 - The most common case for a model to be able to generate is to inherit from `GenerationMixin` directly
         class DummyBertWithMixin(BertModel, GenerationMixin):
             pass
 
-        self.assertTrue(DummyBertWithMixin.can_generate())
+        with CaptureLogger(logger) as cl:
+            can_generate = DummyBertWithMixin.can_generate()
+        self.assertTrue("" == cl.out)
+        self.assertTrue(can_generate)
 
         # 3 - Alternatively, a model can implement a `generate` method
         class DummyBertWithGenerate(BertModel):
             def generate(self):
                 pass
 
-        self.assertTrue(DummyBertWithGenerate.can_generate())
+        with CaptureLogger(logger) as cl:
+            can_generate = DummyBertWithGenerate.can_generate()
+        self.assertTrue("" == cl.out)
+        self.assertTrue(can_generate)
 
-        # 4 - BC: models with a custom `prepare_inputs_for_generation` can generate (it was assumed they inherited
+        # 4 - Finally, it can inherit from a model that can generate
+        class DummyBertWithParent(DummyBertWithMixin):
+            pass
+
+        with CaptureLogger(logger) as cl:
+            can_generate = DummyBertWithParent.can_generate()
+        self.assertTrue("" == cl.out)
+        self.assertTrue(can_generate)
+
+        # 5 - BC: models with a custom `prepare_inputs_for_generation` can generate (it was assumed they inherited
         # `GenerationMixin`)
         class DummyBertWithPrepareInputs(BertModel):
             def prepare_inputs_for_generation(self):
                 pass
 
-        self.assertTrue(DummyBertWithPrepareInputs.can_generate())
+        with CaptureLogger(logger) as cl:
+            can_generate = DummyBertWithPrepareInputs.can_generate()
+        self.assertTrue("it doesn't directly inherit from `GenerationMixin`" in cl.out)
+        self.assertTrue(can_generate)
 
     def test_save_and_load_config_with_custom_generation(self):
         """


### PR DESCRIPTION
# What does this PR do?

The deprecation warning added in #33203 was incomplete: classes inheriting from classes that have received the update were throwing the warning. This PR adds a recursive check to `can_generate()` and tests the warnings thrown by the function.

Example of script that is throwing a warning, but shouldn't (and is fixed in this PR):
```py
from transformers.models.llama import LlamaForCausalLM

class NewLlamaForCausalLM(LlamaForCausalLM):
    pass

model = NewLlamaForCausalLM.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
model.generate()
```

Thank you @regisss for warning me about this one and providing a reproducer 🙏 

