### PR TITLE
Trainer Refactor: Part 1

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2207,23 +2207,33 @@ class Trainer:
         # total number of training steps to execute: max_steps
         total_train_batch_size = self._train_batch_size * args.gradient_accumulation_steps * args.world_size
 
+        # Since the actual `max_steps` depends on if we have a dataloader length, number of epochs, or max_steps,
+        # we keep it defined here first as the "base case" if we don't have a dataloader length later (Case 1)
         max_steps = args.max_steps
+
+        # If max_steps is negative, we use the number of epochs to determine the number of total steps later
+        epoch_based = max_steps < 0
+
         len_dataloader = len(train_dataloader) if has_length(train_dataloader) else None
 
-        if has_length(train_dataloader):
-            num_update_steps_per_epoch = len(train_dataloader) // args.gradient_accumulation_steps
-            num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
-            if args.max_steps < 1:
+        # Case 2: We have a dataloader length and can extrapolate
+        if len_dataloader is not None:
+            num_update_steps_per_epoch = max(len_dataloader // args.gradient_accumulation_steps, 1)
+            # Case 3: We have a length but are using epochs, we can extrapolate the number of steps
+            if epoch_based:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
 
         num_train_tokens = None
         if self.args.include_tokens_per_second:
-            num_train_tokens = self.num_tokens(train_dataloader, max_steps)
-            if has_length(train_dataloader) and args.max_steps < 1:
+            num_train_tokens = self.num_tokens(train_dataloader, None if epoch_based else max_steps)
+            # If going by epochs, multiply tokens linearly
+            if len_dataloader is not None and max_steps < 0:
                 num_train_tokens *= args.num_train_epochs
+            # Otherwise since its steps, we just multiply by grad accum
             else:
                 num_train_tokens *= args.gradient_accumulation_steps
 
+        # Now we figure out `num_examples`, `num_train_epochs`, and `train_samples`
         if has_length(train_dataloader):
             num_examples = self.num_examples(train_dataloader)
             if args.max_steps > 0:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2206,22 +2206,15 @@ class Trainer:
         # number of training steps per epoch: num_update_steps_per_epoch
         # total number of training steps to execute: max_steps
         total_train_batch_size = self._train_batch_size * args.gradient_accumulation_steps * args.world_size
-
-        # Since the actual `max_steps` depends on if we have a dataloader length, number of epochs, or max_steps,
-        # we keep it defined here first as the "base case" if we don't have a dataloader length later (Case 1)
-        max_steps = args.max_steps
-
-        # If max_steps is negative, we use the number of epochs to determine the number of total steps later
-        epoch_based = max_steps < 0
-
-        len_dataloader = len(train_dataloader) if has_length(train_dataloader) else None
-
-        # Case 2: We have a dataloader length and can extrapolate
-        if len_dataloader is not None:
-            num_update_steps_per_epoch = max(len_dataloader // args.gradient_accumulation_steps, 1)
-            # Case 3: We have a length but are using epochs, we can extrapolate the number of steps
-            if epoch_based:
-                max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
+        (
+            num_train_epochs,
+            num_update_steps_per_epoch,
+            num_examples,
+            num_train_samples,
+            epoch_based,
+            len_dataloader,
+            max_steps,
+        ) = self.set_initial_training_values(args, train_dataloader, total_train_batch_size)
 
         num_train_tokens = None
         if self.args.include_tokens_per_second:
@@ -2232,31 +2225,6 @@ class Trainer:
             # Otherwise since its steps, we just multiply by grad accum
             else:
                 num_train_tokens *= args.gradient_accumulation_steps
-
-        # Now we figure out `num_examples`, `num_train_epochs`, and `train_samples`
-        if len_dataloader:
-            num_examples = self.num_examples(train_dataloader)
-            if args.max_steps > 0:
-                num_train_epochs = max_steps // num_update_steps_per_epoch + int(
-                    max_steps % num_update_steps_per_epoch > 0
-                )
-                # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
-                # the best we can do.
-                num_train_samples = max_steps * total_train_batch_size
-            else:
-                num_train_epochs = math.ceil(args.num_train_epochs)
-                num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
-        elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
-            # Setting a very large number of epochs so we go as many times as necessary over the iterator.
-            num_train_epochs = sys.maxsize
-            num_update_steps_per_epoch = max_steps
-            num_examples = total_train_batch_size * args.max_steps
-            num_train_samples = args.max_steps * total_train_batch_size
-        else:
-            raise ValueError(
-                "args.max_steps must be set to a positive value if dataloader does not have a length, was"
-                f" {args.max_steps}"
-            )
 
         if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
             if self.args.n_gpu > 1:
@@ -5104,3 +5072,63 @@ class Trainer:
             num_items_in_batch = num_items_in_batch.item()
 
         return batch_samples, num_items_in_batch
+
+    def set_initial_training_values(
+        self, args: TrainingArguments, dataloader: DataLoader, total_train_batch_size: int
+    ):
+        """
+        Calculates and returns the following values:
+        - `num_train_epochs`
+        - `num_update_steps_per_epoch`
+        - `num_examples`
+        - `num_train_samples`
+        - `epoch_based`
+        - `len_dataloader`
+        - `max_steps`
+        """
+        # Case 1: we rely on `args.max_steps` first
+        max_steps = args.max_steps
+        # If max_steps is negative, we use the number of epochs to determine the number of total steps later
+        epoch_based = max_steps < 0
+        len_dataloader = len(dataloader) if has_length(dataloader) else None
+
+        # Case 2: We have a dataloader length and can extrapolate
+        if len_dataloader is not None:
+            num_update_steps_per_epoch = max(len_dataloader // args.gradient_accumulation_steps, 1)
+            # Case 3: We have a length but are using epochs, we can extrapolate the number of steps
+            if epoch_based:
+                max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
+
+        # Now we figure out `num_examples`, `num_train_epochs`, and `train_samples`
+        if len_dataloader:
+            num_examples = self.num_examples(dataloader)
+            if args.max_steps > 0:
+                num_train_epochs = max_steps // num_update_steps_per_epoch + int(
+                    max_steps % num_update_steps_per_epoch > 0
+                )
+                # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
+                # the best we can do.
+                num_train_samples = max_steps * total_train_batch_size
+            else:
+                num_train_epochs = math.ceil(args.num_train_epochs)
+                num_train_samples = self.num_examples(dataloader) * args.num_train_epochs
+        elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
+            # Setting a very large number of epochs so we go as many times as necessary over the iterator.
+            num_train_epochs = sys.maxsize
+            num_update_steps_per_epoch = max_steps
+            num_examples = total_train_batch_size * args.max_steps
+            num_train_samples = args.max_steps * total_train_batch_size
+        else:
+            raise ValueError(
+                "args.max_steps must be set to a positive value if dataloader does not have a length, was"
+                f" {args.max_steps}"
+            )
+        return (
+            num_train_epochs,
+            num_update_steps_per_epoch,
+            num_examples,
+            num_train_samples,
+            epoch_based,
+            len_dataloader,
+            max_steps,
+        )

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2391,9 +2391,7 @@ class Trainer:
                 )
 
         # Update the references
