### PR TITLE
apply_chat_template: consistent behaviour for return_assistant_tokens_mask=True return_tensors=True

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1734,7 +1734,15 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             for token_id in range(start_token, end_token + 1 if end_token else len(input_ids[i])):
                                 current_mask[token_id] = 1
                         assistant_masks.append(current_mask)
-                    out["assistant_masks"] = assistant_masks if is_batched else assistant_masks[0]
+
+                    if not is_batched and not return_tensors:
+                        assistant_masks = assistant_masks[0]
+
+                    out["assistant_masks"] = assistant_masks
+
+                    if return_tensors:
+                        out.convert_to_tensors(tensor_type=return_tensors)
+
                 return out
             else:
                 return out["input_ids"]

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1282,11 +1282,11 @@ class TokenizerTesterMixin:
                     padding=True,
                     return_assistant_tokens_mask=True,
                     return_dict=True,
-                    return_tensors='pt',
+                    return_tensors="pt",
                 )
 
-                self.assertEqual(type(output_pt['assistant_masks']), torch.Tensor)
-                self.assertEqual(output_pt['assistant_masks'].shape, output_pt['attention_mask'].shape)
+                self.assertEqual(type(output_pt["assistant_masks"]), torch.Tensor)
+                self.assertEqual(output_pt["assistant_masks"].shape, output_pt["input_ids"].shape)
 
                 for i, conv in enumerate(conversations):
                     chat_string = tokenizer_r.apply_chat_template(
@@ -1338,7 +1338,6 @@ class TokenizerTesterMixin:
                         (output_pt["assistant_masks"][i, assistant_end + 1 : assistant_start2] == 0).all(),
                     )
 
-
                 # check not batched
                 output = tokenizer_r.apply_chat_template(
                     conversations[0],
@@ -1353,11 +1352,11 @@ class TokenizerTesterMixin:
                     tokenize=True,
                     return_assistant_tokens_mask=True,
                     return_dict=True,
-                    return_tensors='pt',
+                    return_tensors="pt",
                 )
 
-                self.assertEqual(type(output_pt['assistant_masks']), torch.Tensor)
-                self.assertEqual(output_pt['assistant_masks'].shape, output_pt['attention_mask'].shape)
+                self.assertEqual(type(output_pt["assistant_masks"]), torch.Tensor)
+                self.assertEqual(output_pt["assistant_masks"].shape, output_pt["attention_mask"].shape)
 
                 chat_string = tokenizer_r.apply_chat_template(
                     conversations[0], tokenize=False, chat_template=dummy_template

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1265,6 +1265,8 @@ class TokenizerTesterMixin:
                     self.skipTest(reason="No fast tokenizer defined")
 
                 tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name)
+                if not tokenizer_r.pad_token or tokenizer.pad_token_id < 0:
+                    self.skipTest(reason="This tokenizer has no padding token set, or pad_token_id < 0")
 
                 # check batched
                 output = tokenizer_r.apply_chat_template(

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1265,8 +1265,9 @@ class TokenizerTesterMixin:
                     self.skipTest(reason="No fast tokenizer defined")
 
                 tokenizer_r = self.rust_tokenizer_class.from_pretrained(pretrained_name)
-                if not tokenizer_r.pad_token or tokenizer.pad_token_id < 0:
-                    self.skipTest(reason="This tokenizer has no padding token set, or pad_token_id < 0")
+                self._check_no_pad_token_padding(tokenizer_r, conversations)
+
+                tokenizer_r.padding_side = "right"
 
                 # check batched
                 output = tokenizer_r.apply_chat_template(
@@ -1358,7 +1359,7 @@ class TokenizerTesterMixin:
                 )
 
                 self.assertEqual(type(output_pt["assistant_masks"]), torch.Tensor)
-                self.assertEqual(output_pt["assistant_masks"].shape, output_pt["attention_mask"].shape)
+                self.assertEqual(output_pt["assistant_masks"].shape, output_pt["input_ids"].shape)
 
                 chat_string = tokenizer_r.apply_chat_template(
                     conversations[0], tokenize=False, chat_template=dummy_template


### PR DESCRIPTION
# What does this PR do?

This PR fixes the simultaneous use of flags `return_assistant_tokens_mask`, `return_tensors`, in `apply_chat_template` method.

Is related to https://github.com/huggingface/transformers/issues/28950 and corresponding PR https://github.com/huggingface/transformers/pull/30650


**Before fix**
```python
output = tokenizer.apply_chat_template(
    conversations,
    tokenize=True,
    padding=True,
    return_dict=True,
    return_assistant_tokens_mask=True,
    return_tensors='pt',
)

assert isinstance(output['attention_mask'], torch.Tensor)  # ok
assert isinstance(output['assistant_masks'], torch.Tensor) # not ok: type of `output['assistant_masks']` is `List`
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yonigottesman @amyeroberts @Rocketknight1 
