### PR TITLE
Timm wrapper label names

### DIFF
--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -18,7 +18,11 @@
 from typing import Any, Dict
 
 from ...configuration_utils import PretrainedConfig
-from ...utils import logging
+from ...utils import is_timm_available, logging
+
+
+if is_timm_available():
+    from timm.data import ImageNetInfo, infer_imagenet_subset
 
 
 logger = logging.get_logger(__name__)
@@ -60,10 +64,30 @@ class TimmWrapperConfig(PretrainedConfig):
 
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any], **kwargs):
+        label_names = config_dict.get("label_names", None)
+
+        # if no labels added to config, use imagenet labeller in timm
+        if label_names is None:
+            imagenet_subset = infer_imagenet_subset(config_dict)
+            if imagenet_subset:
+                dataset_info = ImageNetInfo(imagenet_subset)
+                synsets = dataset_info.label_names()
+                label_descriptions = dataset_info.label_descriptions(as_dict=True)
+                label_names = [label_descriptions[synset] for synset in synsets]
+
+        is_custom_model = "num_labels" in kwargs or "id2label" in kwargs
+        if label_names is not None and not is_custom_model:
+            kwargs["id2label"] = dict(enumerate(label_names))
+
+            # if all label names are unique, create label2id mapping as well
+            if len(set(label_names)) == len(label_names):
+                kwargs["label2id"] = {name: i for i, name in enumerate(label_names)}
+            else:
+                kwargs["label2id"] = None
+
         # timm config stores the `num_classes` attribute in both the root of config and in the "pretrained_cfg" dict.
         # We are removing these attributes in order to have the native `transformers` num_labels attribute in config
         # and to avoid duplicate attributes
-
         num_labels_in_kwargs = kwargs.pop("num_labels", None)
         num_labels_in_dict = config_dict.pop("num_classes", None)
 
@@ -80,6 +104,9 @@ class TimmWrapperConfig(PretrainedConfig):
     def to_dict(self) -> Dict[str, Any]:
         output = super().to_dict()
         output["num_classes"] = self.num_labels
+        output["label_names"] = list(self.id2label.values())
+        output.pop("id2label", None)
+        output.pop("label2id", None)
         return output
 
 

--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -65,9 +65,10 @@ class TimmWrapperConfig(PretrainedConfig):
     @classmethod
     def from_dict(cls, config_dict: Dict[str, Any], **kwargs):
         label_names = config_dict.get("label_names", None)
+        is_custom_model = "num_labels" in kwargs or "id2label" in kwargs
 
         # if no labels added to config, use imagenet labeller in timm
-        if label_names is None:
+        if label_names is None and not is_custom_model:
             imagenet_subset = infer_imagenet_subset(config_dict)
             if imagenet_subset:
                 dataset_info = ImageNetInfo(imagenet_subset)
@@ -75,7 +76,6 @@ class TimmWrapperConfig(PretrainedConfig):
                 label_descriptions = dataset_info.label_descriptions(as_dict=True)
                 label_names = [label_descriptions[synset] for synset in synsets]
 
-        is_custom_model = "num_labels" in kwargs or "id2label" in kwargs
         if label_names is not None and not is_custom_model:
             kwargs["id2label"] = dict(enumerate(label_names))
 

--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -37,6 +37,9 @@ class TimmWrapperConfig(PretrainedConfig):
     Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.
 
+    Config loads imagenet label descriptions and stores them in `id2label` attribute, `label2id` attribute for default
+    imagenet models is set to `None` due to occlusions in the label descriptions.
+
     Args:
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.

--- a/src/transformers/pipelines/image_classification.py
+++ b/src/transformers/pipelines/image_classification.py
@@ -217,7 +217,12 @@ class ImageClassificationPipeline(Pipeline):
             raise ValueError(f"Unrecognized `function_to_apply` argument: {function_to_apply}")
 
         dict_scores = [
-            {"label": self.model.config.id2label[i], "score": score.item()} for i, score in enumerate(scores)
+            {
+                "index": i,
+                "label": self.model.config.id2label[i],
+                "score": score.item(),
+            }
+            for i, score in enumerate(scores)
         ]
         dict_scores.sort(key=lambda x: x["score"], reverse=True)
         if top_k is not None:

