### PR TITLE
Fix/best model checkpoint fix

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -39,7 +39,7 @@ from dataclasses import MISSING, fields
 from functools import wraps
 from io import StringIO
 from pathlib import Path
-from typing import Callable, Dict, Iterable, Iterator, List, Optional, Union
+from typing import Callable, Dict, Generator, Iterable, Iterator, List, Optional, Union
 from unittest import mock
 from unittest.mock import patch
 
@@ -1448,6 +1448,18 @@ def get_steps_per_epoch(trainer: Trainer) -> int:
     steps_per_epoch = math.ceil(batches_per_epoch / trainer.args.gradient_accumulation_steps)
 
     return steps_per_epoch
+
+
+def evaluate_side_effect_factory(side_effect_values: List[Dict[str, float]]) -> Generator[Dict[str, float], None, None]:
+    """
+    Function that returns side effects for the _evaluate method.
+    Used when we're unsure of exactly how many times _evaluate will be called.
+    """
+    for side_effect_value in side_effect_values:
+        yield side_effect_value
+
+    while True:
+        yield side_effect_values[-1]
 
 
 #

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -21,6 +21,7 @@ import gc
 import importlib
 import inspect
 import logging
+import math
 import multiprocessing
 import os
 import re
@@ -49,6 +50,7 @@ from huggingface_hub import delete_repo
 from packaging import version
 
 from transformers import logging as transformers_logging
