### PR TITLE
Use modules_to_not_convert in AQLM

### DIFF
--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -23,7 +23,7 @@ if is_torch_available():
 def replace_with_aqlm_linear(
     model,
     quantization_config=None,
-    linear_weights_not_to_quantize=None,
+    modules_to_not_convert=None,
     current_key_name=None,
     has_been_replaced=False,
 ):
@@ -37,7 +37,7 @@ def replace_with_aqlm_linear(
             The model to convert, can be any `torch.nn.Module` instance.
         quantization_config (`AqlmConfig`):
             The quantization config object that contains the quantization parameters.
-        linear_weights_not_to_quantize (`list[str]`, *optional*):
+        modules_to_not_convert (`list[str]`, *optional*):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         current_key_name (`list`, *optional*):
@@ -54,8 +54,8 @@ def replace_with_aqlm_linear(
             f"AQLM requires Accelerate to be installed: `pip install 'accelerate>={ACCELERATE_MIN_VERSION}'`"
         )
 
-    if linear_weights_not_to_quantize is None:
-        linear_weights_not_to_quantize = []
+    if modules_to_not_convert is None:
+        modules_to_not_convert = []
 
     from accelerate import init_empty_weights
     from aqlm import QuantizedLinear
@@ -66,8 +66,8 @@ def replace_with_aqlm_linear(
         current_key_name.append(name)
 
         if isinstance(module, nn.Linear):
-            # Check if the current key is not in the `linear_weights_not_to_quantize`
-            if ".".join(current_key_name) + ".weight" not in linear_weights_not_to_quantize:
+            # Check if the current key is not in the `modules_to_not_convert`
+            if ".".join(current_key_name) + ".weight" not in modules_to_not_convert:
                 with init_empty_weights():
                     in_features = module.in_features
                     out_features = module.out_features
@@ -91,7 +91,7 @@ def replace_with_aqlm_linear(
             _, has_been_replaced = replace_with_aqlm_linear(
                 module,
                 quantization_config=quantization_config,
-                linear_weights_not_to_quantize=linear_weights_not_to_quantize,
+                modules_to_not_convert=modules_to_not_convert,
                 current_key_name=current_key_name,
                 has_been_replaced=has_been_replaced,
             )

--- a/src/transformers/quantizers/quantizer_aqlm.py
+++ b/src/transformers/quantizers/quantizer_aqlm.py
@@ -75,7 +75,7 @@ class AqlmHfQuantizer(HfQuantizer):
         replace_with_aqlm_linear(
             model,
             quantization_config=self.quantization_config,
-            linear_weights_not_to_quantize=self.quantization_config.linear_weights_not_to_quantize,
+            modules_to_not_convert=self.quantization_config.modules_to_not_convert,
         )
         model.config.quantization_config = self.quantization_config
 

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -948,7 +948,7 @@ class AqlmConfig(QuantizationConfigMixin):
             Number of codebooks for the Additive Quantization procedure.
         nbits_per_codebook (`int`, *optional*, defaults to 16):
             Number of bits encoding a single codebook vector. Codebooks size is 2**nbits_per_codebook.
-        linear_weights_not_to_quantize (`Optional[List[str]]`, *optional*):
+        modules_to_not_convert (`Optional[List[str]]`, *optional*):
             List of full paths of `nn.Linear` weight parameters that shall not be quantized.
         kwargs (`Dict[str, Any]`, *optional*):
             Additional parameters from which to initialize the configuration object.
@@ -960,7 +960,7 @@ class AqlmConfig(QuantizationConfigMixin):
         out_group_size: int = 1,
         num_codebooks: int = 1,
         nbits_per_codebook: int = 16,
-        linear_weights_not_to_quantize: Optional[List[str]] = None,
+        modules_to_not_convert: Optional[List[str]] = None,
         **kwargs,
     ):
         self.quant_method = QuantizationMethod.AQLM
@@ -968,7 +968,7 @@ class AqlmConfig(QuantizationConfigMixin):
         self.out_group_size = out_group_size
         self.num_codebooks = num_codebooks
         self.nbits_per_codebook = nbits_per_codebook
-        self.linear_weights_not_to_quantize = linear_weights_not_to_quantize
+        self.modules_to_not_convert = modules_to_not_convert
 
         self.post_init()
 
@@ -985,13 +985,13 @@ class AqlmConfig(QuantizationConfigMixin):
         if not isinstance(self.nbits_per_codebook, int):
             raise TypeError("nbits_per_codebook must be a float")
 
-        if self.linear_weights_not_to_quantize is not None and not isinstance(
-            self.linear_weights_not_to_quantize, list
+        if self.modules_to_not_convert is not None and not isinstance(
+            self.modules_to_not_convert, list
         ):
-            raise ValueError("linear_weights_not_to_quantize must be a list of strings")
+            raise ValueError("modules_to_not_convert must be a list of strings")
 
-        if self.linear_weights_not_to_quantize is None:
-            self.linear_weights_not_to_quantize = []
+        if self.modules_to_not_convert is None:
+            self.modules_to_not_convert = []
 
 
 @dataclass

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -985,9 +985,7 @@ class AqlmConfig(QuantizationConfigMixin):
         if not isinstance(self.nbits_per_codebook, int):
             raise TypeError("nbits_per_codebook must be a float")
 
-        if self.modules_to_not_convert is not None and not isinstance(
-            self.modules_to_not_convert, list
-        ):
+        if self.modules_to_not_convert is not None and not isinstance(self.modules_to_not_convert, list):
             raise ValueError("modules_to_not_convert must be a list of strings")
 
         if self.modules_to_not_convert is None:

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -60,14 +60,14 @@ class AqlmConfigTest(unittest.TestCase):
             "in_group_size": 32,
             "num_codebooks": 8,
             "nbits_per_codebook": 8,
-            "linear_weights_not_to_quantize": ["lm_head.weight"],
+            "modules_to_not_convert": ["lm_head.weight"],
         }
         quantization_config = AqlmConfig.from_dict(dict)
 
         self.assertEqual(dict["in_group_size"], quantization_config.in_group_size)
         self.assertEqual(dict["num_codebooks"], quantization_config.num_codebooks)
         self.assertEqual(dict["nbits_per_codebook"], quantization_config.nbits_per_codebook)
-        self.assertEqual(dict["linear_weights_not_to_quantize"], quantization_config.linear_weights_not_to_quantize)
+        self.assertEqual(dict["modules_to_not_convert"], quantization_config.modules_to_not_convert)
 
 
 @slow
@@ -129,12 +129,12 @@ class AqlmTest(unittest.TestCase):
 
         self.assertEqual(nb_linears, nb_aqlm_linear)
 
-        # Try with `linear_weights_not_to_quantize`
+        # Try with `modules_to_not_convert`
         with init_empty_weights():
             model = OPTForCausalLM(config)
 
         model, _ = replace_with_aqlm_linear(
-            model, quantization_config=quantization_config, linear_weights_not_to_quantize=["lm_head.weight"]
+            model, quantization_config=quantization_config, modules_to_not_convert=["lm_head.weight"]
         )
         nb_aqlm_linear = 0
         for module in model.modules():


### PR DESCRIPTION
# What does this PR do?

Using `modules_to_not_convert` instead of `linear_weights_not_to_quantize` in `aqlm` to standardize it in all quantizers

## Who can review ?

@SunMarc 