### PR TITLE
owlvit/2 dynamic input resolution.

### DIFF
--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -1352,20 +1352,23 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         self.layer_norm = nn.LayerNorm(config.vision_config.hidden_size, eps=config.vision_config.layer_norm_eps)
         self.sigmoid = nn.Sigmoid()
         self.config = config
-        self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        self.sqrt_patch_dim_h = self.sqrt_patch_dim_w = (
+            self.config.vision_config.image_size // self.config.vision_config.patch_size
+        )
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
     @staticmethod
     # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTForObjectDetection.normalize_grid_corner_coordinates
-    def normalize_grid_corner_coordinates(num_patches: int) -> torch.Tensor:
+    def normalize_grid_corner_coordinates(patch_dim_h: int, patch_dim_w: int) -> torch.Tensor:
         # Create grid coordinates using torch
-        x_coordinates = torch.arange(1, num_patches + 1, dtype=torch.float32)
-        y_coordinates = torch.arange(1, num_patches + 1, dtype=torch.float32)
+        x_coordinates = torch.arange(1, patch_dim_h + 1, dtype=torch.float32)
+        y_coordinates = torch.arange(1, patch_dim_w + 1, dtype=torch.float32)
         xx, yy = torch.meshgrid(x_coordinates, y_coordinates, indexing="xy")
 
-        # Stack the coordinates and divide by num_patches
+        # Stack the coordinates and divide by their respective patch counts
         box_coordinates = torch.stack((xx, yy), dim=-1)
-        box_coordinates /= num_patches
+        box_coordinates[..., 0] /= patch_dim_h
+        box_coordinates[..., 1] /= patch_dim_w
 
         # Flatten (h, w, 2) -> (h*w, 2)
         box_coordinates = box_coordinates.view(-1, 2)
@@ -1388,18 +1391,22 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
 
     @lru_cache(maxsize=2)
     # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTForObjectDetection.compute_box_bias
-    def compute_box_bias(self, num_patches: int, feature_map: Optional[torch.FloatTensor] = None) -> torch.Tensor:
+    def compute_box_bias(
+        self, patch_dim_h: int, patch_dim_w: int, feature_map: Optional[torch.FloatTensor] = None
+    ) -> torch.Tensor:
         if feature_map is not None:
             raise ValueError("feature_map has been deprecated as an input. Please pass in num_patches instead")
         # The box center is biased to its position on the feature grid
-        box_coordinates = self.normalize_grid_corner_coordinates(num_patches)
+        box_coordinates = self.normalize_grid_corner_coordinates(patch_dim_h, patch_dim_w)
         box_coordinates = torch.clip(box_coordinates, 0.0, 1.0)
 
         # Unnormalize xy
         box_coord_bias = torch.log(box_coordinates + 1e-4) - torch.log1p(-box_coordinates + 1e-4)
 
         # The box size is biased to the patch size
-        box_size = torch.full_like(box_coord_bias, 1.0 / num_patches)
+        box_size = torch.full_like(box_coord_bias, 1.0)
+        box_size[..., 0] /= patch_dim_h
+        box_size[..., 1] /= patch_dim_w
         box_size_bias = torch.log(box_size + 1e-4) - torch.log1p(-box_size + 1e-4)
 
         # Compute box bias
@@ -1472,14 +1479,10 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             return_dict=True,
         )
 
-        if interpolate_pos_encoding:
-            _, _, height, width = pixel_values.shape
-            # height must eq width.
-            self.sqrt_num_patches = height // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
-        else:
-            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        _, _, height, width = pixel_values.shape
+        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
+        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
         # Get image embeddings
         last_hidden_state = outputs.vision_model_output[0]
@@ -1495,8 +1498,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         # Resize to [batch_size, num_patches, num_patches, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_num_patches,
-            self.sqrt_num_patches,
+            self.sqrt_patch_dim_h,
+            self.sqrt_patch_dim_w,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1517,14 +1520,10 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             pixel_values=pixel_values, interpolate_pos_encoding=interpolate_pos_encoding, return_dict=True
         )
 
-        if interpolate_pos_encoding:
-            _, _, height, width = pixel_values.shape
-            # height must eq width.
-            self.sqrt_num_patches = height // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
-        else:
-            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        _, _, height, width = pixel_values.shape
+        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
+        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
         # Apply post_layernorm to last_hidden_state, return non-projected output
         last_hidden_state = vision_outputs[0]
@@ -1540,8 +1539,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         # Resize to [batch_size, num_patches, num_patches, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_num_patches,
-            self.sqrt_num_patches,
+            self.sqrt_patch_dim_h,
+            self.sqrt_patch_dim_w,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1666,11 +1665,11 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
-        batch_size, num_patches, num_patches, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
 
