### PR TITLE
Add timm_wrapper support to AutoFeatureExtractor

### DIFF
--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -411,6 +411,7 @@ class ImageProcessingMixin(PushToHubMixin):
         """
         image_processor_dict = image_processor_dict.copy()
         return_unused_kwargs = kwargs.pop("return_unused_kwargs", False)
+        is_timm = kwargs.pop("is_timm", False)
 
         # The `size` parameter is a dict and was previously an int or tuple in feature extractors.
         # We set `size` here directly to the `image_processor_dict` so that it is converted to the appropriate
@@ -420,7 +421,10 @@ class ImageProcessingMixin(PushToHubMixin):
         if "crop_size" in kwargs and "crop_size" in image_processor_dict:
             image_processor_dict["crop_size"] = kwargs.pop("crop_size")
 
-        image_processor = cls(**image_processor_dict)
+        if is_timm:
+            image_processor = cls(image_processor_dict)
+        else:
+            image_processor = cls(**image_processor_dict)
 
         # Update image_processor with kwargs if needed
         to_remove = []

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -94,6 +94,7 @@ FEATURE_EXTRACTOR_MAPPING_NAMES = OrderedDict(
         ("swinv2", "ViTFeatureExtractor"),
         ("table-transformer", "DetrFeatureExtractor"),
         ("timesformer", "VideoMAEFeatureExtractor"),
+        ("timm_wrapper", "TimmWrapperImageProcessor"),
         ("tvlt", "TvltFeatureExtractor"),
         ("unispeech", "Wav2Vec2FeatureExtractor"),
         ("unispeech-sat", "Wav2Vec2FeatureExtractor"),

--- a/src/transformers/models/timm_wrapper/image_processing_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/image_processing_timm_wrapper.py
@@ -93,6 +93,15 @@ class TimmWrapperImageProcessor(BaseImageProcessor):
             pretrained_model_name_or_path, image_processor_filename=image_processor_filename, **kwargs
         )
 
+    @classmethod
+    def from_dict(cls, image_processor_dict: Dict[str, Any], **kwargs):
+        """
+        Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
+        created using from_dict and kwargs e.g. `TimmWrapperImageProcessor.from_pretrained(checkpoint)`
+        """
+        kwargs.update({"is_timm": True})
+        return super().from_dict(image_processor_dict, **kwargs)
+
     def preprocess(
         self,
         images: ImageInput,


### PR DESCRIPTION
# What does this PR do?

A few days ago, the PR that adds timm_wrapper was merged #34564 [blog post]( https://huggingface.co/blog/timm-transformers) , enabling the use of timm models directly with Hugging Face interfaces, especially the Auto* ones. However, currently the AutoFeatureExtractor interface doesn't work with these models. This PR addresses that gap.

This PR adds timm_wrapper compatibility to AutoFeatureExtractor.from_pretrained(), enabling it to work with fine-tuned/trained timm model checkpoints.

Currently, when using a checkpoint from a trained/fine-tuned timm model (e.g., using examples/pytorch/image-classification/run_image_classification.py), AutoFeatureExtractor.from_pretrained() fails because timm_wrapper is not included in the interface. 

While there's a warning about missing preprocessor_config.json in checkpoints, users can manually add it to their checkpoint following examples like https://huggingface.co/Factral/vit_large-model/blob/main/preprocessor_config.json. This PR ensures AutoFeatureExtractor works properly when this file is present.

## Changes
- Added timm_wrapper to AutoFeatureExtractor interface
- Enables compatibility with timm model checkpoints when preprocessor_config.json is present
- Added is_timm kwarg in from_dict function

## Before submitting
- [x] Read contributor guidelines
- [x] Updated documentation to reflect changes
- [x] Added necessary tests for timm_wrapper functionality

## Who can review?
@amyeroberts @qubvel - as this relates to vision models and timm integration