### PR TITLE
Update an keyerror on _save_check_point prevent confusion of missing …

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3022,8 +3022,11 @@ class Trainer:
                 metric_value = metrics[metric_to_check]
             except KeyError as exc:
                 raise KeyError(
-                    f"The `metric_for_best_model` training argument is set to '{metric_to_check}', which is not found in the evaluation metrics. "
-                    f"The available evaluation metrics are: {list(metrics.keys())}. Consider changing the `metric_for_best_model` via the TrainingArguments."
+                    f"The `metric_for_best_model` training argument is set to '{metric_to_check}', "
+                    f"which is not found in the evaluation metrics. "
+                    f"The available evaluation metrics are: {list(metrics.keys())}. "
+                    f"Please ensure that the `compute_metrics` function returns a dictionary that includes '{metric_to_check}'"
+                    f"Consider changing the `metric_for_best_model` via the TrainingArguments."
                 ) from exc
 
             operator = np.greater if self.args.greater_is_better else np.less

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2881,8 +2881,11 @@ class Trainer:
                 self.lr_scheduler.step(metrics[metric_to_check])
             except KeyError as exc:
                 raise KeyError(
-                    f"The `metric_for_best_model` training argument is set to '{metric_to_check}', which is not found in the evaluation metrics. "
-                    f"The available evaluation metrics are: {list(metrics.keys())}. Consider changing the `metric_for_best_model` via the TrainingArguments."
+                    f"The `metric_for_best_model` training argument is set to '{metric_to_check}', "
+                    f"which is not found in the evaluation metrics. "
+                    f"The available evaluation metrics are: {list(metrics.keys())}. "
+                    f"Please ensure that the `compute_metrics` function returns a dictionary that includes '{metric_to_check}' or "
+                    f"consider changing the `metric_for_best_model` via the TrainingArguments."
                 ) from exc
         return metrics
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3025,8 +3025,8 @@ class Trainer:
                     f"The `metric_for_best_model` training argument is set to '{metric_to_check}', "
                     f"which is not found in the evaluation metrics. "
                     f"The available evaluation metrics are: {list(metrics.keys())}. "
-                    f"Please ensure that the `compute_metrics` function returns a dictionary that includes '{metric_to_check}'"
-                    f"Consider changing the `metric_for_best_model` via the TrainingArguments."
+                    f"Please ensure that the `compute_metrics` function returns a dictionary that includes '{metric_to_check}' or "
+                    f"consider changing the `metric_for_best_model` via the TrainingArguments."
                 ) from exc
 
             operator = np.greater if self.args.greater_is_better else np.less


### PR DESCRIPTION
# What does this PR do?

### This PR improves the error handling in the `_save_checkpoint` 
- function by updating the `KeyError` message when the `metric_for_best_model` argument is not found in the evaluation metrics. The new error message provides clearer guidance, including suggestions on checking the `compute_metrics` function and updating `TrainingArguments` if necessary.


Fixes issues #33193

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@muellerzr and @SunMarc