-        batch_size, num_patches, num_patches, hidden_dim = query_feature_map.shape
-        query_image_feats = torch.reshape(query_feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = query_feature_map.shape
+        query_image_feats = torch.reshape(query_feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
         # Get top class embedding and best box index for each query image in batch
         query_embeds, best_box_indices, query_pred_boxes = self.embed_image_query(query_image_feats, query_feature_map)
 
@@ -1774,8 +1773,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         text_outputs = outputs.text_model_output
         vision_outputs = outputs.vision_model_output
 
-        batch_size, num_patches, num_patches, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
 
         # Reshape from [batch_size * max_text_queries, hidden_dim] -> [batch_size, max_text_queries, hidden_dim]
         max_text_queries = input_ids.shape[0] // batch_size

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -293,6 +293,7 @@ class Owlv2VisionEmbeddings(nn.Module):
         self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
         self.register_buffer("position_ids", torch.arange(self.num_positions).expand((1, -1)), persistent=False)
 
+    # Copied from transformers.models.clip.modeling_clip.CLIPVisionEmbeddings.interpolate_pos_encoding
     def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
         """
         This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher resolution
@@ -1417,6 +1418,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         self,
         image_feats: torch.FloatTensor,
         feature_map: torch.FloatTensor,
+        interpolate_pos_encoding: bool = False,
     ) -> torch.FloatTensor:
         """
         Args:
@@ -1424,6 +1426,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
                 Features extracted from the image, returned by the `image_text_embedder` method.
             feature_map:
                 A spatial re-arrangement of image_features, also returned by the `image_text_embedder` method.
+            interpolate_pos_encoding:
+                Whether to interpolate the pre-trained position encodings.
         Returns:
             pred_boxes:
                 List of predicted boxes (cxcywh normalized to 0, 1) nested within a dictionary.
@@ -1433,6 +1437,10 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
 
         # Compute the location of each token on the grid and use it to compute a bias for the bbox prediction
         box_bias = self.box_bias.to(feature_map.device)
+        if interpolate_pos_encoding:
+            _, num_patches_height, num_patches_width, _ = feature_map.shape
+            dynamic_box_bias = self.compute_box_bias(num_patches_height, num_patches_width)
+            box_bias = dynamic_box_bias.to(feature_map.device)
         pred_boxes += box_bias
         pred_boxes = self.sigmoid(pred_boxes)
         return pred_boxes
@@ -1478,10 +1486,12 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             return_dict=True,
         )
 
-        _, _, height, width = pixel_values.shape
-        self.num_patches_height = height // self.config.vision_config.patch_size
-        self.num_patches_width = width // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.num_patches_height, self.num_patches_width)
+        num_patches_height = self.num_patches_height
+        num_patches_width = self.num_patches_width
+        if interpolate_pos_encoding:
+            _, _, height, width = pixel_values.shape
+            num_patches_height = height // self.config.vision_config.patch_size
+            num_patches_width = width // self.config.vision_config.patch_size
 
         # Get image embeddings
         last_hidden_state = outputs.vision_model_output[0]
@@ -1497,8 +1507,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         # Resize to [batch_size, num_patches_height, num_patches_width, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.num_patches_height,
-            self.num_patches_width,
+            num_patches_height,
+            num_patches_width,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1519,10 +1529,12 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             pixel_values=pixel_values, interpolate_pos_encoding=interpolate_pos_encoding, return_dict=True
         )
 
-        _, _, height, width = pixel_values.shape
-        self.num_patches_height = height // self.config.vision_config.patch_size
-        self.num_patches_width = width // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.num_patches_height, self.num_patches_width)
+        num_patches_height = self.num_patches_height
+        num_patches_width = self.num_patches_width
+        if interpolate_pos_encoding:
+            _, _, height, width = pixel_values.shape
+            num_patches_height = height // self.config.vision_config.patch_size
+            num_patches_width = width // self.config.vision_config.patch_size
 
         # Apply post_layernorm to last_hidden_state, return non-projected output
         last_hidden_state = vision_outputs[0]
@@ -1538,8 +1550,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         # Resize to [batch_size, num_patches_height, num_patches_width, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.num_patches_height,
-            self.num_patches_width,
+            num_patches_height,
+            num_patches_width,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1548,10 +1560,13 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
 
     # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTForObjectDetection.embed_image_query
     def embed_image_query(
-        self, query_image_features: torch.FloatTensor, query_feature_map: torch.FloatTensor
+        self,
+        query_image_features: torch.FloatTensor,
+        query_feature_map: torch.FloatTensor,
+        interpolate_pos_encoding: bool = False,
     ) -> torch.FloatTensor:
         _, class_embeds = self.class_predictor(query_image_features)
-        pred_boxes = self.box_predictor(query_image_features, query_feature_map)
+        pred_boxes = self.box_predictor(query_image_features, query_feature_map, interpolate_pos_encoding)
         pred_boxes_as_corners = center_to_corners_format(pred_boxes)
 
         # Loop over query images
@@ -1672,13 +1687,15 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             query_feature_map, (batch_size, num_patches_height * num_patches_width, hidden_dim)
         )
         # Get top class embedding and best box index for each query image in batch
-        query_embeds, best_box_indices, query_pred_boxes = self.embed_image_query(query_image_feats, query_feature_map)
+        query_embeds, best_box_indices, query_pred_boxes = self.embed_image_query(
+            query_image_feats, query_feature_map, interpolate_pos_encoding
+        )
 
         # Predict object classes [batch_size, num_patches, num_queries+1]
         (pred_logits, class_embeds) = self.class_predictor(image_feats=image_feats, query_embeds=query_embeds)
 
         # Predict object boxes
