### PR TITLE
Fix TP initialization

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3442,10 +3442,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if tp_plan is not None and tp_plan != "auto":
             # TODO: we can relax this check when we support taking tp_plan from a json file, for example.
             raise ValueError(f"tp_plan supports 'auto' only for now but got {tp_plan}.")
-        
+
         if tp_plan is not None and device_map is not None:
-            raise ValueError(f"`tp_plan` and `device_map` are mutually exclusive. Choose either one for parallelization.")
-        
+                "`tp_plan` and `device_map` are mutually exclusive. Choose either one for parallelization."
+            )
+
         # We need to correctly dispatch the model on the current process device. The easiest way for this is to use a simple
         # `device_map` pointing to the correct device. If we don't, torch will use the default device (index 0) for all
         # childs processes at parallelization time, resulting in excessive memory usage on device 0 and OOMs.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3444,6 +3444,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             raise ValueError(f"tp_plan supports 'auto' only for now but got {tp_plan}.")
 
         if tp_plan is not None and device_map is not None:
+            raise ValueError(
                 "`tp_plan` and `device_map` are mutually exclusive. Choose either one for parallelization."
             )
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3451,6 +3451,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # childs processes at parallelization time, resulting in excessive memory usage on device 0 and OOMs.
         # And temporarily setting the default device to current process rank result in the following error
         # `torch.distributed.DistBackendError: Attempt to perform collective on tensor not on device passed to init_process_group`
+        tp_device = None
         if tp_plan is not None:
             if not torch.distributed.is_initialized():
                 raise ValueError("Tensor Parallel requires torch.distributed to be initialized first.")
@@ -4110,7 +4111,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # Instantiate model.
         init_contexts = [no_init_weights(_enable=_fast_init)]
-        tp_device = None
 
         if is_deepspeed_zero3_enabled() and not is_quantized and not _is_ds_init_called:
             import deepspeed

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3442,6 +3442,26 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if tp_plan is not None and tp_plan != "auto":
             # TODO: we can relax this check when we support taking tp_plan from a json file, for example.
             raise ValueError(f"tp_plan supports 'auto' only for now but got {tp_plan}.")
+        
+        if tp_plan is not None and device_map is not None:
+            raise ValueError(f"`tp_plan` and `device_map` are mutually exclusive. Choose either one for parallelization.")
+        
+        # We need to correctly dispatch the model on the current process device. The easiest way for this is to use a simple
+        # `device_map` pointing to the correct device. If we don't, torch will use the default device (index 0) for all
+        # childs processes at parallelization time, resulting in excessive memory usage on device 0 and OOMs.
+        # And temporarily setting the default device to current process rank result in the following error
+        # `torch.distributed.DistBackendError: Attempt to perform collective on tensor not on device passed to init_process_group`
+        if tp_plan is not None:
+            if not torch.distributed.is_initialized():
+                raise ValueError("Tensor Parallel requires torch.distributed to be initialized first.")
+
+            # Detect the accelerator on the machine. If no accelerator is available, it returns CPU.
+            device_type = torch._C._get_accelerator().type
+            device_module = torch.get_device_module(device_type)
+            # Get device with index assuming equal number of devices per host
+            tp_device = torch.device(device_type, torch.distributed.get_rank() % device_module.device_count())
+            # This is the easiest way to dispatch to the current process device
+            device_map = tp_device
 
         if is_fsdp_enabled():
             low_cpu_mem_usage = True
@@ -4106,16 +4126,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     f"Using `low_cpu_mem_usage=True` or a `device_map` requires Accelerate: `pip install 'accelerate>={ACCELERATE_MIN_VERSION}'`"
                 )
             init_contexts.append(init_empty_weights())
-        elif tp_plan is not None:
-            if not torch.distributed.is_initialized():
-                raise ValueError("Tensor Parallel requires torch.distributed to be initialized first.")
-
-            # Detect the accelerator on the machine. If no accelerator is available, it returns CPU.
-            device_type = torch._C._get_accelerator().type
-            device_module = torch.get_device_module(device_type)
-            # Get device with index assuming equal number of devices per host
-            tp_device = torch.device(device_type, torch.distributed.get_rank() % device_module.device_count())
-            init_contexts.append(tp_device)
 
         if is_deepspeed_zero3_enabled() and is_quantized:
             init_contexts.append(set_quantized_state())
@@ -4249,38 +4259,32 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if dtype_orig is not None:
                 torch.set_default_dtype(dtype_orig)
 
