### PR TITLE
Fix modular edge case + modular sorting order

### DIFF
--- a/examples/modular-transformers/configuration_my_new_model.py
+++ b/examples/modular-transformers/configuration_my_new_model.py
@@ -43,7 +43,7 @@ class MyNewModelConfig(PretrainedConfig):
             The non-linear activation function (function or string) in the decoder.
         max_position_embeddings (`int`, *optional*, defaults to 2048):
             The maximum sequence length that this model might ever be used with. MyNewModel 1 supports up to 2048 tokens,
-            MyNewModel 2 up to 4096, CodeMyNewModel up to 16384.
+            MyNewModel 2 up to 4096, CodeLlama up to 16384.
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         rms_norm_eps (`float`, *optional*, defaults to 1e-06):
@@ -110,7 +110,7 @@ class MyNewModelConfig(PretrainedConfig):
         mlp_bias (`bool`, *optional*, defaults to `False`):
             Whether to use a bias in up_proj, down_proj and gate_proj layers in the MLP layers.
         head_dim (`int`, *optional*):
-            The attention head dimension. If None, it will default to hidden_size // num_heads
+            The attention head dimension. If None, it will default to hidden_size // num_attention_heads
 
     ```python
     >>> from transformers import MyNewModelModel, MyNewModelConfig

--- a/examples/modular-transformers/modeling_dummy.py
+++ b/examples/modular-transformers/modeling_dummy.py
@@ -597,7 +597,7 @@ class DummyModel(DummyPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and (attention_mask == 0.0).any():
                 return attention_mask
             return None
 

--- a/examples/modular-transformers/modeling_multimodal1.py
+++ b/examples/modular-transformers/modeling_multimodal1.py
@@ -597,7 +597,7 @@ class Multimodal1TextModel(Multimodal1TextPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and (attention_mask == 0.0).any():
                 return attention_mask
             return None
 

--- a/examples/modular-transformers/modeling_my_new_model2.py
+++ b/examples/modular-transformers/modeling_my_new_model2.py
@@ -602,7 +602,7 @@ class MyNewModel2Model(MyNewModel2PreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and (attention_mask == 0.0).any():
                 return attention_mask
             return None
 

--- a/examples/modular-transformers/modeling_super.py
+++ b/examples/modular-transformers/modeling_super.py
@@ -519,7 +519,7 @@ class SuperModel(SuperPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and (attention_mask == 0.0).any():
                 return attention_mask
             return None
 

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -612,11 +612,7 @@ class DiffLlamaPreTrainedModel(PreTrainedModel):
 
 
 class DiffLlamaRotaryEmbedding(nn.Module):
-    def __init__(
-        self,
-        config: DiffLlamaConfig,
-        device=None,
-    ):
+    def __init__(self, config: DiffLlamaConfig, device=None):
         super().__init__()
         # BC: "rope_type" was originally "type"
         if hasattr(config, "rope_scaling") and config.rope_scaling is not None:

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -898,7 +898,7 @@ class DiffLlamaModel(DiffLlamaPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and (attention_mask == 0.0).any():
                 return attention_mask
             return None
 

--- a/tests/repo_utils/modular/test_conversion_order.py
+++ b/tests/repo_utils/modular/test_conversion_order.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import unittest
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 sys.path.append(os.path.join(ROOT_DIR, "utils"))
@@ -7,37 +8,51 @@ sys.path.append(os.path.join(ROOT_DIR, "utils"))
 import create_dependency_mapping  # noqa: E402
 
 # This is equivalent to `all` in the current library state (as of 09/01/2025)
-model_root = os.path.join("src", "transformers", "models")
-files_to_parse = [
-    os.path.join(model_root, "starcoder2", "modular_starcoder2.py"),
-    os.path.join(model_root, "gemma", "modular_gemma.py"),
-    os.path.join(model_root, "olmo2", "modular_olmo2.py"),
-    os.path.join(model_root, "diffllama", "modular_diffllama.py"),
-    os.path.join(model_root, "granite", "modular_granite.py"),
-    os.path.join(model_root, "gemma2", "modular_gemma2.py"),
-    os.path.join(model_root, "mixtral", "modular_mixtral.py"),
-    os.path.join(model_root, "olmo", "modular_olmo.py"),
-    os.path.join(model_root, "rt_detr", "modular_rt_detr.py"),
-    os.path.join(model_root, "qwen2", "modular_qwen2.py"),
-    os.path.join(model_root, "llava_next_video", "modular_llava_next_video.py"),
-    os.path.join(model_root, "cohere2", "modular_cohere2.py"),
-    os.path.join(model_root, "modernbert", "modular_modernbert.py"),
-    os.path.join(model_root, "colpali", "modular_colpali.py"),
-    os.path.join(model_root, "deformable_detr", "modular_deformable_detr.py"),
-    os.path.join(model_root, "aria", "modular_aria.py"),
-    os.path.join(model_root, "ijepa", "modular_ijepa.py"),
-    os.path.join(model_root, "bamba", "modular_bamba.py"),
-    os.path.join(model_root, "dinov2_with_registers", "modular_dinov2_with_registers.py"),
-    os.path.join(model_root, "instructblipvideo", "modular_instructblipvideo.py"),
-    os.path.join(model_root, "glm", "modular_glm.py"),
-    os.path.join(model_root, "phi", "modular_phi.py"),
-    os.path.join(model_root, "mistral", "modular_mistral.py"),
+MODEL_ROOT = os.path.join("src", "transformers", "models")
+FILES_TO_PARSE = [
+    os.path.join(MODEL_ROOT, "starcoder2", "modular_starcoder2.py"),
+    os.path.join(MODEL_ROOT, "gemma", "modular_gemma.py"),
+    os.path.join(MODEL_ROOT, "olmo2", "modular_olmo2.py"),
+    os.path.join(MODEL_ROOT, "diffllama", "modular_diffllama.py"),
+    os.path.join(MODEL_ROOT, "granite", "modular_granite.py"),
+    os.path.join(MODEL_ROOT, "gemma2", "modular_gemma2.py"),
+    os.path.join(MODEL_ROOT, "mixtral", "modular_mixtral.py"),
+    os.path.join(MODEL_ROOT, "olmo", "modular_olmo.py"),
+    os.path.join(MODEL_ROOT, "rt_detr", "modular_rt_detr.py"),
+    os.path.join(MODEL_ROOT, "qwen2", "modular_qwen2.py"),
+    os.path.join(MODEL_ROOT, "llava_next_video", "modular_llava_next_video.py"),
+    os.path.join(MODEL_ROOT, "cohere2", "modular_cohere2.py"),
+    os.path.join(MODEL_ROOT, "modernbert", "modular_modernbert.py"),
+    os.path.join(MODEL_ROOT, "colpali", "modular_colpali.py"),
+    os.path.join(MODEL_ROOT, "deformable_detr", "modular_deformable_detr.py"),
+    os.path.join(MODEL_ROOT, "aria", "modular_aria.py"),
+    os.path.join(MODEL_ROOT, "ijepa", "modular_ijepa.py"),
+    os.path.join(MODEL_ROOT, "bamba", "modular_bamba.py"),
+    os.path.join(MODEL_ROOT, "dinov2_with_registers", "modular_dinov2_with_registers.py"),
+    os.path.join(MODEL_ROOT, "instructblipvideo", "modular_instructblipvideo.py"),
+    os.path.join(MODEL_ROOT, "glm", "modular_glm.py"),
+    os.path.join(MODEL_ROOT, "phi", "modular_phi.py"),
+    os.path.join(MODEL_ROOT, "mistral", "modular_mistral.py"),
 ]
 
-# Find the order
-priority_list = create_dependency_mapping.find_priority_list(files_to_parse)
-# Extract just the model names
-model_priority_list = []
 
-def appear_after(model1: str, file2: str) -> bool:
-    pass
+def appear_after(model1: str, model2: str, priority_list: list[str]) -> bool:
+    """Return True if `model1` appear after `model2` in `priority_list`."""
+    return priority_list.index(model1) > priority_list.index(model2)
+
+
+class ConversionOrderTest(unittest.TestCase):
+
+    def test_conversion_order(self):
+        # Find the order
+        priority_list = create_dependency_mapping.find_priority_list(FILES_TO_PARSE)
+        # Extract just the model names
+        model_priority_list = [file.rsplit("modular_")[-1].replace(".py", "") for file in priority_list]
+
+        # These are based on what the current library order should be (as of 09/01/2025)
+        self.assertTrue(appear_after("mixtral", "mistral", model_priority_list))
+        self.assertTrue(appear_after("gemma2", "gemma", model_priority_list))
+        self.assertTrue(appear_after("starcoder2", "mistral", model_priority_list))
+        self.assertTrue(appear_after("olmo2", "olmo", model_priority_list))
+        self.assertTrue(appear_after("diffllama", "mistral", model_priority_list))
+        self.assertTrue(appear_after("cohere2", "gemma2", model_priority_list))

--- a/tests/repo_utils/modular/test_conversion_order.py
+++ b/tests/repo_utils/modular/test_conversion_order.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+sys.path.append(os.path.join(ROOT_DIR, "utils"))
+
+import create_dependency_mapping  # noqa: E402
+
+# This is equivalent to `all` in the current library state (as of 09/01/2025)
+model_root = os.path.join("src", "transformers", "models")
+files_to_parse = [
+    os.path.join(model_root, "starcoder2", "modular_starcoder2.py"),
+    os.path.join(model_root, "gemma", "modular_gemma.py"),
+    os.path.join(model_root, "olmo2", "modular_olmo2.py"),
+    os.path.join(model_root, "diffllama", "modular_diffllama.py"),
+    os.path.join(model_root, "granite", "modular_granite.py"),
+    os.path.join(model_root, "gemma2", "modular_gemma2.py"),
+    os.path.join(model_root, "mixtral", "modular_mixtral.py"),
+    os.path.join(model_root, "olmo", "modular_olmo.py"),
+    os.path.join(model_root, "rt_detr", "modular_rt_detr.py"),
+    os.path.join(model_root, "qwen2", "modular_qwen2.py"),
+    os.path.join(model_root, "llava_next_video", "modular_llava_next_video.py"),
+    os.path.join(model_root, "cohere2", "modular_cohere2.py"),
+    os.path.join(model_root, "modernbert", "modular_modernbert.py"),
+    os.path.join(model_root, "colpali", "modular_colpali.py"),
+    os.path.join(model_root, "deformable_detr", "modular_deformable_detr.py"),
+    os.path.join(model_root, "aria", "modular_aria.py"),
+    os.path.join(model_root, "ijepa", "modular_ijepa.py"),
+    os.path.join(model_root, "bamba", "modular_bamba.py"),
+    os.path.join(model_root, "dinov2_with_registers", "modular_dinov2_with_registers.py"),
+    os.path.join(model_root, "instructblipvideo", "modular_instructblipvideo.py"),
+    os.path.join(model_root, "glm", "modular_glm.py"),
+    os.path.join(model_root, "phi", "modular_phi.py"),
+    os.path.join(model_root, "mistral", "modular_mistral.py"),
+]
+
+# Find the order
+priority_list = create_dependency_mapping.find_priority_list(files_to_parse)
+# Extract just the model names
+model_priority_list = []
+
+def appear_after(model1: str, file2: str) -> bool:
+    pass

--- a/tests/repo_utils/modular/test_conversion_order.py
+++ b/tests/repo_utils/modular/test_conversion_order.py
@@ -2,10 +2,12 @@ import os
 import sys
 import unittest
 
+
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 sys.path.append(os.path.join(ROOT_DIR, "utils"))
 
 import create_dependency_mapping  # noqa: E402
+
 
 # This is equivalent to `all` in the current library state (as of 09/01/2025)
 MODEL_ROOT = os.path.join("src", "transformers", "models")
@@ -44,7 +46,6 @@ def appear_after(model1: str, model2: str, priority_list: list[str]) -> bool:
 
 
 class ConversionOrderTest(unittest.TestCase):
-
     def test_conversion_order(self):
         # Find the order
         priority_list = create_dependency_mapping.find_priority_list(FILES_TO_PARSE)

--- a/tests/repo_utils/modular/test_conversion_order.py
+++ b/tests/repo_utils/modular/test_conversion_order.py
@@ -33,6 +33,8 @@ FILES_TO_PARSE = [
     os.path.join(MODEL_ROOT, "glm", "modular_glm.py"),
     os.path.join(MODEL_ROOT, "phi", "modular_phi.py"),
     os.path.join(MODEL_ROOT, "mistral", "modular_mistral.py"),
+    os.path.join(MODEL_ROOT, "phi3", "modular_phi3.py"),
+    os.path.join(MODEL_ROOT, "cohere", "modular_cohere.py"),
 ]
 
 
@@ -56,3 +58,5 @@ class ConversionOrderTest(unittest.TestCase):
         self.assertTrue(appear_after("olmo2", "olmo", model_priority_list))
         self.assertTrue(appear_after("diffllama", "mistral", model_priority_list))
         self.assertTrue(appear_after("cohere2", "gemma2", model_priority_list))
+        self.assertTrue(appear_after("cohere2", "cohere", model_priority_list))
+        self.assertTrue(appear_after("phi3", "mistral", model_priority_list))

--- a/utils/create_dependency_mapping.py
+++ b/utils/create_dependency_mapping.py
@@ -1,6 +1,7 @@
 import ast
 from collections import defaultdict
 
+
 # Function to perform topological sorting
 def topological_sort(dependencies: dict):
     # Nodes are the name of the models to convert (we only add those to the graph)

--- a/utils/create_dependency_mapping.py
+++ b/utils/create_dependency_mapping.py
@@ -7,13 +7,13 @@ def topological_sort(dependencies):
     new_dependencies = {}
     graph = defaultdict(list)
     for node, deps in dependencies.items():
-        node_name = node.split("/")[-2]
+        node_name = node.rsplit("modular_", 1)[1].replace(".py", "")
         for dep in deps:
             dep_name = dep.split(".")[-2]
             if dep_name == node_name:
                 # Skip self dependencies for topological sort as they create cycles
                 continue
-            if "example" not in node and "auto" not in dep and node_name not in graph[dep_name]:
+            if "auto" not in dep and node_name not in graph[dep_name]:
                 graph[dep_name].append(node_name)
         new_dependencies[node_name] = node
 

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -58,7 +58,7 @@ def get_module_source_from_name(module_name: str) -> str:
 def preserve_case_replace(text, patterns: dict, default_name: str):
     # Create a regex pattern to match all variations
     regex_pattern = "|".join(re.escape(key) for key in patterns.keys())
-    compiled_regex = re.compile(f"({regex_pattern})(.|$)", re.IGNORECASE | re.DOTALL)
+    compiled_regex = re.compile(f"(?<![a-z0-9])({regex_pattern})(.|$)", re.IGNORECASE | re.DOTALL)
 
     def replace(match):
         matched_pattern = match.group(1)

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1691,9 +1691,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.files_to_parse == ["all"]:
         args.files_to_parse = glob.glob("src/transformers/models/**/modular_*.py", recursive=True)
-        args.files_to_parse += glob.glob("examples/**/modular_*.py", recursive=True)
+    if args.files_to_parse == ["examples"]:
+        args.files_to_parse = glob.glob("examples/**/modular_*.py", recursive=True)
 
-    for file_name in find_priority_list(args.files_to_parse):
+    priority_list = find_priority_list(args.files_to_parse)
+    assert len(priority_list) == len(args.files_to_parse), "Some files will not be converted"
+
+    for file_name in priority_list:
         print(f"Converting {file_name} to a single model single file format")
         module_path = file_name.replace("/", ".").replace(".py", "").replace("src.", "")
         converted_files = convert_modular_file(file_name)


### PR DESCRIPTION
# What does this PR do?

Fix a very niche edge-case discovered in https://github.com/huggingface/transformers/pull/35147: if the model name appear in a normal word (e.g. `sam` appears in the word `downsample`, then it is replaced by the new name). This is of course unwanted, and a simple check for previous char in the regex fixes it.

Also fix the `topological_sort` function in `create_dependency_mapping.py`: it is currently fully skipping some files that are silently not converted. I had a hard time finding the exact root, so I mostly rewrote it (I believe it is much simpler now), and it works nicely. I also added a check in `modular_model_converter.py` to ensure that we never silently skip files.

Finally, I added back the possibility to convert the examples. Note that this does not slow down `make fix-copies`, which I think was the reason to remove them, as they are not included in `check_modular_conversion.py` (and it's important that we are able to check on them as well). They will not be converted when doing `python utils/modular_model_converter.py --files_to_parse all` though, I added the keyword `python utils/modular_model_converter.py --files_to_parse examples`.

cc @ArthurZucker and @yonigozlan as you touched it recently as well