### PR TITLE
Update `squad_convert_example_to_features` to work with numpy v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,6 @@ To create the package for pypi.
 9. Copy the release notes from RELEASE.md to the tag in github once everything is looking hunky-dory.
 """
 
-a = 1
-
 import os
 import re
 import shutil

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ To create the package for pypi.
 9. Copy the release notes from RELEASE.md to the tag in github once everything is looking hunky-dory.
 """
 
+a = 1
+
 import os
 import re
 import shutil

--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -249,7 +249,7 @@ def squad_convert_example_to_features(
         else:
             p_mask[-len(span["tokens"]) : -(len(truncated_query) + sequence_added_tokens)] = 0
 
-        pad_token_indices = np.where(span["input_ids"] == tokenizer.pad_token_id)
+        pad_token_indices = np.where(np.atleast_1d(span["input_ids"] == tokenizer.pad_token_id))
         special_token_indices = np.asarray(
             tokenizer.get_special_tokens_mask(span["input_ids"], already_has_special_tokens=True)
         ).nonzero()


### PR DESCRIPTION
# What does this PR do?

We get `numpy==2.1.2` now instead of `numpy==1.26.3` on our CircleCI runner env. (likely due to the `torch==2.6` is out).
We need to use `np.atleast_1` now for a scalar, as

> span["input_ids"] == tokenizer.pad_token_id
is `False` in many case.
