### PR TITLE
[feat] add possibility to give kwargs handler to accelerator in trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4825,31 +4825,31 @@ class Trainer:
             self.repo.git_commit("Add *.sagemaker patterns to .gitignore.")
             self.repo.git_push()
 
-    def _get_accelerator_kwargs_handler(self):
-        kwargs_handler = []
+    def _get_accelerator_kwargs_handlers(self):
+        kwargs_handlers = []
         if self.args.accelerator_config.autocast_kwargs is not None:
             autocast_kwargs = AutocastKwargs(**self.args.accelerator_config.autocast_kwargs)
-            kwargs_handler.append(autocast_kwargs)
+            kwargs_handlers.append(autocast_kwargs)
 
         if self.args.accelerator_config.fp8_recipe_kwargs is not None:
             fp8_recipe_kwargs = FP8RecipeKwargs(**self.args.accelerator_config.fp8_recipe_kwargs)
-            kwargs_handler.append(fp8_recipe_kwargs)
+            kwargs_handlers.append(fp8_recipe_kwargs)
 
         if self.args.accelerator_config.profile_kwargs is not None:
             profile_kwargs = ProfileKwargs(**self.args.accelerator_config.profile_kwargs)
-            kwargs_handler.append(profile_kwargs)
+            kwargs_handlers.append(profile_kwargs)
 
         if self.args.accelerator_config.grad_scale_kwargs is not None:
             grad_scale_kwargs = GradScalerKwargs(**self.args.accelerator_config.grad_scale_kwargs)
-            kwargs_handler.append(grad_scale_kwargs)
+            kwargs_handlers.append(grad_scale_kwargs)
 
         if self.args.accelerator_config.init_process_group_kwargs is not None:
             init_process_group_kwargs = InitProcessGroupKwargs(
                 **self.args.accelerator_config.init_process_group_kwargs
             )
-            kwargs_handler.append(init_process_group_kwargs)
+            kwargs_handlers.append(init_process_group_kwargs)
 
-        return kwargs_handler if len(kwargs_handler) > 0 else None
+        return kwargs_handlers if len(kwargs_handlers) > 0 else None
 
     def create_accelerator_and_postprocess(self):
         grad_acc_kwargs = {}

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4892,10 +4892,16 @@ class Trainer:
                     "`non_blocking` is enabled but `dataloader_pin_memory` is not. For the best performance, it's recommended to enable both."
                 )
             dataloader_config.non_blocking = non_blocking
-        # this would have been updated above, no need for it anymore
-        accelerator_config.pop("gradient_accumulation_kwargs")
 
         kwargs_handlers = self._get_accelerator_kwargs_handlers()
