### PR TITLE
🚨🚨🚨 Delete conversion scripts when making release wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ To create the package for pypi.
 1. Create the release branch named: v<RELEASE>-release, for example v4.19-release. For a patch release checkout the
    current release branch.
 
-   If releasing on a special branch, copy the updated README.md on the main branch for your the commit you will make
+   If releasing on a special branch, copy the updated README.md on the main branch for the commit you will make
    for the post-release and run `make fix-copies` on the main branch as well.
 
 2. Run `make pre-release` (or `make pre-patch` for a patch release) and commit these changes with the message:

--- a/utils/release.py
+++ b/utils/release.py
@@ -123,7 +123,7 @@ def remove_conversion_scripts():
     """
     Delete the scripts that convert models from older, unsupported formats. We don't want to include these
     in release wheels because they often have to open insecure file types (pickle, Torch .bin models). This results in
-    vulnerability scanners flagging us, see an example issue here: https://github.com/huggingface/transformers/issues/34840#issuecomment-2544876106
+    vulnerability scanners flagging us and can cause compliance issues for users with strict security policies.
     """
     model_dir = Path(PATH_TO_MODELS)
     for conversion_script in list(model_dir.glob("**/convert*.py")):

--- a/utils/release.py
+++ b/utils/release.py
@@ -118,6 +118,7 @@ def global_version_update(version: str, patch: bool = False):
         # We don't update the version in the examples for patch releases.
         update_version_in_examples(version)
 
+
 def remove_conversion_scripts():
     """
     Delete the scripts that convert models from older, unsupported formats. We don't want to include these

--- a/utils/release.py
+++ b/utils/release.py
@@ -45,12 +45,14 @@ or use `make post-release`.
 import argparse
 import os
 import re
+from pathlib import Path
 
 import packaging.version
 
 
 # All paths are defined with the intent that this script should be run from the root of the repo.
 PATH_TO_EXAMPLES = "examples/"
+PATH_TO_MODELS = "src/transformers/models"
 # This maps a type of file to the pattern to look for when searching where the version is defined, as well as the
 # template to follow when replacing it with the new version.
 REPLACE_PATTERNS = {
@@ -116,6 +118,16 @@ def global_version_update(version: str, patch: bool = False):
         # We don't update the version in the examples for patch releases.
         update_version_in_examples(version)
 
+def remove_conversion_scripts():
+    """
+    Delete the scripts that convert models from older, unsupported formats. We don't want to include these
+    in release wheels because they often have to open insecure file types (pickle, Torch .bin models). This results in
+    vulnerability scanners flagging us, see an example issue here: https://github.com/huggingface/transformers/issues/34840#issuecomment-2544876106
+    """
+    model_dir = Path(PATH_TO_MODELS)
+    for conversion_script in list(model_dir.glob("**/convert*.py")):
+        conversion_script.unlink()
+
 
 def get_version() -> packaging.version.Version:
     """
@@ -131,7 +143,7 @@ def pre_release_work(patch: bool = False):
     """
     Do all the necessary pre-release steps:
     - figure out the next minor release version and ask confirmation
-    - update the version eveywhere
+    - update the version everywhere
     - clean-up the model list in the main README
 
     Args:
@@ -155,13 +167,15 @@ def pre_release_work(patch: bool = False):
 
     print(f"Updating version to {version}.")
     global_version_update(version, patch=patch)
+    print("Deleting conversion scripts.")
+    remove_conversion_scripts()
 
 
 def post_release_work():
     """
-    Do all the necesarry post-release steps:
+    Do all the necessary post-release steps:
     - figure out the next dev version and ask confirmation
-    - update the version eveywhere
+    - update the version everywhere
     - clean-up the model list in the main README
     """
     # First let's get the current version


### PR DESCRIPTION
This PR updates `release.py` to delete model conversion scripts. These scripts are generally included with specific model classes to convert checkpoints in non-Transformers formats. Often these scripts have to open insecure file types, because those were the file types the model was released with (e.g. `pickle` or old Torch `.bin` checkpoints). This results in vulnerability scanners flagging us, and can cause compliance issues for users. 

We don't see this as a serious attack vector in practice because users would have to be induced to download a malicious file and call an obscure conversion script on it, but excluding these files from release wheels should help with compliance issues!

Fixes #34840