### PR TITLE
Fixes, improvements to `timm` import behaviour

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1302,7 +1302,7 @@ else:
     _import_structure["models.vit"].append("ViTImageProcessorFast")
 
 try:
-    if not is_torchvision_available() and not is_timm_available():
+    if not (is_torchvision_available() and is_timm_available()):
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
     from .utils import dummy_timm_and_torchvision_objects
@@ -6399,7 +6399,7 @@ if TYPE_CHECKING:
         from .models.vit import ViTImageProcessorFast
 
     try:
-        if not is_torchvision_available() and not is_timm_available():
+        if not (is_torchvision_available() and is_timm_available()):
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         from .utils.dummy_timm_and_torchvision_objects import *

--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -18,7 +18,7 @@
 from typing import Any, Dict
 
 from ...configuration_utils import PretrainedConfig
-from ...utils import is_timm_available, logging
+from ...utils import is_timm_available, logging, requires_backends
 
 
 if is_timm_available():
@@ -72,6 +72,7 @@ class TimmWrapperConfig(PretrainedConfig):
 
         # if no labels added to config, use imagenet labeller in timm
         if label_names is None and not is_custom_model:
+            requires_backends(cls, ["timm"])
             imagenet_subset = infer_imagenet_subset(config_dict)
             if imagenet_subset:
                 dataset_info = ImageNetInfo(imagenet_subset)


### PR DESCRIPTION
* Add `requires_backends` to TimmWrapperConfig so that we see a useful error message when wrapper is used without timm installed... now it is
```
ImportError: 
TimmWrapperConfig requires the timm library but it was not found in your environment. You can install it with pip:
`pip install timm`. Please note that you may need to restart your runtime after installation.
```

* Fix logic for timm dummy imports, was `not torchvision and not timm`, now `not (timm and torchvision)`