### PR TITLE
Avoid many test failures for `LlavaNextVideoForConditionalGeneration`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1230,10 +1230,7 @@ class GenerationTesterMixin:
             if any(model_name in model_class.__name__.lower() for model_name in ["marian", "mbart", "pegasus"]):
                 self.skipTest("DoLa is not supported for models that don't return layerwise hidden states")
 
-            if any(
-                model_name == model_class.__name__
-                for model_name in ["VideoLlavaForConditionalGeneration", "LlavaNextVideoForConditionalGeneration"]
-            ):
+            if any(model_name == model_class.__name__ for model_name in ["LlavaNextVideoForConditionalGeneration"]):
                 self.skipTest(f"DoLa is failing for {model_class.__name__}")
 
             # enable cache if the model is not openai-gpt, xlnet, cpm, or xlm

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1230,6 +1230,9 @@ class GenerationTesterMixin:
             if any(model_name in model_class.__name__.lower() for model_name in ["marian", "mbart", "pegasus"]):
                 self.skipTest("DoLa is not supported for models that don't return layerwise hidden states")
 
+            if any(model_name == model_class.__name__ for model_name in ["LlavaNextVideoForConditionalGeneration"]):
+                self.skipTest(f"DoLa is failing for {model_class.__name__}")
+
             # enable cache if the model is not openai-gpt, xlnet, cpm, or xlm
             config, inputs_dict = self.prepare_config_and_inputs_for_generate()
             main_input = inputs_dict[model_class.main_input_name]

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1232,11 +1232,7 @@ class GenerationTesterMixin:
 
             if any(
                 model_name == model_class.__name__
-                for model_name in [
-                    "VideoLlavaForConditionalGeneration",
-                    "LlavaNextForConditionalGeneration",
-                    "LlavaNextVideoForConditionalGeneration",
-                ]
+                for model_name in ["VideoLlavaForConditionalGeneration", "LlavaNextVideoForConditionalGeneration"]
             ):
                 self.skipTest(f"DoLa is failing for {model_class.__name__}")
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1230,7 +1230,14 @@ class GenerationTesterMixin:
             if any(model_name in model_class.__name__.lower() for model_name in ["marian", "mbart", "pegasus"]):
                 self.skipTest("DoLa is not supported for models that don't return layerwise hidden states")
 
-            if any(model_name == model_class.__name__ for model_name in ["LlavaNextVideoForConditionalGeneration"]):
+            if any(
+                model_name == model_class.__name__
+                for model_name in [
+                    "VideoLlavaForConditionalGeneration",
+                    "LlavaNextForConditionalGeneration",
+                    "LlavaNextVideoForConditionalGeneration",
+                ]
+            ):
                 self.skipTest(f"DoLa is failing for {model_class.__name__}")
 
             # enable cache if the model is not openai-gpt, xlnet, cpm, or xlm


### PR DESCRIPTION
# What does this PR do?

This test `test_dola_decoding_sample` failed for `LlavaNextVideo` and affect many subsequential tests for that model