### PR TITLE
check if eigenvalues of covariance matrix are complex. 

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2441,8 +2441,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         covariance = old_centered_embeddings.T @ old_centered_embeddings / old_num_tokens
 
         # Check if the covariance is positive definite.
+        eigenvalues = torch.linalg.eigvals(covariance)
         is_covariance_psd = bool(
-            (covariance == covariance.T).all() and (torch.linalg.eigvals(covariance).real >= 0).all()
+            (covariance == covariance.T).all() and not torch.is_complex(eigenvalues) and (eigenvalues > 0).all()
         )
         if is_covariance_psd:
             # If covariances is positive definite, a distribution can be created. and we can sample new weights from it.

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -694,10 +694,6 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, GenerationTesterMixin, Mod
         self.model_tester.seq_length = original_sequence_length
         return test_inputs
 
-    @unittest.skip(reason="Resizing sometimes goes bad")  #  not worth investigating for now (it's not a popular model)
-    def test_resize_tokens_embeddings(self):
-        pass
-
 
 @require_torch
 class ReformerLSHAttnModelTest(


### PR DESCRIPTION
A follow-up for https://github.com/huggingface/transformers/pull/33950 and https://github.com/huggingface/transformers/pull/33325

This fixes reformer test_resize_tokens_embeddings. We should check if the eigenvalues are complex also to check if the covariance is positive definite.
c.c. @gante Thaks for the other fixes!
and c.c. @ArthurZucker 