-        target_pred_boxes = self.box_predictor(image_feats, feature_map)
+        target_pred_boxes = self.box_predictor(image_feats, feature_map, interpolate_pos_encoding)
 
         if not return_dict:
             output = (
@@ -1792,7 +1809,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         objectness_logits = self.objectness_predictor(image_feats)
 
         # Predict object boxes
-        pred_boxes = self.box_predictor(image_feats, feature_map)
+        pred_boxes = self.box_predictor(image_feats, feature_map, interpolate_pos_encoding)
 
         if not return_dict:
             output = (

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -33,6 +33,7 @@ from ...utils import (
     is_vision_available,
     logging,
     replace_return_docstrings,
+    torch_int,
 )
 from .configuration_owlv2 import Owlv2Config, Owlv2TextConfig, Owlv2VisionConfig
 
@@ -274,6 +275,7 @@ class Owlv2ImageGuidedObjectDetectionOutput(ModelOutput):
 class Owlv2VisionEmbeddings(nn.Module):
     def __init__(self, config: Owlv2VisionConfig):
         super().__init__()
+        self.patch_size = config.patch_size
         self.config = config
         self.embed_dim = config.hidden_size
         self.class_embedding = nn.Parameter(torch.randn(config.hidden_size))
@@ -291,15 +293,58 @@ class Owlv2VisionEmbeddings(nn.Module):
         self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
         self.register_buffer("position_ids", torch.arange(self.num_positions).expand((1, -1)), persistent=False)
 
-    def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+    def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
+        """
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher resolution
+        images. This method is also adapted to support torch.jit tracing.
+
+        Adapted from:
+        - https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py#L174-L194, and
+        - https://github.com/facebookresearch/dinov2/blob/e1277af2ba9496fbadf7aec6eba56e8d882d1e35/dinov2/models/vision_transformer.py#L179-L211
+        """
+
+        num_patches = embeddings.shape[1] - 1
+        position_embedding = self.position_embedding.weight.unsqueeze(0)
+        num_positions = position_embedding.shape[1] - 1
+
+        # always interpolate when tracing to ensure the exported model works for dynamic input shapes
+        if not torch.jit.is_tracing() and num_patches == num_positions and height == width:
+            return self.position_embedding(self.position_ids)
+
+        class_pos_embed = position_embedding[:, :1]
+        patch_pos_embed = position_embedding[:, 1:]
+
+        dim = embeddings.shape[-1]
+
+        new_height = height // self.patch_size
+        new_width = width // self.patch_size
+
+        sqrt_num_positions = torch_int(num_positions**0.5)
+        patch_pos_embed = patch_pos_embed.reshape(1, sqrt_num_positions, sqrt_num_positions, dim)
+        patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
+
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed,
+            size=(new_height, new_width),
+            mode="bicubic",
+            align_corners=False,
+        )
+
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+
+        return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
+
+    def forward(self, pixel_values: torch.FloatTensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
+        batch_size, _, height, width = pixel_values.shape
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [batch_size, num_channels, height, width]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 
         class_embeds = self.class_embedding.expand(batch_size, 1, -1)
         embeddings = torch.cat([class_embeds, patch_embeds], dim=1)
-        embeddings = embeddings + self.position_embedding(self.position_ids)
-
+        if interpolate_pos_encoding:
+            embeddings = embeddings + self.interpolate_pos_encoding(embeddings, height, width)
+        else:
+            embeddings = embeddings + self.position_embedding(self.position_ids)
         return embeddings
 
 
@@ -610,6 +655,8 @@ OWLV2_VISION_INPUTS_DOCSTRING = r"""
         output_hidden_states (`bool`, *optional*):
             Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
             more detail.
+        interpolate_pos_encoding (`bool`, *optional*, defaults `False`):
+            Whether to interpolate the pre-trained position encodings.
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
 """
@@ -635,6 +682,8 @@ OWLV2_INPUTS_DOCSTRING = r"""
         output_hidden_states (`bool`, *optional*):
             Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
             more detail.
+        interpolate_pos_encoding (`bool`, *optional*, defaults `False`):
+            Whether to interpolate the pre-trained position encodings.
         return_base_image_embeds (`bool`, *optional*):
             Whether or not to return the base image embeddings.
         return_dict (`bool`, *optional*):
@@ -914,6 +963,7 @@ class Owlv2VisionTransformer(nn.Module):
         pixel_values: torch.FloatTensor,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
         r"""
@@ -929,7 +979,7 @@ class Owlv2VisionTransformer(nn.Module):
         expected_input_dtype = self.embeddings.patch_embedding.weight.dtype
         pixel_values = pixel_values.to(expected_input_dtype)
 
-        hidden_states = self.embeddings(pixel_values)
+        hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
         hidden_states = self.pre_layernorm(hidden_states)
 
         encoder_outputs = self.encoder(
@@ -976,6 +1026,7 @@ class Owlv2VisionModel(Owlv2PreTrainedModel):
         pixel_values: Optional[torch.FloatTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
         r"""
@@ -1002,6 +1053,7 @@ class Owlv2VisionModel(Owlv2PreTrainedModel):
             pixel_values=pixel_values,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=return_dict,
         )
 
@@ -1084,6 +1136,7 @@ class Owlv2Model(Owlv2PreTrainedModel):
         pixel_values: Optional[torch.FloatTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
         return_dict: Optional[bool] = None,
     ) -> torch.FloatTensor:
         r"""
@@ -1115,6 +1168,7 @@ class Owlv2Model(Owlv2PreTrainedModel):
             pixel_values=pixel_values,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=return_dict,
         )
 
@@ -1133,6 +1187,7 @@ class Owlv2Model(Owlv2PreTrainedModel):
         return_loss: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
         return_base_image_embeds: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, Owlv2Output]:
@@ -1165,6 +1220,7 @@ class Owlv2Model(Owlv2PreTrainedModel):
             pixel_values=pixel_values,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=return_dict,
         )
 
@@ -1295,8 +1351,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
 
         self.layer_norm = nn.LayerNorm(config.vision_config.hidden_size, eps=config.vision_config.layer_norm_eps)
         self.sigmoid = nn.Sigmoid()
-
-        self.sqrt_num_patches = config.vision_config.image_size // config.vision_config.patch_size
+        self.config = config
+        self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
         self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
 
     @staticmethod
@@ -1403,6 +1459,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         attention_mask: torch.Tensor,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
     ) -> Tuple[torch.FloatTensor]:
         # Encode text and image
         outputs = self.owlv2(
@@ -1411,8 +1468,18 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             attention_mask=attention_mask,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
             return_dict=True,
         )
