### PR TITLE
[docs] fix model checkpoint name

### DIFF
--- a/docs/source/en/serialization.md
+++ b/docs/source/en/serialization.md
@@ -130,7 +130,7 @@ Alternative to CLI, you can export a 🤗 Transformers model to ONNX programmati
 >>> from optimum.onnxruntime import ORTModelForSequenceClassification
 >>> from transformers import AutoTokenizer
 
->>> model_checkpoint = "distilbert_base_uncased_squad"
+>>> model_checkpoint = "distilbert/distilbert-base-uncased-distilled-squad"
 >>> save_directory = "onnx/"
 
 >>> # Load a model from transformers and export it to ONNX


### PR DESCRIPTION
## What does this PR do?
The code snippet doesn't work because `distilbert_base_uncased_squad` doesn't exist in HuggingFace model hub. The correct one is `distilbert/distilbert-base-uncased-distilled-squad`.

Documentation: @stevhliu
