### PR TITLE
don't use no_sync when deepspeed doesn't support it for certain zero stages

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2514,8 +2514,8 @@ class Trainer:
 
                     # We explicitly want to avoid relying on `accelerator.accumulate` for generation training
                     disable_deepspeed_no_sync = (
-                            self.accelerator.distributed_type == DistributedType.DEEPSPEED
-                            and self.accelerator.deepspeed_engine_wrapped.engine.zero_optimization_partition_gradients()
+                        self.accelerator.distributed_type == DistributedType.DEEPSPEED
+                        and self.accelerator.deepspeed_engine_wrapped.engine.zero_optimization_partition_gradients()
                     )
                     context = (
                         functools.partial(self.accelerator.no_sync, model=model)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2513,9 +2513,13 @@ class Trainer:
                         self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
                     # We explicitly want to avoid relying on `accelerator.accumulate` for generation training
+                    disable_deepspeed_no_sync = (
+                            self.accelerator.distributed_type == DistributedType.DEEPSPEED
+                            and self.accelerator.deepspeed_engine_wrapped.engine.zero_optimization_partition_gradients()
+                    )
                     context = (
                         functools.partial(self.accelerator.no_sync, model=model)
-                        if i != len(batch_samples) - 1
+                        if i != len(batch_samples) - 1 and not disable_deepspeed_no_sync
                         else contextlib.nullcontext
                     )
                     with context():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2513,13 +2513,9 @@ class Trainer:
                         self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
 
                     # We explicitly want to avoid relying on `accelerator.accumulate` for generation training
-                    disable_deepspeed_no_sync = (
-                        self.accelerator.distributed_type == DistributedType.DEEPSPEED
-                        and self.accelerator.deepspeed_engine_wrapped.engine.zero_optimization_partition_gradients()
-                    )
                     context = (
                         functools.partial(self.accelerator.no_sync, model=model)
-                        if i != len(batch_samples) - 1 and not disable_deepspeed_no_sync
+                        if i != len(batch_samples) - 1 and self.accelerator.distributed_type != DistributedType.DEEPSPEED
                         else contextlib.nullcontext
                     )
                     with context():

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2515,7 +2515,8 @@ class Trainer:
                     # We explicitly want to avoid relying on `accelerator.accumulate` for generation training
                     context = (
                         functools.partial(self.accelerator.no_sync, model=model)
-                        if i != len(batch_samples) - 1 and self.accelerator.distributed_type != DistributedType.DEEPSPEED
+                        if i != len(batch_samples) - 1
+                        and self.accelerator.distributed_type != DistributedType.DEEPSPEED
                         else contextlib.nullcontext
                     )
                     with context():


### PR DESCRIPTION
# What does this PR do?
Deepspeed 0.16 has assertions preventing the use of no_sync with zero 2/3. see https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/engine.py#L1986-L2004

it seems people are reporting this here https://github.com/microsoft/DeepSpeed/issues/6793, and I'm assuming that everyone is using accelerate/transformers as downgrading to deepspeed 0.15.4 makes it "work" for them.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
