### PR TITLE
Idefics: remove double BOS token

### DIFF
--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -198,6 +198,11 @@ class Idefics2Processor(ProcessorMixin):
             elif not isinstance(text, list) and not isinstance(text[0], str):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
 
+            add_special_tokens = True
+            if self.bos_token is not None and text[0].startswith(self.bos_token):
+                add_special_tokens = False
+            output_kwargs["text_kwargs"]["add_special_tokens"] = add_special_tokens
+
             # Replace the image token with fake tokens around the expanded image token sequence of length `image_seq_len`
             fake_image_token = self.fake_image_token.content
             image_token = self.image_token.content

--- a/src/transformers/models/idefics3/processing_idefics3.py
+++ b/src/transformers/models/idefics3/processing_idefics3.py
@@ -156,6 +156,7 @@ class Idefics3Processor(ProcessorMixin):
             ]
         }
         tokenizer.add_special_tokens(tokens_to_add)
+        self.bos_token = self.tokenizer.bos_token
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template, **kwargs)
 
@@ -248,6 +249,11 @@ class Idefics3Processor(ProcessorMixin):
             elif not isinstance(text, list) and not isinstance(text[0], str):
                 raise ValueError("Invalid input text. Please provide a string, or a list of strings")
             n_images_in_text = [sample.count(self.image_token.content) for sample in text]
+
+        add_special_tokens = True
+        if self.bos_token is not None and text[0].startswith(self.bos_token):
+            add_special_tokens = False
+        output_kwargs["text_kwargs"]["add_special_tokens"] = add_special_tokens
 
         if images is not None:
             if is_image_or_image_url(images):


### PR DESCRIPTION
# What does this PR do?

Idefics models have special tokens added to the prompt in their chat templates, but the processor adds another `BOS` token because by default `add_special_tokens=True`. This happens because, unlike tokenizers, in VLMs we had to format the prompt first and let users call the processors. Users usually don't disable special tokens when processing


I guess the easiest decision is to add a check for double `BOS` within processors, as we cannot go over all idefics finetunes in the hub and ask to fix the template. I didn't raise an unactionable warning to not flood the CMD, but the long term goal will be to make this standard for VLMs


Btw, @Rocketknight1 , the same should happen if one tries to use LLM template for formatting only, and then perform special manipulations on the prompt before tokenizing it. Do you think we need to explicitly mention this in the docs or anything?

-------------------------

Reproducer:
```python
from transformers import AutoProcessor
from transformers.image_utils import load_image

image1 = load_image("https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg")
processor = AutoProcessor.from_pretrained("HuggingFaceM4/Idefics3-8B-Llama3")

messages = [
    {
        "role": "user",
        "content": [
            {"type": "image"},
            {"type": "text", "text": "Can you describe the image?"}
        ]
    },
]

prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
inputs = processor(text=prompt, images=[image1], return_tensors="pt")
print(inputs.input_ids[:3]) # starts with two BOS tokens [128000, 128000, 1502, ...]
```
