### PR TITLE
Make `check_repository_consistency` run faster by MP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/installed.txt
             - run: python utils/check_copies.py
-            - run: python utils/check_modular_conversion.py
+            - run: python utils/check_modular_conversion.py --num_workers 4
             - run: python utils/check_table.py
             - run: python utils/check_dummies.py
             - run: python utils/check_repo.py

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -156,6 +156,7 @@ if __name__ == "__main__":
 
         new_ordered_files = ordered_files
         import multiprocessing
+
         with multiprocessing.Pool(4) as p:
             outputs = p.map(compare_files, new_ordered_files)
         for output in outputs:

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -121,7 +121,10 @@ if __name__ == "__main__":
         "--fix_and_overwrite", action="store_true", help="Overwrite the modeling_xxx.py file if differences are found."
     )
     parser.add_argument(
-        "--num_workers", default=1, type=int, help="The number of workers to run. No effect if `fix_and_overwrite` is specified."
+        "--num_workers",
+        default=1,
+        type=int,
+        help="The number of workers to run. No effect if `fix_and_overwrite` is specified.",
     )
     args = parser.parse_args()
     if args.files == ["all"]:

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -120,6 +120,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--fix_and_overwrite", action="store_true", help="Overwrite the modeling_xxx.py file if differences are found."
     )
+    parser.add_argument(
+        "--num_workers", default=1, type=int, help="The number of workers to run. No effect if `fix_and_overwrite` is specified."
+    )
     args = parser.parse_args()
     if args.files == ["all"]:
         args.files = glob.glob("src/transformers/models/**/modular_*.py", recursive=True)
@@ -135,7 +138,7 @@ if __name__ == "__main__":
     skipped_models = set()
     non_matching_files = 0
     ordered_files, dependencies = find_priority_list(args.files)
-    if args.fix_and_overwrite:
+    if args.fix_and_overwrite or args.num_workers == 1:
         for modular_file_path in ordered_files:
             is_guaranteed_no_diff = guaranteed_no_diff(modular_file_path, dependencies, models_in_diff)
             if is_guaranteed_no_diff:


### PR DESCRIPTION
# What does this PR do?

It takes 3 minutes on `main`. This PR simply uses `multiprocessing` to make it faster.
