### PR TITLE
Add security validation for ZeroShotClassificationArgumentHandler hypothesis templates #35874

### DIFF
--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -24,15 +24,15 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
     def _validate_hypothesis_template(self, template: str) -> None:
         """Validates that the hypothesis template only contains simple {} placeholders."""
         import re
-        
+
         # Check for exactly one simple {} placeholder
-        placeholder_pattern = r'\{[^{}]*\}'
+        placeholder_pattern = r"\{[^{}]*\}"
         matches = re.findall(placeholder_pattern, template)
-        
-        if len(matches) != 1 or matches[0] != '{}':
+
+        if len(matches) != 1 or matches[0] != "{}":
             raise ValueError(
-                'hypothesis_template must contain exactly one simple {} placeholder for security reasons. '
-                'Complex Python string formatting patterns (like {:>10}, {!r}, {0}) are not supported.'
+                "hypothesis_template must contain exactly one simple {} placeholder for security reasons. "
+                "Complex Python string formatting patterns (like {:>10}, {!r}, {0}) are not supported."
             )
 
     def _parse_labels(self, labels):
@@ -43,10 +43,10 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
     def __call__(self, sequences, labels, hypothesis_template):
         if len(labels) == 0 or len(sequences) == 0:
             raise ValueError("You must include at least one label and at least one sequence.")
-        
+
         # Validate the template before using it
         self._validate_hypothesis_template(hypothesis_template)
-        
+
         labels = self._parse_labels(labels)
 
         # Verify the template actually uses the placeholder
@@ -57,7 +57,7 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
                     "Make sure the passed template includes formatting syntax such as {{}} where the label should go."
                 ).format(hypothesis_template)
             )
-        
+
         if isinstance(sequences, str):
             sequences = [sequences]
 

--- a/src/transformers/pipelines/zero_shot_classification.py
+++ b/src/transformers/pipelines/zero_shot_classification.py
@@ -48,6 +48,15 @@ class ZeroShotClassificationArgumentHandler(ArgumentHandler):
         self._validate_hypothesis_template(hypothesis_template)
         
         labels = self._parse_labels(labels)
+
+        # Verify the template actually uses the placeholder
+        if hypothesis_template.format(labels[0]) == hypothesis_template:
+            raise ValueError(
+                (
+                    'The provided hypothesis_template "{}" was not able to be formatted with the target labels. '
+                    "Make sure the passed template includes formatting syntax such as {{}} where the label should go."
+                ).format(hypothesis_template)
+            )
         
         if isinstance(sequences, str):
             sequences = [sequences]

--- a/tests/test_zero_shot_classification_handler.py
+++ b/tests/test_zero_shot_classification_handler.py
@@ -1,0 +1,3 @@
+import pytest
+from transformers.pipelines import ZeroShotClassificationArgumentHandler
+

--- a/tests/test_zero_shot_classification_handler.py
+++ b/tests/test_zero_shot_classification_handler.py
@@ -26,6 +26,15 @@ def test_invalid_hypothesis_templates():
     ]
 
     for template in invalid_templates:
-        with pytest.raises(ValueError):
-            handler(sequences, labels, template) 
+        with pytest.raises(ValueError, match=".*must contain exactly one simple {} placeholder.*"):
+            handler(sequences, labels, template)
+
+def test_template_without_placeholder_usage():
+    handler = ZeroShotClassificationArgumentHandler()
+    sequences = ["I love this movie"]
+    labels = ["positive"]
+    template = "This template doesn't use the placeholder"
+
+    with pytest.raises(ValueError, match=".*must contain exactly one simple {} placeholder.*"):
+        handler(sequences, labels, template) 
 

--- a/tests/test_zero_shot_classification_handler.py
+++ b/tests/test_zero_shot_classification_handler.py
@@ -1,16 +1,19 @@
 import pytest
+
 from transformers.pipelines import ZeroShotClassificationArgumentHandler
+
 
 def test_valid_hypothesis_template():
     handler = ZeroShotClassificationArgumentHandler()
     sequences = ["I love this movie"]
     labels = ["positive", "negative"]
     template = "This movie is {}."
-    
+
     # Should work fine with simple template
     sequence_pairs, _ = handler(sequences, labels, template)
     assert len(sequence_pairs) == 2
     assert sequence_pairs[0][1] == "This movie is positive."
+
 
 def test_invalid_hypothesis_templates():
     handler = ZeroShotClassificationArgumentHandler()
