### PR TITLE
feat(ci): ignore trufflehog unverified results

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -16,3 +16,5 @@ jobs:
           fetch-depth: 0
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
We have had a lot of false positives for unverified trufflehog results, causing the CI pipeline to fail.

I had left them intentionally as they were infrequent at first, but given their recent increase in frequency, I feel it's safe to only check for verified secrets.