### PR TITLE
Separate chat templates into a single file

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -526,18 +526,24 @@ class ProcessorMixin(PushToHubMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
+        output_naked_chat_template_file = os.path.join(save_directory, "chat_template.jinja")
         output_chat_template_file = os.path.join(save_directory, "chat_template.json")
 
         processor_dict = self.to_dict()
         # Save `chat_template` in its own file. We can't get it from `processor_dict` as we popped it in `to_dict`
         # to avoid serializing chat template in json config file. So let's get it from `self` directly
         if self.chat_template is not None:
-            chat_template_json_string = (
-                json.dumps({"chat_template": self.chat_template}, indent=2, sort_keys=True) + "\n"
-            )
-            with open(output_chat_template_file, "w", encoding="utf-8") as writer:
-                writer.write(chat_template_json_string)
-            logger.info(f"chat template saved in {output_chat_template_file}")
+            if kwargs.get("save_naked_chat_template", False):
+                with open(output_naked_chat_template_file, "w", encoding="utf-8") as writer:
+                    writer.write(self.chat_template)
+                logger.info(f"chat template saved in {output_naked_chat_template_file}")
+            else:
+                chat_template_json_string = (
+                    json.dumps({"chat_template": self.chat_template}, indent=2, sort_keys=True) + "\n"
+                )
+                with open(output_chat_template_file, "w", encoding="utf-8") as writer:
+                    writer.write(chat_template_json_string)
+                logger.info(f"chat template saved in {output_chat_template_file}")
 
         # For now, let's not save to `processor_config.json` if the processor doesn't have extra attributes and
         # `auto_map` is not specified.

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -526,7 +526,7 @@ class ProcessorMixin(PushToHubMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
-        output_raw_chat_template_file = os.path.join(save_directory, "processor_chat_template.jinja")
+        output_raw_chat_template_file = os.path.join(save_directory, "chat_template.jinja")
         output_chat_template_file = os.path.join(save_directory, "chat_template.json")
 
         processor_dict = self.to_dict()
@@ -622,7 +622,7 @@ class ProcessorMixin(PushToHubMixin):
         else:
             processor_file = PROCESSOR_NAME
             chat_template_file = "chat_template.json"
-            raw_chat_template_file = "processor_chat_template.jinja"
+            raw_chat_template_file = "chat_template.jinja"
             try:
                 # Load from local folder or from cache or download from model Hub and cache
                 resolved_processor_file = cached_file(

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -686,12 +686,11 @@ class ProcessorMixin(PushToHubMixin):
                 )
 
         # Add chat template as kwarg before returning because most models don't have processor config
-        chat_template = None
         if resolved_naked_chat_template_file is not None:
-            with open(resolved_chat_template_file, "r", encoding="utf-8") as reader:
+            with open(resolved_naked_chat_template_file, "r", encoding="utf-8") as reader:
                 chat_template = reader.read()
             kwargs["chat_template"] = chat_template
-        if resolved_chat_template_file is not None:
+        elif resolved_chat_template_file is not None:
             with open(resolved_chat_template_file, "r", encoding="utf-8") as reader:
                 text = reader.read()
             chat_template = json.loads(text)["chat_template"]

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -721,7 +721,7 @@ class ProcessorMixin(PushToHubMixin):
 
         if "chat_template" in processor_dict and processor_dict["chat_template"] is not None:
             logger.warning_once(
-                "Chat templates should be in a 'chat_template.jinja' file but found key='chat_template' "
+                "Chat templates should be in a 'processor_chat_template.jinja' file but found key='chat_template' "
                 "in the processor's config. Make sure to move your template to its own file."
             )
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -514,7 +514,10 @@ class ProcessorMixin(PushToHubMixin):
             # `AutoProcessor` API.
             if hasattr(attribute, "_set_processor_class"):
                 attribute._set_processor_class(self.__class__.__name__)
-            attribute.save_pretrained(save_directory)
+            if getattr(self, "chat_template", None) is not None and getattr(attribute, "chat_template", None) is not None and kwargs.get("save_naked_chat_template", False):
+                attribute.save_pretrained(save_directory, skip_chat_template_save=True)
+            else:
+                attribute.save_pretrained(save_directory)
 
         if self._auto_class is not None:
             # We added an attribute to the init_kwargs of the tokenizers, which needs to be cleaned up.

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -514,7 +514,11 @@ class ProcessorMixin(PushToHubMixin):
             # `AutoProcessor` API.
             if hasattr(attribute, "_set_processor_class"):
                 attribute._set_processor_class(self.__class__.__name__)
-            if getattr(self, "chat_template", None) is not None and getattr(attribute, "chat_template", None) is not None and kwargs.get("save_naked_chat_template", False):
+            if (
+                getattr(self, "chat_template", None) is not None
+                and getattr(attribute, "chat_template", None) is not None
+                and kwargs.get("save_naked_chat_template", False)
+            ):
                 # If we're saving a chat template file, it clobbers any chat template in the tokenizer
                 attribute.save_pretrained(save_directory, skip_chat_template_save=True)
             else:

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -515,6 +515,7 @@ class ProcessorMixin(PushToHubMixin):
             if hasattr(attribute, "_set_processor_class"):
                 attribute._set_processor_class(self.__class__.__name__)
             if getattr(self, "chat_template", None) is not None and getattr(attribute, "chat_template", None) is not None and kwargs.get("save_naked_chat_template", False):
+                # If we're saving a chat template file, it clobbers any chat template in the tokenizer
                 attribute.save_pretrained(save_directory, skip_chat_template_save=True)
             else:
                 attribute.save_pretrained(save_directory)

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -514,15 +514,7 @@ class ProcessorMixin(PushToHubMixin):
             # `AutoProcessor` API.
             if hasattr(attribute, "_set_processor_class"):
                 attribute._set_processor_class(self.__class__.__name__)
-            if (
-                getattr(self, "chat_template", None) is not None
-                and getattr(attribute, "chat_template", None) is not None
-                and kwargs.get("save_naked_chat_template", False)
-            ):
-                # If we're saving a chat template file, it clobbers any chat template in the tokenizer
-                attribute.save_pretrained(save_directory, skip_chat_template_save=True)
-            else:
-                attribute.save_pretrained(save_directory)
+            attribute.save_pretrained(save_directory)
 
         if self._auto_class is not None:
             # We added an attribute to the init_kwargs of the tokenizers, which needs to be cleaned up.
@@ -534,7 +526,7 @@ class ProcessorMixin(PushToHubMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
-        output_naked_chat_template_file = os.path.join(save_directory, "chat_template.jinja")
+        output_naked_chat_template_file = os.path.join(save_directory, "processor_chat_template.jinja")
         output_chat_template_file = os.path.join(save_directory, "chat_template.json")
 
         processor_dict = self.to_dict()
@@ -630,7 +622,7 @@ class ProcessorMixin(PushToHubMixin):
         else:
             processor_file = PROCESSOR_NAME
             chat_template_file = "chat_template.json"
-            naked_chat_template_file = "chat_template.jinja"
+            naked_chat_template_file = "processor_chat_template.jinja"
             try:
                 # Load from local folder or from cache or download from model Hub and cache
                 resolved_processor_file = cached_file(

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -721,7 +721,7 @@ class ProcessorMixin(PushToHubMixin):
 
         if "chat_template" in processor_dict and processor_dict["chat_template"] is not None:
             logger.warning_once(
-                "Chat templates should be in a 'processor_chat_template.jinja' file but found key='chat_template' "
+                "Chat templates should be in a 'chat_template.jinja' file but found key='chat_template' "
                 "in the processor's config. Make sure to move your template to its own file."
             )
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2302,7 +2302,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 "Special tokens have been added in the vocabulary, make sure the associated word embeddings are"
                 " fine-tuned or trained."
             )
-        breakpoint()
         return tokenizer
 
     @staticmethod

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -145,6 +145,7 @@ AudioInput = Union["np.ndarray", "torch.Tensor", List["np.ndarray"], List["torch
 SPECIAL_TOKENS_MAP_FILE = "special_tokens_map.json"
 ADDED_TOKENS_FILE = "added_tokens.json"
 TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+CHAT_TEMPLATE_FILE = "chat_template.jinja"
 
 # Fast tokenizers (provided by HuggingFace tokenizer's library) can be saved in a single file
 FULL_TOKENIZER_FILE = "tokenizer.json"
@@ -1941,6 +1942,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     "tokenizer_config_file": TOKENIZER_CONFIG_FILE,
                     # tokenizer_file used to initialize a slow from a fast. Properly copy the `addedTokens` instead of adding in random orders
                     "tokenizer_file": FULL_TOKENIZER_FILE,
+                    "chat_template_file": CHAT_TEMPLATE_FILE,
                 }
                 vocab_files = {**cls.vocab_files_names, **additional_files_names}
                 if "tokenizer_file" in vocab_files:
@@ -2061,6 +2063,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         from_slow = kwargs.get("from_slow", False)
         gguf_file = kwargs.get("gguf_file", None)
         has_tokenizer_file = resolved_vocab_files.get("tokenizer_file", None) is not None
+        has_chat_template_file = resolved_vocab_files.get("chat_template_file", None) is not None
 
         # If one passes a GGUF file path to `gguf_file` there is no need for this check as the tokenizer will be
         # loaded directly from the GGUF file.
@@ -2096,6 +2099,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         else:
             config_tokenizer_class = None
             init_kwargs = init_configuration
+
+        # If an independent chat template file exists, it takes priority over template entries in the tokenizer config
+        if has_chat_template_file:
+            with open(resolved_vocab_files["chat_template_file"]) as chat_template_handle:
+                chat_template = chat_template_handle.read()
+            init_kwargs["chat_template"] = chat_template  # Clobbers any template in the config
 
         if not _is_local:
             if "auto_map" in init_kwargs:
@@ -2259,6 +2268,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 if key != "additional_special_tokens":
                     init_kwargs[key] = added_tokens_map.get(str(init_kwargs[key]), init_kwargs[key])
 
+
         # Instantiate the tokenizer.
         try:
             tokenizer = cls(*init_inputs, **init_kwargs)
@@ -2396,6 +2406,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         tokenizer_config_file = os.path.join(
             save_directory, (filename_prefix + "-" if filename_prefix else "") + TOKENIZER_CONFIG_FILE
         )
+        chat_template_file = os.path.join(
+            save_directory, (filename_prefix + "-" if filename_prefix else "") + CHAT_TEMPLATE_FILE
+        )
 
         tokenizer_config = copy.deepcopy(self.init_kwargs)
 
@@ -2418,7 +2431,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             if isinstance(self.chat_template, dict):
                 # Chat template dicts are saved to the config as lists of dicts with fixed key names.
                 # They will be reconstructed as a single dict during loading.
+                # We're trying to discourage chat template dicts, and they are always
+                # saved in the config, never as single files.
                 tokenizer_config["chat_template"] = [{"name": k, "template": v} for k, v in self.chat_template.items()]
+            elif kwargs.get("save_chat_template_file", False):
+                with open(chat_template_file, "w", encoding="utf-8") as f:
+                    f.write(self.chat_template)
+                logger.info(f"chat template saved in {chat_template_file}")
             else:
                 tokenizer_config["chat_template"] = self.chat_template
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2437,6 +2437,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 with open(chat_template_file, "w", encoding="utf-8") as f:
                     f.write(self.chat_template)
                 logger.info(f"chat template saved in {chat_template_file}")
+                if "chat_template" in tokenizer_config:
+                    breakpoint()
+                    tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
             else:
                 tokenizer_config["chat_template"] = self.chat_template
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2425,14 +2425,14 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             tokenizer_config["extra_special_tokens"] = self.extra_special_tokens
             tokenizer_config.update(self.extra_special_tokens)
 
-        if self.chat_template is not None and not kwargs.get("skip_chat_template_save", False):
+        if self.chat_template is not None:
             if isinstance(self.chat_template, dict):
                 # Chat template dicts are saved to the config as lists of dicts with fixed key names.
                 # They will be reconstructed as a single dict during loading.
                 # We're trying to discourage chat template dicts, and they are always
                 # saved in the config, never as single files.
                 tokenizer_config["chat_template"] = [{"name": k, "template": v} for k, v in self.chat_template.items()]
-            elif kwargs.get("save_chat_template_file", False):
+            elif kwargs.get("save_raw_chat_template", False):
                 with open(chat_template_file, "w", encoding="utf-8") as f:
                     f.write(self.chat_template)
                 logger.info(f"chat template saved in {chat_template_file}")

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2176,7 +2176,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         # Merge resolved_vocab_files arguments in init_kwargs.
         added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
-        resolved_vocab_files.pop("chat_template_file", None)
         for args_name, file_path in resolved_vocab_files.items():
             if args_name not in init_kwargs:
                 init_kwargs[args_name] = file_path

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2177,7 +2177,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         # Merge resolved_vocab_files arguments in init_kwargs.
         added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
-        chat_template_file = resolved_vocab_files.pop("chat_template_file", None)
+        resolved_vocab_files.pop("chat_template_file", None)
         for args_name, file_path in resolved_vocab_files.items():
             if args_name not in init_kwargs:
                 init_kwargs[args_name] = file_path

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2064,7 +2064,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         gguf_file = kwargs.get("gguf_file", None)
         has_tokenizer_file = resolved_vocab_files.get("tokenizer_file", None) is not None
 
-
         # If one passes a GGUF file path to `gguf_file` there is no need for this check as the tokenizer will be
         # loaded directly from the GGUF file.
         if (from_slow or not has_tokenizer_file) and cls.slow_tokenizer_class is not None and not gguf_file:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2063,7 +2063,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         from_slow = kwargs.get("from_slow", False)
         gguf_file = kwargs.get("gguf_file", None)
         has_tokenizer_file = resolved_vocab_files.get("tokenizer_file", None) is not None
-        has_chat_template_file = resolved_vocab_files.get("chat_template_file", None) is not None
+        chat_template_file = resolved_vocab_files.pop("chat_template_file", None)
 
         # If one passes a GGUF file path to `gguf_file` there is no need for this check as the tokenizer will be
         # loaded directly from the GGUF file.
@@ -2101,10 +2101,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             init_kwargs = init_configuration
 
         # If an independent chat template file exists, it takes priority over template entries in the tokenizer config
-        if has_chat_template_file:
-            with open(resolved_vocab_files["chat_template_file"]) as chat_template_handle:
-                chat_template = chat_template_handle.read()
-            init_kwargs["chat_template"] = chat_template  # Clobbers any template in the config
+        if chat_template_file is not None:
+            with open(chat_template_file) as chat_template_handle:
+                init_kwargs["chat_template"] = chat_template_handle.read()  # Clobbers any template in the config
 
         if not _is_local:
             if "auto_map" in init_kwargs:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2177,6 +2177,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         # Merge resolved_vocab_files arguments in init_kwargs.
         added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
+        chat_template_file = resolved_vocab_files.pop("chat_template_file", None)
         for args_name, file_path in resolved_vocab_files.items():
             if args_name not in init_kwargs:
                 init_kwargs[args_name] = file_path
@@ -2438,7 +2439,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     f.write(self.chat_template)
                 logger.info(f"chat template saved in {chat_template_file}")
                 if "chat_template" in tokenizer_config:
-                    breakpoint()
                     tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
             else:
                 tokenizer_config["chat_template"] = self.chat_template

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2425,7 +2425,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             tokenizer_config["extra_special_tokens"] = self.extra_special_tokens
             tokenizer_config.update(self.extra_special_tokens)
 
-        if self.chat_template is not None:
+        if self.chat_template is not None and not kwargs.get("skip_chat_template_save", False):
             if isinstance(self.chat_template, dict):
                 # Chat template dicts are saved to the config as lists of dicts with fixed key names.
                 # They will be reconstructed as a single dict during loading.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2063,7 +2063,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         from_slow = kwargs.get("from_slow", False)
         gguf_file = kwargs.get("gguf_file", None)
         has_tokenizer_file = resolved_vocab_files.get("tokenizer_file", None) is not None
-        chat_template_file = resolved_vocab_files.pop("chat_template_file", None)
+
 
         # If one passes a GGUF file path to `gguf_file` there is no need for this check as the tokenizer will be
         # loaded directly from the GGUF file.
@@ -2101,6 +2101,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             init_kwargs = init_configuration
 
         # If an independent chat template file exists, it takes priority over template entries in the tokenizer config
+        chat_template_file = resolved_vocab_files.pop("chat_template_file", None)
         if chat_template_file is not None:
             with open(chat_template_file) as chat_template_handle:
                 init_kwargs["chat_template"] = chat_template_handle.read()  # Clobbers any template in the config
@@ -2301,6 +2302,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 "Special tokens have been added in the vocabulary, make sure the associated word embeddings are"
                 " fine-tuned or trained."
             )
+        breakpoint()
         return tokenizer
 
     @staticmethod

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2268,7 +2268,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 if key != "additional_special_tokens":
                     init_kwargs[key] = added_tokens_map.get(str(init_kwargs[key]), init_kwargs[key])
 
-
         # Instantiate the tokenizer.
         try:
             tokenizer = cls(*init_inputs, **init_kwargs)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -535,16 +535,3 @@ class ProcessorTesterMixin:
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
-
-    def test_chat_template_tokenizer_interactions(self):
-        processor = self.get_processor()
-        if not hasattr(processor, "tokenizer"):
-            self.skipTest("This processor doesn't have a tokenizer.")
-        processor.chat_template = "test template"
-        processor.tokenizer.chat_template = "test_template"
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
-            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
-            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
-            # Check that the processor clobbers the tokenizer's template
-            self.assertEqual(processor.tokenizer.chat_template, None)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -532,7 +532,7 @@ class ProcessorTesterMixin:
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
+            processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
             self.assertTrue(Path(tmpdirname, "processor_chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -526,6 +526,7 @@ class ProcessorTesterMixin:
         processor.chat_template = "test template"
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname)
+            self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "processor_chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
@@ -533,5 +534,6 @@ class ProcessorTesterMixin:
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
             self.assertTrue(Path(tmpdirname, "processor_chat_template.jinja").is_file())
+            self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -526,6 +526,7 @@ class ProcessorTesterMixin:
         processor.chat_template = "test template"
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname)
+            existing_tokenizer_template = getattr(processor.tokenizer, "chat_template", None)
             self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
@@ -533,7 +534,7 @@ class ProcessorTesterMixin:
             if hasattr(processor, "tokenizer"):
                 # When we don't use single-file chat template saving, processor and tokenizer chat templates
                 # should remain separate
-                self.assertIsNone(getattr(reloaded_processor.tokenizer, "chat_template", None))
+                self.assertEqual(getattr(reloaded_processor.tokenizer, "chat_template", None), existing_tokenizer_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_raw_chat_template=True)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -526,12 +526,12 @@ class ProcessorTesterMixin:
         processor.chat_template = "test template"
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname)
-            self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
+            self.assertFalse(Path(tmpdirname, "processor_chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
-            self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
+            self.assertTrue(Path(tmpdirname, "processor_chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -535,3 +535,16 @@ class ProcessorTesterMixin:
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+
+    def test_chat_template_tokenizer_interactions(self):
+        processor = self.get_processor()
+        if not hasattr(processor, "tokenizer"):
+            self.skipTest("This processor doesn't have a tokenizer.")
+        processor.chat_template = "test template"
+        processor.tokenizer.chat_template = "test_template"
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
+
+            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
+            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+            self.assertEqual(processor.tokenizer.chat_template, reloaded_processor.tokenizer.chat_template)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -523,18 +523,17 @@ class ProcessorTesterMixin:
 
     def test_chat_template_save_loading(self):
         processor = self.get_processor()
+        existing_tokenizer_template = getattr(processor.tokenizer, "chat_template", None)
         processor.chat_template = "test template"
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname)
-            existing_tokenizer_template = getattr(processor.tokenizer, "chat_template", None)
             self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
-            if hasattr(processor, "tokenizer"):
-                # When we don't use single-file chat template saving, processor and tokenizer chat templates
-                # should remain separate
-                self.assertEqual(getattr(reloaded_processor.tokenizer, "chat_template", None), existing_tokenizer_template)
+            # When we don't use single-file chat template saving, processor and tokenizer chat templates
+            # should remain separate
+            self.assertEqual(getattr(reloaded_processor.tokenizer, "chat_template", None), existing_tokenizer_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
@@ -544,5 +543,4 @@ class ProcessorTesterMixin:
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
             # When we save as single files, tokenizers and processors share a chat template, which means
             # the reloaded tokenizer should get the chat template as well
-            if hasattr(processor, "tokenizer"):
-                self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
+            self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -544,7 +544,7 @@ class ProcessorTesterMixin:
         processor.tokenizer.chat_template = "test_template"
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
-
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
-            self.assertEqual(processor.tokenizer.chat_template, reloaded_processor.tokenizer.chat_template)
+            # Check that the processor clobbers the tokenizer's template
+            self.assertEqual(processor.tokenizer.chat_template, None)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -527,13 +527,13 @@ class ProcessorTesterMixin:
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname)
             self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
-            self.assertFalse(Path(tmpdirname, "processor_chat_template.jinja").is_file())
+            self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
-            self.assertTrue(Path(tmpdirname, "processor_chat_template.jinja").is_file())
+            self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import random
 import tempfile
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -519,3 +520,18 @@ class ProcessorTesterMixin:
             processor.prepare_and_validate_optional_call_args(
                 *(f"optional_{i}" for i in range(num_optional_call_args + 1))
             )
+
+    def test_chat_template_save_loading(self):
+        processor = self.get_processor()
+        processor.chat_template = "test template"
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor.save_pretrained(tmpdirname)
+            self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
+            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
+            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor.save_pretrained(tmpdirname, save_naked_chat_template=True)
+            self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
+            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
+            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1108,13 +1108,13 @@ class TokenizerTesterMixin:
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
                     tokenizer.save_pretrained(tmp_dir_name)
-                    tokenizer = tokenizer.from_pretrained(tmp_dir_name)
+                    new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
 
-                self.assertEqual(tokenizer.chat_template, dummy_template)  # Test template has persisted
-                output = tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)
+                self.assertEqual(new_tokenizer.chat_template, dummy_template)  # Test template has persisted
+                output = new_tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)
                 self.assertEqual(output, expected_output)  # Test output is the same after reloading
                 # Check that no error raised
-                tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
+                new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
                     tokenizer.save_pretrained(tmp_dir_name, save_chat_template_file=True)
@@ -1124,15 +1124,13 @@ class TokenizerTesterMixin:
                     config_dict = json.loads((Path(tmp_dir_name) / "tokenizer_config.json").read_text())
                     # Assert the chat template is not in the config when it's saved as a separate file
                     self.assertNotIn("chat_template", config_dict)
-                    tokenizer = tokenizer.from_pretrained(tmp_dir_name)
-                    # TODO Figure out how "chat_template" gets into init_kwargs
-                    # TODO Ensure "chat_template_file" doesn't end up anywhere! Where is it getting into the config?
+                    new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
 
-                self.assertEqual(tokenizer.chat_template, dummy_template)  # Test template has persisted
-                output = tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)
+                self.assertEqual(new_tokenizer.chat_template, dummy_template)  # Test template has persisted
+                output = new_tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)
                 self.assertEqual(output, expected_output)  # Test output is the same after reloading
                 # Check that no error raised
-                tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
+                new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
     @require_jinja
     def test_chat_template_batched(self):

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1125,6 +1125,8 @@ class TokenizerTesterMixin:
                     # Assert the chat template is not in the config when it's saved as a separate file
                     self.assertNotIn("chat_template", config_dict)
                     tokenizer = tokenizer.from_pretrained(tmp_dir_name)
+                    # TODO Figure out how "chat_template" gets into init_kwargs
+                    # TODO Ensure "chat_template_file" doesn't end up anywhere! Where is it getting into the config?
 
                 self.assertEqual(tokenizer.chat_template, dummy_template)  # Test template has persisted
                 output = tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1557,6 +1557,7 @@ class TokenizerTesterMixin:
                                 {"name": "template2", "template": "{{'b'}}"},
                             ],
                         )
