### PR TITLE
fix: Handle BLIP-2 model output format

### DIFF
--- a/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
+++ b/src/transformers/models/blip_2/convert_blip_2_original_to_pytorch.py
@@ -22,11 +22,13 @@ import argparse
 
 import requests
 import torch
+from lavis.common.registry import registry
 
 # pip3 install salesforce-lavis
 # I'm actually installing a slightly modified version: pip3 install -U git+https://github.com/nielsrogge/LAVIS.git@blip2_float32
 # to make sure we can compare both original and HF implementation in float32
 from lavis.models import load_model_and_preprocess
+from lavis.models.blip2_models.blip2_opt import Blip2OPT
 from PIL import Image
 
 from transformers import (
@@ -44,6 +46,66 @@ from transformers import (
     set_seed,
 )
 from transformers.utils.constants import OPENAI_CLIP_MEAN, OPENAI_CLIP_STD
+
+
+@registry.register_model("blip2_opt_logits")
+class Blip2OPTWithLogits(Blip2OPT):
+    """
+    BLIP2 OPT model that returns logits instead of loss.
+    Inherits from Blip2OPT but modifies the forward method to return logits.
+    """
+
+    def forward(self, samples):
+        image = samples["image"]
+        with self.maybe_autocast():
+            image_embeds = self.ln_vision(self.visual_encoder(image))
+        image_atts = torch.ones(image_embeds.size()[:-1], dtype=torch.long).to(image.device)
+
+        query_tokens = self.query_tokens.expand(image_embeds.shape[0], -1, -1)
+        query_output = self.Qformer.bert(
+            query_embeds=query_tokens,
+            encoder_hidden_states=image_embeds,
+            encoder_attention_mask=image_atts,
+            return_dict=True,
+        )
+
+        inputs_opt = self.opt_proj(query_output.last_hidden_state)
+        atts_opt = torch.ones(inputs_opt.size()[:-1], dtype=torch.long).to(image.device)
+
+        self.opt_tokenizer.padding_side = "right"
+
+        text = [t + "\n" for t in samples["text_input"]]
+
+        opt_tokens = self.opt_tokenizer(
+            text,
+            return_tensors="pt",
+            padding="longest",
+            truncation=True,
+            max_length=self.max_txt_len,
+        ).to(image.device)
+
+        targets = opt_tokens.input_ids.masked_fill(opt_tokens.input_ids == self.opt_tokenizer.pad_token_id, -100)
+        if self.prompt:
+            targets[:, : self.prompt_length] = -100  # do not apply loss to the prompt
+
+        empty_targets = torch.ones(atts_opt.size(), dtype=torch.long).to(image.device).fill_(-100)
+        targets = torch.cat([empty_targets, targets], dim=1)
+
+        inputs_embeds = self.opt_model.model.decoder.embed_tokens(opt_tokens.input_ids)
+        inputs_embeds = torch.cat([inputs_opt, inputs_embeds], dim=1)
+        attention_mask = torch.cat([atts_opt, opt_tokens.attention_mask], dim=1)
+
+        with self.maybe_autocast():
+            outputs = self.opt_model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                return_dict=True,
+                labels=targets,
+            )
+        loss = outputs.loss
+        logits = outputs.logits
+
+        return {"logits": logits, "loss": loss}
 
 
 def load_demo_image():
@@ -167,10 +229,10 @@ def convert_blip2_checkpoint(
         hf_model = Blip2ForConditionalGeneration(config).eval()
 
     model_name_to_original = {
-        "blip2-opt-2.7b": ("blip2_opt", "pretrain_opt2.7b"),
-        "blip2-opt-6.7b": ("blip2_opt", "pretrain_opt6.7b"),
-        "blip2-opt-2.7b-coco": ("blip2_opt", "caption_coco_opt2.7b"),
-        "blip2-opt-6.7b-coco": ("blip2_opt", "caption_coco_opt6.7b"),
+        "blip2-opt-2.7b": ("blip2_opt_logits", "pretrain_opt2.7b"),
+        "blip2-opt-6.7b": ("blip2_opt_logits", "pretrain_opt6.7b"),
+        "blip2-opt-2.7b-coco": ("blip2_opt_logits", "caption_coco_opt2.7b"),
+        "blip2-opt-6.7b-coco": ("blip2_opt_logits", "caption_coco_opt6.7b"),
         "blip2-flan-t5-xl": ("blip2_t5", "pretrain_flant5xl"),
         "blip2-flan-t5-xl-coco": ("blip2_t5", "caption_coco_flant5xl"),
         "blip2-flan-t5-xxl": ("blip2_t5", "pretrain_flant5xxl"),
@@ -295,7 +357,7 @@ def convert_blip2_checkpoint(
 
         with torch.no_grad():
             if "opt" in model_name:
-                original_logits = original_model({"image": original_pixel_values, "text_input": [""]}).logits
+                original_logits = original_model({"image": original_pixel_values, "text_input": [""]})["logits"]
                 logits = hf_model(pixel_values, input_ids).logits
             else:
                 original_logits = original_model(
@@ -309,7 +371,7 @@ def convert_blip2_checkpoint(
         print("First values of HF logits:", logits[0, :3, :3])
 
         # assert values
-        assert torch.allclose(original_logits.to(logits.device), logits, atol=1e-4)
+        assert torch.allclose(original_logits.to(logits.device), logits, atol=2e-4)
         print("Looks ok!")
 
         print("Generating a caption...")


### PR DESCRIPTION
# What does this PR do?

I have modified the code to return logits in addition to loss.

Instead of:

```
return {"loss": loss}
```

The code now returns:
```
return {
    "loss": loss,
    "logits": logits
}
```

Output:
```
Done!
First values of original logits: tensor([[ 1.9322,  1.9379,  7.4007],
        [-1.4741, -1.1189,  8.6593],
        [-1.4213, -1.2489,  6.1976]])
First values of HF logits: tensor([[ 1.9322,  1.9379,  7.4007],
        [-1.4741, -1.1189,  8.6593],
        [-1.4213, -1.2489,  6.1976]])
Looks ok!
Generating a caption...
Original generation: ['merlion']
HF generation: ['Question: what object is in this image? Answer: merlion']
```


Fixes # ([issue](https://github.com/huggingface/transformers/issues/34704#issue-2652956392))


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@amyeroberts, @qubvel
