### PR TITLE
populate quantization_config for kv-cache-scheme only configs

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1105,7 +1105,7 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
         self.sparsity_config = None
 
         # parse from dict to load nested QuantizationScheme objects
-        if config_groups:
+        if config_groups or kv_cache_scheme:
             self.quantization_config = QuantizationConfig.parse_obj(
                 {
                     "config_groups": config_groups,


### PR DESCRIPTION
# What does this PR do?
Follow up to https://github.com/huggingface/transformers/pull/31704/files.
Previously if quantization was done for the kv-cache pathway only from compressed-tensors, then quantization_config would not populate. 
With this pr, it will now populate

Fixes # (issue)
Same as above


## Who can review?

@SunMarc @younesbelkada @dsikka @mgoin 
