### PR TITLE
Add utility for Reload Transformers imports cache for development workflow #35508

### DIFF
--- a/docs/source/en/how_to_hack_models.md
+++ b/docs/source/en/how_to_hack_models.md
@@ -24,7 +24,37 @@ You'll learn how to:
 - Modify a model's architecture by changing its attention mechanism.
 - Apply techniques like Low-Rank Adaptation (LoRA) to specific model components.
 
-We encourage you to contribute your own hacks and share them here with the community1
+We encourage you to contribute your own hacks and share them here with the community!
+
+## Efficient Development Workflow
+
+When modifying model code, you'll often need to test your changes without restarting your Python session. The `clear_import_cache()` utility helps with this workflow, especially during model development and contribution when you need to frequently test and compare model outputs:
+
+```python
+from transformers import AutoModel
+model = AutoModel.from_pretrained("bert-base-uncased")
+
+# Make modifications to the transformers code...
+
+# Clear the cache to reload the modified code
+from transformers.utils.import_utils import clear_import_cache
+clear_import_cache()
+
+# Reimport to get the changes
+from transformers import AutoModel
+model = AutoModel.from_pretrained("bert-base-uncased")  # Will use updated code
+```
+
+This is particularly useful when:
+- Iteratively modifying model architectures
+- Debugging model implementations 
+- Testing changes during model development
+- Comparing outputs between original and modified versions
+- Working on model contributions
+
+The `clear_import_cache()` function removes all cached Transformers modules and allows Python to reload the modified code. This enables rapid development cycles without constantly restarting your environment.
+
+This workflow is especially valuable when implementing new models, where you need to frequently compare outputs between the original implementation and your Transformers version (as described in the [Add New Model](https://huggingface.co/docs/transformers/add_new_model) guide).
 
 ## Example: Modifying the Attention Mechanism in the Segment Anything Model (SAM)
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2275,14 +2275,11 @@ def define_import_structure(module_path: str) -> IMPORT_STRUCTURE_T:
 def clear_import_cache():
     """
     Clear cached Transformers modules to allow reloading modified code.
-    
+
     This is useful when actively developing/modifying Transformers code.
     """
     # Get all transformers modules
-    transformers_modules = [
-        mod_name for mod_name in sys.modules
-        if mod_name.startswith('transformers.')
-    ]
+    transformers_modules = [mod_name for mod_name in sys.modules if mod_name.startswith("transformers.")]
 
     # Remove them from sys.modules
     for mod_name in transformers_modules:
@@ -2293,8 +2290,8 @@ def clear_import_cache():
         del sys.modules[mod_name]
 
     # Force reload main transformers module
-    if 'transformers' in sys.modules:
-        main_module = sys.modules['transformers']
+    if "transformers" in sys.modules:
+        main_module = sys.modules["transformers"]
         if isinstance(main_module, _LazyModule):
             main_module._objects = {}  # Clear cached objects
         importlib.reload(main_module)

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -645,7 +645,7 @@ def is_g2p_en_available():
     return _g2p_en_available
 
 
-@lru_cache
+@lru_cache()
 def is_torch_tpu_available(check_device=True):
     "Checks if `torch_xla` is installed and potentially if a TPU is in the environment"
     warnings.warn(

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2283,7 +2283,7 @@ def clear_import_cache():
         mod_name for mod_name in sys.modules
         if mod_name.startswith('transformers.')
     ]
-    
+
     # Remove them from sys.modules
     for mod_name in transformers_modules:
         module = sys.modules[mod_name]
@@ -2291,7 +2291,7 @@ def clear_import_cache():
         if isinstance(module, _LazyModule):
             module._objects = {}  # Clear cached objects
         del sys.modules[mod_name]
-    
+
     # Force reload main transformers module
     if 'transformers' in sys.modules:
         main_module = sys.modules['transformers']

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,3 +1,30 @@
 import sys
 import pytest
 from transformers.utils.import_utils import clear_import_cache, _LazyModule
+
+def test_clear_import_cache():
+    # Import some transformers modules
+    from transformers import AutoModel, AutoTokenizer
+    
+    # Get initial module count
+    initial_modules = {
+        name: mod for name, mod in sys.modules.items() 
+        if name.startswith('transformers.')
+    }
+    
+    # Verify we have some modules loaded
+    assert len(initial_modules) > 0
+    
+    # Clear cache
+    clear_import_cache()
+    
+    # Check modules were removed
+    remaining_modules = {
+        name: mod for name, mod in sys.modules.items() 
+        if name.startswith('transformers.')
+    }
+    assert len(remaining_modules) < len(initial_modules)
+    
+    # Verify we can reimport
+    from transformers import AutoModel, AutoTokenizer
+    assert 'transformers.models.auto.modeling_auto' in sys.modules 

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,30 +1,29 @@
 import sys
-import pytest
-from transformers.utils.import_utils import clear_import_cache, _LazyModule
+
+from transformers.utils.import_utils import clear_import_cache
+
 
 def test_clear_import_cache():
     # Import some transformers modules
-    from transformers import AutoModel, AutoTokenizer
-    
+
     # Get initial module count
     initial_modules = {
-        name: mod for name, mod in sys.modules.items() 
+        name: mod for name, mod in sys.modules.items()
         if name.startswith('transformers.')
     }
-    
+
     # Verify we have some modules loaded
     assert len(initial_modules) > 0
-    
+
     # Clear cache
     clear_import_cache()
-    
+
     # Check modules were removed
     remaining_modules = {
-        name: mod for name, mod in sys.modules.items() 
+        name: mod for name, mod in sys.modules.items()
         if name.startswith('transformers.')
     }
     assert len(remaining_modules) < len(initial_modules)
-    
+
     # Verify we can reimport
-    from transformers import AutoModel, AutoTokenizer
-    assert 'transformers.models.auto.modeling_auto' in sys.modules 
+    assert 'transformers.models.auto.modeling_auto' in sys.modules

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -2,15 +2,12 @@ import sys
 
 from transformers.utils.import_utils import clear_import_cache
 
+
 def test_clear_import_cache():
     # Import some transformers modules
-    from transformers import AutoModel, AutoTokenizer
 
     # Get initial module count
-    initial_modules = {
-        name: mod for name, mod in sys.modules.items()
-        if name.startswith('transformers.')
-    }
+    initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
 
     # Verify we have some modules loaded
     assert len(initial_modules) > 0
@@ -19,12 +16,8 @@ def test_clear_import_cache():
     clear_import_cache()
 
     # Check modules were removed
-    remaining_modules = {
-        name: mod for name, mod in sys.modules.items()
-        if name.startswith('transformers.')
-    }
+    remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
     assert len(remaining_modules) < len(initial_modules)
 
     # Verify we can reimport
-    from transformers import AutoModel, AutoTokenizer
-    assert 'transformers.models.auto.modeling_auto' in sys.modules
+    assert "transformers.models.auto.modeling_auto" in sys.modules

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,0 +1,3 @@
+import sys
+import pytest
+from transformers.utils.import_utils import clear_import_cache, _LazyModule

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,13 +1,16 @@
 import sys
-
-from transformers.utils.import_utils import clear_import_cache
-
+import pytest
+from transformers.utils.import_utils import clear_import_cache, _LazyModule
 
 def test_clear_import_cache():
     # Import some transformers modules
+    from transformers import AutoModel, AutoTokenizer
 
     # Get initial module count
-    initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+    initial_modules = {
+        name: mod for name, mod in sys.modules.items() 
+        if name.startswith('transformers.')
+    }
 
     # Verify we have some modules loaded
     assert len(initial_modules) > 0
@@ -16,8 +19,12 @@ def test_clear_import_cache():
     clear_import_cache()
 
     # Check modules were removed
-    remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+    remaining_modules = {
+        name: mod for name, mod in sys.modules.items() 
+        if name.startswith('transformers.')
+    }
     assert len(remaining_modules) < len(initial_modules)
 
     # Verify we can reimport
-    assert "transformers.models.auto.modeling_auto" in sys.modules
+    from transformers import AutoModel, AutoTokenizer
+    assert 'transformers.models.auto.modeling_auto' in sys.modules 

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,6 +1,6 @@
 import sys
-import pytest
-from transformers.utils.import_utils import clear_import_cache, _LazyModule
+
+from transformers.utils.import_utils import clear_import_cache
 
 def test_clear_import_cache():
     # Import some transformers modules
@@ -8,7 +8,7 @@ def test_clear_import_cache():
 
     # Get initial module count
     initial_modules = {
-        name: mod for name, mod in sys.modules.items() 
+        name: mod for name, mod in sys.modules.items()
         if name.startswith('transformers.')
     }
 
@@ -20,11 +20,11 @@ def test_clear_import_cache():
 
     # Check modules were removed
     remaining_modules = {
-        name: mod for name, mod in sys.modules.items() 
+        name: mod for name, mod in sys.modules.items()
         if name.startswith('transformers.')
     }
     assert len(remaining_modules) < len(initial_modules)
 
     # Verify we can reimport
     from transformers import AutoModel, AutoTokenizer
-    assert 'transformers.models.auto.modeling_auto' in sys.modules 
+    assert 'transformers.models.auto.modeling_auto' in sys.modules

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -7,10 +7,7 @@ def test_clear_import_cache():
     # Import some transformers modules
 
     # Get initial module count
-    initial_modules = {
-        name: mod for name, mod in sys.modules.items()
-        if name.startswith('transformers.')
-    }
+    initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
 
     # Verify we have some modules loaded
     assert len(initial_modules) > 0
@@ -19,11 +16,8 @@ def test_clear_import_cache():
     clear_import_cache()
 
     # Check modules were removed
-    remaining_modules = {
-        name: mod for name, mod in sys.modules.items()
-        if name.startswith('transformers.')
-    }
+    remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
     assert len(remaining_modules) < len(initial_modules)
 
     # Verify we can reimport
-    assert 'transformers.models.auto.modeling_auto' in sys.modules
+    assert "transformers.models.auto.modeling_auto" in sys.modules


### PR DESCRIPTION
## Problem Statement
When developing or modifying Transformers models, cached imports can prevent code changes from being picked up without manually restarting Python. This makes the development workflow more cumbersome, especially when making iterative changes to model implementations.

Fixes #35508 

## Root Cause Analysis
The issue stems from Python's module caching behavior in `sys.modules`. Additionally, Transformers uses a custom `_LazyModule` system for imports that maintains its own object cache. Both these caches need to be cleared to fully reload modified code.

## Implementation
Added a `clear_import_cache()` utility function to `transformers.utils.import_utils` that:

1. Identifies all Transformers modules in `sys.modules`
2. Clears internal caches of `_LazyModule` instances
3. Removes modules from `sys.modules`
4. Forces reload of the main Transformers module

The implementation is minimally invasive and works with Transformers' existing module system.

## Testing
Added a test case that verifies:

1. Initial module imports work correctly
2. Cache clearing removes modules from `sys.modules`
3. Modules can be reimported after clearing
4. The lazy loading system continues to function properly

The test ensures the cache clearing is thorough while maintaining backward compatibility.

## Screenshots

<img width="1295" alt="Screenshot 2025-01-23 at 10 30 14 PM" src="https://github.com/user-attachments/assets/e279f781-adb9-4eaa-b640-dbc75e7a3e63" />


**cc :** @ArthurZucker @SunMarc @Rocketknight1 and anyone interested in development workflow improvements.