### PR TITLE
move position_ids to position_embedding's device

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -284,7 +284,7 @@ class CLIPTextEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
 
-        position_embeddings = self.position_embedding(position_ids)
+        position_embeddings = self.position_embedding(position_ids.to(self.position_embedding.weight.device))
         embeddings = inputs_embeds + position_embeddings
 
         return embeddings


### PR DESCRIPTION


self.position_ids.device is on cpu by default and it is used when **position_ids** is None or not passed to CLIPTextEmbeddings.forward