### PR TITLE
Past Keys Output now working with output router logits

### DIFF
--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -99,6 +99,9 @@ def load_balancing_loss_func(
     Returns:
         The auxiliary loss.
     """
+
+    is_single_token = gate_logits[0].shape[0] == 1
+                
     if gate_logits is None or not isinstance(gate_logits, tuple):
         return 0
 
@@ -120,15 +123,26 @@ def load_balancing_loss_func(
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
     else:
         batch_size, sequence_length = attention_mask.shape
+       
+        
         num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
-
+        
         # Compute the mask that masks all padding tokens as 0 with the same shape of expert_mask
-        expert_attention_mask = (
-            attention_mask[None, :, :, None, None]
-            .expand((num_hidden_layers, batch_size, sequence_length, top_k, num_experts))
-            .reshape(-1, top_k, num_experts)
-            .to(compute_device)
-        )
+        if not is_single_token:
+            expert_attention_mask = (
+                attention_mask[None, :, :, None, None]
+                .expand((num_hidden_layers, batch_size, sequence_length, top_k, num_experts))
+                .reshape(-1, top_k, num_experts)
+                .to(compute_device)
+            )
+        else:
+            expert_attention_mask = (
+                attention_mask[None, :, -1:, None, None]
+                .expand((len(gate_logits), 1,1, top_k, num_experts))
+                .reshape(-1, top_k, num_experts)
+                .to(compute_device)
+            )
+        
 
         # Compute the percentage of tokens routed to each experts
         tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
@@ -136,13 +150,21 @@ def load_balancing_loss_func(
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert
-        router_per_expert_attention_mask = (
-            attention_mask[None, :, :, None]
-            .expand((num_hidden_layers, batch_size, sequence_length, num_experts))
-            .reshape(-1, num_experts)
-            .to(compute_device)
-        )
-
+        if not is_single_token:
+            router_per_expert_attention_mask = (
+                attention_mask[None, :, :, None]
+                .expand((num_hidden_layers, batch_size, sequence_length, num_experts))
+                .reshape(-1, num_experts)
+                .to(compute_device)
+            )
+        else:
+            router_per_expert_attention_mask = (
+                attention_mask[None, :, -1:, None]
+                .expand((len(gate_logits), 1, 1, num_experts))
+                .reshape(-1, num_experts)
+                .to(compute_device)
+            )
+        
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.sum(routing_weights * router_per_expert_attention_mask, dim=0) / torch.sum(
             router_per_expert_attention_mask, dim=0


### PR DESCRIPTION
# What does this PR do?

This handles the case where output_router_logits are True, and past key values are being used for inference, in the Mistral model. 

Fixes #30731 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker 
