### PR TITLE
Automatic compilation in generate: do not rely on inner function

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -436,3 +436,9 @@ A [`Constraint`] can be used to force the generation to include specific tokens 
 
 [[autodoc]] SynthIDTextWatermarkDetector
     - __call__
+
+## Compile Utils
+
+[[autodoc]] CompileConfig
+    - __call__
+

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -4978,7 +4978,7 @@ if TYPE_CHECKING:
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
 
     # Generation
-    from .generation import GenerationConfig, TextIteratorStreamer, TextStreamer, WatermarkingConfig, CompileConfig
+    from .generation import CompileConfig, GenerationConfig, TextIteratorStreamer, TextStreamer, WatermarkingConfig
     from .hf_argparser import HfArgumentParser
 
     # Integrations

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -4978,7 +4978,7 @@ if TYPE_CHECKING:
     from .feature_extraction_utils import BatchFeature, FeatureExtractionMixin
 
     # Generation
-    from .generation import GenerationConfig, TextIteratorStreamer, TextStreamer, WatermarkingConfig
+    from .generation import GenerationConfig, TextIteratorStreamer, TextStreamer, WatermarkingConfig, CompileConfig
     from .hf_argparser import HfArgumentParser
 
     # Integrations

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -122,11 +122,11 @@ _import_structure = {
     "feature_extraction_utils": ["BatchFeature", "FeatureExtractionMixin"],
     "file_utils": [],
     "generation": [
+        "CompileConfig",
         "GenerationConfig",
         "TextIteratorStreamer",
         "TextStreamer",
         "WatermarkingConfig",
-        "CompileConfig",
     ],
     "hf_argparser": ["HfArgumentParser"],
     "hyperparameter_search": [],

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -126,6 +126,7 @@ _import_structure = {
         "TextIteratorStreamer",
         "TextStreamer",
         "WatermarkingConfig",
+        "CompileConfig",
     ],
     "hf_argparser": ["HfArgumentParser"],
     "hyperparameter_search": [],

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -24,6 +24,7 @@ _import_structure = {
         "GenerationMode",
         "SynthIDTextWatermarkingConfig",
         "WatermarkingConfig",
+        "CompileConfig",
     ],
     "streamers": ["TextIteratorStreamer", "TextStreamer"],
 }

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -20,11 +20,11 @@ from ..utils import OptionalDependencyNotAvailable, _LazyModule, is_flax_availab
 _import_structure = {
     "configuration_utils": [
         "BaseWatermarkingConfig",
+        "CompileConfig",
         "GenerationConfig",
         "GenerationMode",
         "SynthIDTextWatermarkingConfig",
         "WatermarkingConfig",
-        "CompileConfig",
     ],
     "streamers": ["TextIteratorStreamer", "TextStreamer"],
 }

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -193,11 +193,11 @@ else:
 if TYPE_CHECKING:
     from .configuration_utils import (
         BaseWatermarkingConfig,
+        CompileConfig,
         GenerationConfig,
         GenerationMode,
         SynthIDTextWatermarkingConfig,
         WatermarkingConfig,
-        CompileConfig,
     )
     from .streamers import TextIteratorStreamer, TextStreamer
 

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -197,6 +197,7 @@ if TYPE_CHECKING:
         GenerationMode,
         SynthIDTextWatermarkingConfig,
         WatermarkingConfig,
+        CompileConfig,
     )
     from .streamers import TextIteratorStreamer, TextStreamer
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -362,7 +362,7 @@ class GenerationConfig(PushToHubMixin):
             models that support early exit (i.e. models where logits from intermediate layers can be interpreted by the LM head).
 
         > Parameters related to performances and compilation
-         
+
         compile_config (CompileConfig, *optional*):
             If using a static cache, this controls how `generate` will `compile` the forward pass for performance
             gains.

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1595,9 +1595,7 @@ class CompileConfig(object):
         self.options = options
 
     def to_dict(self) -> Dict[str, Any]:
-        """
-        Serializes this instance to a Python dictionary.
-        """
+        """Serializes this instance to a Python dictionary."""
         return copy.deepcopy(self.__dict__)
     
     def __eq__(self, other) -> bool:

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1621,3 +1621,17 @@ class CompileConfig(object):
         if not isinstance(other, CompileConfig):
             raise ValueError(f"Equality not defined between CompileConfig and {type(other)}")
         return self.to_dict() == other.to_dict()
