### PR TITLE
[DO NOT MERGE] Add pytest-subtests to the dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ _deps = [
     "pyyaml>=5.1",
     "pydantic",
     "pytest>=7.2.0,<8.0.0",
+    "pytest-subtests",
     "pytest-timeout",
     "pytest-xdist",
     "python>=3.9.0",
@@ -320,6 +321,7 @@ extras["testing"] = (
     deps_list(
         "pytest",
         "pytest-rich",
+        "pytest-subtests",
         "pytest-xdist",
         "timeout-decorator",
         "parameterized",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -54,6 +54,7 @@ deps = {
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic",
     "pytest": "pytest>=7.2.0,<8.0.0",
+    "pytest-subtests": "pytest-subtests",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",
     "python": "python>=3.9.0",


### PR DESCRIPTION
Pushing a draft PR to check that CI will start catching #34722. If it will, I suggest to update PR #34723 with this change.

As discussed in [1], pytest-subtests changes behavior of .skipTest() having effect to really skip individual subtests or skip the entire test if module is not installed. Huggingface Accelerate has module in its dependencies. It makes sense to add it for Transformers as well to avoid divergent environment between users and ci.

See[1]: https://github.com/huggingface/transformers/pull/34723#issuecomment-2479191402

CC: @ydshieh