### PR TITLE
Fix : BLOOM tie_word_embeddings in GGUF

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -400,7 +400,7 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
 
     # Handle tie_word_embeddings, if lm_head.weight is not present in tensors,
     # tie_word_embeddings is true otherwise false
-    exceptions = ["falcon"]
+    exceptions = ["falcon", "bloom"]
     parsed_parameters["config"]["tie_word_embeddings"] = (
         all("output.weight" != tensor.name for tensor in reader.tensors) or architecture in exceptions
     )

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -633,7 +633,7 @@ class GgufIntegrationTests(unittest.TestCase):
         text = tokenizer(self.example_text, return_tensors="pt")["input_ids"].to(torch_device)
         out = model.generate(text, max_new_tokens=16)
 
-        EXPECTED_TEXT = 'Hello,\nI am trying to use the "get_post_meta"'
+        EXPECTED_TEXT = 'Hello All,\nI am new to this forum.\nI am using the '
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
     @unittest.skip("The test causes a torch.OutOfMemoryError on the CI but it passes with enough memory")

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -633,7 +633,7 @@ class GgufIntegrationTests(unittest.TestCase):
         text = tokenizer(self.example_text, return_tensors="pt")["input_ids"].to(torch_device)
         out = model.generate(text, max_new_tokens=16)
 
-        EXPECTED_TEXT = 'Hello All,\nI am new to this forum.\nI am using the '
+        EXPECTED_TEXT = "Hello All,\nI am new to this forum.\nI am using the "
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
     @unittest.skip("The test causes a torch.OutOfMemoryError on the CI but it passes with enough memory")


### PR DESCRIPTION
# What does this PR do?
Related to this PR : https://github.com/huggingface/transformers/pull/35715, this PR adds `Bloom` as an exception as well to fix issues here : https://github.com/huggingface/transformers/actions/runs/12879032529/job/35906087498

It modifies the expected output of falcon-q2_k to match the expected output

## Who can review ?
@SunMarc