+
+        if interpolate_pos_encoding:
+            _, _, height, width = pixel_values.shape
+            # height must eq width.
+            self.sqrt_num_patches = height // self.config.vision_config.patch_size
+            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        else:
+            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
+            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
 
         # Get image embeddings
         last_hidden_state = outputs.vision_model_output[0]
@@ -1443,9 +1510,21 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         pixel_values: torch.FloatTensor,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
     ) -> Tuple[torch.FloatTensor]:
         # Get Owlv2Model vision embeddings (same as CLIP)
-        vision_outputs = self.owlv2.vision_model(pixel_values=pixel_values, return_dict=True)
+        vision_outputs = self.owlv2.vision_model(
+            pixel_values=pixel_values, interpolate_pos_encoding=interpolate_pos_encoding, return_dict=True
+        )
+
+        if interpolate_pos_encoding:
+            _, _, height, width = pixel_values.shape
+            # height must eq width.
+            self.sqrt_num_patches = height // self.config.vision_config.patch_size
+            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        else:
+            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
+            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
 
         # Apply post_layernorm to last_hidden_state, return non-projected output
         last_hidden_state = vision_outputs[0]
@@ -1519,6 +1598,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         query_pixel_values: Optional[torch.FloatTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
         return_dict: Optional[bool] = None,
     ) -> Owlv2ImageGuidedObjectDetectionOutput:
         r"""
@@ -1576,11 +1656,14 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         return_dict = return_dict if return_dict is not None else self.config.return_dict
 
         # Compute feature maps for the input and query images
-        query_feature_map = self.image_embedder(pixel_values=query_pixel_values)[0]
+        query_feature_map = self.image_embedder(
+            pixel_values=query_pixel_values, interpolate_pos_encoding=interpolate_pos_encoding
+        )[0]
         feature_map, vision_outputs = self.image_embedder(
             pixel_values=pixel_values,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
         batch_size, num_patches, num_patches, hidden_dim = feature_map.shape
@@ -1630,6 +1713,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         attention_mask: Optional[torch.Tensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
         return_dict: Optional[bool] = None,
     ) -> Owlv2ObjectDetectionOutput:
         r"""
@@ -1683,6 +1767,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             attention_mask=attention_mask,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
         # Text and vision model outputs

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -1352,23 +1352,22 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         self.layer_norm = nn.LayerNorm(config.vision_config.hidden_size, eps=config.vision_config.layer_norm_eps)
         self.sigmoid = nn.Sigmoid()
         self.config = config
-        self.sqrt_patch_dim_h = self.sqrt_patch_dim_w = (
-            self.config.vision_config.image_size // self.config.vision_config.patch_size
-        )
-        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
+        self.num_patches_height = self.config.vision_config.image_size // self.config.vision_config.patch_size
+        self.num_patches_width = self.config.vision_config.image_size // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.num_patches_height, self.num_patches_width)
 
     @staticmethod
     # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTForObjectDetection.normalize_grid_corner_coordinates
-    def normalize_grid_corner_coordinates(patch_dim_h: int, patch_dim_w: int) -> torch.Tensor:
+    def normalize_grid_corner_coordinates(num_patches_height: int, num_patches_width: int) -> torch.Tensor:
         # Create grid coordinates using torch
-        x_coordinates = torch.arange(1, patch_dim_h + 1, dtype=torch.float32)
-        y_coordinates = torch.arange(1, patch_dim_w + 1, dtype=torch.float32)
+        x_coordinates = torch.arange(1, num_patches_width + 1, dtype=torch.float32)
+        y_coordinates = torch.arange(1, num_patches_height + 1, dtype=torch.float32)
         xx, yy = torch.meshgrid(x_coordinates, y_coordinates, indexing="xy")
 
         # Stack the coordinates and divide by their respective patch counts
         box_coordinates = torch.stack((xx, yy), dim=-1)
-        box_coordinates[..., 0] /= patch_dim_h
-        box_coordinates[..., 1] /= patch_dim_w
+        box_coordinates[..., 0] /= num_patches_width
+        box_coordinates[..., 1] /= num_patches_height
 
         # Flatten (h, w, 2) -> (h*w, 2)
         box_coordinates = box_coordinates.view(-1, 2)
@@ -1392,12 +1391,12 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
     @lru_cache(maxsize=2)
     # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTForObjectDetection.compute_box_bias
     def compute_box_bias(
-        self, patch_dim_h: int, patch_dim_w: int, feature_map: Optional[torch.FloatTensor] = None
+        self, num_patches_height: int, num_patches_width: int, feature_map: Optional[torch.FloatTensor] = None
     ) -> torch.Tensor:
         if feature_map is not None:
             raise ValueError("feature_map has been deprecated as an input. Please pass in num_patches instead")
         # The box center is biased to its position on the feature grid
