### PR TITLE
Fix `test_auto_backbone_timm_model_from_pretrained`

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -239,7 +239,7 @@ class AutoModelTest(unittest.TestCase):
 
         # Check kwargs are correctly passed to the backbone
         model = AutoBackbone.from_pretrained("resnet18", use_timm_backbone=True, out_indices=(-2, -1))
-        self.assertEqual(model.out_indices, (-2, -1))
+        self.assertEqual(model.out_indices, [-2, -1])
 
         # Check out_features cannot be passed to Timm backbones
         with self.assertRaises(ValueError):


### PR DESCRIPTION
# What does this PR do?

This test assert `model.out_indices, (-2, -1)` and it was written on 2023/12.

However, we have

> out_indices = list(out_indices) if out_indices is not None else None

in `src/transformers/utils/backbone_utils.py` which is written on 2024/05

It's just time to update the test so we don't see it fails forever.