### PR TITLE
[Moshi] disable automatic compilation if the model can't compile

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3183,7 +3183,7 @@ class GenerationMixin:
 
         model_forward = self.__call__
         if isinstance(model_kwargs.get("past_key_values"), Cache):
-            is_compileable = model_kwargs["past_key_values"].is_compileable
+            is_compileable = model_kwargs["past_key_values"].is_compileable and self._supports_static_cache
             if is_compileable and (
                 self.device.type == "cuda" or generation_config.compile_config._compile_all_devices
             ):


### PR DESCRIPTION
# What does this PR do?

Don't trigger automatic compilation if the model can't compile. https://github.com/huggingface/transformers/pull/34544 enabled automatic compilation with any compilation-ready cache. However, some models default to compilation-ready caches AND don't support compilation, e.g. Moshi

Supercedes #35986; Carved from #35989 to reduce the size of that PR.

Fixes Moshi generation tests, e.g. `py.test tests/models/moshi -k test_greedy_generate -vv`