--- a/src/transformers/pipelines/image_classification.py
+++ b/src/transformers/pipelines/image_classification.py
@@ -217,12 +217,7 @@ class ImageClassificationPipeline(Pipeline):
             raise ValueError(f"Unrecognized `function_to_apply` argument: {function_to_apply}")
 
         dict_scores = [
-            {
-                "index": i,
-                "label": self.model.config.id2label[i],
-                "score": score.item(),
-            }
-            for i, score in enumerate(scores)
+            {"label": self.model.config.id2label[i], "score": score.item()} for i, score in enumerate(scores)
         ]
         dict_scores.sort(key=lambda x: x["score"], reverse=True)
         if top_k is not None:


### PR DESCRIPTION
# What does this PR do?

At the moment, `TimmWrapper` does not load ImageNet label names/descriptions because they are not present in the config. This PR adds support for label names resolved with `timm` and stored in the configuration as `label_names` to be compatible with both Transformers and Timm.

To reproduce:

```python
from PIL import Image
from urllib.request import urlopen
from transformers import pipeline

image = Image.open(urlopen(
    'https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png'
))
pipe = pipeline("image-classification", model="timm/convnext_nano.r384_ad_in12k", function_to_apply="softmax")
print(pipe(image))
```

Output on main:
```
[{'label': 'LABEL_8512', 'score': 0.9789659976959229}, {'label': 'LABEL_8345', 'score': 0.0032310006208717823}, {'label': 'LABEL_7597', 'score': 0.002803963143378496}, {'label': 'LABEL_7516', 'score': 0.001975387567654252}, {'label': 'LABEL_8527', 'score': 0.001948392833583057}]
```

Output on branch (correct labels):
```
[{'label': 'cafe au lait', 'score': 0.9789659976959229}, {'label': 'wish-wash', 'score': 0.0032310006208717823}, {'label': 'powdered sugar', 'score': 0.002803963143378496}, {'label': 'continental breakfast, petit dejeuner', 'score': 0.001975387567654252}, {'label': 'cocoa, chocolate, hot chocolate, drinking chocolate', 'score': 0.001948392833583057}]
```

Fixed examples:

1. Loading default timm imagenet pretrained model, `label2id` is not created due to collisions in label names - indexes
```python
>>> model = TimmWrapperForImageClassification.from_pretrained("timm/resnet18.a1_in1k")
>>> print("label2id:", model.config.label2id)
>>> print("id2label:", list(model.config.id2label.items())[:2])
label2id: None
id2label: [(0, 'tench, Tinca tinca'), (1, 'goldfish, Carassius auratus')]
```

2. Custom model with provided `num_labels`
```python
>>> model = TimmWrapperForImageClassification.from_pretrained("timm/resnet18.a1_in1k", num_labels=5, ignore_mismatched_sizes=True)
>>> print(model.config.label2id)
>>> print(model.config.id2label)
{'LABEL_0': 0, 'LABEL_1': 1, 'LABEL_2': 2, 'LABEL_3': 3, 'LABEL_4': 4}
{0: 'LABEL_0', 1: 'LABEL_1', 2: 'LABEL_2', 3: 'LABEL_3', 4: 'LABEL_4'}
```

3. Custom model with provided mappings
```python
>>> model = TimmWrapperForImageClassification.from_pretrained(
...     "timm/resnet18.a1_in1k", num_labels=5, ignore_mismatched_sizes=True,
...     id2label={0: "label_0", 1: "label_1", 2: "label_2", 3: "label_3", 4: "label_4"},
...     label2id={"label_0": 0, "label_1": 1, "label_2": 2, "label_3": 3, "label_4": 4}
>>> )
>>> print(model.config.label2id)
>>> print(model.config.id2label)
{'label_0': 0, 'label_1': 1, 'label_2': 2, 'label_3': 3, 'label_4': 4}
{0: 'label_0', 1: 'label_1', 2: 'label_2', 3: 'label_3', 4: 'label_4'}
```


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
