### PR TITLE
[generate] `torch.distributed`-compatible `DynamicCache`

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -366,7 +366,8 @@ class DynamicCache(Cache):
 
         # `_distributed_cache_data` was originally added for compatibility with `torch.distributed` (DDP). See #36121
         # and #36373 for more information. In a nutshell, it is `map(gather_map, zip(*caches))`, i.e. each item in the
-        # iterable contains the key and value states for a layer gathered across replicas by torch.distributed.
+        # iterable contains the key and value states for a layer gathered across replicas by torch.distributed
+        # (shape=[global batch size, num_heads, seq_len, head_dim]).
         # WARNING: `_distributed_cache_data` must be the first argument in `__init__`, otherwise we'll break
         # compatibility. The name of the argument doesn't matter.
         if _distributed_cache_data is not None:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -371,8 +371,9 @@ class DynamicCache(Cache):
         if _distributed_cache_data is not None:
             for layer_idx in range(len(_distributed_cache_data)):
                 key_states, value_states = zip(*_distributed_cache_data[layer_idx])
-                self.key_cache.append(torch.cat(key_states, dim=-2))
-                self.value_cache.append(torch.cat(value_states, dim=-2))
+                # concat on the batch size dimension
+                self.key_cache.append(torch.cat(key_states, dim=0))
+                self.value_cache.append(torch.cat(value_states, dim=0))
 
     def __getitem__(self, layer_idx: int) -> List[Tuple[torch.Tensor]]:
         """

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -340,6 +340,12 @@ class DynamicCache(Cache):
     It stores the Key and Value states as a list of tensors, one for each layer. The expected shape for each tensor is
     `[batch_size, num_heads, seq_len, head_dim]`.
 
+    Args:
+        cache_data (`Tuple[List[torch.Tensor], List[torch.Tensor]]]`, *optional*):
+            A tuple containing the key and value states for each layer, where each layer's data is an item in the list.
+            This is used to initialize the cache with pre-existing key and value states. If not provided, the cache
+            will be initialized with empty lists.
+
     Example:
 
         ```python
@@ -358,11 +364,14 @@ class DynamicCache(Cache):
         ```
     """
 
