### PR TITLE
Processors: allow tuples of images when checking

### DIFF
--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -221,7 +221,7 @@ class Idefics2Processor(ProcessorMixin):
         if images is not None:
             if is_image_or_image_url(images):
                 images = [[images]]
-            elif isinstance(images, list) and is_image_or_image_url(images[0]):
+            elif isinstance(images, (list, tuple)) and is_image_or_image_url(images[0]):
                 if text is not None:
                     if sum(n_images_in_text) != len(images):
                         raise ValueError(
@@ -238,8 +238,8 @@ class Idefics2Processor(ProcessorMixin):
                     images = [images]
 
             elif (
-                not isinstance(images, list)
-                and not isinstance(images[0], list)
+                not isinstance(images, (list, tuple))
+                and not isinstance(images[0], (list, tuple))
                 and not is_image_or_image_url(images[0][0])
             ):
                 raise ValueError(

--- a/src/transformers/models/idefics3/processing_idefics3.py
+++ b/src/transformers/models/idefics3/processing_idefics3.py
@@ -252,7 +252,7 @@ class Idefics3Processor(ProcessorMixin):
         if images is not None:
             if is_image_or_image_url(images):
                 images = [[images]]
-            elif isinstance(images, list) and is_image_or_image_url(images[0]):
+            elif isinstance(images, (list, tuple)) and is_image_or_image_url(images[0]):
                 if text is not None:
                     if sum(n_images_in_text) != len(images):
                         raise ValueError(
@@ -268,8 +268,8 @@ class Idefics3Processor(ProcessorMixin):
                 else:
                     images = [images]
             elif (
-                not isinstance(images, list)
-                and not isinstance(images[0], list)
+                not isinstance(images, (list, tuple))
+                and not isinstance(images[0], (list, tuple))
                 and not is_image_or_image_url(images[0][0])
             ):
                 raise ValueError(

--- a/src/transformers/models/paligemma/processing_paligemma.py
+++ b/src/transformers/models/paligemma/processing_paligemma.py
@@ -19,7 +19,7 @@ Processor class for PaliGemma.
 from typing import List, Optional, Union
 
 from ...feature_extraction_utils import BatchFeature
-from ...image_utils import ImageInput, is_valid_image, make_flat_list_of_images
+from ...image_utils import ImageInput, is_valid_image, make_flat_list_of_images, make_nested_list_of_images
 from ...processing_utils import (
     ImagesKwargs,
     ProcessingKwargs,
@@ -256,13 +256,7 @@ class PaliGemmaProcessor(ProcessorMixin):
                         )
 
                 # make a nested list of lists to be able to iterate over the images and text below
-                if is_valid_image(images):
-                    images = [[images]]
-                elif isinstance(images, list) and is_valid_image(images[0]):
-                    images = [[image] for image in images]
-                elif not (isinstance(images, list) and isinstance(images[0], list) and is_valid_image(images[0][0])):
-                    raise ValueError("images must be an image, list of images or list of list of images")
-
+                images = make_nested_list_of_images(images)
                 input_strings = [
                     build_string_from_input(
                         prompt=prompt,

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -154,9 +154,13 @@ class PixtralProcessor(ProcessorMixin):
         if images is not None:
             if is_image_or_image_url(images):
                 images = [images]
-            elif isinstance(images, list) and is_image_or_image_url(images[0]):
+            elif isinstance(images, (list, tuple)) and is_image_or_image_url(images[0]):
                 pass
-            elif isinstance(images, list) and isinstance(images[0], list) and is_image_or_image_url(images[0][0]):
+            elif (
+                isinstance(images, (list, tuple))
+                and isinstance(images[0], (list, tuple))
+                and is_image_or_image_url(images[0][0])
+            ):
                 images = [image for sublist in images for image in sublist]
             else:
                 raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/36055

For the rest of models, we don't have a helper to `flatten_and_maybe_load_images` so I just modified code within `processing_xxx.py`. I don't think such a helper is a need for now, we prefer to not allow users to load images like that, and promote proper usage of chat templates