### PR TITLE
Skip eetq test if it attempts to import shard_checkpoint

### DIFF
--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -7,64 +7,64 @@ on:
     - cron: "17 2 * * *"
   push:
     branches:
-      - run_scheduled_ci*
+      - fix_eetq_test
 
 jobs:
-  model-ci:
-    name: Model CI
-    uses: ./.github/workflows/self-scheduled.yml
-    with:
-      job: run_models_gpu
-      slack_report_channel: "#transformers-ci-daily-models"
-      runner: daily-ci
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-    secrets: inherit
+  # model-ci:
+  #   name: Model CI
+  #   uses: ./.github/workflows/self-scheduled.yml
+  #   with:
+  #     job: run_models_gpu
+  #     slack_report_channel: "#transformers-ci-daily-models"
+  #     runner: daily-ci
+  #     docker: huggingface/transformers-all-latest-gpu
+  #     ci_event: Daily CI
+  #   secrets: inherit
 
-  torch-pipeline:
-    name: Torch pipeline CI
-    uses: ./.github/workflows/self-scheduled.yml
-    with:
-      job: run_pipelines_torch_gpu
-      slack_report_channel: "#transformers-ci-daily-pipeline-torch"
-      runner: daily-ci
-      docker: huggingface/transformers-pytorch-gpu
-      ci_event: Daily CI
-    secrets: inherit
+  # torch-pipeline:
+  #   name: Torch pipeline CI
+  #   uses: ./.github/workflows/self-scheduled.yml
+  #   with:
+  #     job: run_pipelines_torch_gpu
+  #     slack_report_channel: "#transformers-ci-daily-pipeline-torch"
+  #     runner: daily-ci
+  #     docker: huggingface/transformers-pytorch-gpu
+  #     ci_event: Daily CI
+  #   secrets: inherit
 
-  tf-pipeline:
-    name: TF pipeline CI
-    uses: ./.github/workflows/self-scheduled.yml
-    with:
-      job: run_pipelines_tf_gpu
-      slack_report_channel: "#transformers-ci-daily-pipeline-tf"
-      runner: daily-ci
-      docker: huggingface/transformers-tensorflow-gpu
-      ci_event: Daily CI
-    secrets: inherit
+  # tf-pipeline:
+  #   name: TF pipeline CI
+  #   uses: ./.github/workflows/self-scheduled.yml
+  #   with:
+  #     job: run_pipelines_tf_gpu
+  #     slack_report_channel: "#transformers-ci-daily-pipeline-tf"
+  #     runner: daily-ci
+  #     docker: huggingface/transformers-tensorflow-gpu
+  #     ci_event: Daily CI
+  #   secrets: inherit
 
-  example-ci:
-    name: Example CI
-    uses: ./.github/workflows/self-scheduled.yml
-    with:
-      job: run_examples_gpu
-      slack_report_channel: "#transformers-ci-daily-examples"
-      runner: daily-ci
-      docker: huggingface/transformers-all-latest-gpu
-      ci_event: Daily CI
-    secrets: inherit
+  # example-ci:
+  #   name: Example CI
+  #   uses: ./.github/workflows/self-scheduled.yml
+  #   with:
+  #     job: run_examples_gpu
+  #     slack_report_channel: "#transformers-ci-daily-examples"
+  #     runner: daily-ci
+  #     docker: huggingface/transformers-all-latest-gpu
+  #     ci_event: Daily CI
+  #   secrets: inherit
 
-  deepspeed-ci:
-    name: DeepSpeed CI
-    uses: ./.github/workflows/self-scheduled.yml
-    with:
-      job: run_torch_cuda_extensions_gpu
-      slack_report_channel: "#transformers-ci-daily-deepspeed"
-      runner: daily-ci
-      docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
-      ci_event: Daily CI
-      working-directory-prefix: /workspace
-    secrets: inherit
+  # deepspeed-ci:
+  #   name: DeepSpeed CI
+  #   uses: ./.github/workflows/self-scheduled.yml
+  #   with:
+  #     job: run_torch_cuda_extensions_gpu
+  #     slack_report_channel: "#transformers-ci-daily-deepspeed"
+  #     runner: daily-ci
+  #     docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
+  #     ci_event: Daily CI
+  #     working-directory-prefix: /workspace
+  #   secrets: inherit
 
   quantization-ci:
     name: Quantization CI

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -7,64 +7,64 @@ on:
     - cron: "17 2 * * *"
   push:
     branches:
-      - fix_eetq_test
+      - run_scheduled_ci*
 
 jobs:
-  # model-ci:
-  #   name: Model CI
-  #   uses: ./.github/workflows/self-scheduled.yml
-  #   with:
-  #     job: run_models_gpu
-  #     slack_report_channel: "#transformers-ci-daily-models"
-  #     runner: daily-ci
-  #     docker: huggingface/transformers-all-latest-gpu
-  #     ci_event: Daily CI
-  #   secrets: inherit
+  model-ci:
+    name: Model CI
+    uses: ./.github/workflows/self-scheduled.yml
+    with:
+      job: run_models_gpu
+      slack_report_channel: "#transformers-ci-daily-models"
+      runner: daily-ci
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+    secrets: inherit
 
