### PR TITLE
Fix: Correct logger formate issues in Paligemma model.

### DIFF
--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -519,8 +519,8 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixi
         # mask out pad-token-ids in labels for BC
         if labels is not None and self.pad_token_id in labels:
             logger.warning_once(
-                "`labels` contains `pad_token_id` which will be masked with `config.ignore_index`. ",
-                "You have to mask out `pad_token_id` when preparing `labels`, this behavior will be removed in v.4.46.",
+                "`labels` contains `pad_token_id` which will be masked with `config.ignore_index`. "
+                "You have to mask out `pad_token_id` when preparing `labels`, this behavior will be removed in v.4.46."
             )
             labels = torch.where(input_ids == self.pad_token_id, self.config.ignore_index, labels)
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Description
The `logger.warning_once` function, if given two arguments, will interpret the first argument as a format string and the second as its arguments. To prevent this unintended string formatting, we use string literal concatenation to pass a single string argument. See [python docs](https://docs.python.org/3/reference/lexical_analysis.html#string-literal-concatenation) and [other code](https://github.com/huggingface/transformers/blob/919220dab1e29f4d04eacd61a197a45a4fec2613/src/transformers/models/llava/processing_llava.py#L172).
Any way this message also need a change here because the current verison is `4.47.1` now.

## Who can review?
@amyeroberts
@qubvel

## Thanks to those who review this PR.