### PR TITLE
Fix tied weigths isuue

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -833,6 +833,8 @@ def _load_state_dict_into_meta_model(
 
     is_torch_e4m3fn_available = hasattr(torch, "float8_e4m3fn")
 
+    data_ptrs = set()
+
     for param_name, param in state_dict.items():
         if param_name not in expected_keys:
             continue
@@ -916,8 +918,13 @@ def _load_state_dict_into_meta_model(
             if is_fsdp_enabled():
                 param_device = "cpu" if is_local_dist_rank_0() else "meta"
 
+            #
+            if set_module_kwargs["value"].data_ptr() in data_ptrs:
+                set_module_kwargs["value"] = set_module_kwargs["value"].clone()
+
             # For backward compatibility with older versions of `accelerate` and for non-quantized params
             set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)
+            data_ptrs.add(model.state_dict()[param_name].data_ptr())
         else:
             hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict, unexpected_keys)
             # For quantized modules with FSDP/DeepSpeed Stage 3, we need to quantize the parameter on the GPU

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2556,9 +2556,7 @@ class TestTensorSharing(TestCasePlus):
 @require_read_token
 @require_torch
 class TestFromPretrained(unittest.TestCase):
-    def test_tie_word_embeddings_false_load_weights_as_untied(
-        self,
-    ):
+    def test_tie_word_embeddings_false_load_weights_as_untied(self):
         with tempfile.TemporaryDirectory() as tempdir:
             checkpoint = "meta-llama/Llama-2-7b-hf"
             config = AutoConfig.from_pretrained(checkpoint)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -91,6 +91,7 @@ if is_torch_available():
         BertModel,
         CLIPTextModel,
         GenerationMixin,
+        LlamaForCausalLM,
         PreTrainedModel,
         T5Config,
         T5ForConditionalGeneration,
@@ -2568,7 +2569,7 @@ class TestFromPretrained(unittest.TestCase):
             config.num_hidden_layers = 2
             config.num_key_value_heads = 4
 
-            model = AutoModelForCausalLM(config=config)
+            model = LlamaForCausalLM(config=config)
 
             local_path = tempdir
             model.save_pretrained(local_path, safe_serialization=False)
@@ -2578,7 +2579,7 @@ class TestFromPretrained(unittest.TestCase):
             expected_keys = list(model.state_dict().keys())
 
             def check(torch_dtype, tie_word_embeddings, device_map):
