### PR TITLE
Update Blip2 `is_pipeline_test_to_skip` method signature

### DIFF
--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -718,9 +718,16 @@ class Blip2ModelTest(ModelTesterMixin, PipelineTesterMixin, GenerationTesterMixi
 
     # TODO: Fix the failed tests
     def is_pipeline_test_to_skip(
-        self, pipeline_test_casse_name, config_class, model_architecture, tokenizer_name, processor_name
+        self,
+        pipeline_test_case_name,
+        config_class,
+        model_architecture,
+        tokenizer_name,
+        image_processor_name,
+        feature_extractor_name,
+        processor_name,
     ):
-        if pipeline_test_casse_name == "VisualQuestionAnsweringPipelineTests":
+        if pipeline_test_case_name == "VisualQuestionAnsweringPipelineTests":
             # Get `RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'`.
             return True
 


### PR DESCRIPTION
# What does this PR do?

Update Blip2 `is_pipeline_test_to_skip` method signature to fix test failure.
https://app.circleci.com/pipelines/github/huggingface/transformers/107299/workflows/7171a45b-75d9-462e-a77c-ca7abd1cab78/jobs/1423992 

cc @Rocketknight1 