### PR TITLE
[Qwen2_5_VL] Fix dtype mismatch in FA2 by removing forced float() cast in rotary embeddings

### DIFF
--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -160,7 +160,7 @@ class Qwen2_5_VLPatchMerger(nn.Module):
 
 
 def apply_rotary_pos_emb_flashatt(tensor: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
-    tensor_ = tensor.float()
+    tensor_ = tensor
     cos = freqs.cos()
     sin = freqs.sin()
     output = apply_rotary_emb(tensor_, cos, sin).type_as(tensor)


### PR DESCRIPTION
# What does this PR do?

This PR fixes a FlashAttention assertion error that occurs in the Qwen2_5_VL vision blocks when a query tensor is forcibly cast to `float32`, but the `cos`/`sin` embedding tensors remain in a lower precision (`bf16` or `fp16`). This mismatch triggers the error during training runs on mixed (text-only + text-image) batches:
```
AssertionError: Input and cos/sin must have the same dtype, got torch.float32 and torch.bfloat16
```

**Changes:**
- Removed forced `.float()` cast in `apply_rotary_pos_emb_flashatt` so that the query tensor and the `cos`/`sin` tensors share the same dtype:
```python
- tensor_ = tensor.float()
+ tensor_ = tensor
```

**Why:**
- FlashAttention requires all inputs to `apply_rotary_emb` to have identical dtypes
- Removing the forced cast ensures that the Qwen2_5_VL vision path works correctly in mixed or lower-precision settings, preventing upstream assertion failures and allowing memory-efficient training in `bf16` or `fp16`
- Verified the fix with seeded runs in mixed precision (bf16 and fp16) settings; tested both text-only and mixed text-image batches to ensure correct behavior