-                model = AutoModelForCausalLM(config=config)
+                model = LlamaForCausalLM(config=config)
 
                 _load_state_dict_into_meta_model(
                     model=model,

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2556,10 +2556,10 @@ class TestTensorSharing(TestCasePlus):
 @require_read_token
 @require_torch
 class TestFromPretrained(unittest.TestCase):
-    def test_tie_word_embeddings_false_load_weights_as_untiedtest_tie_word_embeddings_false_load_weights_as_untied(self):
-
+    def test_tie_word_embeddings_false_load_weights_as_untied(
+        self,
+    ):
         with tempfile.TemporaryDirectory() as tempdir:
-
             checkpoint = "meta-llama/Llama-2-7b-hf"
             config = AutoConfig.from_pretrained(checkpoint)
             config.tie_word_embeddings = True
@@ -2587,14 +2587,17 @@ class TestFromPretrained(unittest.TestCase):
                 _load_state_dict_into_meta_model(
                     model=model,
                     state_dict=state_dict,
-                    start_prefix='',
+                    start_prefix="",
                     expected_keys=expected_keys,
-                    device_map={'': torch.device(device_map)},
+                    device_map={"": torch.device(device_map)},
                     dtype=torch_dtype,
                 )
                 # check the change in `_load_state_dict_into_meta_model` in PR #33913 works as expected
                 # https://github.com/huggingface/transformers/pull/33913/files
-                assert model.state_dict()["model.embed_tokens.weight"].data_ptr() != model.state_dict()["lm_head.weight"].data_ptr()
+                assert (
+                    model.state_dict()["model.embed_tokens.weight"].data_ptr()
+                    != model.state_dict()["lm_head.weight"].data_ptr()
+                )
 
                 # load model
                 model = AutoModelForCausalLM.from_pretrained(

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -104,7 +104,9 @@ if is_torch_available():
     from transformers.modeling_utils import (
         _find_disjoint,
         _find_identical,
+        _load_state_dict_into_meta_model,
         dtype_byte_size,
+        load_state_dict,
     )
     from transformers.pytorch_utils import isin_mps_friendly
 
@@ -2547,3 +2549,77 @@ class TestTensorSharing(TestCasePlus):
         shared_names, identical_names = _find_identical([{"a", "b"}], state_dict)
         self.assertEqual(shared_names, [{"a", "b"}])
         self.assertEqual(identical_names, [])
+
+
+@require_torch
+class TestFromPretrained(unittest.TestCase):
+    def test_tie_word_embeddings_false_load_weights_as_untiedtest_tie_word_embeddings_false_load_weights_as_untied(self):
+
+        with tempfile.TemporaryDirectory() as tempdir:
+
+            checkpoint = "meta-llama/Llama-2-7b-hf"
+            config = AutoConfig.from_pretrained(checkpoint)
+            config.tie_word_embeddings = True
+
+            config.hidden_size = 16
+            config.intermediate_size = 16
+            config.max_position_embeddings = 16
+            config.num_attention_heads = 4
+            config.num_hidden_layers = 2
+            config.num_key_value_heads = 4
+
+            model = AutoModelForCausalLM(config=config)
+
+            local_path = tempdir
+            model.save_pretrained(local_path, safe_serialization=False)
+            pytorch_bin = os.path.join(local_path, "pytorch_model.bin")
+
+            state_dict = load_state_dict(pytorch_bin)
+            expected_keys = list(model.state_dict().keys())
+
+            def check(torch_dtype, tie_word_embeddings, device_map):
+                model = AutoModelForCausalLM(config=config)
+
+                _load_state_dict_into_meta_model(
+                    model=model,
+                    state_dict=state_dict,
+                    start_prefix='',
+                    expected_keys=expected_keys,
+                    device_map={'': torch.device(device_map)},
+                    dtype=torch_dtype,
+                )
+                assert model.state_dict()["model.embed_tokens.weight"].data_ptr() != model.state_dict()["lm_head.weight"].data_ptr()
+
+                # load model
+                model = AutoModelForCausalLM.from_pretrained(
+                    local_path,
+                    torch_dtype=torch_dtype,
+                    tie_word_embeddings=tie_word_embeddings,
+                    device_map=device_map,
+                )
+
+                # modify lm head
+                with torch.no_grad():
+                    model.lm_head.weight += 1
+
+                # check that embed_tokens is not modified
+                if tie_word_embeddings:
+                    assert torch.equal(model.lm_head.weight, model.model.embed_tokens.weight)
+                else:
+                    assert not torch.equal(model.lm_head.weight, model.model.embed_tokens.weight)
+
+                with tempfile.TemporaryDirectory() as tempdir_2:
+                    model.save_pretrained(tempdir_2, safe_serialization=True)
+
+            test_params = [
+                (torch.float32, False, "cpu"),
+                (torch.float32, True, "cpu"),
+                (torch.float16, False, "cpu"),
+                (torch.float16, True, "cpu"),
+                (torch.float32, False, "cuda"),
+                (torch.float32, True, "cuda"),
+                (torch.float16, False, "cuda"),
+                (torch.float16, True, "cuda"),
+            ]
+            for params in test_params:
+                check(*params)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2553,8 +2553,8 @@ class TestTensorSharing(TestCasePlus):
         self.assertEqual(identical_names, [])
 
 
-@require_read_token
 @require_torch
+@require_read_token
 class TestFromPretrained(unittest.TestCase):
     def test_tie_word_embeddings_false_load_weights_as_untied(self):
         with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
# What does this PR do?

Relate to #33689 and #33688

- This line
https://github.com/huggingface/transformers/blob/ab97a78130f96e72eec609c56cb5f719529ffb9e/src/transformers/modeling_utils.py#L4517

  may have `state_dict` containing weights with same `data_ptr` (tied). Those tensors are on `cpu` with `dtype=float32`.
  (Note this call doesn't take into account of `model.config`.)

- This line
https://github.com/huggingface/transformers/blob/ab97a78130f96e72eec609c56cb5f719529ffb9e/src/transformers/modeling_utils.py#L4537

  will arrive [line 1](https://github.com/huggingface/transformers/blob/ab97a78130f96e72eec609c56cb5f719529ffb9e/src/transformers/modeling_utils.py#L935) and **line 2**

https://github.com/huggingface/transformers/blob/ab97a78130f96e72eec609c56cb5f719529ffb9e/src/transformers/modeling_utils.py#L990

- If the specified `torch_dtype` is `torch.float32` and `device_map="cpu"`, the `line 1` and `line 2` won't create new tensors. So the model will get the weights directly from `state_dict` and the tied weights remain tied.

- In other cases, either line 1 or line 2 will create new tensors and assign to `model`, so there is no tied weights inside the model with those new values.
  - This explains why #33689 and #33688 have issue only with `cpu+float32`

This PRs provides a possible fix to avoid tied weights being assigned within `_load_state_dict_into_meta_model`. 

The tied weights will be handled after `_load_pretrained_model` is called within `from_pretrained`, see

https://github.com/huggingface/transformers/blob/ab97a78130f96e72eec609c56cb5f719529ffb9e/src/transformers/modeling_utils.py#L4057-L4058



