### PR TITLE
use torch constraints to check if covariance is positive definite during mean resizing.

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2427,7 +2427,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Check if the covariance is positive definite.
         epsilon = 1e-9
-        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).all()
+        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).item()
         if is_covariance_psd:
             # If covariances is positive definite, a distribution can be created. and we can sample new weights from it.
             distribution = torch.distributions.multivariate_normal.MultivariateNormal(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2427,7 +2427,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Check if the covariance is positive definite.
         epsilon = 1e-9
-        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).all()
+        is_covariance_psd = bool(constraints.positive_definite.check(epsilon * covariance).all())
         if is_covariance_psd:
             # If covariances is positive definite, a distribution can be created. and we can sample new weights from it.
             distribution = torch.distributions.multivariate_normal.MultivariateNormal(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2427,7 +2427,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Check if the covariance is positive definite.
         epsilon = 1e-9
-        is_covariance_psd = bool(constraints.positive_definite.check(epsilon * covariance).all())
+        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).all()
         if is_covariance_psd:
             # If covariances is positive definite, a distribution can be created. and we can sample new weights from it.
             distribution = torch.distributions.multivariate_normal.MultivariateNormal(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2427,7 +2427,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Check if the covariance is positive definite.
         epsilon = 1e-9
-        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).item()
+        is_covariance_psd = constraints.positive_definite.check(epsilon * covariance).all()
         if is_covariance_psd:
             # If covariances is positive definite, a distribution can be created. and we can sample new weights from it.
             distribution = torch.distributions.multivariate_normal.MultivariateNormal(


### PR DESCRIPTION
# What does this PR do?

this PR implements this solution https://github.com/huggingface/transformers/issues/35075.
using torch constraints to check if the covariance is positive definite.


cc: @Rocketknight1
