### PR TITLE
fix(DPT,Depth-Anything) `torch.export`

### DIFF
--- a/src/transformers/models/depth_anything/modeling_depth_anything.py
+++ b/src/transformers/models/depth_anything/modeling_depth_anything.py
@@ -224,16 +224,16 @@ class DepthAnythingFeatureFusionStage(nn.Module):
         hidden_states = hidden_states[::-1]
 
         fused_hidden_states = []
-        # first layer only uses the last hidden_state
-        size = hidden_states[1].shape[2:]
-        fused_hidden_state = self.layers[0](hidden_states[0], size=size)
-        fused_hidden_states.append(fused_hidden_state)
+        fused_hidden_state = None
 
-        # looping from the last layer to the second
-        for idx, (hidden_state, layer) in enumerate(zip(hidden_states[1:], self.layers[1:])):
-            size = hidden_states[1:][idx + 1].shape[2:] if idx != (len(hidden_states[1:]) - 1) else None
+        for idx, (hidden_state, layer) in enumerate(zip(hidden_states, self.layers)):
+            size = hidden_states[idx + 1].shape[2:] if idx != (len(hidden_states) - 1) else None
 
-            fused_hidden_state = layer(fused_hidden_state, hidden_state, size=size)
+            if fused_hidden_state is None:
+                # first layer only uses the last hidden_state
+                fused_hidden_state = layer(hidden_state, size=size)
+            else:
+                fused_hidden_state = layer(fused_hidden_state, hidden_state, size=size)
 
             fused_hidden_states.append(fused_hidden_state)
 

--- a/src/transformers/models/dpt/modeling_dpt.py
+++ b/src/transformers/models/dpt/modeling_dpt.py
@@ -690,14 +690,12 @@ class DPTFeatureFusionStage(nn.Module):
 
         fused_hidden_states = []
         fused_hidden_state = None
-        # looping from the last layer to the second
-        for idx, (hidden_state, layer) in enumerate(zip(hidden_states, self.layers)):
-            if idx == 0:
+        for hidden_state, layer in zip(hidden_states, self.layers):
+            if fused_hidden_state is None:
                 # first layer only uses the last hidden_state
                 fused_hidden_state = layer(hidden_state)
-                fused_hidden_states.append(fused_hidden_state)
-                continue
-            fused_hidden_state = layer(fused_hidden_state, hidden_state)
+            else:
+                fused_hidden_state = layer(fused_hidden_state, hidden_state)
             fused_hidden_states.append(fused_hidden_state)
 
         return fused_hidden_states

--- a/src/transformers/models/dpt/modeling_dpt.py
+++ b/src/transformers/models/dpt/modeling_dpt.py
@@ -689,11 +689,14 @@ class DPTFeatureFusionStage(nn.Module):
         hidden_states = hidden_states[::-1]
 
         fused_hidden_states = []
-        # first layer only uses the last hidden_state
-        fused_hidden_state = self.layers[0](hidden_states[0])
-        fused_hidden_states.append(fused_hidden_state)
+        fused_hidden_state = None
         # looping from the last layer to the second
-        for hidden_state, layer in zip(hidden_states[1:], self.layers[1:]):
+        for idx, (hidden_state, layer) in enumerate(zip(hidden_states, self.layers)):
+            if idx == 0:
+                # first layer only uses the last hidden_state
+                fused_hidden_state = layer(hidden_state)
+                fused_hidden_states.append(fused_hidden_state)
+                continue
             fused_hidden_state = layer(fused_hidden_state, hidden_state)
             fused_hidden_states.append(fused_hidden_state)
 

--- a/src/transformers/models/zoedepth/modeling_zoedepth.py
+++ b/src/transformers/models/zoedepth/modeling_zoedepth.py
@@ -186,14 +186,12 @@ class ZoeDepthFeatureFusionStage(nn.Module):
 
         fused_hidden_states = []
         fused_hidden_state = None
-        # looping from the last layer to the second
-        for idx, (hidden_state, layer) in enumerate(zip(hidden_states, self.layers)):
-            if idx == 0:
+        for hidden_state, layer in zip(hidden_states, self.layers):
+            if fused_hidden_state is None:
                 # first layer only uses the last hidden_state
                 fused_hidden_state = layer(hidden_state)
