### PR TITLE
Fix passing str dtype to static cache

### DIFF
--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -68,7 +68,7 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
             config=self.model.config,
             batch_size=self.model.generation_config.cache_config.batch_size,
             max_cache_len=self.model.generation_config.cache_config.max_cache_len,
-            dtype=self.model.config.torch_dtype,
+            dtype=self.model.dtype,
         )
         self.is_causal = any("CausalLM" in arch for arch in self.model.config.architectures)
         if self.is_causal:

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -181,7 +181,7 @@ class CacheTest(unittest.TestCase):
 
         set_seed(0)
         device = "cpu"
-        dtype = torch.float32
+        dtype = "bfloat16"
         cache_implementation = "static"
         attn_implementation = "sdpa"  # Export and ExecuTorch only works for SdpaAttention
         batch_size = 1


### PR DESCRIPTION
# What does this PR do?

Notice a small bug where the StaticCache is not configured correctly when passing the str type dtype throggh `integration.executorch`. The root cause is because it's using the dtype from config, which can be `str` or `torch.dtype` depending on what is passed from user code. This PR fixed the issue by switching to always use `model.dtype` (alway `torch.dtype`) instead.  With the fix, both passing `str` and `torch.dype` will work.


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker
@gante
@amyeroberts