### PR TITLE
Fix uploading processors/tokenizers to WandB on train end

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -915,13 +915,13 @@ class WandbCallback(TrainerCallback):
         if not self._initialized:
             self.setup(args, state, model, **kwargs)
 
-    def on_train_end(self, args, state, control, model=None, tokenizer=None, **kwargs):
+    def on_train_end(self, args, state, control, model=None, processing_class=None, **kwargs):
         if self._wandb is None:
             return
         if self._log_model.is_enabled and self._initialized and state.is_world_process_zero:
             from ..trainer import Trainer
 
-            fake_trainer = Trainer(args=args, model=model, processing_class=tokenizer, eval_dataset=["fake"])
+            fake_trainer = Trainer(args=args, model=model, processing_class=processing_class, eval_dataset=["fake"])
             with tempfile.TemporaryDirectory() as temp_dir:
                 fake_trainer.save_model(temp_dir)
                 metadata = (

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -1765,7 +1765,7 @@ class ClearMLCallback(TrainerCallback):
         self._log_model = False
         self._checkpoints_saved = []
 
-    def setup(self, args, state, model, tokenizer, **kwargs):
+    def setup(self, args, state, model, processing_class, **kwargs):
         if self._clearml is None:
             return
         if self._initialized:
@@ -1864,25 +1864,25 @@ class ClearMLCallback(TrainerCallback):
                         description=configuration_object_description,
                     )
 
-    def on_train_begin(self, args, state, control, model=None, tokenizer=None, **kwargs):
+    def on_train_begin(self, args, state, control, model=None, processing_class=None, **kwargs):
         if self._clearml is None:
             return
         self._checkpoints_saved = []
         if state.is_hyper_param_search:
             self._initialized = False
         if not self._initialized:
-            self.setup(args, state, model, tokenizer, **kwargs)
+            self.setup(args, state, model, processing_class, **kwargs)
 
     def on_train_end(self, args, state, control, **kwargs):
         if ClearMLCallback._should_close_on_train_end:
             self._clearml_task.close()
             ClearMLCallback._train_run_counter = 0
 
-    def on_log(self, args, state, control, model=None, tokenizer=None, logs=None, **kwargs):
+    def on_log(self, args, state, control, model=None, processing_class=None, logs=None, **kwargs):
         if self._clearml is None:
             return
         if not self._initialized:
-            self.setup(args, state, model, tokenizer, **kwargs)
+            self.setup(args, state, model, processing_class, **kwargs)
         if state.is_world_process_zero:
             eval_prefix = "eval_"
             eval_prefix_len = len(eval_prefix)
@@ -2131,7 +2131,7 @@ class DVCLiveCallback(TrainerCallback):
                 fake_trainer = Trainer(
                     args=args,
                     model=kwargs.get("model"),
-                    processing_class=kwargs.get("tokenizer"),
+                    processing_class=kwargs.get("processing_class"),
                     eval_dataset=["fake"],
                 )
                 name = "best" if args.load_best_model_at_end else "last"


### PR DESCRIPTION
# What does this PR do?

Since `tokenizer` was renamed to `processing_class` in #32385 models uploaded to WandB at the end of training have not included the tokenizer/processor config. This is due to a missed update to the argument names in `WandbCallback.on_train_end`, which is fixed in this PR.  The bug has only impacted the final artifacts saved at the end of training, checkpoints saved during training still upload both the model and the processor config.

If you have wandb setup and logged in you can see the problem by running `examples/pytorch/text-classification` on `main` and this branch, and comparing the artifacts logged to your wandb run (you'll need to delete the local output directory `rm -rf /tmp/mrpc` before starting the script on each branch):

```
export TASK_NAME=mrpc                            
export WANDB_LOG_MODEL=checkpoint
python run_glue.py \
  --model_name_or_path google-bert/bert-base-cased \
  --task_name $TASK_NAME \
  --do_train \
  --do_eval \
  --max_seq_length 128 \
  --per_device_train_batch_size 32 \
  --learning_rate 2e-5 \
  --num_train_epochs 2 \
  --output_dir /tmp/$TASK_NAME/ \
  --report_to wandb \
  --save_strategy epoch \
  --save_total_limit 2 \
  --load_best_model_at_end True \
  --eval_strategy epoch
```

The files in the logged `:latest` model artifact in your run will include the tokenizer config for the run from this branch, but not in the run started on main.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Previous changes: @amyeroberts 

Maybe Trainer: @muellerzr, @SunMarc , though this is more an integration/WandB issue.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
