### PR TITLE
Revert "Unable to use `MimiModel` with DeepSpeed ZeRO-3"

### DIFF
--- a/src/transformers/models/mimi/modeling_mimi.py
+++ b/src/transformers/models/mimi/modeling_mimi.py
@@ -1254,7 +1254,7 @@ class MimiEuclideanCodebook(nn.Module):
 
         self.codebook_size = config.codebook_size
 
-        self.register_buffer("initialized", torch.tensor([True]))
+        self.register_buffer("initialized", torch.Tensor([True]))
         self.register_buffer("cluster_usage", torch.ones(config.codebook_size))
         self.register_buffer("embed_sum", embed)
         self._embed = None


### PR DESCRIPTION
Reverts huggingface/transformers#34735

Introduced failing test `test_modeling_moshi.py::MoshiTest::test_torch_save_load` that was not catched by CI... 