### PR TITLE
Fix `BertGeneration`

### DIFF
--- a/src/transformers/models/bert_generation/modeling_bert_generation.py
+++ b/src/transformers/models/bert_generation/modeling_bert_generation.py
@@ -785,9 +785,7 @@ class BertGenerationEncoder(BertGenerationPreTrainedModel):
 
         # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
-        extended_attention_mask = None
-        if not use_cache:
-            extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape)
+        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape)
 
         # If a 2D or 3D attention mask is provided for the cross-attention
         # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]


### PR DESCRIPTION
# What does this PR do?

`BertGeneration` doesn't prepare the attention mask correctly when it is used as a decoer + `use_cache=True`.

Running the script above:

The hidden states difference (the first item printed) looks

- `[0.0, 0.004747, 0.0062393]` with `main`
- `[0.0, 0.0, 0.0]` with this PR

This is also the reason why 

> tests/models/bert_generation/test_modeling_bert_generation.py::BertGenerationEncoderTest::test_assisted_decoding_matches_greedy_search_1_same

is flaky. With this PR, running 10000 times and all pass.

### Script

```python
import torch
from tests.models.bert_generation.test_modeling_bert_generation import BertGenerationEncoderTest, BertGenerationEncoderTester

torch_device = "cpu"
self = BertGenerationEncoderTest()
self.setUp()
model_class = self.all_generative_model_classes[0]
config, inputs_dict = self.prepare_config_and_inputs_for_generate(batch_size=1)
config.is_decoder = True

inputs_dict['attention_mask'][0, :3] = 0
inputs_dict['attention_mask'][0, 3:] = 1

inputs_dict['use_cache'] = True
inputs_dict['output_hidden_states'] = True
inputs_dict['output_attentions'] = True

model = model_class(config).to(torch_device).eval()

outputs1 = model(**inputs_dict)

shorter_inputs_dict = {k: v for k, v in inputs_dict.items()}
shorter_inputs_dict['input_ids'] = inputs_dict['input_ids'][:, :-1]
shorter_inputs_dict['attention_mask'] = inputs_dict['attention_mask'][:, :-1]

outputs2 = model(**shorter_inputs_dict)
diffs = [float(torch.amax(torch.abs(outputs1.hidden_states[idx][:, -2] - outputs2.hidden_states[idx][:, -1]))) for idx in range(len(outputs1.hidden_states))]
print(diffs)

print(inputs_dict['attention_mask'])
# The attention of the last token in `outputs2` should be the same as of the token at position -2 in `outputs1`
print(outputs1['attentions'][0][0, 0][-2, :-1].detach().tolist())
print(outputs2['attentions'][0][0, 0][-1, :].detach().tolist())
```