+                        self.assertFalse(os.path.exists(os.path.join(tmp_dir_name, "chat_template.jinja")))
                         new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
                     # Assert that the serialized list is correctly reconstructed as a single dict
                     self.assertEqual(new_tokenizer.chat_template, tokenizer.chat_template)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -26,6 +26,7 @@ import unittest
 from collections import OrderedDict
 from itertools import takewhile
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from pathlib import Path
 
 from parameterized import parameterized
 
@@ -1115,6 +1116,23 @@ class TokenizerTesterMixin:
                 # Check that no error raised
                 tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tokenizer.save_pretrained(tmp_dir_name, save_chat_template_file=True)
+                    chat_template_file = Path(tmp_dir_name) / "chat_template.jinja"
+                    self.assertTrue(chat_template_file.is_file())
+                    self.assertEqual(chat_template_file.read_text(), dummy_template)
+                    config_dict = json.loads((Path(tmp_dir_name) / "tokenizer_config.json").read_text())
+                    # Assert the chat template is not in the config when it's saved as a separate file
+                    self.assertNotIn("chat_template", config_dict)
+                    tokenizer = tokenizer.from_pretrained(tmp_dir_name)
+
+                self.assertEqual(tokenizer.chat_template, dummy_template)  # Test template has persisted
+                output = tokenizer.apply_chat_template(dummy_conversation, tokenize=False, return_dict=False)
+                self.assertEqual(output, expected_output)  # Test output is the same after reloading
+                # Check that no error raised
+                tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
+
+
     @require_jinja
     def test_chat_template_batched(self):
         dummy_template = "{% for message in messages %}{{message['role'] + message['content']}}{% endfor %}"