+    
+    def __repr__(self):
+        return f"{self.__class__.__name__} {self.to_json_string()}"
+    
+    def to_json_string(self) -> str:
+        """Serializes this instance to a JSON formatted string."""
+        return json.dumps(self.__dict__, indent=2) + "\n"
+    
+    def to_json_file(self, json_file_path: Union[str, os.PathLike]):
+        """Save this instance to a JSON file."""
+        with open(json_file_path, "w", encoding="utf-8") as writer:
+            config_dict = self.to_dict()
+            json_string = json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
+            writer.write(json_string)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1600,32 +1600,12 @@ class CompileConfig(object):
     ```
     """
 
-    def __init__(
-        self,
-        fullgraph: bool = True,
-        dynamic: Optional[bool] = None,
-        backend: Union[str, Callable] = "inductor",
-        mode: str = "reduce-overhead",
-        options: Optional[dict] = None,
-    ):
-        self.fullgraph = fullgraph
-        self.dynamic = dynamic
-        self.backend = backend
-        self.mode = mode
-        self.options = options
+    fullgraph: bool = True
+    dynamic: Optional[bool] = None
+    backend: Union[str, Callable] = "inductor"
+    mode: str = "reduce-overhead"
+    options: Optional[dict] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serializes this instance to a Python dictionary."""
         return copy.deepcopy(self.__dict__)
-
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, CompileConfig):
-            raise ValueError(f"Equality not defined between CompileConfig and {type(other)}")
-        return self.to_dict() == other.to_dict()
-
-    def __repr__(self):
-        return f"{self.__class__.__name__} {self.to_json_string()}"
-
-    def to_json_string(self) -> str:
-        """Serializes this instance to a JSON formatted string."""
-        return json.dumps(self.__dict__, indent=2) + "\n"

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1569,15 +1569,15 @@ class CompileConfig(object):
     See [`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html) for more details on the arguments.
 
     Args:
-        fullgraph (`bool`, *optional*, defaults to True):
+        fullgraph (`bool`, *optional*, defaults to `True`):
             If `True`, requires that the whole forward be capturable in a single graph.
-        dynamic (`bool` or `None`, *optional*, defaults to None):
+        dynamic (`bool` or `None`, *optional*):
             Whether to try to use dynamic shape graphs.
-        backend (`str` or `Callable`, *optional*, defaults to "inductor"):
+        backend (`str` or `Callable`, *optional*, defaults to `"inductor"`):
             Backend to be used.
-        mode (`str`, *optional*, defaults to "reduce-overhead"):
+        mode (`str`, *optional*, defaults to `"reduce-overhead"`):
             Controls balance between performance and overhead.
-        options (`dict`, *optional*, defaults to None):
+        options (`dict`, *optional*):
             A dictionary of options to pass to the backend.
     """
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -20,7 +20,7 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from .. import __version__
 from ..configuration_utils import PretrainedConfig
@@ -771,7 +771,9 @@ class GenerationConfig(PushToHubMixin):
                         UserWarning,
                     )
         if not isinstance(self.compile_config, CompileConfig):
-            raise ValueError(f"You provided `compile_config` as an instance of {type(self.compile_config)}, but it must be an instance of `CompileConfig`.")
+            raise ValueError(
+                f"You provided `compile_config` as an instance of {type(self.compile_config)}, but it must be an instance of `CompileConfig`."
+            )
 
         # 6.  check watermarking arguments
         if self.watermarking_config is not None:
@@ -1552,6 +1554,7 @@ class SynthIDTextWatermarkingConfig(BaseWatermarkingConfig):
             skip_first_ngram_calls=self.skip_first_ngram_calls,
             debug_mode=self.debug_mode,
         )
+
 
 @dataclass
 class CompileConfig(object):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1562,8 +1562,6 @@ class SynthIDTextWatermarkingConfig(BaseWatermarkingConfig):
             debug_mode=self.debug_mode,
         )
 
-
-@dataclass
 class CompileConfig(object):
     """
     Class that holds arguments relative to `torch.compile` behavior, when using automatic compilation in `generate`.
