### PR TITLE
Fix bug when requesting input normalization with EnCodec

### DIFF
--- a/src/transformers/models/encodec/modeling_encodec.py
+++ b/src/transformers/models/encodec/modeling_encodec.py
@@ -576,7 +576,7 @@ class EncodecModel(EncodecPreTrainedModel):
         scale = None
         if self.config.normalize:
             # if the padding is non zero
-            input_values = input_values * padding_mask
+            input_values = input_values * padding_mask.unsqueeze(1)
             mono = torch.sum(input_values, 1, keepdim=True) / input_values.shape[1]
             scale = mono.pow(2).mean(dim=-1, keepdim=True).sqrt() + 1e-8
             input_values = input_values / scale

--- a/tests/models/encodec/test_modeling_encodec.py
+++ b/tests/models/encodec/test_modeling_encodec.py
@@ -39,7 +39,7 @@ from ...test_pipeline_mixin import PipelineTesterMixin
 if is_torch_available():
     import torch
 
-    from transformers import EncodecModel
+    from transformers import EncodecFeatureExtractor, EncodecModel
 
 
 def prepare_inputs_dict(
@@ -111,6 +111,19 @@ class EncodecModelTester:
 
         return config, inputs_dict
 
+    def prepare_config_and_inputs_for_normalization(self):
+        input_values = floats_tensor([self.batch_size, self.num_channels, self.intermediate_size], scale=1.0)
+        config = self.get_config()
+        config.normalize = True
+
+        processor = EncodecFeatureExtractor(feature_size=config.audio_channels, sampling_rate=config.sampling_rate)
+        input_values = list(input_values.cpu().numpy())
+        inputs_dict = processor(
+            input_values, sampling_rate=config.sampling_rate, padding=True, return_tensors="pt"
+        ).to(torch_device)
+
+        return config, inputs_dict
+
     def get_config(self):
         return EncodecConfig(
             audio_channels=self.num_channels,
@@ -125,9 +138,7 @@ class EncodecModelTester:
 
     def create_and_check_model_forward(self, config, inputs_dict):
         model = EncodecModel(config=config).to(torch_device).eval()
-
-        input_values = inputs_dict["input_values"]
-        result = model(input_values)
+        result = model(**inputs_dict)
         self.parent.assertEqual(
             result.audio_values.shape, (self.batch_size, self.num_channels, self.intermediate_size)
         )
@@ -433,6 +444,10 @@ class EncodecModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     def test_identity_shortcut(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs()
         config.use_conv_shortcut = False
+        self.model_tester.create_and_check_model_forward(config, inputs_dict)
+
+    def test_model_forward_with_normalization(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_normalization()
         self.model_tester.create_and_check_model_forward(config, inputs_dict)
 
 


### PR DESCRIPTION
# What does this PR do?

Fix shape of the padding mask returned by EnCodec's feature extractor, which causes issues when `normalize=True`.

Minimal reproducible example:
```python
import numpy as np

from transformers import EncodecConfig, EncodecModel, EncodecFeatureExtractor


sampling_rate = 24000
num_audio_channels = 1

config = EncodecConfig(
    sampling_rate=sampling_rate,
    audio_channels=num_audio_channels,
    hidden_size=4,
    codebook_size=8,
    normalize=True,
)
feature_extractor = EncodecFeatureExtractor(
    feature_size=num_audio_channels, sampling_rate=sampling_rate
)
model = EncodecModel(config=config)

dummy_audios = [
    np.random.randn(num_audio_channels, 6000).squeeze(),
    np.random.randn(num_audio_channels, 4000).squeeze(),
]
inputs = feature_extractor(
    dummy_audios, sampling_rate=sampling_rate, padding=True, return_tensors="pt"
)

outputs = model(
    input_values=inputs["input_values"],
    padding_mask=inputs["padding_mask"]
)
```

in the example above, `input_values` and `padding_mask` have shape `(2, 1, 6000)` and `(2, 6000)`, respectively. Now, when `EncodecConfig` is initialized with `normalize=True`, `EncodecModel._encode_frame` executes the following code:
```python
        ⋮
        scale = None
        if self.config.normalize:
            # if the padding is non zero
            input_values = input_values * padding_mask
            mono = torch.sum(input_values, 1, keepdim=True) / input_values.shape[1]
            scale = mono.pow(2).mean(dim=-1, keepdim=True).sqrt() + 1e-8
            input_values = input_values / scale
        ⋮
```
due to broadcasting rules, `input_values * padding_mask` results in an output of shape `(2, 2, 6000)`, which eventually leads to an error in a convolutional layer:
```
Traceback (most recent call last):                                                                                                                             
  File "/net/tscratch/people/plgfcariaggi/transformers/encodec_mre.py", line 29, in <module>                                                                   
    outputs = model(                                                                                                                                           
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl         
    return self._call_impl(*args, **kwargs)                                                                                                                    
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl                 
    return forward_call(*args, **kwargs)                                                                                                                       
  File "/net/tscratch/people/plgfcariaggi/transformers/src/transformers/models/encodec/modeling_encodec.py", line 810, in forward                              
    audio_codes, audio_scales = self.encode(input_values, padding_mask, bandwidth, False)                                                                      
  File "/net/tscratch/people/plgfcariaggi/transformers/src/transformers/models/encodec/modeling_encodec.py", line 651, in encode                               
    encoded_frame, scale = self._encode_frame(frame, bandwidth, mask)                                                                                          
  File "/net/tscratch/people/plgfcariaggi/transformers/src/transformers/models/encodec/modeling_encodec.py", line 584, in _encode_frame                        
    embeddings = self.encoder(input_values)                                                                                                                    
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl         
    return self._call_impl(*args, **kwargs)                                                                                                                    
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl                 
    return forward_call(*args, **kwargs)                                                                                                                       
  File "/net/tscratch/people/plgfcariaggi/transformers/src/transformers/models/encodec/modeling_encodec.py", line 312, in forward                              
    hidden_states = layer(hidden_states)                                                                                                                       
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl         
    return self._call_impl(*args, **kwargs)                                                                                                                    
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl                 
    return forward_call(*args, **kwargs)                                                                                                                       
  File "/net/tscratch/people/plgfcariaggi/transformers/src/transformers/models/encodec/modeling_encodec.py", line 171, in forward                              
    hidden_states = self.conv(hidden_states)                                                                                                                   
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl         
    return self._call_impl(*args, **kwargs)                                                                                                                    
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl                 
    return forward_call(*args, **kwargs)                                                                                                                       
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 375, in forward                       
    return self._conv_forward(input, self.weight, self.bias)                                                                                                   
  File "/net/tscratch/people/plgfcariaggi/envs/transformers/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 370, in _conv_forward                 
    return F.conv1d(                                                                                                                                           
RuntimeError: Given groups=1, weight of size [32, 1, 7], expected input[2, 2, 6006] to have 1 channels, but got 2 channels instead
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@hollance, @ylacombe, @eustlb

