### PR TITLE
Changing __repr__ in torchao to show quantized Linear

### DIFF
--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -48,7 +48,7 @@ def find_parent(model, name):
         parent = parent._modules[m]
     return parent
 
-def _quantization_type(weight: torch.Tensor):
+def _quantization_type(weight):
     if isinstance(weight, AffineQuantizedTensor):
         return f"{weight.__class__.__name__}({weight._quantization_type()})"
 

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -47,7 +47,6 @@ def find_parent(model, name):
     for m in module_tree:
         parent = parent._modules[m]
     return parent
-
 def _quantization_type(weight):
     if isinstance(weight, AffineQuantizedTensor):
         return f"{weight.__class__.__name__}({weight._quantization_type()})"

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -33,10 +33,6 @@ if is_torch_available():
     import torch
     import torch.nn as nn
 
-if is_torchao_available():
-    from torchao.quantization import quantize_
-
-
 logger = logging.get_logger(__name__)
 
 
@@ -174,6 +170,7 @@ class TorchAoHfQuantizer(HfQuantizer):
         Each nn.Linear layer that needs to be quantized is processsed here.
         First, we set the value the weight tensor, then we move it to the target device. Finally, we quantize the module.
         """
+        from torchao.quantization import quantize_
 
         module, tensor_name = get_module_from_name(model, param_name)
 

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -47,6 +47,8 @@ def find_parent(model, name):
     for m in module_tree:
         parent = parent._modules[m]
     return parent
+
+
 def _quantization_type(weight):
     if isinstance(weight, AffineQuantizedTensor):
         return f"{weight.__class__.__name__}({weight._quantization_type()})"
@@ -56,8 +58,10 @@ def _quantization_type(weight):
 
     return "not recognized"
 
+
 def _linear_extra_repr(self):
     return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={_quantization_type(self.weight)}"
+
 
 class TorchAoHfQuantizer(HfQuantizer):
     """
@@ -168,11 +172,11 @@ class TorchAoHfQuantizer(HfQuantizer):
 
         module, tensor_name = get_module_from_name(model, param_name)
 
-        if self.pre_quantized :
+        if self.pre_quantized:
             module._parameters[tensor_name] = param_value.to(device=target_device)
             if isinstance(module, nn.Linear):
                 module.extra_repr = types.MethodType(_linear_extra_repr, module)
-        else :
+        else:
             module._parameters[tensor_name] = torch.nn.Parameter(param_value).to(device=target_device)
             quantize_(module, self.quantization_config.get_apply_tensor_subclass())
 

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -57,11 +57,6 @@ def _quantization_type(weight):
     if isinstance(weight, LinearActivationQuantizedTensor):
         return f"{weight.__class__.__name__}(activation={weight.input_quant_func}, weight={_quantization_type(weight.original_weight_tensor)})"
 
-    if type(weight) is torch.Tensor:
-        return "not quantized"
-
-    return "not recognized"
-
 
 def _linear_extra_repr(self):
     return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={_quantization_type(self.weight)}"

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -34,9 +34,8 @@ if is_torch_available():
     import torch.nn as nn
 
 if is_torchao_available():
-    from torchao.dtypes import AffineQuantizedTensor
     from torchao.quantization import quantize_
-    from torchao.quantization.linear_activation_quantized_tensor import LinearActivationQuantizedTensor
+
 
 logger = logging.get_logger(__name__)
 
@@ -51,6 +50,9 @@ def find_parent(model, name):
 
 
 def _quantization_type(weight):
+    from torchao.dtypes import AffineQuantizedTensor
+    from torchao.quantization.linear_activation_quantized_tensor import LinearActivationQuantizedTensor
+
     if isinstance(weight, AffineQuantizedTensor):
         return f"{weight.__class__.__name__}({weight._quantization_type()})"
 
@@ -59,7 +61,11 @@ def _quantization_type(weight):
 
 
 def _linear_extra_repr(self):
-    return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={_quantization_type(self.weight)}"
+    weight = _quantization_type(self.weight)
+    if weight is None:
+        return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight=None"
+    else:
+        return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight={weight}"
 
 
 class TorchAoHfQuantizer(HfQuantizer):


### PR DESCRIPTION
# What does this PR do?

When a model is quantized using TorchAO and then loaded, the representation of its Linear layers is expected to be different compared to the standard representation. This pull request (PR) modifies the representation of these Linear layers to match the format used in TorchAO's implementation : https://github.com/pytorch/ao/blob/main/torchao/quantization/quant_api.py 

Before : 
`
Linear(in_features=4096, out_features=4096, bias=False)
`
After : 
```
Linear(in_features=4096, out_features=4096, weight=AffineQuantizedTensor(shape=torch.Size([4096, 4096]), block_size=(1, 128), device=cuda:0, layout_type=TensorCoreTiledLayoutType(inner_k_tiles=8), layout_tensor_dtype=torch.int32, quant_min=0, quant_max=15))
```
## Who can review?
cc @SunMarc 