### PR TITLE
Append best model checkpoint with active adapter when not default

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1,4 +1,3 @@
-Trainer.py
 # coding=utf-8
 # Copyright 2020-present the HuggingFace Inc. team.
 #
@@ -3179,7 +3178,11 @@ class Trainer:
                         self.model, "load_adapter"
                     ):
                         active_adapter = self._active_adapter_bc(self.model)
-                        output_dir = str(os.path.join(output_dir, active_adapter)) if active_adapter != "default" else output_dir
+                        output_dir = (
+                            str(os.path.join(output_dir, active_adapter))
+                            if active_adapter != "default"
+                            else output_dir
+                        )
                 self.state.best_model_checkpoint = output_dir
 
                 is_new_best_metric = True


### PR DESCRIPTION
# What does this PR do?

When a `PeftModel` is instantiated with an `adapter_name` different than `"default"`, the `Trainer` is unable to find the `best_model_checkpoint` because the path is set without the `adapter_name`.
This happens when `load_best_model_at_end=True`



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