@@ -1582,14 +1580,27 @@ class CompileConfig(object):
             A dictionary of options to pass to the backend.
     """
 
-    fullgraph: bool = True
-    dynamic: Optional[bool] = None
-    backend: Union[str, Callable] = "inductor"
-    mode: str = "reduce-overhead"
-    options: Optional[dict] = None
+    def __init__(
+        self,
+        fullgraph: bool = True,
+        dynamic: Optional[bool] = None,
+        backend: Union[str, Callable] = "inductor",
+        mode: str = "reduce-overhead",
+        options: Optional[dict] = None,
+    ):
+        self.fullgraph = fullgraph
+        self.dynamic = dynamic
+        self.backend = backend
+        self.mode = mode
+        self.options = options
 
     def to_dict(self) -> Dict[str, Any]:
         """
         Serializes this instance to a Python dictionary.
         """
         return copy.deepcopy(self.__dict__)
+    
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, CompileConfig):
+            raise ValueError(f"Equality not defined between CompileConfig and {type(other)}")
+        return self.to_dict() == other.to_dict()

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1177,6 +1177,8 @@ class GenerationConfig(PushToHubMixin):
             del output["_commit_hash"]
         if "_original_object_hash" in output:
             del output["_original_object_hash"]
+        if "compile_config" in output:
+            del output["compile_config"]
 
         # Transformers version when serializing this file
         output["transformers_version"] = __version__

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1579,6 +1579,24 @@ class CompileConfig(object):
             Controls balance between performance and overhead.
         options (`dict`, *optional*):
             A dictionary of options to pass to the backend.
+
+    Examples:
+    ```python
+    >>> from transformers import AutoModelForCausalLM, AutoTokenizer, CompileConfig
+
+    >>> tokenizer = AutoTokenizer.from_pretrained('google/gemma-2-2b')
+    >>> model = AutoModelForCausalLM.from_pretrained('google/gemma-2-2b').cuda()
+
+    >>> # Automatic compile configuration, used with static cache
+    >>> compile_config = CompileConfig(dynamic=True)
+
+    >>> # Generation with static cache and compile config
+    >>> input = tokenizer.encode("Hello there, how", return_tensors="pt").cuda()
+    >>> output = model.generate(
+    ...     input, do_sample=False, max_new_tokens=300, cache_implementation="static", compile_config=compile_config
+    ... )
+    >>> output_text = tokenizer.batch_decode(output, skip_special_tokens=True)[0]
+    ```
     """
 
     def __init__(

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1563,6 +1563,7 @@ class SynthIDTextWatermarkingConfig(BaseWatermarkingConfig):
         )
 
 
+@dataclass
 class CompileConfig(object):
     """
     Class that holds arguments relative to `torch.compile` behavior, when using automatic compilation in `generate`.
@@ -1621,17 +1622,10 @@ class CompileConfig(object):
         if not isinstance(other, CompileConfig):
             raise ValueError(f"Equality not defined between CompileConfig and {type(other)}")
         return self.to_dict() == other.to_dict()
-    
+
     def __repr__(self):
         return f"{self.__class__.__name__} {self.to_json_string()}"
-    
+
     def to_json_string(self) -> str:
         """Serializes this instance to a JSON formatted string."""
         return json.dumps(self.__dict__, indent=2) + "\n"
-    
-    def to_json_file(self, json_file_path: Union[str, os.PathLike]):
-        """Save this instance to a JSON file."""
-        with open(json_file_path, "w", encoding="utf-8") as writer:
-            config_dict = self.to_dict()
-            json_string = json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
-            writer.write(json_string)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1570,15 +1570,15 @@ class CompileConfig(object):
     See [`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html) for more details on the arguments.
 
     Args:
-        - fullgraph (`bool`, *optional*, defaults to True):
+        fullgraph (`bool`, *optional*, defaults to True):
             If `True`, requires that the whole forward be capturable in a single graph.
-        - dynamic (`bool` or `None`, *optional*, defaults to None):
+        dynamic (`bool` or `None`, *optional*, defaults to None):
             Whether to try to use dynamic shape graphs.
-        - backend (`str` or `Callable`, *optional*, defaults to "inductor"):
+        backend (`str` or `Callable`, *optional*, defaults to "inductor"):
             Backend to be used.
-        - mode (`str`, *optional*, defaults to "reduce-overhead"):
+        mode (`str`, *optional*, defaults to "reduce-overhead"):
             Controls balance between performance and overhead.
-        - options (`dict`, *optional*, defaults to None):
+        options (`dict`, *optional*, defaults to None):
             A dictionary of options to pass to the backend.
     """
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1575,23 +1575,14 @@ class CompileConfig(object):
             A dictionary of options to pass to the backend.
     """
 
-    def __init__(
-        self,
-        fullgraph: bool = True,
-        dynamic: Optional[bool] = None,
-        backend: Union[str, Callable] = "inductor",
-        mode: str = "reduce-overhead",
-        options: Optional[dict] = None,
-    ):
-        self.fullgraph = fullgraph
-        self.dynamic = dynamic
-        self.backend = backend
-        self.mode = mode
-        self.options = options
+    fullgraph: bool = True
+    dynamic: Optional[bool] = None
+    backend: Union[str, Callable] = "inductor"
+    mode: str = "reduce-overhead"
+    options: Optional[dict] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """
         Serializes this instance to a Python dictionary.
         """
-        output = copy.deepcopy(self.__dict__)
-        return output
+        return copy.deepcopy(self.__dict__)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1562,6 +1562,7 @@ class SynthIDTextWatermarkingConfig(BaseWatermarkingConfig):
             debug_mode=self.debug_mode,
         )
 
+
 class CompileConfig(object):
     """
     Class that holds arguments relative to `torch.compile` behavior, when using automatic compilation in `generate`.
