### PR TITLE
Close Zamba2Config code block

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -626,6 +626,8 @@
         title: YOSO
       - local: model_doc/zamba
         title: Zamba
+      - local: model_doc/zamba2
+        title: Zamba2
       title: Text models
     - isExpanded: false
       sections:

--- a/src/transformers/models/zamba2/configuration_zamba2.py
+++ b/src/transformers/models/zamba2/configuration_zamba2.py
@@ -120,7 +120,7 @@ class Zamba2Config(PretrainedConfig):
     >>> model = Zamba2Model(configuration)
     >>> # Accessing the model configuration
     >>> configuration = model.config
-    """
+    ```"""
 
     model_type = "zamba2"
     keys_to_ignore_at_inference = ["past_key_values"]


### PR DESCRIPTION
A code block in Zamba2Config is not closed, which is causing doc building to fail.