### PR TITLE
Fix mask slicing for models with HybridCache

### DIFF
--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -642,6 +642,7 @@ class Cohere2Model(Cohere2PreTrainedModel):
                     output_attentions,
                     use_cache,
                     cache_position,
+                    **flash_attn_kwargs,
                 )
             else:
                 layer_outputs = decoder_layer(

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -349,17 +349,21 @@ class Cohere2DecoderLayer(nn.Module):
         """
 
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
-            if self.config._attn_implementation != "flash_attention_2":
+            # In prefill, we may be larger than sliding window
+            effective_seq_len = max(cache_position.shape[0], self.sliding_window)
+            # For FA2, the mask is 2D and is of shape [bs, processed_tokens] (not [bs, max_cache_len]),
+            # thus we must slice from the right (at most `effective_seq_len` elements)
+            if self.config._attn_implementation == "flash_attention_2":
+                attention_mask = attention_mask[:, -effective_seq_len:]
+            # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
+            # from the left
+            else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-            # If we are not in a state with input larger than the sliding window, we need to slice
-            # Here we assume this can only happen during prefill
-            if cache_position.shape[0] < self.sliding_window:
-                attention_mask = attention_mask[..., -self.sliding_window :]
+                attention_mask = attention_mask[..., :effective_seq_len]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -356,6 +356,10 @@ class Cohere2DecoderLayer(nn.Module):
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
+            # If we are not in a state with input larger than the sliding window, we need to slice
+            # Here we assume this can only happen during prefill
+            if cache_position.shape[0] < self.sliding_window:
+                attention_mask = attention_mask[..., -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -259,7 +259,7 @@ class Cohere2Attention(nn.Module):
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
             # Here we need to slice as we use a static cache by default, but FA2 does not support it
-            if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and self.config._attn_implementation == "flash_attention_2":
                 seq_len = attention_mask.shape[-1]
                 key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -356,14 +356,19 @@ class Cohere2DecoderLayer(nn.Module):
             if self.config._attn_implementation == "flash_attention_2":
                 attention_mask = attention_mask[:, -effective_seq_len:]
             # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
-            # from the left
+            # from the left, with an offset if we are beyond the sliding window
             else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                attention_mask = attention_mask[..., :effective_seq_len]
+                # In case we are beyond the sliding window, we need to correctly offset the mask slicing
+                offset = cache_position[-1] + 1 - effective_seq_len
+                # Should only be used when beyond the sliding window (i.e. offset > 0)
+                # Slightly more efficient to use torch ops compared to simple `max(0, offset)`
+                offset = torch.maximum(torch.zeros_like(offset), offset)
+                attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -258,6 +258,11 @@ class Cohere2Attention(nn.Module):
             }
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
+            # Here we need to slice as we use a static cache by default, but FA2 does not support it
+            if self.config._attn_implementation == "flash_attention_2":
+                seq_len = attention_mask.shape[-1]
+                key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
+
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":
             if self.config._attn_implementation == "sdpa" and kwargs.get("output_attentions", False):
@@ -344,18 +349,13 @@ class Cohere2DecoderLayer(nn.Module):
         """
 
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # Flash-attn is a 2D tensor
-            if self.config._attn_implementation == "flash_attention_2":
-                if past_key_value is not None:  # when decoding
-                    attention_mask = attention_mask[:, -self.sliding_window :]
-            else:
+            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
+            if self.config._attn_implementation != "flash_attention_2":
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                if attention_mask.shape[-1] <= 1:  # when decoding
-                    attention_mask = attention_mask[:, :, :, -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -326,6 +326,7 @@ class Cohere2DecoderLayer(nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: int = 0,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """
@@ -346,6 +347,7 @@ class Cohere2DecoderLayer(nn.Module):
                 (see `past_key_values`).
             cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
                 Indices depicting the position of the input sequence tokens in the sequence
+            last_cache_position (`int`): equivalent to `cache_position[-1]` but allow indexing without breaking dynamo tracing
         """
 
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
@@ -364,8 +366,8 @@ class Cohere2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                # `kwargs["last_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
-                offset = kwargs["last_cache_position"] - effective_seq_len
+                # `last_cache_position` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = last_cache_position - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
                 offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
@@ -567,6 +569,7 @@ class Cohere2Model(Cohere2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: Optional[int] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -608,13 +611,14 @@ class Cohere2Model(Cohere2PreTrainedModel):
 
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
-        if "last_cache_position" not in flash_attn_kwargs.keys():
-            last_cache_pos = 0
+        if last_cache_position is None:
+            last_cache_position = 0
             if attention_mask is not None:
                 # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
                 # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
-                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
-            flash_attn_kwargs["last_cache_position"] = last_cache_pos
+                last_cache_position = (
+                    attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                )
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
@@ -642,7 +646,7 @@ class Cohere2Model(Cohere2PreTrainedModel):
                     output_attentions,
                     use_cache,
                     cache_position,
-                    **flash_attn_kwargs,
+                    last_cache_position,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -653,6 +657,7 @@ class Cohere2Model(Cohere2PreTrainedModel):
                     output_attentions=output_attentions,
                     use_cache=use_cache,
                     cache_position=cache_position,
+                    last_cache_position=last_cache_position,
                     **flash_attn_kwargs,
                 )
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -609,13 +609,15 @@ class Cohere2Model(Cohere2PreTrainedModel):
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
         if "last_cache_position" not in flash_attn_kwargs.keys():
-            flash_attn_kwargs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
+            last_cache_pos = 0
+            if attention_mask is not None:
+                # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
+                # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
+                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+            flash_attn_kwargs["last_cache_position"] = last_cache_pos
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
-        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
-        # (retrieving the same value from `cache_position` later on would crash dynamo)
-        flash_attn_kwargs["current_cache_position"] = attention_mask.shape[-1]
 
         hidden_states = inputs_embeds
 

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -364,10 +364,10 @@ class Cohere2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                offset = cache_position[-1] + 1 - effective_seq_len
+                # `kwargs["current_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = kwargs["current_cache_position"] - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
-                # Slightly more efficient to use torch ops compared to simple `max(0, offset)`
-                offset = torch.maximum(torch.zeros_like(offset), offset)
+                offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
 
         residual = hidden_states
@@ -609,6 +609,10 @@ class Cohere2Model(Cohere2PreTrainedModel):
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        flash_attn_kwargs["current_cache_position"] = attention_mask.shape[-1]
+
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -383,8 +383,8 @@ class Cohere2DecoderLayer(CohereDecoderLayer):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                # `kwargs["current_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
-                offset = kwargs["current_cache_position"] - effective_seq_len
+                # `kwargs["last_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = kwargs["last_cache_position"] - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
                 offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
@@ -486,6 +486,10 @@ class Cohere2Model(Gemma2Model):
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        if "last_cache_position" not in flash_attn_kwargs.keys():
+            flash_attn_kwargs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
@@ -594,6 +598,10 @@ class Cohere2ForCausalLM(CohereForCausalLM):
         else:
             # The clone here is for the same reason as for `position_ids`.
             model_inputs = {"input_ids": input_ids.clone(memory_format=torch.contiguous_format), "inputs_embeds": None}
+
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        model_inputs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
 
         if (
             isinstance(past_key_values, HybridCache)

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -297,7 +297,7 @@ class Cohere2Attention(CohereAttention, nn.Module):
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
             # Here we need to slice as we use a static cache by default, but FA2 does not support it
-            if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and self.config._attn_implementation == "flash_attention_2":
                 seq_len = attention_mask.shape[-1]
                 key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
 

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -496,7 +496,9 @@ class Cohere2Model(Gemma2Model):
             if attention_mask is not None:
                 # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
                 # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
-                last_cache_position = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                last_cache_position = (
+                    attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                )
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -368,17 +368,21 @@ class Cohere2DecoderLayer(CohereDecoderLayer):
         """
 
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
-            if self.config._attn_implementation != "flash_attention_2":
+            # In prefill, we may be larger than sliding window
+            effective_seq_len = max(cache_position.shape[0], self.sliding_window)
+            # For FA2, the mask is 2D and is of shape [bs, processed_tokens] (not [bs, max_cache_len]),
+            # thus we must slice from the right (at most `effective_seq_len` elements)
+            if self.config._attn_implementation == "flash_attention_2":
+                attention_mask = attention_mask[:, -effective_seq_len:]
+            # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
+            # from the left
+            else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-            # If we are not in a state with input larger than the sliding window, we need to slice
-            # Here we assume this can only happen during prefill
-            if cache_position.shape[0] < self.sliding_window:
-                attention_mask = attention_mask[..., -self.sliding_window :]
+                attention_mask = attention_mask[..., :effective_seq_len]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -296,6 +296,11 @@ class Cohere2Attention(CohereAttention, nn.Module):
             }
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
+            # Here we need to slice as we use a static cache by default, but FA2 does not support it
+            if self.config._attn_implementation == "flash_attention_2":
+                seq_len = attention_mask.shape[-1]
+                key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
+
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":
             if self.config._attn_implementation == "sdpa" and kwargs.get("output_attentions", False):
@@ -363,18 +368,13 @@ class Cohere2DecoderLayer(CohereDecoderLayer):
         """
 
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # Flash-attn is a 2D tensor
-            if self.config._attn_implementation == "flash_attention_2":
-                if past_key_value is not None:  # when decoding
-                    attention_mask = attention_mask[:, -self.sliding_window :]
-            else:
+            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
+            if self.config._attn_implementation != "flash_attention_2":
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                if attention_mask.shape[-1] <= 1:  # when decoding
-                    attention_mask = attention_mask[:, :, :, -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -522,6 +522,7 @@ class Cohere2Model(Gemma2Model):
                     output_attentions,
                     use_cache,
                     cache_position,
+                    **flash_attn_kwargs,
                 )
             else:
                 layer_outputs = decoder_layer(

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -375,6 +375,10 @@ class Cohere2DecoderLayer(CohereDecoderLayer):
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
+            # If we are not in a state with input larger than the sliding window, we need to slice
+            # Here we assume this can only happen during prefill
+            if cache_position.shape[0] < self.sliding_window:
+                attention_mask = attention_mask[..., -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -489,13 +489,15 @@ class Cohere2Model(Gemma2Model):
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
         if "last_cache_position" not in flash_attn_kwargs.keys():
-            flash_attn_kwargs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
+            last_cache_pos = 0
+            if attention_mask is not None:
+                # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
+                # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
+                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+            flash_attn_kwargs["last_cache_position"] = last_cache_pos
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
-        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
-        # (retrieving the same value from `cache_position` later on would crash dynamo)
-        flash_attn_kwargs["current_cache_position"] = attention_mask.shape[-1]
 
         hidden_states = inputs_embeds
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -224,7 +224,7 @@ class Gemma2Attention(nn.Module):
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
             # Here we need to slice as we use a static cache by default, but FA2 does not support it
-            if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and self.config._attn_implementation == "flash_attention_2":
                 seq_len = attention_mask.shape[-1]
                 key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -286,6 +286,7 @@ class Gemma2DecoderLayer(nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
             # In prefill, we may be larger than sliding window
@@ -303,10 +304,10 @@ class Gemma2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                offset = cache_position[-1] + 1 - effective_seq_len
+                # `kwargs["current_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = kwargs["current_cache_position"] - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
-                # Slightly more efficient to use torch ops compared to simple `max(0, offset)`
-                offset = torch.maximum(torch.zeros_like(offset), offset)
+                offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
 
         residual = hidden_states
@@ -323,6 +324,7 @@ class Gemma2DecoderLayer(nn.Module):
             output_attentions=output_attentions,
             use_cache=use_cache,
             cache_position=cache_position,
+            **kwargs,
         )
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = residual + hidden_states
@@ -613,6 +615,9 @@ class Gemma2Model(Gemma2PreTrainedModel):
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        flash_attn_kwargs["current_cache_position"] = attention_mask.shape[-1]
 
         # embed positions
         hidden_states = inputs_embeds

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -288,16 +288,21 @@ class Gemma2DecoderLayer(nn.Module):
         cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
-            if self.config._attn_implementation != "flash_attention_2":
+            # In prefill, we may be larger than sliding window
+            effective_seq_len = max(cache_position.shape[0], self.sliding_window)
+            # For FA2, the mask is 2D and is of shape [bs, processed_tokens] (not [bs, max_cache_len]),
+            # thus we must slice from the right (at most `effective_seq_len` elements)
+            if self.config._attn_implementation == "flash_attention_2":
+                attention_mask = attention_mask[:, -effective_seq_len:]
+            # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
+            # from the left
+            else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-            # If we are not in a state with input larger than the sliding window, we need to slice
-            if cache_position.shape[0] < self.sliding_window:
-                attention_mask = attention_mask[..., -self.sliding_window :]
+                attention_mask = attention_mask[..., :effective_seq_len]
 
         residual = hidden_states
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -295,14 +295,19 @@ class Gemma2DecoderLayer(nn.Module):
             if self.config._attn_implementation == "flash_attention_2":
                 attention_mask = attention_mask[:, -effective_seq_len:]
             # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
-            # from the left
+            # from the left, with an offset if we are beyond the sliding window
             else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                attention_mask = attention_mask[..., :effective_seq_len]
+                # In case we are beyond the sliding window, we need to correctly offset the mask slicing
+                offset = cache_position[-1] + 1 - effective_seq_len
+                # Should only be used when beyond the sliding window (i.e. offset > 0)
+                # Slightly more efficient to use torch ops compared to simple `max(0, offset)`
+                offset = torch.maximum(torch.zeros_like(offset), offset)
+                attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
 
         residual = hidden_states
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -656,6 +656,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
                     output_attentions,
                     use_cache,
                     cache_position,
+                    **flash_attn_kwargs,
                 )
             else:
                 layer_outputs = decoder_layer(

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -286,6 +286,7 @@ class Gemma2DecoderLayer(nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: int = 0,
         **kwargs,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
@@ -304,8 +305,8 @@ class Gemma2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                # `kwargs["last_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
-                offset = kwargs["last_cache_position"] - effective_seq_len
+                # `last_cache_position` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = last_cache_position - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
                 offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
@@ -572,6 +573,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: Optional[int] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -614,13 +616,14 @@ class Gemma2Model(Gemma2PreTrainedModel):
 
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
-        if "last_cache_position" not in flash_attn_kwargs.keys():
-            last_cache_pos = 0
+        if last_cache_position is None:
+            last_cache_position = 0
             if attention_mask is not None:
                 # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
                 # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
-                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
-            flash_attn_kwargs["last_cache_position"] = last_cache_pos
+                last_cache_position = (
+                    attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                )
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
@@ -656,7 +659,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
                     output_attentions,
                     use_cache,
                     cache_position,
-                    **flash_attn_kwargs,
+                    last_cache_position,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -668,6 +671,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
                     output_attentions=output_attentions,
                     use_cache=use_cache,
                     cache_position=cache_position,
+                    last_cache_position=last_cache_position,
                     **flash_attn_kwargs,
                 )
 

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -256,7 +256,12 @@ class Gemma2Attention(GemmaAttention):
 
         if past_key_value is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
-            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position, "sliding_window": self.sliding_window}
+            cache_kwargs = {
+                "sin": sin,
+                "cos": cos,
+                "cache_position": cache_position,
+                "sliding_window": self.sliding_window,
+            }
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
             # Here we need to slice as we use a static cache by default, but FA2 does not support it
@@ -319,16 +324,16 @@ class Gemma2DecoderLayer(nn.Module):
         cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            mask_len = max(self.sliding_window, cache_position.shape[0])
             # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
-            if self.config._attn_implementation == "flash_attention_2":
-                attention_mask = attention_mask[:, -mask_len :]
-            else:
+            if self.config._attn_implementation != "flash_attention_2":
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
+            # If we are not in a state with input larger than the sliding window, we need to slice
+            if cache_position.shape[0] < self.sliding_window:
+                attention_mask = attention_mask[..., -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -482,6 +482,7 @@ class Gemma2Model(GemmaModel):
                     output_attentions,
                     use_cache,
                     cache_position,
+                    **flash_attn_kwargs,
                 )
             else:
                 layer_outputs = decoder_layer(

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -447,7 +447,9 @@ class Gemma2Model(GemmaModel):
             if attention_mask is not None:
                 # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
                 # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
-                last_cache_position = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                last_cache_position = (
+                    attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+                )
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -340,8 +340,8 @@ class Gemma2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                # `kwargs["current_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
-                offset = kwargs["current_cache_position"] - effective_seq_len
+                # `kwargs["last_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = kwargs["last_cache_position"] - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
                 offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
@@ -438,12 +438,13 @@ class Gemma2Model(GemmaModel):
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        if "last_cache_position" not in flash_attn_kwargs.keys():
+            flash_attn_kwargs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
-        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
-        # (retrieving the same value from `cache_position` later on would crash dynamo)
-        flash_attn_kwargs["current_cache_position"] = attention_mask.shape[-1]
 
         # embed positions
         hidden_states = inputs_embeds
@@ -604,6 +605,7 @@ class Gemma2ForCausalLM(GemmaForCausalLM):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             cache_position=cache_position,
+            **loss_kwargs,
         )
 
         hidden_states = outputs[0]
@@ -671,6 +673,10 @@ class Gemma2ForCausalLM(GemmaForCausalLM):
         else:
             # The clone here is for the same reason as for `position_ids`.
             model_inputs = {"input_ids": input_ids.clone(memory_format=torch.contiguous_format), "inputs_embeds": None}
+
+        # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
+        # (retrieving the same value from `cache_position` later on would crash dynamo)
+        model_inputs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
 
         if (
             isinstance(past_key_values, HybridCache)

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -260,7 +260,7 @@ class Gemma2Attention(GemmaAttention):
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
             # Here we need to slice as we use a static cache by default, but FA2 does not support it
-            if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and self.config._attn_implementation == "flash_attention_2":
                 seq_len = attention_mask.shape[-1]
                 key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
 

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -441,7 +441,12 @@ class Gemma2Model(GemmaModel):
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
         if "last_cache_position" not in flash_attn_kwargs.keys():
-            flash_attn_kwargs["last_cache_position"] = attention_mask.shape[-1] if attention_mask is not None else 0
+            last_cache_pos = 0
+            if attention_mask is not None:
+                # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
+                # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
+                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
+            flash_attn_kwargs["last_cache_position"] = last_cache_pos
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -259,6 +259,11 @@ class Gemma2Attention(GemmaAttention):
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
+            # Here we need to slice as we use a static cache by default, but FA2 does not support it
+            if self.config._attn_implementation == "flash_attention_2":
+                seq_len = attention_mask.shape[-1]
+                key_states, value_states = key_states[:, :, :seq_len, :], value_states[:, :, :seq_len, :]
+
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":
             if self.config._attn_implementation == "sdpa" and kwargs.get("output_attentions", False):
@@ -314,18 +319,13 @@ class Gemma2DecoderLayer(nn.Module):
         cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
-            # Flash-attn is a 2D tensor
-            if self.config._attn_implementation == "flash_attention_2":
-                if past_key_value is not None:  # when decoding
-                    attention_mask = attention_mask[:, -self.sliding_window :]
-            else:
+            # For FA2, the mask is 2D and is of shape [bs, seq_len] (not [bs, fixed_cache_len])
+            if self.config._attn_implementation != "flash_attention_2":
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                if attention_mask.shape[-1] <= 1:  # when decoding
-                    attention_mask = attention_mask[:, :, :, -self.sliding_window :]
 
         residual = hidden_states
 

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -322,6 +322,7 @@ class Gemma2DecoderLayer(nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: int = 0,
         **kwargs,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
@@ -340,8 +341,8 @@ class Gemma2DecoderLayer(nn.Module):
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
                 # In case we are beyond the sliding window, we need to correctly offset the mask slicing
-                # `kwargs["last_cache_position"]` is equivalent to `cache_position[-1]` but without breaking dynamo
-                offset = kwargs["last_cache_position"] - effective_seq_len
+                # `last_cache_position` is equivalent to `cache_position[-1]` but without breaking dynamo
+                offset = last_cache_position - effective_seq_len
                 # Should only be used when beyond the sliding window (i.e. offset > 0)
                 offset = max(0, offset)
                 attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
@@ -398,6 +399,7 @@ class Gemma2Model(GemmaModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        last_cache_position: Optional[int] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -440,13 +442,12 @@ class Gemma2Model(GemmaModel):
 
         # This is needed to correctly slice the mask without data-dependent slicing later on if using dynamo tracing
         # (retrieving the same value from `cache_position` later on would crash dynamo)
-        if "last_cache_position" not in flash_attn_kwargs.keys():
-            last_cache_pos = 0
+        if last_cache_position is None:
+            last_cache_position = 0
             if attention_mask is not None:
                 # In case a 4d mask is passed directly without using `generate`, we have to rely on cache_position
                 # It will break dynamo tracing but there are no way around it (and it should never happen in practice)
-                last_cache_pos = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
-            flash_attn_kwargs["last_cache_position"] = last_cache_pos
+                last_cache_position = attention_mask.shape[-1] if attention_mask.dim() == 2 else cache_position[-1].item()
         causal_mask = self._update_causal_mask(
             attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
         )
@@ -482,7 +483,7 @@ class Gemma2Model(GemmaModel):
                     output_attentions,
                     use_cache,
                     cache_position,
-                    **flash_attn_kwargs,
+                    last_cache_position,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -494,6 +495,7 @@ class Gemma2Model(GemmaModel):
                     output_attentions=output_attentions,
                     use_cache=use_cache,
                     cache_position=cache_position,
+                    last_cache_position=last_cache_position,
                     **flash_attn_kwargs,
                 )
 

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -331,14 +331,19 @@ class Gemma2DecoderLayer(nn.Module):
             if self.config._attn_implementation == "flash_attention_2":
                 attention_mask = attention_mask[:, -effective_seq_len:]
             # Otherwise, the mask is 4D of shape [bs, 1, query_len, max_cache_len] thus we must slice
-            # from the left
+            # from the left, with an offset if we are beyond the sliding window
             else:
                 min_dtype = torch.finfo(hidden_states.dtype).min
                 sliding_window_mask = torch.tril(
                     torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
                 )
                 attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
-                attention_mask = attention_mask[..., :effective_seq_len]
+                # In case we are beyond the sliding window, we need to correctly offset the mask slicing
+                offset = cache_position[-1] + 1 - effective_seq_len
+                # Should only be used when beyond the sliding window (i.e. offset > 0)
+                # Slightly more efficient to use torch ops compared to simple `max(0, offset)`
+                offset = torch.maximum(torch.zeros_like(offset), offset)
+                attention_mask = attention_mask[:, :, :, offset : offset + effective_seq_len]
 
         residual = hidden_states
 

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -357,7 +357,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
         inputs = tokenizer(input_text, padding=True, return_tensors="pt").to(torch_device)
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_id, attn_implementation="flash_attention_2", torch_dtype=torch.float15
+            model_id, attn_implementation="flash_attention_2", torch_dtype=torch.float16
         ).to(torch_device)
 
         # Make sure prefill is larger than sliding window

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -342,7 +342,12 @@ class Cohere2IntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
     @require_read_token
-    def test_long_prefill_flash_attention_2(self):
+    @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
+    def test_generation_beyond_sliding_window(self, attn_implementation: str):
+        """Test that we can correctly generate beyond the sliding window. This is non trivial as
+        we need to correctly slice the attention mask in all cases (because we use a HybridCache).
+        Outputs for every attention functions should be coherent and identical.
+        """
         model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         EXPECTED_COMPLETIONS = [
             " the mountains, the lakes, the rivers, the waterfalls, the waterfalls, the waterfalls, the waterfalls",
@@ -357,7 +362,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
         inputs = tokenizer(input_text, padding=True, return_tensors="pt").to(torch_device)
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_id, attn_implementation="flash_attention_2", torch_dtype=torch.float16
+            model_id, attn_implementation=attn_implementation, torch_dtype=torch.float16
         ).to(torch_device)
 
         # Make sure prefill is larger than sliding window

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -341,8 +341,8 @@ class Cohere2IntegrationTest(unittest.TestCase):
         ep_generated_text = tokenizer.batch_decode(ep_generated_ids, skip_special_tokens=True)
         self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
-    @require_read_token
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
+    @require_read_token
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -394,8 +394,8 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
+    @require_read_token
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -410,7 +410,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
         inputs = tokenizer(input_text, padding=True, return_tensors="pt").to(torch_device)
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_id, attn_implementation="flash_attention_2", torch_dtype=torch.float15
+            model_id, attn_implementation="flash_attention_2", torch_dtype=torch.float16
         ).to(torch_device)
 
         # Make sure prefill is larger than sliding window


### PR DESCRIPTION
# What does this PR do?

As per the title. Models with HybridCache need to correctly slice the key/value states when using FA2 as inputs needs to be unpadded on the right as well (and the mask has shape [bs, seq_len]). Moreover, mask slicing was wrong in all cases when the sequence length is larger than the sliding window. It is currently broken and leads to garbage generation when using padding. This fixes it.