### PR TITLE
[WIP] Set default processing device to best available device in fast image processors

### DIFF
--- a/src/transformers/image_processing_utils_fast.py
+++ b/src/transformers/image_processing_utils_fast.py
@@ -300,6 +300,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
         self.crop_size = get_size_dict(crop_size, param_name="crop_size") if crop_size is not None else None
 
         self.device = kwargs.pop("device", get_best_available_device())
+        print("self.device: ", self.device)
 
         for key in self.valid_init_kwargs.__annotations__.keys():
             kwarg = kwargs.pop(key, None)
@@ -689,6 +690,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
     def to_dict(self):
         encoder_dict = super().to_dict()
         encoder_dict.pop("_valid_processor_keys", None)
+        encoder_dict.pop("device", None)
         return encoder_dict
 
 

--- a/src/transformers/image_processing_utils_fast.py
+++ b/src/transformers/image_processing_utils_fast.py
@@ -300,7 +300,6 @@ class BaseImageProcessorFast(BaseImageProcessor):
         self.crop_size = get_size_dict(crop_size, param_name="crop_size") if crop_size is not None else None
 
         self.device = kwargs.pop("device", get_best_available_device())
-        print("self.device: ", self.device)
 
         for key in self.valid_init_kwargs.__annotations__.keys():
             kwarg = kwargs.pop(key, None)


### PR DESCRIPTION
# What does this PR do?

Process images on the best available device instead of choosing cpu by default, as discussed with Arthur. 
This could be impactful as fast image processors are muuch faster on GPU than cpu, however right now users have to manually specify the device on which to process the image, which is not intuitive as slow image processor don't support a device kwarg.

However this introduces several questions, mainly, if a device is not passed, and for example cuda:0 is chosen as the best device, once processing is done, should we keep the output tensors on cuda or forced them back to cpu?

Forcing them back would be a waste if we do want to use these inputs on cuda, but if we don't force them back to cpu, we will have backward compatibility problems such as:

```python
import torch
import requests

from PIL import Image
from transformers import RTDetrV2ForObjectDetection, RTDetrImageProcessorFast

url = 'http://images.cocodataset.org/val2017/000000039769.jpg'
image = Image.open(requests.get(url, stream=True).raw)

image_processor = RTDetrImageProcessorFast.from_pretrained("PekingU/rtdetr_v2_r50vd")
model = RTDetrV2ForObjectDetection.from_pretrained("PekingU/rtdetr_v2_r50vd")

inputs = image_processor(images=image, return_tensors="pt")

with torch.no_grad():
     outputs = model(**inputs)
```

will raise an error as the model and inputs are not on the same device.

I guess for this PR to work, we would need to do something similar for models, where the best available device would be chosen by default when instantiating them.

Would love to know your thoughts @ArthurZucker @Rocketknight1 @ydshieh 🤗


