### PR TITLE
Clean-up: `get_patch_output_size` can be removed

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import Dict, Iterable, Optional, Union
 
 import numpy as np
 
 from .image_processing_base import BatchFeature, ImageProcessingMixin
 from .image_transforms import center_crop, normalize, rescale
-from .image_utils import ChannelDimension, get_image_size
+from .image_utils import ChannelDimension
 from .utils import logging
 
 
@@ -286,23 +285,3 @@ def select_best_resolution(original_size: tuple, possible_resolutions: list) -> 
             best_fit = (height, width)
 
     return best_fit
-
-
-def get_patch_output_size(image, target_resolution, input_data_format):
-    """
-    Given an image and a target resolution, calculate the output size of the image after cropping to the target
-    """
-    original_height, original_width = get_image_size(image, channel_dim=input_data_format)
-    target_height, target_width = target_resolution
-
-    scale_w = target_width / original_width
-    scale_h = target_height / original_height
-
-    if scale_w < scale_h:
-        new_width = target_width
-        new_height = min(math.ceil(original_height * scale_w), target_height)
-    else:
-        new_height = target_height
-        new_width = min(math.ceil(original_width * scale_h), target_width)
-
-    return new_height, new_width

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import base64
+import math
 import os
 from contextlib import redirect_stdout
 from dataclasses import dataclass
