### PR TITLE
Fix NaNs in cost_matrix for mask2former

### DIFF
--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -474,6 +474,7 @@ class Mask2FormerHungarianMatcher(nn.Module):
             # eliminate infinite values in cost_matrix to avoid the error ``ValueError: cost matrix is infeasible``
             cost_matrix = torch.minimum(cost_matrix, torch.tensor(1e10))
             cost_matrix = torch.maximum(cost_matrix, torch.tensor(-1e10))
+            cost_matrix = torch.nan_to_num(cost_matrix, 0)
             # do the assigmented using the hungarian algorithm in scipy
             assigned_indices: Tuple[np.array] = linear_sum_assignment(cost_matrix.cpu())
             indices.append(assigned_indices)


### PR DESCRIPTION
I don't have a reproduction code (because that often happens after like day of training), but sometimes training Mask2Former gives me an error:

```python3
rank0]:   File "/opt/conda/lib/python3.10/site-packages/transformers/models/mask2former/modeling_mask2former.py", line 478, in forward
[rank0]:     assigned_indices: Tuple[np.array] = linear_sum_assignment(cost_matrix.cpu())
[rank0]: ValueError: matrix contains invalid numeric entries
```
This PR fixes that.

@amyeroberts, @qubvel

