### PR TITLE
fix torch.export on torch=2.5.1 for llama

### DIFF
--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -954,7 +954,8 @@ class AriaTextModel(AriaTextPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -604,7 +604,8 @@ class CohereModel(CoherePreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -843,7 +843,8 @@ class DiffLlamaModel(DiffLlamaPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1422,7 +1422,8 @@ class Emu3TextModel(Emu3PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -585,7 +585,8 @@ class GlmModel(GlmPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -572,7 +572,8 @@ class HeliumModel(HeliumPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -574,7 +574,8 @@ class LlamaModel(LlamaPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -546,7 +546,8 @@ class MistralModel(MistralPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -550,7 +550,8 @@ class OlmoModel(OlmoPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/olmo2/modeling_olmo2.py
+++ b/src/transformers/models/olmo2/modeling_olmo2.py
@@ -551,7 +551,8 @@ class Olmo2Model(Olmo2PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -616,7 +616,8 @@ class Phi3Model(Phi3PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -559,7 +559,8 @@ class Qwen2Model(Qwen2PreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
 
-        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        for idx in range(self.config.num_hidden_layers):
+            decoder_layer = self.layers[idx]
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 


### PR DESCRIPTION
This pr fixes torch.export for llama models and torch=2.5.1

In transformers 4.46.3 the loop was:

```
for decoder_layer in self.layers:
```

which got changed in 4.48 to:

```
for decoder_layer in self.layers[: self.config.num_hidden_layers]:
```

which works with torch=2.6 but breaks using torch 2.5.1

error on torch=2.5.1:

```
  File "/home/ziereis/forks/transformers/src/transformers/models/llama/modeling_llama.py", line 577, in forward
    for decoder_layer in self.layers[: self.config.num_hidden_layers]:
                         ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ziereis/conda/envs/roofdev/lib/python3.11/site-packages/torch/nn/modules/container.py", line 332, in __getitem__
    return self.__class__(list(self._modules.values())[idx])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _ModuleStackTracer.__init__.<locals>.AttrProxy.__init__() missing 1 required positional argument: 'path'
```
