### PR TITLE
cover edge case where decoder_input_ids is provided but it is empty

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -699,7 +699,7 @@ class GenerationMixin:
         elif self.config.model_type in ["whisper"]:
             pass
         # user input but it is empty -> use decoder_start_token_id
-        elif decoder_input_ids.size(-1)==0:
+        elif decoder_input_ids.size(-1) == 0:
             decoder_input_ids = decoder_start_token_id
         # user input but doesn't start with decoder_start_token_id -> prepend decoder_start_token_id (and adjust
         # decoder_attention_mask if provided)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -698,6 +698,9 @@ class GenerationMixin:
             pass
         elif self.config.model_type in ["whisper"]:
             pass
+        # user input but it is empty -> use decoder_start_token_id
+        elif decoder_input_ids.size(-1)==0:
+            decoder_input_ids = decoder_start_token_id
         # user input but doesn't start with decoder_start_token_id -> prepend decoder_start_token_id (and adjust
         # decoder_attention_mask if provided)
         elif (decoder_input_ids[:, 0] != decoder_start_token_id[:, 0]).all().item():


### PR DESCRIPTION
Simply check for the size of the decoder_input_ids before trying to access element 0 which crashes if the provided decoder_input_ids are empty.

If the size is 0 it copies the behaviour which happens when decoder_input_ids is None.