### PR TITLE
Config: lower `save_pretrained` exception to warning

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -380,11 +380,12 @@ class PretrainedConfig(PushToHubMixin):
 
         non_default_generation_parameters = self._get_non_default_generation_parameters()
         if len(non_default_generation_parameters) > 0:
-            raise ValueError(
+            # TODO (joao): this should be an exception if the user has modified the loaded config. See #33886
+            warnings.warn(
                 "Some non-default generation parameters are set in the model config. These should go into either a) "
                 "`model.generation_config` (as opposed to `model.config`); OR b) a GenerationConfig file "
                 "(https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model) "
-                f"\nNon-default generation parameters: {str(non_default_generation_parameters)}"
+                f"\nNon-default generation parameters: {str(non_default_generation_parameters)}", UserWarning
             )
 
         os.makedirs(save_directory, exist_ok=True)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -384,7 +384,8 @@ class PretrainedConfig(PushToHubMixin):
             warnings.warn(
                 "Some non-default generation parameters are set in the model config. These should go into either a) "
                 "`model.generation_config` (as opposed to `model.config`); OR b) a GenerationConfig file "
-                "(https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model) "
+                "(https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)."
+                "This warning will become an exception in the future.",
                 f"\nNon-default generation parameters: {str(non_default_generation_parameters)}", UserWarning
             )
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -385,7 +385,7 @@ class PretrainedConfig(PushToHubMixin):
                 "Some non-default generation parameters are set in the model config. These should go into either a) "
                 "`model.generation_config` (as opposed to `model.config`); OR b) a GenerationConfig file "
                 "(https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)."
-                "This warning will become an exception in the future.",
+                "This warning will become an exception in the future."
                 f"\nNon-default generation parameters: {str(non_default_generation_parameters)}",
                 UserWarning,
             )

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -386,7 +386,8 @@ class PretrainedConfig(PushToHubMixin):
                 "`model.generation_config` (as opposed to `model.config`); OR b) a GenerationConfig file "
                 "(https://huggingface.co/docs/transformers/generation_strategies#save-a-custom-decoding-strategy-with-your-model)."
                 "This warning will become an exception in the future.",
-                f"\nNon-default generation parameters: {str(non_default_generation_parameters)}", UserWarning
+                f"\nNon-default generation parameters: {str(non_default_generation_parameters)}",
+                UserWarning,
             )
 
         os.makedirs(save_directory, exist_ok=True)

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -313,11 +313,12 @@ class ConfigTestUtils(unittest.TestCase):
         old_configuration = old_transformers.models.auto.AutoConfig.from_pretrained(repo)
         self.assertEqual(old_configuration.hidden_size, 768)
 
-    def test_saving_config_with_custom_generation_kwargs_raises_exception(self):
+    def test_saving_config_with_custom_generation_kwargs_raises_warning(self):
         config = BertConfig(min_length=3)  # `min_length = 3` is a non-default generation kwarg
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self.assertRaises(ValueError):
+            with self.assertWarns(UserWarning) as cm:
                 config.save_pretrained(tmp_dir)
+            self.assertIn("min_length", str(cm.warning))
 
     def test_get_non_default_generation_parameters(self):
         config = BertConfig()


### PR DESCRIPTION
# What does this PR do?

Round 2, after #33886 -- TL;DR stops raising exceptions when saving a model config with generative parameters, if the user is not responsible for those parameters being there.

(copied from 33886)
```
In a recent PR (https://github.com/huggingface/transformers/pull/32659), we started raising exceptions if we were to store a model config with generative parameters. If we were saving a model, which saves the config, the generative parameters were moved to GenerationConfig before saving the PreTrainedConfig, working around the issue when saving a model.

However, a common use case was uncovered. If a user loads a PreTrainedConfig with generative parameters and tries to save it, the user has done nothing wrong and yet they see an exception. This PR lowers the exception to a warning in that situation, preventing the code from crashing :)
```

33886 would be my intended solution to the problem, but I ran into multiple implementation issues which I'll iron out in separate PRs 👀 This PR is a poor man's version of the solution, to unblock others: simply lower the exception to a warning. 

(cc @regisss )

