### PR TITLE
Validate the eval dataset in advance.

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -402,7 +402,7 @@ class Trainer:
                     " summary statistics should be returned by the function."
                 )
         if args.eval_strategy is not None and args.eval_strategy != 'no' and eval_dataset is None:
-            raise ValueError("Trainer: evaluation requires an eval_dataset.")
+            raise  ValueError("Trainer: evaluation requires an eval_dataset.")
         self.args = args
         # Seed must be set before instantiating the model when using model
         enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -401,8 +401,8 @@ class Trainer:
                     " boolean argument which will be triggered after the last batch of the eval set to signal that the"
                     " summary statistics should be returned by the function."
                 )
-        if args.eval_strategy is not None and args.eval_strategy != 'no' and eval_dataset is None:
-            raise  ValueError("Trainer: evaluation requires an eval_dataset.")
+        if args.eval_strategy is not None and args.eval_strategy != "no" and eval_dataset is None:
+            raise ValueError("Trainer: evaluation requires an eval_dataset.")
         self.args = args
         # Seed must be set before instantiating the model when using model
         enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -402,7 +402,7 @@ class Trainer:
                     " summary statistics should be returned by the function."
                 )
         if args.eval_strategy is not None and args.eval_strategy != "no" and eval_dataset is None:
-            raise ValueError("Trainer: evaluation requires an eval_dataset.")
+            raise ValueError(f"You have set `args.eval_strategy` to {args.eval_strategy} but you didn't pass an `eval_dataset` to `Trainer`. Either set `args.eval_strategy` to `no` or pass an `eval_dataset`. ")
         self.args = args
         # Seed must be set before instantiating the model when using model
         enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -401,6 +401,8 @@ class Trainer:
                     " boolean argument which will be triggered after the last batch of the eval set to signal that the"
                     " summary statistics should be returned by the function."
                 )
+        if args.eval_strategy is not None and args.eval_strategy != 'no' and eval_dataset is None:
+            raise ValueError("Trainer: evaluation requires an eval_dataset.")
         self.args = args
         # Seed must be set before instantiating the model when using model
         enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -402,7 +402,9 @@ class Trainer:
                     " summary statistics should be returned by the function."
                 )
         if args.eval_strategy is not None and args.eval_strategy != "no" and eval_dataset is None:
-            raise ValueError(f"You have set `args.eval_strategy` to {args.eval_strategy} but you didn't pass an `eval_dataset` to `Trainer`. Either set `args.eval_strategy` to `no` or pass an `eval_dataset`. ")
+            raise ValueError(
+                f"You have set `args.eval_strategy` to {args.eval_strategy} but you didn't pass an `eval_dataset` to `Trainer`. Either set `args.eval_strategy` to `no` or pass an `eval_dataset`. "
+            )
         self.args = args
         # Seed must be set before instantiating the model when using model
         enable_full_determinism(self.args.seed) if self.args.full_determinism else set_seed(self.args.seed)


### PR DESCRIPTION
# What does this PR do?
Validate whether the eval dataset is empty in advance to avoid wasting the time of training for one epoch only to discover this issue.

Fixes # (issue)
fix #33721

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@muellerzr and @SunMarc

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