-                fused_hidden_states.append(fused_hidden_state)
-                continue
-            fused_hidden_state = layer(fused_hidden_state, hidden_state)
+            else:
+                fused_hidden_state = layer(fused_hidden_state, hidden_state)
             fused_hidden_states.append(fused_hidden_state)
 
         return fused_hidden_states

--- a/src/transformers/models/zoedepth/modeling_zoedepth.py
+++ b/src/transformers/models/zoedepth/modeling_zoedepth.py
@@ -185,11 +185,14 @@ class ZoeDepthFeatureFusionStage(nn.Module):
         hidden_states = hidden_states[::-1]
 
         fused_hidden_states = []
-        # first layer only uses the last hidden_state
-        fused_hidden_state = self.layers[0](hidden_states[0])
-        fused_hidden_states.append(fused_hidden_state)
+        fused_hidden_state = None
         # looping from the last layer to the second
-        for hidden_state, layer in zip(hidden_states[1:], self.layers[1:]):
+        for idx, (hidden_state, layer) in enumerate(zip(hidden_states, self.layers)):
+            if idx == 0:
+                # first layer only uses the last hidden_state
+                fused_hidden_state = layer(hidden_state)
+                fused_hidden_states.append(fused_hidden_state)
+                continue
             fused_hidden_state = layer(fused_hidden_state, hidden_state)
             fused_hidden_states.append(fused_hidden_state)
 

--- a/src/transformers/models/zoedepth/modeling_zoedepth.py
+++ b/src/transformers/models/zoedepth/modeling_zoedepth.py
@@ -367,15 +367,12 @@ class ZoeDepthRelativeDepthEstimationHead(nn.Module):
         self.projection = None
         if config.add_projection:
             self.projection = nn.Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
