### PR TITLE
Exploring use of kwargs for timm model and transforms creation

### DIFF
--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -133,10 +133,10 @@ class TimmWrapperModel(TimmWrapperPreTrainedModel):
     Wrapper class for timm models to be used in transformers.
     """
 
-    def __init__(self, config: TimmWrapperConfig):
+    def __init__(self, config: TimmWrapperConfig, **kwargs):
         super().__init__(config)
         # using num_classes=0 to avoid creating classification head
-        self.timm_model = timm.create_model(config.architecture, pretrained=False, num_classes=0)
+        self.timm_model = timm.create_model(config.architecture, pretrained=False, num_classes=0, **kwargs)
         self.post_init()
 
     @add_start_docstrings_to_model_forward(TIMM_WRAPPER_INPUTS_DOCSTRING)
@@ -240,7 +240,7 @@ class TimmWrapperForImageClassification(TimmWrapperPreTrainedModel):
     Wrapper class for timm models to be used in transformers for image classification.
     """
 
-    def __init__(self, config: TimmWrapperConfig):
+    def __init__(self, config: TimmWrapperConfig, **kwargs):
         super().__init__(config)
 
         if config.num_labels == 0:
@@ -250,7 +250,9 @@ class TimmWrapperForImageClassification(TimmWrapperPreTrainedModel):
                 "or use `TimmWrapperModel` for feature extraction."
             )
 
-        self.timm_model = timm.create_model(config.architecture, pretrained=False, num_classes=config.num_labels)
+        self.timm_model = timm.create_model(
+            config.architecture, pretrained=False, num_classes=config.num_labels, **kwargs
+        )
         self.num_labels = config.num_labels
         self.post_init()
 


### PR DESCRIPTION
# What does this PR do?

Allow kwargs to be passed through to timm create_model and create_transforms fns via the TimmWrapperModel and TimmWrapperImageProcessor classes respectively. 

Current exploring use and not ready to finalize. Would like to allow flexibility to configure model and transforms at runtime for added flexibility.

Examples:

Allow dynamic image size for vits
`model = AutoModelForImageClassification.from_pretrained("timm/vit_base_patch16_224.augreg2_in21k_ft_in1k", dynamic_img_size=True)`

Change image size of pre-processor
```
model = AutoModel.from_pretrained("timm/vit_large_patch14_dinov2.lvd142m", dynamic_img_size=True)
proc = transformers.AutoImageProcessor.from_pretrained("timm/vit_large_patch14_dinov2.lvd142m", img_size=448)
```

Customize image transforms, this will enable auto_augment and rand-erasing in train transforms and use the train resolution instead of test target size for eval transform
```
proc = transformers.AutoImageProcessor.from_pretrained("timm/resnet50.a1_in1k", use_train_size=True, auto_augment='rand-m9-inc1-mstd101', re_prob=0.3)
```