### PR TITLE
Fix the config class comparison for remote code models

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -580,7 +580,8 @@ class _BaseAutoModelClass:
             model_class ([`PreTrainedModel`]):
                 The model to register.
         """
-        if hasattr(model_class, "config_class") and str(model_class.config_class) != str(config_class):
+        if hasattr(model_class, "config_class") and model_class.config_class.__name__ != config_class.__name__:
+            breakpoint()
             raise ValueError(
                 "The model class you are passing has a `config_class` attribute that is not consistent with the "
                 f"config class you passed (model has {model_class.config_class} and you passed {config_class}. Fix "

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -581,7 +581,6 @@ class _BaseAutoModelClass:
                 The model to register.
         """
         if hasattr(model_class, "config_class") and model_class.config_class.__name__ != config_class.__name__:
-            breakpoint()
             raise ValueError(
                 "The model class you are passing has a `config_class` attribute that is not consistent with the "
                 f"config class you passed (model has {model_class.config_class} and you passed {config_class}. Fix "


### PR DESCRIPTION
The config class comparison previously used `str(model_class.config_class)`, which resulted in mismatches because the actual class was loaded from a cache dir and therefore had the cache dir path as part of its full class name string.

This new test just uses `model_class.__name__` which is much less error-prone.

Fixes #35584, related to #29854