### PR TITLE
Fix `check_training_gradient_checkpointing`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -847,7 +847,9 @@ class ModelTesterMixin:
                     ]
                     or not model_class.supports_gradient_checkpointing
                 ):
-                    self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
+                    # TODO (ydshieh): use `skipTest` once pytest-dev/pytest-subtests/pull/169 is merged
+                    # self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
+                    continue
 
                 config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
                 config.use_cache = False


### PR DESCRIPTION
# What does this PR do?

Currently inour CI runners' environment, there is no `pytest-subtests` installed. In this case, using `subTest` with `skipTest` in it will skip the whole test even if our goal is to just skip that `subTest` and continue to the next step in the for loop. In `check_training_gradient_checkpointing`, the first `model_class` is the base model and it calls `skipTest` and no other `model_class` being checked.

However, `pytest-subtests` has some issues regarding the reporting. A PR is opened https://github.com/pytest-dev/pytest-subtests/pull/169.

In the meantime, let's use `continue` for now instead of `skipTest` so we can really test gradient checkpointing.