### PR TITLE
Bert is ExecuTorch compatible

### DIFF
--- a/tests/models/bert/test_modeling_bert.py
+++ b/tests/models/bert/test_modeling_bert.py
@@ -16,6 +16,8 @@ import os
 import tempfile
 import unittest
 
+from packaging import version
+
 from transformers import AutoTokenizer, BertConfig, is_torch_available
 from transformers.models.auto import get_values
 from transformers.testing_utils import (
@@ -823,3 +825,43 @@ class BertModelIntegrationTest(unittest.TestCase):
             self.assertTrue(
                 torch.allclose(res_eager.last_hidden_state, res_sdpa.last_hidden_state, atol=1e-5, rtol=1e-4)
             )
+
+    @slow
+    def test_export(self):
+        if version.parse(torch.__version__) < version.parse("2.4.0"):
+            self.skipTest(reason="This test requires torch >= 2.4 to run.")
+
+        bert_model = "google-bert/bert-base-uncased"
+        device = "cpu"
+        attn_implementation = "sdpa"
+        max_length = 512
+
+        tokenizer = AutoTokenizer.from_pretrained(bert_model)
+        inputs = tokenizer(
+            "the man worked as a [MASK].",
+            return_tensors="pt",
+            padding="max_length",
+            max_length=max_length,
+        )
+
+        model = BertForMaskedLM.from_pretrained(
+            bert_model,
+            device_map=device,
+            attn_implementation=attn_implementation,
+            use_cache=True,
+        )
+
+        logits = model(**inputs).logits
+        eg_predicted_mask = tokenizer.decode(logits[0, 6].topk(5).indices)
+        self.assertEqual(eg_predicted_mask.split(), ["carpenter", "waiter", "barber", "mechanic", "salesman"])
+
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
+            strict=True,
+        )
+
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
+        ep_predicted_mask = tokenizer.decode(result.logits[0, 6].topk(5).indices)
+        self.assertEqual(eg_predicted_mask, ep_predicted_mask)


### PR DESCRIPTION
# What does this PR do?

Bert is ExecuTorch compatible.

Unit Test:
`RUN_SLOW=1 pytest tests/models/bert/test_modeling_bert.py -k test_export -v`
```
tests/models/bert/test_modeling_bert.py::BertModelIntegrationTest::test_export PASSED                                                                                                   [100%]
```

E2E test in ExecuTorch:
Patch https://github.com/pytorch/executorch/pull/6509 
`python -m extension.export_util.export_hf_model -hfm="google-bert/bert-base-uncased" -lm="masked_lm"`
```
Saved exported program to ./bert.pte
```
`./cmake-out/backends/xnnpack/xnn_executor_runner --model_path bert.pte`
```
I 00:00:00.130046 executorch:executor_runner.cpp:82] Model file bert.pte is loaded.
I 00:00:00.130076 executorch:executor_runner.cpp:91] Using method forward
I 00:00:00.130077 executorch:executor_runner.cpp:138] Setting up planned buffer 0, size 11155968.
I 00:00:00.187901 executorch:executor_runner.cpp:161] Method loaded.
I 00:00:00.187940 executorch:executor_runner.cpp:171] Inputs prepared.
I 00:00:00.303509 executorch:executor_runner.cpp:180] Model executed successfully.
I 00:00:00.303528 executorch:executor_runner.cpp:184] 1 outputs:
Output 0: tensor(sizes=[1, 64, 30522], [
  -5.31, -5.25653, -5.62139, -5.35147, -5.58368, -5.76769, -5.39854, -5.49406, -5.41472, -5.60033,
  -5.60824, -5.64769, -5.70689, -5.62003, -5.36711, -5.81403, -5.40622, -5.50556, -5.37618, -5.25235,
  -5.4938, -5.61887, -5.47021, -5.50617, -5.24071, -5.41838, -5.49885, -5.6491, -5.62601, -4.98599,
  -5.64714, -5.54412, -5.54532, -5.72253, -5.06812, -5.47294, -5.34288, -5.27819, -5.37329, -5.43782,
  -5.53609, -5.46165, -5.21018, -5.28851, -5.38127, -4.95377, -5.5431, -5.67045, -5.67165, -5.92957,
  -5.32795, -5.5024, -5.20931, -5.71709, -5.74185, -5.28685, -5.38797, -5.52771, -5.33859, -5.84168,
  -5.23825, -5.49683, -5.65671, -5.70298, -5.40745, -5.49082, -5.45573, -5.2697, -5.46876, -5.2727,
  -5.54258, -5.2412, -5.71677, -5.37888, -5.76725, -5.6436, -5.3792, -5.68382, -5.87468, -5.57073,
  -5.62629, -5.48719, -4.89835, -5.87864, -5.73316, -5.2621, -5.5839, -5.54559, -5.56973, -5.56077,
  -5.28284, -5.11866, -5.77843, -5.373, -5.9074, -5.17517, -5.66992, -5.49333, -5.10405, -5.38464,
  ...,
  -5.03352, -5.74726, -3.90867, -2.13927, -5.53828, -3.65071, -9.55079, -5.52908, -5.65968, -1.65796,
  -2.86744, -4.80233, -5.33614, -4.94629, -4.69176, -3.87113, -7.70568, -5.79979, -5.22023, -4.59109,
  -1.37544, -2.02489, -3.94916, -3.0996, -7.91293, -1.34026, -3.35818, -4.66463, -4.11608, -4.97319,
  -6.91719, -6.17901, -4.73535, -7.47833, -2.26579, -4.29045, -2.38045, -6.78713, -5.87505, -2.10658,
  -7.45086, -3.71908, -4.90981, -4.69094, -1.40817, -3.86502, -4.08434, -1.32019, -5.07113, -9.31685,
  -5.29724, -6.87862, -3.78542, -5.81963, -7.6481, -4.51615, -7.94964, -4.45573, -2.57971, -7.64688,
  -2.73065, -5.26966, -5.91819, -4.89055, -3.93077, -4.92867, -3.93575, -5.32761, -4.06602, -2.97809,
  -4.35003, -2.96373, -5.43266, -2.50787, -3.88847, -4.5942, -4.9843, -7.62539, -9.25849, -3.7758,
  -6.6124, -3.78246, -3.56245, -3.91384, -3.44218, -4.49679, -5.97564, -3.77184, -5.44054, -4.61596,
  -3.69274, -6.37589, -5.36977, -4.21502, -5.9998, -6.23449, -3.90434, -4.50337, -6.30893, -1.40617,
])
```


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #32507
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker
@qubvel
