### PR TITLE
Memory optimization for gpt_bigcode

### DIFF
--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -174,10 +174,9 @@ class GPTBigCodeAttention(nn.Module):
             # The bug was fixed in https://github.com/pytorch/pytorch/pull/96086,
             # but the fix has not been released as of pytorch version 2.0.0.
             attn_weights = torch.zeros_like(attn_weights)
-            beta = 1
+            attn_weights = torch.baddbmm(attn_weights, query, key, beta=0, alpha=scale_factor).view(attn_shape)
         else:
-            beta = 0
-        attn_weights = torch.baddbmm(attn_weights, query, key, beta=beta, alpha=scale_factor).view(attn_shape)
+            attn_weights = (torch.matmul(query, key) * scale_factor).view(attn_shape)
 
         if upcast:
             # Use a fused kernel to prevent a large overhead from casting and scaling.


### PR DESCRIPTION
# What does this PR do?

This PR optimizes memory usage for inference with GPT BigCode on devices other than CPU.

There is a spike in memory usage when generating the 1st token and the identified culprit is `torch.baddbm`. Using `torch.matmul` instead reduces the usage and allows for processing significantly larger batch sizes.

Formula for `torch.baddbmm`:
```
out = beta * attn_weights + scale_factor * (query ⋅ key)
```
For beta = 0, this becomes
```
out = scale_factor * (query ⋅ key)
```
and thus can be implemented as `torch.matmul(query, key) * scale_factor`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

cc @ArthurZucker