-            self.projection_act = nn.ReLU()
 
         features = config.fusion_hidden_size
         self.conv1 = nn.Conv2d(features, features // 2, kernel_size=3, stride=1, padding=1)
         self.upsample = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True)
         self.conv2 = nn.Conv2d(features // 2, config.num_relative_features, kernel_size=3, stride=1, padding=1)
-        self.conv2_act = nn.ReLU()
         self.conv3 = nn.Conv2d(config.num_relative_features, 1, kernel_size=1, stride=1, padding=0)
-        self.conv3_act = nn.ReLU()
 
     def forward(self, hidden_states: List[torch.Tensor]) -> torch.Tensor:
         # use last features
@@ -383,16 +380,16 @@ class ZoeDepthRelativeDepthEstimationHead(nn.Module):
 
         if self.projection is not None:
             hidden_states = self.projection(hidden_states)
-            hidden_states = self.projection_act(hidden_states)
+            hidden_states = nn.ReLU()(hidden_states)
 
         hidden_states = self.conv1(hidden_states)
         hidden_states = self.upsample(hidden_states)
         hidden_states = self.conv2(hidden_states)
-        hidden_states = self.conv2_act(hidden_states)
+        hidden_states = nn.ReLU()(hidden_states)
         # we need the features here (after second conv + ReLu)
         features = hidden_states
         hidden_states = self.conv3(hidden_states)
-        hidden_states = self.conv3_act(hidden_states)
+        hidden_states = nn.ReLU()(hidden_states)
 
         predicted_depth = hidden_states.squeeze(dim=1)
 

--- a/tests/models/zoedepth/test_modeling_zoedepth.py
+++ b/tests/models/zoedepth/test_modeling_zoedepth.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from transformers import Dinov2Config, ZoeDepthConfig
 from transformers.file_utils import is_torch_available, is_vision_available
+from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_4
 from transformers.testing_utils import require_torch, require_vision, slow, torch_device
 
 from ...test_configuration_common import ConfigTester
@@ -354,3 +355,29 @@ class ZoeDepthModelIntegrationTest(unittest.TestCase):
         model = ZoeDepthForDepthEstimation.from_pretrained("Intel/zoedepth-nyu-kitti").to(torch_device)
 
         self.check_post_processing_test(image_processor, images, model, pad_input=True, flip_aug=True)
+
+    def test_export(self):
+        self.skipTest(
+            reason="This test fails because the beit backbone of ZoeDepth is not compatible with torch.export"
+        )
+        for strict in [True, False]:
+            with self.subTest(strict=True):
+                if not is_torch_greater_or_equal_than_2_4:
+                    self.skipTest(reason="This test requires torch >= 2.4 to run.")
+                model = ZoeDepthForDepthEstimation.from_pretrained("Intel/zoedepth-nyu").to(torch_device).eval()
+                image_processor = ZoeDepthImageProcessor.from_pretrained("Intel/zoedepth-nyu")
+                image = prepare_img()
+                inputs = image_processor(images=image, return_tensors="pt").to(torch_device)
+
+                exported_program = torch.export.export(
+                    model,
+                    args=(inputs["pixel_values"],),
+                    strict=strict,
+                )
+                with torch.no_grad():
+                    eager_outputs = model(**inputs)
+                    exported_outputs = exported_program.module().forward(inputs["pixel_values"])
+                self.assertEqual(eager_outputs.predicted_depth.shape, exported_outputs.predicted_depth.shape)
+                self.assertTrue(
+                    torch.allclose(eager_outputs.predicted_depth, exported_outputs.predicted_depth, atol=1e-4)
+                )


### PR DESCRIPTION
# What does this PR do?
Small modification of the DPT modeling code to remove a new object creation in a `forward()` method of a Module. This object creation makes the model incompatible with `torch.export`, which is a key part of preparing a model to run on a variety of hardware backends through projects such as [ExecuTorch](https://pytorch.org/executorch/main/intro-overview.html) (related issue: https://github.com/huggingface/transformers/issues/32253)

## Motivation
[torch.export](https://pytorch.org/tutorials/intermediate/torch_export_tutorial.html#) allows you to export PyTorch models into standardized model representations, intended to be optimized and run efficiently using frameworks such as TensorRT or ExecuTorch.

## The Bug 
They key issue was the slice on `self.layers`:
https://github.com/huggingface/transformers/blob/617b21273a349bd3a94e2b3bfb83f8089f45749b/src/transformers/models/dpt/modeling_dpt.py#L696

`self.layers[1:]` creates a new `ModuleList()` each time this line is executed.

https://github.com/pytorch/pytorch/blob/69bcf1035e7f06f2eefd8986d000cc980e9ebd37/torch/nn/modules/container.py#L330

The model tracer in `torch.export` monkey-patches nn.Module constructors during evaluation of the `forward()` pass, so the original DPT modeling code raises the following error:
```
  File "/home/philkuz/.pyenv/versions/gml311/lib/python3.11/site-packages/torch/nn/modules/container.py", line 293, in __getitem__
      return self.__class__(list(self._modules.values())[idx])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 TypeError: _ModuleStackTracer.__init__.<locals>.AttrProxy.__init__() missing 1 required positional argument: 'path'

```

## The Solution
Pytorch recommends users update the modeling code. My team and I figured this could be helpful to the broader community, especially a future where Export to Executorch becomes more widely available: https://github.com/huggingface/transformers/issues/32253

This also removes an unnecessary creation of a new module list as a bonus.

### Tests
I ensured that `tests/models/dpt/test_modeling_dpt.py` passes, which appears to test a portion of the outputs. I also verified that the entire output of the model
before and after my changes matched with the following script:
```python
import os
import sys

import numpy as np
import requests
import torch
from PIL import Image
from transformers import pipeline

url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = Image.open(requests.get(url, stream=True).raw)


model = pipeline("depth-estimation", "facebook/dpt-dinov2-base-kitti")
result = model(image)


output_file = "depth_estimation_output.npy"

if not os.path.exists(output_file):
    # Save the current output
    np.save(output_file, result["predicted_depth"])
    print(f"Depth estimation output saved to {output_file}")
    print("Rerun the script to compare the output")
    sys.exit(0)
# Load existing output and compare
expected_output = np.load(output_file)
np.testing.assert_allclose(
    result["predicted_depth"],
    expected_output,
    rtol=1e-5,
    atol=1e-5,
    err_msg="Depth estimation output has changed",
)
print("Depth estimation output matches the saved version.")
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts, @qubvel

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
