### PR TITLE
Clear unused allocated memory in GPU 

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2398,15 +2398,15 @@ class GenerationMixin:
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
 		
-		if torch.cuda.is_available():
-			total_memory = torch.cuda.get_device_properties(0).total_memory
-			used_memory = torch.cuda.memory_reserved(0)
-			available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
-
-	    	if available_memory_gb < threshold_gb:
+	if torch.cuda.is_available():
+		total_memory = torch.cuda.get_device_properties(0).total_memory
+		used_memory = torch.cuda.memory_reserved(0)
+		available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+	
+		if available_memory_gb < threshold_gb:
 				torch.cuda.empty_cache()
-        
-		return result
+	
+	return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,7 +2397,16 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result
+		
+		if torch.cuda.is_available():
+			total_memory = torch.cuda.get_device_properties(0).total_memory
+			used_memory = torch.cuda.memory_reserved(0)
+			available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+
+	    	if available_memory_gb < threshold_gb:
+				torch.cuda.empty_cache()
+        
+		return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,23 +2397,7 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-
-	# check for low memory and clear unused memory if running on CUDA
-	    
-	check_and_clear_cache()
-        
-	return result
-
-
-    # If memory is low, attempt to clear unused GPU memory 
-
-    def check_and_clear_cache(threshold_gb=1):
-	if torch.cuda.is_available():
-	    total_memory = torch.cuda.get_device_properties(0).total_memory
-	    used_memory = torch.cuda.memory_reserved(0)
-	    available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
-	    if available_memory_gb < threshold_gb:
-		torch.cuda.empty_cache()
+        return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,7 +2397,23 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result
+
+	# check for low memory and clear unused memory if running on CUDA
+	    
+	check_and_clear_cache()
+        
+	return result
+
+
+    # If memory is low, attempt to clear unused GPU memory 
+
+    def check_and_clear_cache(threshold_gb=1):
+	if torch.cuda.is_available():
+	    total_memory = torch.cuda.get_device_properties(0).total_memory
+	    used_memory = torch.cuda.memory_reserved(0)
+	    available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+	    if available_memory_gb < threshold_gb:
+		torch.cuda.empty_cache()
 
     def _has_unfinished_sequences(
         self,


### PR DESCRIPTION
# What does this PR do?

<!--
This update checks if the user has 1 gigabyte or less of vram in their gpu. Then it clears the cache for unused memory at the end of the generation. That is, this change basically checks for critically low memory available after generation is done, and clears the memory to avoid out of memory error. This was solution that worked for my personal chatbot implementation using the transformers library. 
-->

<!-- Remove if not applicable -->

Fixes # (issue)

- Frees up unused memory in gpu.


## Who can review?
@gante 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
