### PR TITLE
support chat generator as input of TextGenerationPipeline

### DIFF
--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -270,15 +270,17 @@ class TextGenerationPipeline(Pipeline):
             if isinstance(text_inputs, types.GeneratorType):
                 text_inputs, _ = itertools.tee(text_inputs)
                 first_item = next(_)
+                is_generator = True
             else:
                 first_item = text_inputs[0]
+                is_generator = False
             if isinstance(first_item, (list, tuple, dict)):
                 # We have one or more prompts in list-of-dicts format, so this is chat mode
                 if isinstance(first_item, dict):
                     return super().__call__(Chat(text_inputs), **kwargs)
                 else:
                     chats = (Chat(chat) for chat in text_inputs)  # 🐈 🐈 🐈
-                    if isinstance(text_inputs, types.GeneratorType):
+                    if is_generator:
                         return super().__call__(chats, **kwargs)
                     else:
                         return super().__call__(list(chats), **kwargs)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -268,12 +268,12 @@ class TextGenerationPipeline(Pipeline):
             else (list, tuple, types.GeneratorType),
         ):
             if isinstance(text_inputs, types.GeneratorType):
-                text_inputs, _ = itertools.tee(text_inputs)
-                first_item = next(_)
                 is_generator = True
+                text_inputs, _ = itertools.tee(text_inputs)
+                text_inputs, first_item = (x for x in text_inputs), next(_)
             else:
-                first_item = text_inputs[0]
                 is_generator = False
+                first_item = text_inputs[0]
             if isinstance(first_item, (list, tuple, dict)):
                 # We have one or more prompts in list-of-dicts format, so this is chat mode
                 if isinstance(first_item, dict):

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -1,5 +1,6 @@
 import enum
 import itertools
+import types
 import warnings
 from typing import Dict
 
@@ -261,7 +262,10 @@ class TextGenerationPipeline(Pipeline):
               ids of the generated text.
         """
         if isinstance(
-            text_inputs, (list, tuple, types.GeneratorType, KeyDataset) if is_torch_available() else (list, tuple, types.GeneratorType)
+            text_inputs,
+            (list, tuple, types.GeneratorType, KeyDataset)
+            if is_torch_available()
+            else (list, tuple, types.GeneratorType),
         ):
             if isinstance(text_inputs, types.GeneratorType):
                 text_inputs, _ = itertools.tee(text_inputs)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -268,11 +268,9 @@ class TextGenerationPipeline(Pipeline):
             else (list, tuple, types.GeneratorType),
         ):
             if isinstance(text_inputs, types.GeneratorType):
-                is_generator = True
                 text_inputs, _ = itertools.tee(text_inputs)
                 text_inputs, first_item = (x for x in text_inputs), next(_)
             else:
-                is_generator = False
                 first_item = text_inputs[0]
             if isinstance(first_item, (list, tuple, dict)):
                 # We have one or more prompts in list-of-dicts format, so this is chat mode
@@ -280,7 +278,7 @@ class TextGenerationPipeline(Pipeline):
                     return super().__call__(Chat(text_inputs), **kwargs)
                 else:
                     chats = (Chat(chat) for chat in text_inputs)  # 🐈 🐈 🐈
-                    if is_generator:
+                    if isinstance(text_inputs, types.GeneratorType):
                         return super().__call__(chats, **kwargs)
                     else:
                         return super().__call__(list(chats), **kwargs)

--- a/src/transformers/pipelines/text_generation.py
+++ b/src/transformers/pipelines/text_generation.py
@@ -1,4 +1,5 @@
 import enum
+import itertools
 import warnings
 from typing import Dict
 
@@ -260,16 +261,24 @@ class TextGenerationPipeline(Pipeline):
               ids of the generated text.
         """
         if isinstance(
-            text_inputs, (list, tuple, KeyDataset) if is_torch_available() else (list, tuple)
-        ) and isinstance(text_inputs[0], (list, tuple, dict)):
-            # We have one or more prompts in list-of-dicts format, so this is chat mode
-            if isinstance(text_inputs[0], dict):
-                return super().__call__(Chat(text_inputs), **kwargs)
+            text_inputs, (list, tuple, types.GeneratorType, KeyDataset) if is_torch_available() else (list, tuple, types.GeneratorType)
+        ):
+            if isinstance(text_inputs, types.GeneratorType):
+                text_inputs, _ = itertools.tee(text_inputs)
+                first_item = next(_)
             else:
