### PR TITLE
Fix FSDP resume Initialization issue

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -271,7 +271,23 @@ def _get_fsdp_ckpt_kwargs():
     else:
         return {}
 
+
 def _init_fsdp(model, accelerator, device):
+    """
+    Initialize Fully Sharded Data Parallel (FSDP) for the model.
+
+    This function is needed to properly initialize FSDP when resuming from a checkpoint.
+    It runs a forward pass with dummy inputs to ensure FSDP is fully initialized.
+    See https://github.com/huggingface/transformers/issues/31892 for more details.
+
+    Args:
+        model: The model to initialize with FSDP.
+        accelerator: The Accelerator object.
+        device: The device to run the model on.
+
+    Returns:
+        The initialized FSDP model.
+    """
     model = accelerator.prepare(model)
     model.train()
     with torch.no_grad():
@@ -287,6 +303,7 @@ def _init_fsdp(model, accelerator, device):
         }
         _ = model(**dummy_input)
     return model
+
 
 if TYPE_CHECKING:
     import optuna

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4912,6 +4912,7 @@ class OptimizerAndModelInspectionTest(unittest.TestCase):
             group = trainer.get_optimizer_group(param)
             self.assertIn(param, group["params"])
 
+
 @require_torch_gpu
 @require_torch
 @require_accelerate

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4912,7 +4912,7 @@ class OptimizerAndModelInspectionTest(unittest.TestCase):
             group = trainer.get_optimizer_group(param)
             self.assertIn(param, group["params"])
 
-@require_cuda
+@require_torch_gpu
 @require_torch
 @require_accelerate
 class TestFSDPInitialization(unittest.TestCase):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4912,7 +4912,7 @@ class OptimizerAndModelInspectionTest(unittest.TestCase):
             group = trainer.get_optimizer_group(param)
             self.assertIn(param, group["params"])
 
-
+@require_cuda
 @require_torch
 @require_accelerate
 class TestFSDPInitialization(unittest.TestCase):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4912,6 +4912,7 @@ class OptimizerAndModelInspectionTest(unittest.TestCase):
             group = trainer.get_optimizer_group(param)
             self.assertIn(param, group["params"])
 
+
 @require_torch
 @require_accelerate
 class TestFSDPInitialization(unittest.TestCase):
@@ -4921,10 +4922,10 @@ class TestFSDPInitialization(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
-                output_dir = tmp_dir,
-                fsdp = True,
-                fsdp_config = {"min_num_params": 1},
-                no_cuda = True,
+                output_dir=tmp_dir,
+                fsdp=True,
+                fsdp_config={"min_num_params": 1},
+                no_cuda=True,
             )
             trainer = Trainer(model=model, args=training_args)
 
@@ -4933,9 +4934,10 @@ class TestFSDPInitialization(unittest.TestCase):
 
             # Check if model is wrapped with FSDP
             from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
             self.assertTrue(trainer.model, FSDP)
 
             # Running a forward pass to ensure FSDP is initialized
-            dummy_input = torch.ones((1,1), dtype=torch.float)
+            dummy_input = torch.ones((1, 1), dtype=torch.float)
             output = trainer.model(dummy_input)
             self.assertTrue(output)


### PR DESCRIPTION
Addresses the issue with Fully Sharded Data Parallel (FSDP) initialization when resuming training from a checkpoint. It implements a solution by adding a dummy forward pass during the initialization process. 

Fixes #31892 

Added tests in the test_trainer.py file to ensure proper FSDP initialization

@muellerzr @SunMarc  I am creating a draft PR, let me know if there anymore changes that I can make

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