-  # torch-pipeline:
-  #   name: Torch pipeline CI
-  #   uses: ./.github/workflows/self-scheduled.yml
-  #   with:
-  #     job: run_pipelines_torch_gpu
-  #     slack_report_channel: "#transformers-ci-daily-pipeline-torch"
-  #     runner: daily-ci
-  #     docker: huggingface/transformers-pytorch-gpu
-  #     ci_event: Daily CI
-  #   secrets: inherit
+  torch-pipeline:
+    name: Torch pipeline CI
+    uses: ./.github/workflows/self-scheduled.yml
+    with:
+      job: run_pipelines_torch_gpu
+      slack_report_channel: "#transformers-ci-daily-pipeline-torch"
+      runner: daily-ci
+      docker: huggingface/transformers-pytorch-gpu
+      ci_event: Daily CI
+    secrets: inherit
 
-  # tf-pipeline:
-  #   name: TF pipeline CI
-  #   uses: ./.github/workflows/self-scheduled.yml
-  #   with:
-  #     job: run_pipelines_tf_gpu
-  #     slack_report_channel: "#transformers-ci-daily-pipeline-tf"
-  #     runner: daily-ci
-  #     docker: huggingface/transformers-tensorflow-gpu
-  #     ci_event: Daily CI
-  #   secrets: inherit
+  tf-pipeline:
+    name: TF pipeline CI
+    uses: ./.github/workflows/self-scheduled.yml
+    with:
+      job: run_pipelines_tf_gpu
+      slack_report_channel: "#transformers-ci-daily-pipeline-tf"
+      runner: daily-ci
+      docker: huggingface/transformers-tensorflow-gpu
+      ci_event: Daily CI
+    secrets: inherit
 
-  # example-ci:
-  #   name: Example CI
-  #   uses: ./.github/workflows/self-scheduled.yml
-  #   with:
-  #     job: run_examples_gpu
-  #     slack_report_channel: "#transformers-ci-daily-examples"
-  #     runner: daily-ci
-  #     docker: huggingface/transformers-all-latest-gpu
-  #     ci_event: Daily CI
-  #   secrets: inherit
+  example-ci:
+    name: Example CI
+    uses: ./.github/workflows/self-scheduled.yml
+    with:
+      job: run_examples_gpu
+      slack_report_channel: "#transformers-ci-daily-examples"
+      runner: daily-ci
+      docker: huggingface/transformers-all-latest-gpu
+      ci_event: Daily CI
+    secrets: inherit
 
-  # deepspeed-ci:
-  #   name: DeepSpeed CI
-  #   uses: ./.github/workflows/self-scheduled.yml
-  #   with:
-  #     job: run_torch_cuda_extensions_gpu
-  #     slack_report_channel: "#transformers-ci-daily-deepspeed"
-  #     runner: daily-ci
-  #     docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
-  #     ci_event: Daily CI
-  #     working-directory-prefix: /workspace
-  #   secrets: inherit
+  deepspeed-ci:
+    name: DeepSpeed CI
+    uses: ./.github/workflows/self-scheduled.yml
+    with:
+      job: run_torch_cuda_extensions_gpu
+      slack_report_channel: "#transformers-ci-daily-deepspeed"
+      runner: daily-ci
+      docker: huggingface/transformers-pytorch-deepspeed-latest-gpu
+      ci_event: Daily CI
+      working-directory-prefix: /workspace
+    secrets: inherit
 
   quantization-ci:
     name: Quantization CI

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1006,6 +1006,17 @@ def is_auto_gptq_available():
 
 
 def is_eetq_available():
+    if not _eetq_available:
+        return _eetq_available
+
+    try:
+        from eetq import EetqLinear  # noqa: F401
+    except ImportError as exc:
+        if "shard_checkpoint" in str(exc):
+            # eetq is currently broken with newer transformers versions because it tries to import shard_checkpoint
+            # see https://github.com/NetEase-FuXi/EETQ/issues/34
+            # TODO: Remove once eetq releasees a fix and this release is used in CI
+            return False
     return _eetq_available
 
 


### PR DESCRIPTION
# What does this PR do?
PR inspired from peft by @BenjaminBossan https://github.com/huggingface/peft/pull/2226. 

EETQ attempts to import the shard_checkpoint function from the transformers library, but this function has been removed in the latest version. As a result, using EETQ currently causes an import error, leading to all tests failing. This fix ensures that EETQ tests are skipped if an import error occurs.

The issue is reported to EETQ: NetEase-FuXi/EETQ#34.

## Who can review  ?
@SunMarc 
