### PR TITLE
Config: allow saving with generative parameters if untouched

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -320,7 +320,7 @@ class PretrainedConfig(PushToHubMixin):
         self._original_object_hash = None
 
     def __hash__(self):
-        return hash(self.to_json_string(use_diff=False, ignore_metadata=True))
+        return hash(self.to_json_string(ignore_metadata=True))
 
     @property
     def name_or_path(self) -> str:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -315,7 +315,8 @@ class PretrainedConfig(PushToHubMixin):
                 logger.error(f"Can't set {key} with value {value} for {self}")
                 raise err
 
-        # If we load the object from an external source, we need to store the original object hash
+        # If we load the object from an external source, we need to store the original object hash. (The hash can't
+        # be set here -- some classes overload __init__ and modify the instance after calling super().__init__)
         self._original_object_hash = None
 
     def __hash__(self):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -857,10 +857,11 @@ class PretrainedConfig(PushToHubMixin):
             output["model_type"] = self.__class__.model_type
         if "_auto_class" in output:
             del output["_auto_class"]
-        if "_commit_hash" in output:
-            del output["_commit_hash"]
         if "_attn_implementation_internal" in output:
             del output["_attn_implementation_internal"]
+
+        for key in METADATA_FIELDS:
+            output.pop(key, None)
 
         # Transformers version when serializing the model
         output["transformers_version"] = __version__

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -557,7 +557,6 @@ class PretrainedConfig(PushToHubMixin):
             )
 
         config = cls.from_dict(config_dict, **kwargs)
