### PR TITLE
Fix test isolation for clear_import_cache utility

### DIFF
--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,23 +1,26 @@
+import importlib
 import sys
 
-from transformers.utils.import_utils import clear_import_cache
+from transformers.utils.import_utils import _LazyModule, clear_import_cache
 
 
 def test_clear_import_cache():
-    # Import some transformers modules
-
-    # Get initial module count
+    # Save initial state
     initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
 
-    # Verify we have some modules loaded
-    assert len(initial_modules) > 0
-
-    # Clear cache
+    # Run the test
     clear_import_cache()
 
-    # Check modules were removed
+    # Verify modules were removed
     remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
     assert len(remaining_modules) < len(initial_modules)
 
-    # Verify we can reimport
-    assert "transformers" in sys.modules
+    # Verify we can reimport a module
+    assert "transformers.models.auto.modeling_auto" in sys.modules
+
+    # Restore initial state
+    for name, module in initial_modules.items():
+        sys.modules[name] = module
+        if isinstance(module, _LazyModule):
+            # Re-initialize lazy module cache
+            importlib.reload(module)

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,11 +1,12 @@
 import importlib
 import os
-import sys
-import pytest
 import subprocess
+import sys
 
-from transformers.utils.import_utils import _LazyModule, clear_import_cache
+import pytest
+
 import transformers.utils.logging
+from transformers.utils.import_utils import _LazyModule
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -13,36 +14,36 @@ def isolate_module_cache():
     """Fixture to save and restore the module cache state before and after each test."""
     # Save initial state
     initial_modules = dict(sys.modules)
-    
+
     # Save logging state
     initial_verbosity = transformers.utils.logging.get_verbosity()
     initial_env_vars = {}
     for env_var in ["TRANSFORMERS_VERBOSITY"]:
         if env_var in os.environ:
             initial_env_vars[env_var] = os.environ[env_var]
-    
+
     yield
-    
+
     # Restore initial state after test
     current_modules = set(sys.modules.keys())
     added_modules = current_modules - set(initial_modules.keys())
-    
+
     # Remove any modules that were added during the test
     for name in added_modules:
         if name in sys.modules:
             del sys.modules[name]
-    
+
     # Restore original modules
     for name, module in initial_modules.items():
         sys.modules[name] = module
         if isinstance(module, _LazyModule):
             # Re-initialize lazy module cache
             importlib.reload(module)
-    
+
     # Restore logging state
     transformers.utils.logging.set_verbosity(initial_verbosity)
     transformers.utils.logging._reset_library_root_logger()
-    
+
     # Restore environment variables
     for env_var in ["TRANSFORMERS_VERBOSITY"]:
         if env_var in initial_env_vars:
