### PR TITLE
[tests] fix bnb test bug 

### DIFF
--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -335,13 +335,13 @@ class EsmModelIntegrationTest(TestCasePlus):
     def test_inference_bitsandbytes(self):
         model = EsmForMaskedLM.from_pretrained("facebook/esm2_t36_3B_UR50D", load_in_8bit=True)
 
-        input_ids = torch.tensor([[0, 6, 4, 13, 5, 4, 16, 12, 11, 7, 2]])
+        input_ids = torch.tensor([[0, 6, 4, 13, 5, 4, 16, 12, 11, 7, 2]]).to(model.device)
         # Just test if inference works
         with torch.no_grad():
             _ = model(input_ids)[0]
 
         model = EsmForMaskedLM.from_pretrained("facebook/esm2_t36_3B_UR50D", load_in_4bit=True)
 
-        input_ids = torch.tensor([[0, 6, 4, 13, 5, 4, 16, 12, 11, 7, 2]])
+        input_ids = torch.tensor([[0, 6, 4, 13, 5, 4, 16, 12, 11, 7, 2]]).to(model.device)
         # Just test if inference works
         _ = model(input_ids)[0]


### PR DESCRIPTION
## What does this PR do?
Currently, the below test fails:

```bash
pytest -rA tests/models/esm/test_modeling_esm.py::EsmModelIntegrationTest::test_inference_bitsandbytes
```

```bash
>       return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
E       RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper_CUDA__index_select)

../../miniforge3/envs/hf-dev/lib/python3.10/site-packages/torch/nn/functional.py:2551: RuntimeError
----------------------------------------------------------- Captured stderr call -----------------------------------------------------------
The `load_in_4bit` and `load_in_8bit` arguments are deprecated and will be removed in the future versions. Please, pass a `BitsAndBytesConfig` object in `quantization_config` argument instead.
`low_cpu_mem_usage` was None, now default to True since model is quantized.
Loading checkpoint shards: 100%|██████████| 2/2 [00:01<00:00,  1.17it/s]
========================================================= short test summary info ==========================================================
FAILED tests/models/esm/test_modeling_esm.py::EsmModelIntegrationTest::test_inference_bitsandbytes - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument fo...
```
This PR fixes it.

cc @ydshieh 