@@ -19,15 +22,16 @@ def test_invalid_hypothesis_templates():
 
     invalid_templates = [
         "{:>10}",  # Format specifier
-        "{!r}",    # Conversion flag
-        "{}{}",    # Multiple placeholders
+        "{!r}",  # Conversion flag
+        "{}{}",  # Multiple placeholders
         "No placeholder",  # Missing placeholder
-        "{0}",     # Indexed placeholder
+        "{0}",  # Indexed placeholder
     ]
 
     for template in invalid_templates:
         with pytest.raises(ValueError, match=".*must contain exactly one simple {} placeholder.*"):
             handler(sequences, labels, template)
+
 
 def test_template_without_placeholder_usage():
     handler = ZeroShotClassificationArgumentHandler()
@@ -36,5 +40,4 @@ def test_template_without_placeholder_usage():
     template = "This template doesn't use the placeholder"
 
     with pytest.raises(ValueError, match=".*must contain exactly one simple {} placeholder.*"):
-        handler(sequences, labels, template) 
-
+        handler(sequences, labels, template)

--- a/tests/test_zero_shot_classification_handler.py
+++ b/tests/test_zero_shot_classification_handler.py
@@ -1,3 +1,13 @@
 import pytest
 from transformers.pipelines import ZeroShotClassificationArgumentHandler
 
+def test_valid_hypothesis_template():
+    handler = ZeroShotClassificationArgumentHandler()
+    sequences = ["I love this movie"]
+    labels = ["positive", "negative"]
+    template = "This movie is {}."
+    
+    # Should work fine with simple template
+    sequence_pairs, _ = handler(sequences, labels, template)
+    assert len(sequence_pairs) == 2
+    assert sequence_pairs[0][1] == "This movie is positive."

--- a/tests/test_zero_shot_classification_handler.py
+++ b/tests/test_zero_shot_classification_handler.py
@@ -11,3 +11,21 @@ def test_valid_hypothesis_template():
     sequence_pairs, _ = handler(sequences, labels, template)
     assert len(sequence_pairs) == 2
     assert sequence_pairs[0][1] == "This movie is positive."
+
+def test_invalid_hypothesis_templates():
+    handler = ZeroShotClassificationArgumentHandler()
+    sequences = ["I love this movie"]
+    labels = ["positive"]
+
+    invalid_templates = [
+        "{:>10}",  # Format specifier
+        "{!r}",    # Conversion flag
+        "{}{}",    # Multiple placeholders
+        "No placeholder",  # Missing placeholder
+        "{0}",     # Indexed placeholder
+    ]
+
+    for template in invalid_templates:
+        with pytest.raises(ValueError):
+            handler(sequences, labels, template) 
+


### PR DESCRIPTION
## Problem
The `ZeroShotClassificationArgumentHandler` currently accepts any valid Python format string syntax in its `hypothesis_template` parameter. This can lead to potential security and resource issues, as demonstrated by inputs like `"{:>9999999999}"` which can consume excessive RAM due to unrestricted format specifiers.

Fixes : #35874 

## Solution
Added validation to ensure only simple `{}` placeholders are allowed in hypothesis templates, rejecting potentially unsafe format patterns. This includes:

1. New validation method to check template format
2. Clear documentation about formatting restrictions
3. Helpful error messages for invalid templates
4. Comprehensive test coverage

## Implementation Details
- Added template validation before any string formatting occurs
- Uses regex pattern matching to enforce simple `{}` placeholder requirement
- Added warning in class docstring about format restrictions
- Improved error messages to guide users
- Maintains original placeholder usage validation

## Testing
Added two test categories to verify the changes:

1. **Valid Templates**: Ensures standard use cases continue working
   - Simple `{}` placeholder works as expected
   - Labels are correctly formatted into templates

2. **Invalid Templates**: Verifies security improvements
   - Rejects format specifiers (e.g., `{:>10}`)
   - Rejects conversion flags (e.g., `{!r}`)
   - Rejects multiple placeholders
   - Rejects missing placeholders
   - Rejects indexed placeholders (e.g., `{0}`)

3. **Template Usage**: Validates placeholder requirements
   - Ensures templates contain exactly one {} placeholder
   - Verifies error message clarity and correctness
   - Confirms validation order (syntax check before usage check)

## Test Results
<img width="1291" alt="Screenshot 2025-01-25 at 5 46 27 PM" src="https://github.com/user-attachments/assets/e21cfb97-075b-4487-bafa-eae687c5bf6b" />


*All tests passing, showing both valid and invalid template cases being handled correctly*

**cc:** @Rocketknight1 
