### PR TITLE
Fix flaky tests

### DIFF
--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -2214,7 +2214,7 @@ class MllamaForConditionalGeneration(MllamaPreTrainedModel, GenerationMixin):
 
         # If we're in pre-fill or cacheless decoding step, then we need pixel_values and aspect ratios
         # to compute image hidden states, otherwise they are cached within each cross attn layer
-        if (input_ids == self.config.image_token_index).any():
+        if cache_position[0] == 0:
             model_inputs["pixel_values"] = pixel_values
             model_inputs["aspect_ratio_ids"] = aspect_ratio_ids
             model_inputs["aspect_ratio_mask"] = aspect_ratio_mask

--- a/utils/check_config_attributes.py
+++ b/utils/check_config_attributes.py
@@ -243,6 +243,7 @@ def check_attribute_being_used(config_class, attributes, default_value, source_s
         "pad_index",
         "unk_index",
         "mask_index",
+        "image_token_index",  # for VLMs
         "image_size",
         "use_cache",
         "out_features",


### PR DESCRIPTION
# What does this PR do?

Fixes flakiness in some generation tests for VLMs. We have to pass the `bad_ids` in all tests that call generate with tiny models.

Plus for Mllama we don't have to check the generation stage that way anymore, since we decided not to support muti-turn conversations.