### PR TITLE
Fix : Nemotron tokenizer for GGUF format

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -339,6 +339,7 @@ else:
             ("musicgen_melody", ("T5Tokenizer", "T5TokenizerFast" if is_tokenizers_available() else None)),
             ("mvp", ("MvpTokenizer", "MvpTokenizerFast" if is_tokenizers_available() else None)),
             ("myt5", ("MyT5Tokenizer", None)),
+            ("nemotron", (None, "PreTrainedTokenizerFast" if is_tokenizers_available() else None)),
             ("nezha", ("BertTokenizer", "BertTokenizerFast" if is_tokenizers_available() else None)),
             (
                 "nllb",

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -835,9 +835,9 @@ class GgufIntegrationTests(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained(self.nemotron_model_id, gguf_file=self.q6_k_nemotron_model_id)
         text = tokenizer(self.example_text, return_tensors="pt")["input_ids"]
-        out = model.generate(text, max_new_tokens=10)
+        out = model.generate(text, max_new_tokens=16)
 
-        EXPECTED_TEXT = "'Hello. hotmail.com.'"
+        EXPECTED_TEXT = "Hello.▁hotmail.com</s>"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
     def test_gemma2_q3_k(self):


### PR DESCRIPTION
# What does this PR do?
Adds the `PretrainedTokenizerFast` class as a tokenizer to `TOKENIZER_MAPPING_NAMES` to fix this : https://github.com/huggingface/transformers/actions/runs/12900045095/job/35970056210 
and fixes an expected output for the nemotron test

## Who can review ?
@SunMarc @Isotr0py 