### PR TITLE
Update `test_flash_attn_2_can_dispatch_composite_models`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4436,8 +4436,14 @@ class ModelTesterMixin:
                 model.save_pretrained(tmpdirname)
                 model = model_class.from_pretrained(tmpdirname, torch_dtype=torch_dtype)
 
-                sub_models_supporting_fa2 = [module._supports_flash_attn_2 for name, module in model.named_modules() if isinstance(module, PreTrainedModel) and name != ""]
-                supports_fa2_all_modules = all(sub_models_supporting_fa2) if len(sub_models_supporting_fa2) > 0 else False
+                sub_models_supporting_fa2 = [
+                    module._supports_flash_attn_2
+                    for name, module in model.named_modules()
+                    if isinstance(module, PreTrainedModel) and name != ""
+                ]
+                supports_fa2_all_modules = (
+                    all(sub_models_supporting_fa2) if len(sub_models_supporting_fa2) > 0 else False
+                )
                 if not supports_fa2_all_modules:
                     with self.assertRaises(ValueError):
                         model_fa2 = model_class.from_pretrained(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4442,7 +4442,9 @@ class ModelTesterMixin:
                     if isinstance(module, PreTrainedModel) and name != ""
                 ]
                 supports_fa2_all_modules = (
-                    all(sub_models_supporting_fa2) if len(sub_models_supporting_fa2) > 0 else False
+                    all(sub_models_supporting_fa2)
+                    if len(sub_models_supporting_fa2) > 0
+                    else model._supports_flash_attn_2
                 )
                 if not supports_fa2_all_modules:
                     with self.assertRaises(ValueError):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4436,11 +4436,8 @@ class ModelTesterMixin:
                 model.save_pretrained(tmpdirname)
                 model = model_class.from_pretrained(tmpdirname, torch_dtype=torch_dtype)
 
-                supports_fa2_all_modules = all(
-                    module._supports_flash_attn_2
-                    for name, module in model.named_modules()
-                    if isinstance(module, PreTrainedModel) and name != ""
-                )
+                sub_models_supporting_fa2 = [module._supports_flash_attn_2 for name, module in model.named_modules() if isinstance(module, PreTrainedModel) and name != ""]
+                supports_fa2_all_modules = all(sub_models_supporting_fa2) if len(sub_models_supporting_fa2) > 0 else False
                 if not supports_fa2_all_modules:
                     with self.assertRaises(ValueError):
                         model_fa2 = model_class.from_pretrained(


### PR DESCRIPTION
# What does this PR do?

We have currently

```python

                supports_fa2_all_modules = all(
                    module._supports_flash_attn_2
                    for name, module in model.named_modules()
                    if isinstance(module, PreTrainedModel) and name != ""
                )
```

But `all([])` is `True`.  The empty list happens for `SamModel` and `CLIPModel` for example, and `SamModel._supports_flash_attn_2 = False` and `CLIPModel._supports_flash_attn_2  = True`.

In this case, let's simplify define `supports_fa2_all_modules = model_class._supports_flash_attn_2`.