-        box_coordinates = self.normalize_grid_corner_coordinates(patch_dim_h, patch_dim_w)
+        box_coordinates = self.normalize_grid_corner_coordinates(num_patches_height, num_patches_width)
         box_coordinates = torch.clip(box_coordinates, 0.0, 1.0)
 
         # Unnormalize xy
@@ -1405,8 +1404,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
 
         # The box size is biased to the patch size
         box_size = torch.full_like(box_coord_bias, 1.0)
-        box_size[..., 0] /= patch_dim_h
-        box_size[..., 1] /= patch_dim_w
+        box_size[..., 0] /= num_patches_width
+        box_size[..., 1] /= num_patches_height
         box_size_bias = torch.log(box_size + 1e-4) - torch.log1p(-box_size + 1e-4)
 
         # Compute box bias
@@ -1480,9 +1479,9 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         )
 
         _, _, height, width = pixel_values.shape
-        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
-        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
+        self.num_patches_height = height // self.config.vision_config.patch_size
+        self.num_patches_width = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.num_patches_height, self.num_patches_width)
 
         # Get image embeddings
         last_hidden_state = outputs.vision_model_output[0]
@@ -1495,11 +1494,11 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
+        # Resize to [batch_size, num_patches_height, num_patches_width, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_patch_dim_h,
-            self.sqrt_patch_dim_w,
+            self.num_patches_height,
+            self.num_patches_width,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1521,9 +1520,9 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         )
 
         _, _, height, width = pixel_values.shape
-        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
-        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
+        self.num_patches_height = height // self.config.vision_config.patch_size
+        self.num_patches_width = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.num_patches_height, self.num_patches_width)
 
         # Apply post_layernorm to last_hidden_state, return non-projected output
         last_hidden_state = vision_outputs[0]
@@ -1536,11 +1535,11 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
+        # Resize to [batch_size, num_patches_height, num_patches_width, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_patch_dim_h,
-            self.sqrt_patch_dim_w,
+            self.num_patches_height,
+            self.num_patches_width,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1665,11 +1664,13 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
-        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
+        batch_size, num_patches_height, num_patches_width, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_height * num_patches_width, hidden_dim))
 
-        batch_size, num_patches_h, num_patches_w, hidden_dim = query_feature_map.shape
-        query_image_feats = torch.reshape(query_feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
+        batch_size, num_patches_height, num_patches_width, hidden_dim = query_feature_map.shape
+        query_image_feats = torch.reshape(
+            query_feature_map, (batch_size, num_patches_height * num_patches_width, hidden_dim)
+        )
         # Get top class embedding and best box index for each query image in batch
         query_embeds, best_box_indices, query_pred_boxes = self.embed_image_query(query_image_feats, query_feature_map)
 
@@ -1773,8 +1774,8 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         text_outputs = outputs.text_model_output
         vision_outputs = outputs.vision_model_output
 
-        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
+        batch_size, num_patches_height, num_patches_width, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_height * num_patches_width, hidden_dim))
 
         # Reshape from [batch_size * max_text_queries, hidden_dim] -> [batch_size, max_text_queries, hidden_dim]
         max_text_queries = input_ids.shape[0] // batch_size

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -1495,7 +1495,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches, num_patches, hidden_size]
+        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
         new_size = (
             image_embeds.shape[0],
             self.sqrt_patch_dim_h,
@@ -1536,7 +1536,7 @@ class Owlv2ForObjectDetection(Owlv2PreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches, num_patches, hidden_size]
+        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
         new_size = (
             image_embeds.shape[0],
             self.sqrt_patch_dim_h,

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1332,19 +1332,22 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         self.layer_norm = nn.LayerNorm(config.vision_config.hidden_size, eps=config.vision_config.layer_norm_eps)
         self.sigmoid = nn.Sigmoid()
         self.config = config
-        self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-        self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        self.sqrt_patch_dim_h = self.sqrt_patch_dim_w = (
+            self.config.vision_config.image_size // self.config.vision_config.patch_size
+        )
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
     @staticmethod
-    def normalize_grid_corner_coordinates(num_patches: int) -> torch.Tensor:
+    def normalize_grid_corner_coordinates(patch_dim_h: int, patch_dim_w: int) -> torch.Tensor:
         # Create grid coordinates using torch
-        x_coordinates = torch.arange(1, num_patches + 1, dtype=torch.float32)
-        y_coordinates = torch.arange(1, num_patches + 1, dtype=torch.float32)
+        x_coordinates = torch.arange(1, patch_dim_h + 1, dtype=torch.float32)
+        y_coordinates = torch.arange(1, patch_dim_w + 1, dtype=torch.float32)
         xx, yy = torch.meshgrid(x_coordinates, y_coordinates, indexing="xy")
 
-        # Stack the coordinates and divide by num_patches
+        # Stack the coordinates and divide by their respective patch counts
         box_coordinates = torch.stack((xx, yy), dim=-1)
-        box_coordinates /= num_patches
+        box_coordinates[..., 0] /= patch_dim_h
+        box_coordinates[..., 1] /= patch_dim_w
 
         # Flatten (h, w, 2) -> (h*w, 2)
         box_coordinates = box_coordinates.view(-1, 2)
@@ -1352,18 +1355,22 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         return box_coordinates
 
     @lru_cache(maxsize=2)
-    def compute_box_bias(self, num_patches: int, feature_map: Optional[torch.FloatTensor] = None) -> torch.Tensor:
+    def compute_box_bias(
+        self, patch_dim_h: int, patch_dim_w: int, feature_map: Optional[torch.FloatTensor] = None
+    ) -> torch.Tensor:
         if feature_map is not None:
             raise ValueError("feature_map has been deprecated as an input. Please pass in num_patches instead")
         # The box center is biased to its position on the feature grid
-        box_coordinates = self.normalize_grid_corner_coordinates(num_patches)
+        box_coordinates = self.normalize_grid_corner_coordinates(patch_dim_h, patch_dim_w)
         box_coordinates = torch.clip(box_coordinates, 0.0, 1.0)
 
         # Unnormalize xy
         box_coord_bias = torch.log(box_coordinates + 1e-4) - torch.log1p(-box_coordinates + 1e-4)
 
         # The box size is biased to the patch size
-        box_size = torch.full_like(box_coord_bias, 1.0 / num_patches)
+        box_size = torch.full_like(box_coord_bias, 1.0)
+        box_size[..., 0] /= patch_dim_h
+        box_size[..., 1] /= patch_dim_w
         box_size_bias = torch.log(box_size + 1e-4) - torch.log1p(-box_size + 1e-4)
 
         # Compute box bias
@@ -1433,14 +1440,10 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
             return_dict=True,
         )
 
-        if interpolate_pos_encoding:
-            _, _, height, width = pixel_values.shape
-            # height must eq width.
-            self.sqrt_num_patches = height // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
-        else:
-            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        _, _, height, width = pixel_values.shape
+        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
+        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
         # Get image embeddings
         last_hidden_state = outputs.vision_model_output[0]
@@ -1453,11 +1456,11 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches, num_patches, hidden_size]
+        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_num_patches,
-            self.sqrt_num_patches,
+            self.sqrt_patch_dim_h,
+            self.sqrt_patch_dim_w,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1477,14 +1480,10 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
             pixel_values=pixel_values, interpolate_pos_encoding=interpolate_pos_encoding, return_dict=True
         )
 
