### PR TITLE
fix: unboundlocalerror when trying to retrieve attention feature maps using Qwen2FlashAttention2().forward()

### DIFF
--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -457,6 +457,11 @@ class Qwen2FlashAttention2(Qwen2Attention):
 
         if not output_attentions:
             attn_weights = None
+        else:
+            attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+            if attention_mask is not None:  # no matter the length, we just slice it
+                causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+                attn_weights = attn_weights + causal_mask
 
         return attn_output, attn_weights, past_key_value
 


### PR DESCRIPTION
# What does this PR do?

Fix "unboundlocalerror" occurrs when trying to retrieve attention layer feature maps for models using `Qwen2FlashAttention2().forward()` to inference such as LLaVA-NeXT:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/da91f90d-60f4-4f23-9d65-f571c3169fdf">


The main issue is in this method, the logic for computing `attn_weights` when flag `output_attentions` is set to `True` was not implemented, therefore leaving variable `atten_weights` unbounded.



Fixes # (issue)

Following code demonstrated in Qwen2Attention(nn.Module).forward(), several lines were added to compute the value of variable `atten_weights` when `output_attentions` is set to `True`:

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/d85dea7d-6188-4f46-a38d-0896b0abbf09">



## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
