### PR TITLE
ViTImageproc handle pil hw images

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -392,7 +392,7 @@ def normalize(
         input_data_format = infer_channel_dimension_format(image)
 
     # if of ChannelDimension.NONE and not made HWC by resize, handle here
-    if ChannelDimension.NONE:
+    if input_data_format == ChannelDimension.NONE:
         input_data_format = ChannelDimension.LAST
         image = np.expand_dims(image, axis=-1) if image.ndim == 2 else image
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -203,11 +203,12 @@ def to_pil_image(
     elif not isinstance(image, np.ndarray):
         raise ValueError("Input image type not supported: {}".format(type(image)))
 
-    # If the channel has been moved to first dim, we put it back at the end.
-    image = to_channel_dimension_format(image, ChannelDimension.LAST, input_data_format)
+    # If the channel has been moved to first dim, we put it back at the end if not 2d image
+    if input_data_format != ChannelDimension.NONE and image.shape != 2:
+        image = to_channel_dimension_format(image, ChannelDimension.LAST, input_data_format)
 
-    # If there is a single channel, we squeeze it, as otherwise PIL can't handle it.
-    image = np.squeeze(image, axis=-1) if image.shape[-1] == 1 else image
+        # If there is a single channel, we squeeze it, as otherwise PIL can't handle it.
+        image = np.squeeze(image, axis=-1) if image.shape[-1] == 1 else image
 
     # PIL.Image can only store uint8 values so we rescale the image to be between 0 and 255 if needed.
     do_rescale = _rescale_for_pil_conversion(image) if do_rescale is None else do_rescale
@@ -349,9 +350,11 @@ def resize(
         # so we need to add it back if necessary.
         resized_image = np.expand_dims(resized_image, axis=-1) if resized_image.ndim == 2 else resized_image
         # The image is always in channels last format after converting from a PIL image
-        resized_image = to_channel_dimension_format(
-            resized_image, data_format, input_channel_dim=ChannelDimension.LAST
-        )
+        # if was initally a HW image then the added dim will be at the end already
+        if input_data_format != ChannelDimension.NONE:
+            resized_image = to_channel_dimension_format(
+                resized_image, data_format, input_channel_dim=ChannelDimension.LAST
+            )
         # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
         # rescale it back to the original range.
         resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
@@ -387,6 +390,11 @@ def normalize(
 
     if input_data_format is None:
         input_data_format = infer_channel_dimension_format(image)
+
+    # if of ChannelDimension.NONE and not made HWC by resize, handle here
+    if ChannelDimension.NONE:
+        input_data_format = ChannelDimension.LAST
+        image = np.expand_dims(image, axis=-1) if image.ndim == 2 else image
 
     channel_axis = get_channel_dimension_axis(image, input_data_format=input_data_format)
     num_channels = image.shape[channel_axis]

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -82,8 +82,11 @@ def to_channel_dimension_format(
 
     if input_channel_dim is None:
         input_channel_dim = infer_channel_dimension_format(image)
-
     target_channel_dim = ChannelDimension(channel_dim)
+
+    if target_channel_dim == ChannelDimension.NONE and input_channel_dim != ChannelDimension.NONE:
+        raise ValueError(f"Can't convert from dim format {input_channel_dim} to {target_channel_dim}")
+
     if input_channel_dim == target_channel_dim:
         return image
 

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -240,6 +240,8 @@ def infer_channel_dimension_format(
         first_dim, last_dim = 0, 2
     elif image.ndim == 4:
         first_dim, last_dim = 1, 3
+    elif image.ndim == 2:
+        raise ValueError("must specify input_data_format = ChannelDimension.NONE and use supported image processor to use (height, width) image")
     else:
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -95,6 +95,7 @@ VideoInput = Union[
 class ChannelDimension(ExplicitEnum):
     FIRST = "channels_first"
     LAST = "channels_last"
+    NONE = "none"
 
 
 class AnnotationFormat(ExplicitEnum):

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -241,7 +241,9 @@ def infer_channel_dimension_format(
     elif image.ndim == 4:
         first_dim, last_dim = 1, 3
     elif image.ndim == 2:
-        raise ValueError("must specify input_data_format = ChannelDimension.NONE and use supported image processor to use (height, width) image")
+        raise ValueError(
+            "must specify input_data_format = ChannelDimension.NONE and use supported image processor to use (height, width) image"
+        )
     else:
         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
 

--- a/src/transformers/models/vit/image_processing_vit.py
+++ b/src/transformers/models/vit/image_processing_vit.py
@@ -240,7 +240,7 @@ class ViTImageProcessor(BaseImageProcessor):
             size=size,
             resample=resample,
         )
-        
+
         if do_convert_rgb:
             if not input_data_format == ChannelDimension.NONE:
                 images = [convert_to_rgb(image) for image in images]

--- a/src/transformers/models/vit/image_processing_vit.py
+++ b/src/transformers/models/vit/image_processing_vit.py
@@ -207,7 +207,7 @@ class ViTImageProcessor(BaseImageProcessor):
                 from the input image. Can be one of:
                 - `"channels_first"` or `ChannelDimension.FIRST`: image in (num_channels, height, width) format.
                 - `"channels_last"` or `ChannelDimension.LAST`: image in (height, width, num_channels) format.
-                - `"none"` or `ChannelDimension.NONE`: image in (height, width) format.
+                - `"none"` or `ChannelDimension.NONE`: image in (height, width) format - must be specifed to use the format.
             do_convert_rgb (`bool`, *optional*, defaults to `self.do_convert_rgb`):
                 Whether to convert the image to RGB.
         """
@@ -240,9 +240,14 @@ class ViTImageProcessor(BaseImageProcessor):
             size=size,
             resample=resample,
         )
-
+        
         if do_convert_rgb:
-            images = [convert_to_rgb(image) for image in images]
+            if not input_data_format == ChannelDimension.NONE:
+                images = [convert_to_rgb(image) for image in images]
+            # handle HW PIL images to HWC by conversion to RGB - 3 channel allows for normalization with imagenet mean
+            else:
+                images = [convert_to_rgb(np.stack([image] * 3, axis=-1)) for image in images]
+                input_data_format = ChannelDimension.LAST
 
         # All transformations expect numpy arrays.
         images = [to_numpy_array(image) for image in images]


### PR DESCRIPTION
# What does this PR do?

fixes #34820 

Modifies image transformations and ViTImageProcessor such that HW PIL images can be have __call__ applied given the right arguments.

To supply an HW image to the ViTImageProcessor use the `input_data_format='none' or `input_data_format=ChannelDimension.NONE`. Further it is required that this is converted to RGB via the `do_convert_rgb=True` as the first option

```
    dataset = load_dataset("ylecun/mnist")
    processor = AutoImageProcessor.from_pretrained("farleyknight-org-username/vit-base-mnist")

    def process(examples):
        processed_inputs = processor(examples["image"],
                                             input_data_format="none",
                                             do_convert_rgb=True)
        return processed_inputs


    processed_dataset = dataset.map(process, batched=True)
``` 
or to leave it as a single channeled np.array by setting the mean and std of the image processor with `image_mean=[mean_value]` and `image_std=[std_value]`
```
...
    def process(examples):
        processed_inputs = teacher_processor(examples["image"],
                                             input_data_format="none",
                                             do_convert_rgb=False,
                                             image_mean=[.5],
                                             image_std=[.5])
        return processed_inputs
...
```



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
 @amyeroberts, @qubvel
