### PR TITLE
T5 Attention fix and tests

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -477,6 +477,16 @@ class T5Attention(nn.Module):
         """
         Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).
         """
+        if cache_position is None:
+            if past_key_value is not None:
+                logger.warning_once(
+                    f"{self.__class__.__name__} forward called without cache_position when using cache, which might result in errors. "
+                    "Please provide a cache_position when calling this function. "
+                    "See 'Best Practices for Generation with Cache' in the docs for more information. "
+                    "Assuming cache position starts at 0."
+                )
+            cache_position = torch.arange(hidden_states.shape[1])
+
         # Input is (batch_size, seq_length, dim)
         # Mask is (batch_size, 1, 1, key_length) (non-causal encoder) or (batch_size, 1, seq_length, key_length) (causal decoder)
         batch_size, seq_length = hidden_states.shape[:2]

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -529,6 +529,20 @@ class T5ModelTester:
         self.parent.assertEqual(model.get_output_embeddings().weight.shape[0], prev_vocab_size - 10)
         self.parent.assertEqual(model.config.vocab_size, prev_vocab_size - 10)
 
+    def create_and_check_attention_forward(self, config):
+        torch.manual_seed(0)
+        model = T5Model(config=config).get_decoder().block[0].layer[0] # T5LayerSelfAttention
+        model.to(torch_device).eval()
+
+        seq_len = self.encoder_seq_length
+        batch_size = self.batch_size
+        embed_size = self.hidden_size
+
+        test_input = torch.randn((batch_size, seq_len, embed_size), device=torch_device)
+        output = model(test_input)
+
+        self.parent.assertFalse(torch.isnan(output).any().item())
+
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
         (
@@ -928,6 +942,9 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, 
             attn_weights = out[attn_name] if attn_name == attention_names[0] else out[attn_name][-1]
             self.assertEqual(sum([w.sum().item() for w in attn_weights]), 0.0)
 
+    def test_create_and_check_attention_forward(self):
+        config = self.model_tester.prepare_config_and_inputs()[0]
+        self.model_tester.create_and_check_attention_forward(config)
 
 class T5EncoderOnlyModelTester:
     def __init__(

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -531,7 +531,7 @@ class T5ModelTester:
 
     def create_and_check_attention_forward(self, config):
         torch.manual_seed(0)
-        model = T5Model(config=config).get_decoder().block[0].layer[0] # T5LayerSelfAttention
+        model = T5Model(config=config).get_decoder().block[0].layer[0]  # T5LayerSelfAttention
         model.to(torch_device).eval()
 
         seq_len = self.encoder_seq_length
@@ -945,6 +945,7 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, 
     def test_create_and_check_attention_forward(self):
         config = self.model_tester.prepare_config_and_inputs()[0]
         self.model_tester.create_and_check_attention_forward(config)
+
 
 class T5EncoderOnlyModelTester:
     def __init__(

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -539,9 +539,9 @@ class T5ModelTester:
         embed_size = self.hidden_size
 
         test_input = torch.randn((batch_size, seq_len, embed_size), device=torch_device)
-        output = model(test_input)
+        attn_out, _kv_state, _pos_bias = model(test_input)
 
-        self.parent.assertFalse(torch.isnan(output).any().item())
+        self.parent.assertFalse(torch.isnan(attn_out).any().item())
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

Fixes a bug which crashes the forward pass of T5Attention when not using the KV Cache or the `cache_position` parameter, and adds tests to verify the fix.

- [x] Add test
- [ ] Fix bug in T5Attention
- [ ] Linting & code quality

Fixes # (issue)
https://github.com/huggingface/transformers/issues/34448

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp 
