### PR TITLE
Fix PushToHubMixin when pusing to a PR revision

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -802,7 +802,7 @@ class PushToHubMixin:
                     CommitOperationAdd(path_or_fileobj=os.path.join(working_dir, file), path_in_repo=file)
                 )
 
-        if revision is not None:
+        if revision is not None and not revision.startswith("refs/pr"):
             try:
                 create_branch(repo_id=repo_id, branch=revision, token=token, exist_ok=True)
             except HfHubHTTPError as e:


### PR DESCRIPTION
This PR fixes `PushToHubMixin` when trying to push a component to a PR revision.

In `.push_to_hub`, if a revision is passed, it currently tries to create a branch with that name. To be honest I don't think this should be the role of `transformers` to try to auto-create a branch if the user asked to push to it. It can lead to misleading behavior where a branch is autocreated even if the user made a typo in the revision name. But we won't change that at least for the sake of not introducing a breaking change.

This PR introduces a fix when the passed revision is in fact a PR ref (`"refs/pr/1"`). In that case, we should not try to create a branch otherwise a HTTP 400 Bad request: `Invalid reference for a branch: refs/pr/1` is raised. I've added a test following the same structure as existing tests.

---
Context: this issue has been reported by a user that wants to push both a model and a tokenizer to the same PR. So what they want to do is:
1. create an empty PR
2. push the model
3. push the tokenizer

Which is currently not possible because of the issue above.