### PR TITLE
[`peft`] Given that `self.active_adapter` is deprecated, avoid using it

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -457,7 +457,7 @@ class PeftAdapterMixin:
         from peft import get_peft_model_state_dict
 
         if adapter_name is None:
-            adapter_name = self.active_adapter()
+            adapter_name = self.active_adapters()[0]
 
         adapter_state_dict = get_peft_model_state_dict(self, adapter_name=adapter_name)
         return adapter_state_dict

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -381,7 +381,7 @@ class PeftAdapterMixin:
         If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
         official documentation: https://huggingface.co/docs/peft
 
-        Enable adapters that are attached to the model. The model will use `self.active_adapter()`
+        Enable adapters that are attached to the model.
         """
         check_peft_version(min_version=MIN_PEFT_VERSION)
 


### PR DESCRIPTION
# What does this PR do?

`PeftAdapterMixin.active_adapter` has been deprecated since #26407 added multi-adapter support, but it's still being used in `PeftAdapterMixin.get_adapter_state_dict`. This results in a FutureWarning every time I save a checkpoint after training with `model.add_adapter(...)`.

This PR updates the latter to use the correct `PeftAdapterMixin.active_adapters()[0]` method instead, which is identical in behaviour, except minus the warning.

The deprecated `active_adapter`: https://github.com/huggingface/transformers/blob/54739a320e38bc86cd250303a35e68d5d3f14a83/src/transformers/integrations/peft.py#L433-L438

Additionally, the comment 
```
The model will use `self.active_adapter()`
```
in `enable_adapters` seemed to be a bit misleading - that method wasn't being used. For clarity, I removed it.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @BenjaminBossan

- Tom Aarsen
