### PR TITLE
add a new flax example for Bert model inference

### DIFF
--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -548,11 +548,11 @@ python3 -m torch.distributed.launch --nproc_per_node ${NUM_GPUS} run_mlm.py \
 The following example demonstrates performing inference with a language model using the JAX/Flax backend.
 
 The example script run_bert_flax.py uses bert-base-uncased, and the model is loaded into `FlaxBertModel`.
-The input data are just random generated tokens, and the model is also jitted with JAX.
-By default, it uses float32 precision for inference, users could use below commands to run inference with float32.
+The input data are randomly generated tokens, and the model is also jitted with JAX.
+By default, it uses float32 precision for inference. To enable bfloat16, add the flag shown in the command below.
+
 ```bash
-python3 run_bert_flax.py
-```
+python3 run_bert_flax.py --precision bfloat16
 > NOTE: For JAX Versions after v0.4.33 or later, users will need to set the below environment variables as a \
 > temporary workaround to use Bfloat16 datatype. \
 > This restriction is expected to be removed in future version

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -565,9 +565,4 @@ By changing the dtype for `FlaxBertModel `to `jax.numpy.bfloat16`, you get the p
 import jax
 model = FlaxBertModel.from_pretrained("bert-base-uncased", config=config, dtype=jax.numpy.bfloat16)
 ```
-To evaluate the performance speedup on bfloat16, users just need to add an argument "--precision bfloat16" for this example.
-
-```bash
-python3 run_bert_flax.py --precision bfloat16
-```
 On a AWS c7i.4xlarge with Intel Sapphire Rapids, we get  > 2X speedup by changing precision from float32 to bfloat16.

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -565,4 +565,4 @@ By changing the dtype for `FlaxBertModel `to `jax.numpy.bfloat16`, you get the p
 import jax
 model = FlaxBertModel.from_pretrained("bert-base-uncased", config=config, dtype=jax.numpy.bfloat16)
 ```
-On a AWS c7i.4xlarge with Intel Sapphire Rapids, we get  > 2X speedup by changing precision from float32 to bfloat16.
+Switching from float32 to bfloat16 can increase the speed of an AWS c7i.4xlarge with Intel Sapphire Rapids by more than 2x.

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -559,9 +559,8 @@ python3 run_bert_flax.py --precision bfloat16
 ```bash
 export XLA_FLAGS=--xla_cpu_use_thunk_runtime=false
 ```
-Bfloat16 will give better performance on GPUs, and also Intel CPUs (Sapphire Rapids or later) with Advanced Matrix Extension (Intel AMX).  
-By changing the dtype for FlaxBertModel to jax.numpy.bfloat16, users will get the performance benefits of underling hardware support.
-on this Bert example.
+bfloat16 gives better performance on GPUs and also Intel CPUs (Sapphire Rapids or later) with Advanced Matrix Extension (Intel AMX).  
+By changing the dtype for `FlaxBertModel `to `jax.numpy.bfloat16`, you get the performance benefits of the underlying hardware.
 ```python
 import jax
 model = FlaxBertModel.from_pretrained("bert-base-uncased", config=config, dtype=jax.numpy.bfloat16)

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -547,7 +547,7 @@ python3 -m torch.distributed.launch --nproc_per_node ${NUM_GPUS} run_mlm.py \
 
 The following example demonstrates performing inference with a language model using the JAX/Flax backend.
 
-The example run_bert_flax.py uses bert-base-uncased and the model is loaded into FlaxBertModel.
+The example script run_bert_flax.py uses bert-base-uncased, and the model is loaded into `FlaxBertModel`.
 The input data are just random generated tokens, and the model is also jitted with JAX.
 By default, it uses float32 precision for inference, users could use below commands to run inference with float32.
 ```bash

