### PR TITLE
Add @require_bitsandbytes to Aria test_batched_generation

### DIFF
--- a/tests/models/aria/test_modeling_aria.py
+++ b/tests/models/aria/test_modeling_aria.py
@@ -428,6 +428,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch
     @require_vision
+    @require_bitsandbytes
     def test_batched_generation(self):
         model = AriaForConditionalGeneration.from_pretrained("rhymes-ai/Aria", load_in_4bit=True)
 


### PR DESCRIPTION
I noticed this test seems to require bitsandbytes but has not been marked as such.