### PR TITLE
Fix how we compute the final non-padding token for ForSequenceClassification models

### DIFF
--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -1122,21 +1122,21 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -1126,7 +1126,7 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -1123,18 +1123,17 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/bloom/modeling_bloom.py
+++ b/src/transformers/models/bloom/modeling_bloom.py
@@ -1127,7 +1127,7 @@ class BloomForSequenceClassification(BloomPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -791,18 +791,17 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -789,23 +789,22 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
 
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
-
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[range(batch_size), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -794,7 +794,7 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -795,7 +795,7 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/ctrl/modeling_tf_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_tf_ctrl.py
@@ -869,7 +869,7 @@ class TFCTRLForSequenceClassification(TFCTRLPreTrainedModel, TFSequenceClassific
             training=training,
         )
         hidden_states = transformer_outputs[0]
-        logits = self.score(hidden_states)
+        logits = self.classifier(hidden_states)
         logits_shape = shape_list(logits)
         batch_size = logits_shape[0]
 

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -1221,7 +1221,7 @@ class DiffLlamaForSequenceClassification(DiffLlamaPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -1217,18 +1217,17 @@ class DiffLlamaForSequenceClassification(DiffLlamaPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -1216,17 +1216,17 @@ class DiffLlamaForSequenceClassification(DiffLlamaPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -1225,6 +1225,10 @@ class DiffLlamaForSequenceClassification(DiffLlamaPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -1220,7 +1220,7 @@ class DiffLlamaForSequenceClassification(DiffLlamaPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1363,7 +1363,7 @@ class FalconForSequenceClassification(FalconPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1360,18 +1360,17 @@ class FalconForSequenceClassification(FalconPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1359,21 +1359,21 @@ class FalconForSequenceClassification(FalconPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -1364,7 +1364,7 @@ class FalconForSequenceClassification(FalconPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -957,6 +957,10 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -949,18 +949,17 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -948,17 +948,17 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -953,7 +953,7 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -952,7 +952,7 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1043,7 +1043,7 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
                 non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
-                token_indices = torch.arange(input_ids.size(-1), device=logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1038,17 +1038,17 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.size(-1), device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1039,18 +1039,17 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1043,7 +1043,7 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1047,6 +1047,10 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -1042,7 +1042,7 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -962,7 +962,7 @@ class GlmForSequenceClassification(GlmPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -967,6 +967,10 @@ class GlmForSequenceClassification(GlmPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -963,7 +963,7 @@ class GlmForSequenceClassification(GlmPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -959,18 +959,17 @@ class GlmForSequenceClassification(GlmPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -958,17 +958,17 @@ class GlmForSequenceClassification(GlmPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1401,7 +1401,7 @@ class GPT2ForSequenceClassification(GPT2PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1393,25 +1393,24 @@ class GPT2ForSequenceClassification(GPT2PreTrainedModel):
         else:
             batch_size, sequence_length = inputs_embeds.shape[:2]
 
-        assert (
-            self.config.pad_token_id is not None or batch_size == 1
-        ), "Cannot handle batch sizes > 1 if no padding token is defined."
+        if self.config.pad_token_id is None and batch_size != 1:
+            raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1400,7 +1400,7 @@ class GPT2ForSequenceClassification(GPT2PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1397,18 +1397,17 @@ class GPT2ForSequenceClassification(GPT2PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gpt2/modeling_tf_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_tf_gpt2.py
@@ -1177,39 +1177,33 @@ class TFGPT2ForSequenceClassification(TFGPT2PreTrainedModel, TFSequenceClassific
             return_dict=return_dict,
             training=training,
         )
-
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)
         logits_shape = shape_list(logits)
-        in_logits = None
+        batch_size = logits_shape[0]
+
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
         else:
             if input_ids is not None:
-                sequence_lengths = (
-                    tf.argmax(tf.cast(tf.math.equal(input_ids, self.config.pad_token_id), input_ids.dtype), axis=-1)
-                    - 1
-                )
-                sequence_lengths = tf.where(sequence_lengths >= 0, sequence_lengths, input_ids.shape[-1] - 1)
-                in_logits = tf.gather(logits, sequence_lengths, batch_dims=1, axis=1)
+                token_indices = tf.range(shape_list(input_ids)[-1])
+                non_pad_mask = tf.cast(input_ids != self.config.pad_token_id, token_indices.dtype)
+                last_non_pad_token = tf.reduce_max(token_indices * non_pad_mask, axis=-1)
             else:
-                sequence_lengths = -1
+                last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
         loss = None
 
+        pooled_logits = tf.gather(logits, last_non_pad_token, batch_dims=1, axis=1)
+
         if labels is not None:
-            assert (
-                self.config.pad_token_id is not None or logits_shape[0] == 1
-            ), "Cannot handle batch sizes > 1 if no padding token is defined."
+            if self.config.pad_token_id is None and logits_shape[0] != 1:
+                raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
 
-            if not tf.is_tensor(sequence_lengths):
-                in_logits = logits[0 : logits_shape[0], sequence_lengths]
-
-            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(in_logits, [-1, self.num_labels]))
-        pooled_logits = in_logits if in_logits is not None else logits
+            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(pooled_logits, [-1, self.num_labels]))
 
         if not return_dict:
             output = (pooled_logits,) + transformer_outputs[1:]

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -1284,18 +1284,17 @@ class GPTBigCodeForSequenceClassification(GPTBigCodePreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -1287,7 +1287,7 @@ class GPTBigCodeForSequenceClassification(GPTBigCodePreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -1280,25 +1280,24 @@ class GPTBigCodeForSequenceClassification(GPTBigCodePreTrainedModel):
         else:
             batch_size, sequence_length = inputs_embeds.shape[:2]
 
-        assert (
-            self.config.pad_token_id is not None or batch_size == 1
-        ), "Cannot handle batch sizes > 1 if no padding token is defined."
+        if self.config.pad_token_id is None and batch_size != 1:
+            raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/modeling_gpt_bigcode.py
@@ -1288,7 +1288,7 @@ class GPTBigCodeForSequenceClassification(GPTBigCodePreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -1102,18 +1102,17 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -1106,7 +1106,7 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -1105,7 +1105,7 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -1101,21 +1101,21 @@ class GPTNeoForSequenceClassification(GPTNeoPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -1206,21 +1206,21 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -1207,18 +1207,17 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -1210,7 +1210,7 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -1211,7 +1211,7 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -1247,7 +1247,7 @@ class GPTJForSequenceClassification(GPTJPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -1243,21 +1243,21 @@ class GPTJForSequenceClassification(GPTJPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -1248,7 +1248,7 @@ class GPTJForSequenceClassification(GPTJPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/gptj/modeling_gptj.py
+++ b/src/transformers/models/gptj/modeling_gptj.py
@@ -1244,18 +1244,17 @@ class GPTJForSequenceClassification(GPTJPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/gptj/modeling_tf_gptj.py
+++ b/src/transformers/models/gptj/modeling_tf_gptj.py
@@ -941,35 +941,30 @@ class TFGPTJForSequenceClassification(TFGPTJPreTrainedModel, TFSequenceClassific
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)
         logits_shape = shape_list(logits)
-        in_logits = None
+        batch_size = logits_shape[0]
+
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
         else:
             if input_ids is not None:
-                sequence_lengths = (
-                    tf.argmax(tf.cast(tf.math.equal(input_ids, self.config.pad_token_id), input_ids.dtype), axis=-1)
-                    - 1
-                )
-                sequence_lengths = tf.where(
-                    sequence_lengths >= 0,
-                    sequence_lengths,
-                    tf.cast(shape_list(input_ids[-1]), sequence_lengths.dtype) - 1,
-                )
-                in_logits = tf.gather(logits, sequence_lengths, batch_dims=1, axis=1)
+                token_indices = tf.range(shape_list(input_ids)[-1])
+                non_pad_mask = tf.cast(input_ids != self.config.pad_token_id, token_indices.dtype)
+                last_non_pad_token = tf.reduce_max(token_indices * non_pad_mask, axis=-1)
             else:
-                sequence_lengths = -1
+                last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
         loss = None
 
-        if labels is not None:
-            if not tf.is_tensor(sequence_lengths):
-                in_logits = logits[0 : logits_shape[0], sequence_lengths]
+        pooled_logits = tf.gather(logits, last_non_pad_token, batch_dims=1, axis=1)
 
-            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(in_logits, [-1, self.num_labels]))
-        pooled_logits = in_logits if in_logits is not None else logits
+        if labels is not None:
+            if self.config.pad_token_id is None and logits_shape[0] != 1:
+                raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
+
+            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(pooled_logits, [-1, self.num_labels]))
 
         if not return_dict:
             output = (pooled_logits,) + transformer_outputs[1:]

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -946,18 +946,17 @@ class HeliumForSequenceClassification(HeliumPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -945,17 +945,17 @@ class HeliumForSequenceClassification(HeliumPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -949,7 +949,7 @@ class HeliumForSequenceClassification(HeliumPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -950,7 +950,7 @@ class HeliumForSequenceClassification(HeliumPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -954,6 +954,10 @@ class HeliumForSequenceClassification(HeliumPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1679,17 +1679,17 @@ class JambaForSequenceClassification(JambaPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1688,6 +1688,10 @@ class JambaForSequenceClassification(JambaPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1680,18 +1680,17 @@ class JambaForSequenceClassification(JambaPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1684,7 +1684,7 @@ class JambaForSequenceClassification(JambaPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1683,7 +1683,7 @@ class JambaForSequenceClassification(JambaPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1455,17 +1455,17 @@ class JetMoeForSequenceClassification(JetMoePreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1464,6 +1464,10 @@ class JetMoeForSequenceClassification(JetMoePreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1456,18 +1456,17 @@ class JetMoeForSequenceClassification(JetMoePreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1459,7 +1459,7 @@ class JetMoeForSequenceClassification(JetMoePreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -1460,7 +1460,7 @@ class JetMoeForSequenceClassification(JetMoePreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -952,7 +952,7 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -951,7 +951,7 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -948,18 +948,17 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -956,6 +956,10 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1040,7 +1040,7 @@ class MistralForSequenceClassification(MistralPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1041,7 +1041,7 @@ class MistralForSequenceClassification(MistralPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1037,18 +1037,17 @@ class MistralForSequenceClassification(MistralPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1036,17 +1036,17 @@ class MistralForSequenceClassification(MistralPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -1045,6 +1045,10 @@ class MistralForSequenceClassification(MistralPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/mistral/modeling_tf_mistral.py
+++ b/src/transformers/models/mistral/modeling_tf_mistral.py
@@ -996,39 +996,30 @@ class TFMistralForSequenceClassification(TFMistralPreTrainedModel, TFSequenceCla
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)
         logits_shape = shape_list(logits)
-        in_logits = None
+        batch_size = logits_shape[0]
 
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = tf.fill((batch_size,), value=-1)
         else:
             if input_ids is not None:
-                sequence_lengths = (
-                    tf.argmax(tf.cast(tf.math.equal(input_ids, self.config.pad_token_id), input_ids.dtype), axis=-1)
-                    - 1
-                )
-                sequence_lengths = tf.where(
-                    sequence_lengths >= 0,
-                    sequence_lengths,
-                    tf.cast(shape_list(input_ids[-1]), sequence_lengths.dtype) - 1,
-                )
-                in_logits = tf.gather(logits, sequence_lengths, batch_dims=1, axis=1)
+                token_indices = tf.range(shape_list(input_ids)[-1])
+                non_pad_mask = tf.cast(input_ids != self.config.pad_token_id, token_indices.dtype)
+                last_non_pad_token = tf.reduce_max(token_indices * non_pad_mask, axis=-1)
             else:
-                sequence_lengths = -1
+                last_non_pad_token = tf.fill((batch_size,), value=-1)
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
         loss = None
 
+        pooled_logits = tf.gather(logits, last_non_pad_token, batch_dims=1, axis=1)
+
         if labels is not None:
             if self.config.pad_token_id is None and logits_shape[0] != 1:
                 raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
 
-            if not tf.is_tensor(sequence_lengths):
-                in_logits = logits[0 : logits_shape[0], sequence_lengths]
-
-            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(in_logits, [-1, self.num_labels]))
-        pooled_logits = in_logits if in_logits is not None else logits
+            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(pooled_logits, [-1, self.num_labels]))
 
         if not return_dict:
             output = (pooled_logits,) + transformer_outputs[1:]

--- a/src/transformers/models/mistral/modeling_tf_mistral.py
+++ b/src/transformers/models/mistral/modeling_tf_mistral.py
@@ -999,14 +999,14 @@ class TFMistralForSequenceClassification(TFMistralPreTrainedModel, TFSequenceCla
         batch_size = logits_shape[0]
 
         if self.config.pad_token_id is None:
-            last_non_pad_token = tf.fill((batch_size,), value=-1)
+            last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
         else:
             if input_ids is not None:
                 token_indices = tf.range(shape_list(input_ids)[-1])
                 non_pad_mask = tf.cast(input_ids != self.config.pad_token_id, token_indices.dtype)
                 last_non_pad_token = tf.reduce_max(token_indices * non_pad_mask, axis=-1)
             else:
-                last_non_pad_token = tf.fill((batch_size,), value=-1)
+                last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1198,6 +1198,10 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1190,18 +1190,17 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1189,17 +1189,17 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1194,7 +1194,7 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -1193,7 +1193,7 @@ class MixtralForSequenceClassification(MixtralPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -686,7 +686,7 @@ class MptForSequenceClassification(MptPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -681,21 +681,21 @@ class MptForSequenceClassification(MptPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -685,7 +685,7 @@ class MptForSequenceClassification(MptPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/mpt/modeling_mpt.py
+++ b/src/transformers/models/mpt/modeling_mpt.py
@@ -682,18 +682,17 @@ class MptForSequenceClassification(MptPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1203,6 +1203,10 @@ class NemotronForSequenceClassification(NemotronPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1195,18 +1195,17 @@ class NemotronForSequenceClassification(NemotronPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1198,7 +1198,7 @@ class NemotronForSequenceClassification(NemotronPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1194,17 +1194,17 @@ class NemotronForSequenceClassification(NemotronPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/nemotron/modeling_nemotron.py
+++ b/src/transformers/models/nemotron/modeling_nemotron.py
@@ -1199,7 +1199,7 @@ class NemotronForSequenceClassification(NemotronPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -807,18 +807,17 @@ class OpenAIGPTForSequenceClassification(OpenAIGPTPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -811,7 +811,7 @@ class OpenAIGPTForSequenceClassification(OpenAIGPTPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -810,7 +810,7 @@ class OpenAIGPTForSequenceClassification(OpenAIGPTPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/openai/modeling_openai.py
+++ b/src/transformers/models/openai/modeling_openai.py
@@ -805,23 +805,22 @@ class OpenAIGPTForSequenceClassification(OpenAIGPTPreTrainedModel):
         # Ensure the batch size is > 1 if there is no padding.
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
-
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[range(batch_size), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/openai/modeling_tf_openai.py
+++ b/src/transformers/models/openai/modeling_tf_openai.py
@@ -876,43 +876,33 @@ class TFOpenAIGPTForSequenceClassification(TFOpenAIGPTPreTrainedModel, TFSequenc
             return_dict=return_dict,
             training=training,
         )
-
         hidden_states = transformer_outputs[0]
         logits = self.score(hidden_states)
-        in_logits = None
+        logits_shape = shape_list(logits)
+        batch_size = logits_shape[0]
+
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
         else:
             if input_ids is not None:
-                sequence_lengths = (
-                    tf.argmax(tf.cast(tf.math.equal(input_ids, self.config.pad_token_id), input_ids.dtype), axis=-1)
-                    - 1
-                )
-                sequence_lengths = tf.where(sequence_lengths >= 0, sequence_lengths, input_ids.shape[-1] - 1)
-                in_logits = tf.gather(logits, sequence_lengths, batch_dims=1, axis=1)
+                token_indices = tf.range(shape_list(input_ids)[-1])
+                non_pad_mask = tf.cast(input_ids != self.config.pad_token_id, token_indices.dtype)
+                last_non_pad_token = tf.reduce_max(token_indices * non_pad_mask, axis=-1)
             else:
-                sequence_lengths = -1
+                last_non_pad_token = tf.fill((batch_size,), value=logits_shape[1] - 1)
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
         loss = None
 
+        pooled_logits = tf.gather(logits, last_non_pad_token, batch_dims=1, axis=1)
+
         if labels is not None:
-            if input_ids is not None:
-                batch_size, sequence_length = shape_list(input_ids)[:2]
-            else:
-                batch_size, sequence_length = shape_list(inputs_embeds)[:2]
-            assert (
-                self.config.pad_token_id is not None or batch_size == 1
-            ), "Cannot handle batch sizes > 1 if no padding token is defined."
+            if self.config.pad_token_id is None and logits_shape[0] != 1:
+                raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
 
-            if not tf.is_tensor(sequence_lengths):
-                in_logits = logits[0:batch_size, sequence_lengths]
-
-            loss = self.hf_compute_loss(tf.reshape(labels, [-1, 1]), tf.reshape(in_logits, [-1, self.num_labels]))
-
-        pooled_logits = in_logits if in_logits is not None else logits
+            loss = self.hf_compute_loss(tf.reshape(labels, [-1]), tf.reshape(pooled_logits, [-1, self.num_labels]))
 
         if not return_dict:
             output = (pooled_logits,) + transformer_outputs[1:]

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1299,18 +1299,17 @@ class OPTForSequenceClassification(OPTPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1303,7 +1303,7 @@ class OPTForSequenceClassification(OPTPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1302,7 +1302,7 @@ class OPTForSequenceClassification(OPTPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/opt/modeling_opt.py
+++ b/src/transformers/models/opt/modeling_opt.py
@@ -1295,22 +1295,24 @@ class OPTForSequenceClassification(OPTPreTrainedModel):
         else:
             batch_size, sequence_length = inputs_embeds.shape[:2]
 
+        if self.config.pad_token_id is None and batch_size != 1:
+            raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
                 logger.warning_once(
                     f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                     "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
                 )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -1014,7 +1014,7 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -1013,7 +1013,7 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -1009,17 +1009,17 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -1018,6 +1018,10 @@ class PersimmonForSequenceClassification(PersimmonPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -930,6 +930,10 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -921,17 +921,17 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -926,7 +926,7 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -925,7 +925,7 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -922,18 +922,17 @@ class PhiForSequenceClassification(PhiPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1066,6 +1066,10 @@ class Phi3ForSequenceClassification(Phi3PreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1058,18 +1058,17 @@ class Phi3ForSequenceClassification(Phi3PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1057,17 +1057,17 @@ class Phi3ForSequenceClassification(Phi3PreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1061,7 +1061,7 @@ class Phi3ForSequenceClassification(Phi3PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -1062,7 +1062,7 @@ class Phi3ForSequenceClassification(Phi3PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1597,17 +1597,17 @@ class PhimoeForSequenceClassification(PhimoePreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1601,7 +1601,7 @@ class PhimoeForSequenceClassification(PhimoePreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1606,6 +1606,10 @@ class PhimoeForSequenceClassification(PhimoePreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1602,7 +1602,7 @@ class PhimoeForSequenceClassification(PhimoePreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1598,18 +1598,17 @@ class PhimoeForSequenceClassification(PhimoePreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -932,17 +932,17 @@ class Qwen2ForSequenceClassification(Qwen2PreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -941,6 +941,10 @@ class Qwen2ForSequenceClassification(Qwen2PreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -936,7 +936,7 @@ class Qwen2ForSequenceClassification(Qwen2PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -933,18 +933,17 @@ class Qwen2ForSequenceClassification(Qwen2PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -937,7 +937,7 @@ class Qwen2ForSequenceClassification(Qwen2PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1438,17 +1438,17 @@ class Qwen2MoeForSequenceClassification(Qwen2MoePreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1439,18 +1439,17 @@ class Qwen2MoeForSequenceClassification(Qwen2MoePreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1442,7 +1442,7 @@ class Qwen2MoeForSequenceClassification(Qwen2MoePreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1443,7 +1443,7 @@ class Qwen2MoeForSequenceClassification(Qwen2MoePreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1447,6 +1447,10 @@ class Qwen2MoeForSequenceClassification(Qwen2MoePreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1266,18 +1266,17 @@ class StableLmForSequenceClassification(StableLmPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1265,17 +1265,17 @@ class StableLmForSequenceClassification(StableLmPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1269,7 +1269,7 @@ class StableLmForSequenceClassification(StableLmPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1270,7 +1270,7 @@ class StableLmForSequenceClassification(StableLmPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -1274,6 +1274,10 @@ class StableLmForSequenceClassification(StableLmPreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -949,7 +949,7 @@ class Starcoder2ForSequenceClassification(Starcoder2PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -953,6 +953,10 @@ class Starcoder2ForSequenceClassification(Starcoder2PreTrainedModel):
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
                 last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -945,18 +945,17 @@ class Starcoder2ForSequenceClassification(Starcoder2PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -948,7 +948,7 @@ class Starcoder2ForSequenceClassification(Starcoder2PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -944,17 +944,17 @@ class Starcoder2ForSequenceClassification(Starcoder2PreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -1432,17 +1432,21 @@ class ZambaForSequenceClassification(ZambaPreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -1436,7 +1436,7 @@ class ZambaForSequenceClassification(ZambaPreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -1433,18 +1433,17 @@ class ZambaForSequenceClassification(ZambaPreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -1437,7 +1437,7 @@ class ZambaForSequenceClassification(ZambaPreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1859,18 +1859,17 @@ class Zamba2ForSequenceClassification(Zamba2PreTrainedModel):
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
             last_non_pad_token = -1
+        elif input_ids is not None:
+            # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+            non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
+            token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
         else:
-            if input_ids is not None:
-                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
-                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
-            else:
-                last_non_pad_token = -1
-                logger.warning_once(
-                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
-                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
-                )
+            last_non_pad_token = -1
+            logger.warning_once(
+                f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+            )
 
         pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1863,7 +1863,7 @@ class Zamba2ForSequenceClassification(Zamba2PreTrainedModel):
             # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
             non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
             token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
-            last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
+            last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
             logger.warning_once(

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1858,17 +1858,21 @@ class Zamba2ForSequenceClassification(Zamba2PreTrainedModel):
         if self.config.pad_token_id is None and batch_size != 1:
             raise ValueError("Cannot handle batch sizes > 1 if no padding token is defined.")
         if self.config.pad_token_id is None:
-            sequence_lengths = -1
+            last_non_pad_token = -1
         else:
             if input_ids is not None:
-                # if no pad token found, use modulo instead of reverse indexing for ONNX compatibility
-                sequence_lengths = torch.eq(input_ids, self.config.pad_token_id).int().argmax(-1) - 1
-                sequence_lengths = sequence_lengths % input_ids.shape[-1]
-                sequence_lengths = sequence_lengths.to(logits.device)
+                # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
+                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
+                last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:
-                sequence_lengths = -1
+                last_non_pad_token = -1
+                logger.warning_once(
+                    f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
+                    "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
+                )
 
-        pooled_logits = logits[torch.arange(batch_size, device=logits.device), sequence_lengths]
+        pooled_logits = logits[torch.arange(batch_size, device=logits.device), last_non_pad_token]
 
         loss = None
         if labels is not None:

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1862,7 +1862,7 @@ class Zamba2ForSequenceClassification(Zamba2PreTrainedModel):
         else:
             if input_ids is not None:
                 # To handle both left- and right- padding, we take the rightmost token that is not equal to pad_token_id
-                non_pad_mask = torch.ne(input_ids, self.config.pad_token_id).int().to(logits.device)
+                non_pad_mask = (input_ids != self.config.pad_token_id).to(logits.device, torch.int32)
                 token_indices = torch.arange(input_ids.shape[-1], device=logits.device)
                 last_non_pad_token = (token_indices * non_pad_mask).max(-1).values
             else:


### PR DESCRIPTION
We have a lot of CLM models with `ForSequenceClassification` heads. These models are supposed to use the hidden state at the final non-padding token as the input to the classification head. However, the way they compute it is a bit weird - they get the index of the leftmost token that is equal to `pad_token_id` and subtract 1 from it. This has a few issues:

- It breaks on left-padding
- It creates index arithmetic issues when `pad_token_id` is absent, that need workarounds
- It depends on implementation details of `argmax()`, specifically that when multiple indices have the same maximum value, it always returns the smallest one

This PR replaces that logic with simpler logic that actually searches for what we want, the **rightmost non-padding token**, not the **token next to the leftmost padding token**. This means the same logic works with left-padding, right-padding, no-padding, or even padding on both sides (I don't think any models do that, but we're ready if they do!)

Fixes #30004
Fixes #35352
Fixes #35909