### PR TITLE
feat: add benchmarks pg indexes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,6 @@ jobs:
             commit_id=$GITHUB_SHA
           fi
           commit_msg=$(git show -s --format=%s | cut -c1-70)
-          df -h
           python3 benchmark/llama.py "${{ github.head_ref || github.ref_name }}" "$commit_id" "$commit_msg"
         env:
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}

--- a/benchmark/init_db.sql
+++ b/benchmark/init_db.sql
@@ -7,6 +7,10 @@ CREATE TABLE IF NOT EXISTS benchmarks (
   created_at timestamp without time zone NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'UTC')
 );
 
+CREATE INDEX IF NOT EXISTS benchmarks_benchmark_id_idx ON benchmarks (benchmark_id);
+
+CREATE INDEX IF NOT EXISTS benchmarks_branch_idx ON benchmarks (branch);
+
 CREATE TABLE IF NOT EXISTS device_measurements (
   measurement_id SERIAL PRIMARY KEY,
   benchmark_id int REFERENCES benchmarks (benchmark_id),
@@ -17,6 +21,8 @@ CREATE TABLE IF NOT EXISTS device_measurements (
   time timestamp without time zone NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'UTC')
 );
 
+CREATE INDEX IF NOT EXISTS device_measurements_branch_idx ON device_measurements (benchmark_id);
+
 CREATE TABLE IF NOT EXISTS model_measurements (
   measurement_id SERIAL PRIMARY KEY,
   benchmark_id int REFERENCES benchmarks (benchmark_id),
@@ -24,3 +30,4 @@ CREATE TABLE IF NOT EXISTS model_measurements (
   time timestamp without time zone NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'UTC')
 );
 
+CREATE INDEX IF NOT EXISTS model_measurements_branch_idx ON model_measurements (benchmark_id);


### PR DESCRIPTION
We want to make queries efficient as the content of the benchmarks tables grows, making dashboards more responsive and reducing load on the database. Hence the addition of indexes on the most used fields for filtering/joining.