### PR TITLE
Fix some tests

### DIFF
--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -595,6 +595,7 @@ class DiffLlamaPreTrainedModel(PreTrainedModel):
     _skip_keys_device_placement = ["past_key_values"]
     _supports_flash_attn_2 = True
     _supports_sdpa = True
+    _supports_flex_attn = False
     _supports_cache_class = True
     _supports_quantized_cache = True
     _supports_static_cache = True

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -595,7 +595,6 @@ class DiffLlamaPreTrainedModel(PreTrainedModel):
     _skip_keys_device_placement = ["past_key_values"]
     _supports_flash_attn_2 = True
     _supports_sdpa = True
-    _supports_flex_attn = True
     _supports_cache_class = True
     _supports_quantized_cache = True
     _supports_static_cache = True

--- a/src/transformers/models/diffllama/modular_diffllama.py
+++ b/src/transformers/models/diffllama/modular_diffllama.py
@@ -433,6 +433,7 @@ class DiffLlamaDecoderLayer(LlamaDecoderLayer):
 class DiffLlamaPreTrainedModel(LlamaPreTrainedModel):
     _supports_flex_attn = False
 
+
 class DiffLlamaModel(LlamaModel):
     pass
 

--- a/src/transformers/models/diffllama/modular_diffllama.py
+++ b/src/transformers/models/diffllama/modular_diffllama.py
@@ -431,8 +431,7 @@ class DiffLlamaDecoderLayer(LlamaDecoderLayer):
 
 
 class DiffLlamaPreTrainedModel(LlamaPreTrainedModel):
-    pass
-
+    _supports_flex_attn = False
 
 class DiffLlamaModel(LlamaModel):
     pass

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -986,6 +986,17 @@ def require_torch_gpu(test_case):
     return unittest.skipUnless(torch_device == "cuda", "test requires CUDA")(test_case)
 
 