-            load_contexts = []
-            # Make sure we load onto targeted device
-            if tp_device is not None:
-                load_contexts.append(tp_device)
-
-            with ContextManagers(load_contexts):
-                (
-                    model,
-                    missing_keys,
-                    unexpected_keys,
-                    mismatched_keys,
-                    offload_index,
-                    error_msgs,
-                ) = cls._load_pretrained_model(
-                    model,
-                    state_dict,
-                    loaded_state_dict_keys,  # XXX: rename?
-                    resolved_archive_file,
-                    pretrained_model_name_or_path,
-                    ignore_mismatched_sizes=ignore_mismatched_sizes,
-                    sharded_metadata=sharded_metadata,
-                    _fast_init=_fast_init,
-                    low_cpu_mem_usage=low_cpu_mem_usage,
-                    device_map=device_map,
-                    offload_folder=offload_folder,
-                    offload_state_dict=offload_state_dict,
-                    dtype=torch_dtype,
-                    hf_quantizer=hf_quantizer,
-                    keep_in_fp32_modules=keep_in_fp32_modules,
-                    gguf_path=gguf_path,
-                    weights_only=weights_only,
-                )
+            (
+                model,
+                missing_keys,
+                unexpected_keys,
+                mismatched_keys,
+                offload_index,
+                error_msgs,
+            ) = cls._load_pretrained_model(
+                model,
+                state_dict,
+                loaded_state_dict_keys,  # XXX: rename?
+                resolved_archive_file,
+                pretrained_model_name_or_path,
+                ignore_mismatched_sizes=ignore_mismatched_sizes,
+                sharded_metadata=sharded_metadata,
+                _fast_init=_fast_init,
+                low_cpu_mem_usage=low_cpu_mem_usage,
+                device_map=device_map,
+                offload_folder=offload_folder,
+                offload_state_dict=offload_state_dict,
+                dtype=torch_dtype,
+                hf_quantizer=hf_quantizer,
+                keep_in_fp32_modules=keep_in_fp32_modules,
+                gguf_path=gguf_path,
+                weights_only=weights_only,
+            )
 
         # make sure token embedding weights are still tied if needed
         model.tie_weights()

--- a/tests/tp/test_tp.py
+++ b/tests/tp/test_tp.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
-import textwrap
-import tempfile
 import subprocess
+import tempfile
+import textwrap
 
 from transformers import is_torch_available
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -64,7 +64,7 @@ class TestTensorParallel(TestCasePlus):
             model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, tp_plan="auto")
             torch.distributed.barrier()
 
-            # The expected full model memory footprint 
+            # The expected full model memory footprint
             expected_model_memory = 16
             overhead_factor = 1.2
 
@@ -94,7 +94,6 @@ class TestTensorParallel(TestCasePlus):
             print(sub.stdout)
             print(sub.stderr)
             # successful return here == success - any errors would have caused an error in the sub-call
-
 
 
 if __name__ == "__main__":

--- a/tests/tp/test_tp.py
+++ b/tests/tp/test_tp.py
@@ -93,7 +93,7 @@ class TestTensorParallel(TestCasePlus):
                 raise ValueError("Each model shard is larger than what is expected.")
 
             torch.distributed.barrier()
-            torch.utils.distributed.destroy_process_group()
+            torch.distributed.destroy_process_group()
             """
         )
         self.torchrun(script_to_run)

--- a/tests/tp/test_tp.py
+++ b/tests/tp/test_tp.py
@@ -72,7 +72,7 @@ class TestTensorParallel(TestCasePlus):
             if not torch.cuda.max_memory_allocated(device) / 1024**3 < expected_model_memory * overhead_factor:
                 raise ValueError("Loading the model used more than the full model size")
 
-            # Assert we correctly handled the sharding (we use 20 GB)
+            # Assert we correctly handled the sharding between devices
             if not torch.cuda.memory_allocated(device) / 1024**3 < (expected_model_memory / world_size) * overhead_factor:
                 raise ValueError("Each model shard is larger than what is expected.")
 

--- a/tests/tp/test_tp.py
+++ b/tests/tp/test_tp.py
@@ -47,7 +47,7 @@ class TestTensorParallel(TestCasePlus):
             try:
                 _ = subprocess.run(cmd, capture_output=True, env=self.get_env(), text=True, check=True)
             except subprocess.CalledProcessError as e:
-                raise Exception(f"The following error was capture: {e.stderr}")
+                raise Exception(f"The following error was captured: {e.stderr}")
 
     @require_torch_multi_gpu
     def test_tp(self):


### PR DESCRIPTION
# What does this PR do?

As per the title. When TP was introduced in https://github.com/huggingface/transformers/pull/34184, it used a context manager `with torch.device` to set the model device. However, the context manager actually does NOT put the tensor on the device explicitly (it simply changes the default device if using name without indices, such as "cuda" or .cuda()). This means that the model was still on CPU.

Then `parallelize_module` would automatically switch the model, however it uses the SAME gpu for all child processes. So it's fine for small models, but will OOM for larger ones (e.g. Llama 8B on 4x L4 GPU (24 GB) would OOM, even though it's supposed to take ~16 GB only).

It does not look like we can instantiate only the model shards from the CPU to the different devices to avoid loading the full model on each device at the start.
To avoid that, I believe we could instantiate model on `meta` device, then recursively loading and dispatching each layer, which would avoif loading the full model in RAM then dispatching which goes against parallelization idea. Will try to explore it/see with accelerate team how we can do it.
