### PR TITLE
[WIP] Add support for flex attention (paged attention)

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2182,9 +2182,10 @@ class PagedAttentionCache(Cache):
         KV_B, KV_H, KV_S, QK_D = key_states.shape
         device = key_states.device
         batch_idx = torch.arange(KV_B, device=device, dtype=torch.int32)
+
         self.paged_attentions[layer_idx].assign(
             batch_idx,
-            cache_kwargs["cache_position"].unsqueeze(0),
+            cache_kwargs["cache_position"].unsqueeze(0).expand([KV_B, KV_S]),
             key_states,
             value_states,
             self.key_cache[layer_idx],

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2184,7 +2184,7 @@ class PagedAttentionCache(Cache):
         batch_idx = torch.arange(KV_B, device=device, dtype=torch.int32)
         self.paged_attentions[layer_idx].assign(
             batch_idx,
-            cache_kwargs["cache_position"],
+            cache_kwargs["cache_position"].unsqueeze(0),
             key_states,
             value_states,
             self.key_cache[layer_idx],

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2123,7 +2123,7 @@ class OffloadedStaticCache(StaticCache):
 
 
 class PagedAttentionCache(Cache):
-    def __init__(self, n_pages, page_size=128, device=torch.device("cpu")):
+    def __init__(self, n_pages, page_size=128):
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
         self.paged_attentions = []
@@ -2147,14 +2147,14 @@ class PagedAttentionCache(Cache):
         KV_B, KV_H, KV_S, QK_D = key_states.shape
         _, _, _, V_D = value_states.shape
         device = key_states.device
+        dtype = key_states.dtype
         from torch.nn.attention.experimental._paged_attention import PagedAttention
         if len(self.paged_attentions) <= layer_idx:
             max_cached_seq_len = self.n_pages * self.page_size
             self.paged_attentions.append(PagedAttention(self.n_pages, self.page_size, KV_B, device=device))
-            self.key_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, QK_D, device=device))
-            self.value_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, V_D, device=device))
-
-        self.batch_reserve(self.paged_attentions[layer_idx], torch.tensor([KV_S]))
+            self.key_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, QK_D, device=device, dtype=dtype))
+            self.value_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, V_D, device=device, dtype=dtype))
+        self.batch_reserve(self.paged_attentions[layer_idx], torch.tensor([cache_kwargs['cache_position'][-1]+1 for _ in range(KV_B)]))
         batch_idx = torch.arange(KV_B, device=device, dtype=torch.int32)
         self.paged_attentions[layer_idx].assign(batch_idx, cache_kwargs['cache_position'], key_states, value_states, self.key_cache[layer_idx], self.value_cache[layer_idx])
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
@@ -2162,3 +2162,11 @@ class PagedAttentionCache(Cache):
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
         """Returns the sequence length of the cached states. A layer index can be optionally passed."""
         return self._seen_tokens if layer_idx == 0 else self._seen_tokens - 1
+
+    def reorder_cache(self, beam_idx):
+        for layer_idx in range(len(self.paged_attentions)):
+            if self.key_cache[layer_idx] != []:
+                page_table = self.paged_attentions[layer_idx].page_table.clone()
+                for batch_idx, target_batch_idx in enumerate(beam_idx.tolist()):
+                    page_table[batch_idx] = self.paged_attentions[layer_idx].page_table[target_batch_idx]
+                self.paged_attentions[layer_idx].page_table = page_table

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2147,7 +2147,7 @@ class PagedAttentionCache(Cache):
             self.value_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, V_D, device=device, dtype=dtype))
             self.batch_reserve(self.paged_attentions[i], torch.tensor([max_cache_len for _ in range(batch_size)]))
 
-        block_mask = create_block_mask(noop_mask, batch_size, 1, max_cached_seq_len, max_cached_seq_len, device=device, BLOCK_SIZE=page_size)
+        block_mask = create_block_mask(noop_mask, batch_size, 1, max_cache_len, max_cache_len, device=device, BLOCK_SIZE=page_size)
         self.block_mask = self.paged_attentions[0].convert_logical_block_mask(block_mask)
         self.score_mods = []
         self.score_mods.append(None)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2147,7 +2147,7 @@ class PagedAttentionCache(Cache):
             self.value_cache.append(torch.zeros(1, KV_H, max_cached_seq_len, V_D, device=device, dtype=dtype))
             self.batch_reserve(self.paged_attentions[i], torch.tensor([max_cache_len for _ in range(batch_size)]))
 
-        block_mask = create_block_mask(noop_mask, batch_size, 1, max_cache_len, max_cache_len, device=device, BLOCK_SIZE=page_size)
+        block_mask = create_block_mask(noop_mask, batch_size, 1, 1, max_cache_len, device=device, BLOCK_SIZE=page_size)
         self.block_mask = self.paged_attentions[0].convert_logical_block_mask(block_mask)
         self.score_mods = []
         self.score_mods.append(None)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2123,7 +2123,9 @@ class OffloadedStaticCache(StaticCache):
 
 
 class PagedAttentionCache(Cache):