@@ -91,10 +92,11 @@ sys.exit(0 if result else 1)
 """
     # Create a temporary script file
     import tempfile
-    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as f:
-        f.write(test_script.encode('utf-8'))
+
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+        f.write(test_script.encode("utf-8"))
         temp_script = f.name
-    
+
     try:
         # Run the script in a subprocess
         result = subprocess.run([sys.executable, temp_script], capture_output=True, text=True)
@@ -111,4 +113,3 @@ sys.exit(0 if result else 1)
 def test_clear_import_cache():
     """Wrapper that runs the actual test in a subprocess."""
     assert run_in_subprocess("test_clear_import_cache_impl")
-            

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,71 +1,76 @@
 import importlib
 import os
-import subprocess
 import sys
 
 import pytest
 
-import transformers.utils.logging
 from transformers.utils.import_utils import _LazyModule
 
 
-def run_in_subprocess(func_name):
-    """Run a test function in a separate subprocess to fully isolate it."""
-    test_script = f"""
-import os
+@pytest.mark.skipif(
+    "PYTEST_XDIST_WORKER" in os.environ,
+    reason="This test should not run under pytest-xdist workers",
+)
+def test_clear_import_cache(monkeypatch):
+    """Test the clear_import_cache function in a way that doesn't affect other tests."""
+    # Create a temporary Python script that runs the test
+    import tempfile
+    import subprocess
+    
+    test_script = """
 import sys
-import importlib
+import os
+
+# Import the function to test
 from transformers.utils.import_utils import clear_import_cache
 
-def {func_name}():
-    # Import the function to test
-    from transformers.utils.import_utils import clear_import_cache
+# First, ensure we have some transformers modules loaded
+import transformers.models.auto.modeling_auto
 
-    # First, ensure we have some transformers modules loaded
-    import transformers.models.auto.modeling_auto
+# Save initial state
+initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+assert len(initial_modules) > 0, "No transformers modules loaded before test"
 
-    # Save initial state
-    initial_modules = {{name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}}
-    assert len(initial_modules) > 0, "No transformers modules loaded before test"
+# Run the test
+clear_import_cache()
 
-    # Run the test
-    clear_import_cache()
+# Verify modules were removed
+remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+assert len(remaining_modules) < len(initial_modules), "No modules were removed"
 
-    # Verify modules were removed
-    remaining_modules = {{name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}}
-    assert len(remaining_modules) < len(initial_modules), "No modules were removed"
+# Import and verify module exists
+from transformers.models.auto import modeling_auto
+assert "transformers.models.auto.modeling_auto" in sys.modules
+assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
 
-    # Import and verify module exists
-    from transformers.models.auto import modeling_auto
-    assert "transformers.models.auto.modeling_auto" in sys.modules
-    assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
-
-    return True
-
-# Run the test function directly
-result = {func_name}()
-sys.exit(0 if result else 1)
+# Exit with success
+sys.exit(0)
 """
-    # Create a temporary script file
-    import tempfile
-
+    
     with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
         f.write(test_script.encode("utf-8"))
         temp_script = f.name
-
+    
     try:
-        # Run the script in a subprocess
-        result = subprocess.run([sys.executable, temp_script], capture_output=True, text=True)
+        # Run the script in a subprocess with a clean environment
+        env = os.environ.copy()
+        # Clear any transformers-related environment variables
+        for key in list(env.keys()):
+            if key.startswith("TRANSFORMERS_"):
+                del env[key]
+        
+        result = subprocess.run(
+            [sys.executable, temp_script],
+            env=env,
+            capture_output=True,
+            text=True
+        )
+        
         # Check if the test passed
-        passed = result.returncode == 0
-        if not passed:
+        if result.returncode != 0:
             print(f"Subprocess test failed with output:\n{result.stdout}\n{result.stderr}")
-        return passed
+        
+        assert result.returncode == 0, "Subprocess test failed"
     finally:
         # Clean up the temporary file
         os.unlink(temp_script)
-
-
-def test_clear_import_cache():
-    """Wrapper that runs the actual test in a subprocess."""
-    assert run_in_subprocess("test_clear_import_cache_impl")

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -15,9 +15,9 @@ def test_clear_import_cache():
     remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
     assert len(remaining_modules) < len(initial_modules)
 
-    # Verify we can reimport a module
-    from transformers.models.auto.modeling_auto import AutoModel  # Actually import the module first
-    assert "transformers.models.auto.modeling_auto" in sys.modules
+    # Import and verify module exists
+    from transformers.models.auto import modeling_auto
+    assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
 
     # Restore initial state
     for name, module in initial_modules.items():

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -7,7 +7,6 @@ from transformers.testing_utils import run_test_using_subprocess
 from transformers.utils.import_utils import clear_import_cache
 
 