@@ -1526,18 +1544,20 @@ class TokenizerTesterMixin:
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
-                tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
-                with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    tokenizer.save_pretrained(tmp_dir_name)
-                    config_dict = json.load(open(os.path.join(tmp_dir_name, "tokenizer_config.json")))
-                    # Assert that chat templates are correctly serialized as lists of dictionaries
-                    self.assertEqual(
-                        config_dict["chat_template"],
-                        [{"name": "template1", "template": "{{'a'}}"}, {"name": "template2", "template": "{{'b'}}"}],
-                    )
-                    new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
-                # Assert that the serialized list is correctly reconstructed as a single dict
-                self.assertEqual(new_tokenizer.chat_template, tokenizer.chat_template)
+                for save_chat_template_file in (True, False):
+                    tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
+                    with tempfile.TemporaryDirectory() as tmp_dir_name:
+                        # Test that save_chat_template_file is ignored when there's a dict of multiple templates
+                        tokenizer.save_pretrained(tmp_dir_name, save_chat_template_file=save_chat_template_file)
+                        config_dict = json.load(open(os.path.join(tmp_dir_name, "tokenizer_config.json")))
+                        # Assert that chat templates are correctly serialized as lists of dictionaries
+                        self.assertEqual(
+                            config_dict["chat_template"],
+                            [{"name": "template1", "template": "{{'a'}}"}, {"name": "template2", "template": "{{'b'}}"}],
+                        )
+                        new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
+                    # Assert that the serialized list is correctly reconstructed as a single dict
+                    self.assertEqual(new_tokenizer.chat_template, tokenizer.chat_template)
 
     def test_number_of_added_tokens(self):
         tokenizers = self.get_tokenizers(do_lower_case=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1132,7 +1132,6 @@ class TokenizerTesterMixin:
                 # Check that no error raised
                 new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
-
     @require_jinja
     def test_chat_template_batched(self):
         dummy_template = "{% for message in messages %}{{message['role'] + message['content']}}{% endfor %}"
@@ -1573,7 +1572,7 @@ class TokenizerTesterMixin:
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
                     tokenizer.chat_template = dummy_template1
                     tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=False)
