### PR TITLE
Fix: take into account meta device

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -378,7 +378,7 @@ def check_support_param_buffer_assignment(model_to_load, state_dict, start_prefi
         return False
 
     # If the model does, the incoming `state_dict` and the `model_to_load` must be the same dtype
-    first_key = list(model_to_load.state_dict().keys())[0]
+    first_key = next(iter(model_to_load.state_dict().keys()))
     if start_prefix + first_key in state_dict:
         return state_dict[start_prefix + first_key].dtype == model_to_load.state_dict()[first_key].dtype
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -361,6 +361,9 @@ def check_support_param_buffer_assignment(model_to_load, state_dict, start_prefi
 
     Note: We fully disable this if we are using `deepspeed`
     """
+    if model_to_load.device.type == "meta":
+        return False
+
     if len([key for key in state_dict if key.startswith(start_prefix)]) == 0:
         return False
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -467,16 +467,11 @@ class ModelUtilsTest(TestCasePlus):
                 model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype)
                 return all(value.device.type == "meta" for value in model.state_dict().values())
 
-        result = {}
-        expected = {}
         model_ids = ("fxmarty/tiny-llama-fast-tokenizer", "fxmarty/small-llama-testing")
         dtypes = (None, "auto", torch.float16)
 
         for model_id, dtype in itertools.product(model_ids, dtypes):
-            result[(model_id, dtype)] = is_on_meta(model_id, dtype)
-            expected[(model_id, dtype)] = True
-
-        assert result == expected
+            self.assertTrue(is_on_meta(model_id, dtype))
 
     def test_model_from_pretrained_torch_dtype(self):
         # test that the model can be instantiated with dtype of either

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -460,7 +460,7 @@ class ModelUtilsTest(TestCasePlus):
         with self.assertRaises(ValueError):
             model = AutoModel.from_pretrained(TINY_T5, torch_dtype="int64")
 
-    @slow
+    @require_torch
     def test_model_from_pretrained_meta_device(self):
         def is_on_meta(model_id, dtype):
             with torch.device("meta"):


### PR DESCRIPTION
Fixes #34091

The models given in the issues' example have different torch_dtype which results in a different handling in `check_support_param_buffer_assignment`.
fxmarty/small-llama-testing: torch_dtype=float32
fxmarty/tiny-llama-fast-tokenizer: torch_dtype=float16


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@LysandreJik @fxmarty @muellerzr
