### PR TITLE
uniformize kwargs for OneFormer

### DIFF
--- a/src/transformers/models/altclip/processing_altclip.py
+++ b/src/transformers/models/altclip/processing_altclip.py
@@ -99,8 +99,6 @@ class AltCLIPProcessor(ProcessorMixin):
         if text is None and images is None:
             raise ValueError("You must specify either text or images.")
 
-        if text is None and images is None:
-            raise ValueError("You must specify either text or images.")
         output_kwargs = self._merge_kwargs(
             AltClipProcessorKwargs,
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -119,9 +119,22 @@ class OneFormerProcessor(ProcessorMixin):
 
         return task_inputs
 
+    @staticmethod
+    def _add_args_for_backward_compatibility(args):
+        """
+        Remove this function once support for args is dropped in __call__
+        """
+        if len(args) > 2:
+            raise ValueError("Too many positional arguments")
+        return {
+            key: value
+            for key, value in zip(("task_inputs", "segmentation_maps"), args)
+        }
+
     def __call__(
         self,
         images: Optional[ImageInput] = None,
+        *args,  # to be deprecated
         text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
         audio=None,
         videos=None,
@@ -162,6 +175,7 @@ class OneFormerProcessor(ProcessorMixin):
             OneFormerProcessorKwargs,
             tokenizer_init_kwargs=self.tokenizer.init_kwargs,
             **kwargs,
+            **self._add_args_for_backward_compatibility(args),
         )
         segmentation_maps = output_kwargs["images_kwargs"].pop("segmentation_maps", None)
         task_inputs = output_kwargs["images_kwargs"].pop("task_inputs", None)

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -50,10 +50,7 @@ class OneFormerImagesKwargs(ImagesKwargs):
 class OneFormerProcessorKwargs(ProcessingKwargs, total=False):
     images_kwargs: OneFormerImagesKwargs
     _defaults = {
-        "text_kwargs": {
-            "max_seq_length": 77,
-            "task_seq_length": 77
-        },
+        "text_kwargs": {"max_seq_length": 77, "task_seq_length": 77},
     }
 
 
@@ -126,10 +123,7 @@ class OneFormerProcessor(ProcessorMixin):
         """
         if len(args) > 2:
             raise ValueError("Too many positional arguments")
-        return {
-            key: value
-            for key, value in zip(("task_inputs", "segmentation_maps"), args)
-        }
+        return dict(zip(("task_inputs", "segmentation_maps"), args))
 
     def __call__(
         self,

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -74,7 +74,7 @@ class OneFormerProcessor(ProcessorMixin):
     attributes = ["image_processor", "tokenizer"]
     image_processor_class = "OneFormerImageProcessor"
     tokenizer_class = ("CLIPTokenizer", "CLIPTokenizerFast")
-    optional_call_args = ["segmentation_maps", "task_inputs"]
+    optional_call_args = ["task_inputs", "segmentation_maps"]
 
     def __init__(
         self,
@@ -120,7 +120,7 @@ class OneFormerProcessor(ProcessorMixin):
     def __call__(
         self,
         images: Optional[ImageInput] = None,
-        # The following is to capture `segmentation_maps` and `task_inputs` arguments
+        # The following is to capture `task_inputs and `segmentation_maps` arguments
         # that may be passed as a positional argument.
         # See transformers.processing_utils.ProcessorMixin.prepare_and_validate_optional_call_args for more details,
         # or this conversation for more context:
@@ -169,8 +169,8 @@ class OneFormerProcessor(ProcessorMixin):
             **kwargs,
             **self.prepare_and_validate_optional_call_args(*args),
         )
-        segmentation_maps = output_kwargs["images_kwargs"].pop("segmentation_maps", None)
         task_inputs = output_kwargs["images_kwargs"].pop("task_inputs", None)
+        segmentation_maps = output_kwargs["images_kwargs"].pop("segmentation_maps", None)
         if isinstance(task_inputs, str):
             task_inputs = [task_inputs]
         self._validate_input_types(images, task_inputs)

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -99,25 +99,20 @@ class OneFormerProcessor(ProcessorMixin):
         return token_inputs
 
     @staticmethod
-    def _check_args(
+    def _validate_input_types(
         images: Optional[ImageInput] = None,
-        task_inputs: Optional[Union[TextInput, PreTokenizedInput]] = None,
-    ):
+        task_inputs: Optional[PreTokenizedInput] = None,
+    ) -> None:
         if task_inputs is None:
             raise ValueError("You have to specify the task_inputs. Found None.")
         elif images is None:
             raise ValueError("You have to specify the images. Found None.")
-
-        if isinstance(task_inputs, str):
-            task_inputs = [task_inputs]
 
         if not isinstance(task_inputs, List) or not task_inputs:
             raise TypeError("task_inputs should be a string or a list of strings.")
 
         if not all(task in ["semantic", "instance", "panoptic"] for task in task_inputs):
             raise ValueError("task_inputs must be semantic, instance, or panoptic.")
-
-        return task_inputs
 
     @staticmethod
     def _add_args_for_backward_compatibility(args):
@@ -179,7 +174,9 @@ class OneFormerProcessor(ProcessorMixin):
         )
         segmentation_maps = output_kwargs["images_kwargs"].pop("segmentation_maps", None)
         task_inputs = output_kwargs["images_kwargs"].pop("task_inputs", None)
-        task_inputs = self._check_args(images, task_inputs)
+        if isinstance(task_inputs, str):
+            task_inputs = [task_inputs]
+        self._validate_input_types(images, task_inputs)
 
         encoded_inputs = self.image_processor(images, task_inputs, segmentation_maps, **output_kwargs["images_kwargs"])
 
@@ -204,7 +201,9 @@ class OneFormerProcessor(ProcessorMixin):
         task_inputs. Please refer to the docstring of this method for more information.
         """
 
-        task_inputs = self._check_args(images, task_inputs)
+        if isinstance(task_inputs, str):
+            task_inputs = [task_inputs]
+        self._validate_input_types(images, task_inputs)
 
         encoded_inputs = self.image_processor.encode_inputs(images, task_inputs, segmentation_maps, **kwargs)
 

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Union
 
 from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput
-from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin, TextKwargs, Unpack
+from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import is_torch_available
 

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -120,9 +120,7 @@ class OneFormerProcessor(ProcessorMixin):
         task_inputs: Optional[List[Literal["semantic", "instance", "panoptic"]]] = None,
     ) -> None:
         if task_inputs is None or images is None:
