### PR TITLE
 Enable users to use their own loss functions + deal with prefetching for grad accum

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3646,6 +3646,8 @@ class Trainer:
             labels = inputs.pop("labels")
         else:
             labels = None
+        if num_items_in_batch is not None:
+            inputs["num_items_in_batch"] = num_items_in_batch
         outputs = model(**inputs)
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.
@@ -3660,11 +3662,7 @@ class Trainer:
                 model_name = unwrapped_model._get_name()
             # User-defined compute_loss function
             if self.compute_loss is not None:
-                # Check if `num_items` is a parameter of the compute_loss function
-                if "num_items_in_batch" in inspect.signature(self.compute_loss).parameters.keys():
-                    loss = self.compute_loss(outputs, labels, num_items_in_batch=num_items_in_batch)
-                else:
-                    loss = self.compute_loss(outputs, labels)
+                loss = self.compute_loss(outputs, labels, num_items_in_batch=num_items_in_batch)
             elif model_name in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.values():
                 loss = self.label_smoother(outputs, labels, shift_labels=True)
             else:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2420,9 +2420,11 @@ class Trainer:
             num_items_in_batch = None
             if remainder == 0:
                 remainder = args.gradient_accumulation_steps
+            update_step = -1
             total_updates = max_steps // args.gradient_accumulation_steps + 1
             for _ in range(total_updates):
-                if step == (total_updates - 1):
+                update_step += 1
+                if update_step == (total_updates - 1):
                     num_batches = remainder
                 else:
                     num_batches = args.gradient_accumulation_steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -373,12 +373,25 @@ class Trainer:
             The function may have zero argument, or a single one containing the optuna/Ray Tune/SigOpt trial object, to
             be able to choose different architectures according to hyper parameters (such as layer count, sizes of
             inner layers, dropout probabilities etc).
+        compute_loss (`Callable`, *optional*):
+            A function that accepts the raw model outputs, labels, and the number of items in the entire accumulated
+            batch (batch_size * gradient_accumulation_steps) and returns the loss. For example, here is one using
+            the loss function from `transformers`:
+            ```python
+            from functools import partial
+            from transformers.loss import ForCausalLMLoss
+
+            def loss_fn(model_output, labels, num_items_in_batch, vocab_size):
+                return ForCausalLMLoss(model_output["logits"], labels, vocab_size=vocab_size, num_items_in_batch=num_items_in_batch)
+
+            compute_loss = partial(loss_fn, vocab_size=30522)
+            ```
         compute_metrics (`Callable[[EvalPrediction], Dict]`, *optional*):
             The function that will be used to compute metrics at evaluation. Must take a [`EvalPrediction`] and return
             a dictionary string to metric values. *Note* When passing TrainingArgs with `batch_eval_metrics` set to
             `True`, your compute_metrics function must take a boolean `compute_result` argument. This will be triggered
             after the last eval batch to signal that the function needs to calculate and return the global summary
-            statistics rather than accumulating the batch-level statistics.
+            statistics rather than accumulating the batch-level statistics
         callbacks (List of [`TrainerCallback`], *optional*):
             A list of callbacks to customize the training loop. Will add those to the list of default callbacks
             detailed in [here](callback).

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3585,7 +3585,7 @@ class Trainer:
             return loss_mb.reduce_mean().detach().to(self.args.device)
 
         with self.compute_loss_context_manager():
