### PR TITLE
[docs] fix example code bug

### DIFF
--- a/docs/source/en/tasks/image_text_to_text.md
+++ b/docs/source/en/tasks/image_text_to_text.md
@@ -229,7 +229,7 @@ Now let's call the `model_inference` function we created and stream the values.
 ```python
 generator = model_inference(
     user_prompt="And what is in this image?",
-    chat_history=messages,
+    chat_history=messages[:2],
     max_new_tokens=100,
     images=images
 )


### PR DESCRIPTION
## What does this PR do?
The current code example will give me the following error:

```bash
Traceback (most recent call last):
  File "/home/sdp/fanli/transformers/playground.py", line 110, in <module>
    for value in generator:
  File "/home/sdp/fanli/transformers/playground.py", line 80, in model_inference
    inputs = processor(
  File "/home/sdp/fanli/transformers/src/transformers/models/idefics2/processing_idefics2.py", line 227, in __call__
    raise ValueError(
ValueError: The total number of <image> tokens in the prompts should be the same as the number of images passed. Found 3 <image> tokens and 2 images.
```

This is because the `messages` were used in the previous example, while in this example an additional prompt is added. 


Documentation: @stevhliu