-            raise ValueError(
-                f"You have to specify both images and task_inputs. Found {images} and {task_inputs}."
-            )
+            raise ValueError(f"You have to specify both images and task_inputs. Found {images} and {task_inputs}.")
 
     def __call__(
         self,
@@ -134,9 +132,7 @@ class OneFormerProcessor(ProcessorMixin):
         # https://github.com/huggingface/transformers/pull/32544#discussion_r1720208116
         # This behavior is only needed for backward compatibility and will be removed in future versions.
         *args,
-        text: Union[
-            TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]
-        ] = None,
+        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
         audio=None,
         videos=None,
         **kwargs: Unpack[OneFormerProcessorKwargs],
@@ -179,16 +175,12 @@ class OneFormerProcessor(ProcessorMixin):
             **self.prepare_and_validate_optional_call_args(*args),
         )
         task_inputs = output_kwargs["images_kwargs"].pop("task_inputs", None)
-        segmentation_maps = output_kwargs["images_kwargs"].pop(
-            "segmentation_maps", None
-        )
+        segmentation_maps = output_kwargs["images_kwargs"].pop("segmentation_maps", None)
         if isinstance(task_inputs, str):
             task_inputs = [task_inputs]
         self._validate_input_types(images, task_inputs)
 
-        encoded_inputs = self.image_processor(
-            images, task_inputs, segmentation_maps, **output_kwargs["images_kwargs"]
-        )
+        encoded_inputs = self.image_processor(images, task_inputs, segmentation_maps, **output_kwargs["images_kwargs"])
 
         task_token_inputs = []
         for task in task_inputs:
@@ -230,9 +222,7 @@ class OneFormerProcessor(ProcessorMixin):
             task_inputs = [task_inputs]
         self._validate_input_types(images, task_inputs)
 
-        encoded_inputs = self.image_processor.encode_inputs(
-            images, task_inputs, segmentation_maps, **kwargs
-        )
+        encoded_inputs = self.image_processor.encode_inputs(images, task_inputs, segmentation_maps, **kwargs)
 
         task_token_inputs = []
         for task in task_inputs:

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -80,6 +80,7 @@ class OneFormerProcessor(ProcessorMixin):
         tokenizer=None,
         max_seq_length: int = 77,
         task_seq_length: int = 77,
+        **kwargs,
     ):
         if image_processor is None:
             raise ValueError("You need to specify an `image_processor`.")

--- a/src/transformers/models/oneformer/processing_oneformer.py
+++ b/src/transformers/models/oneformer/processing_oneformer.py
@@ -201,14 +201,15 @@ class OneFormerProcessor(ProcessorMixin):
         )
 
         if hasattr(encoded_inputs, "text_inputs"):
