### PR TITLE
[docs] Fix Korean toctree

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -332,7 +332,6 @@
         title: (번역중) BertGeneration
       - local: model_doc/bert-japanese
         title: 일본어 Bert
-      - local: in_translation
       - local: model_doc/bertweet
         title: Bertweet
       - local: in_translation


### PR DESCRIPTION
One more fix to the Korean `toctree` which was missing a `title` key