### PR TITLE
Use `weights_only=True` with `torch.load` for `transfo_xl`

### DIFF
--- a/src/transformers/models/deprecated/transfo_xl/tokenization_transfo_xl.py
+++ b/src/transformers/models/deprecated/transfo_xl/tokenization_transfo_xl.py
@@ -222,7 +222,7 @@ class TransfoXLTokenizer(PreTrainedTokenizer):
                             "from a PyTorch pretrained vocabulary, "
                             "or activate it with environment variables USE_TORCH=1 and USE_TF=0."
                         )
-                    vocab_dict = torch.load(pretrained_vocab_file)
+                    vocab_dict = torch.load(pretrained_vocab_file, weights_only=True)
 
             if vocab_dict is not None:
                 for key, value in vocab_dict.items():
@@ -705,7 +705,7 @@ class TransfoXLCorpus:
 
         # Instantiate tokenizer.
         corpus = cls(*inputs, **kwargs)
-        corpus_dict = torch.load(resolved_corpus_file)
+        corpus_dict = torch.load(resolved_corpus_file, weights_only=True)
         for key, value in corpus_dict.items():
             corpus.__dict__[key] = value
         corpus.vocab = vocab
@@ -784,7 +784,7 @@ def get_lm_corpus(datadir, dataset):
     fn_pickle = os.path.join(datadir, "cache.pkl")
     if os.path.exists(fn):
         logger.info("Loading cached dataset...")
-        corpus = torch.load(fn_pickle)
+        corpus = torch.load(fn_pickle, weights_only=True)
     elif os.path.exists(fn):
         logger.info("Loading cached dataset from pickle...")
         if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):


### PR DESCRIPTION
# What does this PR do?

Just to move forward with a [huntr report](https://huntr.com/bounties/adc0155f-4af7-455a-a7c1-33ad799c1d24). Use `weights_only=True` for `torch.load` in `src/transformers/models/deprecated/transfo_xl/tokenization_transfo_xl.py`.

### Remark

Although `TransfoXL` is deprecated, I am trying to check if this PR breaks something by running

>  tokenizer = TransfoXLTokenizer.from_pretrained("transfo-xl-wt103")

but that is failing even on `main`. I  don't do anything trying to fix it though.