-        config._original_object_hash = hash(config)  # config object loaded from external source -> store hash
         return config
 
     @classmethod

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -857,21 +857,22 @@ class PretrainedConfig(PushToHubMixin):
         Returns:
             `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
         """
-        output = copy.deepcopy(self.__dict__)
+        self_dict = copy.deepcopy(self.__dict__)
         if hasattr(self.__class__, "model_type"):
-            output["model_type"] = self.__class__.model_type
-        if "_auto_class" in output:
-            del output["_auto_class"]
-        if "_attn_implementation_internal" in output:
-            del output["_attn_implementation_internal"]
+            self_dict["model_type"] = self.__class__.model_type
+        if "_auto_class" in self_dict:
+            del self_dict["_auto_class"]
+        if "_attn_implementation_internal" in self_dict:
+            del self_dict["_attn_implementation_internal"]
 
         for key in METADATA_FIELDS:
-            output.pop(key, None)
+            self_dict.pop(key, None)
 
         # Transformers version when serializing the model
-        output["transformers_version"] = __version__
+        self_dict["transformers_version"] = __version__
 
-        for key, value in output.items():
+        output = {}
+        for key, value in self_dict.items():
             # Deal with nested configs like CLIP
             if isinstance(value, PretrainedConfig):
                 value = value.to_dict()
@@ -919,7 +920,7 @@ class PretrainedConfig(PushToHubMixin):
                 config_dict.pop(metadata_field, None)
             # nested metadata
             for value in config_dict.values():
-                if isinstance(value, PretrainedConfig):
+                if isinstance(value, dict):
                     for metadata_field in METADATA_FIELDS:
                         value.pop(metadata_field, None)
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -485,8 +485,11 @@ class GenerationConfig(PushToHubMixin):
         # Validate the values of the attributes
         self.validate(is_init=True)
 
+        # Finally, store the original hash of the object (to detect post-loading changes)
+        self._original_object_hash = hash(self)
+
     def __hash__(self):
-        return hash(self.to_json_string(ignore_metadata=True))
+        return hash(self.to_json_string(use_diff=False, ignore_metadata=True))
 
     def __eq__(self, other):
         if not isinstance(other, GenerationConfig):
@@ -1055,11 +1058,9 @@ class GenerationConfig(PushToHubMixin):
 
         if kwargs.get("return_unused_kwargs") is True:
             config, unused_kwargs = cls.from_dict(config_dict, **kwargs)
-            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
             return config, unused_kwargs
         else:
             config = cls.from_dict(config_dict, **kwargs)
-            config._original_object_hash = hash(config)  # Hash to detect whether the instance was modified
             return config
 
     @classmethod
@@ -1096,6 +1097,7 @@ class GenerationConfig(PushToHubMixin):
         config = cls(**{**config_dict, **kwargs})
         unused_kwargs = config.update(**kwargs)
 
+        config._original_object_hash = hash(config)  # `from_dict` is a valid initializer and has post __init__ changes
         logger.info(f"Generate config {config}")
         if return_unused_kwargs:
             return config, unused_kwargs
@@ -1256,7 +1258,7 @@ class GenerationConfig(PushToHubMixin):
             ):
                 generation_config.return_dict_in_generate = True
 
-        # Hash to detect whether the instance was modified
+        # `from_model_config` is a valid initializer and has post __init__ changes
         generation_config._original_object_hash = hash(generation_config)
         return generation_config
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -490,7 +490,7 @@ class GenerationConfig(PushToHubMixin):
         self._original_object_hash = None
 
     def __hash__(self):
-        return hash(self.to_json_string(use_diff=False, ignore_metadata=True))
+        return hash(self.to_json_string(ignore_metadata=True))
 
     def __eq__(self, other):
         if not isinstance(other, GenerationConfig):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -485,8 +485,8 @@ class GenerationConfig(PushToHubMixin):
         # Validate the values of the attributes
         self.validate(is_init=True)
 
-        # Finally, store the original hash of the object (to detect post-loading changes)
-        self._original_object_hash = hash(self)
+        # If we load the object from an external source, we need to store the original object hash
+        self._original_object_hash = None
 
     def __hash__(self):
         return hash(self.to_json_string(use_diff=False, ignore_metadata=True))
@@ -1058,9 +1058,11 @@ class GenerationConfig(PushToHubMixin):
 
         if kwargs.get("return_unused_kwargs") is True:
             config, unused_kwargs = cls.from_dict(config_dict, **kwargs)
+            config._original_object_hash = hash(config)  # config object loaded from external source -> store hash
             return config, unused_kwargs
         else:
             config = cls.from_dict(config_dict, **kwargs)
+            config._original_object_hash = hash(config)  # config object loaded from external source -> store hash
             return config
 
     @classmethod
@@ -1097,7 +1099,7 @@ class GenerationConfig(PushToHubMixin):
         config = cls(**{**config_dict, **kwargs})
         unused_kwargs = config.update(**kwargs)
 
-        config._original_object_hash = hash(config)  # `from_dict` is a valid initializer and has post __init__ changes
+        config._original_object_hash = hash(config)  # config object loaded from external source -> store hash
         logger.info(f"Generate config {config}")
         if return_unused_kwargs:
             return config, unused_kwargs

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1152,10 +1152,8 @@ class GenerationConfig(PushToHubMixin):
         output = copy.deepcopy(self.__dict__)
 
         # Fields to ignore at serialization time
-        if "_commit_hash" in output:
-            del output["_commit_hash"]
-        if "_original_object_hash" in output:
-            del output["_original_object_hash"]
+        for key in METADATA_FIELDS:
+            output.pop(key, None)
 
         # Transformers version when serializing this file
         output["transformers_version"] = __version__

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -485,7 +485,8 @@ class GenerationConfig(PushToHubMixin):
         # Validate the values of the attributes
         self.validate(is_init=True)
 
-        # If we load the object from an external source, we need to store the original object hash
+        # If we load the object from an external source, we need to store the original object hash. (The hash can't
+        # be set here -- some classes overload __init__ and modify the instance after calling super().__init__)
         self._original_object_hash = None
 
     def __hash__(self):

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -57,6 +57,7 @@ from transformers.generation import (
     UnbatchedClassifierFreeGuidanceLogitsProcessor,
     WatermarkLogitsProcessor,
 )
+from transformers.generation.configuration_utils import METADATA_FIELDS
 from transformers.testing_utils import TOKEN, USER, is_staging_test, torch_device
 
 
@@ -700,7 +701,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = GenerationConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
@@ -720,7 +721,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = GenerationConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
@@ -739,7 +740,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = GenerationConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
@@ -759,7 +760,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = GenerationConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -85,7 +85,7 @@ class ConfigTester:
             config_first.to_json_file(json_file_path)
             config_second = self.config_class.from_json_file(json_file_path)
 
-        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+        self.parent.assertEqual(config_second, config_first)
 
     def create_and_test_config_from_and_save_pretrained(self):
         config_first = self.config_class(**self.inputs_dict)
@@ -94,7 +94,7 @@ class ConfigTester:
             config_first.save_pretrained(tmpdirname)
             config_second = self.config_class.from_pretrained(tmpdirname)
 
-        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+        self.parent.assertEqual(config_second, config_first)
 
         with self.parent.assertRaises(OSError):
             self.config_class.from_pretrained(f".{tmpdirname}")
@@ -108,7 +108,7 @@ class ConfigTester:
             config_first.save_pretrained(sub_tmpdirname)
             config_second = self.config_class.from_pretrained(tmpdirname, subfolder=subfolder)
 
-        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+        self.parent.assertEqual(config_second, config_first)
 
     def create_and_test_config_with_num_labels(self):
         config = self.config_class(**self.inputs_dict, num_labels=5)

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -346,7 +346,8 @@ class ConfigTestUtils(unittest.TestCase):
             with self.assertRaises(ValueError):
                 config.save_pretrained(tmp_dir)
 
-        # However, if the user loads a pretrained config with generation parameters, we should not raise an exception.
+        # However, if the user loads a pretrained config with generation parameters, we should not raise an exception
+        # at save time
         config = AutoConfig.from_pretrained("openai/whisper-small")
         self.assertTrue(len(config._get_non_default_generation_parameters()) > 0)  # sanity check: has gen params
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -219,17 +219,15 @@ class ConfigTestUtils(unittest.TestCase):
 
     def test_config_common_kwargs_is_complete(self):
         base_config = PretrainedConfig()
-        missing_keys = [key for key in base_config.__dict__ if key not in config_common_kwargs]
+        missing_keys = {key for key in base_config.__dict__ if key not in config_common_kwargs}
         # If this part of the test fails, you have arguments to addin config_common_kwargs above.
-        self.assertListEqual(
+        self.assertSetEqual(
             missing_keys,
-            [
+            {
                 "is_encoder_decoder",
                 "_name_or_path",
-                "_commit_hash",
                 "_attn_implementation_internal",
-                "transformers_version",
-            ],
+            } | set(METADATA_FIELDS),
         )
         keys_with_defaults = [key for key, value in config_common_kwargs.items() if value == getattr(base_config, key)]
         if len(keys_with_defaults) > 0:

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -227,7 +227,8 @@ class ConfigTestUtils(unittest.TestCase):
                 "is_encoder_decoder",
                 "_name_or_path",
                 "_attn_implementation_internal",
-            } | set(METADATA_FIELDS),
+            }
+            | set(METADATA_FIELDS),
         )
         keys_with_defaults = [key for key, value in config_common_kwargs.items() if value == getattr(base_config, key)]
         if len(keys_with_defaults) > 0:

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -117,9 +117,7 @@ class ConfigPushToHubTester(unittest.TestCase):
                 config.push_to_hub(tmp_repo, token=self._token)
 
                 new_config = BertConfig.from_pretrained(tmp_repo)
-                for k, v in config.to_dict().items():
-                    if k != "transformers_version":
-                        self.assertEqual(v, getattr(new_config, k))
+                self.assertEqual(config.to_dict(), new_config.to_dict())
             finally:
                 # Always (try to) delete the repo.
                 self._try_delete_repo(repo_id=tmp_repo, token=self._token)

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -26,7 +26,7 @@ from huggingface_hub import HfFolder, delete_repo
 from requests.exceptions import HTTPError
 
 from transformers import AutoConfig, BertConfig, GPT2Config
-from transformers.configuration_utils import PretrainedConfig
+from transformers.configuration_utils import METADATA_FIELDS, PretrainedConfig
 from transformers.testing_utils import TOKEN, USER, is_staging_test
 
 
@@ -117,7 +117,9 @@ class ConfigPushToHubTester(unittest.TestCase):
                 config.push_to_hub(tmp_repo, token=self._token)
 
                 new_config = BertConfig.from_pretrained(tmp_repo)
-                self.assertEqual(config.to_dict(), new_config.to_dict())
+                for k, v in config.to_dict().items():
+                    if k not in METADATA_FIELDS:
+                        self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
                 self._try_delete_repo(repo_id=tmp_repo, token=self._token)
@@ -135,7 +137,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = BertConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
@@ -152,7 +154,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = BertConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.
@@ -170,7 +172,7 @@ class ConfigPushToHubTester(unittest.TestCase):
 
                 new_config = BertConfig.from_pretrained(tmp_repo)
                 for k, v in config.to_dict().items():
-                    if k != "transformers_version":
+                    if k not in METADATA_FIELDS:
                         self.assertEqual(v, getattr(new_config, k))
             finally:
                 # Always (try to) delete the repo.


### PR DESCRIPTION
# What does this PR do?

⚠️ ⚠️ ⚠️ don't review yet, sorting all tests and use cases is taking more time than I thought 👀 

______________________

In a recent PR (#32659), we started raising exceptions if we were to store a model config with generative parameters. If we were saving a model, which saves the config, the generative parameters were moved to `GenerationConfig` before saving the `PreTrainedConfig`, working around the issue when saving a model.

However, a common use case was uncovered. If a user loads a `PreTrainedConfig` with generative parameters and tries to save it, the user has done nothing wrong and yet they see an exception. This PR lowers the exception to a warning in that situation, preventing the code from crashing :)

(Thank you @regisss for flagging this issue and @ydshieh for the testing suggestion)