+def require_torch_large_gpu(test_case, memory: float = 20):
+    """Decorator marking a test that requires a GPU with more than `memory` GiB of memory."""
+    if torch_device != "cuda":
+        return unittest.skip(reason=f"test requires a GPU with more than {memory} GiB of memory")(test_case)
+
+    return unittest.skipUnless(
+        torch.cuda.get_device_properties(0).total_memory / 1024**3 > memory,
+        f"test requires a GPU with more than {memory} GiB of memory",
+    )(test_case)
+
+
 def require_torch_gpu_if_bnb_not_multi_backend_enabled(test_case):
     """
     Decorator marking a test that requires a GPU if bitsandbytes multi-backend feature is not enabled.

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -987,9 +987,9 @@ def require_torch_gpu(test_case):
 
 
 def require_torch_large_gpu(test_case, memory: float = 20):
-    """Decorator marking a test that requires a GPU with more than `memory` GiB of memory."""
+    """Decorator marking a test that requires a CUDA GPU with more than `memory` GiB of memory."""
     if torch_device != "cuda":
-        return unittest.skip(reason=f"test requires a GPU with more than {memory} GiB of memory")(test_case)
+        return unittest.skip(reason=f"test requires a CUDA GPU with more than {memory} GiB of memory")(test_case)
 
     return unittest.skipUnless(
         torch.cuda.get_device_properties(0).total_memory / 1024**3 > memory,

--- a/tests/models/cohere/test_modeling_cohere.py
+++ b/tests/models/cohere/test_modeling_cohere.py
@@ -347,7 +347,7 @@ class CohereIntegrationTest(unittest.TestCase):
                 [[0.0000, 0.1866, -0.1997], [0.0000, -0.0736, 0.1785], [0.0000, -0.1965, -0.0569]],
                 [[0.0000, -0.0302, 0.1488], [0.0000, -0.0402, 0.1351], [0.0000, -0.0341, 0.1116]],
             ]
-        ).to(torch_device)
+        ).to(device=torch_device, dtype=torch.float16)
 
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         model = CohereForCausalLM.from_pretrained(model_id, low_cpu_mem_usage=True, torch_dtype=torch.float16).to(

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -26,7 +26,6 @@ from transformers.testing_utils import (
     require_flash_attn,
     require_read_token,
     require_torch,
-    require_torch_gpu,
     require_torch_large_gpu,
     slow,
     torch_device,
@@ -285,7 +284,10 @@ class Cohere2IntegrationTest(unittest.TestCase):
         if version.parse(torch.__version__) < version.parse("2.5.0"):
             self.skipTest(reason="This test requires torch >= 2.5 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleWithStaticCache, convert_and_export_with_cache
+        from transformers.integrations.executorch import (
+            TorchExportableModuleWithStaticCache,
+            convert_and_export_with_cache,
+        )
 
         model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         EXPECTED_TEXT_COMPLETION = [

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -202,7 +202,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
 
     @require_read_token
     def test_model_bf16(self):
-        model_id = "CohereForAI/command-r7b-12-2024"
+        model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         EXPECTED_TEXTS = [
             "<BOS_TOKEN>Hello I am doing a project on the 1918 flu pandemic and I am trying to find out how many",
             "<PAD><PAD><BOS_TOKEN>Hi today I'm going to be talking about the history of the United States. The United States of America",
@@ -222,7 +222,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
 
     @require_read_token
     def test_model_fp16(self):
-        model_id = "CohereForAI/command-r7b-12-2024"
+        model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         EXPECTED_TEXTS = [
             "<BOS_TOKEN>Hello I am doing a project on the 1918 flu pandemic and I am trying to find out how many",
             "<PAD><PAD><BOS_TOKEN>Hi today I'm going to be talking about the history of the United States. The United States of America",
@@ -243,7 +243,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
     @require_read_token
     def test_model_pipeline_bf16(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Cohere2 before this PR
-        model_id = "CohereForAI/command-r7b-12-2024"
+        model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         # EXPECTED_TEXTS should match the same non-pipeline test, minus the special tokens
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the 1918 flu pandemic and I am trying to find out how many",
@@ -268,7 +268,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
     @slow
     def test_model_flash_attn(self):
         # See https://github.com/huggingface/transformers/issues/31953 --- flash attn was generating garbage for Gemma2, especially in long context
-        model_id = "CohereForAI/command-r7b-12-2024"
+        model_id = "CohereForAI/c4ai-command-r7b-12-2024"
         EXPECTED_TEXTS = [
             '<BOS_TOKEN>Hello I am doing a project on the 1918 flu pandemic and I am trying to find out how many people died in the United States. I have found a few sites that say 500,000 but I am not sure if that is correct. I have also found a site that says 675,000 but I am not sure if that is correct either. I am trying to find out how many people died in the United States. I have found a few',
             "<PAD><PAD><BOS_TOKEN>Hi today I'm going to be talking about the history of the United States. The United States of America is a country in North America. It is the third largest country in the world by total area and the third most populous country with over 320 million people. The United States is a federal republic consisting of 50 states and a federal district. The 48 contiguous states and the district of Columbia are in central North America between Canada and Mexico. The state of Alaska is in the"
@@ -297,7 +297,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
         )
 
         tokenizer = AutoTokenizer.from_pretrained(
-            "CohereForAI/command-r7b-12-2024", pad_token="<PAD>", padding_side="right"
+            "CohereForAI/c4ai-command-r7b-12-2024", pad_token="<PAD>", padding_side="right"
         )
         EXPECTED_TEXT_COMPLETION = [
             "Hello I am doing a project for my school and I need to know how to make a program that will take a number",
@@ -313,7 +313,7 @@ class Cohere2IntegrationTest(unittest.TestCase):
         attn_implementation = "sdpa"
         batch_size = 1
         model = AutoModelForCausalLM.from_pretrained(
-            "CohereForAI/command-r7b-12-2024",
+            "CohereForAI/c4ai-command-r7b-12-2024",
             device_map=device,
             torch_dtype=dtype,
             attn_implementation=attn_implementation,

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -24,6 +24,7 @@ from transformers.testing_utils import (
     require_flash_attn,
     require_torch,
     require_torch_accelerator,
+    require_torch_large_gpu,
     require_torch_sdpa,
     slow,
     torch_device,
@@ -433,7 +434,7 @@ class GlmIntegrationTest(unittest.TestCase):
             # 8 is for A100 / A10 and 7 for T4
             cls.cuda_compute_capability_major_version = torch.cuda.get_device_capability()[0]
 
-    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
+    @require_torch_large_gpu
     def test_model_9b_fp16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -452,7 +453,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
+    @require_torch_large_gpu
     def test_model_9b_bf16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -471,7 +472,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
+    @require_torch_large_gpu
     def test_model_9b_eager(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -496,7 +497,7 @@ class GlmIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_torch_sdpa
-    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
+    @require_torch_large_gpu
     def test_model_9b_sdpa(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -522,7 +523,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
     @require_flash_attn
     @pytest.mark.flash_attn_test
-    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
+    @require_torch_large_gpu
     def test_model_9b_flash_attn(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -23,7 +23,6 @@ from transformers.testing_utils import (
     is_flaky,
     require_flash_attn,
     require_torch,
-    require_torch_accelerator,
     require_torch_large_gpu,
     require_torch_sdpa,
     slow,

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -433,6 +433,7 @@ class GlmIntegrationTest(unittest.TestCase):
             # 8 is for A100 / A10 and 7 for T4
             cls.cuda_compute_capability_major_version = torch.cuda.get_device_capability()[0]
 
+    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
     def test_model_9b_fp16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -451,6 +452,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
+    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
     def test_model_9b_bf16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -469,6 +471,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
+    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
     def test_model_9b_eager(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -493,6 +496,7 @@ class GlmIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_torch_sdpa
+    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
     def test_model_9b_sdpa(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -518,6 +522,7 @@ class GlmIntegrationTest(unittest.TestCase):
 
     @require_flash_attn
     @pytest.mark.flash_attn_test
+    @unittest.skip(reason="This passes locally on A100, but model is too big for CI.")
     def test_model_9b_flash_attn(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -419,7 +419,7 @@ class GlmModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
 
 @slow
-@require_torch_accelerator
+@require_torch_large_gpu
 class GlmIntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
     model_id = "THUDM/glm-4-9b"
@@ -434,7 +434,6 @@ class GlmIntegrationTest(unittest.TestCase):
             # 8 is for A100 / A10 and 7 for T4
             cls.cuda_compute_capability_major_version = torch.cuda.get_device_capability()[0]
 
-    @require_torch_large_gpu
     def test_model_9b_fp16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -453,7 +452,6 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_torch_large_gpu
     def test_model_9b_bf16(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -472,7 +470,6 @@ class GlmIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_torch_large_gpu
     def test_model_9b_eager(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -497,7 +494,6 @@ class GlmIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_torch_sdpa
-    @require_torch_large_gpu
     def test_model_9b_sdpa(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
@@ -523,7 +519,6 @@ class GlmIntegrationTest(unittest.TestCase):
 
     @require_flash_attn
     @pytest.mark.flash_attn_test
-    @require_torch_large_gpu
     def test_model_9b_flash_attn(self):
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",


### PR DESCRIPTION
# What does this PR do?

Fixes some tests:

- Glm (add a decorator to avoid oom)
- Cohere (fix dtype issue)
- Cohere2 (fix model name + fix expected completion + use decorator to avoid oom), see also https://github.com/huggingface/transformers/pull/35681 which was discovered
- DiffLlama (removes _support_flex_attention)
