### PR TITLE
Add weight norm rename in _load_state_dict_into_model

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -669,6 +669,17 @@ def _load_state_dict_into_model(model_to_load, state_dict, start_prefix, assign_
             # We add only the first key as an example
             new_key = key.replace("beta", "bias")
             renamed_beta[key] = new_key if not renamed_beta else renamed_beta
+
+        if hasattr(nn.utils.parametrizations, "weight_norm"):
+            if "weight_g" in key:
+                new_key = key.replace("weight_g", "parametrizations.weight.original0")
+            if "weight_v" in key:
+                new_key = key.replace("weight_v", "parametrizations.weight.original1")
+        else:
+            if "parametrizations.weight.original0" in key:
+                new_key = key.replace("parametrizations.weight.original0", "weight_g")
+            if "parametrizations.weight.original1" in key:
+                new_key = key.replace("parametrizations.weight.original1", "weight_v")
         if new_key:
             old_keys.append(key)
             new_keys.append(new_key)
@@ -829,7 +840,6 @@ def _load_state_dict_into_meta_model(
             new_key = key.replace("beta", "bias")
             renamed_beta[key] = new_key if not renamed_beta else renamed_beta
 
-        # To reproduce `_load_state_dict_into_model` behaviour, we need to manually rename parametrized weigth norm, if necessary.
         if hasattr(nn.utils.parametrizations, "weight_norm"):
             if "weight_g" in key:
                 new_key = key.replace("weight_g", "parametrizations.weight.original0")


### PR DESCRIPTION
# What does this PR do?

#33275 fixed old parametrization of weight_norm for _load_state_dict_into_meta_model, but the issue also holds for _load_state_dict_into_model when using an old version of torch, e.g., 1.13.

Namely, weights are not loaded correctly for wav2vec2.encoder.pos_conv_embed.conv.weight_g, wav2vec2.encoder.pos_conv_embed.conv.weight_v for a model trained on a PyTorch version where weight_g and weight_v were renamed to original0 and original1. 

What happens is that 
- cls._load_pretrained_model is called in from_pretrained
- _fix_key is called to ensure no more warnings for renamed keys as nicely fixed by #33275
- _load_state_dict_into_model is called, with the state_dict containing still unrenamed keys https://github.com/huggingface/transformers/blob/7f95372c6267d3163fd2aa74aeff9d84ddb6cc35/src/transformers/modeling_utils.py#L4712
- _load_state_dict_into_model adjusts beta and gamma names but not weight_g and weight_v: https://github.com/huggingface/transformers/blob/7f95372c6267d3163fd2aa74aeff9d84ddb6cc35/src/transformers/modeling_utils.py#L666
- This is however, done in _load_state_dict_into_meta_model creating an inconsistency between the two: https://github.com/huggingface/transformers/blob/7f95372c6267d3163fd2aa74aeff9d84ddb6cc35/src/transformers/modeling_utils.py#L832

Related to #31970.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

cc @LysandreJik and @ArthurZucker 
