### PR TITLE
Update `unwrap_and_save_reload_schedule` to use `weights_only=False`

### DIFF
--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -59,7 +59,7 @@ def unwrap_and_save_reload_schedule(scheduler, num_steps=10):
                 file_name = os.path.join(tmpdirname, "schedule.bin")
                 torch.save(scheduler.state_dict(), file_name)
 
-                state_dict = torch.load(file_name)
+                state_dict = torch.load(file_name, weights_only=True)
                 scheduler.load_state_dict(state_dict)
     return lrs
 

--- a/tests/optimization/test_optimization.py
+++ b/tests/optimization/test_optimization.py
@@ -59,7 +59,7 @@ def unwrap_and_save_reload_schedule(scheduler, num_steps=10):
                 file_name = os.path.join(tmpdirname, "schedule.bin")
                 torch.save(scheduler.state_dict(), file_name)
 
-                state_dict = torch.load(file_name, weights_only=True)
+                state_dict = torch.load(file_name, weights_only=False)
                 scheduler.load_state_dict(state_dict)
     return lrs
 


### PR DESCRIPTION
# What does this PR do?

Our CircleCI already has torch 2.6. With this torch version, We need to use `weights_only=False` explicitly if the checkpoint contains other stuffs than weights.