### PR TITLE
set supports_gradient_checkpointing = False in SwitchTransformer

### DIFF
--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -769,7 +769,6 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
 
     config_class = SwitchTransformersConfig
     base_model_prefix = "switch_transformers"
-    supports_gradient_checkpointing = False
     _supports_cache_class = True
     _supports_static_cache = False
     _no_split_modules = ["SwitchTransformersBlock"]

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -769,7 +769,7 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
 
     config_class = SwitchTransformersConfig
     base_model_prefix = "switch_transformers"
-    supports_gradient_checkpointing = True
+    supports_gradient_checkpointing = False
     _supports_cache_class = True
     _supports_static_cache = False
     _no_split_modules = ["SwitchTransformersBlock"]

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -863,8 +863,7 @@ class ModelTesterMixin:
                     ]
                     or not model_class.supports_gradient_checkpointing
                 ):
-                    # TODO (ydshieh): use `skipTest` once pytest-dev/pytest-subtests/pull/169 is merged
-                    # self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
+                    self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
                     continue
 
                 config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -863,7 +863,8 @@ class ModelTesterMixin:
                     ]
                     or not model_class.supports_gradient_checkpointing
                 ):
-                    self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
+                    # TODO (ydshieh): use `skipTest` once pytest-dev/pytest-subtests/pull/169 is merged
+                    # self.skipTest(reason=f"`supports_gradient_checkpointing` is False for {model_class.__name__}.")
                     continue
 
                 config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

Recently, CircleCI's `tests_torch` sometimes fails (Reference: [tests_torch](https://app.circleci.com/pipelines/github/huggingface/transformers/113436/workflows/802101b9-ed24-49ac-bc1d-7f2ae9dce240/jobs/1515817?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) - Failed), because some models which don't support gradient_checkpointing or have MoE module like SwitchTransformer will occasionally have weights without gradients.

I found maybe-related PR: https://github.com/huggingface/transformers/pull/34806, and the situation described in the PR was already fixed (https://github.com/pytest-dev/pytest-subtests/pull/169 was already merged).

In https://github.com/huggingface/transformers/pull/34806, @ydshieh said: `TODO (ydshieh): use skipTest once pytest-dev/pytest-subtests/pull/169 is merged`, so I reverted the stopgap fix.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @ydshieh @muellerzr @SunMarc