-            text_inputs = [
-                self._preprocess_text(
-                    texts,
-                    max_length=self.max_seq_length,
-                    text_kwargs=output_kwargs["text_kwargs"],
-                ).unsqueeze(0)
-                for texts in encoded_inputs.text_inputs
-            ]
+            text_inputs = []
+            for texts in encoded_inputs.text_inputs:
+                text_inputs.append(
+                    self._preprocess_text(
+                        texts,
+                        max_length=self.max_seq_length,
+                        text_kwargs=output_kwargs["text_kwargs"],
+                    ).unsqueeze(0)
+                )
             encoded_inputs["text_inputs"] = torch.cat(text_inputs, dim=0)
 
         return encoded_inputs
@@ -246,10 +247,15 @@ class OneFormerProcessor(ProcessorMixin):
         )
 
         if hasattr(encoded_inputs, "text_inputs"):
-            text_inputs = [
-                self._preprocess_text(texts, max_length=self.max_seq_length, text_kwargs=text_kwargs).unsqueeze(0)
-                for texts in encoded_inputs.text_inputs
-            ]
+            text_inputs = []
+            for texts in encoded_inputs.text_inputs:
+                text_inputs.append(
+                    self._preprocess_text(
+                        texts,
+                        max_length=self.max_seq_length,
+                        text_kwargs=text_kwargs,
+                    ).unsqueeze(0)
+                )
             encoded_inputs["text_inputs"] = torch.cat(text_inputs, dim=0)
 
         return encoded_inputs

--- a/tests/models/oneformer/test_processor_oneformer.py
+++ b/tests/models/oneformer/test_processor_oneformer.py
@@ -221,7 +221,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, Image.Image)
 
         # Test not batched input
-        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -232,7 +236,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
+        tokenized_task_inputs = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -244,7 +252,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs,
+            task_inputs=["semantic"] * len(image_inputs),
+            return_tensors="pt",
+        ).pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -256,7 +268,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -273,7 +285,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, np.ndarray)
 
         # Test not batched input
-        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -284,7 +300,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
+        tokenized_task_inputs = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -296,7 +316,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs,
+            task_inputs=["semantic"] * len(image_inputs),
+            return_tensors="pt",
+        ).pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -308,7 +332,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -325,7 +349,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, torch.Tensor)
 
         # Test not batched input