-        if interpolate_pos_encoding:
-            _, _, height, width = pixel_values.shape
-            # height must eq width.
-            self.sqrt_num_patches = height // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
-        else:
-            self.sqrt_num_patches = self.config.vision_config.image_size // self.config.vision_config.patch_size
-            self.box_bias = self.compute_box_bias(self.sqrt_num_patches)
+        _, _, height, width = pixel_values.shape
+        self.sqrt_patch_dim_h = height // self.config.vision_config.patch_size
+        self.sqrt_patch_dim_w = width // self.config.vision_config.patch_size
+        self.box_bias = self.compute_box_bias(self.sqrt_patch_dim_h, self.sqrt_patch_dim_w)
 
         # Apply post_layernorm to last_hidden_state, return non-projected output
         last_hidden_state = vision_outputs[0]
@@ -1500,8 +1499,8 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         # Resize to [batch_size, num_patches, num_patches, hidden_size]
         new_size = (
             image_embeds.shape[0],
-            self.sqrt_num_patches,
-            self.sqrt_num_patches,
+            self.sqrt_patch_dim_h,
+            self.sqrt_patch_dim_w,
             image_embeds.shape[-1],
         )
         image_embeds = image_embeds.reshape(new_size)
@@ -1610,11 +1609,11 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
-        batch_size, num_patches, num_patches, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
 
-        batch_size, num_patches, num_patches, hidden_dim = query_feature_map.shape
-        query_image_feats = torch.reshape(query_feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = query_feature_map.shape
+        query_image_feats = torch.reshape(query_feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
         # Get top class embedding and best box index for each query image in batch
         query_embeds, best_box_indices, query_pred_boxes = self.embed_image_query(query_image_feats, query_feature_map)
 
@@ -1716,8 +1715,8 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         text_outputs = outputs.text_model_output
         vision_outputs = outputs.vision_model_output
 
-        batch_size, num_patches, num_patches, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches * num_patches, hidden_dim))
+        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
 
         # Reshape from [batch_size * max_text_queries, hidden_dim] -> [batch_size, max_text_queries, hidden_dim]
         max_text_queries = input_ids.shape[0] // batch_size

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1496,7 +1496,7 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         image_embeds = image_embeds[:, 1:, :] * class_token_out
         image_embeds = self.layer_norm(image_embeds)
 
-        # Resize to [batch_size, num_patches, num_patches, hidden_size]
+        # Resize to [batch_size, num_patches_h, num_patches_w, hidden_size]
         new_size = (
             image_embeds.shape[0],
             self.sqrt_patch_dim_h,

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -1716,8 +1716,8 @@ class OwlViTForObjectDetection(OwlViTPreTrainedModel):
         text_outputs = outputs.text_model_output
         vision_outputs = outputs.vision_model_output
 
-        batch_size, num_patches_h, num_patches_w, hidden_dim = feature_map.shape
-        image_feats = torch.reshape(feature_map, (batch_size, num_patches_h * num_patches_w, hidden_dim))
+        batch_size, num_patches_height, num_patches_width, hidden_dim = feature_map.shape
+        image_feats = torch.reshape(feature_map, (batch_size, num_patches_height * num_patches_width, hidden_dim))
 
         # Reshape from [batch_size * max_text_queries, hidden_dim] -> [batch_size, max_text_queries, hidden_dim]
         max_text_queries = input_ids.shape[0] // batch_size

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -947,39 +947,6 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
         ).to(torch_device)
         self.assertTrue(torch.allclose(outputs.pred_boxes[0, :3, :3], expected_slice_boxes, atol=1e-4))
 
