### PR TITLE
Add `position_ids` in `XLMRobertaXLForCausalLM.prepare_inputs_for_generation`

### DIFF
--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -1122,7 +1122,9 @@ class XLMRobertaXLForCausalLM(XLMRobertaXLPreTrainedModel, GenerationMixin):
         # Create missing `position_ids` on the fly
         position_ids = None
         if model_kwargs.get("position_ids") is None:
-            position_ids = create_position_ids_from_input_ids(input_ids, padding_idx=self.config.pad_token_id)  # placed in kwargs for further processing (see below)
+            position_ids = create_position_ids_from_input_ids(
+                input_ids, padding_idx=self.config.pad_token_id
+            )  # placed in kwargs for further processing (see below)
 
         # cut decoder_input_ids if past_key_values is used
         if past_key_values is not None:

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -1140,7 +1140,12 @@ class XLMRobertaXLForCausalLM(XLMRobertaXLPreTrainedModel, GenerationMixin):
             if position_ids is not None:
                 position_ids = position_ids[:, remove_prefix_length:]
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask, "position_ids": position_ids, "past_key_values": past_key_values}
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": past_key_values,
+        }
 
     def _reorder_cache(self, past_key_values, beam_idx):
         reordered_past = ()

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -1119,6 +1119,12 @@ class XLMRobertaXLForCausalLM(XLMRobertaXLPreTrainedModel, GenerationMixin):
         if attention_mask is None:
             attention_mask = input_ids.new_ones(input_shape)
 
+        # Create missing `position_ids` on the fly
+        position_ids = None
+        if model_kwargs.get("position_ids") is None:
+            position_ids = create_position_ids_from_input_ids(input_ids, padding_idx=self.config.pad_token_id)
+            position_ids = position_ids  # placed in kwargs for further processing (see below)
+
         # cut decoder_input_ids if past_key_values is used
         if past_key_values is not None:
             past_length = past_key_values[0][0].shape[2]
@@ -1131,8 +1137,10 @@ class XLMRobertaXLForCausalLM(XLMRobertaXLPreTrainedModel, GenerationMixin):
                 remove_prefix_length = input_ids.shape[1] - 1
 
             input_ids = input_ids[:, remove_prefix_length:]
+            if position_ids is not None:
+                position_ids = position_ids[:, remove_prefix_length:]
 
-        return {"input_ids": input_ids, "attention_mask": attention_mask, "past_key_values": past_key_values}
+        return {"input_ids": input_ids, "attention_mask": attention_mask, "position_ids": position_ids, "past_key_values": past_key_values}
 
     def _reorder_cache(self, past_key_values, beam_idx):
         reordered_past = ()

--- a/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/modeling_xlm_roberta_xl.py
@@ -1122,8 +1122,7 @@ class XLMRobertaXLForCausalLM(XLMRobertaXLPreTrainedModel, GenerationMixin):
         # Create missing `position_ids` on the fly
         position_ids = None
         if model_kwargs.get("position_ids") is None:
-            position_ids = create_position_ids_from_input_ids(input_ids, padding_idx=self.config.pad_token_id)
-            position_ids = position_ids  # placed in kwargs for further processing (see below)
+            position_ids = create_position_ids_from_input_ids(input_ids, padding_idx=self.config.pad_token_id)  # placed in kwargs for further processing (see below)
 
         # cut decoder_input_ids if past_key_values is used
         if past_key_values is not None:


### PR DESCRIPTION
# What does this PR do?

The model component `XLMRobertaXLEmbeddings` will perform

> position_ids = create_position_ids_from_input_ids(input_ids, self.padding_idx, past_key_values_length)

if `position_ids` is not passed to the model (say `XLMRobertaXLForCausalLM`).

However, during the decoding, even if `past_key_values_length` is passed, the `create_position_ids_from_input_ids` will compute the wrong `position_ids` when the `input_ids` is only the single last token. This is because `create_position_ids_from_input_ids` relies the whole  `input_ids` in order to get the number of padding tokens:

>     mask = input_ids.ne(padding_idx).int()

(since `past_key_values_length` doesn't contain this information.)

In general, we need to prepare `position_ids` in `prepare_inputs_for_generation`, like what has been done in

> GenerationMixin.prepare_inputs_for_generation

This PR adds this for `XLMRobertaXLForCausalLM` (whose `prepare_inputs_for_generation` is already overwritten from the parent class)

---------------------------------------------------------------------------------------------------------------------------------

As a bonus:

> tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py::XLMRobertaXLModelTest::test_assisted_decoding_matches_greedy_search_1_same

is also no longer flaky (running 10000 times) while it was failing 5% of the time before this PR.