-    def __init__(self, config, batch_size, max_cache_len, device, dtype, layer_device_map, n_pages=None, page_size=128):
+    def __init__(
+        self, config, batch_size, max_cache_len, device, dtype, layer_device_map, n_pages=None, page_size=128
+    ):
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
         self.paged_attentions = []
@@ -2180,7 +2182,14 @@ class PagedAttentionCache(Cache):
         KV_B, KV_H, KV_S, QK_D = key_states.shape
         device = key_states.device
         batch_idx = torch.arange(KV_B, device=device, dtype=torch.int32)
-        self.paged_attentions[layer_idx].assign(batch_idx, cache_kwargs['cache_position'], key_states, value_states, self.key_cache[layer_idx], self.value_cache[layer_idx])
+        self.paged_attentions[layer_idx].assign(
+            batch_idx,
+            cache_kwargs["cache_position"],
+            key_states,
+            value_states,
+            self.key_cache[layer_idx],
+            self.value_cache[layer_idx],
+        )
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2134,7 +2134,7 @@ class PagedAttentionCache(Cache):
             self.n_pages = n_pages
         else:
             self.n_pages = (max_cache_len + page_size - 1) // page_size * batch_size
-        KV_H = config.num_key_value_heads
+        KV_H = config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads
         QK_D = config.hidden_size // config.num_attention_heads
         V_D = QK_D
         from torch.nn.attention.experimental._paged_attention import PagedAttention

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -59,6 +59,7 @@ if is_torch_available():
         SlidingWindowCache,
         StaticCache,
         StaticCacheConfig,
+        PagedAttentionCache,
     )
     from .logits_process import SynthIDTextWatermarkLogitsProcessor, WatermarkLogitsProcessor
 
@@ -70,6 +71,7 @@ if is_torch_available():
         "sliding_window": SlidingWindowCache,
         "hybrid": HybridCache,
         "mamba": MambaCache,
+        "paged": PagedAttentionCache,
     }
     QUANT_BACKEND_CLASSES_MAPPING = {"quanto": QuantoQuantizedCache, "HQQ": HQQQuantizedCache}
     ALL_CACHE_IMPLEMENTATIONS = list(NEED_SETUP_CACHE_CLASSES_MAPPING.keys()) + list(NEEDS_CACHE_CONFIG.keys())

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -54,12 +54,12 @@ if is_torch_available():
         HybridCache,
         MambaCache,
         OffloadedStaticCache,
+        PagedAttentionCache,
         QuantizedCacheConfig,
         QuantoQuantizedCache,
         SlidingWindowCache,
         StaticCache,
         StaticCacheConfig,
-        PagedAttentionCache,
     )
     from .logits_process import SynthIDTextWatermarkLogitsProcessor, WatermarkLogitsProcessor
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1785,8 +1785,6 @@ class GenerationMixin:
                 model_kwargs[cache_name] = cache_class(cache_config)
             elif generation_config.cache_implementation == "offloaded":
                 model_kwargs[cache_name] = OffloadedCache()
-            elif generation_config.cache_implementation == "paged":
-                model_kwargs[cache_name] = PagedAttentionCache(10, 64)
 
         # Use DynamicCache() instance by default. This will avoid back and forth from legacy format that
         # keeps copying the cache thus using much more memory

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3225,26 +3225,7 @@ class GenerationMixin:
             # prepare variable output controls (note: some models won't accept all output controls)
             model_inputs.update({"output_attentions": output_attentions} if output_attentions else {})
             model_inputs.update({"output_hidden_states": output_hidden_states} if output_hidden_states else {})
-            # if self.config._attn_implementation == "paged_attention" and model_inputs["input_ids"].shape[1] == 1:
-            #     self._set_paged_attention_mod(model_inputs['past_key_values'], model_inputs['input_ids'].shape[0], model_inputs['input_ids'].shape[1], input_ids.device)
-            # forward pass to get next token
-            # if model_inputs['input_ids'].shape[1]>1:
-            #     outputs = self(**model_inputs, return_dict=True)
-            #     outputs = self(**model_inputs, return_dict=True)
-            # def trace_handler(prof):
-            #     print(prof.key_averages().table(
-            #         sort_by="self_cpu_time_total", row_limit=-1))
-            # with torch.profiler.profile(
-            #         activities=[
-            #             torch.profiler.ProfilerActivity.CPU],
-            #         schedule=torch.profiler.schedule(
-            #             wait=0,
-            #             warmup=0,
-            #             active=1),
-            #         on_trace_ready=trace_handler
-            #         ) as prof:
             outputs = self(**model_inputs, return_dict=True)
