### PR TITLE
Fix failling GGML test

### DIFF
--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -623,8 +623,8 @@ class GgufIntegrationTests(unittest.TestCase):
             torch_dtype=torch.float16,
         )
 
-        text = tokenizer(self.example_text, return_tensors="pt").to(torch_device)
-        out = model.generate(**text, max_new_tokens=10)
+        text = tokenizer(self.example_text, return_tensors="pt")["input_ids"].to(torch_device)
+        out = model.generate(text, max_new_tokens=10)
 
         EXPECTED_TEXT = "Hello All,\nI am new to this forum."
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)


### PR DESCRIPTION
# What does this PR do?
This PR fixes a failling test in `test_ggml.py` related to the function `test_falcon7b_q2_k`. The error that was occuring is 
```
The following `model_kwargs` are not used by the model: ['token_type_ids'] (note: typos in the generate arguments will also show up in this list)
```
## Who can review ?
@SunMarc 