### PR TITLE
Add BidirectionalWordpieceTokenizer for improved Korean/Japanese tokenization

### DIFF
--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -509,7 +509,8 @@ class BidirectionalWordpieceTokenizer(WordpieceTokenizer):
 
     def __init__(self, vocab, unk_token="[UNK]", max_input_chars_per_word=100):
         super().__init__(vocab=vocab, unk_token=unk_token, max_input_chars_per_word=max_input_chars_per_word)
-        self.backward_vocab = {k[::-1]: v for k, v in vocab.items()}
+        self.forward_vocab = vocab
+        self.backward_vocab = {k[::-1]: v for k, v in self.forward_vocab.items()}
 
     def tokenize(self, text):
         """Tokenizes a piece of text into its word pieces using bidirectional tokenization.
@@ -544,14 +545,14 @@ class BidirectionalWordpieceTokenizer(WordpieceTokenizer):
                     substr = "".join(chars[start:end])
                     if start > 0:
                         substr = "##" + substr
-                    if substr in self.vocab:
+                    if substr in self.forward_vocab:
                         cur_substr = substr
                         break
                     end -= 1
                 if cur_substr is None:
                     is_bad_forward = True
                     break
-                forward_sub_tokens.append((cur_substr, self.vocab[cur_substr]))
+                forward_sub_tokens.append((cur_substr, self.forward_vocab[cur_substr]))
                 start = end
 
             # Backward tokenization

--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -506,6 +506,7 @@ class WordpieceTokenizer:
 
 class BidirectionalWordpieceTokenizer(WordpieceTokenizer):
     """Runs WordPiece tokenization with bidirectional support."""
+
     def __init__(self, vocab, unk_token="[UNK]", max_input_chars_per_word=100):
         super().__init__(vocab=vocab, unk_token=unk_token, max_input_chars_per_word=max_input_chars_per_word)
         self.backward_vocab = {k[::-1]: v for k, v in vocab.items()}

--- a/src/transformers/models/bert/tokenization_bert.py
+++ b/src/transformers/models/bert/tokenization_bert.py
@@ -504,4 +504,86 @@ class WordpieceTokenizer:
         return output_tokens
 
 
-__all__ = ["BasicTokenizer", "BertTokenizer", "WordpieceTokenizer"]
+class BidirectionalWordpieceTokenizer(WordpieceTokenizer):
+    """Runs WordPiece tokenization with bidirectional support."""
+    def __init__(self, vocab, unk_token="[UNK]", max_input_chars_per_word=100):
+        super().__init__(vocab=vocab, unk_token=unk_token, max_input_chars_per_word=max_input_chars_per_word)
+        self.backward_vocab = {k[::-1]: v for k, v in vocab.items()}
+
+    def tokenize(self, text):
+        """Tokenizes a piece of text into its word pieces using bidirectional tokenization.
+
+        This uses a greedy longest-match-first algorithm to perform tokenization using both forward
+        and backward vocabularies, choosing the better tokenization. The algorithm tries both forward
+        and backward tokenization and selects the one that produces fewer tokens.
+
+        Args:
+            text: A single token or whitespace separated tokens. This should have
+                already been passed through BasicTokenizer.
+
+        Returns:
+            A list of wordpiece tokens.
+        """
+        output_tokens = []
+
+        for token in whitespace_tokenize(text):
+            chars = list(token)
+            if len(chars) > self.max_input_chars_per_word:
+                output_tokens.append(self.unk_token)
+                continue
+
+            # Forward tokenization
+            is_bad_forward = False
+            start = 0
+            forward_sub_tokens = []
+            while start < len(chars):
+                end = len(chars)
+                cur_substr = None
+                while start < end:
+                    substr = "".join(chars[start:end])
+                    if start > 0:
+                        substr = "##" + substr
+                    if substr in self.vocab:
+                        cur_substr = substr
+                        break
+                    end -= 1
+                if cur_substr is None:
+                    is_bad_forward = True
+                    break
+                forward_sub_tokens.append((cur_substr, self.vocab[cur_substr]))
+                start = end
+
+            # Backward tokenization
+            is_bad_backward = False
+            start = len(chars)
+            backward_sub_tokens = []
+            while start > 0:
+                end = 0
+                cur_substr = None
+                while start > end:
+                    substr = "".join(chars[end:start][::-1])
+                    if start < len(chars):
+                        substr = substr + "##"
+                    if substr in self.backward_vocab:
+                        cur_substr = substr
+                        break
+                    end += 1
+                if cur_substr is None:
+                    is_bad_backward = True
+                    break
+                backward_sub_tokens.append((cur_substr[::-1], self.backward_vocab[cur_substr]))
+                start = end
+
+            # Choose better tokenization
+            if is_bad_forward and is_bad_backward:
+                output_tokens.append(self.unk_token)
+            else:
+                if is_bad_backward or (not is_bad_forward and len(forward_sub_tokens) <= len(backward_sub_tokens)):
+                    output_tokens.extend([t for t, _ in forward_sub_tokens])
+                else:
+                    output_tokens.extend([t for t, _ in reversed(backward_sub_tokens)])
+
+        return output_tokens
+
+
+__all__ = ["BasicTokenizer", "BertTokenizer", "WordpieceTokenizer", "BidirectionalWordpieceTokenizer"]

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -22,6 +22,7 @@ from transformers.models.bert.tokenization_bert import (
     VOCAB_FILES_NAMES,
     BasicTokenizer,
     BertTokenizer,
+    BidirectionalWordpieceTokenizer,
     WordpieceTokenizer,
     _is_control,
     _is_punctuation,
@@ -201,6 +202,21 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         self.assertListEqual(tokenizer.tokenize("unwanted running"), ["un", "##want", "##ed", "runn", "##ing"])
 
+        self.assertListEqual(tokenizer.tokenize("unwantedX running"), ["[UNK]", "runn", "##ing"])
+
+    def test_bidirectional_wordpiece_tokenizer(self):
+        vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn", "##ing"]
+        
+        vocab = {}
+        for i, token in enumerate(vocab_tokens):
+            vocab[token] = i
+
+        tokenizer = BidirectionalWordpieceTokenizer(vocab=vocab, unk_token="[UNK]")
+
+        self.assertListEqual(tokenizer.tokenize(""), [])
+        
+        self.assertListEqual(tokenizer.tokenize("unwanted running"), ["un", "##want", "##ed", "runn", "##ing"])
+        
         self.assertListEqual(tokenizer.tokenize("unwantedX running"), ["[UNK]", "runn", "##ing"])
 
     def test_is_whitespace(self):

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -206,7 +206,7 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
     def test_bidirectional_wordpiece_tokenizer(self):
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn", "##ing"]
-        
+
         vocab = {}
         for i, token in enumerate(vocab_tokens):
             vocab[token] = i
@@ -214,9 +214,9 @@ class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokenizer = BidirectionalWordpieceTokenizer(vocab=vocab, unk_token="[UNK]")
 
         self.assertListEqual(tokenizer.tokenize(""), [])
-        
+
         self.assertListEqual(tokenizer.tokenize("unwanted running"), ["un", "##want", "##ed", "runn", "##ing"])
-        
+
         self.assertListEqual(tokenizer.tokenize("unwantedX running"), ["[UNK]", "runn", "##ing"])
 
     def test_is_whitespace(self):


### PR DESCRIPTION
This PR adds a new BidirectionalWordpieceTokenizer class that supports bidirectional tokenization while maintaining compatibility with the existing WordpieceTokenizer interface. This implementation is based on the technique introduced in KR-BERT: A Small-Scale Korean-Specific Language Model (https://arxiv.org/abs/2008.03979), which has shown improved performance particularly for Korean and Japanese text processing.
Key changes:

Add BidirectionalWordpieceTokenizer class
Implement bidirectional tokenization with forward and backward vocabularies
Choose tokenization based on token length
Add test cases to verify functionality

The implementation has been tested and passes all core tokenization tests.
The bidirectional approach has demonstrated better performance specifically for Korean and Japanese languages, making it a valuable addition to our tokenization capabilities.
