### PR TITLE
Revert `accelerate` error caused by `46d09af`

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1936,7 +1936,7 @@ class TrainingArguments:
                 warnings.warn("`--xla_fsdp_grad_ckpt` is useful only when `--xla` is set to true.")
 
         # accelerate integration for FSDP
-        if len(self.fsdp) > 0 and is_accelerate_available("0.28.0"):
+        if len(self.fsdp) > 0 and not self.fsdp_config["xla"]:
             os.environ["ACCELERATE_USE_FSDP"] = "true"
             from accelerate.utils.constants import (
                 FSDP_AUTO_WRAP_POLICY,


### PR DESCRIPTION
# What does this PR do?

Fixes #34176 

Starting from `v4.45.0` Trainer was not able to train on TPU VMs.
so i tested commits between `v4.44.2` and `v4.45.0` one by one, then found this 1 line change commit [46d09af](https://github.com/huggingface/transformers/commit/46d09af4fc62db59cb836099d17a2c6102b39835) causes this error.
You can see full test result on #34176.


## Before submitting
- [x] This PR fixes a bug on code, not a typo
- [x] Read Pull Request Guideline
- [x] Discussed before on github issue.
- [x] No Document update is required. 1 line change.
- [x] Did you write any new necessary tests?


## Reviewers
Trainer: @muellerzr and @SunMarc
Deepspeed: HF Trainer/Accelerate: @muellerzr