### PR TITLE
Automatic device_map for the rotary embedding module

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4158,8 +4158,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         elif device_map is not None:
             # Make sure we correctly place the rotary embedding module by default if not provided, as we moved it from
             # inside the Layers to the Model
-            for buffer in {name for name, _ in model.named_buffers()}:
-                rotary_module = None
+            rotary_module = None
+            for buffer, _ in model.named_buffers():
                 if "rotary_emb.inv_freq" in buffer and "layer" not in buffer:
                     rotary_module = buffer.replace(".inv_freq", "")
                     break

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4164,8 +4164,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     rotary_module = buffer.replace(".inv_freq", "")
                     break
             if rotary_module is not None and rotary_module not in device_map:
-                # Place it on the same device as the embedding if set and exists, else 0
-                device_map[rotary_module] = device_map.get(rotary_module.replace("rotary_emb", "embed_tokens"), 0)
+                devices = {device for device in device_map.values() if not isinstance(device, str)}
+                if len(devices) == 0:
+                    min_device = "cpu"
+                elif isinstance(list(devices)[0], torch.device):
+                    min_device = torch.device(min(device.index for device in devices))
+                else:
+                    min_device = min(devices)
+                # Place it on the same device as the embedding if set and exists, else min_device found
+                device_map[rotary_module] = device_map.get(
+                    rotary_module.replace("rotary_emb", "embed_tokens"), min_device
+                )
             model.tie_weights()
             tied_params = find_tied_parameters(model)
             # check if we don't have tied param in different devices

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4160,7 +4160,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # inside the Layers to the Model
             for buffer in {name for name, _ in model.named_buffers()}:
                 rotary_module = None
-                if "rotary_emb.inv_freq" in buffer and not "layer" in buffer:
+                if "rotary_emb.inv_freq" in buffer and "layer" not in buffer:
                     rotary_module = buffer.replace(".inv_freq", "")
                     break
             if rotary_module is not None and rotary_module not in device_map:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4160,7 +4160,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # inside the Layers to the Model
             for buffer in {name for name, _ in model.named_buffers()}:
                 rotary_module = None
-                if "rotary_emb.inv_freq" in buffer:
+                if "rotary_emb.inv_freq" in buffer and not "layer" in buffer:
                     rotary_module = buffer.replace(".inv_freq", "")
                     break
             if rotary_module is not None and rotary_module not in device_map:


### PR DESCRIPTION
# What does this PR do?

As per the title. As the rotary has been moved to the Model instead of Layer some time ago, and this is going to be the new standard as we refactor more models, this provides a way to automatically set the rotary_emb module on GPU when a custom device_map is passed, for BC
