### PR TITLE
fix a typo bug where 'id2label' was incorrectly written as 'i2label' when reading config

### DIFF
--- a/examples/pytorch/image-classification/run_image_classification_no_trainer.py
+++ b/examples/pytorch/image-classification/run_image_classification_no_trainer.py
@@ -331,7 +331,7 @@ def main():
     config = AutoConfig.from_pretrained(
         args.model_name_or_path,
         num_labels=len(labels),
-        i2label=id2label,
+        id2label=id2label,
         label2id=label2id,
         finetuning_task="image-classification",
         trust_remote_code=args.trust_remote_code,


### PR DESCRIPTION
fix a typo bug in examples/pytorch/image-classification/run_image_classification_no_trainer.py where 'id2label' was incorrectly written as 'i2label' when reading pretrained config

# What does this PR do?
Fix a  typo bug in examples/pytorch/image-classification/run_image_classification_no_trainer.py
Where 'id2label' was incorrectly written as 'i2label' when reading pretrained config; 
This bug will cause the saved config to not properly reflect the relationship between tags and ids.

## Before submitting
- [ √] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:
- vision models: @amyeroberts, @qubvel

Maintained examples (not research project or legacy):
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
