### PR TITLE
feat: allow to use hf-models

### DIFF
--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -50,11 +50,6 @@ class TimmBackbone(PreTrainedModel, BackboneMixin):
         if config.backbone is None:
             raise ValueError("backbone is not set in the config. Please set it to a timm model name.")
 
-        # Certain timm models have the structure `model_name.version` e.g. vit_large_patch14_dinov2.lvd142m
-        base_backbone_model = config.backbone.split(".")[0]
-        if base_backbone_model not in timm.list_models():
-            raise ValueError(f"backbone {base_backbone_model} is not supported by timm.")
-
         if hasattr(config, "out_features") and config.out_features is not None:
             raise ValueError("out_features is not supported by TimmBackbone. Please use out_indices instead.")
 


### PR DESCRIPTION
# What does this PR do?

Problem: This doesn't currently work, but should in my opinion? 

```python
        import transformers
        model = transformers.AutoBackbone.from_pretrained(
            "hf-hub:bioptimus/H-optimus-0",
            use_timm_backbone=True,
            use_pretrained_backbone=True,
        )
```

Solution approach: 

Just remove the two lines which explicitly check whether the string is in `timm.list_models()`. Alternatively, we could introduce more e.g. `backbone_kwargs` arguments.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Models:

- vision models: @amyeroberts, @qubvel
