### PR TITLE
Support Python 3.10+ Union style in chat template type hints parsing

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -15,6 +15,7 @@
 import inspect
 import json
 import re
+import types
 from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
@@ -97,7 +98,7 @@ def _parse_type_hint(hint: str) -> Dict:
                 "Couldn't parse this type hint, likely due to a custom class or object: ", hint
             )
 
-    elif origin is Union or origin is types.UnionType:
+    elif origin in {Union, getattr(types, "UnionType", None)}:
         # Recurse into each of the subtypes in the Union, except None, which is handled separately at the end
         subtypes = [_parse_type_hint(t) for t in args if t is not type(None)]
         if len(subtypes) == 1:

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -98,7 +98,7 @@ def _parse_type_hint(hint: str) -> Dict:
                 "Couldn't parse this type hint, likely due to a custom class or object: ", hint
             )
 
-    elif origin in {Union, getattr(types, "UnionType", None)}:
+    elif origin is Union or (hasattr(types, "UnionType") and origin is types.UnionType):
         # Recurse into each of the subtypes in the Union, except None, which is handled separately at the end
         subtypes = [_parse_type_hint(t) for t in args if t is not type(None)]
         if len(subtypes) == 1:

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -97,7 +97,7 @@ def _parse_type_hint(hint: str) -> Dict:
                 "Couldn't parse this type hint, likely due to a custom class or object: ", hint
             )
 
-    elif origin is Union:
+    elif origin is Union or origin is types.UnionType:
         # Recurse into each of the subtypes in the Union, except None, which is handled separately at the end
         subtypes = [_parse_type_hint(t) for t in args if t is not type(None)]
         if len(subtypes) == 1:


### PR DESCRIPTION
# What does this PR do?

This PR fixes the parsing of type hints for chat templates by supporting the 3.10+ Union style (eg `str | None`, vs the older `Union[str, None]`).

The union was already detected in the `get_origin` function, and the arguments were also already parsed by `get_args` [here](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/chat_template_utils.py#L89), but it wasn't handled in the condition block.

## Example

### Before:
```py
def get_current_temperature(location: str, unit: str | None = None) -> float:
    """
    Get the current temperature at a location.

    Args:
        location: The location to get the temperature for, in the format "City, Country"
        unit: The unit to return the temperature in. (choices: ["celsius", "fahrenheit"])
    Returns:
        The current temperature at the specified location in the specified units, as a float.
    """
    return 22.0  # A real function should probably actually get the temperature!
```
was throwing this error:
```txt
Traceback (most recent call last):
  .....
  File "...../tools.py", line 73, in from_langchain
    function_parameters = _convert_type_hints_to_json_schema(langchain_tool._run)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../site-packages/transformers/utils/chat_template_utils.py", line 166, in _convert_type_hints_to_json_schema
    properties[param_name] = _parse_type_hint(param_type)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../site-packages/transformers/utils/chat_template_utils.py", line 151, in _parse_type_hint
    raise TypeHintParsingException("Couldn't parse this type hint, likely due to a custom class or object: ", hint)
transformers.utils.chat_template_utils.TypeHintParsingException: ("Couldn't parse this type hint, likely due to a custom class or object: ", str | None)
```

and now works and generate the following schema:
```txt
{
  "type": "function",
  "function": {
    "name": "get_current_temperature",
    "description": "Get the current temperature at a location.",
    "parameters": {
      "type": "object",
      "properties": {
        "location": {
          "type": "string",
          "description": "The location to get the temperature for, in the format 'City, Country'"
        },
        "unit": {
          "type": "string",
          "nullable": True,
          "enum": [
            "celsius",
            "fahrenheit"
          ],
          "description": "The unit to return the temperature in."
        }
      },
      "required": [
        "location"
      ]
    },
    "return": {
      "type": "number",
      "description": "The current temperature at the specified location in the specified units, as a float."
    }
  }
}
```


<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- chat templates: @Rocketknight1