### PR TITLE
Remove pyav pin to allow python 3.11 to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ if stale_egg_info.exists():
 _deps = [
     "Pillow>=10.0.1,<=15.0",
     "accelerate>=0.26.0",
-    "av==9.2.0",  # Latest version of PyAV (10.0.0) has issues with audio stream.
+    "av",
     "beautifulsoup4",
     "blobfile",
     "codecarbon>=2.8.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -4,7 +4,7 @@
 deps = {
     "Pillow": "Pillow>=10.0.1,<=15.0",
     "accelerate": "accelerate>=0.26.0",
-    "av": "av==9.2.0",
+    "av": "av",
     "beautifulsoup4": "beautifulsoup4",
     "blobfile": "blobfile",
     "codecarbon": "codecarbon>=2.8.1",


### PR DESCRIPTION
# What does this PR do?
Remove the two year old pin on `av==9.2.0`, this pin was made due to issue with the audio stream in `av==10.0.0`, this seems to not be an issue anymore sinve `av` is not used to extract audio streams anywhere.

Fixes #35803


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@vanpelt