-        self.state.init_training_references(
-            self, train_dataloader, max_steps, num_train_epochs, trial
-        )
+        self.state.init_training_references(self, train_dataloader, max_steps, num_train_epochs, trial)
 
         # tr_loss is a tensor to avoid synchronization of TPUs through .item()
         tr_loss = torch.tensor(0.0).to(args.device)

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2216,6 +2216,7 @@ class Trainer:
             if args.max_steps < 1:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
 
+        num_train_tokens = None
         if self.args.include_tokens_per_second:
             num_train_tokens = self.num_tokens(train_dataloader, max_steps)
             if has_length(train_dataloader) and args.max_steps < 1:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2227,14 +2227,14 @@ class Trainer:
         if self.args.include_tokens_per_second:
             num_train_tokens = self.num_tokens(train_dataloader, None if epoch_based else max_steps)
             # If going by epochs, multiply tokens linearly
-            if len_dataloader is not None and max_steps < 0:
+            if len_dataloader is not None and epoch_based:
                 num_train_tokens *= args.num_train_epochs
             # Otherwise since its steps, we just multiply by grad accum
             else:
                 num_train_tokens *= args.gradient_accumulation_steps
 
         # Now we figure out `num_examples`, `num_train_epochs`, and `train_samples`
-        if has_length(train_dataloader):
+        if len_dataloader:
             num_examples = self.num_examples(train_dataloader)
             if args.max_steps > 0:
                 num_train_epochs = max_steps // num_update_steps_per_epoch + int(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2210,10 +2210,11 @@ class Trainer:
         max_steps = args.max_steps
         len_dataloader = len(train_dataloader) if has_length(train_dataloader) else None
 
-        if args.max_steps < 1 and has_length(train_dataloader):
+        if has_length(train_dataloader):
             num_update_steps_per_epoch = len(train_dataloader) // args.gradient_accumulation_steps
             num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
-            max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
+            if args.max_steps < 1:
+                max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
 
         if self.args.include_tokens_per_second:
             num_train_tokens = self.num_tokens(train_dataloader, max_steps)

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -164,7 +164,6 @@ class TrainerState:
             setattr(self, f"{step_kind}_steps", num_steps)
 
 
