### PR TITLE
Fix the eval_use_gather_object flag usage

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4357,6 +4357,10 @@ class Trainer:
 
         # After all calls to `.gather_function`, reset to `gather_for_metrics`:
         self.gather_function = self.accelerator.gather_for_metrics
+        if "use_gather_object" in inspect.signature(self.gather_function).parameters.keys():
+            self.gather_function = functools.partial(
+                self.gather_function, use_gather_object=self.args.eval_use_gather_object
+            )
         if args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of the evaluation loop
             delattr(self, "_past")


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/36213

After the first eval, the 2nd eval is crashing, while trying to concat batches with different shapes, as if the flag` eval_use_gather_object` stopped working. In evaluation_loop, the `self.gather_function` is reset, and the `eval_use_gather_object` is not used

This PR fixes that, using the same code line, which is used at accelerator creation.

@muellerzr and @SunMarc
