### PR TITLE
Add future import for Py < 3.10

### DIFF
--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 import asyncio
 from queue import Queue
 from typing import TYPE_CHECKING, Optional

--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import asyncio
 from queue import Queue
 from typing import TYPE_CHECKING, Optional

--- a/src/transformers/models/olmo2/convert_olmo2_weights_to_hf.py
+++ b/src/transformers/models/olmo2/convert_olmo2_weights_to_hf.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import argparse
 import gc
 import json


### PR DESCRIPTION
One of our files uses `X | None` style types, which requires `from __future__ import annotations` on versions of Python < 3.10. This PR adds the import

Fixes #35639