### PR TITLE
Use torch 2.5.0 for deepspeed amd image

### DIFF
--- a/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-amd-gpu/Dockerfile
@@ -2,7 +2,7 @@ FROM rocm/dev-ubuntu-22.04:6.2.4
 LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG PYTORCH='2.5.1'
+ARG PYTORCH='2.5.0'
 ARG TORCH_VISION='0.20.0'
 ARG TORCH_AUDIO='2.5.0'
 ARG ROCM='6.2'


### PR DESCRIPTION
torchvision 0.20.0 depends on torch 2.5.0, so 2.5.1 was a mistake.