-
 class ExportableState:
     """
     A class for objects that include the ability to have its state
@@ -562,6 +561,7 @@ class CallbackHandler(TrainerCallback):
         self.trial_params = None
         if trial is not None:
             from transformers.integrations import hp_params
+
             assignments = trial.assignments if trainer.hp_search_backend == HPSearchBackend.SIGOPT else trial
             self.trial_params = hp_params(assignments)
 
@@ -569,7 +569,6 @@ class CallbackHandler(TrainerCallback):
         self.num_train_epochs = num_train_epochs
         self.is_local_process_zero = trainer.is_local_process_zero()
         self.is_world_process_zero = trainer.is_world_process_zero()
-
 
 
 class DefaultFlowCallback(TrainerCallback):

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -164,6 +164,30 @@ class TrainerState:
                     num_steps = math.ceil(max_steps * num_steps)
                 setattr(self, f"{step_kind}_steps", num_steps)
 
+    def init_training_references(self, trainer, train_dataloader, max_steps, num_train_epochs, trial):
+        """
+        Stores the initial training references needed in `self`
+        """
+        for attr in ("model", "optimizer", "lr_scheduler"):
+            setattr(self, attr, getattr(trainer, attr))
+
+        self.train_dataloader = train_dataloader
+        if trainer.hp_name is not None and trainer._trial is not None:
+            # use self._trial because the SigOpt/Optuna hpo only call `_hp_search_setup(trial)` instead of passing trial
+            # parameter to Train when using DDP.
+            self.trial_name = trainer.hp_name(trainer._trial)
+        self.trial_params = None
+        if trial is not None:
+            from transformers.integrations import hp_params
+
+            assignments = trial.assignments if trainer.hp_search_backend == HPSearchBackend.SIGOPT else trial
+            self.trial_params = hp_params(assignments)
+
+        self.max_steps = max_steps
+        self.num_train_epochs = num_train_epochs
+        self.is_local_process_zero = trainer.is_local_process_zero()
+        self.is_world_process_zero = trainer.is_world_process_zero()
+
 
 class ExportableState:
     """
@@ -546,30 +570,6 @@ class CallbackHandler(TrainerCallback):
             if result is not None:
                 control = result
         return control
