### PR TITLE
Add rust to deepspeed image so it can build tokenizers

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -15,6 +15,10 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip
 ARG REF=main
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 
+# Install Rust for Tokenizers
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+
 RUN python3 -m pip install --no-cache-dir ./transformers[deepspeed-testing]
 
 # Install latest release PyTorch


### PR DESCRIPTION
# What does this PR do?
The deepspeed image build CI has been [failing](https://github.com/huggingface/transformers/actions/runs/13001128582/job/36259855640) because the base image is not able to build tokenizers.
This PR adds rust to the image so that it can get past this error.
