### PR TITLE
Add generation config validation using Pydantic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ _deps = [
     "protobuf",
     "psutil",
     "pyyaml>=5.1",
-    "pydantic",
+    "pydantic>=2.0.0",
     "pytest>=7.2.0,<8.0.0",
     "pytest-asyncio",
     "pytest-timeout",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -52,7 +52,7 @@ deps = {
     "protobuf": "protobuf",
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
-    "pydantic": "pydantic",
+    "pydantic": "pydantic>=2.0.0",
     "pytest": "pytest>=7.2.0,<8.0.0",
     "pytest-asyncio": "pytest-asyncio",
     "pytest-timeout": "pytest-timeout",

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -20,7 +20,7 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Final, Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, confloat, conint, model_validator
 
@@ -597,7 +597,7 @@ class GenerationConfig(BaseModel, PushToHubMixin):
             present in `generate`'s signature will be used in the model forward pass.
     """
 
-    extra_output_flags: ClassVar[Tuple[str]] = (
+    extra_output_flags: Final[Tuple[str]] = (
         "output_attentions",
         "output_hidden_states",
         "output_scores",
@@ -619,7 +619,7 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     num_beams: Optional[conint(ge=1)] = 1
     num_beam_groups: Optional[conint(ge=1)] = 1
     penalty_alpha: Optional[confloat(ge=0.0)] = None
-    dola_layers: Optional[Union[str, List[int]]] = None
+    dola_layers: Optional[Union[Literal["low", "high"], List[int]]] = None
 
     # Parameters that control the cache
     use_cache: bool = True

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -52,6 +52,7 @@ ALL_CACHE_IMPLEMENTATIONS = []
 
 if is_torch_available():
     from ..cache_utils import (
+        CacheConfig,
         HQQQuantizedCache,
         HybridCache,
         MambaCache,
@@ -606,7 +607,7 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     model_config = ConfigDict(extra="allow", strict=True, revalidate_instances="subclass-instances")
 
     # Parameters that control the length of the output
-    max_length: Optional[conint(ge=0)] = 20
+    max_length: Optional[conint(ge=1)] = 20
     max_new_tokens: Optional[conint(gt=0)] = None
     min_length: Optional[conint(ge=0)] = 0
     min_new_tokens: Optional[conint(ge=0)] = None
@@ -624,7 +625,7 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     # Parameters that control the cache
     use_cache: bool = True
     cache_implementation: Optional[str] = None
-    cache_config: Optional[Dict] = None
+    cache_config: Optional[Union[dict, "CacheConfig"]] = None
     if cache_implementation is not None and cache_implementation in CACHE_CONFIG_MAPPING:
         cache_config_class = CACHE_CONFIG_MAPPING[cache_implementation]
         if isinstance(cache_config, dict):
@@ -632,16 +633,16 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     return_legacy_cache: Optional[bool] = None
 
     # Parameters for manipulation of the model output logits
-    temperature: Optional[confloat(ge=0.0, le=2.0)] = 1.0
-    top_k: Optional[conint(ge=0)] = 50
+    temperature: Optional[confloat(ge=0.0)] = 1.0
+    top_k: Optional[conint(ge=1)] = 50
     top_p: Optional[confloat(ge=0.0, le=1.0)] = 1.0
     min_p: Optional[confloat(ge=0.0, le=1.0)] = None
     typical_p: Optional[confloat(ge=0.0, le=1.0)] = 1.0
     epsilon_cutoff: Optional[confloat(ge=0.0, le=1.0)] = 0.0
     eta_cutoff: Optional[confloat(ge=0.0, le=1.0)] = 0.0
     diversity_penalty: Optional[confloat(ge=0.0)] = 0.0
-    repetition_penalty: Optional[confloat(ge=1.0)] = 1.0
-    encoder_repetition_penalty: Optional[confloat(ge=1.0)] = 1.0
+    repetition_penalty: Optional[confloat(ge=0.0)] = 1.0
+    encoder_repetition_penalty: Optional[confloat(ge=0.0)] = 1.0
     length_penalty: float = 1.0
     no_repeat_ngram_size: Optional[conint(ge=0)] = 0
     bad_words_ids: Optional[List[List[int]]] = None
@@ -678,7 +679,7 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     # Special tokens that can be used at generation time
     pad_token_id: Optional[int] = None
     bos_token_id: Optional[conint(ge=0)] = None
-    eos_token_id: Optional[Union[conint(ge=0), List[conint(ge=0)]]] = None
+    eos_token_id: Optional[Union[int, List[int]]] = None
 
     # Generation parameters exclusive to encoder-decoder models
     encoder_no_repeat_ngram_size: Optional[conint(ge=0)] = 0
@@ -689,12 +690,12 @@ class GenerationConfig(BaseModel, PushToHubMixin):
     num_assistant_tokens: Optional[conint(ge=1)] = 20
     num_assistant_tokens_schedule: Optional[str] = "constant"
     assistant_confidence_threshold: Optional[confloat(ge=0.0, le=1.0)] = 0.4
-    prompt_lookup_num_tokens: Optional[conint(ge=0)] = None
-    max_matching_ngram_size: Optional[conint(ge=0)] = None
+    prompt_lookup_num_tokens: Optional[conint(ge=1)] = None
+    max_matching_ngram_size: Optional[conint(ge=1)] = None
     assistant_early_exit: Optional[conint(ge=0)] = None
     ## assistant generation for different tokenizers, the windows size for assistant/target model
-    assistant_lookbehind: Optional[conint(ge=0)] = 10
-    target_lookbehind: Optional[conint(ge=0)] = 10
+    assistant_lookbehind: Optional[conint(ge=1)] = 10
+    target_lookbehind: Optional[conint(ge=1)] = 10
 
     # Performances
     compile_config: Optional["CompileConfig"] = CompileConfig()

--- a/src/transformers/models/bark/generation_configuration_bark.py
+++ b/src/transformers/models/bark/generation_configuration_bark.py
@@ -15,7 +15,7 @@
 """BARK model generation configuration"""
 
 import copy
-from typing import Dict
+from typing import ClassVar, Dict
 
 from ...generation.configuration_utils import GenerationConfig
 from ...utils import logging
@@ -25,7 +25,7 @@ logger = logging.get_logger(__name__)
 
 
 class BarkSemanticGenerationConfig(GenerationConfig):
-    model_type = "semantic"
+    model_type : ClassVar[str] = "semantic"
 
     def __init__(
         self,
@@ -116,7 +116,7 @@ class BarkSemanticGenerationConfig(GenerationConfig):
 
 
 class BarkCoarseGenerationConfig(GenerationConfig):
-    model_type = "coarse_acoustics"
+    model_type : ClassVar[str] = "coarse_acoustics"
 
     def __init__(
         self,
@@ -196,7 +196,7 @@ class BarkCoarseGenerationConfig(GenerationConfig):
 
 
 class BarkFineGenerationConfig(GenerationConfig):
-    model_type = "fine_acoustics"
+    model_type : ClassVar[str] = "fine_acoustics"
 
     def __init__(
         self,
@@ -239,8 +239,8 @@ class BarkFineGenerationConfig(GenerationConfig):
 
 
 class BarkGenerationConfig(GenerationConfig):
-    model_type = "bark"
-    is_composition = True
+    model_type : ClassVar[str] = "bark"
+    is_composition : ClassVar[bool] = True
 
     # TODO (joao): nested from_dict
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -94,7 +94,7 @@ GGUF_MIN_VERSION = "0.10.0"
 XLA_FSDPV2_MIN_VERSION = "2.2.0"
 HQQ_MIN_VERSION = "0.2.1"
 VPTQ_MIN_VERSION = "0.0.4"
-
+PYDANTIC_MIN_VERSION = "2.0.0"
 
 _accelerate_available, _accelerate_version = _is_package_available("accelerate", return_version=True)
 _apex_available = _is_package_available("apex")
@@ -167,6 +167,7 @@ _pygments_available = _is_package_available("pygments")
 _pytesseract_available = _is_package_available("pytesseract")
 _pytest_available = _is_package_available("pytest")
 _pytorch_quantization_available = _is_package_available("pytorch_quantization")
+_pydantic_available, _pydantic_version = _is_package_available("pydantic", return_version=True)
 _rjieba_available = _is_package_available("rjieba")
 _sacremoses_available = _is_package_available("sacremoses")
 _safetensors_available = _is_package_available("safetensors")
@@ -1284,6 +1285,20 @@ def is_triton_available():
     return _triton_available
 
 
+def is_pydantic_available(min_version: str = PYDANTIC_MIN_VERSION):
+    return _pydantic_available and version.parse(_pydantic_version) >= version.parse(min_version)
+
+
+# docstyle-ignore
+PYDANTIC_IMPORT_ERROR = """
+{0} requires the pydantic library >= {PYDANTIC_MIN_VERSION} it was not found in your environment.
+You can install or update it with: 
+```
+pip install -U pydantic 
+```
+Please note that you may need to restart your runtime after installation.
+"""
+
 # docstyle-ignore
 AV_IMPORT_ERROR = """
 {0} requires the PyAv library but it was not found in your environment. You can install it with:
@@ -1665,6 +1680,7 @@ BACKENDS_MAPPING = OrderedDict(
         ("protobuf", (is_protobuf_available, PROTOBUF_IMPORT_ERROR)),
         ("pyctcdecode", (is_pyctcdecode_available, PYCTCDECODE_IMPORT_ERROR)),
         ("pytesseract", (is_pytesseract_available, PYTESSERACT_IMPORT_ERROR)),
+        ("pydantic", (is_pydantic_available, PYDANTIC_IMPORT_ERROR)),
         ("sacremoses", (is_sacremoses_available, SACREMOSES_IMPORT_ERROR)),
         ("pytorch_quantization", (is_pytorch_quantization_available, PYTORCH_QUANTIZATION_IMPORT_ERROR)),
         ("sentencepiece", (is_sentencepiece_available, SENTENCEPIECE_IMPORT_ERROR)),


### PR DESCRIPTION
# What does this PR do?

Follow up to #34726

The goal of this PR is to add validation for generation config using Pydantic to fail early when invalid values are passed and not let things fail silently as suggested in issue #33690.

- Adding  extra="allow” in Pydantic `ConfigDict` replaces the code responsible for setting additional attributes without default values.
- Moved individual validation logic from `validate()` into the constructor.
- Sneaked in `sequence_bias` docstring correction because it’s still referencing the older dictionary format which is confusing for users.
- Moved classes to avoid the Undefined name error by Ruff.
- Added Pydantic Import Error to require having Pydantic in env while specifying min version Pydantic V2.0.

## Who can review?

@ArthurZucker @zucchini-nlp