### PR TITLE
Small Fix to modular converter

### DIFF
--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1087,12 +1087,18 @@ def convert_modular_file(modular_file, old_model_name=None, new_model_name=None,
         for file, node in cst_transformers.files.items():
             if node != {}:
                 # Get relative path starting from src/transformers/
-                relative_path = re.search(
+                regex_relative_path = re.search(
                     f"{os.sep}(src{os.sep}transformers{os.sep}.*)", os.path.abspath(modular_file)
-                ).group(1)
-                header = AUTO_GENERATED_MESSAGE.format(
-                    relative_path=relative_path, short_name=os.path.basename(relative_path)
                 )
+                if regex_relative_path is None:
+                    header = AUTO_GENERATED_MESSAGE.format(
+                        relative_path="<path_to_modular_file.py>", short_name="modular_xxx.py"
+                    )
+                else:
+                    relative_path = regex_relative_path.group(1)
+                    header = AUTO_GENERATED_MESSAGE.format(
+                        relative_path=relative_path, short_name=os.path.basename(relative_path)
+                    )
                 ruffed_code = run_ruff(header + node.code, True)
                 formatted_code = run_ruff(ruffed_code, False)
                 output[file] = [formatted_code, ruffed_code]

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1087,18 +1087,13 @@ def convert_modular_file(modular_file, old_model_name=None, new_model_name=None,
         for file, node in cst_transformers.files.items():
             if node != {}:
                 # Get relative path starting from src/transformers/
-                regex_relative_path = re.search(
-                    f"{os.sep}(src{os.sep}transformers{os.sep}.*)", os.path.abspath(modular_file)
+                relative_path = re.search(
+                    rf"(src{os.sep}transformers{os.sep}.*|examples{os.sep}.*)", os.path.abspath(modular_file)
+                ).group(1)
+ 
+                header = AUTO_GENERATED_MESSAGE.format(
+                    relative_path=relative_path, short_name=os.path.basename(relative_path)
                 )
-                if regex_relative_path is None:
-                    header = AUTO_GENERATED_MESSAGE.format(
-                        relative_path="<path_to_modular_file.py>", short_name="modular_xxx.py"
-                    )
-                else:
-                    relative_path = regex_relative_path.group(1)
-                    header = AUTO_GENERATED_MESSAGE.format(
-                        relative_path=relative_path, short_name=os.path.basename(relative_path)
-                    )
                 ruffed_code = run_ruff(header + node.code, True)
                 formatted_code = run_ruff(ruffed_code, False)
                 output[file] = [formatted_code, ruffed_code]

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1090,7 +1090,7 @@ def convert_modular_file(modular_file, old_model_name=None, new_model_name=None,
                 relative_path = re.search(
                     rf"(src{os.sep}transformers{os.sep}.*|examples{os.sep}.*)", os.path.abspath(modular_file)
                 ).group(1)
- 
+
                 header = AUTO_GENERATED_MESSAGE.format(
                     relative_path=relative_path, short_name=os.path.basename(relative_path)
                 )


### PR DESCRIPTION
# What does this PR do?

This update addresses a small issue in the modular converter. The relative path used in `AUTO_GENERATED_MESSAGE` is generated using a regex that assumes all models reside in the `src/transformers` directory. This approach fails when handling examples located in the `examples/` folder.

The fix is simple : the regex is modified to make sure `examples/` is also taken into account with `src/transformers`

If it's not needed, feel free to disregard.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

cc @ArthurZucker 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
