### PR TITLE
Fix weight loading of `weight_g_idx` compressed-tensors parameters

### DIFF
--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -55,7 +55,6 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
             self.weight_norm = torch.nn.utils.parametrizations.weight_norm
             delattr(torch.nn.utils.parametrizations, "weight_norm")
 
-
     def validate_environment(self, *args, **kwargs):
         if not is_compressed_tensors_available():
             raise ImportError(
@@ -85,7 +84,6 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
             apply_quantization_config(model, ct_quantization_config, run_compressed=True)
         elif not self.is_quantization_compressed:
             apply_quantization_config(model, ct_quantization_config)
-
 
     def _process_model_after_weight_loading(self, model, **kwargs):
         """Decompress loaded model if necessary - need for qat"""


### PR DESCRIPTION
# What does this PR do?

- There is currently a check in `modeling_utils.py` which replaces parameters  with the `weight_g` substring in the parameter key with `parametrizations.weight.original0`. This incorrectly replaces the substring of `compressed-tensors` model parameters with the key `weight_g_idx`, resulting in a loading error. 

https://github.com/huggingface/transformers/blob/02a492a8384abc2fa22516f859e17e8528dd1aa6/src/transformers/modeling_utils.py#L4380

- Updates the `src/transformers/quantizers/quantizer_compressed_tensors.py` logic to temporarily turn off the `weight_norm` attribute such that the substring replacement does not occur in `modeling_utils.py` during weight loading. It then turns it back on in `_process_model_after_weight_loading`. This allows the models to be loaded correctly

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@SunMarc 
@ArthurZucker 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
