### PR TITLE
[bugfix] incorrect usage of warning_once

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -758,7 +758,6 @@ class GenerationConfig(PushToHubMixin):
                 if getattr(self, arg_name) is not None:
                     logger.warning_once(
                         no_cache_warning.format(cache_arg=arg_name, cache_arg_value=getattr(self, arg_name)),
-                        UserWarning,
                     )
 
         # 6.  check watermarking arguments


### PR DESCRIPTION
Hi, I'm a developer for the vllm library. We use transformers a lot!

Recently, we find that this simple code will emit many lines of error:

```python
from vllm.transformers_utils.config import try_get_generation_config
try_get_generation_config("BAAI/bge-multilingual-gemma2", False)
``` 

The error log cannot be suppressed by `try-except`, leading to something like:

```text
TypeError: not all arguments converted during string formatting
Call stack:
  File "/data/youkaichao/vllm/testf.py", line 2, in <module>
    try_get_generation_config("BAAI/bge-multilingual-gemma2", False)
  File "/data/youkaichao/vllm/vllm/transformers_utils/config.py", line 403, in try_get_generation_config
    return GenerationConfig.from_model_config(config)
  File "/data/youkaichao/miniconda/envs/vllm/lib/python3.9/site-packages/transformers/generation/configuration_utils.py", line 1235, in from_model_config
    generation_config = cls.from_dict(config_dict, return_unused_kwargs=False, _from_model_config=True)
  File "/data/youkaichao/miniconda/envs/vllm/lib/python3.9/site-packages/transformers/generation/configuration_utils.py", line 1093, in from_dict
    config = cls(**{**config_dict, **kwargs})
  File "/data/youkaichao/miniconda/envs/vllm/lib/python3.9/site-packages/transformers/generation/configuration_utils.py", line 475, in __init__
    self.validate(is_init=True)
  File "/data/youkaichao/miniconda/envs/vllm/lib/python3.9/site-packages/transformers/generation/configuration_utils.py", line 751, in validate
    logger.warning_once(
  File "/data/youkaichao/miniconda/envs/vllm/lib/python3.9/site-packages/transformers/utils/logging.py", line 328, in warning_once
    self.warning(*args, **kwargs)
Message: 'You have set `use_cache` to `False`, but cache_implementation is set to hybrid. cache_implementation will have no effect.'
Arguments: (<class 'UserWarning'>,)
```

I think this is caused by incorrect usage of `warning_once` . I have searched for all usages of `warning_once` , it should not have that `UserWarning` argument.

Hope it helps.