### PR TITLE
Add feature dim attributes to BitLinear for easier PEFT integration

### DIFF
--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -127,6 +127,8 @@ class BitLinear(nn.Module):
     def __init__(self, in_features: int, out_features: int, bias: bool, device=None, dtype=None):
         super().__init__()
         self.dtype = dtype
+        self.in_features = in_features
+        self.out_features = out_features
         self.register_buffer(
             "weight",
             torch.zeros(


### PR DESCRIPTION
# What does this PR do?

This PR is an extremely simple two-liner (adding `in_features` and `out_features` as attributes to `BitLinear`) whose only purpose is to improve accessibility for `BitLinear` to users that want to employ `peft`. Currently, `BitLinear` is not usable with LoRAs in `peft` out-of-the-box.

The typical flow for enabling LoRAs for custom layers in `peft` is to construct a custom class that describes the LoRAs behavior and then registers it with a private API. The problem is that `peft` still needs additional information on input and output dimensionality via `in_features` and `out_features`, which `BitLinear` currently lacks. The current solution for this problem is to wrap `BitLinear` with another module that adds these attributes during initialization and then replace all instances of `BitLinear` with that new module. Alternatively, the LoRA source code would have to be revised to support `BitLinear` and derive the feature dimensions from its weight matrix. From the perspective of potential users, adding the aforementioned attributes improves accessibility and avoids requiring some hacky looking fixes from their end.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Other checkmarks are left untouched, as they don't look relevant.

## Who can review?

- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber
- bitnet contributors: @MekkCyber 