-    def __init__(self, _cache_data: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> None:
+    def __init__(self, cache_data: Optional[Tuple[List[torch.Tensor], List[torch.Tensor]]] = None) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
-        if _cache_data is not None:
-            self.key_cache, self.value_cache = _cache_data
+
+        # `cache_data` was originally added for compatibility with `torch.distributed`. See #36121 and #36373 for more
+        # information. Some training methods, like prefix tuning, require the cache to be passed to the model's forward
+        if cache_data is not None:
+            self.key_cache, self.value_cache = cache_data
         else:
             self.key_cache: List[torch.Tensor] = []
             self.value_cache: List[torch.Tensor] = []

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -358,11 +358,14 @@ class DynamicCache(Cache):
         ```
     """
 
-    def __init__(self) -> None:
+    def __init__(self, _cache_data: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
-        self.key_cache: List[torch.Tensor] = []
-        self.value_cache: List[torch.Tensor] = []
+        if _cache_data is not None:
+            self.key_cache, self.value_cache = _cache_data
+        else:
+            self.key_cache: List[torch.Tensor] = []
+            self.value_cache: List[torch.Tensor] = []
 
     def __getitem__(self, layer_idx: int) -> List[Tuple[torch.Tensor]]:
         """

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -365,9 +365,10 @@ class DynamicCache(Cache):
         self.value_cache: List[torch.Tensor] = []
 
         # `_distributed_cache_data` was originally added for compatibility with `torch.distributed` (DDP). See #36121
-        # and #36373 for more information. In a nutshell, it contains zip(*caches), i.e. each item in the list
-        # corresponds to a layer and contains tuples of key and values ( [(k_0, v_0), (k_1, v_1), ..., (k_n, v_n)],
-        # where n is the number of caches gathered by torch.distributed, one cache per replica).
+        # and #36373 for more information. In a nutshell, it is `map(gather_map, zip(*caches))`, i.e. each item in the
+        # iterable contains the key and value states for a layer gathered across replicas by torch.distributed.
+        # WARNING: `_distributed_cache_data` must be the first argument in `__init__`, otherwise we'll break
+        # compatibility. The name of the argument doesn't matter.
         if _distributed_cache_data is not None:
             for key_states, value_states in _distributed_cache_data:
                 self.key_cache.append(key_states)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -369,11 +369,9 @@ class DynamicCache(Cache):
         # corresponds to a layer and contains tuples of key and values ( [(k_0, v_0), (k_1, v_1), ..., (k_n, v_n)],
         # where n is the number of caches gathered by torch.distributed, one cache per replica).
         if _distributed_cache_data is not None:
-            for cache_data in _distributed_cache_data:
-                key_states, value_states = zip(*cache_data)
-                # concat on the batch size dimension
-                self.key_cache.append(torch.cat(key_states, dim=0))
-                self.value_cache.append(torch.cat(value_states, dim=0))
+            for key_states, value_states in _distributed_cache_data:
+                self.key_cache.append(key_states)
+                self.value_cache.append(value_states)
 
     def __getitem__(self, layer_idx: int) -> List[Tuple[torch.Tensor]]:
         """

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -20,12 +20,14 @@ from parameterized import parameterized
 
 from transformers import set_seed
 from transformers.testing_utils import (
+    get_gpu_count,
     is_torch_available,
     require_gptq,
     require_non_xpu,
     require_read_token,
     require_torch,
     require_torch_gpu,
+    require_torch_multi_gpu,
     slow,
     torch_device,
 )
@@ -620,3 +622,29 @@ class CacheIntegrationTest(unittest.TestCase):
             'You are a helpful assistant. What is the capital of France?\n\n\n## Response:Paris is the capital of France.\n\n\n\n\n\n## Query:\n\nIn a detailed analysis, compare the economic impacts of the introduction of the'
         ]  # fmt: skip
         self.assertEqual(responses, EXPECTED_DECODED_TEXT)
+
+    @require_torch_multi_gpu
+    def test_data_parallel_dynamic_cache(self):
+        """
+        Tests that the dynamic cache works with nn.DataParallel. Under the hood, `DynamicCache` is rebuilt from
+        multiple `DynamicCache`in the gather step.
+        """
+
+        model_repo = "hf-internal-testing/tiny-random-MistralForCausalLM"
+        model = AutoModelForCausalLM.from_pretrained(model_repo).to(torch_device)
+        tokenizer = AutoTokenizer.from_pretrained(model_repo)
+
+        # w/o DP: batch_size = num_gpu
+        # w DP: batch_size = 1 (with num_gpus replicas)
+        num_gpus = get_gpu_count()
+        model_inputs = tokenizer(["foo bar"] * num_gpus, return_tensors="pt").to(model.device)
+
+        # w/o DP
+        no_parallelism_cache = model(**model_inputs).past_key_values
+
+        # w DP
+        model = torch.nn.DataParallel(model)
+        parallelism_cache = model(**model_inputs).past_key_values
+
+        # Check that the caches are the same
+        breakpoint()

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -627,7 +627,7 @@ class CacheIntegrationTest(unittest.TestCase):
     def test_data_parallel_dynamic_cache(self):
         """
         Tests that the dynamic cache works with nn.DataParallel. Under the hood, `DynamicCache` is rebuilt from
-        multiple `DynamicCache`in the gather step.
+        multiple `DynamicCache` in the gather step.
         """
 
         model_repo = "hf-internal-testing/tiny-random-MistralForCausalLM"

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -641,10 +641,16 @@ class CacheIntegrationTest(unittest.TestCase):
 
         # w/o DP
         no_parallelism_cache = model(**model_inputs).past_key_values
+        self.assertIsInstance(no_parallelism_cache, DynamicCache)
 
         # w DP
         model = torch.nn.DataParallel(model)
         parallelism_cache = model(**model_inputs).past_key_values
+        self.assertIsInstance(parallelism_cache, DynamicCache)
 
         # Check that the caches are the same
-        breakpoint()
+        for layer_idx in range(len(no_parallelism_cache)):
+            for kv_idx in range(2):  # 0 = key, 1 = value
+                torch.testing.assert_close(
+                    actual=no_parallelism_cache[layer_idx][kv_idx], expected=parallelism_cache[layer_idx][kv_idx]
+                )

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -652,5 +652,5 @@ class CacheIntegrationTest(unittest.TestCase):
         for layer_idx in range(len(no_parallelism_cache)):
             for kv_idx in range(2):  # 0 = key, 1 = value
                 torch.testing.assert_close(
-                    actual=no_parallelism_cache[layer_idx][kv_idx], expected=parallelism_cache[layer_idx][kv_idx]
+                    actual=parallelism_cache[layer_idx][kv_idx], expected=no_parallelism_cache[layer_idx][kv_idx]
                 )


### PR DESCRIPTION
# What does this PR do?

`DynamicCache` was not compatible with `torch.distributed` before, and #36212 exposed the issue. See the discussion starting [here](https://github.com/huggingface/transformers/pull/36212#issuecomment-2665247860) for more details. The added code contains comments explaining what's going on.

Fixes `Trainer` + DP when `use_cache=True`, such as in prefix tuning training runs.