### PR TITLE
Remove unnecessary masked_fill in deberta models

### DIFF
--- a/src/transformers/models/deberta/modeling_deberta.py
+++ b/src/transformers/models/deberta/modeling_deberta.py
@@ -290,7 +290,6 @@ class DisentangledSelfAttention(nn.Module):
         attention_scores = attention_scores.masked_fill(~(attention_mask), torch.finfo(query_layer.dtype).min)
         # bsz x height x length x dimension
         attention_probs = nn.functional.softmax(attention_scores, dim=-1)
-        attention_probs.masked_fill(attention_mask, 0)
 
         attention_probs = self.dropout(attention_probs)
         if self.head_weights_proj is not None:

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -267,7 +267,6 @@ class DisentangledSelfAttention(nn.Module):
         attention_scores = attention_scores.masked_fill(~(attention_mask), torch.finfo(query_layer.dtype).min)
         # bsz x height x length x dimension
         attention_probs = nn.functional.softmax(attention_scores, dim=-1)
-        attention_probs.masked_fill(attention_mask, 0)
 
         attention_probs = self.dropout(attention_probs)
         context_layer = torch.bmm(


### PR DESCRIPTION
# What does this PR do?

Both models Deberta and DebertaV2 executes one instruction with no impact on the result. It is the last line among the 

```python
attention_scores = attention_scores.masked_fill(~(attention_mask), torch.finfo(query_layer.dtype).min)
# bsz x height x length x dimension
attention_probs = nn.functional.softmax(attention_scores, dim=-1)
attention_probs.masked_fill(attention_mask, 0)  # no impact on what follows
```

The line can be removed safely. If we replace it by one inplace modification ``attention_probs.masked_fill(attention_mask, 0)`` then the attention_probs will be null because:

* line 1: replace all False mask values by - infinity
* line 2: compute softmax, then the replaced values become 0
* line 3: if modified with inplace modification, it would replace all True mask value by 0

At the end, the output tensor would be null. No unit test was added because the numerical results are not impacted.

Fixes #35162.