### PR TITLE
allow unused input parameters passthrough when chunking in asr pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,9 +125,6 @@ dmypy.json
 .vs
 .vscode
 
-# devcontainer in vscode
-.devcontainer/
-
 # Pycharm
 .idea
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dmypy.json
 .vs
 .vscode
 
+# devcontainers in vscode
+.devcontainer/
+
 # Pycharm
 .idea
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,7 @@ dmypy.json
 .vs
 .vscode
 
-# devcontainers in vscode
+# devcontainer in vscode
 .devcontainer/
 
 # Pycharm

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dmypy.json
 .vs
 .vscode
 
+# devcontainer in vscode
+.devcontainer/
+
 # Pycharm
 .idea
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -434,7 +434,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             for item in chunk_iter(
                 inputs, self.feature_extractor, chunk_len, stride_left, stride_right, self.torch_dtype
             ):
-                yield item
+                yield {**item, **extra}
         else:
             if self.type == "seq2seq_whisper" and inputs.shape[0] > self.feature_extractor.n_samples:
                 processed = self.feature_extractor(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1442,6 +1442,22 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer([audio_tiled], batch_size=2)
         self.assertEqual(output, [{"text": ANY(str)}])
         self.assertEqual(output[0]["text"][:6], "ZBT ZC")
+    
+    @require_torch
+    def test_chunking_parameter_passthrough(self):
+        speech_recognizer = pipeline(
+            task="automatic-speech-recognition",
+            model="hf-internal-testing/tiny-random-wav2vec2",
+            chunk_length_s=10.0,
+        )
+
+        ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation").sort("id")
+        audio = ds[40]["audio"]["array"]
+
+        n_repeats = 2
+        audio_tiled = np.tile(audio, n_repeats)
+        output = speech_recognizer([audio_tiled], batch_size=2, unused_parameter = "unused")
+        assert output["unused_parameter"] == "unused"
 
     @require_torch
     def test_return_timestamps_ctc_fast(self):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1462,9 +1462,6 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
             chunked_output.keys() == non_chunked_output.keys()
         ), "The output structure should be the same for chunked vs non-chunked versions of asr pipelines."
 
-        # Make sure that the output structure follows the expected inference type.
-        compare_pipeline_output_to_hub_spec(chunked_output, AutomaticSpeechRecognitionOutput)
-
     @require_torch
     def test_return_timestamps_ctc_fast(self):
         speech_recognizer = pipeline(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1456,7 +1456,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
         n_repeats = 2
         audio_tiled = np.tile(audio, n_repeats)
-        output = speech_recognizer([audio_tiled], batch_size=2, unused_parameter = "unused")
+        output = speech_recognizer([audio_tiled], batch_size=2, unused_parameter="unused")
         assert output["unused_parameter"] == "unused"
 
     @require_torch

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1442,7 +1442,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         output = speech_recognizer([audio_tiled], batch_size=2)
         self.assertEqual(output, [{"text": ANY(str)}])
         self.assertEqual(output[0]["text"][:6], "ZBT ZC")
-    
+
     @require_torch
     def test_chunking_parameter_passthrough(self):
         speech_recognizer = pipeline(

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1461,7 +1461,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         assert (
             chunked_output.keys() == non_chunked_output.keys()
         ), "The output structure should be the same for chunked vs non-chunked versions of asr pipelines."
-        
+
         # Make sure that the output structure follows the expected inference type.
         compare_pipeline_output_to_hub_spec(chunked_output, AutomaticSpeechRecognitionOutput)
 

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1461,6 +1461,9 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         assert (
             chunked_output.keys() == non_chunked_output.keys()
         ), "The output structure should be the same for chunked vs non-chunked versions of asr pipelines."
+        
+        # Make sure that the output structure follows the expected inference type.
+        compare_pipeline_output_to_hub_spec(chunked_output, AutomaticSpeechRecognitionOutput)
 
     @require_torch
     def test_return_timestamps_ctc_fast(self):

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1444,12 +1444,11 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
         self.assertEqual(output[0]["text"][:6], "ZBT ZC")
 
     @require_torch
-    def test_input_parameter_input_passthrough(self):
+    def test_input_parameter_passthrough(self):
         """Test that chunked vs non chunked versions of ASR pipelines returns the same structure for the same inputs."""
         speech_recognizer = pipeline(
             task="automatic-speech-recognition",
             model="hf-internal-testing/tiny-random-wav2vec2",
-            chunk_length_s=10.0,
         )
 
         ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation").sort("id")

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -1456,7 +1456,7 @@ class AutomaticSpeechRecognitionPipelineTests(unittest.TestCase):
 
         inputs = {"raw": audio, "sampling_rate": 16_000, "id": 1}
 
-        chunked_output = speech_recognizer(inputs.copy(), chunked_length_s=30)
+        chunked_output = speech_recognizer(inputs.copy(), chunk_length_s=30)
         non_chunked_output = speech_recognizer(inputs.copy())
         assert (
             chunked_output.keys() == non_chunked_output.keys()


### PR DESCRIPTION
# What does this PR do?

Harmonizing behaviour for what input data is passthrough automatic speech recognition pipelines.

Today you can get different return dictionaries keys when using ASR pipeline with and without the call parameter `chunk_length_s`. With this parameter you will only get a dictionary with the transformed input data, while omitting this parameter allows you to retrieve any unused input data parameter back in the resulting dictionary. This inconsistency can be confusing as sometimes you need to keep track of which inputs corresponds to which outputs, while it is not obvious to a user why.

The following code snippet highlights these differences:

```
import torch
from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
import numpy as np


device = "cuda:0" if torch.cuda.is_available() else "cpu"
torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32

model_id = "openai/whisper-large-v3-turbo"

model = AutoModelForSpeechSeq2Seq.from_pretrained(
    model_id, torch_dtype=torch_dtype, low_cpu_mem_usage=True, use_safetensors=True
)
model.to(device)

processor = AutoProcessor.from_pretrained(model_id)

pipe = pipeline(
    "automatic-speech-recognition",
    model=model,
    tokenizer=processor.tokenizer,
    feature_extractor=processor.feature_extractor,
    torch_dtype=torch_dtype,
    device=device,
)

data = {"raw": np.zeros(100), "sampling_rate": 16_000, "id": 1}

chunk_output = pipe(data.copy(), chunk_length_s=30)
non_chunk_output = pipe(data.copy())

print(chunk_output)
print(non_chunk_output)
assert chunk_output.keys() == non_chunk_output.keys()
```

This will print the following and fail the assert.

```
{'text': ' you'}
{'text': ' you', 'id': [1]}
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
