### PR TITLE
CI: fix `test-save-trainer`

### DIFF
--- a/tests/test_training_args.py
+++ b/tests/test_training_args.py
@@ -9,7 +9,7 @@ class TestTrainingArguments(unittest.TestCase):
     def test_default_output_dir(self):
         """Test that output_dir defaults to 'tmp_trainer' when not specified."""
         args = TrainingArguments(output_dir=None)
-        self.assertEqual(args.output_dir, "tmp_trainer")
+        self.assertEqual(args.output_dir, "trainer_output")
 
     def test_custom_output_dir(self):
         """Test that output_dir is respected when specified."""

--- a/tests/test_training_args.py
+++ b/tests/test_training_args.py
@@ -7,7 +7,7 @@ from transformers import TrainingArguments
 
 class TestTrainingArguments(unittest.TestCase):
     def test_default_output_dir(self):
-        """Test that output_dir defaults to 'tmp_trainer' when not specified."""
+        """Test that output_dir defaults to 'trainer_output' when not specified."""
         args = TrainingArguments(output_dir=None)
         self.assertEqual(args.output_dir, "trainer_output")
 


### PR DESCRIPTION
# What does this PR do?

As per title, fixes the test. The default directory is indeed called `trainer_output`, so the test is not correctly checking it