### PR TITLE
Use `rsfE` with `pytest`

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -32,7 +32,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PT_FLAX_CROSS_TESTS": False,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
-COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile", "vvv": None, "rsf":None}
+COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile", "vvv": None, "rsfE":None}
 DEFAULT_DOCKER_IMAGE = [{"image": "cimg/python:3.8.12"}]
 
 

--- a/.circleci/parse_test_outputs.py
+++ b/.circleci/parse_test_outputs.py
@@ -18,8 +18,11 @@ def parse_pytest_output(file_path):
 def parse_pytest_failure_output(file_path):
     failed_tests = {}
     failed_count = 0
+    has_error = False
     with open(file_path, 'r') as file:
         for line in file:
+            if "==== ERRORS ===" in line:
+                has_error = True
             match = re.match(r'^FAILED (tests/.*) - (.*): (.*)$', line)
             if match:
                 failed_count += 1
@@ -28,7 +31,8 @@ def parse_pytest_failure_output(file_path):
     for k,v in sorted(failed_tests.items(), key=lambda x:len(x[1])):
         print(f"{len(v):4} failed because `{v[0]}` -> {k}")
     print("Number of failed tests:", failed_count)
-    if failed_count>0:
+    print("Error encountered:", has_error)
+    if failed_count > 0 or has_error:
         exit(1)
 
 def parse_pytest_errors_output(file_path):

--- a/.circleci/parse_test_outputs.py
+++ b/.circleci/parse_test_outputs.py
@@ -18,11 +18,8 @@ def parse_pytest_output(file_path):
 def parse_pytest_failure_output(file_path):
     failed_tests = {}
     failed_count = 0
-    has_error = False
     with open(file_path, 'r') as file:
         for line in file:
-            if "==== ERRORS ===" in line:
-                has_error = True
             match = re.match(r'^FAILED (tests/.*) - (.*): (.*)$', line)
             if match:
                 failed_count += 1
@@ -31,8 +28,7 @@ def parse_pytest_failure_output(file_path):
     for k,v in sorted(failed_tests.items(), key=lambda x:len(x[1])):
         print(f"{len(v):4} failed because `{v[0]}` -> {k}")
     print("Number of failed tests:", failed_count)
-    print("Error encountered:", has_error)
-    if failed_count > 0 or has_error:
+    if failed_count>0:
         exit(1)
 
 def parse_pytest_errors_output(file_path):


### PR DESCRIPTION
# What does this PR do?

> parse_pytest_errors_output (in `.circleci/parse_test_outputs.py`)

requires `rsfE` flag in `pytest`