-        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -336,7 +364,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
+        tokenized_task_inputs = processor(
+            image_inputs[0],
+            task_inputs=["semantic"],
+            return_tensors="pt",
+        ).task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -348,7 +380,11 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
+        encoded_images = processor(
+            image_inputs,
+            task_inputs=["semantic"] * len(image_inputs),
+            return_tensors="pt",
+        ).pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -360,7 +396,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -388,8 +424,8 @@ class OneFormerProcessingTest(unittest.TestCase):
 
         inputs = processor(
             image_inputs,
-            ["semantic"] * len(image_inputs),
-            annotations,
+            task_inputs=["semantic"] * len(image_inputs),
+            segmentation_maps=annotations,
             return_tensors="pt",
             instance_id_to_semantic_id=instance_id_to_semantic_id,
             pad_and_return_pixel_mask=True,

--- a/tests/models/oneformer/test_processor_oneformer.py
+++ b/tests/models/oneformer/test_processor_oneformer.py
@@ -204,7 +204,7 @@ class OneFormerProcessingTest(ProcessorTesterMixin, unittest.TestCase):
     def processor_dict(self):
         return self.processing_tester.prepare_processor_dict()
 
-    # START - override commont tests due to mandatory argument task_inputs
+    # START - override common tests due to mandatory argument task_inputs
     def test_image_processor_defaults_preserved_by_image_kwargs(self):
         """
         We use do_rescale=True, rescale_factor=-1 to ensure that image_processor kwargs are preserved in the processor.

--- a/tests/models/oneformer/test_processor_oneformer.py
+++ b/tests/models/oneformer/test_processor_oneformer.py
@@ -128,8 +128,6 @@ class OneFormerProcessorTester:
         return {
             "image_processor": image_processor,
             "tokenizer": tokenizer,
-            "max_seq_length": self.max_seq_length,
-            "task_seq_length": self.task_seq_length,
         }
 
     def get_expected_values(self, image_inputs, batched=False):
@@ -205,8 +203,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = self.processing_class(**self.processor_dict)
         self.assertTrue(hasattr(processor, "image_processor"))
         self.assertTrue(hasattr(processor, "tokenizer"))
-        self.assertTrue(hasattr(processor, "max_seq_length"))
-        self.assertTrue(hasattr(processor, "task_seq_length"))
 
     @unittest.skip
     def test_batch_feature(self):
@@ -480,8 +476,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         # prepare the images and annotations
@@ -490,6 +484,8 @@ class OneFormerProcessingTest(unittest.TestCase):
             pixel_values_list,
             ["semantic", "semantic"],
             [panoptic_map1, panoptic_map2],
+            max_seq_length=self.processing_tester.max_seq_length,
+            task_seq_length=self.processing_tester.task_seq_length,
             instance_id_to_semantic_id=[inst2class1, inst2class2],
             return_tensors="pt",
         )
@@ -568,8 +564,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         # prepare the images and annotations
@@ -578,6 +572,8 @@ class OneFormerProcessingTest(unittest.TestCase):
             pixel_values_list,
             ["instance", "instance"],
             [panoptic_map1, panoptic_map2],
+            max_seq_length=self.processing_tester.max_seq_length,
+            task_seq_length=self.processing_tester.task_seq_length,
             instance_id_to_semantic_id=[inst2class1, inst2class2],
             return_tensors="pt",
         )
@@ -656,8 +652,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         # prepare the images and annotations
@@ -666,6 +660,8 @@ class OneFormerProcessingTest(unittest.TestCase):
             pixel_values_list,
             ["panoptic", "panoptic"],
             [panoptic_map1, panoptic_map2],
+            max_seq_length=self.processing_tester.max_seq_length,
+            task_seq_length=self.processing_tester.task_seq_length,
             instance_id_to_semantic_id=[inst2class1, inst2class2],
             return_tensors="pt",
         )
@@ -723,8 +719,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         outputs = self.processing_tester.get_fake_oneformer_outputs()
@@ -757,8 +751,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         outputs = self.processing_tester.get_fake_oneformer_outputs()
@@ -783,8 +775,6 @@ class OneFormerProcessingTest(unittest.TestCase):
         processor = OneFormerProcessor(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            max_seq_length=77,
-            task_seq_length=77,
         )
 
         outputs = self.processing_tester.get_fake_oneformer_outputs()

--- a/tests/models/oneformer/test_processor_oneformer.py
+++ b/tests/models/oneformer/test_processor_oneformer.py
@@ -221,11 +221,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, Image.Image)
 
         # Test not batched input
-        encoded_images = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -236,11 +232,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).task_inputs
+        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -252,11 +244,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(
-            image_inputs,
-            task_inputs=["semantic"] * len(image_inputs),
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -268,7 +256,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -285,11 +273,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, np.ndarray)
 
         # Test not batched input
-        encoded_images = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -300,11 +284,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).task_inputs
+        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -316,11 +296,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(
-            image_inputs,
-            task_inputs=["semantic"] * len(image_inputs),
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -332,7 +308,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -349,11 +325,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             self.assertIsInstance(image, torch.Tensor)
 
         # Test not batched input
-        encoded_images = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs[0], ["semantic"], return_tensors="pt").pixel_values
 
         expected_height, expected_width, expected_sequence_length = self.processing_tester.get_expected_values(
             image_inputs
@@ -364,11 +336,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             (1, self.processing_tester.num_channels, expected_height, expected_width),
         )
 
-        tokenized_task_inputs = processor(
-            image_inputs[0],
-            task_inputs=["semantic"],
-            return_tensors="pt",
-        ).task_inputs
+        tokenized_task_inputs = processor(image_inputs[0], ["semantic"], return_tensors="pt").task_inputs
 
         self.assertEqual(
             tokenized_task_inputs.shape,
@@ -380,11 +348,7 @@ class OneFormerProcessingTest(unittest.TestCase):
             image_inputs, batched=True
         )
 
-        encoded_images = processor(
-            image_inputs,
-            task_inputs=["semantic"] * len(image_inputs),
-            return_tensors="pt",
-        ).pixel_values
+        encoded_images = processor(image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt").pixel_values
         self.assertEqual(
             encoded_images.shape,
             (
@@ -396,7 +360,7 @@ class OneFormerProcessingTest(unittest.TestCase):
         )
 
         tokenized_task_inputs = processor(
-            image_inputs, task_inputs=["semantic"] * len(image_inputs), return_tensors="pt"
+            image_inputs, ["semantic"] * len(image_inputs), return_tensors="pt"
         ).task_inputs
 
         self.assertEqual(
@@ -424,8 +388,8 @@ class OneFormerProcessingTest(unittest.TestCase):
 
         inputs = processor(
             image_inputs,
-            task_inputs=["semantic"] * len(image_inputs),
-            segmentation_maps=annotations,
+            ["semantic"] * len(image_inputs),
+            annotations,
             return_tensors="pt",
             instance_id_to_semantic_id=instance_id_to_semantic_id,
             pad_and_return_pixel_mask=True,


### PR DESCRIPTION
Adds uniformized processors for OneFormer following #31911.

Small changes to simplify code.

Additional check via `test_processor_oneformer.py` that the `inputs` are the same before and after the changes (with fixed random seeds).

@qubvel @molbap
