### PR TITLE
feat: pyutils variable for pytorch 2.5

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -30,6 +30,7 @@ logger = logging.get_logger(__name__)
 
 parsed_torch_version_base = version.parse(version.parse(torch.__version__).base_version)
 
+is_torch_greater_or_equal_than_2_5 = parsed_torch_version_base >= version.parse("2.5")
 is_torch_greater_or_equal_than_2_4 = parsed_torch_version_base >= version.parse("2.4")
 is_torch_greater_or_equal_than_2_3 = parsed_torch_version_base >= version.parse("2.3")
 is_torch_greater_or_equal_than_2_2 = parsed_torch_version_base >= version.parse("2.2")

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -44,7 +44,7 @@ is_torch_greater_or_equal_than_1_12 = parsed_torch_version_base >= version.parse
 # Cache this result has it's a C FFI call which can be pretty time-consuming
 _torch_distributed_available = torch.distributed.is_available()
 
-if is_torch_greater_or_equal("2.5") and _torch_distributed_available:
+if is_torch_greater_or_equal_than_2_5 and _torch_distributed_available:
     from torch.distributed.tensor import Replicate
     from torch.distributed.tensor.parallel import (
         ColwiseParallel,


### PR DESCRIPTION
Pytorch 2.5 released in October 17, 2024 features a new CuDNN backend for SDPA, improvements to TorchDynamo, regional compilation of torch.compile, and more.

https://pytorch.org/blog/pytorch2-5/

This also causes some backward compatibility issue, where some old models could not run on the newer Pytorch stable release version 2.5, so they will need this variable to assists (this variable needs to be `FALSE` in that case).

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

