### PR TITLE
VitMaePreTrain Example norm_pix_loss arg set default to False

### DIFF
--- a/examples/pytorch/image-pretraining/README.md
+++ b/examples/pytorch/image-pretraining/README.md
@@ -160,7 +160,7 @@ python run_mae.py \
     --remove_unused_columns False \
     --label_names pixel_values \
     --mask_ratio 0.75 \
-    --norm_pix_loss \
+    --norm_pix_loss False\
     --do_train \
     --do_eval \
     --base_learning_rate 1.5e-4 \

--- a/examples/pytorch/image-pretraining/run_mae.py
+++ b/examples/pytorch/image-pretraining/run_mae.py
@@ -156,7 +156,7 @@ class ModelArguments:
         default=0.75, metadata={"help": "The ratio of the number of masked tokens in the input sequence."}
     )
     norm_pix_loss: bool = field(
-        default=True, metadata={"help": "Whether or not to train with normalized pixel values as target."}
+        default=False, metadata={"help": "Whether or not to train with normalized pixel values as target."}
     )
 
 


### PR DESCRIPTION
# What does this PR do?
Changes will set the default value of ```norm_pix_loss``` to ```False``` in ```run_mae.py``` and  explicitly set ```--norm_pix_loss``` to ```False``` in the example script.  This is a workaround for issue #29416 until the real problem can be solved in reference to the VitMae whitepaper suggesting to normalize pixel values. However, it seems that there is a deeper issue causing pixel outputs to be abnormal.


