### PR TITLE
[docs] Remove Hiera from AUDIO MODELS in docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -754,8 +754,6 @@
         title: dac
       - local: model_doc/encodec
         title: EnCodec
-      - local: model_doc/hiera
-        title: Hiera
       - local: model_doc/hubert
         title: Hubert
       - local: model_doc/mctct


### PR DESCRIPTION
Hiera is a visual model and should not appear in audio model...

<img width="847" alt="image" src="https://github.com/user-attachments/assets/d1e90f8f-5aee-42bf-8c86-a92e0b25c3a3" />

We should remove Hiera from  [_toctree.yml](https://github.com/huggingface/transformers/blob/12ba96aa3cb3e4ed2a3ffb77b59f53f8ce9ac1fa/docs/source/en/_toctree.yml#L757C26-L757C31).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

