### PR TITLE
Re-add missing __all__ for Cohere and Phi3

### DIFF
--- a/src/transformers/models/cohere/modular_cohere.py
+++ b/src/transformers/models/cohere/modular_cohere.py
@@ -391,3 +391,10 @@ class CohereForCausalLM(LlamaForCausalLM):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+
+__all__ = [
+    "CohereForCausalLM",
+    "CohereModel",
+    "CoherePreTrainedModel",  # noqa: F822
+]

--- a/src/transformers/models/phi3/modular_phi3.py
+++ b/src/transformers/models/phi3/modular_phi3.py
@@ -309,3 +309,12 @@ class Phi3ForSequenceClassification(MistralForSequenceClassification):
 
 class Phi3ForTokenClassification(MistralForTokenClassification):
     pass
+
+
+__all__ = [
+    "Phi3PreTrainedModel",
+    "Phi3Model",  # noqa: F822
+    "Phi3ForCausalLM",
+    "Phi3ForSequenceClassification",
+    "Phi3ForTokenClassification",
+]


### PR DESCRIPTION
# What does this PR do?

As per the title. They got lost somehow in the refactor.

cc @ArthurZucker 