### PR TITLE
IDEFICS2: explicit error if SDPA is requested

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -296,7 +296,8 @@ class PretrainedConfig(PushToHubMixin):
 
         # Attention implementation to use, if relevant.
         self._attn_implementation_internal = kwargs.pop("attn_implementation", None)
-        self._attn_implementation_autoset = False
+        self._attn_implementation_autoset_was_run = False
+        self._attn_implementation_was_set_by_autoset = False
 
         # Drop the transformers version info
         self.transformers_version = kwargs.pop("transformers_version", None)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4087,7 +4087,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             init_contexts.append(init_empty_weights())
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in from_pretrained.
-        if not getattr(config, "_attn_implementation_autoset", False):
+
+        # Set the `attn_implementation` attribute of the config if not manually specified
+        if (
+            not getattr(config, "_attn_implementation_autoset", False)
+            and getattr(config, "_attn_implementation_internal", None) is None
+        ):
             config = cls._autoset_attn_implementation(
                 config, use_flash_attention_2=use_flash_attention_2, torch_dtype=torch_dtype, device_map=device_map
             )

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1620,6 +1620,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     if not isinstance(requested_attn_implementation, dict)
                     else requested_attn_implementation.get(key, None)
                 )
+                if curr_attn_implementation is None:
+                    sub_config._attn_implementation_autoset = True
                 sub_config._attn_implementation_internal = curr_attn_implementation
 
         if use_flash_attention_2:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1621,7 +1621,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     else requested_attn_implementation.get(key, None)
                 )
                 if curr_attn_implementation is None:
-                    sub_config._attn_implementation_autoset = True
+                    config._attn_implementation_autoset = True
                 sub_config._attn_implementation_internal = curr_attn_implementation
 
         if use_flash_attention_2:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1576,7 +1576,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if config._attn_implementation != "flash_attention_2" and use_flash_attention_2:
                 raise ValueError(
                     f'Both attn_implementation="{config._attn_implementation}" and `use_flash_attention_2=True` were '
-                    'used when loading the model, which are not compatible.'
+                    "used when loading the model, which are not compatible."
                     ' We recommend to just use `attn_implementation="flash_attention_2"` when loading the model.'
                 )
 
@@ -1594,7 +1594,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 if cls._supports_sdpa:
                     message += (
                         ', `"attn_implementation=sdpa"` '
-                        '(implementation using torch.nn.functional.scaled_dot_product_attention)'
+                        "(implementation using torch.nn.functional.scaled_dot_product_attention)"
                     )
                 raise ValueError(message + ".")
 
@@ -1626,7 +1626,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if use_flash_attention_2:
             logger.warning_once(
-                'The model was loaded with use_flash_attention_2=True, which is deprecated and may be removed in a '
+                "The model was loaded with use_flash_attention_2=True, which is deprecated and may be removed in a "
                 'future release. Please use `attn_implementation="flash_attention_2"` instead.'
             )
             config._attn_implementation = "flash_attention_2"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1560,19 +1560,23 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     ):
         """
         Automatically checks and dispatches to a default attention implementation. In order of priority:
-            1. An implementation specified in `config._attn_implementation` (due for example to the argument attn_implementation="sdpa" in from_pretrained).
-            2. DEPRECATED: if use_flash_attention_2 is set to `True` and `flash_attn` is available, flash attention. (`LlamaFlashAttention` for example)
+            1. An implementation specified in `config._attn_implementation` (due for example to the argument
+               attn_implementation="sdpa" in from_pretrained).
+            2. DEPRECATED: if use_flash_attention_2 is set to `True` and `flash_attn` is available, flash attention.
+               (`LlamaFlashAttention` for example)
             3. SDPA implementation, if available and supported by the model type. (`LlamaSdpaAttention` for example)
             4. The default model's implementation otherwise (`LlamaAttention` for example) .
         """
-        # Here we use config._attn_implementation_internal to check whether the attention implementation was explicitely set by the user.
-        # The property `PretrainedConfig._attn_implementation` is never `None`, for backward compatibility (always fall back on "eager").
-        # The `hasattr` here is used as some Transformers tests for some reason do not call PretrainedConfig __init__ (e.g. test_no_super_init_config_and_model)
+        # Here we use config._attn_implementation_internal to check whether the attention implementation was
+        # explicitely set by the user. The property `PretrainedConfig._attn_implementation` is never `None`, for
+        # backward compatibility (always fall back on "eager"). The `hasattr` here is used as some Transformers tests
+        # for some reason do not call PretrainedConfig __init__ (e.g. test_no_super_init_config_and_model)
         requested_attn_implementation = None
         if hasattr(config, "_attn_implementation_internal") and config._attn_implementation_internal is not None:
             if config._attn_implementation != "flash_attention_2" and use_flash_attention_2:
                 raise ValueError(
-                    f'Both attn_implementation="{config._attn_implementation}" and `use_flash_attention_2=True` were used when loading the model, which are not compatible.'
+                    f'Both attn_implementation="{config._attn_implementation}" and `use_flash_attention_2=True` were '
+                    'used when loading the model, which are not compatible.'
                     ' We recommend to just use `attn_implementation="flash_attention_2"` when loading the model.'
                 )
 
