### PR TITLE
add empty cache before load_best_model to prevent cuda OOM

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2612,6 +2612,8 @@ class Trainer:
             elif is_sagemaker_mp_enabled():
                 smp.barrier()
 
+            # empty cache to prevent OOM
+            torch.cuda.empty_cache()
             self._load_best_model()
 
         # add remaining tr_loss


### PR DESCRIPTION
# What does this PR do?

Sometimes `load_best_model` causes cuda OOM at the end of training. 
This PR clears the cache before loading the model and fixes this issue.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

