### PR TITLE
Add proper jinja2 error

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -363,7 +363,9 @@ def _render_with_assistant_indices(
 @lru_cache
 def _compile_jinja_template(chat_template):
     if not is_jinja_available():
-        raise ImportError("apply_chat_template requires jinja2 to be installed. Please install it using `pip install jinja2`.")
+        raise ImportError(
+            "apply_chat_template requires jinja2 to be installed. Please install it using `pip install jinja2`."
+        )
 
     class AssistantTracker(Extension):
         # This extension is used to track the indices of assistant-generated tokens in the rendered chat

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -28,8 +28,6 @@ from .import_utils import is_jinja_available, is_torch_available, is_vision_avai
 
 if is_jinja_available():
     import jinja2
-    from jinja2.ext import Extension
-    from jinja2.sandbox import ImmutableSandboxedEnvironment
 else:
     jinja2 = None
 
@@ -362,11 +360,11 @@ def _render_with_assistant_indices(
 
 @lru_cache
 def _compile_jinja_template(chat_template):
-    class AssistantTracker(Extension):
+    class AssistantTracker(jinja2.ext.Extension):
         # This extension is used to track the indices of assistant-generated tokens in the rendered chat
         tags = {"generation"}
 
-        def __init__(self, environment: ImmutableSandboxedEnvironment):
+        def __init__(self, environment: jinja2.sandbox.ImmutableSandboxedEnvironment):
             # The class is only initiated by jinja.
             super().__init__(environment)
             environment.extend(activate_tracker=self.activate_tracker)
@@ -420,7 +418,7 @@ def _compile_jinja_template(chat_template):
     def strftime_now(format):
         return datetime.now().strftime(format)
 
-    jinja_env = ImmutableSandboxedEnvironment(
+    jinja_env = jinja2.sandbox.ImmutableSandboxedEnvironment(
         trim_blocks=True, lstrip_blocks=True, extensions=[AssistantTracker, jinja2.ext.loopcontrols]
     )
     jinja_env.filters["tojson"] = tojson

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -28,6 +28,8 @@ from .import_utils import is_jinja_available, is_torch_available, is_vision_avai
 
 if is_jinja_available():
     import jinja2
+    from jinja2.ext import Extension
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
 else:
     jinja2 = None
 
@@ -360,11 +362,14 @@ def _render_with_assistant_indices(
 
 @lru_cache
 def _compile_jinja_template(chat_template):
-    class AssistantTracker(jinja2.ext.Extension):
+    if not is_jinja_available():
+        raise ImportError("apply_chat_template requires jinja2 to be installed. Please install it using `pip install jinja2`.")
+
+    class AssistantTracker(Extension):
         # This extension is used to track the indices of assistant-generated tokens in the rendered chat
         tags = {"generation"}
 
-        def __init__(self, environment: jinja2.sandbox.ImmutableSandboxedEnvironment):
+        def __init__(self, environment: ImmutableSandboxedEnvironment):
             # The class is only initiated by jinja.
             super().__init__(environment)
             environment.extend(activate_tracker=self.activate_tracker)
@@ -418,7 +423,7 @@ def _compile_jinja_template(chat_template):
     def strftime_now(format):
         return datetime.now().strftime(format)
 
-    jinja_env = jinja2.sandbox.ImmutableSandboxedEnvironment(
+    jinja_env = ImmutableSandboxedEnvironment(
         trim_blocks=True, lstrip_blocks=True, extensions=[AssistantTracker, jinja2.ext.loopcontrols]
     )
     jinja_env.filters["tojson"] = tojson


### PR DESCRIPTION
Several users reported confusion in #34397 when `jinja2` is not installed, because the code imports some submodules of `jinja2`, and the error message when these submodules is undefined doesn't reference `jinja2` at all.

This PR adds a proper error so people know what's going on!