### PR TITLE
Run `test_medium_seamless_m4t_pt` in `subprocess` to avoid many failures

### DIFF
--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -67,10 +67,9 @@ class TextToAudioPipelineTests(unittest.TestCase):
         audio = [output["audio"] for output in outputs]
         self.assertEqual([ANY(np.ndarray), ANY(np.ndarray)], audio)
 
-    # TODO: @ylacombe
+    # TODO: @ylacombe: `SeamlessM4TForTextToSpeech.generate` has issue with `generation_config`. See issue #34811
     @slow
     @require_torch
-    # @unittest.skip("`SeamlessM4TForTextToSpeech.generate` has issue with `generation_config`. See issue #34811")
     @run_test_using_subprocess
     def test_medium_seamless_m4t_pt(self):
         speech_generator = pipeline(task="text-to-audio", model="facebook/hf-seamless-m4t-medium", framework="pt")

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -66,8 +66,10 @@ class TextToAudioPipelineTests(unittest.TestCase):
         audio = [output["audio"] for output in outputs]
         self.assertEqual([ANY(np.ndarray), ANY(np.ndarray)], audio)
 
+    # TODO: @ylacombe
     @slow
     @require_torch
+    @unittest.skip("`SeamlessM4TForTextToSpeech.generate` has issue with `generation_config`. See issue #34811")
     def test_medium_seamless_m4t_pt(self):
         speech_generator = pipeline(task="text-to-audio", model="facebook/hf-seamless-m4t-medium", framework="pt")
 

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -27,6 +27,7 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_or_tf,
+    run_test_using_subprocess,
     slow,
     torch_device,
 )
@@ -69,7 +70,8 @@ class TextToAudioPipelineTests(unittest.TestCase):
     # TODO: @ylacombe
     @slow
     @require_torch
-    @unittest.skip("`SeamlessM4TForTextToSpeech.generate` has issue with `generation_config`. See issue #34811")
+    # @unittest.skip("`SeamlessM4TForTextToSpeech.generate` has issue with `generation_config`. See issue #34811")
+    @run_test_using_subprocess
     def test_medium_seamless_m4t_pt(self):
         speech_generator = pipeline(task="text-to-audio", model="facebook/hf-seamless-m4t-medium", framework="pt")
 


### PR DESCRIPTION
# What does this PR do?

This (pipeline) test 

> test_medium_seamless_m4t_pt

is always failing all the time. 

Previously, the pipeline test is running on CPU, but after #34026, it's running on GPU if available.

And with the issue #34811, this failed test affect many subsequent pipeline tests because of

> RuntimeError: CUDA error: device-side assert triggered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect. 