### PR TITLE
Remove coupled type imports from integration_utils.py

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -35,7 +35,6 @@ import packaging.version
 
 from .. import __version__ as version
 from ..utils import (
-    PushToHubMixin,
     flatten_dict,
     is_datasets_available,
     is_pandas_available,

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
 import numpy as np
 import packaging.version
 
-from .. import PreTrainedModel, TFPreTrainedModel
 from .. import __version__ as version
 from ..utils import (
     PushToHubMixin,
@@ -714,17 +713,9 @@ class TensorBoardCallback(TrainerCallback):
 
 def save_model_architecture_to_file(model: Any, output_dir: str):
     with open(f"{output_dir}/model_architecture.txt", "w+") as f:
-        if isinstance(model, PreTrainedModel):
-            print(model, file=f)
-        elif is_tf_available() and isinstance(model, TFPreTrainedModel):
-
-            def print_to_file(s):
-                print(s, file=f)
-
-            model.summary(print_fn=print_to_file)
-        elif is_torch_available() and (
-            isinstance(model, (torch.nn.Module, PushToHubMixin)) and hasattr(model, "base_model")
-        ):
+        if is_tf_available() and hasattr(model, "summary"):
+            model.summary(print_fn=lambda s: print(s, file=f))
+        else:
             print(model, file=f)
 
 


### PR DESCRIPTION
In #30135, `TFPreTrainedModel` and `PreTrainedModel` were introduced as imports in `integration_utils.py` for the sole purpose of type checking (see diff [here](https://github.com/huggingface/transformers/pull/30135/files#diff-70576373928eee203a92800d5ea1f6270d45462a9bde494cde65338710a0a331)). This results in a fairly heavy set of imports that makes it difficult to separate out builds that are dependent on only TF or Torch (as any module importing `integration_utils` will now import both `modeling_utils.py` and `modeling_tf_utils.py`, which together require both TF and Torch). This logic removes the need for those coupled imports while still working as intended within this module.
