### PR TITLE
Fix `zero_shot_image_classification` documentation guide link in SigLIP

### DIFF
--- a/docs/source/en/model_doc/siglip.md
+++ b/docs/source/en/model_doc/siglip.md
@@ -102,7 +102,7 @@ If you want to do the pre- and postprocessing yourself, here's how to do that:
 
 A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with SigLIP.
 
-- [Zero-shot image classification task guide](../tasks/zero_shot_image_classification_md)
+- [Zero-shot image classification task guide](../tasks/zero_shot_image_classification)
 - Demo notebooks for SigLIP can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/SigLIP). 🌎
 
 If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we'll review it! The resource should ideally demonstrate something new instead of duplicating an existing resource.


### PR DESCRIPTION
# What does this PR do?
Fixes the computer vision zero-shot image classification guide link in the SigLIP docs 

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@stevhliu