### PR TITLE
Make ASR pipeline compliant with Hub spec + add tests

### DIFF
--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import numpy as np
 import requests
+import warnings
 
 from ..tokenization_utils import PreTrainedTokenizer
 from ..utils import is_torch_available, is_torchaudio_available, logging
@@ -269,8 +270,6 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
                 The dictionary of ad-hoc parametrization of `generate_config` to be used for the generation call. For a
                 complete overview of generate, check the [following
                 guide](https://huggingface.co/docs/transformers/en/main_classes/text_generation).
-            max_new_tokens (`int`, *optional*):
-                The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
 
         Return:
             `Dict`: A dictionary with the following keys:
@@ -310,6 +309,10 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
 
         forward_params = defaultdict(dict)
         if max_new_tokens is not None:
+            warnings.warn(
+                "`max_new_tokens` is deprecated and will be removed in version 5 of Transformers. To remove this warning, pass `max_new_tokens` as a key inside `generate_kwargs` instead.",
+                FutureWarning,
+            )
             forward_params["max_new_tokens"] = max_new_tokens
         if generate_kwargs is not None:
             if max_new_tokens is not None and "max_new_tokens" in generate_kwargs:

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import numpy as np
 import requests
-import warnings
 
 from ..tokenization_utils import PreTrainedTokenizer
 from ..utils import is_torch_available, is_torchaudio_available, logging

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -310,7 +310,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
         forward_params = defaultdict(dict)
         if max_new_tokens is not None:
             warnings.warn(
-                "`max_new_tokens` is deprecated and will be removed in version 5 of Transformers. To remove this warning, pass `max_new_tokens` as a key inside `generate_kwargs` instead.",
+                "`max_new_tokens` is deprecated and will be removed in version 4.49 of Transformers. To remove this warning, pass `max_new_tokens` as a key inside `generate_kwargs` instead.",
                 FutureWarning,
             )
             forward_params["max_new_tokens"] = max_new_tokens

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2622,12 +2622,10 @@ def compare_pipeline_output_to_hub_spec(output, hub_spec):
     for field in fields(hub_spec):
         if field.default is MISSING and field.name not in output:
             missing_keys.append(field.name)
-            raise KeyError(f"Pipeline output is missing mandatory field in Hub spec: {field.name}")
 
     for output_key in output:
         if output_key not in all_field_names:
             unexpected_keys.append(output_key)
-            raise KeyError(f"Pipeline output contains field not present in Hub spec: {output_key}")
 
     if missing_keys or unexpected_keys:
         error = ["Pipeline output does not match Hub spec!"]
@@ -2636,5 +2634,5 @@ def compare_pipeline_output_to_hub_spec(output, hub_spec):
         if missing_keys:
             error.append(f"Missing mandatory keys in pipeline output: {missing_keys}")
         if unexpected_keys:
-            error.append(f"Keys in pipeline output that do not exist in Hub spec: {unexpected_keys}")
+            error.append(f"Keys in pipeline output that are not in Hub spec: {unexpected_keys}")
         raise KeyError("\n".join(error))

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -31,6 +31,7 @@ import time
 import unittest
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import MISSING, fields
 from functools import wraps
 from io import StringIO
 from pathlib import Path
@@ -2610,3 +2611,14 @@ if is_torch_available():
         update_mapping_from_spec(BACKEND_MANUAL_SEED, "MANUAL_SEED_FN")
         update_mapping_from_spec(BACKEND_EMPTY_CACHE, "EMPTY_CACHE_FN")
         update_mapping_from_spec(BACKEND_DEVICE_COUNT, "DEVICE_COUNT_FN")
+
+
+def compare_pipeline_output_to_hub_spec(output, hub_spec):
+    for field in fields(hub_spec):
+        if field.default is MISSING and field.name not in output:
+            raise KeyError(f"Pipeline output is missing mandatory field in Hub spec: {field.name}")
+
+    all_field_names = {field.name for field in fields(hub_spec)}
+    for output_key in output:
+        if output_key not in all_field_names:
+            raise KeyError(f"Pipeline output contains field not present in Hub spec: {output_key}")

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2619,10 +2619,12 @@ def compare_pipeline_output_to_hub_spec(output, hub_spec):
     all_field_names = {field.name for field in fields(hub_spec)}
     matching_keys = sorted([key for key in output.keys() if key in all_field_names])
 
+    # Fields with a MISSING default are required and must be in the output
     for field in fields(hub_spec):
         if field.default is MISSING and field.name not in output:
             missing_keys.append(field.name)
 
+    # All output keys must match either a required or optional field in the Hub spec
     for output_key in output:
         if output_key not in all_field_names:
             unexpected_keys.append(output_key)
@@ -2632,7 +2634,7 @@ def compare_pipeline_output_to_hub_spec(output, hub_spec):
         if matching_keys:
             error.append(f"Matching keys: {matching_keys}")
         if missing_keys:
-            error.append(f"Missing mandatory keys in pipeline output: {missing_keys}")
+            error.append(f"Missing required keys in pipeline output: {missing_keys}")
         if unexpected_keys:
             error.append(f"Keys in pipeline output that are not in Hub spec: {unexpected_keys}")
         raise KeyError("\n".join(error))

--- a/tests/pipelines/test_pipelines_audio_classification.py
+++ b/tests/pipelines/test_pipelines_audio_classification.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from dataclasses import fields
 
 import numpy as np
 from huggingface_hub import AudioClassificationOutputElement
@@ -21,6 +20,7 @@ from huggingface_hub import AudioClassificationOutputElement
 from transformers import MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING, TF_MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING
 from transformers.pipelines import AudioClassificationPipeline, pipeline
 from transformers.testing_utils import (
+    compare_pipeline_output_to_hub_spec,
     is_pipeline_test,
     nested_simplify,
     require_tf,
@@ -68,10 +68,8 @@ class AudioClassificationPipelineTests(unittest.TestCase):
 
         self.run_torchaudio(audio_classifier)
 
-        spec_output_keys = {field.name for field in fields(AudioClassificationOutputElement)}
         for single_output in output:
-            output_keys = set(single_output.keys())
-            self.assertEqual(spec_output_keys, output_keys, msg="Pipeline output keys do not match HF Hub spec!")
+            compare_pipeline_output_to_hub_spec(single_output, AudioClassificationOutputElement)
 
     @require_torchaudio
     def run_torchaudio(self, audio_classifier):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -14,11 +14,12 @@
 
 import time
 import unittest
+from dataclasses import fields
 
 import numpy as np
 import pytest
 from datasets import Audio, load_dataset
-from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub import AutomaticSpeechRecognitionOutput, hf_hub_download, snapshot_download
 
 from transformers import (
     MODEL_FOR_CTC_MAPPING,
@@ -85,6 +86,10 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         audio = np.zeros((34000,))
         outputs = speech_recognizer(audio)
         self.assertEqual(outputs, {"text": ANY(str)})
+
+        spec_output_keys = {field.name for field in fields(AutomaticSpeechRecognitionOutput)}
+        output_keys = set(outputs.keys())
+        self.assertEqual(spec_output_keys, output_keys, msg="Pipeline output keys do not match HF Hub spec!")
 
         # Striding
         audio = {"raw": audio, "stride": (0, 4000), "sampling_rate": speech_recognizer.feature_extractor.sampling_rate}

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -14,7 +14,6 @@
 
 import time
 import unittest
-from dataclasses import fields
 
 import numpy as np
 import pytest
@@ -37,6 +36,7 @@ from transformers.pipelines import AutomaticSpeechRecognitionPipeline, pipeline
 from transformers.pipelines.audio_utils import chunk_bytes_iter
 from transformers.pipelines.automatic_speech_recognition import _find_timestamp_sequence, chunk_iter
 from transformers.testing_utils import (
+    compare_pipeline_output_to_hub_spec,
     is_pipeline_test,
     is_torch_available,
     nested_simplify,
@@ -87,9 +87,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         outputs = speech_recognizer(audio)
         self.assertEqual(outputs, {"text": ANY(str)})
 
-        spec_output_keys = {field.name for field in fields(AutomaticSpeechRecognitionOutput)}
-        output_keys = set(outputs.keys())
-        self.assertEqual(spec_output_keys, output_keys, msg="Pipeline output keys do not match HF Hub spec!")
+        compare_pipeline_output_to_hub_spec(outputs, AutomaticSpeechRecognitionOutput)
 
         # Striding
         audio = {"raw": audio, "stride": (0, 4000), "sampling_rate": speech_recognizer.feature_extractor.sampling_rate}

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -25,9 +25,9 @@ from pathlib import Path
 from textwrap import dedent
 from typing import get_args
 
-from huggingface_hub import AudioClassificationInput
+from huggingface_hub import AudioClassificationInput, AutomaticSpeechRecognitionInput
 
-from transformers.pipelines import AudioClassificationPipeline
+from transformers.pipelines import AudioClassificationPipeline, AutomaticSpeechRecognitionPipeline
 from transformers.testing_utils import (
     is_pipeline_test,
     require_decord,
@@ -104,6 +104,7 @@ task_to_pipeline_and_spec_mapping = {
     # Adding a task to this list will cause its pipeline input signature to be checked against the corresponding
     # task spec in the HF Hub
     "audio-classification": (AudioClassificationPipeline, AudioClassificationInput),
+    "automatic-speech-recognition": (AutomaticSpeechRecognitionPipeline, AutomaticSpeechRecognitionInput),
 }
 
 for task, task_info in pipeline_test_mapping.items():


### PR DESCRIPTION
As well as making the ASR pipeline compliant, this PR also refactors out the output test, so we can just import that in future PRs as well.