### PR TITLE
[cache] add a test to confirm we can use cache at train time

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1791,7 +1791,7 @@ class ModelUtilsTest(TestCasePlus):
         )
         self.assertTrue(check_models_equal(model, model_loaded))
 
-    def test_cache_at_train_time(self):
+    def test_cache_when_needed_at_train_time(self):
         """
         Some fine-tuning methods require the use of cache, like prefix tuning in PEFT. This test checks that a cache
         is at train time used if we request it. Related issue: #35648


### PR DESCRIPTION
# What does this PR do?

In #35648, the idea of always disabling the cache at train-time was floated. However, @BenjaminBossan pointed to me that some fine-tuning scripts need cache at train time (e.g. prefix tuning in PEFT).

I couldn't find any test that ensured the survival of this property, so this PR adds a test that will fail if we decide to disable it :) 