### PR TITLE
not to use A100 for `benchmark.yml`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,8 @@ jobs:
     name: Benchmark
     strategy:
       matrix:
-        group: [aws-g5-4xlarge-cache, aws-p4d-24xlarge-plus]
+        # group: [aws-g5-4xlarge-cache, aws-p4d-24xlarge-plus] (A100 runner is not enabled)
+        group: [aws-g5-4xlarge-cache]
     runs-on:
       group: ${{ matrix.group }}
     if: |


### PR DESCRIPTION
# What does this PR do?

From internally discussion

> yes technically we can use A100 on CI. I did the conf for @McPatate, but this WF only use 1 GPU, so i disabled this p4d instance for now because we wasted 7 GPU on it