### PR TITLE
draft to test dduf compatibility with file explorer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -28,7 +28,6 @@ from ...tokenization_utils import PreTrainedTokenizer
 from ...tokenization_utils_base import TOKENIZER_CONFIG_FILE
 from ...utils import (
     cached_file,
-    extract_commit_hash,
     is_g2p_en_available,
     is_sentencepiece_available,
     is_tokenizers_available,
@@ -706,10 +705,11 @@ def get_tokenizer_config(
     if resolved_config_file is None:
         logger.info("Could not locate the tokenizer configuration file, will try to use the model config instead.")
         return {}
-    commit_hash = extract_commit_hash(resolved_config_file, commit_hash)
+    # TODO: handle this correctly
+    # commit_hash = extract_commit_hash(resolved_config_file, commit_hash)
+    commit_hash = None
 
-    with open(resolved_config_file, encoding="utf-8") as reader:
-        result = json.load(reader)
+    result = json.loads(resolved_config_file.read_text())
     result["_commit_hash"] = commit_hash
     return result
 


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/pull/2692, https://github.com/huggingface/diffusers/pull/10037 and https://github.com/huggingface/transformers/pull/35093.

And more precisely to https://github.com/huggingface/huggingface_hub/pull/2703 which aims at unifying the interface to handle a filesystem (e.g. a local directory) and a zip file (e.g. a DDUF file). Still a lot of changes to make if we go in this direction. I preferred to open the PR early for discussions.

### Reproduction steps:

#### Install
```sh
pip install git+https://github.com/huggingface/transformers.git@dduf-compatibility-with-file-explorer
pip install git+https://github.com/huggingface/huggingface_hub.git@draft-file-explorer
``` 

#### Run on test DDUF file
```py
from huggingface_hub import hf_hub_download
from transformers import AutoTokenizer

dduf_path = hf_hub_download("DDUF/Flux.1-Dev-Tnf4-TE2NF4", "Flux.1-Dev-Tnf4-TE2NF4.dduf")

tokenizer = AutoTokenizer.from_pretrained(dduf_path, subfolder="tokenizer")
```