+from transformers import Trainer
 
 from .integrations import (
     is_clearml_available,
@@ -1438,6 +1440,14 @@ def get_tests_dir(append_path=None):
         return os.path.join(tests_dir, append_path)
     else:
         return tests_dir
+
+
+def get_steps_per_epoch(trainer: Trainer) -> int:
+    train_dataloader = trainer.get_train_dataloader()
+    batches_per_epoch = len(train_dataloader)
+    steps_per_epoch = math.ceil(batches_per_epoch / trainer.args.gradient_accumulation_steps)
+
+    return steps_per_epoch
 
 
 #

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -21,7 +21,6 @@ import gc
 import importlib
 import inspect
 import logging
-import math
 import multiprocessing
 import os
 import re
@@ -1443,9 +1442,15 @@ def get_tests_dir(append_path=None):
 
 
 def get_steps_per_epoch(trainer: Trainer) -> int:
+    training_args = trainer.args
     train_dataloader = trainer.get_train_dataloader()
-    batches_per_epoch = len(train_dataloader)
-    steps_per_epoch = math.ceil(batches_per_epoch / trainer.args.gradient_accumulation_steps)
+
+    initial_training_values = trainer.set_initial_training_values(
+        args=training_args,
+        dataloader=train_dataloader,
+        total_train_batch_size=training_args.per_device_train_batch_size,
+    )
+    steps_per_epoch = initial_training_values[1]
 
     return steps_per_epoch
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -49,8 +49,8 @@ import urllib3
 from huggingface_hub import delete_repo
 from packaging import version
 
-from transformers import logging as transformers_logging
 from transformers import Trainer
+from transformers import logging as transformers_logging
 
 from .integrations import (
     is_clearml_available,
@@ -1450,7 +1450,9 @@ def get_steps_per_epoch(trainer: Trainer) -> int:
     return steps_per_epoch
 
 
-def evaluate_side_effect_factory(side_effect_values: List[Dict[str, float]]) -> Generator[Dict[str, float], None, None]:
+def evaluate_side_effect_factory(
+    side_effect_values: List[Dict[str, float]],
+) -> Generator[Dict[str, float], None, None]:
     """
     Function that returns side effects for the _evaluate method.
     Used when we're unsure of exactly how many times _evaluate will be called.

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3178,12 +3178,10 @@ class Trainer:
                 self.state.best_metric = float("-inf") if self.args.greater_is_better else float("inf")
 
             if operator(metric_value, self.state.best_metric):
-                run_dir = self._get_output_dir(trial=trial)
-                checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
-                output_dir = os.path.join(run_dir, checkpoint_folder)
-
                 self.state.best_metric = metric_value
-                self.state.best_model_checkpoint = output_dir
+
+                if self.args.save_strategy in [SaveStrategy.STEPS, SaveStrategy.EPOCH]:
+                    self.state.best_global_step = self.state.global_step
 
                 is_new_best_metric = True
 
@@ -3203,6 +3201,13 @@ class Trainer:
         run_dir = self._get_output_dir(trial=trial)
         output_dir = os.path.join(run_dir, checkpoint_folder)
         self.save_model(output_dir, _internal_call=True)
+
+        if self.args.save_strategy in [SaveStrategy.STEPS, SaveStrategy.EPOCH] and self.state.best_global_step:
+            best_checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.best_global_step}"
+            best_checkpoint_dir = os.path.join(run_dir, best_checkpoint_folder)
+
+            if os.path.exists(best_checkpoint_dir):
+                self.state.best_model_checkpoint = best_checkpoint_dir
 
         if not self.args.save_only_model:
             # Save optimizer and scheduler

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -74,6 +74,9 @@ class TrainerState:
             The list of logs done since the beginning of training.
         best_metric (`float`, *optional*):
             When tracking the best model, the value of the best metric encountered so far.
+        best_global_step (`int`, *optional*):
+            When tracking the best model, the step at which the best metric was encountered.
+            Used for setting `best_model_checkpoint`.
         best_model_checkpoint (`str`, *optional*):
             When tracking the best model, the value of the name of the checkpoint for the best model encountered so
             far.
@@ -103,6 +106,7 @@ class TrainerState:
     total_flos: float = 0
     log_history: List[Dict[str, float]] = None
     best_metric: Optional[float] = None
+    best_global_step: Optional[int] = None
     best_model_checkpoint: Optional[str] = None
     is_local_process_zero: bool = True
     is_world_process_zero: bool = True

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2987,9 +2987,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         )
         trainer.train()
         # Check that we have the last known step:
-        assert os.path.exists(os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")), (
-            f"Could not find checkpoint-{trainer.state.max_steps}"
-        )
+        assert os.path.exists(
+            os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")
+        ), f"Could not find checkpoint-{trainer.state.max_steps}"
         # And then check the last step
         assert os.path.exists(os.path.join(tmp_dir, "checkpoint-9")), "Could not find checkpoint-9"
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -62,6 +62,7 @@ from transformers.testing_utils import (
     TemporaryHubRepo,
     TestCasePlus,
     backend_device_count,
+    evaluate_side_effect_factory,
     execute_subprocess_async,
     get_gpu_count,
     get_steps_per_epoch,
@@ -4770,11 +4771,13 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             with patch.object(
                 trainer,
                 "_evaluate",
-                side_effect=[
-                    {"eval_accuracy": 0.59, "epoch": 1.0},
-                    {"eval_accuracy": 0.57, "epoch": 2.0},
-                    {"eval_accuracy": 0.55, "epoch": 3.0},
-                ],
+                side_effect=evaluate_side_effect_factory(
+                    [
+                        {"eval_accuracy": 0.59, "epoch": 1.0},
+                        {"eval_accuracy": 0.57, "epoch": 2.0},
+                        {"eval_accuracy": 0.55, "epoch": 3.0},
+                    ]
+                ),
             ):
                 trainer.train()
 
@@ -4804,11 +4807,13 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             with patch.object(
                 trainer,
                 "_evaluate",
-                side_effect=[
-                    {"eval_accuracy": 0.59, "epoch": 1.0},
-                    {"eval_accuracy": 0.57, "epoch": 2.0},
-                    {"eval_accuracy": 0.55, "epoch": 3.0},
-                ],
+                side_effect=evaluate_side_effect_factory(
+                    [
+                        {"eval_accuracy": 0.59, "epoch": 1.0},
+                        {"eval_accuracy": 0.57, "epoch": 2.0},
+                        {"eval_accuracy": 0.55, "epoch": 3.0},
+                    ]
+                ),
             ):
                 trainer.train()
 
@@ -4840,17 +4845,13 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             with patch.object(
                 trainer,
                 "_evaluate",
-                side_effect=[
-                    {"eval_accuracy": 0.90, "epoch": 0.5},
-                    {"eval_accuracy": 0.80, "epoch": 1.0},
-                    {"eval_accuracy": 0.70, "epoch": 1.5},
-                    {"eval_accuracy": 0.70, "epoch": 2.0},
-                    {"eval_accuracy": 0.70},
-                    {"eval_accuracy": 0.70},
-                    {"eval_accuracy": 0.70},
-                    {"eval_accuracy": 0.70},
-                    {"eval_accuracy": 0.70},
-                ],
+                side_effect=evaluate_side_effect_factory(
+                    [
+                        {"eval_accuracy": 0.90, "epoch": 0.5},
+                        {"eval_accuracy": 0.80, "epoch": 1.0},
+                        {"eval_accuracy": 0.70, "epoch": 1.5},
+                    ]
+                ),
             ):
                 trainer.train()
 
@@ -4881,11 +4882,13 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             with patch.object(
                 trainer,
                 "_evaluate",
-                side_effect=[
-                    {"eval_accuracy": 0.90, "epoch": 1.5},
-                    {"eval_accuracy": 0.80, "epoch": 2.0},
-                    {"eval_accuracy": 0.70},
-                ],
+                side_effect=evaluate_side_effect_factory(
+                    [
+                        {"eval_accuracy": 0.90, "epoch": 1.5},
+                        {"eval_accuracy": 0.80, "epoch": 2.0},
+                        {"eval_accuracy": 0.70},
+                    ]
+                ),
             ):
                 trainer.train()
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4890,10 +4890,8 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             ):
                 trainer.train()
 
-            steps_per_epoch = get_steps_per_epoch(trainer)
-
             assert trainer.state.best_metric == 0.90
-            assert trainer.state.best_global_step == steps_per_epoch * 1.5
+            assert trainer.state.best_global_step == 3
 
             assert trainer.state.best_model_checkpoint is None
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4773,9 +4773,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 "_evaluate",
                 side_effect=evaluate_side_effect_factory(
                     [
-                        {"eval_accuracy": 0.59, "epoch": 1.0},
-                        {"eval_accuracy": 0.57, "epoch": 2.0},
-                        {"eval_accuracy": 0.55, "epoch": 3.0},
+                        {"eval_accuracy": 0.59},
+                        {"eval_accuracy": 0.57},
+                        {"eval_accuracy": 0.55},
                     ]
                 ),
             ):
@@ -4809,9 +4809,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 "_evaluate",
                 side_effect=evaluate_side_effect_factory(
                     [
-                        {"eval_accuracy": 0.59, "epoch": 1.0},
-                        {"eval_accuracy": 0.57, "epoch": 2.0},
-                        {"eval_accuracy": 0.55, "epoch": 3.0},
+                        {"eval_accuracy": 0.59},
+                        {"eval_accuracy": 0.57},
+                        {"eval_accuracy": 0.55},
                     ]
                 ),
             ):
@@ -4847,18 +4847,16 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 "_evaluate",
                 side_effect=evaluate_side_effect_factory(
                     [
-                        {"eval_accuracy": 0.90, "epoch": 0.5},
-                        {"eval_accuracy": 0.80, "epoch": 1.0},
-                        {"eval_accuracy": 0.70, "epoch": 1.5},
+                        {"eval_accuracy": 0.90},
+                        {"eval_accuracy": 0.80},
+                        {"eval_accuracy": 0.70},
                     ]
                 ),
             ):
                 trainer.train()
 
-            steps_per_epoch = get_steps_per_epoch(trainer)
-
             assert trainer.state.best_metric == 0.90
-            assert trainer.state.best_global_step == steps_per_epoch // 2
+            assert trainer.state.best_global_step == 1
 
             best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
             assert trainer.state.best_model_checkpoint == best_ckpt
@@ -4884,8 +4882,8 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 "_evaluate",
                 side_effect=evaluate_side_effect_factory(
                     [
-                        {"eval_accuracy": 0.90, "epoch": 1.5},
-                        {"eval_accuracy": 0.80, "epoch": 2.0},
+                        {"eval_accuracy": 0.90},
+                        {"eval_accuracy": 0.80},
                         {"eval_accuracy": 0.70},
                     ]
                 ),

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2987,9 +2987,9 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
         )
         trainer.train()
         # Check that we have the last known step:
-        assert os.path.exists(
-            os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")
-        ), f"Could not find checkpoint-{trainer.state.max_steps}"
+        assert os.path.exists(os.path.join(tmp_dir, f"checkpoint-{trainer.state.max_steps}")), (
+            f"Could not find checkpoint-{trainer.state.max_steps}"
+        )
         # And then check the last step
         assert os.path.exists(os.path.join(tmp_dir, "checkpoint-9")), "Could not find checkpoint-9"
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -64,6 +64,7 @@ from transformers.testing_utils import (
     backend_device_count,
     execute_subprocess_async,
     get_gpu_count,
+    get_steps_per_epoch,
     get_tests_dir,
     is_staging_test,
     require_accelerate,
@@ -4777,8 +4778,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             ):
                 trainer.train()
 
+            steps_per_epoch = get_steps_per_epoch(trainer)
+
             assert trainer.state.best_metric == 0.59
-            assert trainer.state.best_global_step == 2
+            assert trainer.state.best_global_step == steps_per_epoch
 
             best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
             assert trainer.state.best_model_checkpoint == best_ckpt
@@ -4809,8 +4812,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             ):
                 trainer.train()
 
+            steps_per_epoch = get_steps_per_epoch(trainer)
+
             assert trainer.state.best_metric == 0.59
-            assert trainer.state.best_global_step == 2
+            assert trainer.state.best_global_step == steps_per_epoch
 
             best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
             assert trainer.state.best_model_checkpoint == best_ckpt
@@ -4849,8 +4854,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             ):
                 trainer.train()
 
+            steps_per_epoch = get_steps_per_epoch(trainer)
+
             assert trainer.state.best_metric == 0.90
-            assert trainer.state.best_global_step == 1
+            assert trainer.state.best_global_step == steps_per_epoch // 2
 
             best_ckpt = os.path.join(tmpdir, f"{PREFIX_CHECKPOINT_DIR}-{trainer.state.best_global_step}")
             assert trainer.state.best_model_checkpoint == best_ckpt
@@ -4882,8 +4889,10 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             ):
                 trainer.train()
 
+            steps_per_epoch = get_steps_per_epoch(trainer)
+
             assert trainer.state.best_metric == 0.90
-            assert trainer.state.best_global_step == 3
+            assert trainer.state.best_global_step == steps_per_epoch * 1.5
 
             assert trainer.state.best_model_checkpoint is None
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/35609 (TL;DR `best_model_checkpoint` is being set when the checkpoint may not even exist)

- Add a new attribute to TrainerState called `best_global_step` that keeps track of the step where we performed evaluation and achieved a new best metric.
- Moved setting `best_model_checkpoint` from `_determine_best_metric` to `_save_checkpoint`.
- Inside `_save_checkpoint`, check if the `best_model_checkpoint` actually exists, and set it if so.

This was a bit trickier than I thought it would be, since the Trainer's saving and evaluation logic are not tightly coupled as would be in the `save_strategy == "best"` scenario.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/transformers/issues/35609
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@muellerzr 
@SunMarc 
@tomaarsen 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