-
 @pytest.mark.skipif(
     "PYTEST_XDIST_WORKER" in os.environ,
     reason="This test should not run under pytest-xdist workers",
@@ -32,5 +31,6 @@ def test_clear_import_cache():
 
     # Import and verify module exists
     from transformers.models.auto import modeling_auto
+
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -17,6 +17,7 @@ def test_clear_import_cache():
 
     # Import and verify module exists
     from transformers.models.auto import modeling_auto
+
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
 
     # Restore initial state

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,16 +1,9 @@
-import os
 import sys
-
-import pytest
 
 from transformers.testing_utils import run_test_using_subprocess
 from transformers.utils.import_utils import clear_import_cache
 
 
-@pytest.mark.skipif(
-    "PYTEST_XDIST_WORKER" in os.environ,
-    reason="This test should not run under pytest-xdist workers",
-)
 @run_test_using_subprocess
 def test_clear_import_cache():
     """Test the clear_import_cache function."""
@@ -28,5 +21,6 @@ def test_clear_import_cache():
 
     # Import and verify module exists
     from transformers.models.auto import modeling_auto
+
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -9,49 +9,6 @@ import transformers.utils.logging
 from transformers.utils.import_utils import _LazyModule
 
 
-@pytest.fixture(scope="function", autouse=True)
-def isolate_module_cache():
-    """Fixture to save and restore the module cache state before and after each test."""
-    # Save initial state
-    initial_modules = dict(sys.modules)
-
-    # Save logging state
-    initial_verbosity = transformers.utils.logging.get_verbosity()
-    initial_env_vars = {}
-    for env_var in ["TRANSFORMERS_VERBOSITY"]:
-        if env_var in os.environ:
-            initial_env_vars[env_var] = os.environ[env_var]
-
-    yield
-
-    # Restore initial state after test
-    current_modules = set(sys.modules.keys())
-    added_modules = current_modules - set(initial_modules.keys())
-
-    # Remove any modules that were added during the test
-    for name in added_modules:
-        if name in sys.modules:
-            del sys.modules[name]
-
-    # Restore original modules
-    for name, module in initial_modules.items():
-        sys.modules[name] = module
-        if isinstance(module, _LazyModule):
-            # Re-initialize lazy module cache
-            importlib.reload(module)
-
-    # Restore logging state
-    transformers.utils.logging.set_verbosity(initial_verbosity)
-    transformers.utils.logging._reset_library_root_logger()
-
-    # Restore environment variables
-    for env_var in ["TRANSFORMERS_VERBOSITY"]:
-        if env_var in initial_env_vars:
-            os.environ[env_var] = initial_env_vars[env_var]
-        elif env_var in os.environ:
-            del os.environ[env_var]
-
-
 def run_in_subprocess(func_name):
     """Run a test function in a separate subprocess to fully isolate it."""
     test_script = f"""

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,11 +1,11 @@
-import importlib
 import os
 import sys
 
 import pytest
 
 from transformers.testing_utils import run_test_using_subprocess
-from transformers.utils.import_utils import _LazyModule
+from transformers.utils.import_utils import clear_import_cache
+
 
 
 @pytest.mark.skipif(
@@ -16,10 +16,8 @@ from transformers.utils.import_utils import _LazyModule
 def test_clear_import_cache():
     """Test the clear_import_cache function."""
     # Import the function to test
-    from transformers.utils.import_utils import clear_import_cache
 
     # First, ensure we have some transformers modules loaded
-    import transformers.models.auto.modeling_auto
 
     # Save initial state
     initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -14,15 +14,12 @@ from transformers.utils.import_utils import clear_import_cache
 @run_test_using_subprocess
 def test_clear_import_cache():
     """Test the clear_import_cache function."""
-    # Import the function to test
-
-    # First, ensure we have some transformers modules loaded
 
     # Save initial state
     initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
     assert len(initial_modules) > 0, "No transformers modules loaded before test"
 
-    # Run the test
+    # Execute clear_import_cache() function
     clear_import_cache()
 
     # Verify modules were removed
@@ -31,6 +28,5 @@ def test_clear_import_cache():
 
     # Import and verify module exists
     from transformers.models.auto import modeling_auto
-
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+from transformers.testing_utils import run_test_using_subprocess
 from transformers.utils.import_utils import _LazyModule
 
 
@@ -11,66 +12,27 @@ from transformers.utils.import_utils import _LazyModule
     "PYTEST_XDIST_WORKER" in os.environ,
     reason="This test should not run under pytest-xdist workers",
 )
-def test_clear_import_cache(monkeypatch):
-    """Test the clear_import_cache function in a way that doesn't affect other tests."""
-    # Create a temporary Python script that runs the test
-    import tempfile
-    import subprocess
-    
-    test_script = """
-import sys
-import os
+@run_test_using_subprocess
+def test_clear_import_cache():
+    """Test the clear_import_cache function."""
+    # Import the function to test
+    from transformers.utils.import_utils import clear_import_cache
 
-# Import the function to test
-from transformers.utils.import_utils import clear_import_cache
+    # First, ensure we have some transformers modules loaded
+    import transformers.models.auto.modeling_auto
 
-# First, ensure we have some transformers modules loaded
-import transformers.models.auto.modeling_auto
+    # Save initial state
+    initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+    assert len(initial_modules) > 0, "No transformers modules loaded before test"
 
-# Save initial state
-initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
-assert len(initial_modules) > 0, "No transformers modules loaded before test"
+    # Run the test
+    clear_import_cache()
 
-# Run the test
-clear_import_cache()
+    # Verify modules were removed
+    remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
+    assert len(remaining_modules) < len(initial_modules), "No modules were removed"
 
-# Verify modules were removed
-remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
-assert len(remaining_modules) < len(initial_modules), "No modules were removed"
-
-# Import and verify module exists
-from transformers.models.auto import modeling_auto
-assert "transformers.models.auto.modeling_auto" in sys.modules
-assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
-
-# Exit with success
-sys.exit(0)
-"""
-    
-    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
-        f.write(test_script.encode("utf-8"))
-        temp_script = f.name
-    
-    try:
-        # Run the script in a subprocess with a clean environment
-        env = os.environ.copy()
-        # Clear any transformers-related environment variables
-        for key in list(env.keys()):
-            if key.startswith("TRANSFORMERS_"):
-                del env[key]
-        
-        result = subprocess.run(
-            [sys.executable, temp_script],
-            env=env,
-            capture_output=True,
-            text=True
-        )
-        
-        # Check if the test passed
-        if result.returncode != 0:
-            print(f"Subprocess test failed with output:\n{result.stdout}\n{result.stderr}")
-        
-        assert result.returncode == 0, "Subprocess test failed"
-    finally:
-        # Clean up the temporary file
-        os.unlink(temp_script)
+    # Import and verify module exists
+    from transformers.models.auto import modeling_auto
+    assert "transformers.models.auto.modeling_auto" in sys.modules
+    assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -16,6 +16,7 @@ def test_clear_import_cache():
     assert len(remaining_modules) < len(initial_modules)
 
     # Verify we can reimport a module
+    from transformers.models.auto.modeling_auto import AutoModel  # Actually import the module first
     assert "transformers.models.auto.modeling_auto" in sys.modules
 
     # Restore initial state

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,28 +1,114 @@
 import importlib
+import os
 import sys
+import pytest
+import subprocess
 
 from transformers.utils.import_utils import _LazyModule, clear_import_cache
+import transformers.utils.logging
 
 
-def test_clear_import_cache():
+@pytest.fixture(scope="function", autouse=True)
+def isolate_module_cache():
+    """Fixture to save and restore the module cache state before and after each test."""
     # Save initial state
-    initial_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
-
-    # Run the test
-    clear_import_cache()
-
-    # Verify modules were removed
-    remaining_modules = {name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}
-    assert len(remaining_modules) < len(initial_modules)
-
-    # Import and verify module exists
-    from transformers.models.auto import modeling_auto
-
-    assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
-
-    # Restore initial state
+    initial_modules = dict(sys.modules)
+    
+    # Save logging state
+    initial_verbosity = transformers.utils.logging.get_verbosity()
+    initial_env_vars = {}
+    for env_var in ["TRANSFORMERS_VERBOSITY"]:
+        if env_var in os.environ:
+            initial_env_vars[env_var] = os.environ[env_var]
+    
+    yield
+    
+    # Restore initial state after test
+    current_modules = set(sys.modules.keys())
+    added_modules = current_modules - set(initial_modules.keys())
+    
+    # Remove any modules that were added during the test
+    for name in added_modules:
+        if name in sys.modules:
+            del sys.modules[name]
+    
+    # Restore original modules
     for name, module in initial_modules.items():
         sys.modules[name] = module
         if isinstance(module, _LazyModule):
             # Re-initialize lazy module cache
             importlib.reload(module)
+    
+    # Restore logging state
+    transformers.utils.logging.set_verbosity(initial_verbosity)
+    transformers.utils.logging._reset_library_root_logger()
+    
+    # Restore environment variables
+    for env_var in ["TRANSFORMERS_VERBOSITY"]:
+        if env_var in initial_env_vars:
+            os.environ[env_var] = initial_env_vars[env_var]
+        elif env_var in os.environ:
+            del os.environ[env_var]
+
+
+def run_in_subprocess(func_name):
+    """Run a test function in a separate subprocess to fully isolate it."""
+    file_path = os.path.abspath(__file__)
+    test_script = f"""
+import os
+import sys
+import importlib
+from transformers.utils.import_utils import clear_import_cache
+
+def {func_name}():
+    # Import the function to test
+    from transformers.utils.import_utils import clear_import_cache
+    
+    # First, ensure we have some transformers modules loaded
+    import transformers.models.auto.modeling_auto
+    
+    # Save initial state
+    initial_modules = {{name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}}
+    assert len(initial_modules) > 0, "No transformers modules loaded before test"
+
+    # Run the test
+    clear_import_cache()
+
+    # Verify modules were removed
+    remaining_modules = {{name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}}
+    assert len(remaining_modules) < len(initial_modules), "No modules were removed"
+
+    # Import and verify module exists
+    from transformers.models.auto import modeling_auto
+    assert "transformers.models.auto.modeling_auto" in sys.modules
+    assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
+    
+    return True
+
+# Run the test function directly
+result = {func_name}()
+sys.exit(0 if result else 1)
+"""
+    # Create a temporary script file
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as f:
+        f.write(test_script.encode('utf-8'))
+        temp_script = f.name
+    
+    try:
+        # Run the script in a subprocess
+        result = subprocess.run([sys.executable, temp_script], capture_output=True, text=True)
+        # Check if the test passed
+        passed = result.returncode == 0
+        if not passed:
+            print(f"Subprocess test failed with output:\n{result.stdout}\n{result.stderr}")
+        return passed
+    finally:
+        # Clean up the temporary file
+        os.unlink(temp_script)
+
+
+def test_clear_import_cache():
+    """Wrapper that runs the actual test in a subprocess."""
+    assert run_in_subprocess("test_clear_import_cache_impl")
+            

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -54,7 +54,6 @@ def isolate_module_cache():
 
 def run_in_subprocess(func_name):
     """Run a test function in a separate subprocess to fully isolate it."""
-    file_path = os.path.abspath(__file__)
     test_script = f"""
 import os
 import sys
@@ -64,10 +63,10 @@ from transformers.utils.import_utils import clear_import_cache
 def {func_name}():
     # Import the function to test
     from transformers.utils.import_utils import clear_import_cache
-    
+
     # First, ensure we have some transformers modules loaded
     import transformers.models.auto.modeling_auto
-    
+
     # Save initial state
     initial_modules = {{name: mod for name, mod in sys.modules.items() if name.startswith("transformers.")}}
     assert len(initial_modules) > 0, "No transformers modules loaded before test"
@@ -83,7 +82,7 @@ def {func_name}():
     from transformers.models.auto import modeling_auto
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
-    
+
     return True
 
 # Run the test function directly


### PR DESCRIPTION
## Problem
The `test_clear_import_cache()` test in `tests/utils/test_import_utils.py` is affecting the state of subsequent tests, causing failures in the test suite. This is happening because the test modifies the global module cache without properly restoring it.

## Solution
Updated the test to:
1. Save the initial state of all transformers modules before running the test
2. Run the test to verify `clear_import_cache()` functionality
3. Restore the initial state after the test completes, including proper handling of `_LazyModule` instances

The core functionality of `clear_import_cache()` remains unchanged - this fix only addresses test isolation.

Edit : #36334

## Screenshots
<img width="780" alt="Screenshot 2025-02-22 at 4 43 58 PM" src="https://github.com/user-attachments/assets/c539e8f9-c800-4366-a869-35dd5c859e01" />

cc @dvrogozh