### PR TITLE
Fix `trainer_seq2seq.py`'s `__init__` type annotations

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -55,7 +55,7 @@ class Seq2SeqTrainer(Trainer):
         model: Union["PreTrainedModel", nn.Module] = None,
         args: "TrainingArguments" = None,
         data_collator: Optional["DataCollator"] = None,
-        train_dataset: Optional[Union[Dataset, IterableDataset, "datasets.Dataset"]] = None,
+        train_dataset: Optional[Union[Dataset, "IterableDataset", "datasets.Dataset"]] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
         processing_class: Optional[
             Union["PreTrainedTokenizerBase", "BaseImageProcessor", "FeatureExtractionMixin", "ProcessorMixin"]

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -24,13 +24,16 @@ from torch.utils.data import Dataset
 from .generation.configuration_utils import GenerationConfig
 from .integrations.deepspeed import is_deepspeed_zero3_enabled
 from .trainer import Trainer
-from .utils import logging
+from .utils import is_datasets_available, logging
 from .utils.deprecation import deprecate_kwarg
 
 
+if is_datasets_available():
+    import datasets
+
 if TYPE_CHECKING:
     from torch.utils.data import IterableDataset
-    
+
     from .data.data_collator import DataCollator
     from .feature_extraction_utils import FeatureExtractionMixin
     from .image_processing_utils import BaseImageProcessor
@@ -40,9 +43,6 @@ if TYPE_CHECKING:
     from .trainer_callback import TrainerCallback
     from .trainer_utils import EvalPrediction, PredictionOutput
     from .training_args import TrainingArguments
-
-    if is_datasets_available():
-        import datasets
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -29,6 +29,8 @@ from .utils.deprecation import deprecate_kwarg
 
 
 if TYPE_CHECKING:
+    from torch.utils.data import IterableDataset
+    
     from .data.data_collator import DataCollator
     from .feature_extraction_utils import FeatureExtractionMixin
     from .image_processing_utils import BaseImageProcessor
@@ -38,6 +40,9 @@ if TYPE_CHECKING:
     from .trainer_callback import TrainerCallback
     from .trainer_utils import EvalPrediction, PredictionOutput
     from .training_args import TrainingArguments
+
+    if is_datasets_available():
+        import datasets
 
 
 logger = logging.get_logger(__name__)
@@ -50,7 +55,7 @@ class Seq2SeqTrainer(Trainer):
         model: Union["PreTrainedModel", nn.Module] = None,
         args: "TrainingArguments" = None,
         data_collator: Optional["DataCollator"] = None,
-        train_dataset: Optional[Dataset] = None,
+        train_dataset: Optional[Union[Dataset, IterableDataset, "datasets.Dataset"]] = None,
         eval_dataset: Optional[Union[Dataset, Dict[str, Dataset]]] = None,
         processing_class: Optional[
             Union["PreTrainedTokenizerBase", "BaseImageProcessor", "FeatureExtractionMixin", "ProcessorMixin"]


### PR DESCRIPTION
Fix type annotations for `trainer_seq2seq.py`'s `__init__` call.

@ylacombe @eustlb
@muellerzr @SunMarc

Apologies if I tagged irrelevant people, this is my first PR. I also see some other type annotation issues, e.g. `overloads` that are missing. If this kind of PR will be considered, I would be happy to contribute other fixes too!