@@ -453,8 +454,8 @@ def get_image_size_for_max_height_width(
     height_scale = max_height / height
     width_scale = max_width / width
     min_scale = min(height_scale, width_scale)
-    new_height = int(height * min_scale)
-    new_width = int(width * min_scale)
+    new_height = math.ceil(height * min_scale)
+    new_width = math.ceil(width * min_scale)
     return new_height, new_width
 
 

--- a/src/transformers/models/aria/modular_aria.py
+++ b/src/transformers/models/aria/modular_aria.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -27,6 +26,7 @@ from ...image_utils import (
     ImageInput,
     PILImageResampling,
     get_image_size,
+    get_image_size_for_max_height_width,
     infer_channel_dimension_format,
     make_flat_list_of_images,
     to_numpy_array,
@@ -456,23 +456,6 @@ class AriaProjector(nn.Module):
         return out
 
 
-def _get_patch_output_size(image, target_resolution, input_data_format):
-    original_height, original_width = get_image_size(image, channel_dim=input_data_format)
-    target_height, target_width = target_resolution
-
-    scale_w = target_width / original_width
-    scale_h = target_height / original_height
-
-    if scale_w < scale_h:
-        new_width = target_width
-        new_height = min(math.ceil(original_height * scale_w), target_height)
-    else:
-        new_height = target_height
-        new_width = min(math.ceil(original_width * scale_h), target_width)
-
-    return new_height, new_width
-
-
 class AriaImageProcessor(BaseImageProcessor):
     """
     A vision processor for the Aria model that handles image preprocessing.
@@ -729,7 +712,11 @@ class AriaImageProcessor(BaseImageProcessor):
         Returns:
             np.array: The resized and padded image.
         """
-        new_height, new_width = _get_patch_output_size(image, target_resolution, input_data_format)
+        target_height, target_width = target_resolution
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         # Resize the image
         resized_image = resize(image, (new_height, new_width), resample=resample, input_data_format=input_data_format)
@@ -743,7 +730,10 @@ class AriaImageProcessor(BaseImageProcessor):
         Pad an image to a target resolution while maintaining aspect ratio.
         """
         target_height, target_width = target_resolution
-        new_height, new_width = _get_patch_output_size(image, target_resolution, input_data_format)
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         paste_x = (target_width - new_width) // 2
         paste_y = (target_height - new_height) // 2

--- a/src/transformers/models/llava_next/image_processing_llava_next.py
+++ b/src/transformers/models/llava_next/image_processing_llava_next.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Image processor class for LLaVa-NeXT."""
 
-import math
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -35,6 +34,7 @@ from ...image_utils import (
     ImageInput,
     PILImageResampling,
     get_image_size,
+    get_image_size_for_max_height_width,
     infer_channel_dimension_format,
     is_scaled_image,
     make_flat_list_of_images,
@@ -97,23 +97,6 @@ def expand_to_square(image: np.array, background_color, input_data_format) -> np
         result = np.ones((height, height, image.shape[2]), dtype=image.dtype) * background_color
         result[:, (height - width) // 2 : (height - width) // 2 + width] = image
         return result
-
-
-def _get_patch_output_size(image, target_resolution, input_data_format):
-    original_height, original_width = get_image_size(image, channel_dim=input_data_format)
-    target_height, target_width = target_resolution
-
-    scale_w = target_width / original_width
-    scale_h = target_height / original_height
-
-    if scale_w < scale_h:
-        new_width = target_width
-        new_height = min(math.ceil(original_height * scale_w), target_height)
-    else:
-        new_height = target_height
-        new_width = min(math.ceil(original_width * scale_h), target_width)
-
-    return new_height, new_width
 
 
 class LlavaNextImageProcessor(BaseImageProcessor):
@@ -429,7 +412,11 @@ class LlavaNextImageProcessor(BaseImageProcessor):
         Returns:
             np.array: The resized and padded image.
         """
-        new_height, new_width = _get_patch_output_size(image, target_resolution, input_data_format)
+        target_height, target_width = target_resolution
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         # Resize the image
         resized_image = resize(image, (new_height, new_width), resample=resample, input_data_format=input_data_format)
@@ -443,8 +430,10 @@ class LlavaNextImageProcessor(BaseImageProcessor):
         Pad an image to a target resolution while maintaining aspect ratio.
         """
         target_height, target_width = target_resolution
-        new_height, new_width = _get_patch_output_size(image, target_resolution, input_data_format)
-
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
         paste_x = (target_width - new_width) // 2
         paste_y = (target_height - new_height) // 2
 

--- a/src/transformers/models/llava_next/image_processing_llava_next_fast.py
+++ b/src/transformers/models/llava_next/image_processing_llava_next_fast.py
@@ -16,7 +16,7 @@
 
 from typing import List, Optional, Union
 
-from ...image_processing_utils import BatchFeature, get_patch_output_size, select_best_resolution
+from ...image_processing_utils import BatchFeature, select_best_resolution
 from ...image_processing_utils_fast import (
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING,
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING_PREPROCESS,
@@ -35,6 +35,7 @@ from ...image_utils import (
     PILImageResampling,
     SizeDict,
     get_image_size,
+    get_image_size_for_max_height_width,
     make_flat_list_of_images,
 )
 from ...processing_utils import Unpack
@@ -157,7 +158,11 @@ class LlavaNextImageProcessorFast(BaseImageProcessorFast):
         Returns:
             "torch.Tensor": The resized and padded image.
         """
-        new_height, new_width = get_patch_output_size(image, target_resolution, input_data_format)
+        target_height, target_width = target_resolution
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         # Resize the image
         resized_image = F.resize(image, (new_height, new_width), interpolation=interpolation)
@@ -171,7 +176,10 @@ class LlavaNextImageProcessorFast(BaseImageProcessorFast):
         Pad an image to a target resolution while maintaining aspect ratio.
         """
         target_height, target_width = target_resolution
-        new_height, new_width = get_patch_output_size(image, target_resolution, input_data_format)
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         paste_x = (target_width - new_width) // 2
         paste_y = (target_height - new_height) // 2

--- a/src/transformers/models/llava_onevision/image_processing_llava_onevision_fast.py
+++ b/src/transformers/models/llava_onevision/image_processing_llava_onevision_fast.py
@@ -7,7 +7,7 @@
 
 from typing import List, Optional, Union
 
-from ...image_processing_utils import BatchFeature, get_patch_output_size, select_best_resolution
+from ...image_processing_utils import BatchFeature, select_best_resolution
 from ...image_processing_utils_fast import (
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING,
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING_PREPROCESS,
@@ -26,6 +26,7 @@ from ...image_utils import (
     PILImageResampling,
     SizeDict,
     get_image_size,
+    get_image_size_for_max_height_width,
     make_flat_list_of_images,
 )
 from ...processing_utils import Unpack
@@ -139,7 +140,11 @@ class LlavaOnevisionImageProcessorFast(BaseImageProcessorFast):
         Returns:
             "torch.Tensor": The resized and padded image.
         """
-        new_height, new_width = get_patch_output_size(image, target_resolution, input_data_format)
+        target_height, target_width = target_resolution
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         # Resize the image
         resized_image = F.resize(image, (new_height, new_width), interpolation=interpolation)
@@ -153,7 +158,10 @@ class LlavaOnevisionImageProcessorFast(BaseImageProcessorFast):
         Pad an image to a target resolution while maintaining aspect ratio.
         """
         target_height, target_width = target_resolution
-        new_height, new_width = get_patch_output_size(image, target_resolution, input_data_format)
+        height, width = get_image_size(image)
+        new_height, new_width = get_image_size_for_max_height_width(
+            (height, width), max_height=target_height, max_width=target_width
+        )
 
         paste_x = (target_width - new_width) // 2
         paste_y = (target_height - new_height) // 2

--- a/tests/test_training_args.py
+++ b/tests/test_training_args.py
@@ -9,7 +9,7 @@ class TestTrainingArguments(unittest.TestCase):
     def test_default_output_dir(self):
         """Test that output_dir defaults to 'tmp_trainer' when not specified."""
         args = TrainingArguments(output_dir=None)
-        self.assertEqual(args.output_dir, "tmp_trainer")
+        self.assertEqual(args.output_dir, "trainer_output")
 
     def test_custom_output_dir(self):
         """Test that output_dir is respected when specified."""


### PR DESCRIPTION
# What does this PR do?

As per title, removing redundant helpers :)

The tests for the models are passing and I verified that both helpers are identical, except for one ceils up and the other rounds down. Not much of a difference imo, and I opted for `ceil` because that's what we do in modeling code when postprocessing llava image features