@@ -1597,7 +1598,7 @@ class CompileConfig(object):
     def to_dict(self) -> Dict[str, Any]:
         """Serializes this instance to a Python dictionary."""
         return copy.deepcopy(self.__dict__)
-    
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, CompileConfig):
             raise ValueError(f"Equality not defined between CompileConfig and {type(other)}")

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3235,8 +3235,7 @@ class GenerationMixin:
             if self.device.type == "cuda":
                 logger.warning_once("Using `torch.compile`.")
                 os.environ["TOKENIZERS_PARALLELISM"] = "0"
-                self._set_compile_call(generation_config.compile_config)
-                model_forward = self.compiled_call
+                model_forward = self.get_compiled_call(generation_config.compile_config)
 
         is_prefill = True
         while self._has_unfinished_sequences(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3252,7 +3252,7 @@ class GenerationMixin:
                 outputs = self(**model_inputs, return_dict=True)
                 is_prefill = False
             else:
-                outputs = model_forward(self, return_dict=True, **model_inputs)
+                outputs = model_forward(**model_inputs, return_dict=True)
 
             # synced_gpus: don't waste resources running the code we don't need; kwargs must be updated before skipping
             model_kwargs = self._update_model_kwargs_for_generation(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3235,6 +3235,7 @@ class GenerationMixin:
             if self.device.type == "cuda":
                 logger.warning_once("Using `torch.compile`.")
                 os.environ["TOKENIZERS_PARALLELISM"] = "0"
+                self._set_compile_call(generation_config.compile_config)
                 model_forward = self.compiled_call
 
         is_prefill = True

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3235,7 +3235,7 @@ class GenerationMixin:
             if self.device.type == "cuda":
                 logger.warning_once("Using `torch.compile`.")
                 os.environ["TOKENIZERS_PARALLELISM"] = "0"
-                model_forward = self.compiled_forward
+                model_forward = self.compiled_call
 
         is_prefill = True
         while self._has_unfinished_sequences(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5083,26 +5083,20 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             loss_type = "ForCausalLM"
         return LOSS_MAPPING[loss_type]
 
-    @property
-    def compiled_call(self):
+    def get_compiled_call(self, compile_config: CompileConfig):
         """Return a `torch.compile`'d version of `self.__call__`. This is useful to dynamically choose between
         non-compiled/compiled `forward` during inference, especially to switch between prefill (where we don't
         want to use compiled version to avoid recomputing the graph with new shapes) and iterative decoding
         (where we want the speed-ups of compiled version with static shapes)."""
-        if not hasattr(self, "_compiled_call"):
-            default_config = getattr(self.generation_config, "compile_config", CompileConfig())
-            self._set_compile_call(default_config)
-        return self._compiled_call
-
-    def _set_compile_call(self, compile_config: CompileConfig):
-        """Set the mode (arguments) for the compiled version of `self.__call__`."""
         # Only reset it if not present or different from previous config
+        default_config = getattr(self.generation_config, "compile_config", CompileConfig())
         if (
             not hasattr(self, "_compiled_call")
-            or getattr(self, "_last_compile_config", CompileConfig()) != compile_config
+            or getattr(self, "_last_compile_config", default_config) != compile_config
         ):
             self._last_compile_config = compile_config
             self._compiled_call = torch.compile(self.__call__, **compile_config.to_dict())
+        return self._compiled_call
 
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5092,7 +5092,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not hasattr(self, "_compiled_call"):
             self._compiled_call = torch.compile(self.__call__, mode="reduce-overhead", fullgraph=True)
         return self._compiled_call
-    
+
     def compile_call(self, *args, **kwargs):
         """Set the mode for the automatic `compile` in `generate`, if using a static cache. Note that contrary to using
         `model.compile(...)`, calling this function does NOT mean that subsequent calls to forward with `model(input,...)`

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5082,7 +5082,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
             loss_type = "ForCausalLM"
         return LOSS_MAPPING[loss_type]
-    
 
     @property
     def compiled_forward(self):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -43,7 +43,7 @@ from torch.utils.checkpoint import checkpoint
 from .activations import get_activation
 from .configuration_utils import PretrainedConfig
 from .dynamic_module_utils import custom_object_save
-from .generation import GenerationConfig, GenerationMixin, CompileConfig
+from .generation import CompileConfig, GenerationConfig, GenerationMixin
 from .integrations import PeftAdapterMixin, deepspeed_config, is_deepspeed_zero3_enabled
 from .loss.loss_utils import LOSS_MAPPING
 from .pytorch_utils import (  # noqa: F401

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5092,6 +5092,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if not hasattr(self, "_compiled_call"):
             self._compiled_call = torch.compile(self.__call__, mode="reduce-overhead", fullgraph=True)
         return self._compiled_call
+    
+    def compile_call(self, *args, **kwargs):
+        """Set the mode for the automatic `compile` in `generate`, if using a static cache. Note that contrary to using
+        `model.compile(...)`, calling this function does NOT mean that subsequent calls to forward with `model(input,...)`
+        will use the compiled version, it will only set the compile arguments for later automatic usage.
+
+        See `torch.compile` for details on the arguments of this function.
+        """
+        self._compiled_call = torch.compile(self.__call__, *args, **kwargs)
 
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5082,6 +5082,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             )
             loss_type = "ForCausalLM"
         return LOSS_MAPPING[loss_type]
+    
+
+    @property
+    def compiled_forward(self):
+        if not hasattr(self, "_compiled_forward"):
+            self._compiled_forward = torch.compile(self._call_impl, mode="reduce-overhead", fullgraph=True)
+        return self._compiled_forward
 
 
 PreTrainedModel.push_to_hub = copy_func(PreTrainedModel.push_to_hub)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5087,7 +5087,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
     @property
     def compiled_forward(self):
         if not hasattr(self, "_compiled_forward"):
-            self._compiled_forward = torch.compile(self._call_impl, mode="reduce-overhead", fullgraph=True)
+            self._compiled_forward = torch.compile(self.__call__, mode="reduce-overhead", fullgraph=True)
         return self._compiled_forward
 
 

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -247,13 +247,6 @@ class ConstraintListState(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class CompileConfig(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class DisjunctiveConstraint(metaclass=DummyObject):
     _backends = ["torch"]
 

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -247,6 +247,13 @@ class ConstraintListState(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
+class CompileConfig(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
+
 class DisjunctiveConstraint(metaclass=DummyObject):
     _backends = ["torch"]
 


### PR DESCRIPTION
# What does this PR do?

As discussed, I don't think we should rely on defining an inner function and compiling it for every call to `generate`.

This moves the compiled forward to `PreTrainedModel` instead for reuse, which makes the most sense for me. That way, every `PreTrainedModel` effectively has 2 forwards, and we can dynamically choose between non-compiled (prefill) and compiled (iterative decoding). This is similar to what PyTorch does internally when calling `model.compile()` inplace, except in their case they force the use of the compiled one after the call was invoked.

Let me know what you think @ArthurZucker 

Also address https://github.com/huggingface/transformers/issues/34906