+
+        # this would have been updated above, no need for it anymore
+        accelerator_config.pop("gradient_accumulation_kwargs")
+        accelerator_config.pop("autocast_kwargs")
+        accelerator_config.pop("fp8_recipe_kwargs")
+        accelerator_config.pop("profile_kwargs")
+        accelerator_config.pop("grad_scale_kwargs")
+        accelerator_config.pop("init_process_group_kwargs")
 
         args = {
             "deepspeed_plugin": self.args.deepspeed_plugin,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -227,11 +227,19 @@ if is_peft_available():
 
 
 if is_accelerate_available():
-    from accelerate import Accelerator, skip_first_batches
+    from accelerate import (
+        Accelerator,
+        AutocastKwargs,
+        GradScalerKwargs,
+        InitProcessGroupKwargs,
+        ProfileKwargs,
+        skip_first_batches,
+    )
     from accelerate import __version__ as accelerate_version
     from accelerate.utils import (
         DistributedDataParallelKwargs,
         DistributedType,
+        FP8RecipeKwargs,
         GradientAccumulationPlugin,
         load_fsdp_model,
         load_fsdp_optimizer,
@@ -4817,6 +4825,32 @@ class Trainer:
             self.repo.git_commit("Add *.sagemaker patterns to .gitignore.")
             self.repo.git_push()
 
+    def _get_accelerator_kwargs_handler(self):
+        kwargs_handler = []
+        if self.args.accelerator_config.autocast_kwargs is not None:
+            autocast_kwargs = AutocastKwargs(**self.args.accelerator_config.autocast_kwargs)
+            kwargs_handler.append(autocast_kwargs)
+
+        if self.args.accelerator_config.fp8_recipe_kwargs is not None:
+            fp8_recipe_kwargs = FP8RecipeKwargs(**self.args.accelerator_config.fp8_recipe_kwargs)
+            kwargs_handler.append(fp8_recipe_kwargs)
+
+        if self.args.accelerator_config.profile_kwargs is not None:
+            profile_kwargs = ProfileKwargs(**self.args.accelerator_config.profile_kwargs)
+            kwargs_handler.append(profile_kwargs)
+
+        if self.args.accelerator_config.grad_scale_kwargs is not None:
+            grad_scale_kwargs = GradScalerKwargs(**self.args.accelerator_config.grad_scale_kwargs)
+            kwargs_handler.append(grad_scale_kwargs)
+
+        if self.args.accelerator_config.init_process_group_kwargs is not None:
+            init_process_group_kwargs = InitProcessGroupKwargs(
+                **self.args.accelerator_config.init_process_group_kwargs
+            )
+            kwargs_handler.append(init_process_group_kwargs)
+
+        return kwargs_handler if len(kwargs_handler) > 0 else None
+
     def create_accelerator_and_postprocess(self):
         grad_acc_kwargs = {}
         if is_accelerate_available("0.28.0") and self.args.accelerator_config.gradient_accumulation_kwargs is not None:
@@ -4861,9 +4895,12 @@ class Trainer:
         # this would have been updated above, no need for it anymore
         accelerator_config.pop("gradient_accumulation_kwargs")
 
+        kwargs_handlers = self._get_accelerator_kwargs_handlers()
+
         args = {
             "deepspeed_plugin": self.args.deepspeed_plugin,
             "gradient_accumulation_plugin": gradient_accumulation_plugin,
+            "kwargs_handlers": kwargs_handlers,
         }
         if is_accelerate_available("0.28.0"):
             args["dataloader_config"] = dataloader_config

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1320,6 +1320,42 @@ class AcceleratorConfig:
         },
     )
 
+    autocast_kwargs: Optional[Dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional kwargs to customize how torch.autocast behaves, see [`class accelerate.AutocastKwargs`]."
+        },
+    )
+
+    fp8_recipe_kwargs: Optional[Dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional kwargs to customize the initialization of the recipe for FP8 mixed precision training, "
+            "see [`class accelerate.utils.FP8RecipeKwargs`]."
+        },
+    )
+
+    profile_kwargs: Optional[Dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional kwargs to customize the initialization of the profiler, see [`class accelerate.ProfileKwargs`]."
+        },
+    )
+
+    grad_scale_kwargs: Optional[Dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional kwargs to customize the behavior of mixed precision, see [`class accelerate.GradScalerKwargs`]."
+        },
+    )
+
+    init_process_group_kwargs: Optional[Dict] = field(
+        default=None,
+        metadata={
+            "help": "Additional kwargs to configure initialization of the distributed processes, see [`class accelerate.InitProcessGroupKwargs`]."
+        },
+    )
+
     @classmethod
     def from_json_file(cls, json_file):
         # Check if exists


### PR DESCRIPTION
# What does this PR do?

At one point I wanted to change the `timeout` of `Accelerator`'s `init_process_group` and I couldn't find an easy way to access this property when using the `Trainer` since it handles the `Accelerator` instantiation internally but gives limited access to what arguments we can modify.

In this PR I added some fields to the `AcceleratorConfig` to allow passing arguments to construct the different `kwargs_handlers` available for `Accelerator` and also updated the `create_accelerator_and_postprocess` method to create and  inject the `kwargs_handlers` when instantiating the `Accelerator`.
I left out the `DistributedDataParallelKwargs` because it seems it's already handled internally in `Trainer`. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr and @SunMarc as this relates to `Trainer`.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
