### PR TITLE
Fixed num_quantizers to use variable codebook_size

### DIFF
--- a/src/transformers/models/encodec/configuration_encodec.py
+++ b/src/transformers/models/encodec/configuration_encodec.py
@@ -186,4 +186,5 @@ class EncodecConfig(PretrainedConfig):
 
     @property
     def num_quantizers(self) -> int:
-        return int(1000 * self.target_bandwidths[-1] // (self.frame_rate * 10))
+        return int(max(1, math.floor(self.target_bandwidths[-1] * 1000 / (self.frame_rate * math.log2(self.codebook_size)))))
+


### PR DESCRIPTION
# What does this PR do?

Adds the modification for "num_quantizer in EncodecConfig should accept variable codebook size #34521"
It adds on code provided by a user originally in a comment and tested on use cases.


Fixes # (issue)

It fixes the issue of not being able to use the variable coodbook_size in config_encodec.

## Before submitting
- [Yes ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ Yes] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ No] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [No Need for Changes ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [Not Needed ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sgugger 
@maintainer
Hi, I am new to all this, please help me tag an appropriate person


 