### PR TITLE
Fix flaky `test_beam_search_low_memory`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1077,7 +1077,10 @@ class GenerationTesterMixin:
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")
 
+            set_model_tester_for_less_flaky_test(self)
+
             config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            set_config_for_less_flaky_test(config)
             # batch_size=1 is ok, but batch_size>1 will cause non-identical output
 
             config.use_cache = True
@@ -1085,6 +1088,7 @@ class GenerationTesterMixin:
 
             # test output equality of low versus high memory
             model = model_class(config).to(torch_device).eval()
+            set_model_for_less_flaky_test(model)
 
             low_output = model.generate(
                 **inputs_dict,

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -204,9 +204,8 @@ class GenerationTesterMixin:
                 "vision_start_token_id",
             ]:
                 token_index = getattr(config, key, None)
-                if token_index is None:
-                    if hasattr(self, "model_tester"):
-                        token_index = getattr(self.model_tester, key, None)
+                if token_index is None and hasattr(self, "model_tester"):
+                    token_index = getattr(self.model_tester, key, None)
                 if token_index is not None and token_index < config.get_text_config().vocab_size:
                     logits_processor_kwargs["bad_words_ids"].append([token_index])
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1093,6 +1093,8 @@ class GenerationTesterMixin:
             model = model_class(config).to(torch_device).eval()
             set_model_for_less_flaky_test(model)
 
+            logits_processor_kwargs = self._get_logits_processor_kwargs(config=model.config)
+
             low_output = model.generate(
                 **inputs_dict,
                 max_new_tokens=8,
@@ -1100,6 +1102,7 @@ class GenerationTesterMixin:
                 early_stopping=True,
                 low_memory=True,
                 use_cache=True,
+                **logits_processor_kwargs,
             )
 
             high_output = model.generate(
@@ -1109,6 +1112,7 @@ class GenerationTesterMixin:
                 early_stopping=True,
                 low_memory=False,
                 use_cache=True,
+                **logits_processor_kwargs,
             )
             self.assertListEqual(low_output.tolist(), high_output.tolist())
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1102,6 +1102,9 @@ class GenerationTesterMixin:
                 early_stopping=True,
                 low_memory=True,
                 use_cache=True,
+                output_scores=True,
+                output_logits=True,
+                return_dict_in_generate=True,
                 **logits_processor_kwargs,
             )
 
@@ -1112,9 +1115,13 @@ class GenerationTesterMixin:
                 early_stopping=True,
                 low_memory=False,
                 use_cache=True,
+                output_scores=True,
+                output_logits=True,
+                return_dict_in_generate=True,
                 **logits_processor_kwargs,
             )
-            self.assertListEqual(low_output.tolist(), high_output.tolist())
+            # The two outputs must match and their shape must be as expected
+            self._check_similar_generate_outputs(low_output, high_output)
 
     @pytest.mark.generate
     @parameterized.expand([("random",), ("same",)])

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -204,6 +204,9 @@ class GenerationTesterMixin:
                 "vision_start_token_id",
             ]:
                 token_index = getattr(config, key, None)
+                if token_index is None:
+                    if hasattr(self, "model_tester"):
+                        token_index = getattr(self.model_tester, key, None)
                 if token_index is not None and token_index < config.get_text_config().vocab_size:
                     logits_processor_kwargs["bad_words_ids"].append([token_index])
 


### PR DESCRIPTION
# What does this PR do?

`test_beam_search_low_memory` is very flaky for `Emu3Vision2TextModelTest`.

The 3 fixes in this PR are all necessary to have 0 failure in a suite of 100 runs.

- call `set_xxx_less_flaky` methods
- avoid generate image tokens
- compare with `_check_similar_generate_outputs`

The final version run 500 times without failure.