-        # (1264 // 16), (1024 // 16) -> num_patches (79, 64)
-        expected_box_bias = torch.tensor(
-            [
-                [-4.1369, -4.3489, -4.1369, -4.3489],
-                [-3.4309, -4.3489, -4.1369, -4.3489],
-                [-3.0102, -4.3489, -4.1369, -4.3489],
-            ]
-        )
-        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
-
-        processor.image_processor.size = {"height": 1024, "width": 1268}
-        image = prepare_img()
-        inputs = processor(
-            text=[["a photo of a cat", "a photo of a dog"]],
-            images=image,
-            max_length=16,
-            padding="max_length",
-            return_tensors="pt",
-        ).to(torch_device)
-
-        with torch.no_grad():
-            outputs = model(**inputs, interpolate_pos_encoding=True)
-
-        expected_box_bias = torch.tensor(
-            [
-                [-4.3489, -4.1369, -4.3489, -4.1369],
-                [-3.6468, -4.1369, -4.3489, -4.1369],
-                [-3.2296, -4.1369, -4.3489, -4.1369],
-            ]
-        )
-        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
-
-        processor.image_processor.size = {"height": 1264, "width": 1024}
         query_image = prepare_img()
         inputs = processor(
             images=image,

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -939,15 +939,47 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
 
         num_queries = int(
             (inputs.pixel_values.shape[-2] // model.config.vision_config.patch_size)
-            * (inputs.pixel_values.shape[-1] / model.config.vision_config.patch_size)
+            * (inputs.pixel_values.shape[-1] // model.config.vision_config.patch_size)
         )
         self.assertEqual(outputs.pred_boxes.shape, torch.Size((1, num_queries, 4)))
         expected_slice_boxes = torch.tensor(
-            [[0.2068, 0.1142, 0.4153], [0.1126, 0.0528, 0.2040], [0.2080, 0.0524, 0.3914]]
+            [[0.2438, 0.0945, 0.4675], [0.1361, 0.0431, 0.2406], [0.2465, 0.0428, 0.4429]]
         ).to(torch_device)
-
         self.assertTrue(torch.allclose(outputs.pred_boxes[0, :3, :3], expected_slice_boxes, atol=1e-4))
 
+        # (1264 // 16), (1024 // 16) -> num_patches (79, 64)
+        expected_box_bias = torch.tensor(
+            [
+                [-4.1369, -4.3489, -4.1369, -4.3489],
+                [-3.4309, -4.3489, -4.1369, -4.3489],
+                [-3.0102, -4.3489, -4.1369, -4.3489],
+            ]
+        )
+        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
+
+        processor.image_processor.size = {"height": 1024, "width": 1268}
+        image = prepare_img()
+        inputs = processor(
+            text=[["a photo of a cat", "a photo of a dog"]],
+            images=image,
+            max_length=16,
+            padding="max_length",
+            return_tensors="pt",
+        ).to(torch_device)
+
+        with torch.no_grad():
+            outputs = model(**inputs, interpolate_pos_encoding=True)
+
+        expected_box_bias = torch.tensor(
+            [
+                [-4.3489, -4.1369, -4.3489, -4.1369],
+                [-3.6468, -4.1369, -4.3489, -4.1369],
+                [-3.2296, -4.1369, -4.3489, -4.1369],
+            ]
+        )
+        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
+
+        processor.image_processor.size = {"height": 1264, "width": 1024}
         query_image = prepare_img()
         inputs = processor(
             images=image,
@@ -963,7 +995,7 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
         # No need to check the logits, we just check inference runs fine.
         num_queries = int(
             (inputs.pixel_values.shape[-2] // model.config.vision_config.patch_size)
-            * (inputs.pixel_values.shape[-1] / model.config.vision_config.patch_size)
+            * (inputs.pixel_values.shape[-1] // model.config.vision_config.patch_size)
         )
         self.assertEqual(outputs.target_pred_boxes.shape, torch.Size((1, num_queries, 4)))
 

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -940,38 +940,6 @@ class OwlViTModelIntegrationTest(unittest.TestCase):
         ).to(torch_device)
         self.assertTrue(torch.allclose(outputs.pred_boxes[0, :3, :3], expected_slice_boxes, atol=1e-4))
 
-        # (1264 // 32), (1024 // 32) -> num_patches (39, 32)
-        expected_box_bias = torch.tensor(
-            [
-                [-3.4309, -3.6338, -3.4309, -3.6338],
-                [-2.7066, -3.6338, -3.4309, -3.6338],
-                [-2.2677, -3.6338, -3.4309, -3.6338],
-            ]
-        )
-        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
-
-        processor.image_processor.size = {"height": 1024, "width": 1268}
-        image = prepare_img()
-        inputs = processor(
-            text=[["a photo of a cat", "a photo of a dog"]],
-            images=image,
-            max_length=16,
-            padding="max_length",
-            return_tensors="pt",
-        ).to(torch_device)
-
-        with torch.no_grad():
-            outputs = model(**inputs, interpolate_pos_encoding=True)
-
-        expected_box_bias = torch.tensor(
-            [
-                [-3.6338, -3.4309, -3.6338, -3.4309],
-                [-2.9159, -3.4309, -3.6338, -3.4309],
-                [-2.4837, -3.4309, -3.6338, -3.4309],
-            ]
-        )
-        self.assertTrue(torch.allclose(model.box_bias[:3, :4], expected_box_bias, atol=1e-4))
-
         query_image = prepare_img()
         inputs = processor(
             images=image,

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -822,6 +822,91 @@ class OwlViTModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.allclose(outputs.logits_per_image, expected_logits, atol=1e-3))
 
     @slow
+    def test_inference_interpolate_pos_encoding(self):
+        model_name = "google/owlvit-base-patch32"
+        model = OwlViTModel.from_pretrained(model_name).to(torch_device)
+        processor = OwlViTProcessor.from_pretrained(model_name)
+        processor.image_processor.size = {"height": 800, "width": 800}
+
+        image = prepare_img()
+        inputs = processor(
+            text=[["a photo of a cat", "a photo of a dog"]],
+            images=image,
+            max_length=16,
+            padding="max_length",
+            return_tensors="pt",
+        ).to(torch_device)
+
+        # forward pass
+        with torch.no_grad():
+            outputs = model(**inputs, interpolate_pos_encoding=True)
+
+        # verify the logits
+        self.assertEqual(
+            outputs.logits_per_image.shape,
+            torch.Size((inputs.pixel_values.shape[0], inputs.input_ids.shape[0])),
+        )
+        self.assertEqual(
+            outputs.logits_per_text.shape,
+            torch.Size((inputs.input_ids.shape[0], inputs.pixel_values.shape[0])),
+        )
+        expected_logits = torch.tensor([[3.6278, 0.8861]], device=torch_device)
+        self.assertTrue(torch.allclose(outputs.logits_per_image, expected_logits, atol=1e-3))
+
+        expected_shape = torch.Size((1, 626, 768))
+        self.assertEqual(outputs.vision_model_output.last_hidden_state.shape, expected_shape)
+
+        # OwlViTForObjectDetection part.
+        model = OwlViTForObjectDetection.from_pretrained(model_name).to(torch_device)
+
+        with torch.no_grad():
+            outputs = model(**inputs, interpolate_pos_encoding=True)
+
+        num_queries = int((inputs.pixel_values.shape[-1] // model.config.vision_config.patch_size) ** 2)
+        self.assertEqual(outputs.pred_boxes.shape, torch.Size((1, num_queries, 4)))
+
+        expected_slice_boxes = torch.tensor(
+            [[0.0680, 0.0422, 0.1347], [0.2071, 0.0450, 0.4146], [0.2000, 0.0418, 0.3476]]
+        ).to(torch_device)
+        self.assertTrue(torch.allclose(outputs.pred_boxes[0, :3, :3], expected_slice_boxes, atol=1e-4))
+
+        model = OwlViTForObjectDetection.from_pretrained(model_name).to(torch_device)
+        query_image = prepare_img()
+        inputs = processor(
+            images=image,
+            query_images=query_image,
+            max_length=16,
+            padding="max_length",
+            return_tensors="pt",
+        ).to(torch_device)
+
+        with torch.no_grad():
+            outputs = model.image_guided_detection(**inputs, interpolate_pos_encoding=True)
+
+        # No need to check the logits, we just check inference runs fine.
+        num_queries = int((inputs.pixel_values.shape[-1] / model.config.vision_config.patch_size) ** 2)
+        self.assertEqual(outputs.target_pred_boxes.shape, torch.Size((1, num_queries, 4)))
+
+        # Deactivate interpolate_pos_encoding on same model, and use default image size.
+        # Verify the dynamic change caused by the activation/deactivation of interpolate_pos_encoding of variables: self.sqrt_num_patches, self.box_bias from (OwlViTForObjectDetection).
+        processor = OwlViTProcessor.from_pretrained(model_name)
+
+        image = prepare_img()
+        inputs = processor(
+            text=[["a photo of a cat", "a photo of a dog"]],
+            images=image,
+            max_length=16,
+            padding="max_length",
+            return_tensors="pt",
+        ).to(torch_device)
+
+        with torch.no_grad():
+            outputs = model(**inputs, interpolate_pos_encoding=False)
+
+        num_queries = int((inputs.pixel_values.shape[-1] // model.config.vision_config.patch_size) ** 2)
+        self.assertEqual(outputs.pred_boxes.shape, torch.Size((1, num_queries, 4)))
+
+    @slow
     def test_inference_object_detection(self):
         model_name = "google/owlvit-base-patch32"
         model = OwlViTForObjectDetection.from_pretrained(model_name).to(torch_device)


### PR DESCRIPTION
# What does this PR do?

Towards https://github.com/huggingface/transformers/issues/30579
Hey, this is a draft, Im wondering how can we manage the variables impacted by the dynamic input change in the OwlViTForObjectDetection class (self.sqrt_num_patches, self.box_bias) ?
Is there a better way to handle this ?

The interpolate_pos_encoding allows new input size respecting height==width strictly  ? 
In that case I should ensure this.
If not, I think  sqrt_num_patches needs to be decomposed too (_h, _w), some examples where it might throws exc:
https://github.com/bastrob/transformers/blob/30f3c2d56729974ec0d1d9e2fc4fd633ab697eb2/src/transformers/models/owlvit/modeling_owlvit.py#L1355
https://github.com/bastrob/transformers/blob/30f3c2d56729974ec0d1d9e2fc4fd633ab697eb2/src/transformers/models/owlvit/modeling_owlvit.py#L1459
https://github.com/bastrob/transformers/blob/30f3c2d56729974ec0d1d9e2fc4fd633ab697eb2/src/transformers/models/owlvit/modeling_owlvit.py#L1719

Fixes: #34622

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@amyeroberts
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
