### PR TITLE
Remove `decoder_config=None`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1036,7 +1036,7 @@ class PretrainedConfig(PushToHubMixin):
             if decoder_config is not self:
                 default_config = decoder_config.__class__()
             else:
-                decoder_config = None
+                default_config = None
 
         # If it is a composite model, we want to check the subconfig that will be used for generation
         self_decoder_config = self if decoder_attribute_name is None else getattr(self, decoder_attribute_name)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1036,7 +1036,6 @@ class PretrainedConfig(PushToHubMixin):
             if decoder_config is not self:
                 default_config = decoder_config.__class__()
             else:
-                default_config = None
                 decoder_config = None
 
         # If it is a composite model, we want to check the subconfig that will be used for generation


### PR DESCRIPTION
# What does this PR do?
I've merged this [PR](https://github.com/huggingface/transformers/pull/33934) a little to fast, we need to remove a line as stated [here](https://github.com/huggingface/transformers/pull/33934#discussion_r1790157995). 