### PR TITLE
Update test fetcher when we want to test all

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -998,6 +998,7 @@ def infer_tests_to_run(
     output_file: str,
     diff_with_last_commit: bool = False,
     filter_models: bool = False,
+    test_all: bool = False
 ):
     """
     The main function called by the test fetcher. Determines the tests to run from the diff.
@@ -1018,7 +1019,10 @@ def infer_tests_to_run(
             Whether or not to filter the tests to core models only, when a file modified results in a lot of model
             tests.
     """
-    modified_files = get_modified_python_files(diff_with_last_commit=diff_with_last_commit)
+    if not test_all:
+        modified_files = get_modified_python_files(diff_with_last_commit=diff_with_last_commit)
+    else:
+        modified_files = PATH_TO_TESTS.glob("*")
     print(f"\n### MODIFIED FILES ###\n{_print_list(modified_files)}")
 
     # Create the map that will give us all impacted modules.
@@ -1230,5 +1234,6 @@ if __name__ == "__main__":
             args.output_file,
             diff_with_last_commit=diff_with_last_commit,
             filter_models=False,
+            test_all=args.fetch_all
         )
         filter_tests(args.output_file, ["repo_utils"])

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1229,6 +1229,6 @@ if __name__ == "__main__":
             diff_with_last_commit = True
 
         infer_tests_to_run(
-            args.output_file, diff_with_last_commit=diff_with_last_commit, filter_models=False, test_all=args.fetch_all
+            args.output_file, diff_with_last_commit=diff_with_last_commit, filter_models=False, test_all=commit_flags["test_all"]
         )
         filter_tests(args.output_file, ["repo_utils"])

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1019,7 +1019,7 @@ def infer_tests_to_run(
     if not test_all:
         modified_files = get_modified_python_files(diff_with_last_commit=diff_with_last_commit)
     else:
-        modified_files = [ str(k) for k in PATH_TO_TESTS.glob("*/*") if str(k).endswith(".py") and "test_" in str(k)]
+        modified_files = [str(k) for k in PATH_TO_TESTS.glob("*/*") if str(k).endswith(".py") and "test_" in str(k)]
         print("\n### test_all is TRUE, FETCHING ALL FILES###\n")
     print(f"\n### MODIFIED FILES ###\n{_print_list(modified_files)}")
 
@@ -1229,6 +1229,9 @@ if __name__ == "__main__":
             diff_with_last_commit = True
 
         infer_tests_to_run(
-            args.output_file, diff_with_last_commit=diff_with_last_commit, filter_models=False, test_all=commit_flags["test_all"]
+            args.output_file,
+            diff_with_last_commit=diff_with_last_commit,
+            filter_models=False,
+            test_all=commit_flags["test_all"],
         )
         filter_tests(args.output_file, ["repo_utils"])

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -995,10 +995,7 @@ def _print_list(l) -> str:
 
 
 def infer_tests_to_run(
-    output_file: str,
-    diff_with_last_commit: bool = False,
-    filter_models: bool = False,
-    test_all: bool = False
+    output_file: str, diff_with_last_commit: bool = False, filter_models: bool = False, test_all: bool = False
 ):
     """
     The main function called by the test fetcher. Determines the tests to run from the diff.
@@ -1023,6 +1020,7 @@ def infer_tests_to_run(
         modified_files = get_modified_python_files(diff_with_last_commit=diff_with_last_commit)
     else:
         modified_files = PATH_TO_TESTS.glob("*")
+        print("\n### test_all is TRUE, FETCHING ALL FILES###\n")
     print(f"\n### MODIFIED FILES ###\n{_print_list(modified_files)}")
 
     # Create the map that will give us all impacted modules.
@@ -1231,9 +1229,6 @@ if __name__ == "__main__":
             diff_with_last_commit = True
 
         infer_tests_to_run(
-            args.output_file,
-            diff_with_last_commit=diff_with_last_commit,
-            filter_models=False,
-            test_all=args.fetch_all
+            args.output_file, diff_with_last_commit=diff_with_last_commit, filter_models=False, test_all=args.fetch_all
         )
         filter_tests(args.output_file, ["repo_utils"])

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1019,7 +1019,7 @@ def infer_tests_to_run(
     if not test_all:
         modified_files = get_modified_python_files(diff_with_last_commit=diff_with_last_commit)
     else:
-        modified_files = PATH_TO_TESTS.glob("*")
+        modified_files = [ str(k) for k in PATH_TO_TESTS.glob("*/*") if str(k).endswith(".py") and "test_" in str(k)]
         print("\n### test_all is TRUE, FETCHING ALL FILES###\n")
     print(f"\n### MODIFIED FILES ###\n{_print_list(modified_files)}")
 


### PR DESCRIPTION
# What does this PR do?
There is no need to check the diff when you want to test all. As computing the diff might sometimes take a looong time. 