### PR TITLE
Fix `utils/check_bad_commit.py` (for auto ping in CI)

### DIFF
--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -59,7 +59,7 @@ elif f"{target_test} FAILED" in result.stdout:
 exit(0)
 """
 
-    with open("target_script..py", "w") as fp:
+    with open("target_script.py", "w") as fp:
         fp.write(script.strip())
 
 

--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -46,7 +46,7 @@ result = subprocess.run(
 print(result.stdout)
 
 if len(result.stderr) > 0:
-    if "ERROR: not found: " in result.stderr:
+    if "ERROR: file or directory not found: " in result.stderr:
         print("test not found in this commit")
         exit(0)
     else:
@@ -59,7 +59,7 @@ elif f"{target_test} FAILED" in result.stdout:
 exit(0)
 """
 
-    with open("target_script.py", "w") as fp:
+    with open("target_script..py", "w") as fp:
         fp.write(script.strip())
 
 


### PR DESCRIPTION
# What does this PR do?

We check a test if failing between a range commits.
If it is a new test that is not in previous commits, the status from those previous commits should be marked as `passing` (as that test doesn't exist in those commits)

Otherwise `git bisect` would fail and we don't receive any report.

This is the case in today CI with the 

> tests/models/olmo2/test_modeling_olmo2.py::Olmo2ModelTest::test_generate_compile_1_end_to_end

(see PR #34864)