### PR TITLE
Workaround for bark issue in pipelines

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1721,6 +1721,8 @@ class BarkModel(BarkPreTrainedModel):
                     kwargs_fine[key] = value
 
         # 1. Generate from the semantic model
+        if 'generation_config' in kwargs_semantic:
+            kwargs_semantic.pop('generation_config')
         semantic_output = self.semantic.generate(
             input_ids,
             history_prompt=history_prompt,
@@ -1729,6 +1731,8 @@ class BarkModel(BarkPreTrainedModel):
         )
 
         # 2. Generate from the coarse model
+        if 'generation_config' in kwargs_coarse:
+            kwargs_coarse.pop('generation_config')
         coarse_output = self.coarse_acoustics.generate(
             semantic_output,
             history_prompt=history_prompt,
@@ -1746,6 +1750,8 @@ class BarkModel(BarkPreTrainedModel):
             output_lengths = output_lengths // coarse_generation_config.n_coarse_codebooks
 
         # 3. "generate" from the fine model
+        if 'generation_config' in kwargs_fine:
+            kwargs_fine.pop('generation_config')
         output = self.fine_acoustics.generate(
             coarse_output,
             history_prompt=history_prompt,

--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1721,8 +1721,8 @@ class BarkModel(BarkPreTrainedModel):
                     kwargs_fine[key] = value
 
         # 1. Generate from the semantic model
-        if 'generation_config' in kwargs_semantic:
-            kwargs_semantic.pop('generation_config')
+        if "generation_config" in kwargs_semantic:
+            kwargs_semantic.pop("generation_config")
         semantic_output = self.semantic.generate(
             input_ids,
             history_prompt=history_prompt,
@@ -1731,8 +1731,8 @@ class BarkModel(BarkPreTrainedModel):
         )
 
         # 2. Generate from the coarse model
-        if 'generation_config' in kwargs_coarse:
-            kwargs_coarse.pop('generation_config')
+        if "generation_config" in kwargs_coarse:
+            kwargs_coarse.pop("generation_config")
         coarse_output = self.coarse_acoustics.generate(
             semantic_output,
             history_prompt=history_prompt,
@@ -1750,8 +1750,8 @@ class BarkModel(BarkPreTrainedModel):
             output_lengths = output_lengths // coarse_generation_config.n_coarse_codebooks
 
         # 3. "generate" from the fine model
-        if 'generation_config' in kwargs_fine:
-            kwargs_fine.pop('generation_config')
+        if "generation_config" in kwargs_fine:
+            kwargs_fine.pop("generation_config")
         output = self.fine_acoustics.generate(
             coarse_output,
             history_prompt=history_prompt,


### PR DESCRIPTION
The way we pass `generation_config` to `Bark` seems to cause some issues with duplicated keys, see #33779. This was caused by changes in #33480

This issue doesn't seem to occur with other `text-to-speech` or `text-to-audio` models, and I got a local workaround working. However, I suspect there's probably a cleaner solution to the issue than what I did here! More importantly, I probably need to investigate why this wasn't flagged in the CI/nightly runs.

cc @gante @sanchit-gandhi @ylacombe 