### PR TITLE
Bitnet test fix to avoid using gated  model

### DIFF
--- a/tests/quantization/bitnet_integration/test_bitnet.py
+++ b/tests/quantization/bitnet_integration/test_bitnet.py
@@ -65,7 +65,7 @@ class BitNetTest(unittest.TestCase):
         """
         Load the model
         """
-        cls.tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B-Instruct")
+        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
         cls.quantized_model = AutoModelForCausalLM.from_pretrained(cls.model_name, device_map=cls.device)
 
     def tearDown(self):


### PR DESCRIPTION
# What does this PR do?
Simple fix  to fix the test for bitnet in the CI. Instead of using a gated repo we use a public one.

## Who can review ?
@SunMarc 