### PR TITLE
Bump Replicate guard to torch 2.5

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -30,6 +30,7 @@ logger = logging.get_logger(__name__)
 
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
+is_torch_greater_or_equal_than_2_5 = parsed_torch_version_base >= version.parse("2.5")
 is_torch_greater_or_equal_than_2_4 = parsed_torch_version_base >= version.parse("2.4")
 is_torch_greater_or_equal_than_2_3 = parsed_torch_version_base >= version.parse("2.3")
 is_torch_greater_or_equal_than_2_2 = parsed_torch_version_base >= version.parse("2.2")
@@ -39,7 +40,7 @@ is_torch_greater_or_equal_than_1_13 = parsed_torch_version_base >= version.parse
 is_torch_greater_or_equal_than_1_12 = parsed_torch_version_base >= version.parse("1.12")
 
 
-if is_torch_greater_or_equal_than_2_4:
+if is_torch_greater_or_equal_than_2_5:
     from torch.distributed.tensor import Replicate
     from torch.distributed.tensor.parallel import (
         ColwiseParallel,


### PR DESCRIPTION
# What does this PR do?

With torch 2.4 `transformers` imports fail on

```
from torch.distributed.tensor import Replicate
```

this PR update import guard to torch >= 2.5

Fixes #34831

## Who can review?