-            #   prof.step()
             # synced_gpus: don't waste resources running the code we don't need; kwargs must be updated before skipping
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs,

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3223,7 +3223,7 @@ class GenerationMixin:
             # prepare variable output controls (note: some models won't accept all output controls)
             model_inputs.update({"output_attentions": output_attentions} if output_attentions else {})
             model_inputs.update({"output_hidden_states": output_hidden_states} if output_hidden_states else {})
-            if self.config._attn_implementation == "paged_attention":
+            if self.config._attn_implementation == "paged_attention" and model_inputs["input_ids"].shape[1] == 1:
                 self._set_paged_attention_mod(model_inputs['past_key_values'], model_inputs['input_ids'].shape[0], model_inputs['input_ids'].shape[1], input_ids.device)
             # forward pass to get next token
             outputs = self(**model_inputs, return_dict=True)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3223,8 +3223,8 @@ class GenerationMixin:
             # prepare variable output controls (note: some models won't accept all output controls)
             model_inputs.update({"output_attentions": output_attentions} if output_attentions else {})
             model_inputs.update({"output_hidden_states": output_hidden_states} if output_hidden_states else {})
-            if self.config._attn_implementation == "paged_attention" and model_inputs["input_ids"].shape[1] == 1:
-                self._set_paged_attention_mod(model_inputs['past_key_values'], model_inputs['input_ids'].shape[0], model_inputs['input_ids'].shape[1], input_ids.device)
+            # if self.config._attn_implementation == "paged_attention" and model_inputs["input_ids"].shape[1] == 1:
+            #     self._set_paged_attention_mod(model_inputs['past_key_values'], model_inputs['input_ids'].shape[0], model_inputs['input_ids'].shape[1], input_ids.device)
             # forward pass to get next token
             outputs = self(**model_inputs, return_dict=True)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 import copy
 import inspect
+import time
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
-import time
+
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -32,7 +33,6 @@ from ..cache_utils import (
     OffloadedCache,
     QuantizedCacheConfig,
     StaticCache,
-    PagedAttentionCache,
 )
 from ..configuration_utils import PretrainedConfig
 from ..integrations.deepspeed import is_deepspeed_zero3_enabled

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -258,6 +258,7 @@ class GPTJAttention(nn.Module):
 
         return outputs  # a, present, (attentions)
 
+
 class GPTJPagedAttention(nn.Module):
     def __init__(self, config, layer_idx=None):
         super().__init__()
@@ -415,7 +416,15 @@ class GPTJPagedAttention(nn.Module):
                 key, value = layer_past.update(key, value, self.layer_idx, cache_kwargs)
 
             from torch.nn.attention.flex_attention import flex_attention
-            attn_output = flex_attention(query.to(key.dtype), key, value, block_mask=layer_past.block_mask,  return_lse=False, kernel_options={"SKIP_MASK_SCORE": True})
+
+            attn_output = flex_attention(
+                query.to(key.dtype),
+                key,
+                value,
+                block_mask=layer_past.block_mask,
+                return_lse=False,
+                kernel_options={"SKIP_MASK_SCORE": True},
+            )
 
         attn_weights = None
 
@@ -428,6 +437,7 @@ class GPTJPagedAttention(nn.Module):
             outputs += (attn_weights,)
 
         return outputs  # a, present, (attentions)
