### PR TITLE
Fix typing issue

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -242,7 +242,7 @@ def reverse_reshape_bias(weights: np.ndarray, n_head: int, n_embed: int):
 
 
 def split_moe_expert_tensor(
-    weights: np.ndarray, parsed_parameters: Dict[str, Any], name: str, tensor_key_mapping: dict
+    weights: np.ndarray, parsed_parameters: Dict[str, Dict], name: str, tensor_key_mapping: dict
 ):
     # Original merge implementation
     # https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L1994-L2022

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 from tqdm import tqdm
@@ -242,7 +242,7 @@ def reverse_reshape_bias(weights: np.ndarray, n_head: int, n_embed: int):
 
 
 def split_moe_expert_tensor(
-    weights: np.ndarray, parsed_parameters: dict[str, dict], name: str, tensor_key_mapping: dict
+    weights: np.ndarray, parsed_parameters: Dict[str, Any], name: str, tensor_key_mapping: dict
 ):
     # Original merge implementation
     # https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L1994-L2022

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import re
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 import numpy as np
 from tqdm import tqdm


### PR DESCRIPTION
# What does this PR do ?
This PR fixes a typing issue that this [PR](https://github.com/huggingface/transformers/pull/33940) introduced. 
TLDR: we can't do dict[str,dict] with python 3.8 cc @ydshieh 

Traceback received: 

```
Traceback (most recent call last):
  File "/home/marc/transformers/src/transformers/utils/import_utils.py", line 1780, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/marc/transformers/src/transformers/models/__init__.py", line 15, in <module>
    from . import (
  File "/home/marc/transformers/src/transformers/models/mt5/__init__.py", line 36, in <module>
    from ..t5.tokenization_t5_fast import T5TokenizerFast
  File "/home/marc/transformers/src/transformers/models/t5/tokenization_t5_fast.py", line 23, in <module>
    from ...tokenization_utils_fast import PreTrainedTokenizerFast
  File "/home/marc/transformers/src/transformers/tokenization_utils_fast.py", line 34, in <module>
    from .modeling_gguf_pytorch_utils import load_gguf_checkpoint
  File "/home/marc/transformers/src/transformers/modeling_gguf_pytorch_utils.py", line 245, in <module>
    weights: np.ndarray, parsed_parameters: dict[str, dict], name: str, tensor_key_mapping: dict
TypeError: 'type' object is not subscriptable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "test_gemma_save.py", line 1, in <module>
    from transformers import AutoModelForCausalLM
  File "<frozen importlib._bootstrap>", line 1039, in _handle_fromlist
  File "/home/marc/transformers/src/transformers/utils/import_utils.py", line 1770, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/home/marc/transformers/src/transformers/utils/import_utils.py", line 1782, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import transformers.models.auto because of the following error (look up to see its traceback):
'type' object is not subscriptable
```