### PR TITLE
[docs] add return_timestamps=True for Whisper long-form transcription

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -534,8 +534,8 @@ class WhisperGenerationMixin(GenerationMixin):
         >>> inputs = processor(audio, return_tensors="pt", truncation=False, padding="longest", return_attention_mask=True, sampling_rate=16_000)
         >>> inputs = inputs.to("cuda", torch.float32)
 
-        >>> # transcribe audio to ids
-        >>> generated_ids = model.generate(**inputs)
+        >>> # transcribe audio to ids, and set `return_timestamps=True` for long-form transcription
+        >>> generated_ids = model.generate(**inputs, return_timestamps=True)
 
         >>> transcription = processor.batch_decode(generated_ids, skip_special_tokens=True)
         >>> transcription[0]


### PR DESCRIPTION
In the [example of WhisperForConditionalGeneration.generate](https://huggingface.co/docs/transformers/model_doc/whisper#transformers.WhisperForConditionalGeneration.generate.example), `return_timestamps=True` should be set, otherwise it will trigger the ValueError [here](https://github.com/huggingface/transformers/blob/15bd3e61f8d3680ca472c9314ad07584d20f7b81/src/transformers/models/whisper/generation_whisper.py#L1306):

```shell
in _set_return_timestamps
    raise ValueError(
ValueError: You have passed more than 3000 mel input features (> 30 seconds) which automatically enables long-form generation which requires the model to predict timestamp tokens. Please either pass `return_timestamps=True` or make sure to 
pass no more than 3000 mel input features.
```

After adjusting to `generated_ids = model.generate(**inputs, return_timestamps=True)`, it works correctly:

It seems like it was just forgotten to be added :)