### PR TITLE
[CI] Skip EETQ tests while package is broken with latest transformers

### DIFF
--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -64,6 +64,8 @@ class EetqHfQuantizer(HfQuantizer):
                     "You are using a version of EETQ that is incompatible with the current transformers version. "
                     "Either downgrade transformers to <= v4.46.3 or, if available, upgrade EETQ to > v1.0.0."
                 ) from exc
+            else:
+                raise
 
         if not is_accelerate_available():
             raise ImportError("Loading an EETQ quantized model requires accelerate (`pip install accelerate`)")

--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -53,6 +53,18 @@ class EetqHfQuantizer(HfQuantizer):
                 "Please install the latest version of eetq from : https://github.com/NetEase-FuXi/EETQ"
             )
 
+        try:
+            import eetq  # noqa: F401
+        except ImportError as exc:
+            if "shard_checkpoint" in str(exc):
+                # EETQ 1.0.0 is currently broken with the latest transformers because it tries to import the removed
+                # shard_checkpoint function, see https://github.com/NetEase-FuXi/EETQ/issues/34.
+                # TODO: Update message once eetq releases a fix
+                raise ImportError(
+                    "You are using a version of EETQ that is incompatible with the current transformers version. "
+                    "Either downgrade transformers to <= v4.46.3 or, if available, upgrade EETQ to > v1.0.0."
+                ) from exc
+
         if not is_accelerate_available():
             raise ImportError("Loading an EETQ quantized model requires accelerate (`pip install accelerate`)")
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1143,7 +1143,17 @@ def require_eetq(test_case):
     """
     Decorator marking a test that requires eetq
     """
-    return unittest.skipUnless(is_eetq_available(), "test requires eetq")(test_case)
+    eetq_available = is_eetq_available()
+    if eetq_available:
+        try:
+            from eetq import EetqLinear  # noqa: F401
+        except ImportError as exc:
+            if "shard_checkpoint" in str(exc):
+                # EETQ is currently broken with the latest transformers because it tries to import the removed
+                # shard_checkpoint function, see https://github.com/NetEase-FuXi/EETQ/issues/34.
+                # TODO: Remove once eetq releases a fix and this release is used in CI
+                eetq_available = False
+    return unittest.skipUnless(eetq_available, "test requires eetq")(test_case)
 
 
 def require_av(test_case):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1146,10 +1146,10 @@ def require_eetq(test_case):
     eetq_available = is_eetq_available()
     if eetq_available:
         try:
-            from eetq import EetqLinear  # noqa: F401
+            import eetq  # noqa: F401
         except ImportError as exc:
             if "shard_checkpoint" in str(exc):
-                # EETQ is currently broken with the latest transformers because it tries to import the removed
+                # EETQ 1.0.0 is currently broken with the latest transformers because it tries to import the removed
                 # shard_checkpoint function, see https://github.com/NetEase-FuXi/EETQ/issues/34.
                 # TODO: Remove once eetq releases a fix and this release is used in CI
                 eetq_available = False


### PR DESCRIPTION
# What does this PR do?

EETQ tries to import the `shard_checkpoint` function from transformers but the function has been removed. Therefore, trying to use EETQ currently results in an import error. This fix results in EETQ tests being skipped if there is an import error.

The issue has been reported to EETQ:

https://github.com/NetEase-FuXi/EETQ/issues/34

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?