### PR TITLE
Fix the structure of images in PixtralProcessor

### DIFF
--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -206,10 +206,7 @@ class PixtralProcessor(ProcessorMixin):
             if is_image_or_image_url(images):
                 images = [[images]]
             elif isinstance(images, list) and is_image_or_image_url(images[0]):
-                if isinstance(text, list):
-                    images = [[im] for im in images]
-                else:
-                    images = [images]
+                images = [images]
             elif isinstance(images, list) and isinstance(images[0], list) and is_image_or_image_url(images[0][0]):
                 pass
             else:

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -206,7 +206,11 @@ class PixtralProcessor(ProcessorMixin):
             if is_image_or_image_url(images):
                 images = [[images]]
             elif isinstance(images, list) and is_image_or_image_url(images[0]):
-                images = [images]
+                if isinstance(text, str) or isinstance(text, list) and len(text) == 1:
+                    # If there's a single sample, all images must belong to it
+                    images = [images]
+                else:
+                    raise ValueError("You have supplied multiple text samples, but only a flat list of images. When processing multiple samples, `images` should be a list of lists of images, one list per sample.")
             elif isinstance(images, list) and isinstance(images[0], list) and is_image_or_image_url(images[0][0]):
                 pass
             else:

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -210,7 +210,9 @@ class PixtralProcessor(ProcessorMixin):
                     # If there's a single sample, all images must belong to it
                     images = [images]
                 else:
-                    raise ValueError("You have supplied multiple text samples, but only a flat list of images. When processing multiple samples, `images` should be a list of lists of images, one list per sample.")
+                    raise ValueError(
+                        "You have supplied multiple text samples, but only a flat list of images. When processing multiple samples, `images` should be a list of lists of images, one list per sample."
+                    )
             elif isinstance(images, list) and isinstance(images[0], list) and is_image_or_image_url(images[0][0]):
                 pass
             else:

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -204,14 +204,20 @@ class PixtralProcessor(ProcessorMixin):
 
         if images is not None:
             if is_image_or_image_url(images):
-                images = [[images]]
+                if isinstance(text, str) or isinstance(text, list) and len(text) == 1:
+                    # If there's a single sample, the image must belong to it
+                    images = [[images]]
+                else:
+                    raise ValueError(
+                        "You have supplied multiple text samples, but `images` is not a nested list. When processing multiple samples, `images` should be a list of lists of images, one list per sample."
+                    )
             elif isinstance(images, list) and is_image_or_image_url(images[0]):
                 if isinstance(text, str) or isinstance(text, list) and len(text) == 1:
                     # If there's a single sample, all images must belong to it
                     images = [images]
                 else:
                     raise ValueError(
-                        "You have supplied multiple text samples, but only a flat list of images. When processing multiple samples, `images` should be a list of lists of images, one list per sample."
+                        "You have supplied multiple text samples, but `images` is not a nested list. When processing multiple samples, `images` should be a list of lists of images, one list per sample."
                     )
             elif isinstance(images, list) and isinstance(images[0], list) and is_image_or_image_url(images[0][0]):
                 pass

--- a/tests/models/pixtral/test_processor_pixtral.py
+++ b/tests/models/pixtral/test_processor_pixtral.py
@@ -253,7 +253,7 @@ class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",
         ] * 5
         processor.tokenizer.pad_token = "</s>"
-        image_inputs = [self.image_0] * 5
+        image_inputs = [[self.image_0] * 5]
 
         # Make small for checking image token expansion
         processor.image_processor.size = {"longest_edge": 30}

--- a/tests/models/pixtral/test_processor_pixtral.py
+++ b/tests/models/pixtral/test_processor_pixtral.py
@@ -253,7 +253,7 @@ class PixtralProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "USER: [IMG]\nWhat's the content of the image? ASSISTANT:",
         ] * 5
         processor.tokenizer.pad_token = "</s>"
-        image_inputs = [[self.image_0] * 5]
+        image_inputs = [[self.image_0]] * 5
 
         # Make small for checking image token expansion
         processor.image_processor.size = {"longest_edge": 30}


### PR DESCRIPTION
The `PixtralProcessor` has some issues regarding correct nesting depth of inputs. If we are fully explicit about input nesting, then `text` should be `List[str]` and `images` should be `List[List[Image]]`. This is because each sample only has one text, but can have multiple images.

The start of the Pixtral processor code handles cases when users don't supply fully nested inputs. However, it uses the heuristic that if the user passes `List[str]` for `text` and `List[Image]` for `images`, then this indicates **one image per sample**. This is [very confusing](https://github.com/huggingface/transformers/pull/34332#issuecomment-2519369424) for users, especially because it means output changes when `batch_size==1`, depending on whether that single input is passed as `str` or `[str]`.

With this PR, we avoid that assumption. If the user supplies a single image or flat list of images, then we assign them all to the first sample in the event that `batch_size==1`. If `batch_size>1` then we throw an error, asking them to supply an explicit list of lists instead. This seems much safer!