### PR TITLE
Qwen2VL: skip base `input_ids`-`inputs_embeds` equivalence check

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1610,7 +1610,7 @@ class GenerationTesterMixin:
                 inputs_dict.pop("pixel_values_images", None)
             #   2.C - No easy fix, let's skip the check that compares the outputs from `input_ids` and `inputs_embeds`
             has_complex_embeds_computation = any(
-                model_name in model_class.__name__.lower() for model_name in ["moshi"]
+                model_name in model_class.__name__.lower() for model_name in ["moshi", "qwen2vl"]
             )
             # 3 - `inputs_dict` doesn't contain `attention_mask`. When `attention_mask` is not passed to generate,
             # we infer it from `input_ids`. The last test case will fail if there is a pad token in the original input.


### PR DESCRIPTION
# What does this PR do?

Computing `inputs_embeds` in `Qwen2VL` is more complex than simply embedding `input_ids` (see `Qwen2VLForConditionalGeneration`), so the basic check doesn't apply :)

Fixes:
```
py.test tests/models/qwen2_vl/test_modeling_qwen2_vl.py::Qwen2VLModelTest::test_generate_from_inputs_embeds_1_beam_search --flake-finder --flake-runs 100
```