-            loss = self._compute_loss(model, inputs, num_items_in_batch)
+            loss = self._compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
 
         del inputs
         if (

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2433,9 +2433,13 @@ class Trainer:
                     except StopIteration:
                         break
                 if len(batch_samples) > 0 and "labels" in batch_samples[0]:
-                    num_items_in_batch = sum(
-                        [data_batch["labels"][..., 1:].ne(-100).sum().item() for data_batch in batch_samples]
-                    )
+                    # For now we don't support object detection
+                    try:
+                        num_items_in_batch = sum(
+                            [data_batch["labels"][..., 1:].ne(-100).sum().item() for data_batch in batch_samples]
+                        )
+                    except TypeError:
+                        pass
                 for inputs in batch_samples:
                     step += 1
                     total_batched_samples += 1

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3631,6 +3631,7 @@ class Trainer:
             with amp.scale_loss(loss, self.optimizer) as scaled_loss:
                 scaled_loss.backward()
         else:
+            loss *= self.args.gradient_accumulation_steps
             self.accelerator.backward(loss, **kwargs)
 
         return loss.detach() / self.args.gradient_accumulation_steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2562,6 +2562,7 @@ class Trainer:
                                 self.lr_scheduler.step()
 
                         model.zero_grad()
+                        print("Called!", is_last_step_and_steps_less_than_grad_acc)
                         self.state.global_step += 1
                         self.state.epoch = epoch + (step + 1 + steps_skipped) / steps_in_epoch
                         self.control = self.callback_handler.on_step_end(args, self.state, self.control)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2421,7 +2421,7 @@ class Trainer:
             if remainder == 0:
                 remainder = args.gradient_accumulation_steps
             update_step = -1
-            total_updates = max_steps // args.gradient_accumulation_steps + 1
+            total_updates = steps_in_epoch // args.gradient_accumulation_steps + 1
             for _ in range(total_updates):
                 update_step += 1
                 if update_step == (total_updates - 1):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2522,8 +2522,6 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 max_steps=11,
             )
             trainer.train()
-            # Print all files at tmpdir
-            print(os.listdir(tmpdir))
             # Check that we have the last known step:
             assert os.path.exists(os.path.join(tmpdir, "checkpoint-11")), "Could not find checkpoint-11"
             # And then check the last multiple

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2366,6 +2366,8 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 max_steps=11,
             )
             trainer.train()
+            # Print all files at tmpdir
+            print(os.listdir(tmpdir))
             # Check that we have the last known step:
             assert os.path.exists(os.path.join(tmpdir, "checkpoint-11")), "Could not find checkpoint-11"
             # And then check the last multiple

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -661,16 +661,16 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
 
     def setUp(self):
         super().setUp()
-        # args = TrainingArguments("..")
-        # self.n_epochs = args.num_train_epochs
-        # self.batch_size = args.train_batch_size
-        # trainer = get_regression_trainer(learning_rate=0.1)
-        # trainer.train()
-        # self.default_trained_model = (trainer.model.a, trainer.model.b)
+        args = TrainingArguments("..")
+        self.n_epochs = args.num_train_epochs
+        self.batch_size = args.train_batch_size
+        trainer = get_regression_trainer(learning_rate=0.1)
+        trainer.train()
+        self.default_trained_model = (trainer.model.a, trainer.model.b)
 