-                    with open(os.path.join(tmp_dir_name, "chat_template.jinja"), "w") as f:
+                    with Path(tmp_dir_name, "chat_template.jinja").open("w") as f:
                         f.write(dummy_template2)
                     new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
                 # Assert the file template clobbers any template in the config

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -25,8 +25,8 @@ import traceback
 import unittest
 from collections import OrderedDict
 from itertools import takewhile
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 from parameterized import parameterized
 
@@ -1132,7 +1132,6 @@ class TokenizerTesterMixin:
                 # Check that no error raised
                 tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
-
     @require_jinja
     def test_chat_template_batched(self):
         dummy_template = "{% for message in messages %}{{message['role'] + message['content']}}{% endfor %}"
@@ -1553,7 +1552,10 @@ class TokenizerTesterMixin:
                         # Assert that chat templates are correctly serialized as lists of dictionaries
                         self.assertEqual(
                             config_dict["chat_template"],
-                            [{"name": "template1", "template": "{{'a'}}"}, {"name": "template2", "template": "{{'b'}}"}],
+                            [
+                                {"name": "template1", "template": "{{'a'}}"},
+                                {"name": "template2", "template": "{{'b'}}"},
+                            ],
                         )
                         new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
                     # Assert that the serialized list is correctly reconstructed as a single dict

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1117,7 +1117,7 @@ class TokenizerTesterMixin:
                 new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    tokenizer.save_pretrained(tmp_dir_name, save_chat_template_file=True)
