### PR TITLE
Fix NoneType type as it requires py>=3.10

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -19,7 +19,6 @@ import types
 from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
-from types import NoneType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, get_args, get_origin, get_type_hints
 
 from packaging import version
@@ -78,7 +77,7 @@ def _get_json_schema_type(param_type: str) -> Dict[str, str]:
         float: {"type": "number"},
         str: {"type": "string"},
         bool: {"type": "boolean"},
-        NoneType: {"type": "null"},
+        type(None): {"type": "null"},
         Any: {},
     }
     if is_vision_available():


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue for older version of python (3.9) wrt `NoneType`. The `types.NoneType` was introduced in Python 3.10. So, we need to use type(None) instead. 
We have this [issue](https://github.com/huggingface/accelerate/actions/runs/12900277369/job/36002947315?pr=3350) in accelerate CI 