### PR TITLE
CI: fix failures

### DIFF
--- a/src/transformers/models/video_llava/modeling_video_llava.py
+++ b/src/transformers/models/video_llava/modeling_video_llava.py
@@ -561,6 +561,7 @@ class VideoLlavaForConditionalGeneration(VideoLlavaPreTrainedModel, GenerationMi
             )
 
         video_features = None
+        num_frames = 0
         if pixel_values_videos is not None:
             video_features, num_frames = self.get_video_features(
                 pixel_values_videos=pixel_values_videos, vision_feature_layer=vision_feature_layer

--- a/tests/models/instructblip/test_modeling_instructblip.py
+++ b/tests/models/instructblip/test_modeling_instructblip.py
@@ -621,7 +621,7 @@ class InstructBlipModelIntegrationTest(unittest.TestCase):
             logits = model(**inputs).logits
 
         expected_slice = torch.tensor(
-            [[-3.3926, -12.2969, 8.4922], [-5.0195, -11.9531, 8.1406], [-4.0039, -13.3594, 9.2578]],
+            [[-3.3047, -12.0625, 8.4922], [-4.9258, -11.7578, 8.1406], [-3.9297, -13.5000, 9.2500]],
             device=torch_device,
         )
 


### PR DESCRIPTION
# What does this PR do?

Fixes failures caused by some previously merged PRs from our internal daily CI feedback. Some errors like `eager_matched_sdpa` were flaky, so no need to fix those. 

InstructBLIP was failing because earlier we dispatched in "eager" by default and now we dispatch on "sdpa" for LLM

@ydshieh the new feature for CI feedback is perfect, and super easy to navigate and locate when the tests started failing. Thanks!