### PR TITLE
PEFT fix: T5 prefix-tuning with new cache format 

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -1479,9 +1479,23 @@ class LongT5Stack(LongT5PreTrainedModel):
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
         if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=inputs_embeds.device)
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+                encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
+                )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -1046,11 +1046,23 @@ class MT5Stack(MT5PreTrainedModel):
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
         if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
                 encoder_attention_mask = torch.ones(
                     encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
                 )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -1440,11 +1440,25 @@ class Pix2StructTextModel(Pix2StructPreTrainedModel):
 
         # If a 2D or 3D attention mask is provided for the cross-attention
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
-        if encoder_hidden_states is not None:
+        if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=inputs_embeds.device)
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+                encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
+                )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -882,9 +882,23 @@ class Pop2PianoStack(Pop2PianoPreTrainedModel):
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
         if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=inputs_embeds.device)
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+                encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
+                )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1059,11 +1059,23 @@ class T5Stack(T5PreTrainedModel):
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
         if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
                 encoder_attention_mask = torch.ones(
                     encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
                 )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -1434,7 +1434,25 @@ class UdopStack(UdopPreTrainedModel):
             causal_mask = causal_mask.to(dtype=inputs_embeds.dtype)
             causal_mask = (1.0 - causal_mask) * torch.finfo(inputs_embeds.dtype).min
 
-        if self.is_decoder and encoder_attention_mask is not None:
+        if self.is_decoder and encoder_hidden_states is not None:
+            encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
+            if encoder_attention_mask is None:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+                encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
+                )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None

--- a/src/transformers/models/umt5/modeling_umt5.py
+++ b/src/transformers/models/umt5/modeling_umt5.py
@@ -745,9 +745,23 @@ class UMT5Stack(UMT5PreTrainedModel):
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
         if self.is_decoder and encoder_hidden_states is not None:
             encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if past_key_values is not None and not past_key_values.is_updated.get(0, False):
+                past_seen_tokens_cross_attn = past_key_values.cross_attention_cache.get_seq_length()
+                encoder_sequence_length += past_seen_tokens_cross_attn
+
             if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=inputs_embeds.device)
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+                encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=inputs_embeds.device, dtype=torch.long
+                )
+            # Edge case for PEFT tuning when several virtual tokens are added. We'll need to create attn mask
+            # of shape current/actual `encoder_hidden_states` + vitual token `encoder_hidden_states`
+            elif encoder_attention_mask is not None and encoder_attention_mask.shape[1] < encoder_sequence_length:
+                encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length - encoder_attention_mask.shape[1])
+                new_encoder_attention_mask = torch.ones(
+                    encoder_hidden_shape, device=encoder_attention_mask.device, dtype=torch.long
+                )
+                encoder_attention_mask = torch.cat([new_encoder_attention_mask, encoder_attention_mask], dim=-1)
             encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
         else:
             encoder_extended_attention_mask = None


### PR DESCRIPTION
# What does this PR do?

Fixes prefix tuning for T5 models which started breaking after the recent compile-compatibility PR. However, note this will not enable correct prefix tuning unless https://github.com/huggingface/peft/pull/2096#pullrequestreview-2385144033 is merged

The main issue was that in new cache format we don't concatenate new key/values with cached key/values if `past_key_values.is_updated`. That issue is fixed on PEFT side by init a cache object and setting `is_updated=False`.

Another issue is the mask shape mismatch since we have to extend `cross_attention_mask` to account for new virtual tokens. Current PR adds enables it but I am also thinking if it will be possible to do in PEFT and pass already extended attention masks?

Tested with the below code for T5:
```python
import torch
from transformers import AutoModelForSeq2SeqLM
from peft import PrefixTuningConfig, get_peft_model

inputs = {
    "input_ids": torch.tensor([[1, 2, 3, 4, 5, 6, 7]]),
    "decoder_input_ids": torch.tensor([[1, 2, 3, 4, 5]]),
    "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1, 1]]),
}
model_id = "ybelkada/tiny-random-T5ForConditionalGeneration-calibrated"
model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
model(**inputs)

config = PrefixTuningConfig(num_virtual_tokens=20, task_type="SEQ_2_SEQ_LM")
model = get_peft_model(model, config)

output = model(**inputs)

```

cc @BenjaminBossan wdyt?