### PR TITLE
Fix: Llama - adjust the rotary embedding dimensions.

### DIFF
--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -460,6 +460,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/chameleon/modeling_chameleon.py
+++ b/src/transformers/models/chameleon/modeling_chameleon.py
@@ -176,6 +176,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -107,6 +107,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -106,6 +106,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -119,6 +119,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -104,6 +104,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -182,6 +182,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -121,6 +121,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
+++ b/src/transformers/models/gpt_neox_japanese/modeling_gpt_neox_japanese.py
@@ -314,6 +314,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/granite/modeling_granite.py
+++ b/src/transformers/models/granite/modeling_granite.py
@@ -77,6 +77,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/granitemoe/modeling_granitemoe.py
+++ b/src/transformers/models/granitemoe/modeling_granitemoe.py
@@ -248,6 +248,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -479,6 +479,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -170,6 +170,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/mimi/modeling_mimi.py
+++ b/src/transformers/models/mimi/modeling_mimi.py
@@ -456,6 +456,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -87,6 +87,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -200,6 +200,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -641,6 +641,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -330,6 +330,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/moshi/modeling_moshi.py
+++ b/src/transformers/models/moshi/modeling_moshi.py
@@ -400,6 +400,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -93,6 +93,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/olmo2/modeling_olmo2.py
+++ b/src/transformers/models/olmo2/modeling_olmo2.py
@@ -82,6 +82,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/olmoe/modeling_olmoe.py
+++ b/src/transformers/models/olmoe/modeling_olmoe.py
@@ -250,6 +250,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/persimmon/modeling_persimmon.py
+++ b/src/transformers/models/persimmon/modeling_persimmon.py
@@ -148,6 +148,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -70,6 +70,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -104,6 +104,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -87,6 +87,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -259,6 +259,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/recurrent_gemma/modeling_recurrent_gemma.py
+++ b/src/transformers/models/recurrent_gemma/modeling_recurrent_gemma.py
@@ -124,6 +124,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/stablelm/modeling_stablelm.py
+++ b/src/transformers/models/stablelm/modeling_stablelm.py
@@ -154,6 +154,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -107,6 +107,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -350,6 +350,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
+
+    # Adjust the rotary embedding dimensions if they don't match q's last dimension.
+    if cos.shape[-1] != q.shape[-1]:
+        cos = cos[..., : q.shape[-1]]
+        sin = sin[..., : q.shape[-1]]
+
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed


### PR DESCRIPTION
# What does this PR do?

I noticed a small bug with llama-3.1-8B-Instruct where rotary embedding dimensions don't match q's last dimension. This PR  adjusts the rotary embedding dimensions if they don't match q's last dimension.

## Description of the fix

I use hidden_size=4096, num_hidden_layers=32, num_attention_heads=32 and num_key_value_heads=32 in my model configuration. When I try to get the model's input embeddings using input_ids, `apply_rotary_pos_emb` raises a runtime error because of unmatched tensor dimensions.

This fix checks if the last dimension of cos (and sin) matches the last dimension of q. If not, it slices cos and sin along their last dimension so that they have the same size as q. This is important because the mismatch (e.g., 128 vs. 32) causes the multiplication (q * cos) to fail.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

I think @ArthurZucker might be the best person to review this PR.