### PR TITLE
Fix OS err

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3153,7 +3153,6 @@ class Trainer:
                         self.state.stateful_callbacks[cb_name] = cb_state
                 self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
 
-            with self.accelerator.local_main_process_first():
                 if os.path.exists(output_dir):
                     try:
                         os.renames(output_dir, checkpoint_dir)


### PR DESCRIPTION
# What does this PR do?

There's an issue with https://github.com/huggingface/transformers/pull/35580 where if we have too many GPUs, we hit race conditions while trying to do the `os.rename`/move. Since we only need this once per node, really it just needs to happen under `args.should_save` (since that will make it happen only once per node or per instance as a whole if not doing save-on-each-node). 

This PR fixes this race condition.

I tested it on the cluster on 8 GPUs, which replicated the issue

Fixes https://github.com/huggingface/transformers/issues/36076


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 