### PR TITLE
add xpu device check in device_placement

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1148,6 +1148,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             elif self.device.type == "musa":
                 with torch.musa.device(self.device):
                     yield
+            elif self.device.type == "xpu":
+                with torch.xpu.device(self.device):
+                    yield
             else:
                 yield
 


### PR DESCRIPTION
## What does this PR do?
To align with other hardware accelerators, we need to add XPU device check for the following code:
```python
from transformers import pipeline
pipe = pipeline(model="facebook/opt-1.3b", device=2)
with pipe.device_placement():
    output = pipe("This is a cool example!", do_sample=True, top_p=0.95)
print(output)
```

@ydshieh 