### PR TITLE
[docs] update `load_tool` 

### DIFF
--- a/docs/source/en/agents_advanced.md
+++ b/docs/source/en/agents_advanced.md
@@ -216,15 +216,28 @@ You can leverage `gradio.Chatbot`to display your agent's thoughts using `stream_
 ```py
 import gradio as gr
 from transformers import (
-    load_tool,
     ReactCodeAgent,
     HfApiEngine,
     stream_to_gradio,
 )
+from transformers.agents.tools import Tool
+from huggingface_hub import InferenceClient
 
-# Import tool from Hub
-image_generation_tool = load_tool("m-ric/text-to-image")
 
+class TextToImageTool(Tool):
+    description = "This is a tool that creates an image according to a prompt, which is a text description."
+    name = "image_generator"
+    inputs = {"prompt": {"type": "string", "description": "The image generator prompt. Don't hesitate to add details in the prompt to make the image look better, like 'high-res, photorealistic', etc."}}
+    output_type = "image"
+    model_sdxl = "stabilityai/stable-diffusion-xl-base-1.0"
+    client = InferenceClient(model_sdxl)
+
+
+    def forward(self, prompt):
+        return self.client.text_to_image(prompt)
+
+
+image_generation_tool = TextToImageTool()
 llm_engine = HfApiEngine("meta-llama/Meta-Llama-3-70B-Instruct")
 
 # Initialize the agent with the image generation tool


### PR DESCRIPTION
## What does this PR do?
This model `m-ric/text-to-image` seems to not exit anymore on the HuggingFace Model Hub. When running the example code, I got the following error: 
```bash
You're loading a tool from the Hub from None. Please make sure this is a source that you trust as the code within that tool will be executed on your machine. Always verify the code of the tools that you load. We recommend specifying a `revision` to ensure you're loading the code that you have checked.
Traceback (most recent call last):
  File "/home/sdp/fanli/transformers/training.py", line 10, in <module>
    image_generation_tool = load_tool("m-ric/text-to-image")
  File "/home/sdp/fanli/transformers/src/transformers/agents/tools.py", line 801, in load_tool
    return Tool.from_hub(task_or_repo_id, model_repo_id=model_repo_id, token=token, **kwargs)
  File "/home/sdp/fanli/transformers/src/transformers/agents/tools.py", line 357, in from_hub
    return tool_class(**kwargs)
  File "/home/sdp/fanli/transformers/src/transformers/agents/tools.py", line 97, in new_init
    self.validate_arguments(do_validate_forward=do_validate_forward)
  File "/home/sdp/fanli/transformers/src/transformers/agents/tools.py", line 152, in validate_arguments
    raise TypeError(f"You must set an attribute {attr} of type {expected_type.__name__}.")
TypeError: You must set an attribute inputs of type Dict.
```
I only found [this ](https://huggingface.co/spaces/m-ric/text-to-image/blob/main/tool.py) page, so I used the code from there to update the doc. If it is better to use load tool directly from model hub, pls advice me one, so I can update my PR to use a working `image_generation_tool`. 

@stevhliu
