### PR TITLE
Add freq time masking to ast

### DIFF
--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -197,9 +197,9 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
             frequency_mask_length (`int`, *optional*):
                 The maximum possible length of the mask in the frequency domain. Functions as a data augmentation that could be useful during training. Torchaudio is required to use this parameter.
             add_noise (`bool`, *optional*):
-                Whether or not to add noise to the input. Used in the original AST paper in combination with add_temporal_shift when training for certain use-cases.
+                Whether or not to add noise to the input. Used in the original AST paper in combination with `add_temporal_shift` when training for certain use-cases.
             add_temporal_shift (`bool`, *optional*):
-                Whether or not to shift the input. Used in the original AST paper in combination with add_noise when training for certain use-cases.
+                Whether or not to shift the input. Used in the original AST paper in combination with `add_noise` when training for certain use-cases.
         """
 
         if sampling_rate is not None:
@@ -236,8 +236,8 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         # check that all the inputs have at least length 400, else pad them and warn the user
         for i, waveform in enumerate(raw_speech):
             if len(waveform) < 400:
-                logger.warning(
-                    f"Input {i} has length {len(waveform)}, which is less than the minimum of 400. This would result in an error when creating the spectrogram. Padding it to have length 400.",
+                logger.warning_once(
+                    f"One of the input waveforms has length {len(waveform)}, which is less than the minimum of 400. This would result in an error when creating the spectrogram. Padding it to have length 400.",
                 )
                 raw_speech[i] = np.pad(waveform, (0, 400 - len(waveform)))
 
@@ -298,7 +298,9 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
 
     # from https://github.com/YuanGongND/ast but converted into numpy
     def add_noise(self, fbank: np.ndarray) -> np.ndarray:
-        fbank += np.random.rand(fbank.shape[0], fbank.shape[1]) * (np.random.rand() / 10)
+        noise = np.random.rand(fbank.shape[0], fbank.shape[1]) 
+        noise = noise * (np.random.rand() / 10)
+        fbank += noise
         return fbank
 
     def add_temporal_shift(self, fbank: np.ndarray) -> np.ndarray:

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -233,6 +233,14 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         if not is_batched:
             raw_speech = [raw_speech]
 
+        # check that all the inputs have at least length 400, else pad them and warn the user
+        for i, waveform in enumerate(raw_speech):
+            if len(waveform) < 400:
+                logger.warning(
+                    f"Input {i} has length {len(waveform)}, which is less than the minimum of 400. This would result in an error when creating the spectrogram. Padding it to have length 400.",
+                )
+                raw_speech[i] = np.pad(waveform, (0, 400 - len(waveform)))
+
         # extract fbank features and pad/truncate to max_length
         features = [self._extract_fbank_features(waveform, max_length=self.max_length) for waveform in raw_speech]
 

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -169,9 +169,10 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         raw_speech: Union[np.ndarray, List[float], List[np.ndarray], List[List[float]]],
         sampling_rate: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
-        timem: Optional[int] = 0,
-        freqm: Optional[int] = 0,
+        time_mask_length: Optional[int] = None,
+        frequency_mask_length: Optional[int] = None,
         add_noise: Optional[bool] = False,
+        add_temporal_shift: Optional[bool] = False,
         **kwargs,
     ) -> BatchFeature:
         """
@@ -191,12 +192,14 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
                 - `'tf'`: Return TensorFlow `tf.constant` objects.
                 - `'pt'`: Return PyTorch `torch.Tensor` objects.
                 - `'np'`: Return Numpy `np.ndarray` objects.
-            timem (`int`, *optional*):
-                The maximum possible length of the mask in the time domain.
-            freqm (`int`, *optional*):
-                The maximum possible length of the mask in the frequency domain.
+            time_mask_length (`int`, *optional*):
+                The maximum possible length of the mask in the time domain. Functions as a data augmentation that could be useful during training. Torchaudio is required to use this parameter.
+            frequency_mask_length (`int`, *optional*):
+                The maximum possible length of the mask in the frequency domain. Functions as a data augmentation that could be useful during training. Torchaudio is required to use this parameter.
             add_noise (`bool`, *optional*):
