### PR TITLE
Add embedding scaling

### DIFF
--- a/src/transformers/models/mistral/configuration_mistral.py
+++ b/src/transformers/models/mistral/configuration_mistral.py
@@ -81,6 +81,8 @@ class MistralConfig(PretrainedConfig):
             Sliding window attention window size. If not specified, will default to `4096`.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        embedding_scale (`float`, *optional*, defaults to 1.0):
+            A scaling factor applied to the model's embeddings. If not specified, will default to `1.0`.
 
     ```python
     >>> from transformers import MistralModel, MistralConfig
@@ -129,6 +131,7 @@ class MistralConfig(PretrainedConfig):
         rope_theta=10000.0,
         sliding_window=4096,
         attention_dropout=0.0,
+        embedding_scale=1.0,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -151,6 +154,7 @@ class MistralConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.rope_theta = rope_theta
         self.attention_dropout = attention_dropout
+        self.embedding_scale = embedding_scale
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -691,6 +691,7 @@ class MistralModel(MistralPreTrainedModel):
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.embedding_scale = config.embedding_scale
         self.layers = nn.ModuleList(
             [MistralDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
@@ -740,8 +741,7 @@ class MistralModel(MistralPreTrainedModel):
             use_cache = False
 
         if inputs_embeds is None:
-            inputs_embeds = self.embed_tokens(input_ids)
-
+            inputs_embeds = self.embed_tokens(input_ids) * self.embedding_scale
         # kept for BC (non `Cache` `past_key_values` inputs)
         return_legacy_cache = False
         if use_cache and not isinstance(past_key_values, Cache):


### PR DESCRIPTION
# What does this PR do?

This PR introduces support for **embedding scaling** in the `MistralModel`. The feature is inspired by the [Scaled Embed method](https://arxiv.org/pdf/2312.16903), which demonstrates that applying a scaling factor to the embeddings significantly improves the stability of large language model (LLM) training, effectively mitigating gradient spikes.

### Key Changes:
- Adds a new configuration parameter:  
  **`embedding_scale`** (`float`, *optional*, defaults to `1.0`): A scaling factor applied to the model's embeddings.
- Updates the `MistralModel` implementation to apply the scaling factor to the embeddings during training and inference.

This implementation currently supports the **PyTorch backend**. Support for TensorFlow and Flax backends can be added in the future.

---

# Motivation

The Scaled Embed method improves training stability and helps mitigate gradient spikes, as shown in the referenced paper. By implementing this feature, we aim to bring these benefits to the `MistralModel` while maintaining backward compatibility.

---

# Open Questions for Discussion

1. **Relevance:**  
   Do you see this feature as relevant for integration into the library? Would it make sense to extend this functionality to other models, such as `LlamaModel`?

2. **Implementation Scope:**  
   Should embedding scaling be integrated more broadly across models in the library or should it remain model-specific ?  
---

Let me know if further adjustments or refinements are needed!