### PR TITLE
Processor: prevent duplicated tokens in apply_chat_template

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1246,6 +1246,7 @@ class ProcessorMixin(PushToHubMixin):
                 text=prompt,
                 images=images if images else None,
                 videos=videos if videos else None,
+                add_special_tokens=False,
                 **kwargs,
             )
             if return_dict:


### PR DESCRIPTION
# What does this PR do?

TLDR: `add_special_tokens=False` in `processor.apply_chat_template`

## Discussion

When using text-only LLMs, the chat template is expected to take care of adding the required special tokens, such as bos. Hence, [tokenization must not include special tokens](https://github.com/huggingface/transformers/blob/b5f327f350eaa8e53d8bdcaf14cd4a72307e1e8e/src/transformers/tokenization_utils_base.py#L1723).

The same contract should be honored by multimodal processors.

This is a [frequent cause of friction](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct/discussions/23#679801437d631a669438d0ab) for VLM users, because until now they had to prepare the input text and _then_ tokenize, so they needed to remember to include `add_special_tokens=False` in their code. With the new and great one-go API, this should work out of the box.

## Reproduction:

```python
from transformers import AutoProcessor

model_id = "meta-llama/Llama-3.2-11B-Vision-Instruct"
processor = AutoProcessor.from_pretrained(model_id)

url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/0052a70beed5bf71b92610a43a52df6d286cd5f3/diffusers/rabbit.jpg"

messages = [
    {"role": "user", "content": [
        {"type": "image", "url": url},
        {"type": "text", "text": "If I had to write a haiku for this one, it would be: "}
    ]}
]
input_ids = processor.apply_chat_template(
    messages,
    add_generation_prompt=True,
    tokenize=True,
)
print(processor.decode(input_ids[0]))
```

### Before:

```
<|begin_of_text|><|begin_of_text|><|start_header_id|>user<|end_header_id|>

<|image|>If I had to write a haiku for this one, it would be: <|eot_id|><|start_header_id|>assistant<|end_header_id|>
```

### After:

```
<|begin_of_text|><|start_header_id|>user<|end_header_id|>

<|image|>If I had to write a haiku for this one, it would be: <|eot_id|><|start_header_id|>assistant<|end_header_id|>
```
