### PR TITLE
adjust beam search early stopping to any criteria as opposed to all

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3605,7 +3605,7 @@ class GenerationMixin:
             # increase cur_len
             cur_len = cur_len + 1
 
-            if beam_scorer.is_done or all(stopping_criteria(input_ids, scores)):
+            if beam_scorer.is_done or any(stopping_criteria(input_ids, scores)):
                 this_peer_finished = True
 
         sequence_outputs = beam_scorer.finalize(


### PR DESCRIPTION
Please ignore this PR. Creating another to see if the failing test on the original PR is somehow non-deterministic.