### PR TITLE
Use `args.num_workers` in `check_modular_conversion.py`

### DIFF
--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
 
         import multiprocessing
 
-        with multiprocessing.Pool(4) as p:
+        with multiprocessing.Pool(args.num_workers) as p:
             outputs = p.map(compare_files, new_ordered_files)
         for output in outputs:
             non_matching_files += output


### PR DESCRIPTION
# What does this PR do?

Another mistake I forgot to update before merge in #36175