-                Whether or not to add noise to the input.
+                Whether or not to add noise to the input. Used in the original AST paper in combination with add_temporal_shift when training for certain use-cases.
+            add_temporal_shift (`bool`, *optional*):
+                Whether or not to shift the input. Used in the original AST paper in combination with add_noise when training for certain use-cases.
         """
 
         if sampling_rate is not None:
@@ -233,7 +236,11 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         # extract fbank features and pad/truncate to max_length
         features = [self._extract_fbank_features(waveform, max_length=self.max_length) for waveform in raw_speech]
 
-        features = [self.mask(feature, freqm, timem) for feature in features]
+        if time_mask_length or frequency_mask_length:
+            features = [
+                self.apply_time_frequency_masks(feature, frequency_mask_length, time_mask_length)
+                for feature in features
+            ]
 
         # convert into BatchFeature
         padded_inputs = BatchFeature({"input_values": features})
@@ -248,7 +255,10 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
             padded_inputs["input_values"] = [self.normalize(feature) for feature in input_values]
 
         if add_noise:
-            padded_inputs["input_values"] = [self.add_noise(feature) for feature in input_values]
+            padded_inputs["input_values"] = [self.add_noise(feature) for feature in padded_inputs["input_values"]]
+
+        if add_temporal_shift:
+            padded_inputs["input_values"] = [self.add_temporal_shift(feature) for feature in padded_inputs["input_values"]]
 
         if return_tensors is not None:
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)
@@ -256,9 +266,7 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         return padded_inputs
 
     # from https://github.com/YuanGongND/ast with minor changes
-    def mask(self, fbank, freqm, timem):
-        if freqm == 0 and timem == 0:
-            return fbank
+    def apply_time_frequency_masks(self, fbank, frequency_mask_length, time_mask_length):
         if not is_speech_available():
             raise ImportError("Torchaudio is required to use frequency and/or time masking.")
         if not isinstance(fbank, torch.Tensor):
@@ -266,11 +274,11 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         fbank = torch.transpose(fbank, 0, 1)
         # this is just to satisfy new torchaudio version, which only accept [1, freq, time]
         fbank = fbank.unsqueeze(0)
-        if freqm != 0:
-            freqm = FrequencyMasking(freqm)
+        if frequency_mask_length:
+            freqm = FrequencyMasking(frequency_mask_length)
             fbank = freqm(fbank)
-        if timem != 0:
-            timem = TimeMasking(timem)
+        if time_mask_length:
+            timem = TimeMasking(time_mask_length)
             fbank = timem(fbank)
         # squeeze it back, it is just a trick to satisfy new torchaudio version
         fbank = fbank.squeeze(0)
@@ -281,5 +289,8 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
     # from https://github.com/YuanGongND/ast but converted into numpy
     def add_noise(self, fbank: np.ndarray) -> np.ndarray:
         fbank += np.random.rand(fbank.shape[0], fbank.shape[1]) * (np.random.rand() / 10)
+        return fbank
+
+    def add_temporal_shift(self, fbank: np.ndarray) -> np.ndarray:
         fbank = np.roll(fbank, np.random.randint(-10, 10), axis=0)
         return fbank

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -258,7 +258,9 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
             padded_inputs["input_values"] = [self.add_noise(feature) for feature in padded_inputs["input_values"]]
 
         if add_temporal_shift:
-            padded_inputs["input_values"] = [self.add_temporal_shift(feature) for feature in padded_inputs["input_values"]]
+            padded_inputs["input_values"] = [
+                self.add_temporal_shift(feature) for feature in padded_inputs["input_values"]
+            ]
 
         if return_tensors is not None:
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -298,7 +298,7 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
 
     # from https://github.com/YuanGongND/ast but converted into numpy
     def add_noise(self, fbank: np.ndarray) -> np.ndarray:
-        noise = np.random.rand(fbank.shape[0], fbank.shape[1]) 
+        noise = np.random.rand(fbank.shape[0], fbank.shape[1])
         noise = noise * (np.random.rand() / 10)
         fbank += noise
         return fbank

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -191,6 +191,12 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
                 - `'tf'`: Return TensorFlow `tf.constant` objects.
                 - `'pt'`: Return PyTorch `torch.Tensor` objects.
                 - `'np'`: Return Numpy `np.ndarray` objects.
+            timem (`int`, *optional*):
+                The maximum possible length of the mask in the time domain.
+            freqm (`int`, *optional*):
+                The maximum possible length of the mask in the frequency domain.
+            add_noise (`bool`, *optional*):
+                Whether or not to add noise to the input.
         """
 
         if sampling_rate is not None:
