### PR TITLE
Skip `MobileNetV1ModelTest::test_batching_equivalence` for now

### DIFF
--- a/tests/models/mobilenet_v1/test_modeling_mobilenet_v1.py
+++ b/tests/models/mobilenet_v1/test_modeling_mobilenet_v1.py
@@ -214,6 +214,8 @@ class MobileNetV1ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         model = MobileNetV1Model.from_pretrained(model_name)
         self.assertIsNotNone(model)
 
+    # TODO: ydshieh
+    @unittest.skip("skip for now as #35564 fails this test more frequently for this model")
     @is_flaky(description="is_flaky https://github.com/huggingface/transformers/pull/31258")
     def test_batching_equivalence(self):
         super().test_batching_equivalence()


### PR DESCRIPTION
# What does this PR do?

skip for now as #35564 fails this test more frequently for this model

will check it later