### PR TITLE
fix error in _get_eval_sampler when group_by_length enabled

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -965,7 +965,7 @@ class Trainer:
         return self.accelerator.prepare(DataLoader(train_dataset, **dataloader_params))
 
     def _get_eval_sampler(self, eval_dataset: Dataset) -> Optional[torch.utils.data.Sampler]:
-        if self.eval_dataset is None or not has_length(self.eval_dataset):
+        if eval_dataset is None or not has_length(eval_dataset):
             return None
         # Build the sampler.
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -986,10 +986,10 @@ class Trainer:
                 return SequentialSampler(eval_dataset)
 
         if self.args.group_by_length:
-            if is_datasets_available() and isinstance(self.eval_dataset, datasets.Dataset):
+            if is_datasets_available() and isinstance(eval_dataset, datasets.Dataset):
                 lengths = (
-                    self.eval_dataset[self.args.length_column_name]
-                    if self.args.length_column_name in self.eval_dataset.column_names
+                    eval_dataset[self.args.length_column_name]
+                    if self.args.length_column_name in eval_dataset.column_names
                     else None
                 )
             else:
@@ -997,7 +997,7 @@ class Trainer:
             model_input_name = self.tokenizer.model_input_names[0] if self.tokenizer is not None else None
             return LengthGroupedSampler(
                 self.args.eval_batch_size,
-                dataset=self.eval_dataset,
+                dataset=eval_dataset,
                 lengths=lengths,
                 model_input_name=model_input_name,
             )


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/33514
this PR adds group_by_length support for evaluation. But, this part uses self.eval_dataset instead of eval_dataset. So, if eval_dataset is dictionary it fails.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
- trainer: @muellerzr and @SunMarc