@@ -1581,22 +1585,33 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 "sdpa",
                 "flash_attention_2",
             ]:
-                message = f'Specified `attn_implementation="{config._attn_implementation}"` is not supported. The only possible arguments are `attn_implementation="eager"` (manual attention implementation)'
+                message = (
+                    f'Specified `attn_implementation="{config._attn_implementation}"` is not supported. The only '
+                    'possible arguments are `attn_implementation="eager"` (manual attention implementation)'
+                )
                 if cls._supports_flash_attn_2:
                     message += ', `"attn_implementation=flash_attention_2"` (implementation using flash attention 2)'
                 if cls._supports_sdpa:
-                    message += ', `"attn_implementation=sdpa"` (implementation using torch.nn.functional.scaled_dot_product_attention)'
+                    message += (
+                        ', `"attn_implementation=sdpa"` '
+                        '(implementation using torch.nn.functional.scaled_dot_product_attention)'
+                    )
                 raise ValueError(message + ".")
 
-            # If a config is passed with a preset attn_implementation, we skip the automatic dispatch and use the user-provided config, with hard checks that the requested attention implementation is available.
+            # If a config is passed with a preset attn_implementation, we skip the automatic dispatch and use the
+            # user-provided config, with hard checks that the requested attention implementation is available.
             requested_attn_implementation = config._attn_implementation_internal
+        else:
+            config._attn_implementation_autoset = True
 
         # Composite models consisting of several PretrainedModels have to specify attention impl as a dict
         # where keys are sub-config names. But most people will specify one `str` which means that should dispatch it
         # for all sub-models.
-        # Below we check if a config is composite and manually prepare a dict of attn impl if not already passed as a dict.
-        # Later each sub-module will dispatch with its own attn impl, by calling `XXXModel._from_config(config.text_config)`
-        # If any of sub-modules doesn't support requested attn, an error will be raised. See https://github.com/huggingface/transformers/pull/32238
+        # Below we check if a config is composite and manually prepare a dict of attn impl if not already passed as a
+        # dict. Later each sub-module will dispatch with its own attn impl, by calling
+        # `XXXModel._from_config(config.text_config)`
+        # If any of sub-modules doesn't support requested attn, an error will be raised.
+        # See https://github.com/huggingface/transformers/pull/32238
         for key in config:
             if isinstance(getattr(config, key), PretrainedConfig):
                 sub_config = getattr(config, key)
@@ -1609,7 +1624,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if use_flash_attention_2:
             logger.warning_once(
-                'The model was loaded with use_flash_attention_2=True, which is deprecated and may be removed in a future release. Please use `attn_implementation="flash_attention_2"` instead.'
+                'The model was loaded with use_flash_attention_2=True, which is deprecated and may be removed in a '
+                'future release. Please use `attn_implementation="flash_attention_2"` instead.'
             )
             config._attn_implementation = "flash_attention_2"
 
@@ -1634,7 +1650,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 and torch.cuda.device_count() > 1
             ):
                 logger.warning_once(
-                    "Using the `SDPA` attention implementation on multi-gpu setup with ROCM may lead to performance issues due to the FA backend. Disabling it to use alternative backends."
+                    "Using the `SDPA` attention implementation on multi-gpu setup with ROCM may lead to performance "
+                    "issues due to the FA backend. Disabling it to use alternative backends."
                 )
                 torch.backends.cuda.enable_flash_sdp(False)
         elif isinstance(requested_attn_implementation, dict):
@@ -1642,7 +1659,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         else:
             config._attn_implementation = "eager"
 
-        config._attn_implementation_autoset = True
         return config
 
     @classmethod
@@ -4087,12 +4103,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             init_contexts.append(init_empty_weights())
 
         config = copy.deepcopy(config)  # We do not want to modify the config inplace in from_pretrained.