+
 
 class GPTJFlashAttention2(GPTJAttention):
     """

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1399,7 +1399,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             logits = torch.cat(logits, dim=-1)
         else:
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :].contiguous())
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1399,7 +1399,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
             logits = torch.cat(logits, dim=-1)
         else:
             # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :].contiguous())
+            logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -766,8 +766,7 @@ class LlamaPagedAttention(LlamaAttention):
             key_states = repeat_kv(key_states, self.num_key_value_groups)
             value_states = repeat_kv(value_states, self.num_key_value_groups)
             from torch.nn.attention.flex_attention import flex_attention
-            # attn_output = flex_attention(query_states, key_states, value_states, block_mask=past_key_value.block_mask, score_mod=past_key_value.score_mods[idx], return_lse=output_attentions)
-            attn_output = flex_attention(query_states, key_states, value_states, block_mask=past_key_value.block_mask,  return_lse=output_attentions)
+            attn_output = flex_attention(query_states, key_states, value_states, block_mask=past_key_value.block_mask,  return_lse=output_attentions, kernel_options={"SKIP_MASK_SCORE": True})
         attn_weights = None
         if output_attentions:
             attn_output = attn_output[0]

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -772,14 +772,15 @@ class LlamaPagedAttention(LlamaAttention):
                 key_states, value_states = past_key_value.update(
                     key_states, value_states, self.layer_idx, cache_kwargs
                 )
-            key_states = repeat_kv(key_states, self.num_key_value_groups)
-            value_states = repeat_kv(value_states, self.num_key_value_groups)
+            # key_states = repeat_kv(key_states, self.num_key_value_groups)
+            # value_states = repeat_kv(value_states, self.num_key_value_groups)
             from torch.nn.attention.flex_attention import flex_attention
 
             attn_output = flex_attention(
                 query_states,
                 key_states,
                 value_states,
+                enable_gqa=True if self.num_key_value_groups != 1 else False,
                 block_mask=past_key_value.block_mask,
                 return_lse=output_attentions,
                 kernel_options={"SKIP_MASK_SCORE": True},

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -1305,52 +1305,6 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
     def get_decoder(self):
         return self.model
 
-    def _set_paged_attention_mod(self, past_key_value, bsz, q_len, device):
-        from torch.nn.attention.flex_attention import create_block_mask, noop_mask
-        block_mask = create_block_mask(noop_mask, bsz, 1, q_len, q_len, device=device, BLOCK_SIZE=past_key_value.paged_attentions[0].page_size)
-        block_mask = past_key_value.paged_attentions[0].convert_logical_block_mask(block_mask)
-        # from torch.nn.attention.flex_attention import create_block_mask
-        # def noop(score, b, h, q_idx, kv_idx):
-        #     return score
-        # def causal_mask(score, b, h, q_idx, kv_idx):
-        #     return torch.where(q_idx >= kv_idx, score, -float("inf"))
-
-        # def generate_causal_offset(offset: torch.Tensor):
-        #     def causal_offset_mask(b, h, q_idx, kv_idx):
-        #         return (offset + q_idx) >= kv_idx
-
-        #     return causal_offset_mask
-        # if past_key_value.get_seq_length() == 0:
-        #     mod = generate_causal_offset(
-        #         torch.tensor(q_len, device=device, dtype=torch.int32)
-        #     )
-        # else:
-        #     mod = generate_causal_offset(
-        #         torch.tensor(past_key_value.get_seq_length(), device=device, dtype=torch.int32)
-        #     )
-        # idx = 0
-        # if q_len == 1:
-        #     idx = 1
-        # block_mask = create_block_mask(mod, bsz, 1, q_len, q_len, device=device, BLOCK_SIZE=past_key_value.paged_attentions[0].page_size)
-        # block_mask = past_key_value.paged_attentions[0].convert_logical_block_mask(block_mask)
-        # past_key_value.block_mask = block_mask
-        # copy attritubes to avoid re-compile
-        past_key_value.block_mask.kv_num_blocks = block_mask.kv_num_blocks
-        past_key_value.block_mask.kv_indices = block_mask.kv_indices
-        past_key_value.block_mask.full_kv_num_blocks = block_mask.full_kv_num_blocks
-        past_key_value.block_mask.full_kv_indices = block_mask.full_kv_indices
-        past_key_value.block_mask.q_num_blocks = block_mask.q_num_blocks
-        past_key_value.block_mask.q_indices = block_mask.q_indices
-        past_key_value.block_mask.full_q_num_blocks = block_mask.full_q_num_blocks
-        past_key_value.block_mask.full_q_indices = block_mask.full_q_indices
-        past_key_value.block_mask.BLOCK_SIZE = block_mask.BLOCK_SIZE
-        past_key_value.block_mask.sparsity = block_mask.sparsity
-        past_key_value.block_mask.mask_mod = block_mask.mask_mod
-
-        # score_mod = past_key_value.paged_attentions[0].get_score_mod(causal_mask if q_len > 1 else noop)
-        # if past_key_value.score_mods[idx] is None:
-        #     past_key_value.score_mods[idx] = score_mod
-
     @add_start_docstrings_to_model_forward(LLAMA_INPUTS_DOCSTRING)
     @replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
     def forward(

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -120,6 +120,12 @@ class StaticCache(metaclass=DummyObject):
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+class PagedAttentionCache(metaclass=DummyObject):
+    _backends = ["torch"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch"])
+
 
 class GlueDataset(metaclass=DummyObject):
     _backends = ["torch"]

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -120,6 +120,7 @@ class StaticCache(metaclass=DummyObject):
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["torch"])
 
+
 class PagedAttentionCache(metaclass=DummyObject):
     _backends = ["torch"]
 


### PR DESCRIPTION
# What does this PR do?

This pr integrates PyTorch Flex attention (paged attention) into Llama and GPT-J (greedy search).

## TODOs
- [ ] Add flex attention for first token. The current implementation uses SDPA for first token and flex attention for next token
- [ ] Address re-compile issues to eliminate hard-coded logic
- [ ] Extend support to beam search

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.


