### PR TITLE
remove `benchmark` job in `push-important-models.yml`

### DIFF
--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -134,10 +134,3 @@ jobs:
           slackChannel: ${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}
           slackToken: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           waitForSSH: true
-
-  benchmark:
-    name: Benchmark workflow
-    needs: get_modified_models
-    if: ${{ needs.get_modified_models.outputs.matrix != '[]' && needs.get_modified_models.outputs.matrix != '' && fromJson(needs.get_modified_models.outputs.matrix)[0] != null }}
-    uses: ./.github/workflows/benchmark.yml
-    secrets: inherit


### PR DESCRIPTION
# What does this PR do?

As discussed offline: the benchmark workflow is updated and is triggered directly with push to main / pull_request events.
There is no need to be called in  `.github/workflows/push-important-models.yml` (and it's currently failing due to the format mismatching)