### PR TITLE
[docs] add explanation to `release_memory()`

### DIFF
--- a/docs/source/en/llm_tutorial_optimization.md
+++ b/docs/source/en/llm_tutorial_optimization.md
@@ -147,7 +147,7 @@ Let's call it now for the next experiment.
 ```python
 flush()
 ```
-In the recent version of the accelerate library, you can also use a device-agnostic utility method called `release_memory()`, which takes various hardware backends like XPU, MLU, NPU, MPS etc. into account:
+From the Accelerate library, you can also use a device-agnostic utility method called [release_memory](https://github.com/huggingface/accelerate/blob/29be4788629b772a3b722076e433b5b3b5c85da3/src/accelerate/utils/memory.py#L63), which takes various hardware backends like XPU, MLU, NPU, MPS, and more into account.
 
 ```python
 from accelerate.utils import release_memory

--- a/docs/source/en/llm_tutorial_optimization.md
+++ b/docs/source/en/llm_tutorial_optimization.md
@@ -147,7 +147,7 @@ Let's call it now for the next experiment.
 ```python
 flush()
 ```
-In the recent version of the accelerate library, you can also use a utility method called `release_memory()`
+In the recent version of the accelerate library, you can also use a device-agnostic utility method called `release_memory()`, which takes various hardware backends like XPU, MLU, NPU, MPS etc. into account:
 
 ```python
 from accelerate.utils import release_memory


### PR DESCRIPTION
## What does this PR do?
As a non-cuda user, it would be good to get explained that `release_memory()` is a device-agnostic implementation.

Documentation: @stevhliu