### PR TITLE
Allow for nightly packages of `compressed_tensors`

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -143,7 +143,8 @@ _auto_gptq_available = _is_package_available("auto_gptq")
 # `importlib.metadata.version` doesn't work with `awq`
 _auto_awq_available = importlib.util.find_spec("awq") is not None
 _quanto_available = _is_package_available("quanto")
-_compressed_tensors_available = _is_package_available("compressed_tensors")
+# For compressed_tensors, only check spec to allow compress_tensors-nightly package
+_compressed_tensors_available = importlib.util.find_spec("compressed_tensors") is not None
 _pandas_available = _is_package_available("pandas")
 _peft_available = _is_package_available("peft")
 _phonemizer_available = _is_package_available("phonemizer")

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -143,7 +143,7 @@ _auto_gptq_available = _is_package_available("auto_gptq")
 # `importlib.metadata.version` doesn't work with `awq`
 _auto_awq_available = importlib.util.find_spec("awq") is not None
 _quanto_available = _is_package_available("quanto")
-# For compressed_tensors, only check spec to allow compress_tensors-nightly package
+# For compressed_tensors, only check spec to allow compressed_tensors-nightly package
 _compressed_tensors_available = importlib.util.find_spec("compressed_tensors") is not None
 _pandas_available = _is_package_available("pandas")
 _peft_available = _is_package_available("peft")


### PR DESCRIPTION
# What does this PR do?
This PR follows up on #31704 by allowing the `compressed-tensors-nightly` package to be used to load compressed tensors modules. This is done by relaxing installation requirements to only require the `compressed-tensors` module spec, but not the `compressed-tensors` package.

Compressed Tensors models cannot be loaded with nightly package
```python3
from transformers import AutoModel
model = AutoModel.from_pretrained("nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A8_tensor_weight_static_per_tensor_act-e2e")
# ImportError: Using `compressed_tensors` quantized models requires the compressed-tensors library: `pip install compressed-tensors`
```

Compressed Tensors is reported as unavailable, despite the module being available through the nightly package
```python3
from transformers.utils.import_utils import is_compressed_tensors_available
is_compressed_tensors_available()
# False
```

After the changes, models can be imported with the nightly package and compressed tensors is reported as being available

## Who can review?
@SunMarc @ArthurZucker
@dsikka @dhuangnm @andy-neuma
Anyone in the community is free to review the PR once the tests have passed.
