### PR TITLE
[docs] Fix GenerationConfig params

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -93,7 +93,7 @@ class GenerationMode(ExplicitEnum):
 
 class GenerationConfig(PushToHubMixin):
     # no-format
-    rf"""
+    """
     Class that holds a configuration for a generation task. A `generate` call supports the following generation methods
     for text-decoder, text-to-text, speech-to-text, and vision-to-text models:
 


### PR DESCRIPTION
Fixes #34273 #33756  to display all the `GenerationConfig` parameters as shown [here](https://moon-ci-docs.huggingface.co/docs/transformers/pr_34297/en/main_classes/text_generation). Can be merged after https://github.com/huggingface/transformers/pull/34293 which fixes the failing `build_pr_documentation` test.