### PR TITLE
Update tests regarding attention types after  #35235

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4459,7 +4459,8 @@ class ModelTesterMixin:
                     for name, submodule in model_fa2.named_modules():
                         class_name = submodule.__class__.__name__
                         if (
-                            class_name.endswith("Attention")
+                            "Attention" in class_name
+                            and getattr(submodule, "config", None)
                             and submodule.config._attn_implementation == "flash_attention_2"
                         ):
                             has_fa2 = True

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4446,7 +4446,11 @@ class ModelTesterMixin:
                     has_fa2 = False
                     for name, submodule in model_fa2.named_modules():
                         class_name = submodule.__class__.__name__
-                        if "FlashAttention" in class_name or (class_name.endswith("Attention") and getattr(submodule, "config", None) and submodule.config._attn_implementation == "flash_attention_2"):
+                        if "FlashAttention" in class_name or (
+                            class_name.endswith("Attention")
+                            and getattr(submodule, "config", None)
+                            and submodule.config._attn_implementation == "flash_attention_2"
+                        ):
                             has_fa2 = True
                             break
                     if not has_fa2:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4446,7 +4446,7 @@ class ModelTesterMixin:
                     has_fa2 = False
                     for name, submodule in model_fa2.named_modules():
                         class_name = submodule.__class__.__name__
-                        if "FlashAttention" in class_name:
+                        if "FlashAttention" in class_name or (class_name.endswith("Attention") and getattr(submodule, "config", None) and submodule.config._attn_implementation == "flash_attention_2"):
                             has_fa2 = True
                             break
                     if not has_fa2:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3871,7 +3871,11 @@ class ModelTesterMixin:
 
             for name, submodule in model.named_modules():
                 class_name = submodule.__class__.__name__
-                if class_name.endswith("Attention") and submodule.config._attn_implementation != "eager":
+                if (
+                    class_name.endswith("Attention")
+                    and hasattr(submodule, "config")
+                    and submodule.config._attn_implementation != "eager"
+                ):
                     raise ValueError(
                         f"The eager model should not have SDPA/FA2 attention layers but got `{class_name}.config._attn_implementation={submodule.config._attn_implementation}`"
                     )
@@ -3905,7 +3909,11 @@ class ModelTesterMixin:
 
                 for name, submodule in model_eager.named_modules():
                     class_name = submodule.__class__.__name__
-                    if class_name.endswith("Attention") and submodule.config._attn_implementation == "sdpa":
+                    if (
+                        class_name.endswith("Attention")
+                        and hasattr(submodule, "config")
+                        and submodule.config._attn_implementation == "sdpa"
+                    ):
                         raise ValueError(
                             f"The eager model should not have SDPA attention layers but got `{class_name}.config._attn_implementation={submodule.config._attn_implementation}`"
                         )
@@ -3959,7 +3967,11 @@ class ModelTesterMixin:
 
                 for name, submodule in model_eager.named_modules():
                     class_name = submodule.__class__.__name__
-                    if class_name.endswith("Attention") and submodule.config._attn_implementation == "sdpa":
+                    if (
+                        class_name.endswith("Attention")
+                        and hasattr(submodule, "config")
+                        and submodule.config._attn_implementation == "sdpa"
+                    ):
                         raise ValueError("The eager model should not have SDPA attention layers")
 
     @parameterized.expand([("float16",), ("bfloat16",), ("float32",)])

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4446,9 +4446,8 @@ class ModelTesterMixin:
                     has_fa2 = False
                     for name, submodule in model_fa2.named_modules():
                         class_name = submodule.__class__.__name__
-                        if "FlashAttention" in class_name or (
+                        if (
                             class_name.endswith("Attention")
-                            and getattr(submodule, "config", None)
                             and submodule.config._attn_implementation == "flash_attention_2"
                         ):
                             has_fa2 = True

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3873,7 +3873,7 @@ class ModelTesterMixin:
                 class_name = submodule.__class__.__name__
                 if (
                     class_name.endswith("Attention")
-                    and hasattr(submodule, "config")
+                    and getattr(submodule, "config", None)
                     and submodule.config._attn_implementation != "eager"
                 ):
                     raise ValueError(
@@ -3911,7 +3911,7 @@ class ModelTesterMixin:
                     class_name = submodule.__class__.__name__
                     if (
                         class_name.endswith("Attention")
-                        and hasattr(submodule, "config")
+                        and getattr(submodule, "config", None)
                         and submodule.config._attn_implementation == "sdpa"
                     ):
                         raise ValueError(
@@ -3969,7 +3969,7 @@ class ModelTesterMixin:
                     class_name = submodule.__class__.__name__
                     if (
                         class_name.endswith("Attention")
-                        and hasattr(submodule, "config")
+                        and getattr(submodule, "config", None)
                         and submodule.config._attn_implementation == "sdpa"
                     ):
                         raise ValueError("The eager model should not have SDPA attention layers")


### PR DESCRIPTION
# What does this PR do?

As discussed offline, let's update `test_flash_attn_2_can_dispatch_composite_models` after #35235.

I keep the original condition and using `or (....new condition)`, although  `the new condition` should work well anyway.