### PR TITLE
Avoid calling `get_max_length`

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -911,7 +911,7 @@ class BloomForCausalLM(BloomPreTrainedModel, GenerationMixin):
         # This part differs from other models because BLOOM needs a 2D mask to construct alibi tensor
         # The only difference is the usage of 2D instead of 4D mask, but the shape will be static
         if isinstance(past_key_values, StaticCache) and attention_mask is not None:
-            target_length = past_key_values.get_max_length()
+            target_length = past_key_values.get_max_cache_shape()
             batch_size, seq_length = attention_mask.shape
             diff = target_length - seq_length
 

--- a/src/transformers/models/granite/modeling_granite.py
+++ b/src/transformers/models/granite/modeling_granite.py
@@ -909,7 +909,7 @@ class GraniteModel(GranitePreTrainedModel):
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
         if using_static_cache:
-            target_length = past_key_values.get_max_length()
+            target_length = past_key_values.get_max_cache_shape()
         else:
             target_length = (
                 attention_mask.shape[-1]

--- a/src/transformers/models/granitemoe/modeling_granitemoe.py
+++ b/src/transformers/models/granitemoe/modeling_granitemoe.py
@@ -1142,7 +1142,7 @@ class GraniteMoeModel(GraniteMoePreTrainedModel):
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
         if using_static_cache:
-            target_length = past_key_values.get_max_length()
+            target_length = past_key_values.get_max_cache_shape()
         else:
             target_length = (
                 attention_mask.shape[-1]

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -353,7 +353,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixi
         min_dtype = torch.finfo(dtype).min
         sequence_length = inputs_embeds.shape[1]
         if using_static_cache:
-            target_length = past_key_values.get_max_length()
+            target_length = past_key_values.get_max_cache_shape()
         else:
             target_length = (
                 attention_mask.shape[-1]


### PR DESCRIPTION
# What does this PR do?

Some tests are failing after #34247 as they are calling `get_max_length` which calls `logger`, and torch dynamo hate it with

> torch._dynamo.exc.Unsupported: Logger not supported for non-export cases

Let's just call `get_max_cache_shape` as `get_max_length` is just `logger + get_max_cache_shape`

`PaliGemmaForConditionalGenerationModelTest::test_generate_with_static_cache` and `tests/models/granite/test_modeling_granite.py::GraniteModelTest::test_generate_from_inputs_embeds_with_static_cache ` are passing now but 

> GraniteMoeModelTest::test_generate_from_inputs_embeds_with_static_cache

still has data dependent operation issue and failed. That should be addressed in a separate PR.

