### PR TITLE
Fix: Falcon tie_word_embeddings in GGUF

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -400,9 +400,10 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
 
     # Handle tie_word_embeddings, if lm_head.weight is not present in tensors,
     # tie_word_embeddings is true otherwise false
+    exceptions = ["falcon"]
     parsed_parameters["config"]["tie_word_embeddings"] = all(
         "output.weight" != tensor.name for tensor in reader.tensors
-    )
+    ) or architecture in exceptions
 
     # List all key-value pairs in a columnized format
     for gguf_key, field in reader.fields.items():

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -401,9 +401,9 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
     # Handle tie_word_embeddings, if lm_head.weight is not present in tensors,
     # tie_word_embeddings is true otherwise false
     exceptions = ["falcon"]
-    parsed_parameters["config"]["tie_word_embeddings"] = all(
-        "output.weight" != tensor.name for tensor in reader.tensors
-    ) or architecture in exceptions
+    parsed_parameters["config"]["tie_word_embeddings"] = (
+        all("output.weight" != tensor.name for tensor in reader.tensors) or architecture in exceptions
+    )
 
     # List all key-value pairs in a columnized format
     for gguf_key, field in reader.fields.items():


### PR DESCRIPTION
# What does this PR do?
In the `modeling_gguf_pytorch_utils.py` file, the value of `tie_word_embeddings` is determined by the presence (or absence) of the tensor `output.weight` in the GGUF file. While this approach is generally a good indicator, the Falcon architecture is an exception to the rule as you can see here : https://huggingface.co/tiiuae/falcon-7b/tree/main?show_file_info=model-00002-of-00002.safetensors (hf format) and here https://huggingface.co/tensorblock/falcon-7b-GGUF/tree/main?show_file_info=falcon-7b-Q2_K.gguf (gguf format)

In Falcon, `word_embeddings` are tied to the `lm_head` weights. Despite this, `output.weight` is still present in the GGUF file, and `lm_head` is included in the Hugging Face model format. To handle this edge case, I added an exception array for such architectures.

This issue was causing a subtle error related to parameters not being on the same device, which was only discoverable in multi-GPU settings.

## Who can review ?
@SunMarc @Isotr0py 