### PR TITLE
Fix: 'Gemma2Attention' object has no attribute '_flash_attn_uses_top_left_mask'

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -36,6 +36,7 @@ from .utils import (
     copy_func,
     download_url,
     extract_commit_hash,
+    is_flash_attn_greater_or_equal_2_10,
     is_remote_url,
     is_timm_config_dict,
     is_torch_available,
@@ -303,6 +304,8 @@ class PretrainedConfig(PushToHubMixin):
         # Attention implementation to use, if relevant.
         self._attn_implementation_internal = kwargs.pop("attn_implementation", None)
         self._attn_implementation_autoset = False
+
+        self._flash_attn_uses_top_left_mask = not is_flash_attn_greater_or_equal_2_10()
 
         # Drop the transformers version info
         self.transformers_version = kwargs.pop("transformers_version", None)

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -199,7 +199,7 @@ def eager_attention_forward(
 
 
 def flash_attention_forward(
-    config: Gemma2Config,
+    self: 'Gemma2Attention',
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -218,13 +218,14 @@ def flash_attention_forward(
     key_states = key.transpose(1, 2)
     value_states = value.transpose(1, 2)
 
-    dropout_rate = config.attention_dropout if config.training else 0.0
+    dropout_rate = self.config.attention_dropout if self.training else 0.0
 
     input_dtype = query_states.dtype
     if input_dtype == torch.float32:
         query_states = query_states.to(target_dtype)
         key_states = key_states.to(target_dtype)
         value_states = value_states.to(target_dtype)
+
 
     attn_output = _flash_attention_forward(
         query_states,
@@ -233,11 +234,11 @@ def flash_attention_forward(
         mask,
         seq_len,
         dropout=dropout_rate,
-        softmax_scale=config.scaling,
-        is_causal=config.is_causal,
-        sliding_window=config.sliding_window,
-        use_top_left_mask=config._flash_attn_uses_top_left_mask,
-        softcap=config.attn_logit_softcapping if is_flash_attn_greater_or_equal("2.6.0") else None,
+        softmax_scale=self.scaling,
+        is_causal=self.is_causal,
+        sliding_window=self.config.sliding_window,
+        use_top_left_mask=self.config._flash_attn_uses_top_left_mask,
+        softcap=self.config.attn_logit_softcapping if is_flash_attn_greater_or_equal("2.6.0") else None,
     )
 
     return attn_output, None


### PR DESCRIPTION
# What does this PR do?
A PR to fix the 'no attribute '_flash_attn_uses_top_left_mask'' error occurring in each model with the flash_attention module, including gemma2.
## Reproduction Code
```python
from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer


def main() -> None:
    repo_id = "google/gemma-2-2b-it"
    config = AutoConfig.from_pretrained(repo_id, _attn_implementation="flash_attention_2")
    model = AutoModelForCausalLM.from_pretrained(repo_id, config=config, device_map="cpu")
    tokenizer = AutoTokenizer.from_pretrained(repo_id)

    text = tokenizer.apply_chat_template([{"role": "user", "content": "Hello!"}], tokenize=False)
    input_param = tokenizer(text, return_tensors="pt", return_attention_mask=True)
    input_param["labels"] = input_param["input_ids"].clone()
    output = model(**input_param)


if "__main__" in __name__:
    main()

```
> pip install git+https://github.com/huggingface/transformers.git@5615a393691c81e00251e420c73e4d04c6fe22e5
## Env
```
- `transformers` version: 4.48.0.dev0
- Platform: Linux-5.15.0-124-generic-x86_64-with-glibc2.35
- Python version: 3.10.12
- Huggingface_hub version: 0.26.2
- Safetensors version: 0.4.5
- Accelerate version: 1.1.1
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
