### PR TITLE
Fix compatibility issues when using auto_gptq with these older versions

### DIFF
--- a/src/transformers/quantizers/quantizer_gptq.py
+++ b/src/transformers/quantizers/quantizer_gptq.py
@@ -100,7 +100,11 @@ class GptqHfQuantizer(HfQuantizer):
             raise RuntimeError("We can only quantize pure text model.")
 
         if self.pre_quantized:
-            model = self.optimum_quantizer.convert_model(model, **kwargs)
+            # compat: latest optimum has gptqmodel refactor
+            if version.parse(importlib.metadata.version("optimum")) <= version.parse("1.23.99"):
+                model = self.optimum_quantizer.convert_model(model)
+            else:
+                model = self.optimum_quantizer.convert_model(model, **kwargs)
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
         if self.pre_quantized:


### PR DESCRIPTION
# What does this PR do?

The `convert_model` method in versions of optimum prior to 1.23.99 only accepts a single parameter `model: nn.Module`, latest version allows the acceptance of `model: nn.Module` and `**kwargs`. To resolve compatibility issues when using auto_gptq with these older versions, a condition needs to be added.

gptqmodel checks the version of optimum as well when verifying versions, so this issue does not exist. (https://github.com/huggingface/transformers/blob/a142f161313199bcfa67afe1990d1f0f39a973bb/src/transformers/quantizers/quantizer_gptq.py#L76-L80)

# Fixed this issue:

PKG Version:
`transformers`: latest source
`auto-gptq`: latest release
`optimum`: latest release

Traceback:
```python
self = <transformers.quantizers.quantizer_gptq.GptqHfQuantizer object at 0x7787215014d0>
model = OPTForCausalLM(
  (model): OPTModel(
    (decoder): OPTDecoder(
      (embed_tokens): Embedding(50272, 768, padding_id...entwise_affine=True)
        )
      )
    )
  )
  (lm_head): Linear(in_features=768, out_features=50272, bias=False)
)
kwargs = {'device_map': 'auto', 'keep_in_fp32_modules': []}

    def _process_model_before_weight_loading(self, model: "PreTrainedModel", **kwargs):
        if model.__class__.main_input_name != "input_ids":
            raise RuntimeError("We can only quantize pure text model.")
    
        if self.pre_quantized:
>           model = self.optimum_quantizer.convert_model(model, **kwargs)
E           TypeError: GPTQQuantizer.convert_model() got an unexpected keyword argument 'device_map'

../../../anaconda3/envs/peft-test/lib/python3.11/site-packages/transformers/quantizers/quantizer_gptq.py:104: TypeError
```

## Who can review?
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber @BenjaminBossan 
