### PR TITLE
Guard against unset resolved_archive_file

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4505,7 +4505,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             archive_file = (
                 resolved_archive_file[0] if isinstance(resolved_archive_file, (list, tuple)) else resolved_archive_file
             )
-            is_safetensors = archive_file.endswith(".safetensors")
+            is_safetensors = archive_file is not None and archive_file.endswith(".safetensors")
             if offload_folder is None and not is_safetensors:
                 raise ValueError(
                     "The current `device_map` had weights offloaded to the disk. Please provide an `offload_folder`"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4241,19 +4241,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if hf_quantizer is not None:
                 hf_quantizer.validate_environment(device_map=device_map)
 
-            if gguf_path:
-                remapped_devices = set()
-                for name, device in device_map.items():
-                    if device == "disk":
-                        device_map[name] = "cpu"
-                        remapped_devices.add(name)
-                if len(remapped_devices) > 0:
-                    logger.warning(
-                        "Accelerate has auto-mapped modules to disk but disk offload is not supported for "
-                        "models loaded from GGUF files. Remapping modules to the cpu: "
-                        ", ".join(remapped_devices)
-                    )
-
         elif device_map is not None:
             model.tie_weights()
             tied_params = find_tied_parameters(model)
@@ -4261,7 +4248,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             check_tied_parameters_on_same_device(tied_params, device_map)
 
         if gguf_path and device_map is not None and "disk" in device_map.values():
-            raise NotImplementedError(
+            raise RuntimeError(
                 "One or more modules is configured to be mapped to disk. Disk offload is not supported for models "
                 "loaded from GGUF files."
             )

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -223,7 +223,7 @@ class GgufIntegrationTests(unittest.TestCase):
         from collections import OrderedDict
 
         q2_k_gguf_model_id = self.gguf_filename.format(quant_type=QuantType.Q2_K.name)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(RuntimeError):
             AutoModelForCausalLM.from_pretrained(
                 self.gguf_model_id,
                 device_map=OrderedDict(

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -219,6 +219,49 @@ class GgufIntegrationTests(unittest.TestCase):
         EXPECTED_TEXT = "Hello, World!\n\nStep 3: Add"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
+    def test_gguf_errors_disk_offload(self):
+        from collections import OrderedDict
+
+        q2_k_gguf_model_id = self.gguf_filename.format(quant_type=QuantType.Q2_K.name)
+        with self.assertRaises(NotImplementedError):
+            AutoModelForCausalLM.from_pretrained(
+                self.gguf_model_id,
+                device_map=OrderedDict(
+                    [
+                        ("model.embed_tokens", "cpu"),
+                        ("lm_head", "cpu"),
+                        ("model.layers.0", "cpu"),
+                        ("model.layers.1", "cpu"),
+                        ("model.layers.2", "cpu"),
+                        ("model.layers.3", "cpu"),
+                        ("model.layers.4", "cpu"),
+                        ("model.layers.5", "cpu"),
+                        ("model.layers.6", "cpu"),
+                        ("model.layers.7", "cpu"),
+                        ("model.layers.8", "cpu"),
+                        ("model.layers.9", "cpu"),
+                        ("model.layers.10", "disk"),
+                        ("model.layers.11", "disk"),
+                        ("model.layers.12", "disk"),
+                        ("model.layers.13", "disk"),
+                        ("model.layers.14", "disk"),
+                        ("model.layers.15", "disk"),
+                        ("model.layers.16", "disk"),
+                        ("model.layers.17", "disk"),
+                        ("model.layers.18", "disk"),
+                        ("model.layers.19", "disk"),
+                        ("model.layers.20", "disk"),
+                        ("model.layers.21", "disk"),
+                        ("model.layers.22", "disk"),
+                        ("model.norm", "disk"),
+                        ("model.rotary_emb", "disk"),
+                    ]
+                ),
+                gguf_file=q2_k_gguf_model_id,
+                offload_folder="offload",
+                offload_state_dict=True,
+            )
+
 
 @require_gguf
 @require_torch_gpu


### PR DESCRIPTION
# What does this PR do?

`resolved_archive_file` in `_load_pretrained_model()` appears to be optional. In my case, I was loading a model from a GGUF file and it was `None`:

```python
model = AutoModelForCausalLM.from_pretrained(train_config.model_name,
                                             device_map='auto',
                                             gguf_file='llama3.2.gguf',
                                             offload_folder='offload')
```

In that case, `archive_file` ends up being `None` and the check for safe tensors raises an error. The change guards against that case and allows loading to continue.

I thought this change was minor enough that new tests were not warranted. If you feel otherwise, happy to add one if you can point me at the right place to do it.