### PR TITLE
fix(dvclive): pass fake dataset to avoid exception in trainer init

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2125,7 +2125,12 @@ class DVCLiveCallback(TrainerCallback):
             from transformers.trainer import Trainer
 
             if self._log_model is True:
-                fake_trainer = Trainer(args=args, model=kwargs.get("model"), processing_class=kwargs.get("tokenizer"))
+                fake_trainer = Trainer(
+                    args=args,
+                    model=kwargs.get("model"),
+                    processing_class=kwargs.get("tokenizer"),
+                    eval_dataset=["fake"],
+                )
                 name = "best" if args.load_best_model_at_end else "last"
                 output_dir = os.path.join(args.output_dir, name)
                 fake_trainer.save_model(output_dir)


### PR DESCRIPTION
Fixes these failing tests https://github.com/iterative/dvclive/actions/runs/11545815176/job/32134865977?pr=846 downstream.

The cause is this change: https://github.com/huggingface/transformers/pull/33743 which made `trainer` ctr a bit more strict.

I see that `WandbCallback` is also using the same technique (initializing fake trainer). @parambharat could you check if we need to add a similar fix there.