@@ -254,7 +260,7 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         if freqm == 0 and timem == 0:
             return fbank
         if not is_speech_available():
-            raise ImportError("Torchaudio is required for use with frequency and time masking.")
+            raise ImportError("Torchaudio is required to use frequency and/or time masking.")
         if not isinstance(fbank, torch.Tensor):
             fbank = torch.tensor(fbank)
         fbank = torch.transpose(fbank, 0, 1)

--- a/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
+++ b/src/transformers/models/audio_spectrogram_transformer/feature_extraction_audio_spectrogram_transformer.py
@@ -28,6 +28,7 @@ from ...utils import TensorType, is_speech_available, is_torch_available, loggin
 
 if is_speech_available():
     import torchaudio.compliance.kaldi as ta_kaldi
+    from torchaudio.transforms import FrequencyMasking, TimeMasking
 
 if is_torch_available():
     import torch
@@ -81,7 +82,12 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         return_attention_mask=False,
         **kwargs,
     ):
-        super().__init__(feature_size=feature_size, sampling_rate=sampling_rate, padding_value=padding_value, **kwargs)
+        super().__init__(
+            feature_size=feature_size,
+            sampling_rate=sampling_rate,
+            padding_value=padding_value,
+            **kwargs,
+        )
         self.num_mel_bins = num_mel_bins
         self.max_length = max_length
         self.do_normalize = do_normalize
@@ -163,6 +169,9 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         raw_speech: Union[np.ndarray, List[float], List[np.ndarray], List[List[float]]],
         sampling_rate: Optional[int] = None,
         return_tensors: Optional[Union[str, TensorType]] = None,
