### PR TITLE
fix: dtype might change during resize

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -366,6 +366,7 @@ def resize(
     # To maintain backwards compatibility with the resizing done in previous image feature extractors, we use
     # the pillow library to resize the image and then convert back to numpy
     do_rescale = False
+    original_type = image.dtype
     if not isinstance(image, PIL.Image.Image):
         do_rescale = _rescale_for_pil_conversion(image)
         image = to_pil_image(image, do_rescale=do_rescale, input_data_format=input_data_format)
@@ -385,6 +386,7 @@ def resize(
         # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
         # rescale it back to the original range.
         resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
+        resized_image = resized_image.astype(original_type)
     return resized_image
 
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -366,10 +366,12 @@ def resize(
     # To maintain backwards compatibility with the resizing done in previous image feature extractors, we use
     # the pillow library to resize the image and then convert back to numpy
     do_rescale = False
-    original_type = image.dtype
+    original_type = None
     if not isinstance(image, PIL.Image.Image):
+        original_type = image.dtype
         do_rescale = _rescale_for_pil_conversion(image)
         image = to_pil_image(image, do_rescale=do_rescale, input_data_format=input_data_format)
+
     height, width = size
     # PIL images are in the format (width, height)
     resized_image = image.resize((width, height), resample=resample, reducing_gap=reducing_gap)
@@ -386,7 +388,9 @@ def resize(
         # If an image was rescaled to be in the range [0, 255] before converting to a PIL image, then we need to
         # rescale it back to the original range.
         resized_image = rescale(resized_image, 1 / 255) if do_rescale else resized_image
-        resized_image = resized_image.astype(original_type)
+        # convert back to original type if original image was np.ndarray
+        if original_type is not None:
+            resized_image = resized_image.astype(original_type)
     return resized_image
 
 

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -277,6 +277,11 @@ class ImageTransformsTester(unittest.TestCase):
         self.assertIsInstance(resized_image, np.ndarray)
         self.assertEqual(resized_image.shape, (4, 30, 40))
 
+        # check that resize keeps dtype
+        image = np.zeros((1, 128, 128), dtype=np.float32)
+        resized_image = resize(image, size=(64, 64))
+        self.assertEqual(image.dtype, resized_image.dtype)
+
     def test_normalize(self):
         image = np.random.randint(0, 256, (224, 224, 3)) / 255
 


### PR DESCRIPTION
# What does this PR do?

I noticed a small bug, where an np.ndarray changes dtype when calling resize:

```python
import numpy as np
from transformers.image_transforms import resize

x = np.zeros((3, 100, 100), dtype=np.float32)
print(x.dtype) # prints np.float32
x = resize(x, size=(50, 50))
print(x.dtype) # prints np.uint8`
```

When using natural numbers in a float array, the image is not rescaled and converted into a `PIL.Image` as-is but when returning back to a numpy array, the type stays `uint8`.

This PR, stores the original dtype and casts the array back to this type before returning. I also added tests to check for this behavior in the future. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

I think @amyeroberts might be best suited since she wrote lots of surrounding code. 
