### PR TITLE
Fix flex_attention in training mode

### DIFF
--- a/src/transformers/integrations/flex_attention.py
+++ b/src/transformers/integrations/flex_attention.py
@@ -27,7 +27,7 @@ def flex_attention_forward(
         if softcap is not None:
             score = softcap * torch.tanh(score / softcap)
         if causal_mask is not None:
-            score += causal_mask[b][0][q_idx][kv_idx]
+            score = score + causal_mask[b][0][q_idx][kv_idx]
         return score
 
     attn_output, attention_weights = flex_attention(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4790,6 +4790,19 @@ class ModelTesterMixin:
             # Assert the last tokens are actually the same (except for the natural fluctuation due to order of FP ops)
             self.assertTrue(torch.allclose(all_logits[:, -1:, :], last_token_logits, atol=1e-5))
 
+    @require_torch_gpu
+    def test_flex_attention_with_grads(self):
+        for model_class in self.all_model_classes:
+            if not model_class._supports_flex_attn:
+                self.skipTest(reason="This model does not support flex attention")
+            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            config._attn_implementation = "flex_attention"
+            model = model_class(config).to(device=torch_device, dtype=torch.float16)
+            self.assertTrue(model.config._attn_implementation == "flex_attention")
+
+            # If this does not raise an error, the test passes (see https://github.com/huggingface/transformers/pull/35605)
+            out = model(inputs_dict["input_ids"].to(torch_device))
+
 
 global_rng = random.Random()
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4801,7 +4801,7 @@ class ModelTesterMixin:
             self.assertTrue(model.config._attn_implementation == "flex_attention")
 
             # If this does not raise an error, the test passes (see https://github.com/huggingface/transformers/pull/35605)
-            out = model(inputs_dict["input_ids"].to(torch_device))
+            _ = model(inputs_dict["input_ids"].to(torch_device))
 
 
 global_rng = random.Random()


### PR DESCRIPTION
# What does this PR do?

As per the title.
In training mode, the in-place operation would produce `RuntimeError: FakeTensor is wrapped to wrong device, found cpu, expected cuda:1`. It is however working when gradients are not required (i.e. with `generate`), which is the reason why it wasn't detected before.
I am not entirely sure what's happening behind the scene and the root of the issue, but switching to explicit operation fixes the issue.
