### PR TITLE
Fix new FA2 if `is_causal` is passed explicitly

### DIFF
--- a/src/transformers/integrations/flash_attention.py
+++ b/src/transformers/integrations/flash_attention.py
@@ -44,6 +44,9 @@ def flash_attention_forward(
         else:
             target_dtype = next(layer for layer in module.modules() if isinstance(layer, torch.nn.Linear)).weight.dtype
 
+    # FA2 always relies on the value set in the module, so remove it if present in kwargs
+    kwargs.pop("is_causal", None)
+
     attn_output = _flash_attention_forward(
         query,
         key,

--- a/src/transformers/integrations/flash_attention.py
+++ b/src/transformers/integrations/flash_attention.py
@@ -44,7 +44,7 @@ def flash_attention_forward(
         else:
             target_dtype = next(layer for layer in module.modules() if isinstance(layer, torch.nn.Linear)).weight.dtype
 
-    # FA2 always relies on the value set in the module, so remove it if present in kwargs
+    # FA2 always relies on the value set in the module, so remove it if present in kwargs to avoid passing it twice
     kwargs.pop("is_causal", None)
 
     attn_output = _flash_attention_forward(

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -285,9 +285,9 @@ class DecisionTransformerGPT2Attention(nn.Module):
         shape_q = (*query_states.shape[:-1], -1, self.head_dim)
         shape_kv = (*key_states.shape[:-1], -1, self.head_dim)
 
-        query_states = query_states.reshape(shape_q).transpose(1, 2)
-        key_states = key_states.reshape(shape_kv).transpose(1, 2)
-        value_states = value_states.reshape(shape_kv).transpose(1, 2)
+        query_states = query_states.view(shape_q).transpose(1, 2)
+        key_states = key_states.view(shape_kv).transpose(1, 2)
+        value_states = value_states.view(shape_kv).transpose(1, 2)
 
         if layer_past is not None:
             past_key, past_value = layer_past

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -295,9 +295,9 @@ class GPT2Attention(nn.Module):
         shape_q = (*query_states.shape[:-1], -1, self.head_dim)
         shape_kv = (*key_states.shape[:-1], -1, self.head_dim)
 
-        query_states = query_states.reshape(shape_q).transpose(1, 2)
-        key_states = key_states.reshape(shape_kv).transpose(1, 2)
-        value_states = value_states.reshape(shape_kv).transpose(1, 2)
+        query_states = query_states.view(shape_q).transpose(1, 2)
+        key_states = key_states.view(shape_kv).transpose(1, 2)
+        value_states = value_states.view(shape_kv).transpose(1, 2)
 
         if layer_past is not None:
             past_key, past_value = layer_past


### PR DESCRIPTION
# What does this PR do?

In GPT2 we have to pass `is_causal` explicitly for SDPA, but it causes double occurence for FA2 as highlighted in https://github.com/huggingface/transformers/issues/35380. This fixes it.
Also reverts the `reshape` to simple `view` for simplicity (even if they are technically equivalent, as reshape calls view if possible)


