### PR TITLE
Updating `char_to_token` documentation to note behaviour when `trim_offsets` is True

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -598,7 +598,8 @@ class BatchEncoding(UserDict):
 
 
         Returns:
-            `int`: Index of the token.
+            `int`: Index of the token, or None if the char index refers to a whitespace only token and whitespace is
+                   trimmed with `trim_offsets=True`.
         """
 
         if not self._encodings:


### PR DESCRIPTION
# What does this PR do?

Updates the documentation for `BatchEncoding.char_to_token` to note that the return value can be `None` if `trim_offsets` is true and the char index points to a whitespace character.

Fixes #33237.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Discussed in #33237.


## Who can review?

@ArthurZucker @itazap 
