### PR TITLE
Clear unused allocated GPU memory when available GPU memory is low. 

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2398,15 +2398,15 @@ class GenerationMixin:
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
 		
-		if torch.cuda.is_available():
-			total_memory = torch.cuda.get_device_properties(0).total_memory
-			used_memory = torch.cuda.memory_reserved(0)
-			available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
-
-	    	if available_memory_gb < threshold_gb:
+	if torch.cuda.is_available():
+		total_memory = torch.cuda.get_device_properties(0).total_memory
+		used_memory = torch.cuda.memory_reserved(0)
+		available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+	
+		if available_memory_gb < threshold_gb:
 				torch.cuda.empty_cache()
-        
-		return result
+	
+	return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,7 +2397,16 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result
+		
+		if torch.cuda.is_available():
+			total_memory = torch.cuda.get_device_properties(0).total_memory
+			used_memory = torch.cuda.memory_reserved(0)
+			available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+
+	    	if available_memory_gb < threshold_gb:
+				torch.cuda.empty_cache()
+        
+		return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,23 +2397,7 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-
-	# check for low memory and clear unused memory if running on CUDA
-	    
-	check_and_clear_cache()
-        
-	return result
-
-
-    # If memory is low, attempt to clear unused GPU memory 
-
-    def check_and_clear_cache(threshold_gb=1):
-	if torch.cuda.is_available():
-	    total_memory = torch.cuda.get_device_properties(0).total_memory
-	    used_memory = torch.cuda.memory_reserved(0)
-	    available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
-	    if available_memory_gb < threshold_gb:
-		torch.cuda.empty_cache()
+        return result
 
     def _has_unfinished_sequences(
         self,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2397,7 +2397,23 @@ class GenerationMixin:
                 should_convert_cache = True
             if should_convert_cache:
                 result.past_key_values = result.past_key_values.to_legacy_cache()
-        return result
+
+	# check for low memory and clear unused memory if running on CUDA
+	    
+	check_and_clear_cache()
+        
+	return result
+
+
+    # If memory is low, attempt to clear unused GPU memory 
+
+    def check_and_clear_cache(threshold_gb=1):
+	if torch.cuda.is_available():
+	    total_memory = torch.cuda.get_device_properties(0).total_memory
+	    used_memory = torch.cuda.memory_reserved(0)
+	    available_memory_gb = (total_memory - used_memory) / (1024 ** 3)
+	    if available_memory_gb < threshold_gb:
+		torch.cuda.empty_cache()
 
     def _has_unfinished_sequences(
         self,


### PR DESCRIPTION
# What does this PR do?
This update checks for low memory and clears out cache is memory is getting low on the gpu at the end of generation. This should reduce overhead caused by clearing the cache.

Fixes # (issue)

Clear unused allocated cache memory at the end of generation. 

## Who can review?

@gante 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


