### PR TITLE
load once first before memory measure for `test_from_pretrained_low_cpu_mem_usage_equal`

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1003,6 +1003,9 @@ class ModelUtilsTest(TestCasePlus):
 
         mname = "hf-internal-testing/tiny-random-bert"
 
+        # let's do it once to get a local cache first
+        AutoModel.from_pretrained(mname, low_cpu_mem_usage=False)
+
         preamble = "from transformers import AutoModel"
         one_liner_str = f'{preamble}; AutoModel.from_pretrained("{mname}", low_cpu_mem_usage=False)'
         # Save this output as `max_rss_normal` if testing memory results


### PR DESCRIPTION
# What does this PR do?

I don't have any valid theory, but this tests fails (almost every time) if there is no local cache.
Once we have a local cache, it seems passing all the time.