### PR TITLE
Drop inplace operation for loss computation with gradient accumulation

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3700,7 +3700,7 @@ class Trainer:
         else:
             # Finally we need to normalize the loss for reporting
             if num_items_in_batch is None:
-                loss /= self.args.gradient_accumulation_steps
+                loss = loss / self.args.gradient_accumulation_steps
 
             self.accelerator.backward(loss, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?

Fix 

```
RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
```

reported here: https://huggingface.co/answerdotai/ModernBERT-base/discussions/9#6769e0390519344317755b3b

Initially introduced in #35207

The solution does solve the issue, tested locally.
 
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @SunMarc @ArthurZucker who reviewed #35207