### PR TITLE
update docker file `transformers-pytorch-deepspeed-latest-gpu`

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -1,5 +1,5 @@
 # https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-23-11.html#rel-23-11
-FROM nvcr.io/nvidia/pytorch:23.04-py3
+FROM nvcr.io/nvidia/pytorch:23.11-py3
 LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
# What does this PR do?

Previously one has python 3.8, but that is dropped recently and cause docker image failing to build.

Just an update with a newer base image with python 3.10

image is now built : https://github.com/huggingface/transformers/actions/runs/13015529608/job/36303666404

