### PR TITLE
Fix EncoderDecoder cache candidate edge case

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -398,15 +398,10 @@ def _crop_past_key_values(model, past_key_values, max_length):
         past_key_values.crop(max_length)
     elif past_key_values is not None:
         for idx in range(len(past_key_values)):
-            if past_key_values[idx] != ([], []):
-                new_past.append(
-                    (
-                        past_key_values[idx][0][:, :, :max_length, :],
-                        past_key_values[idx][1][:, :, :max_length, :],
-                    )
-                )
+            if past_key_values[idx] != ([],) * len(past_key_values[idx]):
+                new_past.append(tuple(past_key_value[:, :, :max_length, :] for past_key_value in past_key_values[idx]))
             else:
-                new_past.append((past_key_values[idx][0], past_key_values[idx][1]))
+                new_past.append(past_key_values[idx])
         past_key_values = tuple(new_past)
     return past_key_values
 


### PR DESCRIPTION
# What does this PR do?
Whisper introduced `EncoderDecoder` cache, which in some cases - e.g distil whisper, can have empty cache layers. This aims to fix this.

Note that this allows speculative decoding for Whisper again, but that the two linked issues still fails because the decoding with assistant decoder is not as fast, at least on my machine: `test_speculative_decoding_whisper_distil` , `test_speculative_decoding_distil`


cc @ArthurZucker @eustlb
