### PR TITLE
Update missing model error message

### DIFF
--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1057,10 +1057,10 @@ class AutoConfig:
                 config_class = CONFIG_MAPPING[config_dict["model_type"]]
             except KeyError:
                 raise ValueError(
-                    f"\nThe checkpoint you are trying to load has model type `{config_dict['model_type']}` "
+                    f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                     "but Transformers does not recognize this architecture. This could be because of an "
                     "issue with the checkpoint, or because your version of Transformers is out of date.\n\n"
-                    "You can update transformers with the command `pip install --upgrade transformers`. If this "
+                    "You can update Transformers with the command `pip install --upgrade transformers`. If this "
                     "does not work, and the checkpoint is very new, then there may not be a release version "
                     "that supports this model yet. In this case, you can get the most up-to-date code by installing "
                     "Transformers from source with the command "

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1059,7 +1059,10 @@ class AutoConfig:
                 raise ValueError(
                     f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                     "but Transformers does not recognize this architecture. This could be because of an "
-                    "issue with the checkpoint, or because your version of Transformers is out of date."
+                    "issue with the checkpoint, or because your version of Transformers is out of date. "
+                    "If this checkpoint was released very recently then you may need to install "
+                    "the latest version of Transformers from source with the command "
+                    "`pip install git+https://github.com/huggingface/transformers.git`"
                 )
             return config_class.from_dict(config_dict, **unused_kwargs)
         else:

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1057,9 +1057,9 @@ class AutoConfig:
                 config_class = CONFIG_MAPPING[config_dict["model_type"]]
             except KeyError:
                 raise ValueError(
-                    f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
+                    f"\nThe checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                     "but Transformers does not recognize this architecture. This could be because of an "
-                    "issue with the checkpoint, or because your version of Transformers is out of date. "
+                    "issue with the checkpoint, or because your version of Transformers is out of date.\n\n"
                     "You can update transformers with the command `pip install --upgrade transformers`. If this "
                     "does not work, and the checkpoint is very new, then there may not be a release version "
                     "that supports this model yet. In this case, you can get the most up-to-date code by installing "

--- a/src/transformers/models/auto/configuration_auto.py
+++ b/src/transformers/models/auto/configuration_auto.py
@@ -1060,8 +1060,10 @@ class AutoConfig:
                     f"The checkpoint you are trying to load has model type `{config_dict['model_type']}` "
                     "but Transformers does not recognize this architecture. This could be because of an "
                     "issue with the checkpoint, or because your version of Transformers is out of date. "
-                    "If this checkpoint was released very recently then you may need to install "
-                    "the latest version of Transformers from source with the command "
+                    "You can update transformers with the command `pip install --upgrade transformers`. If this "
+                    "does not work, and the checkpoint is very new, then there may not be a release version "
+                    "that supports this model yet. In this case, you can get the most up-to-date code by installing "
+                    "Transformers from source with the command "
                     "`pip install git+https://github.com/huggingface/transformers.git`"
                 )
             return config_class.from_dict(config_dict, **unused_kwargs)


### PR DESCRIPTION
This PR updates the missing model error message to suggest installing from `main` for very new models. This can be important because a lot of users want to download new models, but often don't understand why it won't work!

Fixes #35362 