### PR TITLE
Fix update stateful callbacks state to save checkpoint

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1683,8 +1683,7 @@ class Trainer:
         output_dir = os.path.join(checkpoint_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}")
         self.save_model(output_dir, _internal_call=True)
         if self.args.should_save:
-            # Update the `TrainerControl` state to where we are currently
-            self.state.stateful_callbacks["TrainerControl"] = self.control.state()
+            self._update_stateful_callbacks()
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
             torch.save(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))
             torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
@@ -3041,16 +3040,7 @@ class Trainer:
 
         # Save the Trainer state
         if self.args.should_save:
-            # Update `ExportableState` callbacks and `TrainerControl` state to where we are currently
-            for cb in [
-                cb for cb in self.callback_handler.callbacks + [self.control] if isinstance(cb, ExportableState)
-            ]:
-                cb_name = cb.__class__.__name__
-                cb_state = cb.state()
-                if isinstance(self.state.stateful_callbacks[cb_name], list):
-                    self.state.stateful_callbacks[cb_name].append(cb_state)
-                else:
-                    self.state.stateful_callbacks[cb_name] = cb_state
+            self._update_stateful_callbacks()
             self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 
         if self.args.push_to_hub:
@@ -3061,6 +3051,21 @@ class Trainer:
             # Solely rely on numerical checkpoint id for rotation.
             # mtime is not reliable especially on some fuse fs in cloud environments.
             self._rotate_checkpoints(use_mtime=False, output_dir=run_dir)
+
+    def _update_stateful_callbacks(self):
+        new_stateful_callbacks = {}
+        # Update `ExportableState` callbacks and `TrainerControl` state to where we are currently
+        for cb in [cb for cb in self.callback_handler.callbacks + [self.control] if isinstance(cb, ExportableState)]:
+            cb_name = cb.__class__.__name__
+            cb_state = cb.state()
+            if isinstance(self.state.stateful_callbacks[cb_name], list):
+                if cb_name not in new_stateful_callbacks:
+                    new_stateful_callbacks[cb_name] = []
+                new_stateful_callbacks[cb_name].append(cb_state)
+            else:
+                new_stateful_callbacks[cb_name] = cb_state
+
+        self.state.stateful_callbacks = new_stateful_callbacks
 
     def _save_rng_state(self, output_dir):
         # Save RNG state in non-distributed training

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -32,7 +32,7 @@ from transformers import (
     is_torch_available,
 )
 from transformers.testing_utils import require_torch
-from transformers.trainer_callback import ExportableState
+from transformers.trainer_callback import ExportableState, TrainerControl
 
 
 if is_torch_available():
@@ -44,11 +44,18 @@ if is_torch_available():
 class MyTestExportableCallback(TrainerCallback, ExportableState):
     def __init__(self, my_test_state="test"):
         self.my_test_state = my_test_state
+        self.my_step_counter = 0
+
+    def on_step_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        self.my_step_counter = self.my_step_counter + 1
 
     def state(self):
         return {
             "args": {
                 "my_test_state": self.my_test_state,
+            },
+            "attributes": {
+                "my_step_counter": self.my_step_counter,
             },
         }
 
@@ -381,7 +388,9 @@ class TrainerCallbackTest(unittest.TestCase):
         ]
         assert len(cbs) == 2
         assert cbs[0].my_test_state == "first"
+        assert cbs[0].my_step_counter > 2
         assert cbs[1].my_test_state == "second"
+        assert cbs[1].my_step_counter > 2
 
     def test_missing_stateful_callback(self):
         cb = EarlyStoppingCallback()


### PR DESCRIPTION
* fix: avoid appending to the same list in every callback state update, when there are multiple callbacks of the same class

* fix: make _tune_save_checkpoint method updates callbacks state too

* test_stateful_duplicate_callbacks: add modifiable field to test changes in state while training

# What does this PR do?

This PR fixes a problem when there are multiple stateful callbacks of the same class to be saved. Their states are updated, but they are appended to the same list (of all callbacks of that same class) every time a checkpoint is saved, causing it to grow without limit. In these cases, as a consequence, when training is resumed from a checkpoint, only the first callback states (of the same class) are loaded to the callback handler, possibly ignoring further changes in their states (the latest elements in the list). To solve this problem, a new list is created with the updated callback states, instead of appending them to the existing list.

Regarding the update of the callback states, this PR also makes method _tune_save_checkpoint(...) do the same thing as method _save_checkpoint(...).

## Who can review?

@muellerzr @amyeroberts @pedrobrs 
