### PR TITLE
[generate] can instantiate `GenerationConfig(cache_implementation="static")`

### DIFF
--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -259,6 +259,12 @@ class GenerationConfigTest(unittest.TestCase):
         config = GenerationConfig()
         self.assertEqual(config.get_generation_mode(assistant_model="foo"), GenerationMode.ASSISTED_GENERATION)
 
+    def test_static_cache_without_cache_config(self):
+        """Regression test for #35026 -- static cache should work without a cache config."""
+        config = GenerationConfig(cache_implementation="static")
+        self.assertEqual(config.cache_implementation, "static")
+        self.assertEqual(config.cache_config, None)
+
 
 class GenerationConfigSerializationTest(unittest.TestCase):
     def test_serialize_generation_sequence_bias(self):


### PR DESCRIPTION
# What does this PR do?

See title -- we should be able to instantiate `GenerationConfig(cache_implementation="static")`, to configure `generate` calls with static caches. In other words, we shouldn't need any further parameterization, as it can be inferred at inference time.

Fixes #35026 