### PR TITLE
run_audio_classification.py freeze_base_model in w2v-bert

### DIFF
--- a/examples/pytorch/audio-classification/run_audio_classification.py
+++ b/examples/pytorch/audio-classification/run_audio_classification.py
@@ -369,7 +369,11 @@ def main():
 
     # freeze the convolutional waveform encoder
     if model_args.freeze_feature_encoder:
-        model.freeze_feature_encoder()
+        from transformers import Wav2Vec2BertForSequenceClassification
+        if isinstance(model, Wav2Vec2BertForSequenceClassification):
+            model.freeze_base_model()
+        else:
+            model.freeze_feature_encoder()
 
     if training_args.do_train:
         if data_args.max_train_samples is not None:


### PR DESCRIPTION
# What does this PR do?
In audio classification using wav2vec. it needs freeze_base_model in w2v-bert


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ylacombe