-
-    def init_training_references(self, trainer, train_dataloader, max_steps, num_train_epochs, trial):
-        """
-        Stores the initial training references needed in `self`
-        """
-        for attr in ("model", "optimizer", "lr_scheduler"):
-            setattr(self, attr, getattr(trainer, attr))
-
-        self.train_dataloader = train_dataloader
-        if trainer.hp_name is not None and trainer._trial is not None:
-            # use self._trial because the SigOpt/Optuna hpo only call `_hp_search_setup(trial)` instead of passing trial
-            # parameter to Train when using DDP.
-            self.trial_name = trainer.hp_name(trainer._trial)
-        self.trial_params = None
-        if trial is not None:
-            from transformers.integrations import hp_params
-
-            assignments = trial.assignments if trainer.hp_search_backend == HPSearchBackend.SIGOPT else trial
-            self.trial_params = hp_params(assignments)
-
-        self.max_steps = max_steps
-        self.num_train_epochs = num_train_epochs
-        self.is_local_process_zero = trainer.is_local_process_zero()
-        self.is_world_process_zero = trainer.is_world_process_zero()
 
 
 class DefaultFlowCallback(TrainerCallback):

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -159,9 +159,10 @@ class TrainerState:
         """
         for step_kind in ("logging", "eval", "save"):
             num_steps = getattr(args, f"{step_kind}_steps")
-            if num_steps < 1:
-                num_steps = math.ceil(max_steps * num_steps)
-            setattr(self, f"{step_kind}_steps", num_steps)
+            if num_steps is not None:
+                if num_steps < 1:
+                    num_steps = math.ceil(max_steps * num_steps)
+                setattr(self, f"{step_kind}_steps", num_steps)
 
 
 class ExportableState:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -18,13 +18,14 @@ Callbacks to use with the Trainer class and customize the training loop.
 
 import dataclasses
 import json
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 import numpy as np
 from tqdm.auto import tqdm
 
-from .trainer_utils import IntervalStrategy, SaveStrategy, has_length
+from .trainer_utils import HPSearchBackend, IntervalStrategy, SaveStrategy, has_length
 from .training_args import TrainingArguments
 from .utils import logging
 
@@ -149,6 +150,19 @@ class TrainerState:
         with open(json_path, "r", encoding="utf-8") as f:
             text = f.read()
         return cls(**json.loads(text))
+
+    def compute_steps(self, args, max_steps):
+        """
+        Calculates and stores the absolute value for logging,
+        eval, and save steps based on if it was a proportion
+        or not.
+        """
+        for step_kind in ("logging", "eval", "save"):
+            num_steps = getattr(args, f"{step_kind}_steps")
+            if num_steps < 1:
+                num_steps = math.ceil(max_steps * num_steps)
+            setattr(self, f"{step_kind}_steps", num_steps)
+
 
 
 class ExportableState:
@@ -532,6 +546,30 @@ class CallbackHandler(TrainerCallback):
             if result is not None:
                 control = result
         return control
+
+    def init_training_references(self, trainer, train_dataloader, max_steps, num_train_epochs, trial):
+        """
+        Stores the initial training references needed in `self`
+        """
+        for attr in ("model", "optimizer", "lr_scheduler"):
+            setattr(self, attr, getattr(trainer, attr))
+
+        self.train_dataloader = train_dataloader
+        if trainer.hp_name is not None and trainer._trial is not None:
+            # use self._trial because the SigOpt/Optuna hpo only call `_hp_search_setup(trial)` instead of passing trial
+            # parameter to Train when using DDP.
+            self.trial_name = trainer.hp_name(trainer._trial)
+        self.trial_params = None
+        if trial is not None:
+            from transformers.integrations import hp_params
+            assignments = trial.assignments if trainer.hp_search_backend == HPSearchBackend.SIGOPT else trial
+            self.trial_params = hp_params(assignments)
+
+        self.max_steps = max_steps
+        self.num_train_epochs = num_train_epochs
+        self.is_local_process_zero = trainer.is_local_process_zero()
+        self.is_world_process_zero = trainer.is_world_process_zero()
+
 
 
 class DefaultFlowCallback(TrainerCallback):

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1403,4 +1403,4 @@ def set_rng_state_for_device(device_name, device_module, checkpoint_rng_state, i
             device_module.random.set_rng_state(checkpoint_rng_state[device_state_key])
     except Exception as e:
         # Log error if setting RNG state fails
-        logger.info(err_template.format(backend=device_name, exception=e))
+        logger.error(err_template.format(backend=device_name, exception=e))

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -40,6 +40,8 @@ from torch.utils.data.distributed import DistributedSampler
 
 from .integrations.deepspeed import is_deepspeed_zero3_enabled
 from .tokenization_utils_base import BatchEncoding
+
+# check if circular import?
 from .utils import (
     is_sagemaker_mp_enabled,
     is_torch_available,

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -40,8 +40,6 @@ from torch.utils.data.distributed import DistributedSampler
 
 from .integrations.deepspeed import is_deepspeed_zero3_enabled
 from .tokenization_utils_base import BatchEncoding
-
-# check if circular import?
 from .utils import (
     is_sagemaker_mp_enabled,
     is_torch_available,

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1390,3 +1390,17 @@ class LayerWiseDummyScheduler(LRScheduler):
 
     def _get_closed_form_lr(self):
         return self.base_lrs
+
+
+def set_rng_state_for_device(device_name, device_module, checkpoint_rng_state, is_distributed):
+    """Helper to set RNG state for a specific device type (CUDA, NPU, MLU, MUSA)"""
+    device_state_key = device_name.lower()
+    err_template = "Didn't manage to set back the RNG states of the {backend} because of the following error:\n {exception}\nThis won't yield the same results as if the training had not been interrupted."
+    try:
+        if is_distributed:
+            device_module.random.set_rng_state_all(checkpoint_rng_state[device_state_key])
+        else:
+            device_module.random.set_rng_state(checkpoint_rng_state[device_state_key])
+    except Exception as e:
+        # Log error if setting RNG state fails
+        logger.info(err_template.format(backend=device_name, exception=e))


### PR DESCRIPTION
# What does this PR do?

This is the first chunk in my attempt to clean up the trainer **without** breaking core capabilities (and integration capabilities/projects).

The aim is for *readability* rather than enhancement of features. I've started this process by:
* Refactoring how we get the "core" training values (max_steps, update_steps_per_epoch, num_train_tokens) in a more flow-based pattern than before (e.g. grouping num_train_tokens together)
* All `*_steps` based setups for the `Trainer.state` are now a func inside of `TrainerState` (a user should only need to know that's being done, realistically)
* Similarly there is a `init_training_references` which transparently hints that things are being stored in the `state`
* I've also refactored the RNG state setters to a helper func, to reduce repeated code that will repeat as more device support comes. 
* Lastly I've simplified a bit of the accelerate-based setup items. 


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 
@tomaarsen 
@Rocketknight1 