### PR TITLE
Stop mutating input dicts in audio classification pipeline

### DIFF
--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -172,6 +172,7 @@ class AudioClassificationPipeline(Pipeline):
             inputs = ffmpeg_read(inputs, self.feature_extractor.sampling_rate)
 
         if isinstance(inputs, dict):
+            inputs = inputs.copy()  # So we don't mutate the original dictionary outside the pipeline
             # Accepting `"array"` which is the key defined in `datasets` for
             # better integration
             if not ("sampling_rate" in inputs and ("raw" in inputs or "array" in inputs)):


### PR DESCRIPTION
The audio classification pipeline was taking a dict as input and popping keys out of it, which mutates the original dict in the calling function, and is probably not what users expect. To avoid that, we copy the dict instead.

Fixes #35740