### PR TITLE
Fix flaky test execution caused by `Thread`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -29,7 +29,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial, wraps
-from threading import Thread
+from multiprocessing import Process
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from zipfile import is_zipfile
 
@@ -3839,11 +3839,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                                     **has_file_kwargs,
                                 }
                                 if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
-                                    Thread(
+                                    Process(
                                         target=auto_conversion,
                                         args=(pretrained_model_name_or_path,),
                                         kwargs={"ignore_errors_during_conversion": True, **cached_file_kwargs},
-                                        name="Thread-autoconversion",
+                                        name="Process-auto_conversion",
                                     ).start()
                         else:
                             # Otherwise, no PyTorch file was found, maybe there is a TF or Flax model file.


### PR DESCRIPTION
# What does this PR do?

As discussed offline:

> Would it possible if we change Thread to Process below :pray: ?
I know it's not good to change code that is working and making sense for the sole purpose of testing, but Thread  (without join) here making some test(s) flaky failing
test_cached_model_has_minimum_calls_to_head
where we count the number of calls to Hub. Some other tests that (eventually) calling from_pretrained  entering Thread line  will affect test_cached_model_has_minimum_calls_to_head
because they are running at the same time in the same process.
There are other solutions, but the changes involves patching (a lot of) tests (so at conftest level which is not good neither IMO.
https://github.com/huggingface/transformers/blob/d5cf91b3462b5ed57260074a0708f09b16e787a8/src/transformers/modeling_utils.py#L3842

----------------------------------------------

To check the PR works (make sure tensorflow is available): 

> python gradio2.py

where `script.py`
```python
for i in range(20):
    import os
    os.system('python -m pytest -v tests/models/auto/test_modeling_auto.py tests/models/auto/test_modeling_tf_auto.py -k "test_from_pretrained_identifier or test_cached_model_has_minimum_calls_to_head"')
    # or running several times on CI workflow: it's flaky and not easy to reproduce
    # or add `time.sleep(0.5)` at the beginning of `auto_convenanorsion`

```