-
-        # Set the `attn_implementation` attribute of the config if not manually specified
-        if (
-            not getattr(config, "_attn_implementation_autoset", False)
-            and getattr(config, "_attn_implementation_internal", None) is None
-        ):
+        if not getattr(config, "_attn_implementation_autoset", False):
             config = cls._autoset_attn_implementation(
                 config, use_flash_attention_2=use_flash_attention_2, torch_dtype=torch_dtype, device_map=device_map
             )

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -600,7 +600,6 @@ class Idefics2PreTrainedModel(PreTrainedModel):
     _no_split_modules = ["Idefics2VisionAttention", "Idefics2MLP", "Idefics2PerceiverLayer", "Idefics2DecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
-    _supports_sdpa = False
     _supports_cache_class = True
 
     def _init_weights(self, module):
@@ -647,7 +646,6 @@ IDEFICS2_INPUTS_DOCSTRING = r"""
     IDEFICS2_START_DOCSTRING,
 )
 class Idefics2VisionTransformer(Idefics2PreTrainedModel):
-    _supports_sdpa = False
     config_class = Idefics2VisionConfig
 
     def __init__(self, config: Idefics2VisionConfig):
@@ -1085,7 +1083,6 @@ IDEFICS2_INPUTS_DOCSTRING = r"""
     IDEFICS2_START_DOCSTRING,
 )
 class Idefics2PerceiverResampler(Idefics2PreTrainedModel):
-    _supports_sdpa = False
     config_class = Idefics2PerceiverConfig
 
     def __init__(self, config) -> None:

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -617,10 +617,10 @@ class Idefics2PreTrainedModel(PreTrainedModel):
             # explicitly sets `attn_implementation="sdpa"`, the code will crash. Let's raise an informative
             # exception instead.
             # TODO (@raushan?): A better fix would be to implement SDPA in the vision model.
-            if config._attn_implementation_autoset is False and config._attn_implementation == "sdpa":
+            if config._attn_implementation_was_set_by_autoset is False and config._attn_implementation == "sdpa":
                 raise ValueError(
                     "Idefics2 only supports SDPA in the text model. Please remove `attn_implementation='sdpa'` at "
-                    "model initialization time -- by default SDPA is used in the text model."
+                    "model initialization time -- by default SDPA will be used in the text model."
                 )
         super().__init__(*args, **kwargs)
 

--- a/src/transformers/models/idefics2/modeling_idefics2.py
+++ b/src/transformers/models/idefics2/modeling_idefics2.py
@@ -600,7 +600,7 @@ class Idefics2PreTrainedModel(PreTrainedModel):
     _no_split_modules = ["Idefics2VisionAttention", "Idefics2MLP", "Idefics2PerceiverLayer", "Idefics2DecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
-    _supports_sdpa = True
+    _supports_sdpa = False
     _supports_cache_class = True
 
     def _init_weights(self, module):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -700,6 +700,7 @@ class ModelTesterMixin:
                 check_equal(load_state_dict(pt_checkpoint_path))
 
     def test_initialization(self):
+        torch.set_default_dtype(torch.float32)  # Other tests may change the default dtype, this test requires float32
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         configs_no_init = _config_zero_init(config)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -700,7 +700,8 @@ class ModelTesterMixin:
                 check_equal(load_state_dict(pt_checkpoint_path))
 
     def test_initialization(self):
-        torch.set_default_dtype(torch.float32)  # Other tests may change the default dtype, this test requires float32
+        # TODO (ydshieh) -- Other tests may change the default dtype, this test requires float32
+        torch.set_default_dtype(torch.float32)
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         configs_no_init = _config_zero_init(config)

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -229,6 +229,7 @@ class ConfigTestUtils(unittest.TestCase):
                 "_commit_hash",
                 "_attn_implementation_internal",
                 "_attn_implementation_autoset_was_run",
+                "_attn_implementation_was_set_by_autoset",
                 "transformers_version",
             ],
         )

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -228,7 +228,7 @@ class ConfigTestUtils(unittest.TestCase):
                 "_name_or_path",
                 "_commit_hash",
                 "_attn_implementation_internal",
-                "_attn_implementation_autoset",
+                "_attn_implementation_autoset_was_run",
                 "transformers_version",
             ],
         )


### PR DESCRIPTION
# What does this PR do?

1. Raises an informative exception if we specify `attn_implementation="sdpa"` while loading IDEFICS2 -- the model has partial support, some components don't support SDPA
2. Relaxes `test_eager_matches_sdpa_generate` to handle partial SDPA support

The following command is fixed in this PR:
```
RUN_SLOW=1 python3 -m pytest -v --flake-finder --flake-runs=1 tests/models/idefics2/test_modeling_idefics2.py::Idefics2ForConditionalGenerationModelTest -k "( test_eager_matches_sdpa_generate) or (test_initialization)"
```