+                    tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=True)
                     chat_template_file = Path(tmp_dir_name) / "chat_template.jinja"
                     self.assertTrue(chat_template_file.is_file())
                     self.assertEqual(chat_template_file.read_text(), dummy_template)
@@ -1543,11 +1543,11 @@ class TokenizerTesterMixin:
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
-                for save_chat_template_file in (True, False):
+                for save_raw_chat_template in (True, False):
                     tokenizer.chat_template = {"template1": dummy_template_1, "template2": dummy_template_2}
                     with tempfile.TemporaryDirectory() as tmp_dir_name:
-                        # Test that save_chat_template_file is ignored when there's a dict of multiple templates
-                        tokenizer.save_pretrained(tmp_dir_name, save_chat_template_file=save_chat_template_file)
+                        # Test that save_raw_chat_template is ignored when there's a dict of multiple templates
+                        tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=save_raw_chat_template)
                         config_dict = json.load(open(os.path.join(tmp_dir_name, "tokenizer_config.json")))
                         # Assert that chat templates are correctly serialized as lists of dictionaries
                         self.assertEqual(


### PR DESCRIPTION
We have several issues with chat templates because they're stored as single lines in the JSON config files:

- Impossible to review diffs
- Very hard to edit in the web UI (or in general)
- Differences between `processor` templates in `chat_template.json` and `tokenizer` templates in `tokenizer_config.json` causing confusion
- Some models use multiple templates, requiring a template dict, but we're trying to discourage that in future and move those models to single templates with conditional behaviour instead

The solution:

- Just move chat templates to a single `chat_template.jinja` file in the repo
- If multiple templates are required, then they should still be stored in the JSON file. This is not supported for `Processor` classes, so processors should always be able to save their template as a raw Jinja file. In general, we'll be gently deprecating multiple templates in future.
- If a `chat_template.jinja` file is present, it overrides the JSON files. If a tokenizer is loaded with both Jinja and JSON chat templates and resaved, it should save only the Jinja file, and not have any `chat_template` entry in `tokenizer_config.json`.

For now, we continue saving in the old format by default. I'll probably keep it this way for several versions before making the new format the default, to ensure that most users are able to load the new format before it becomes common. Until then, the new format should mostly be used for testing, to make sure it's ready for deployment when we do the switch.

Extremely draft PR for now, since it'll probably break lots of things!

TODO:
- [X] Add loading/saving single files in tokenizers
- [x] Add loading/saving single files in processors
- [x] Add tokenizer tests for saving + loading + push_to_hub working correctly
- [x] Add processor tests for saving + loading + push_to_hub working correctly
- [x] Ensure processors + tokenizers don't clash when both saving chat templates