--- a/examples/flax/language-modeling/README.md
+++ b/examples/flax/language-modeling/README.md
@@ -543,8 +543,9 @@ python3 -m torch.distributed.launch --nproc_per_node ${NUM_GPUS} run_mlm.py \
     --save_strategy="no"
 ```
 
-## Language model inference on BFloat16
-The following example showcases how to inference a language model using the JAX/Flax backend.
+## Language model inference with bfloat16
+
+The following example demonstrates performing inference with a language model using the JAX/Flax backend.
 
 The example run_bert_flax.py uses bert-base-uncased and the model is loaded into FlaxBertModel.
 The input data are just random generated tokens, and the model is also jitted with JAX.

--- a/examples/flax/language-modeling/run_bert_flax.py
+++ b/examples/flax/language-modeling/run_bert_flax.py
@@ -1,49 +1,56 @@
 #!/usr/bin/env python3
+import time
 from argparse import ArgumentParser
 
 import jax
-from transformers import AutoTokenizer, FlaxBertModel, BertConfig
 import numpy as np
 
+from transformers import BertConfig, FlaxBertModel
+
+
 parser = ArgumentParser()
-parser.add_argument('--precision', type=str, choices=["float32", "bfloat16"], default="float32")
+parser.add_argument("--precision", type=str, choices=["float32", "bfloat16"], default="float32")
 args = parser.parse_args()
 
 dtype = jax.numpy.float32
 if args.precision == "bfloat16":
-  dtype = jax.numpy.bfloat16
+    dtype = jax.numpy.bfloat16
 
 VOCAB_SIZE = 30522
 BS = 32
 SEQ_LEN = 128
 
+
 def get_input_data(batch_size=1, seq_length=384):
-  shape = (batch_size, seq_length)
-  input_ids = np.random.randint(1, VOCAB_SIZE, size=shape).astype(np.int32)
-  token_type_ids = np.ones(shape).astype(np.int32)
-  attention_mask  = np.ones(shape).astype(np.int32)
-  return { 'input_ids': input_ids, 'token_type_ids': token_type_ids, 'attention_mask': attention_mask }
+    shape = (batch_size, seq_length)
+    input_ids = np.random.randint(1, VOCAB_SIZE, size=shape).astype(np.int32)
+    token_type_ids = np.ones(shape).astype(np.int32)
+    attention_mask = np.ones(shape).astype(np.int32)
+    return {"input_ids": input_ids, "token_type_ids": token_type_ids, "attention_mask": attention_mask}
+
 
 inputs = get_input_data(BS, SEQ_LEN)
 config = BertConfig.from_pretrained("bert-base-uncased", hidden_act="gelu_new")
 model = FlaxBertModel.from_pretrained("bert-base-uncased", config=config, dtype=dtype)
 
+
 @jax.jit
 def func():
-  outputs = model(**inputs)
-  return outputs
+    outputs = model(**inputs)
+    return outputs
+
 
 (nwarmup, nbenchmark) = (5, 100)
 
 # warmpup
 for _ in range(nwarmup):
-  func()
+    func()
 
 # benchmark
-import time
+
 start = time.time()
 for _ in range(nbenchmark):
-  func()
+    func()
 end = time.time()
-print(end-start)
+print(end - start)
 print(f"Throughput: {((nbenchmark * BS)/(end-start)):.3f} examples/sec")

--- a/examples/flax/language-modeling/run_bert_flax.py
+++ b/examples/flax/language-modeling/run_bert_flax.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+
+import jax
+from transformers import AutoTokenizer, FlaxBertModel, BertConfig
+import numpy as np
+
+parser = ArgumentParser()
+parser.add_argument('--precision', type=str, choices=["float32", "bfloat16"], default="float32")
+args = parser.parse_args()
+
+dtype = jax.numpy.float32
+if args.precision == "bfloat16":
+  dtype = jax.numpy.bfloat16
+
+VOCAB_SIZE = 30522
+BS = 32
+SEQ_LEN = 128
+
+def get_input_data(batch_size=1, seq_length=384):
+  shape = (batch_size, seq_length)
+  input_ids = np.random.randint(1, VOCAB_SIZE, size=shape).astype(np.int32)
+  token_type_ids = np.ones(shape).astype(np.int32)
+  attention_mask  = np.ones(shape).astype(np.int32)
+  return { 'input_ids': input_ids, 'token_type_ids': token_type_ids, 'attention_mask': attention_mask }
+
+inputs = get_input_data(BS, SEQ_LEN)
+config = BertConfig.from_pretrained("bert-base-uncased", hidden_act="gelu_new")
+model = FlaxBertModel.from_pretrained("bert-base-uncased", config=config, dtype=dtype)
+
+@jax.jit
+def func():
+  outputs = model(**inputs)
+  return outputs
+
+(nwarmup, nbenchmark) = (5, 100)
+
+# warmpup
+for _ in range(nwarmup):
+  func()
+
+# benchmark
+import time
+start = time.time()
+for _ in range(nbenchmark):
+  func()
+end = time.time()
+print(end-start)
+print(f"Throughput: {((nbenchmark * BS)/(end-start)):.3f} examples/sec")


### PR DESCRIPTION
# What does this PR do?

Add a new Flax inference example and show case how to optimize performance with Bfloat16 data types.
Most of the Flax examples are for Training/Fine Tuning, so it should be a good reference for inference



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?



@ArthurZucker
@sanchit-gandhi
@stevhliu
@agramesh1
@mdfaijul