### PR TITLE
Remove remote code warning

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3491,7 +3491,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         use_auth_token = kwargs.pop("use_auth_token", None)
-        trust_remote_code = kwargs.pop("trust_remote_code", None)
+        _ = kwargs.pop("trust_remote_code", None)
         _ = kwargs.pop("mirror", None)
         from_pipeline = kwargs.pop("_from_pipeline", None)
         from_auto_class = kwargs.pop("_from_auto", False)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3568,11 +3568,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         if use_safetensors is None and not is_safetensors_available():
             use_safetensors = False
-        if trust_remote_code is True:
-            logger.warning(
-                "The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is"
-                " ignored."
-            )
 
         if gguf_file is not None and not is_accelerate_available():
             raise ValueError("accelerate is required when loading a GGUF file `pip install accelerate`.")


### PR DESCRIPTION
When `trust_remote_code=True` is passed to a non-Auto class, the class raises a warning that the argument has no effect, but continues.

This warning is getting thrown because some of our pipelines are passing the `trust_remote_code` kwarg through to the model. Users can't avoid this because `trust_remote_code` is required for the pipeline. I can dig into that in future, to make sure unnecessary args aren't going to `model.from_pretrained()` but for now I think we can just remove this warning because it's kind of pointless and our code needs fewer warnings anyway :sparkles: 

Fixes #36273