### PR TITLE
[pipeline] missing import regarding assisted generation

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -65,6 +65,7 @@ if is_torch_available():
     import torch
     from torch.utils.data import DataLoader, Dataset
 
+    from ..modeling_utils import PreTrainedModel
     from ..models.auto.modeling_auto import AutoModel
 
     # Re-export for backward compatibility
@@ -447,7 +448,7 @@ def load_assistant_model(
     if not model.can_generate() or assistant_model is None:
         return None, None
 
-    if not isinstance(model, PreTrainedModel):
+    if getattr(model, "framework") != "pt" or not isinstance(model, PreTrainedModel):
         raise ValueError(
             "Assisted generation, triggered by the `assistant_model` argument, is only available for "
             "`PreTrainedModel` model instances. For instance, TF or JAX models are not supported."


### PR DESCRIPTION
# What does this PR do?

Noticed while working on #34639 

#34504 introduced an import error that was not caught in CI (and we had fast tests for the related flag, which were failing). This PR fixes it.