### PR TITLE
Specifying torch dtype in Qwen2VLForConditionalGeneration

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1499,7 +1499,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             torch_dtype (`torch.dtype`, *optional*):
                 Override the default `torch.dtype` and load the model under this dtype.
         """
-        torch_dtype = kwargs.pop("torch_dtype", None)
+        torch_dtype = kwargs.pop("torch_dtype", torch.get_default_dtype())
         use_flash_attention_2 = kwargs.pop("use_flash_attention_2", False)
 
         # override default dtype if needed

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -1422,7 +1422,9 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
     def __init__(self, config):
         super().__init__(config)
         self.visual = Qwen2VisionTransformerPretrainedModel._from_config(
-            config.vision_config, attn_implementation=config._attn_implementation
+            config.vision_config,
+            attn_implementation=config._attn_implementation,
+            torch_dtype=config.torch_dtype,
         )
         self.model = Qwen2VLModel(config)
         self.vocab_size = config.vocab_size

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -1422,9 +1422,7 @@ class Qwen2VLForConditionalGeneration(Qwen2VLPreTrainedModel, GenerationMixin):
     def __init__(self, config):
         super().__init__(config)
         self.visual = Qwen2VisionTransformerPretrainedModel._from_config(
-            config.vision_config,
-            attn_implementation=config._attn_implementation,
-            torch_dtype=config.torch_dtype,
+            config.vision_config, attn_implementation=config._attn_implementation
         )
         self.model = Qwen2VLModel(config)
         self.vocab_size = config.vocab_size


### PR DESCRIPTION
Fixing a bug that led to the warning

```You are attempting to use Flash Attention 2.0 without specifying a torch dtype. This might lead to unexpected behaviour```

every time this model was initialized with `attn_implementation="flash_attention_2"`, even with the dtype specified.

@amyeroberts, @qubvel