### PR TITLE
Fix for TypeError in train_new_from_iterator() in tokenization_utils_fast.py

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -811,14 +811,14 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             kwargs["unk_token"] = unk_token
         if (
             tokenizer_json["pre_tokenizer"] is not None
-            and tokenizer_json["pre_tokenizer"]["type"] == "ByteLevel"
-            or tokenizer_json["pre_tokenizer"]["type"] == "Sequence"
+            and ((tokenizer_json["pre_tokenizer"]["type"] == "ByteLevel"
+            or tokenizer_json["pre_tokenizer"]["type"] == "Sequence")
             and "pretokenizers" in tokenizer_json["pre_tokenizer"]
             and any(
                 pretokenizer["type"] == "ByteLevel"
                 for pretokenizer in tokenizer_json["pre_tokenizer"]["pretokenizers"]
             )
-        ):
+        )):
             kwargs["initial_alphabet"] = pre_tokenizers_fast.ByteLevel.alphabet()
 
         trainer_class = MODEL_TO_TRAINER_MAPPING[tokenizer_json["model"]["type"]]

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -809,16 +809,17 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             kwargs["end_of_word_suffix"] = tokenizer_json["model"]["end_of_word_suffix"]
         if tokenizer_json["model"]["type"] == "Unigram" and unk_token is not None:
             kwargs["unk_token"] = unk_token
-        if (
-            tokenizer_json["pre_tokenizer"] is not None
-            and ((tokenizer_json["pre_tokenizer"]["type"] == "ByteLevel"
-            or tokenizer_json["pre_tokenizer"]["type"] == "Sequence")
+        if tokenizer_json["pre_tokenizer"] is not None and (
+            (
+                tokenizer_json["pre_tokenizer"]["type"] == "ByteLevel"
+                or tokenizer_json["pre_tokenizer"]["type"] == "Sequence"
+            )
             and "pretokenizers" in tokenizer_json["pre_tokenizer"]
             and any(
                 pretokenizer["type"] == "ByteLevel"
                 for pretokenizer in tokenizer_json["pre_tokenizer"]["pretokenizers"]
             )
-        )):
+        ):
             kwargs["initial_alphabet"] = pre_tokenizers_fast.ByteLevel.alphabet()
 
         trainer_class = MODEL_TO_TRAINER_MAPPING[tokenizer_json["model"]["type"]]


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

When calling train_new_from_iterator() on a tokenizer initialized using AutoTokenizer.from_pretrained(), the following error is raised:
```
tokenizer = AutoTokenizer.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
new_tokenizer = tokenizer.train_new_from_iterator(
    training_corpus, vocab_size=vocab_keep_items
)
```

Error traceback:
```
    new_tokenizer = tokenizer.train_new_from_iterator(
  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils_fast.py", line 818, in train_new_from_iterator
    or tokenizer_json["pre_tokenizer"]["type"] == "Sequence"
    TypeError: 'NoneType' object is not subscriptable
```

Root Cause

The issue is due to improper handling of the conditional check for pre_tokenizer in tokenization_utils_fast.py. The current implementation does not correctly account for the case where tokenizer_json does not contain the "pre_tokenizer" key. This results in attempting to access "type" from a NoneType object, causing a TypeError. This bug seems to be existing from transformers version 4.45.2 onwards.


Manually tested with the above code. 

@ArthurZucker
