### PR TITLE
add optional 'do_normalize' to qwen2_audio processor

### DIFF
--- a/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/processing_qwen2_audio.py
@@ -57,6 +57,7 @@ class Qwen2AudioProcessor(ProcessorMixin):
         audios: Union[np.ndarray, List[np.ndarray]] = None,
         padding: Union[bool, str, PaddingStrategy] = False,
         sampling_rate: Optional[int] = None,
+        do_normalize: Optional[int] = None,
         **kwargs,
     ) -> BatchFeature:
         """
@@ -92,7 +93,8 @@ class Qwen2AudioProcessor(ProcessorMixin):
 
         if audios is not None:
             audio_inputs = self.feature_extractor(
-                audios, sampling_rate=sampling_rate, return_attention_mask=True, padding="max_length", **kwargs
+                audios, sampling_rate=sampling_rate, return_attention_mask=True, padding="max_length",
+                do_normalize=do_normalize, **kwargs
             )
             audio_inputs["feature_attention_mask"] = audio_inputs.pop(
                 "attention_mask"


### PR DESCRIPTION

the input args  "do_normalize" of  feature_extractor_whisper __call__  function is False in default， and  processing_qwen2_audio.py __call__  function  
```
audio_inputs = self.feature_extractor(
audios, sampling_rate=sampling_rate, return_attention_mask=True, padding="max_length", **kwargs)
```
didn't fill do_normalize， then the raw speech values may lead loss to overflow when using bf16 or fp16

fix:  add optional arg "do_noramlize"   to  processing_qwen2_audio  __call__ function


issue inference:
https://github.com/modelscope/ms-swift/issues/1653

@ArthurZucker  @ylacombe