### PR TITLE
[`trainer`] fix the GA `model_accepts_loss_kwargs`

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -620,8 +620,8 @@ class Trainer:
             else unwrapped_model.get_base_model().forward
         )
         forward_params = inspect.signature(model_forward).parameters
-        self.model_accepts_loss_kwargs = (
-            "loss_kwargs" in forward_params and forward_params["loss_kwargs"].kind == inspect.Parameter.VAR_KEYWORD
+        self.model_accepts_loss_kwargs = any(
+            k.kind == inspect.Parameter.VAR_KEYWORD for k in forward_params
         )
 
         self.neftune_noise_alpha = args.neftune_noise_alpha

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -620,7 +620,7 @@ class Trainer:
             else unwrapped_model.get_base_model().forward
         )
         forward_params = inspect.signature(model_forward).parameters
-        self.model_accepts_loss_kwargs = any(k.kind == inspect.Parameter.VAR_KEYWORD for k in forward_params)
+        self.model_accepts_loss_kwargs = any(k.kind == inspect.Parameter.VAR_KEYWORD for k in forward_params.values())
 
         self.neftune_noise_alpha = args.neftune_noise_alpha
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -620,9 +620,7 @@ class Trainer:
             else unwrapped_model.get_base_model().forward
         )
         forward_params = inspect.signature(model_forward).parameters
-        self.model_accepts_loss_kwargs = any(
-            k.kind == inspect.Parameter.VAR_KEYWORD for k in forward_params
-        )
+        self.model_accepts_loss_kwargs = any(k.kind == inspect.Parameter.VAR_KEYWORD for k in forward_params)
 
         self.neftune_noise_alpha = args.neftune_noise_alpha
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3644,7 +3644,10 @@ class Trainer:
             return loss_mb.reduce_mean().detach().to(self.args.device)
 
         with self.compute_loss_context_manager():
-            loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
+            if self.model_accepts_loss_kwargs:
+                loss = self.compute_loss(model, inputs)
+            else:
+                loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
 
         del inputs
         if (


### PR DESCRIPTION
# What does this PR do?
Fixes #34577
`model_accepts_loss_kwargs` was wrongly looking at kwarg names, while you should only need kwargs (since the name can vary for FlashAttentionKwargs, LossKwargs etc)