-                chats = [Chat(chat) for chat in text_inputs]  # 🐈 🐈 🐈
-                return super().__call__(chats, **kwargs)
-        else:
-            return super().__call__(text_inputs, **kwargs)
+                first_item = text_inputs[0]
+            if isinstance(first_item, (list, tuple, dict)):
+                # We have one or more prompts in list-of-dicts format, so this is chat mode
+                if isinstance(first_item, dict):
+                    return super().__call__(Chat(text_inputs), **kwargs)
+                else:
+                    chats = (Chat(chat) for chat in text_inputs)  # 🐈 🐈 🐈
+                    if isinstance(text_inputs, types.GeneratorType):
+                        return super().__call__(chats, **kwargs)
+                    else:
+                        return super().__call__(list(chats), **kwargs)
+        return super().__call__(text_inputs, **kwargs)
 
     def preprocess(
         self,

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -292,6 +292,50 @@ class TextGenerationPipelineTests(unittest.TestCase):
                 ],
             )
 
+    @require_torch
+    def test_small_chat_model_with_iterator_pt(self):
+        from transformers.pipelines.pt_utils import PipelineIterator
+
+        text_generator = pipeline(
+            task="text-generation", model="hf-internal-testing/tiny-gpt2-with-chatml-template", framework="pt"
+        )
+
+        # Using `do_sample=False` to force deterministic output
+        chat1 = [
+            {"role": "system", "content": "This is a system message."},
+            {"role": "user", "content": "This is a test"},
+        ]
+        chat2 = [
+            {"role": "system", "content": "This is a system message."},
+            {"role": "user", "content": "This is a second test"},
+        ]
+        expected_chat1 = chat1 + [
+            {
+                "role": "assistant",
+                "content": " factors factors factors factors factors factors factors factors factors factors",
+            }
+        ]
+        expected_chat2 = chat2 + [
+            {
+                "role": "assistant",
+                "content": " stairs stairs stairs stairs stairs stairs stairs stairs stairs stairs",
+            }
+        ]
+
+        def data():
+            yield from [chat1, chat2]
+
+        outputs = text_generator(data(), do_sample=False, max_new_tokens=10)
+        assert isinstance(outputs, PipelineIterator)
+        outputs = list(outputs)
+        self.assertEqual(
+            outputs,
+            [
+                [{"generated_text": expected_chat1}],
+                [{"generated_text": expected_chat2}],
+            ],
+        )
+
     @require_tf
     def test_small_model_tf(self):
         text_generator = pipeline(task="text-generation", model="sshleifer/tiny-ctrl", framework="tf")


### PR DESCRIPTION
Pipelines generally accept a generator input like `pipe(input for input in inputs)`. In this case the output is an iterator that yields results one by one as they arrive from the pipeline.

TextGenerationPipeline does accept a generator of strings `pipe(text for text in texts)`. Hoewever it doesn't accept a generator of chats `pipe(chat for chat in chats)` at the moment. This PR fixes this issue and adds support for `pipe(chat for chat in chats)`.

In particular this PR enables this use case with a nice tqdm bar :)

```python
>>> import pandas as pd
>>> from tqdm import tqdm
>>> df = pd.DataFrame({"text": ["Nvidia announces new RTX graphics cards"] * 10})
>>> prompt = "What is the main topic of this text ? REPLY IN LESS THAN 3 WORDS. Text: '{}'"
>>> df["main_topic"] = [
...     y[0]["generated_text"][1]["content"]
...     for y in pipe(([{"role": "user", "content": prompt.format(x)}] for x in tqdm(df["text"])), do_sample=False)
... ]
100%|███████████████████████████████████████████████████████████████████| 10/10 [00:05<00:00,  1.96it/s]
>>> df.head()
                                      text                    main_topic
0  Nvidia announces new RTX graphics cards  New Graphics Cards Announced
1  Nvidia announces new RTX graphics cards  New Graphics Cards Announced
2  Nvidia announces new RTX graphics cards  New Graphics Cards Announced
3  Nvidia announces new RTX graphics cards  New Graphics Cards Announced
4  Nvidia announces new RTX graphics cards  New Graphics Cards Announced
```

currently it raises

```
File ~/hf/transformers/src/transformers/pipelines/text_generation.py:310, in TextGenerationPipeline.preprocess(self, prompt_text, prefix, handle_long_generation, add_special_tokens, truncation, padding, max_length, continue_final_message, **generate_kwargs)
    301     inputs = self.tokenizer.apply_chat_template(
    302         prompt_text.messages,
    303         add_generation_prompt=not continue_final_message,
   (...)
    307         **tokenizer_kwargs,
    308     )
    309 else:
--> 310     inputs = self.tokenizer(prefix + prompt_text, return_tensors=self.framework, **tokenizer_kwargs)
    312 inputs["prompt_text"] = prompt_text
    314 if handle_long_generation == "hole":

TypeError: can only concatenate str (not "list") to str
```