### PR TITLE
Fix : Nemotron Processor in GGUF conversion

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -220,6 +220,15 @@ class MambaTensorProcessor(TensorProcessor):
             weights = np.log(-weights)
         return GGUFTensor(weights, name, {})
 
+class NemotronTensorProcessor(TensorProcessor):
+    def __init__(self, config=None):
+        super().__init__(config=config)
+
+    #ref : https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L4666
+    def process(self, weights, name, **kwargs):
+        if "norm.weight" in name:
+            weights = weights - 1
+        return GGUFTensor(weights, name, {})
 
 class Gemma2TensorProcessor(TensorProcessor):
     def __init__(self, config=None):
@@ -241,7 +250,8 @@ TENSOR_PROCESSORS = {
     "t5encoder": T5TensorProcessor,
     "gpt2": GPT2TensorProcessor,
     "mamba": MambaTensorProcessor,
-    "gemma2": Gemma2TensorProcessor,
+    "nemotron": NemotronTensorProcessor,
+    "gemma2": Gemma2TensorProcessor
 }
 
 

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -220,15 +220,17 @@ class MambaTensorProcessor(TensorProcessor):
             weights = np.log(-weights)
         return GGUFTensor(weights, name, {})
 
+
 class NemotronTensorProcessor(TensorProcessor):
     def __init__(self, config=None):
         super().__init__(config=config)
 
-    #ref : https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L4666
+    # ref : https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L4666
     def process(self, weights, name, **kwargs):
         if "norm.weight" in name:
             weights = weights - 1
         return GGUFTensor(weights, name, {})
+
 
 class Gemma2TensorProcessor(TensorProcessor):
     def __init__(self, config=None):
@@ -251,7 +253,7 @@ TENSOR_PROCESSORS = {
     "gpt2": GPT2TensorProcessor,
     "mamba": MambaTensorProcessor,
     "nemotron": NemotronTensorProcessor,
-    "gemma2": Gemma2TensorProcessor
+    "gemma2": Gemma2TensorProcessor,
 }
 
 


### PR DESCRIPTION
# What does this PR do?
Fixes an issue when converting models from gguf format for Nemotron models. In RMSNorm we should substract 1 from the weights, see https://github.com/ggerganov/llama.cpp/blob/master/convert_hf_to_gguf.py#L4666
The test `test_nemotron_weights_conversion_fp16` covers this and it passes with the fix.
## Who can review 
@SunMarc @Isotr0py 