### PR TITLE
skip Fuyu from test_generate

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1202,6 +1202,7 @@ class GenerationTesterMixin:
                     "prophetnet",
                     "seamlessm4t",
                     "clvp",
+                    "fuyu"
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1202,7 +1202,7 @@ class GenerationTesterMixin:
                     "prophetnet",
                     "seamlessm4t",
                     "clvp",
-                    "fuyu"
+                    "fuyu",
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")


### PR DESCRIPTION
# What does this PR do?

skip Fuyu model from `test_prompt_lookup_decoding_matches_greedy_search` to fix `tests_generate`'s failure.

## Backgrounds
Recently, `test_generate` in CircleCI fails due to FuyuModelTest.
([reference] [tests_generate](https://app.circleci.com/pipelines/github/huggingface/transformers/113356/workflows/1e152e04-8f26-496a-9925-549ac7435e88/jobs/1514539?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) - Failed)

The direct cause is `RuntimeError: The size of tensor a (2) must match the size of tensor b (0) at non-singleton dimension 1`, perhaps caused by `eos_token_id should consist of positive integers, but is tensor([-1]). Your generation will not stop until the maximum length is reached. Depending on other flags, it may even crash.` 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- generate: @zucchini-nlp
