### PR TITLE
Optimized set_initialized_submodules.

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -565,13 +565,15 @@ def set_initialized_submodules(model, state_dict_keys):
     Sets the `_is_hf_initialized` flag in all submodules of a given model when all its weights are in the loaded state
     dict.
     """
+    state_dict_keys = set(state_dict_keys)
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
-        loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
-        # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":
-            loaded_keys = set(state_dict_keys)
-        if loaded_keys.issuperset(module.state_dict()):
+            # When checking if the root module is loaded there's no need to prepend module_name.
+            module_keys = set(module.state_dict())
+        else:
+            module_keys = {f"{module_name}.{k}" for k in module.state_dict()}
+        if module_keys.issubset(state_dict_keys):
             module._is_hf_initialized = True
         else:
             not_initialized_submodules[module_name] = module


### PR DESCRIPTION
Fixed an insanely slow function `set_initialized_submodules`, when loading DeepSeek V3, since it has so many experts, the amount of `state_dict_keys` are huge and also there are a lot of `named_modules`.
```py
loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
```
This line, especially `k.startswith(f"{module_name}.")`, gets called at least 1 million times, which is insanely slow, it takes at least 10 minutes runtime.

My optimization reduces the runtime to less than 10 seconds by not iterating through `state_dict_keys` and deleting `module_name` from the start for every `named_module`, instead, it prepends the `module_name` before the `module.state_dict()` keys.

cc: @ArthurZucker