### PR TITLE
Fix: bamba error handling kwargs with forward pass 

### DIFF
--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -1204,6 +1204,7 @@ class BambaModel(BambaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -1206,6 +1206,12 @@ class BambaModel(BambaPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
+        """
+        Args:
+            kwargs (`dict`, *optional*):
+                Arbitrary kwargs that are passed and to be ignored. In the future support for
+                FlashAttentionKwargs will be added.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/bamba/modular_bamba.py
+++ b/src/transformers/models/bamba/modular_bamba.py
@@ -947,6 +947,7 @@ class BambaModel(BambaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/src/transformers/models/bamba/modular_bamba.py
+++ b/src/transformers/models/bamba/modular_bamba.py
@@ -949,6 +949,12 @@ class BambaModel(BambaPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Union[Tuple, BaseModelOutputWithPast]:
+        """
+        Args:
+            kwargs (`dict`, *optional*):
+                Arbitrary kwargs that are passed and to be ignored. In the future support for
+                FlashAttentionKwargs will be added.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states


### PR DESCRIPTION
This PR adds a small change to handle additional kwargs passed to the forward function of `BambaModel` architecture. 

Fixes a behavior when tuning Bamba models - when HF Trainer would pass additional LossArgs to `BambaForCausalLM.forward()` , which are  passed to `BambaModel.forward` , and need to be ignored. 
This would fix the error - `num_items_in_batch` is an unexpected arg , while tuning the model.

Additional Context:
 [LlamaForCausalLM](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L784) class passes all kwargs to self.model.forward , hence they need to be handled. 
In the future, we would add support for flashAttentionKwargs in BambaModel.forward() . 

cc: @fabianlim 

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
