### PR TITLE
LLaVA OV: fix unpadding precision

### DIFF
--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -152,7 +152,8 @@ class LlavaNextProcessor(ProcessorMixin):
                 for sample in text:
                     while self.image_token in sample:
                         image_size = next(image_sizes)
-                        orig_height, orig_width = image_size
+                        # cast to list to avoid numerical precision errors when calculating unpadding
+                        orig_height, orig_width = image_size.tolist()
                         num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                         if self.vision_feature_select_strategy == "default":
                             num_image_tokens -= 1

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -152,8 +152,9 @@ class LlavaNextProcessor(ProcessorMixin):
                 for sample in text:
                     while self.image_token in sample:
                         image_size = next(image_sizes)
-                        # cast to list to avoid numerical precision errors when calculating unpadding
-                        orig_height, orig_width = image_size.tolist()
+                        if not isinstance(image_size, (list, tuple)):
+                            # cast to list to avoid numerical precision errors when calculating unpadding
+                            orig_height, orig_width = image_size.tolist()
                         num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                         if self.vision_feature_select_strategy == "default":
                             num_image_tokens -= 1

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -177,7 +177,8 @@ class LlavaNextVideoProcessor(ProcessorMixin):
                 for sample in text:
                     while self.image_token in sample:
                         image_size = next(image_sizes)
-                        orig_height, orig_width = image_size
+                        # cast to list to avoid numerical precision errors when calculating unpadding
+                        orig_height, orig_width = image_size.tolist()
                         num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                         if self.vision_feature_select_strategy == "default":
                             num_image_tokens -= 1

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -177,8 +177,9 @@ class LlavaNextVideoProcessor(ProcessorMixin):
                 for sample in text:
                     while self.image_token in sample:
                         image_size = next(image_sizes)
-                        # cast to list to avoid numerical precision errors when calculating unpadding
-                        orig_height, orig_width = image_size.tolist()
+                        if not isinstance(image_size, (list, tuple)):
+                            # cast to list to avoid numerical precision errors when calculating unpadding
+                            orig_height, orig_width = image_size.tolist()
                         num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                         if self.vision_feature_select_strategy == "default":
                             num_image_tokens -= 1

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -189,9 +189,8 @@ class LlavaOnevisionProcessor(ProcessorMixin):
             while special_token in sample:
                 image_size_list = next(image_sizes)
                 original_size = image_size_list[0] if num_frames != 1 else image_size_list
-                orig_height, orig_width = (
-                    original_size.tolist()
-                )  # cast to list to avoid numerical precision errors when calculating unpadding
+                # cast to list to avoid numerical precision errors when calculating unpadding
+                orig_height, orig_width = original_size.tolist()
                 num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                 if self.vision_feature_select_strategy == "default":
                     num_image_tokens -= 1

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -189,8 +189,9 @@ class LlavaOnevisionProcessor(ProcessorMixin):
             while special_token in sample:
                 image_size_list = next(image_sizes)
                 original_size = image_size_list[0] if num_frames != 1 else image_size_list
-                # cast to list to avoid numerical precision errors when calculating unpadding
-                orig_height, orig_width = original_size.tolist()
+                if not isinstance(original_size, (list, tuple)):
+                    # cast to list to avoid numerical precision errors when calculating unpadding
+                    orig_height, orig_width = original_size.tolist()
                 num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                 if self.vision_feature_select_strategy == "default":
                     num_image_tokens -= 1

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -188,7 +188,10 @@ class LlavaOnevisionProcessor(ProcessorMixin):
         for sample in text:
             while special_token in sample:
                 image_size_list = next(image_sizes)
-                orig_height, orig_width = image_size_list[0] if num_frames != 1 else image_size_list
+                original_size = image_size_list[0] if num_frames != 1 else image_size_list
+                orig_height, orig_width = (
+                    original_size.tolist()
+                )  # cast to list to avoid numerical precision errors when calculating unpadding
                 num_image_tokens = self._get_number_of_features(orig_height, orig_width, height, width)
                 if self.vision_feature_select_strategy == "default":
                     num_image_tokens -= 1


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/34625. There was a small precision error in unpadding because the modeling code casts the size to list, while processing code works with tensors. This PR casts everything to list to match the calculations 