### PR TITLE
fix `test_generated_length_assisted_generation`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3365,7 +3365,14 @@ class GenerationIntegrationTests(unittest.TestCase, GenerationIntegrationTestsMi
             assistant_model=assistant,
             min_new_tokens=10,
         )
-        self.assertTrue((input_length + 10) <= out.shape[-1] <= 20)
+        self.assertTrue((input_length + 10) <= out.shape[-1])
+
+        out = model.generate(
+            input_ids,
+            assistant_model=assistant,
+            max_new_tokens=7,
+        )
+        self.assertTrue(out.shape[-1] <= (input_length + 7))
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
         # PT-only test: TF doesn't support assisted decoding yet.


### PR DESCRIPTION
# What does this PR do?

This PR fixes and expands the `test_generated_length_assisted_generation` test in `test_utils.py`.

## Before submitting
- [x] This PR fixes and expands an existing test.
- [x] Did you read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue or the [[forum](https://discuss.huggingface.co/)](https://discuss.huggingface.co/)? Not applicable for this minor change.
- [x] Did you ensure that all other tests pass after this change?

## Who can review?
- Generate: @gante