### PR TITLE
Fix: tensor of examples of the same length triggers invalid stacking

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -438,8 +438,9 @@ def _torch_collate_batch(examples, tokenizer, pad_to_multiple_of: Optional[int] 
     # Check if padding is necessary.
 
     are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
-    if are_tensors_same_length and (pad_to_multiple_of is None or length_of_first % pad_to_multiple_of == 0) and not isinstance(examples, torch.Tensor):
-        return torch.stack(examples, dim=0)
+    if are_tensors_same_length and (pad_to_multiple_of is None or length_of_first % pad_to_multiple_of == 0):
+        if not isinstance(examples, torch.Tensor):
+            return torch.stack(examples, dim=0)
 
     # If yes, check if we have a `pad_token`.
     if tokenizer._pad_token is None:

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -438,7 +438,7 @@ def _torch_collate_batch(examples, tokenizer, pad_to_multiple_of: Optional[int] 
     # Check if padding is necessary.
 
     are_tensors_same_length = all(x.size(0) == length_of_first for x in examples)
-    if are_tensors_same_length and (pad_to_multiple_of is None or length_of_first % pad_to_multiple_of == 0):
+    if are_tensors_same_length and (pad_to_multiple_of is None or length_of_first % pad_to_multiple_of == 0) and not isinstance(examples, torch.Tensor):
         return torch.stack(examples, dim=0)
 
     # If yes, check if we have a `pad_token`.


### PR DESCRIPTION
Fix: tensor of examples of the same length triggers invalid stacking

# What does this PR do?

This PR fixes the issue that occurs when `DataCollatorForLanguageModelling` is used on whole tensors (e.g. `input_ids` being a long tensor of shape `(4, 2048)`). When this happens, `torch.stack` fails because it is expecting `examples` argument to be a tuple of tensors and not a tensor on its own.
Note that if the preprocessing step applied to the dataset (e.g. batched `dataset.map`) produces tensors of varying length, this occurs only in the very rare (and difficult to track down) special case when the collator happens to come across two tensors of exactly the same length. This is what occurred to me on the GSM8k dataset in roughly one out of every three runs.

@ArthurZucker