### PR TITLE
Fix set_initialized_submodules bugs + improve asymptotic runtime

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -583,9 +583,10 @@ def set_initialized_submodules(model, state_dict_keys):
             i += 1
         # This next block is just for debug testing and should be removed before merging
         old_loaded_keys = {
-            k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
+            k.removeprefix(f"{module_name}.") for k in state_dict_keys if k.startswith(f"{module_name}.")
         }
-        assert old_loaded_keys == loaded_keys
+        if not old_loaded_keys == loaded_keys:
+            breakpoint()
         # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":
             loaded_keys = set(state_dict_keys)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -580,12 +580,6 @@ def set_initialized_submodules(model, state_dict_keys):
             # Iterate until we reach the end of the keys with this prefix
             loaded_keys.add(state_dict_keys[i].removeprefix(prefix))
             i += 1
-        # This next block is just for debug testing and should be removed before merging
-        old_loaded_keys = {
-            k.removeprefix(f"{module_name}.") for k in state_dict_keys if k.startswith(f"{module_name}.")
-        }
-        if not old_loaded_keys == loaded_keys:
-            breakpoint()
         # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":
             loaded_keys = set(state_dict_keys)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -566,9 +566,8 @@ def set_initialized_submodules(model, state_dict_keys):
     Sets the `_is_hf_initialized` flag in all submodules of a given model when all its weights are in the loaded state
     dict.
     """
-    state_dict_keys = sorted(
-        state_dict_keys
-    )  # So we can do binary search on it - this becomes important when it's big
+    # So we can do binary search on it - this becomes important when it's big
+    state_dict_keys = sorted(state_dict_keys)
 
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -32,6 +32,7 @@ from functools import partial, wraps
 from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 from zipfile import is_zipfile
+from bisect import bisect_left, bisect_right
 
 import torch
 from huggingface_hub import split_torch_state_dict_into_shards
@@ -565,9 +566,22 @@ def set_initialized_submodules(model, state_dict_keys):
     Sets the `_is_hf_initialized` flag in all submodules of a given model when all its weights are in the loaded state
     dict.
     """
+    state_dict_keys = sorted(state_dict_keys)  # So we can do binary search on it - this becomes important when it's big
+
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
-        loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
+        # loaded_keys is the set of keys that are in state_dict_keys and start with module_name + "."
+        prefix = module_name + "."
+        loaded_keys = set()
+        # Use binary search to find the start of the keys that have this prefix
+        i = bisect_left(state_dict_keys, prefix)
+        while i < len(state_dict_keys) and state_dict_keys[i].startswith(prefix):
+            # Iterate until we reach the end of the keys with this prefix
+            loaded_keys.add(state_dict_keys[i].removeprefix(prefix))
+            i += 1
+        # This next block is just for debug testing and should be removed before merging
+        old_loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
+        assert old_loaded_keys == loaded_keys
         # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":
             loaded_keys = set(state_dict_keys)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -26,13 +26,13 @@ import re
 import shutil
 import tempfile
 import warnings
+from bisect import bisect_left
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial, wraps
 from threading import Thread
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 from zipfile import is_zipfile
-from bisect import bisect_left, bisect_right
 
 import torch
 from huggingface_hub import split_torch_state_dict_into_shards
@@ -566,7 +566,9 @@ def set_initialized_submodules(model, state_dict_keys):
     Sets the `_is_hf_initialized` flag in all submodules of a given model when all its weights are in the loaded state
     dict.
     """
-    state_dict_keys = sorted(state_dict_keys)  # So we can do binary search on it - this becomes important when it's big
+    state_dict_keys = sorted(
+        state_dict_keys
+    )  # So we can do binary search on it - this becomes important when it's big
 
     not_initialized_submodules = {}
     for module_name, module in model.named_modules():
@@ -580,7 +582,9 @@ def set_initialized_submodules(model, state_dict_keys):
             loaded_keys.add(state_dict_keys[i].removeprefix(prefix))
             i += 1
         # This next block is just for debug testing and should be removed before merging
-        old_loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
+        old_loaded_keys = {
+            k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")
+        }
         assert old_loaded_keys == loaded_keys
         # When checking if the root module is loaded all state_dict_keys must be used.
         if module_name == "":


### PR DESCRIPTION
Our old `set_initialized_submodules` function had this line:

```python
loaded_keys = {k.replace(f"{module_name}.", "") for k in state_dict_keys if k.startswith(f"{module_name}.")}
```

This line has two problems. Firstly, it's buggy - it can replace the substring `"{module_name}."` **even if it does not occur at the start of the string.** In testing, this was mangling keys in several models, particular models which had a key on the base model object with a name like `"embeddings"`.

The second problem is performance: this line iterates over every key in the state dict. That iteration is O(N), where N is the number of weights in the state dict, and is executed once per `module` in the model. Since there are O(N) modules as well, the overall function is O(N^2). As is characteristic of O(N^2) functions, they're fine until inputs get sufficiently large and then their runtime totally blows up, which [happened recently with DeepSeek-v3](https://github.com/huggingface/transformers/issues/35635)

This PR replaces the full list scan with a sort, O(NlogN), followed by binary search which is O(log N), and then iterates forward until the prefix no longer matches. Therefore, the scan is now O(log(N) + k), where k is the average number of weights in a module, and the overall runtime is O(NlogN + Nk), which is much faster than O(N^2). It also fixes the incorrect replacements bug by using `removeprefix()` instead of `replace()`.

Fixes #35635