### PR TITLE
Fix : adding einops lib in the CI docker for some bitsandbytes tests

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -66,7 +66,7 @@ RUN python3 -m pip install --no-cache-dir python-Levenshtein
 RUN python3 -m pip install --no-cache-dir g2p-en
 
 # For Some bitsandbytes tests
-RUN python3 -m pip install einops
+RUN python3 -m pip install --no-cache-dir einops
 
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -65,6 +65,9 @@ RUN python3 -m pip install --no-cache-dir python-Levenshtein
 # For `FastSpeech2ConformerTokenizer` tokenizer
 RUN python3 -m pip install --no-cache-dir g2p-en
 
+# For Some bitsandbytes tests
+RUN python3 -m pip install einops
+
 # When installing in editable mode, `transformers` is not recognized as a package.
 # this line must be added in order for python to be aware of transformers.
 RUN cd transformers && python3 setup.py develop


### PR DESCRIPTION
# What does this PR do?
Adds the einops library in docker for some `bitsandbytes` tests
<img width="1040" alt="Screenshot 2025-01-13 at 10 58 31" src="https://github.com/user-attachments/assets/fefda907-0665-4f16-9bc6-8c79f899e3ed" />

https://github.com/huggingface/transformers/actions/runs/12729761010/job/35482083926
## Who can review ?
@ydshieh 