### PR TITLE
Fix modular model converter unable to generate Processor classes

### DIFF
--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -502,7 +502,7 @@ def replace_call_to_super(class_finder: ClassFinder, updated_node: cst.ClassDef,
 TYPE_TO_FILE_TYPE = {
     "Config": "configuration",
     "Tokenizer": "tokenization",
-    "Processor": "processor",
+    "Processor": "processing",
     "ImageProcessor": "image_processing",
     "FeatureExtractor": "feature_extractor",
 }


### PR DESCRIPTION
# What does this PR do?

[Modular 🤗 transformers](https://huggingface.co/docs/transformers/main/en/modular_transformers#modular-transformers) is awesome, but a typo in the code prevents the user to generate a `processing_xxx.py` file from `modular_xxx.py`. This PR solves this problem.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Note: I believe the last 3 checks don't apply to my PR. Feel free to correct me if I'm wrong!

## Who can review?

- @ArthurZucker → follow-up of your previous PR https://github.com/huggingface/transformers/pull/33248
- @yonigozlan → who's been helping me with the integration of ColPali in 🤗 transfomers (see https://github.com/huggingface/transformers/pull/33736)

## E2E Test

Before:

```bash
❯ python utils/modular_model_converter.py --files_to_parse src/transformers/models/colpali/modular_colpali.py
Converting src/transformers/models/colpali/modular_colpali.py to a single model single file format
Traceback (most recent call last):
  File "/Users/tony/Documents/illuin-repositories/transformers/utils/modular_model_converter.py", line 781, in <module>
    converted_files = convert_modular_file(file_name, args.old_model_name, args.new_model_name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/utils/modular_model_converter.py", line 726, in convert_modular_file
    wrapper.visit(cst_transformers)
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/metadata/wrapper.py", line 204, in visit
    return self.module.visit(visitor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/module.py", line 89, in visit
    result = super(Module, self).visit(visitor)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/base.py", line 227, in visit
    _CSTNodeSelfT, self._visit_and_replace_children(visitor)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/module.py", line 74, in _visit_and_replace_children
    body=visit_body_sequence(self, "body", self.body, visitor),
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/internal.py", line 227, in visit_body_sequence
    return tuple(visit_body_iterable(parent, fieldname, children, visitor))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/internal.py", line 193, in visit_body_iterable
    new_child = child.visit(visitor)
                ^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_nodes/base.py", line 236, in visit
    leave_result = visitor.on_leave(self, with_updated_children)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/.venv/lib/python3.11/site-packages/libcst/_visitors.py", line 71, in on_leave
    updated_node = leave_func(original_node, updated_node)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tony/Documents/illuin-repositories/transformers/utils/modular_model_converter.py", line 681, in leave_ClassDef
    self.files[key][class_name] = {"insert_idx": self.global_scope_index, "node": updated_node}
    ~~~~~~~~~~^^^^^
KeyError: 'processor'
```

After, with the proposed fix:

```
❯ python utils/modular_model_converter.py --files_to_parse src/transformers/models/colpali/modular_colpali.py
Converting src/transformers/models/colpali/modular_colpali.py to a single model single file format
```
