### PR TITLE
[whisper] added dropping of attention weights after DTW calculations related to word timestamps if these weights are not requested in the output

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -511,6 +511,7 @@ class WhisperGenerationMixin(GenerationMixin):
 
         # 3. Make sure generation config is correctly set
         # Make sure the generation config is correctly set depending on whether timestamps are to be returned or not
+        org_gen_config_output_attention = bool(generation_config.output_attentions)
         return_dict_in_generate = self._set_return_outputs(
             return_dict_in_generate=return_dict_in_generate,
             return_token_timestamps=return_token_timestamps,
@@ -710,6 +711,14 @@ class WhisperGenerationMixin(GenerationMixin):
                     idx=i,
                     return_token_timestamps=return_token_timestamps,
                 )
+                if not org_gen_config_output_attention:
+                    for s in segments:
+                        if "encoder_attentions" in s["result"].keys():
+                            del s["result"]["encoder_attentions"]
+                        if "decoder_attentions" in s["result"].keys():
+                            del s["result"]["decoder_attentions"]
+                        if "cross_attentions" in s["result"].keys():
+                            del s["result"]["cross_attentions"]
 
                 current_segments[prev_i] += segments
 


### PR DESCRIPTION
# What does this PR do?
We observed significantly increased memory usage when using word-level timestamps  (`return_timestamps='word'`), which increased with each segment processed - especially when processing longer recordings.
It turned out that for DTW calculations, cross-attention weights are extracted for each segment, and then they are accumulated in intermediate segments. However, when the user doesn't need the model output - they are not used any more - just sequences are returned. This accumulation of weights unnecessarily increases memory consumption.

It's simple whisper patch for when attention weights are not explicitly requested (but need to be extracted to be used in DTW for timestamps), so weights are not accumulated across segment objects, minimizing memory usage.

Probably related to #27834


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