+        timem: Optional[int] = 0,
+        freqm: Optional[int] = 0,
+        add_noise: Optional[bool] = False,
         **kwargs,
     ) -> BatchFeature:
         """
@@ -218,6 +227,8 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         # extract fbank features and pad/truncate to max_length
         features = [self._extract_fbank_features(waveform, max_length=self.max_length) for waveform in raw_speech]
 
+        features = [self.mask(feature, freqm, timem) for feature in features]
+
         # convert into BatchFeature
         padded_inputs = BatchFeature({"input_values": features})
 
@@ -230,7 +241,39 @@ class ASTFeatureExtractor(SequenceFeatureExtractor):
         if self.do_normalize:
             padded_inputs["input_values"] = [self.normalize(feature) for feature in input_values]
 
+        if add_noise:
+            padded_inputs["input_values"] = [self.add_noise(feature) for feature in input_values]
+
         if return_tensors is not None:
             padded_inputs = padded_inputs.convert_to_tensors(return_tensors)
 
         return padded_inputs
+
+    # from https://github.com/YuanGongND/ast with minor changes
+    def mask(self, fbank, freqm, timem):
+        if freqm == 0 and timem == 0:
+            return fbank
+        if not is_speech_available():
+            raise ImportError("Torchaudio is required for use with frequency and time masking.")
+        if not isinstance(fbank, torch.Tensor):
+            fbank = torch.tensor(fbank)
+        fbank = torch.transpose(fbank, 0, 1)
+        # this is just to satisfy new torchaudio version, which only accept [1, freq, time]
+        fbank = fbank.unsqueeze(0)
+        if freqm != 0:
+            freqm = FrequencyMasking(freqm)
+            fbank = freqm(fbank)
+        if timem != 0:
+            timem = TimeMasking(timem)
+            fbank = timem(fbank)
+        # squeeze it back, it is just a trick to satisfy new torchaudio version
+        fbank = fbank.squeeze(0)
+        fbank = torch.transpose(fbank, 0, 1)
+        fbank = fbank.numpy()
+        return fbank
+
+    # from https://github.com/YuanGongND/ast but converted into numpy
+    def add_noise(self, fbank: np.ndarray) -> np.ndarray:
+        fbank += np.random.rand(fbank.shape[0], fbank.shape[1]) * (np.random.rand() / 10)
+        fbank = np.roll(fbank, np.random.randint(-10, 10), axis=0)
+        return fbank

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -143,6 +143,34 @@ class ASTFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Test
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
+    def test_call_with_all_data_augmentations(self):
+        # Tests that all call wrap to encode_plus and batch_encode_plus
+        feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        # create three inputs of length 800, 1000, and 1200
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+        np_speech_inputs = [np.asarray(speech_input) for speech_input in speech_inputs]
+
+        # Test not batched input with time_mask_length and frequency_mask_length
+        torch.manual_seed(0)
+        encoded_sequences_1 = feat_extract(
+            speech_inputs[0],
+            return_tensors="np",
+            time_mask_length=400,
+            frequency_mask_length=400,
+            add_noise=True,
+            add_temporal_shift=True,
+        ).input_values
+        torch.manual_seed(0)
+        encoded_sequences_2 = feat_extract(
+            np_speech_inputs[0],
+            return_tensors="np",
+            time_mask_length=400,
+            frequency_mask_length=400,
+            add_noise=True,
+            add_temporal_shift=True,
+        ).input_values
+        self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
+
     def test_call_with_time_mask_length_and_frequency_mask_length(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
@@ -178,11 +206,11 @@ class ASTFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Test
         np_speech_inputs = np.asarray(speech_inputs)
         torch.manual_seed(0)
         encoded_sequences_1 = feat_extract(
-            speech_inputs, return_tensors="np", time_mask_length=400, freqm=400
+            speech_inputs, return_tensors="np", time_mask_length=400, frequency_mask_length=400
         ).input_values
         torch.manual_seed(0)
         encoded_sequences_2 = feat_extract(
-            np_speech_inputs, return_tensors="np", time_mask_length=400, freqm=400
+            np_speech_inputs, return_tensors="np", time_mask_length=400, frequency_mask_length=400
         ).input_values
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -14,14 +14,12 @@
 # limitations under the License.
 
 
-import functools
 import itertools
 import logging
 import os
 import random
 import tempfile
 import unittest
-from unittest import mock
 
 import numpy as np
 

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -19,7 +19,6 @@ import os
 import random
 import tempfile
 import unittest
-from typing import override
 
 import numpy as np
 
@@ -320,7 +319,6 @@ class ASTFeatureExtractionWithoutTorchaudioTest(ASTFeatureExtractionTest):
 
         self.assertFalse(is_speech_available())
 
-    @override
     def test_call_with_time_mask_length_and_frequency_mask_length(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = floats_list((1, 800))[0]
@@ -328,7 +326,6 @@ class ASTFeatureExtractionWithoutTorchaudioTest(ASTFeatureExtractionTest):
         with self.assertRaises(ImportError) as _:
             feat_extract(speech_inputs, return_tensors="np", time_mask_length=400, frequency_mask_length=400)
 
-    @override
     def test_call_with_only_time_mask_length(self):
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = floats_list((1, 800))[0]

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -178,6 +178,14 @@ class ASTFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Test
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
+    def test_call_with_add_noise(self):
+        # Tests that all call wrap to encode_plus and batch_encode_plus
+        feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        # create three inputs of length 800, 1000, and 1200
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+
+        feat_extract(speech_inputs[0], return_tensors="np", add_noise=True).input_values
+
     @require_torch
     def test_double_precision_pad(self):
         import torch

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -23,10 +23,16 @@ import unittest
 import numpy as np
 
 from transformers import ASTFeatureExtractor
-from transformers.testing_utils import check_json_file_has_correct_format, require_torch, require_torchaudio
+from transformers.testing_utils import (
+    check_json_file_has_correct_format,
+    require_torch,
+    require_torchaudio,
+)
 from transformers.utils.import_utils import is_torch_available
 
-from ...test_sequence_feature_extraction_common import SequenceFeatureExtractionTestMixin
+from ...test_sequence_feature_extraction_common import (
+    SequenceFeatureExtractionTestMixin,
+)
 
 
 global_rng = random.Random()
@@ -136,6 +142,42 @@ class ASTFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Test
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
+    def test_call_with_timem_and_freqm(self):
+        # Tests that all call wrap to encode_plus and batch_encode_plus
+        feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        # create three inputs of length 800, 1000, and 1200
+        speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
+        np_speech_inputs = [np.asarray(speech_input) for speech_input in speech_inputs]
+
+        # Test not batched input with timem and freqm
+        torch.manual_seed(0)
+        encoded_sequences_1 = feat_extract(speech_inputs[0], return_tensors="np", timem=400, freqm=400).input_values
+        torch.manual_seed(0)
+        encoded_sequences_2 = feat_extract(np_speech_inputs[0], return_tensors="np", timem=400, freqm=400).input_values
+        self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
+
+        # Test batched input with timem and freqm
+        torch.manual_seed(0)
+        encoded_sequences_1 = feat_extract(
+            speech_inputs, padding=True, return_tensors="np", timem=400, freqm=400
+        ).input_values
+        torch.manual_seed(0)
+        encoded_sequences_2 = feat_extract(
+            np_speech_inputs, padding=True, return_tensors="np", timem=400, freqm=400
+        ).input_values
+        for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
+            self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
+
+        # Test 2-D numpy arrays are batched with timem and freqm
+        speech_inputs = [floats_list((1, x))[0] for x in (800, 800, 800)]
+        np_speech_inputs = np.asarray(speech_inputs)
+        torch.manual_seed(0)
+        encoded_sequences_1 = feat_extract(speech_inputs, return_tensors="np", timem=400, freqm=400).input_values
+        torch.manual_seed(0)
+        encoded_sequences_2 = feat_extract(np_speech_inputs, return_tensors="np", timem=400, freqm=400).input_values
+        for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
+            self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
+
     @require_torch
     def test_double_precision_pad(self):
         import torch
@@ -220,3 +262,10 @@ class ASTFeatureExtractionWithoutTorchaudioTest(ASTFeatureExtractionTest):
         )
 
         self.assertFalse(is_speech_available())
+
+    def test_call_with_timem_and_freqm(self):
+        feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
+        speech_inputs = floats_list((1, 800))[0]
+
+        with self.assertRaises(ImportError) as _:
+            feat_extract(speech_inputs, return_tensors="np", timem=400, freqm=400)


### PR DESCRIPTION
Supersedes #33493 because I was stupid enough to delete the forked repository.

# What does this PR do?

Adds frequency and time masking, as well as random noise data augmentations to AST feature extractor. This is very useful for training as AST has a tendency to overfit on practical data, at least in my own personal experience. This is also what was used in the original paper and [code](https://github.com/YuanGongND/ast/blob/master/src/dataloader.py#L187).


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request) Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [x] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed.

@ylacombe

This is my first time contributing to `transformers`, so please let me know if I need to make any changes :)