### PR TITLE
Fix flaky `test_batching_equivalence`

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1421,6 +1421,11 @@ def set_model_tester_for_less_flaky_test(test_case):
         test_case.model_tester.text_config = copy.deepcopy(test_case.model_tester.text_config)
         test_case.model_tester.text_config["num_hidden_layers"] = 1
 
+    # A few model class specific handling
+
+    # For Albert
+    if hasattr(test_case.model_tester, "num_hidden_groups"):
+        test_case.model_tester.num_hidden_groups = test_case.model_tester.num_hidden_layers
 
 def set_config_for_less_flaky_test(config):
     target_attrs = [

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1426,8 +1426,14 @@ def set_model_tester_for_less_flaky_test(test_case):
     # For Albert
     if hasattr(test_case.model_tester, "num_hidden_groups"):
         test_case.model_tester.num_hidden_groups = test_case.model_tester.num_hidden_layers
+    # For DPT
     if hasattr(test_case.model_tester, "neck_hidden_sizes"):
         test_case.model_tester.neck_hidden_sizes = test_case.model_tester.neck_hidden_sizes[
+            : test_case.model_tester.num_hidden_layers
+        ]
+    # For DPT auto backbone
+    if hasattr(test_case.model_tester, "out_features"):
+        test_case.model_tester.out_features = test_case.model_tester.out_features[
             : test_case.model_tester.num_hidden_layers
         ]
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1432,10 +1432,11 @@ def set_model_tester_for_less_flaky_test(test_case):
             : test_case.model_tester.num_hidden_layers
         ]
     # For DPT auto backbone
-    if hasattr(test_case.model_tester, "out_features"):
-        test_case.model_tester.out_features = test_case.model_tester.out_features[
-            : test_case.model_tester.num_hidden_layers
-        ]
+    if hasattr(test_case.model_tester, "num_hidden_layers"):
+        if hasattr(test_case.model_tester, "out_features"):
+            test_case.model_tester.out_features = test_case.model_tester.out_features[
+                : test_case.model_tester.num_hidden_layers
+            ]
 
 
 def set_config_for_less_flaky_test(config):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1410,10 +1410,12 @@ def assert_screenout(out, what):
 
 def set_model_tester_for_less_flaky_test(test_case):
     if hasattr(test_case.model_tester, "num_hidden_layers"):
-        test_case.model_tester.num_hidden_layers = 1
+        if not (hasattr(test_case.model_tester, "out_features") or hasattr(test_case.model_tester, "out_indices")):
+            test_case.model_tester.num_hidden_layers = 1
     if (
         hasattr(test_case.model_tester, "vision_config")
         and "num_hidden_layers" in test_case.model_tester.vision_config
+        and (not (hasattr(test_case.model_tester.vision_config, "out_features") or hasattr(test_case.model_tester.vision_config, "out_indices")))
     ):
         test_case.model_tester.vision_config = copy.deepcopy(test_case.model_tester.vision_config)
         test_case.model_tester.vision_config["num_hidden_layers"] = 1
@@ -1431,12 +1433,6 @@ def set_model_tester_for_less_flaky_test(test_case):
         test_case.model_tester.neck_hidden_sizes = test_case.model_tester.neck_hidden_sizes[
             : test_case.model_tester.num_hidden_layers
         ]
-    # For DPT auto backbone
-    if hasattr(test_case.model_tester, "num_hidden_layers"):
-        if hasattr(test_case.model_tester, "out_features"):
-            test_case.model_tester.out_features = test_case.model_tester.out_features[
-                : test_case.model_tester.num_hidden_layers
-            ]
 
 
 def set_config_for_less_flaky_test(config):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1426,6 +1426,8 @@ def set_model_tester_for_less_flaky_test(test_case):
     # For Albert
     if hasattr(test_case.model_tester, "num_hidden_groups"):
         test_case.model_tester.num_hidden_groups = test_case.model_tester.num_hidden_layers
+    if hasattr(test_case.model_tester, "neck_hidden_sizes"):
+        test_case.model_tester.neck_hidden_sizes = test_case.model_tester.neck_hidden_sizes[:test_case.model_tester.num_hidden_layers]
 
 def set_config_for_less_flaky_test(config):
     target_attrs = [

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1427,7 +1427,10 @@ def set_model_tester_for_less_flaky_test(test_case):
     if hasattr(test_case.model_tester, "num_hidden_groups"):
         test_case.model_tester.num_hidden_groups = test_case.model_tester.num_hidden_layers
     if hasattr(test_case.model_tester, "neck_hidden_sizes"):
-        test_case.model_tester.neck_hidden_sizes = test_case.model_tester.neck_hidden_sizes[:test_case.model_tester.num_hidden_layers]
+        test_case.model_tester.neck_hidden_sizes = test_case.model_tester.neck_hidden_sizes[
+            : test_case.model_tester.num_hidden_layers
+        ]
+
 
 def set_config_for_less_flaky_test(config):
     target_attrs = [

--- a/tests/models/upernet/test_modeling_upernet.py
+++ b/tests/models/upernet/test_modeling_upernet.py
@@ -82,7 +82,6 @@ class UperNetModelTester:
         self.out_features = out_features
         self.num_labels = num_labels
         self.scope = scope
-        self.num_hidden_layers = num_stages
 
     def prepare_config_and_inputs(self):
         pixel_values = floats_tensor([self.batch_size, self.num_channels, self.image_size, self.image_size])

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -816,7 +816,10 @@ class ModelTesterMixin:
                     ),
                 )
 
+        set_model_tester_for_less_flaky_test(self)
+
         config, batched_input = self.model_tester.prepare_config_and_inputs_for_common()
+        set_config_for_less_flaky_test(config)
         equivalence = get_tensor_equivalence_function(batched_input)
 
         for model_class in self.all_model_classes:
@@ -827,6 +830,7 @@ class ModelTesterMixin:
                 config, batched_input = self.model_tester.prepare_config_and_inputs_for_model_class(model_class)
             batched_input_prepared = self._prepare_for_class(batched_input, model_class)
             model = model_class(config).to(torch_device).eval()
+            set_model_for_less_flaky_test(model)
 
             batch_size = self.model_tester.batch_size
             single_row_input = {}


### PR DESCRIPTION
# What does this PR do?

I am the king serial killer of flaky tests in `transformers`!

The **the ratio of failures**:
- `tests/models/flaubert/test_modeling_flaubert.py::FlaubertModelTest::test_batching_equivalence`: 
  - 3000 runs: 
    - main: 1.2 %
    - PR: 0 %
- `tests/models/mobilevitv2/test_modeling_mobilevitv2.py::MobileViTV2ModelTest::test_batching_equivalence`: 
  - 300 runs: 
    - main: 2.3 %
    - PR: 0 %
- `tests/models/xlm/test_modeling_xlm.py::XLMModelTest::test_batching_equivalence`: 
  - 300 runs: 
    - main: 3.3 %
    - PR: 0 %

I will apply the same changes to overwritten tests wherever they are flaky too.