### PR TITLE
[`modernbert`] Add ModernBertTokenizerFast to allow for 'add_prefix_space'

### DIFF
--- a/docs/source/en/model_doc/modernbert.md
+++ b/docs/source/en/model_doc/modernbert.md
@@ -68,6 +68,10 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 
 [[autodoc]] ModernBertConfig
 
+## ModernBertTokenizerFast
+
+[[autodoc]] ModernBertTokenizerFast
+
 <frameworkcontent>
 <pt>
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1114,6 +1114,7 @@ else:
     _import_structure["models.mbart"].append("MBartTokenizerFast")
     _import_structure["models.mbart50"].append("MBart50TokenizerFast")
     _import_structure["models.mobilebert"].append("MobileBertTokenizerFast")
+    _import_structure["models.modernbert"].append("ModernBertTokenizerFast")
     _import_structure["models.mpnet"].append("MPNetTokenizerFast")
     _import_structure["models.mt5"].append("MT5TokenizerFast")
     _import_structure["models.mvp"].append("MvpTokenizerFast")
@@ -6136,6 +6137,7 @@ if TYPE_CHECKING:
         from .models.mbart import MBartTokenizerFast
         from .models.mbart50 import MBart50TokenizerFast
         from .models.mobilebert import MobileBertTokenizerFast
+        from .models.modernbert import ModernBertTokenizerFast
         from .models.mpnet import MPNetTokenizerFast
         from .models.mt5 import MT5TokenizerFast
         from .models.mvp import MvpTokenizerFast

--- a/src/transformers/models/modernbert/__init__.py
+++ b/src/transformers/models/modernbert/__init__.py
@@ -20,6 +20,7 @@ from ...utils.import_utils import define_import_structure
 if TYPE_CHECKING:
     from .configuration_modernbert import *
     from .modeling_modernbert import *
+    from .tokenization_modernbert_fast import *
 else:
     import sys
 

--- a/src/transformers/models/modernbert/tokenization_modernbert_fast.py
+++ b/src/transformers/models/modernbert/tokenization_modernbert_fast.py
@@ -86,4 +86,5 @@ class ModernBertTokenizerFast(PreTrainedTokenizerFast):
 
         self.add_prefix_space = add_prefix_space
 
+
 __all__ = ["ModernBertTokenizerFast"]

--- a/src/transformers/models/modernbert/tokenization_modernbert_fast.py
+++ b/src/transformers/models/modernbert/tokenization_modernbert_fast.py
@@ -1,0 +1,89 @@
+# Copyright 2024 Answer.AI, LightOn, and contributors, and the HuggingFace Inc. team. All rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from tokenizers import pre_tokenizers
+
+from ...tokenization_utils_fast import PreTrainedTokenizerFast
+
+
+class ModernBertTokenizerFast(PreTrainedTokenizerFast):
+    """
+    Construct a "fast" ModernBERT tokenizer (backed by HuggingFace's *tokenizers* library).
+
+    This tokenizer inherits from [`PreTrainedTokenizerFast`] which contains most of the main methods. Users should
+    refer to this superclass for more information regarding those methods.
+
+    Args:
+        vocab_file (`str`, *optional*):
+            Path to the vocabulary file.
+        tokenizer_file (`str`, *optional*):
+            The path to a tokenizer file to use instead of the vocab file.
+        sep_token (`str`, *optional*, defaults to `"[SEP]"`):
+            The separator token, which is used when building a sequence from multiple sequences, e.g. two sequences for
+            sequence classification or for a text and a question for question answering. It is also used as the last
+            token of a sequence built with special tokens.
+        cls_token (`str`, *optional*, defaults to `"[CLS]"`):
+            The classifier token which is used when doing sequence classification (classification of the whole sequence
+            instead of per-token classification). It is the first token of the sequence when built with special tokens.
+        unk_token (`str`, *optional*, defaults to `"[UNK]"`):
+            The unknown token. A token that is not in the vocabulary cannot be converted to an ID and is set to be this
+            token instead.
+        pad_token (`str`, *optional*, defaults to `"[PAD]"`):
+            The token used for padding, for example when batching sequences of different lengths.
+        mask_token (`str`, *optional*, defaults to `"[MASK]"`):
+            The token used for masking values. This is the token used when training this model with masked language
+            modeling. This is the token which the model will try to predict.
+        add_prefix_space (`bool`, *optional*, defaults to `False`):
+            Whether or not to add an initial space to the input. This allows to treat the leading word just as any
+            other word.
+    """
+
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __init__(
+        self,
+        vocab_file=None,
+        tokenizer_file=None,
+        sep_token="[SEP]",
+        cls_token="[CLS]",
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        mask_token="[MASK]",
+        add_prefix_space=False,
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_file,
+            tokenizer_file=tokenizer_file,
+            sep_token=sep_token,
+            cls_token=cls_token,
+            unk_token=unk_token,
+            pad_token=pad_token,
+            mask_token=mask_token,
+            add_prefix_space=add_prefix_space,
+            **kwargs,
+        )
+
+        pre_tok_state = json.loads(self.backend_tokenizer.pre_tokenizer.__getstate__())
+        if pre_tok_state.get("add_prefix_space", add_prefix_space) != add_prefix_space:
+            pre_tok_class = getattr(pre_tokenizers, pre_tok_state.pop("type"))
+            pre_tok_state["add_prefix_space"] = add_prefix_space
+            self.backend_tokenizer.pre_tokenizer = pre_tok_class(**pre_tok_state)
+
+        self.add_prefix_space = add_prefix_space
+
+__all__ = ["ModernBertTokenizerFast"]

--- a/src/transformers/utils/dummy_tokenizers_objects.py
+++ b/src/transformers/utils/dummy_tokenizers_objects.py
@@ -303,6 +303,13 @@ class MobileBertTokenizerFast(metaclass=DummyObject):
         requires_backends(self, ["tokenizers"])
 
 
+class ModernBertTokenizerFast(metaclass=DummyObject):
+    _backends = ["tokenizers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["tokenizers"])
+
+
 class MPNetTokenizerFast(metaclass=DummyObject):
     _backends = ["tokenizers"]
 


### PR DESCRIPTION
# What does this PR do?

Experiments by the ModernBert authors show that `add_prefix_space=True` is required in some cases for proper performance. This PR adds a small TokenizerFast class that applies the same `add_prefix_space` fix as 13 other tokenizers: https://github.com/search?q=repo%3Ahuggingface%2Ftransformers+%22self.backend_tokenizer.pre_tokenizer+%3D+pre_tok_class%28**pre_tok_state%29%22&type=code

Internal discussions: https://huggingface.slack.com/archives/C07AC3MCFGE/p1736171722040829

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

Presumably there should be tests for this as well.

## Open questions
Should the default of `add_prefix_space` be True or False? I've used False for now as that's the default in a few other tokenizers.

## Who can review?

@ArthurZucker

ModernBert team: @warner-benjamin @bclavie @NohTow 

- Tom Aarsen
