### PR TITLE
[tokenizer] fix llama tokenizer (slow)

### DIFF
--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -288,7 +288,7 @@ class LlamaTokenizer(PreTrainedTokenizer):
         for i, token in enumerate(tokens):
             # make sure that special tokens are not decoded using sentencepiece model
             if token in self.all_special_tokens:
-                if not prev_is_special and i != 0 and self.legacy:
+                if not prev_is_special and i != 0 and out_string != "" and self.legacy:
                     out_string += " "
                 out_string += self.sp_model.decode(current_sub_tokens) + token
                 prev_is_special = True

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -414,6 +414,11 @@ class TokenizerTesterMixin:
                 # next is failing for almost all the Fast tokenizers now.
                 # self.assertEqual(token_2[0], SPECIAL_TOKEN_2)
 
+                texts = ["tokenizer\n", SPECIAL_TOKEN_1, "\n", SPECIAL_TOKEN_2]
+                token_1 = tokenizer.tokenize(" ".join(texts))
+                token_2 = [token for text in texts for token in tokenizer.tokenize(text)]
+                self.assertEqual(token_1, token_2)
+
     # TODO: this test could be extended to all tokenizers - not just the sentencepiece
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):
         """Test ``_tokenize`` and ``convert_tokens_to_string``."""
@@ -959,6 +964,7 @@ class TokenizerTesterMixin:
 
                 text = tokenizer.decode(ids + encoded_special_token, clean_up_tokenization_spaces=False)
                 encoded = tokenizer.encode(text, add_special_tokens=False)
+                self.assertEqual(input_text, text.rstrip(special_token))
 
                 input_encoded = tokenizer.encode(input_text, add_special_tokens=False)
                 special_token_id = tokenizer.encode(special_token, add_special_tokens=False)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -414,11 +414,6 @@ class TokenizerTesterMixin:
                 # next is failing for almost all the Fast tokenizers now.
                 # self.assertEqual(token_2[0], SPECIAL_TOKEN_2)
 
-                texts = ["tokenizer\n", SPECIAL_TOKEN_1, "\n", SPECIAL_TOKEN_2]
-                token_1 = tokenizer.tokenize(" ".join(texts))
-                token_2 = [token for text in texts for token in tokenizer.tokenize(text)]
-                self.assertEqual(token_1, token_2)
-
     # TODO: this test could be extended to all tokenizers - not just the sentencepiece
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):
         """Test ``_tokenize`` and ``convert_tokens_to_string``."""

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -959,7 +959,7 @@ class TokenizerTesterMixin:
 
                 text = tokenizer.decode(ids + encoded_special_token, clean_up_tokenization_spaces=False)
                 encoded = tokenizer.encode(text, add_special_tokens=False)
-                self.assertEqual(input_text, text.rstrip(special_token))
+                self.assertEqual(input_text, text.rstrip(special_token).rstrip(" "))
 
                 input_encoded = tokenizer.encode(input_text, add_special_tokens=False)
                 special_token_id = tokenizer.encode(special_token, add_special_tokens=False)


### PR DESCRIPTION
# What does this PR do?

Fix the `convert_tokens_to_string` function of llama tokenizer.

In the `convert_tokens_to_string` function, when `out_string != ""` and the next token is a special token, the function will add `[whitespace]` before `text`.

https://github.com/huggingface/transformers/blob/42865860ec6dc135972d9555753cb7ee17f51fb4/src/transformers/models/llama/tokenization_llama.py#L285-L301

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@ArthurZucker 
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
