### PR TITLE
Update utils.py

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,7 +2397,23 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result
+
+	# check for low memory and clear unused memory if running on CUDA
+	    
+	check_and_clear_cache()
+        
+	return result
+
+
+    # If memory is low, attempt to clear unused GPU memory 
+
+    def check_and_clear_cache(threshold_gb=1):
+	if torch.cuda.is_available():
+	    total_memory = torch.cuda.get_device_properties(0).total_memory
+	    used_memory = torch.cuda.memory_reserved(0)
+	    available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+	    if available_memory_gb < threshold_gb:
+		torch.cuda.empty_cache()
 
     def _has_unfinished_sequences(
         self,


### PR DESCRIPTION
Check for low memory availability and clearing unused memory to make more space available.

# What does this PR do?

<!--
I have made a small change to the generate function generation/utils.py. It is meant to check for low memory on the users GPU devices. If the available memory is below 1 GB, unused cache memory will then be cleared. This causes a little bit of an overhead, but given that this will only be called at the end of generation and only when memory is low, this shouldn't impact performance. 
-->


Fixes # (issue)
- Memory out of error due to unused allocated cache space taking up GPU memory. 


## Who can review?
@gante
