### PR TITLE
[docs] add XPU besides CUDA, MPS etc.

### DIFF
--- a/docs/source/en/quantization/quanto.md
+++ b/docs/source/en/quantization/quanto.md
@@ -28,7 +28,7 @@ Try Quanto + transformers with this [notebook](https://colab.research.google.com
 - weights quantization (`float8`,`int8`,`int4`,`int2`)
 - activation quantization (`float8`,`int8`)
 - modality agnostic (e.g CV,LLM)
-- device agnostic (e.g CUDA,MPS,CPU)
+- device agnostic (e.g CUDA,XPU,MPS,CPU)
 - compatibility with `torch.compile`
 - easy to add custom kernel for specific device
 - supports quantization aware training


### PR DESCRIPTION
## What does this PR do?
We should have XPU as one option in device-agnostic. 

Documentation: @stevhliu

