### PR TITLE
Fix train loss to be normal regardless of num_items_in_batch

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3707,7 +3707,7 @@ class Trainer:
                 scaled_loss.backward()
         else:
             # Finally we need to normalize the loss for reporting
-            if num_items_in_batch is None:
+            if num_items_in_batch is None or self.args.gradient_accumulation_steps > 1:
                 loss = loss / self.args.gradient_accumulation_steps
 
             self.accelerator.backward(loss, **kwargs)


### PR DESCRIPTION
# What does this PR do?
This PR tries to fix train loss scale bug.

Currently, num_items_in_batch is calculated by sum of labels having no IGNORE_INDEX.
In case labels having some no IGNORE_INDEX, num_items_in_batch will be not None, leading to grad_acc not applied.

(Ex. Any kinds of generative loss training having labels to be trained to remember some format)

#35438 also pointed out that this num_items_in_batch can make train loss weird.
Also, #35203 says grad_norm should be fixed by manipulating num_items_in_batch.

I'll close this PR if there is any better fixing logic or this can affect other side effects.

Please fix train loss scale bug in no time.

+) Current code also makes accelerator backward loss bigger if accumulation step is larger with same global_batch settings.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr and @SunMarc

