### PR TITLE
Raise `accelerate` dependency error in case of defaulting `low_cpu_mem_usage=True`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3477,7 +3477,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # Force-set to `True` for more mem efficiency
             if low_cpu_mem_usage is None:
                 low_cpu_mem_usage = True
-                logger.warning("`low_cpu_mem_usage` was None, now set to True since model is quantized.")
+                logger.warning("`low_cpu_mem_usage` was None, now default to True since model is quantized.")
         is_quantized = hf_quantizer is not None
 
         # This variable will flag if we're loading a sharded checkpoint. In this case the archive file is just the
@@ -3891,6 +3891,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
             init_contexts = [deepspeed.zero.Init(config_dict_or_path=deepspeed_config())] + init_contexts
         elif low_cpu_mem_usage:
+            if not is_accelerate_available():
+                raise ImportError(
+                    f"Using `low_cpu_mem_usage=True` or a `device_map` requires Accelerate: `pip install 'accelerate>={ACCELERATE_MIN_VERSION}'`"
+                )
             init_contexts.append(init_empty_weights())
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in from_pretrained.


### PR DESCRIPTION
# What does this PR do?

Fixes bugs where the `low_cpu_mem_usage` argument is changed during loading but after checking for accelerate installation.

Set up environment
```bash
python3 -m pip install compressed-tensors
```

In an environment where accelerate is not installed
```python3
from transformers import AutoModel
model = AutoModel.from_pretrained("nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A8_tensor_weight_static_per_tensor_act-e2e")
# `low_cpu_mem_usage` was None, now set to True since model is quantized. 
# NameError: name 'init_empty_weights' is not defined
```

After changes
```python3
from transformers import AutoModel
model = AutoModel.from_pretrained("nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A8_tensor_weight_static_per_tensor_act-e2e")
# `low_cpu_mem_usage` was None, now default to True since model is quantized.
# ImportError: Using `low_cpu_mem_usage=True` or a `device_map` requires Accelerate: `pip install 'accelerate>=0.26.0'`

# Now the user knows to either install accelerate or set low_cpu_mem_usage=False
```

## Who can review?
@mgoin @SunMarc @ArthurZucker
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.