-        # trainer = get_regression_trainer(learning_rate=0.1, seed=314)
-        # trainer.train()
-        # self.alternate_trained_model = (trainer.model.a, trainer.model.b)
+        trainer = get_regression_trainer(learning_rate=0.1, seed=314)
+        trainer.train()
+        self.alternate_trained_model = (trainer.model.a, trainer.model.b)
 
     def check_trained_model(self, model, alternate_seed=False):
         # Checks a training seeded with learning_rate = 0.1

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -196,9 +196,10 @@ def ForCausalLMLoss(logits, labels, vocab_size, num_items_in_batch, disable_num_
     # Enable model parallelism
     shift_labels = shift_labels.to(shift_logits.device)
     if num_items_in_batch is None or disable_num_items_in_batch:
-        num_items_in_batch = shift_labels.numel()
-    loss = nn.functional.cross_entropy(shift_logits, shift_labels, ignore_index=-100, reduction="sum")
-    loss = loss / num_items_in_batch
+        loss = nn.functional.cross_entropy(shift_logits, shift_labels, ignore_index=-100, reduction="mean")
+    else:
+        loss = nn.functional.cross_entropy(shift_logits, shift_labels, ignore_index=-100, reduction="sum")
+        loss = loss / num_items_in_batch
     return loss
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -42,6 +42,7 @@ from transformers import (
     AutoImageProcessor,
     AutoProcessor,
     AutoTokenizer,
+    DataCollatorForLanguageModeling,
     IntervalStrategy,
     PretrainedConfig,
     TrainerCallback,
@@ -49,6 +50,7 @@ from transformers import (
     get_polynomial_decay_schedule_with_warmup,
     is_torch_available,
     logging,
+    set_seed,
 )
 from transformers.hyperparameter_search import ALL_HYPERPARAMETER_SEARCH_BACKENDS
 from transformers.testing_utils import (
@@ -153,6 +155,19 @@ if is_accelerate_available():
 PATH_SAMPLE_TEXT = f"{get_tests_dir()}/fixtures/sample_text.txt"
 
 
+class StoreLossCallback(TrainerCallback):
+    """
+    Simple callback to store the loss.
+    """
+
+    def __init__(self):
+        self.losses = []
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        if "loss" in logs:
+            self.losses.append(logs["loss"])
+
+
 class MockCudaOOMCallback(TrainerCallback):
     """
     Simple callback to simulate CUDA OOM error if
@@ -166,6 +181,25 @@ class MockCudaOOMCallback(TrainerCallback):
         # simulate OOM on the first step
         if state.train_batch_size >= self.batch_size_limit:
             raise RuntimeError("CUDA out of memory.")
+
+
+def ForCausalLMLoss(logits, labels, vocab_size, num_items_in_batch, disable_num_items_in_batch=False):
+    # Upcast to float if we need to compute the loss to avoid potential precision issues
+    logits = logits.float()
+    # Shift so that tokens < n predict n
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+
+    # Flatten the tokens
+    shift_logits = shift_logits.view(-1, vocab_size)
+    shift_labels = shift_labels.view(-1)
+    # Enable model parallelism
+    shift_labels = shift_labels.to(shift_logits.device)
+    if num_items_in_batch is None or disable_num_items_in_batch:
+        num_items_in_batch = shift_labels.numel()
+    loss = nn.functional.cross_entropy(shift_logits, shift_labels, ignore_index=-100, reduction="sum")
+    loss = loss / num_items_in_batch
+    return loss
 
 
 class RegressionDataset:
@@ -438,6 +472,31 @@ if is_torch_available():
             loss = nn.functional.mse_loss(y, labels)
             return (loss, y)
 
+    class BasicTextGenerationModel(nn.Module):
+        def __init__(self, vocab_size, hidden_size):
+            super().__init__()
+            self.embedding = nn.Embedding(vocab_size, hidden_size)
+            self.lstm = nn.LSTM(hidden_size, hidden_size, batch_first=True)
+            self.fc = nn.Linear(hidden_size, vocab_size)
+
+        def forward(self, input_ids, **kwargs):
+            embedded = self.embedding(input_ids)
+            lstm_out, _ = self.lstm(embedded)
+            logits = self.fc(lstm_out)
+            return logits
+
+    def create_dummy_dataset_for_text_generation(vocab_size, seq_length, num_samples):
+        import datasets
+        import numpy as np
+
+        # Create random input sequences
+        input_ids = np.random.randint(0, vocab_size, (num_samples, seq_length))
+
+        # Create a datasets.Dataset
+        dataset = datasets.Dataset.from_dict({"input_ids": input_ids, "labels": input_ids})
+
+        return dataset
+
     class TstLayer(nn.Module):
         def __init__(self, hidden_size):
             super().__init__()
@@ -602,16 +661,16 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
 
     def setUp(self):
         super().setUp()
-        args = TrainingArguments("..")
-        self.n_epochs = args.num_train_epochs
-        self.batch_size = args.train_batch_size
-        trainer = get_regression_trainer(learning_rate=0.1)
-        trainer.train()
-        self.default_trained_model = (trainer.model.a, trainer.model.b)
+        # args = TrainingArguments("..")
+        # self.n_epochs = args.num_train_epochs
+        # self.batch_size = args.train_batch_size
+        # trainer = get_regression_trainer(learning_rate=0.1)
+        # trainer.train()
+        # self.default_trained_model = (trainer.model.a, trainer.model.b)
 
-        trainer = get_regression_trainer(learning_rate=0.1, seed=314)
-        trainer.train()
-        self.alternate_trained_model = (trainer.model.a, trainer.model.b)
+        # trainer = get_regression_trainer(learning_rate=0.1, seed=314)
+        # trainer.train()
+        # self.alternate_trained_model = (trainer.model.a, trainer.model.b)
 
     def check_trained_model(self, model, alternate_seed=False):
         # Checks a training seeded with learning_rate = 0.1
@@ -676,8 +735,105 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
         trainer.train()
         self.check_trained_model(trainer.model, alternate_seed=True)
 
+    @slow
+    def test_gradient_accumulation_loss_alignment(self):
+        set_seed(42)
+        import datasets
+
+        model_name = "distilgpt2"
+        dataset_name = "wikitext"
+        dataset_config = "wikitext-2-raw-v1"
+        dataset = datasets.load_dataset(dataset_name, dataset_config, split="train[:500]")
+        dataset = dataset.train_test_split(test_size=0.2)
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        def tokenize_function(examples):
+            return tokenizer(examples["text"])
+
+        tokenized_dataset = dataset.map(tokenize_function, batched=True, remove_columns=dataset["train"].column_names)
+
+        tokenizer.pad_token = tokenizer.eos_token
+        data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+
+        def compute_loss(logits, labels, vocab_size, num_items_in_batch, disable_num_items_in_batch=False):
+            return ForCausalLMLoss(
+                logits["logits"], labels, vocab_size, num_items_in_batch, disable_num_items_in_batch
+            )
+
+        loss_fn = partial(compute_loss, vocab_size=model.config.vocab_size, disable_num_items_in_batch=False)
+
+        base_loss_callback = StoreLossCallback()
+
+        args_kwargs = {
+            "report_to": "none",
+            "logging_steps": 1,
+            "max_steps": 20,
+            "learning_rate": 3e-4,
+            "disable_tqdm": True,
+        }
+
+        args = TrainingArguments(
+            "./generation",
+            **args_kwargs,
+        )
+        trainer = Trainer(
+            model,
+            args,
+            train_dataset=tokenized_dataset["train"],
+            callbacks=[base_loss_callback],
+            compute_loss_func=loss_fn,
+            data_collator=data_collator,
+        )
+        trainer.train()
+
+        grad_accum_loss_callback = StoreLossCallback()
+        args = TrainingArguments(
+            "./generation",
+            **args_kwargs,
+            gradient_accumulation_steps=2,
+            per_device_train_batch_size=4,
+        )
+        set_seed(42)
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        trainer = Trainer(
+            model,
+            args,
+            train_dataset=tokenized_dataset["train"],
+            callbacks=[grad_accum_loss_callback],
+            compute_loss_func=loss_fn,
+            data_collator=data_collator,
+        )
+        trainer.train()
+
+        set_seed(42)
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        broken_loss_callback = StoreLossCallback()
+        loss_fn = partial(compute_loss, vocab_size=model.config.vocab_size, disable_num_items_in_batch=True)
+        trainer = Trainer(
+            model,
+            args,
+            train_dataset=tokenized_dataset["train"],
+            callbacks=[broken_loss_callback],
+            compute_loss_func=loss_fn,
+            data_collator=data_collator,
+        )
+        trainer.train()
+
+        # Calculate the difference between the base loss and the grad_accum loss
+        diff_truth = [base - grad for base, grad in zip(base_loss_callback.losses, grad_accum_loss_callback.losses)]
+        diff_broken = [base - grad for base, grad in zip(base_loss_callback.losses, broken_loss_callback.losses)]
+        # These should be quite close
+        for diff in diff_truth:
+            self.assertLess(abs(diff), 0.1, f"Difference {diff} is not within 0.1")
+
+        # These should be very off
+        for diff in diff_broken:
+            self.assertGreater(abs(diff), 0.1, f"Difference {diff} is not greater than 0.1")
+
     def test_gradient_accumulation(self):
-        # Training with half the batch size but accumulation steps as 2 should give the same results.
+        # Training with half the batch size but accumulation steps as 2 should give the same training losses.
         trainer = get_regression_trainer(
             gradient_accumulation_steps=2, per_device_train_batch_size=4, learning_rate=0.1
         )


### PR DESCRIPTION
# What does this PR do?

In conjunction with https://github.com/huggingface/transformers/pull/34191, this PR solves the other half of what's needed:

1. Letting users pass in their own loss functions directly to the Trainer via `compute_loss`
2. Prefetching the first `gradient_accumulation_steps` worth of data each complete step and marking how many samples were seen (`num_items_in_batch`), which can be passed to a loss function if it takes in `num_items_seen` (name TBD)

A bit of feedback needed we need to coordinate:

* Should it be called `num_items_in_batch` and then passed through to the loss functions as such? Or is there a better name we can think of

Fixes https://github.com/huggingface/trl/issues/2175


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik @ArthurZucker 

