### PR TITLE
Fix inference error in LlavaNextForConditionalGeneration with text-only input

### DIFF
--- a/src/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/transformers/models/llava_next/modeling_llava_next.py
@@ -862,7 +862,6 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
                 vision_feature_select_strategy=vision_feature_select_strategy,
                 image_newline=self.image_newline,
             )
-        
         if image_features is not None:
             if legacy_processing:
                 logger.warning_once(
@@ -913,7 +912,7 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
                     attention_mask = torch.cat((extended_attention_mask, attention_mask[:, -target_length:]), dim=1)
                     position_ids = torch.sum(attention_mask, dim=1).unsqueeze(-1) - 1
                     cache_position = torch.arange(attention_mask.shape[1], device=attention_mask.device)[-target_length:]
-
+                    
             # TODO: @raushan retain only the new behavior after v4.47
             else:
                 n_image_tokens = (input_ids == self.config.image_token_index).sum().item()
@@ -1008,3 +1007,6 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
             model_inputs["image_sizes"] = image_sizes
 
         return model_inputs
+
+
+__all__ = ["LlavaNextForConditionalGeneration", "LlavaNextPreTrainedModel"]

--- a/src/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/transformers/models/llava_next/modeling_llava_next.py
@@ -912,7 +912,6 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
                     attention_mask = torch.cat((extended_attention_mask, attention_mask[:, -target_length:]), dim=1)
                     position_ids = torch.sum(attention_mask, dim=1).unsqueeze(-1) - 1
                     cache_position = torch.arange(attention_mask.shape[1], device=attention_mask.device)[-target_length:]
-                    
             # TODO: @raushan retain only the new behavior after v4.47
             else:
                 n_image_tokens = (input_ids == self.config.image_token_index).sum().item()


### PR DESCRIPTION
# What does this PR do?
This simple fix addresses an issue where running inference with text-only input (a.k.a. without any image data ) causes an error on line 874, as `image_features` is `None`. The update restructures the checks for `image_features` and `legacy_processing` to properly handle cases where no image data is present, while preserving the integrity of the remaining processing steps. This is a suggested fix to the reported issue #35421


Fixes #35421


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
  - It is discussed via a Github issue: #35421
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
Vision models: @amyeroberts, @qubvel
