### PR TITLE
add support for empty list as input to create_model_card

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -489,7 +489,7 @@ class TrainingSummary:
                 f" [{self.finetuned_from}](https://huggingface.co/{self.finetuned_from}) on "
             )
 
-        if self.dataset is None:
+        if self.dataset is None or (isinstance(self.dataset, list) and len(self.dataset) == 0):
             model_card += "an unknown dataset."
         else:
             if isinstance(self.dataset, str):


### PR DESCRIPTION
## What does this PR do?

This PR fixes [#35163](https://github.com/huggingface/transformers/issues/35163) by ensuring that `trainer.create_model_card(..., dataset=[])` properly supports cases where the `dataset` is passed as an empty list.

@muellerzr and @SunMarc, please review this PR at your convenience. Thank you in advance!

This is my first PR, and I've done my best to follow the contribution guidelines. I welcome any feedback.