### PR TITLE
set empty list of suppress tokens to None

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1010,6 +1010,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
             ):
                 self.generation_config.pad_token_id = self.tokenizer.pad_token_id
 
+            if self.generation_config.suppress_tokens == []:
+                self.generation_config.suppress_tokens = None
+
         self.call_count = 0
         self._batch_size = kwargs.pop("batch_size", None)
         self._num_workers = kwargs.pop("num_workers", None)


### PR DESCRIPTION
# What does this PR do?


Fixes #36341 

pytest /tests/pipelines/ run locally and the same number of tests fail on main as on this branch

```
14 failed, 146 passed, 161 skipped, 25 warnings in 857.97s (0:14:17) 
```

this may not be the best way to solve the issue, but it looked like other aspects of the config were being overridden at this point. 

Arguably the line `prev_start_of_text = suppress_tokens[-2] if suppress_tokens is not None else None` which is causing the errors should be changed instead though it has been here for > 1 year so I assume the same kind of check exists in a lot of places in the codebase.

This new state of affairs is probably more in-line with existing documentation than before as in multiple places the docs state that this parameter should be a list and don't mention anything about overriding with None e.g. https://huggingface.co/docs/transformers/v4.49.0/en/internal/generation_utils#transformers.FlaxSuppressTokensLogitsProcessor 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),

@Rocketknight1 @ylacombe

