### PR TITLE
[CLI] add import guards

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -181,6 +181,7 @@ from .import_utils import (
     is_pytesseract_available,
     is_pytest_available,
     is_pytorch_quantization_available,
+    is_rich_available,
     is_rjieba_available,
     is_sacremoses_available,
     is_safetensors_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -149,7 +149,6 @@ _auto_gptq_available = _is_package_available("auto_gptq")
 _gptqmodel_available = _is_package_available("gptqmodel")
 # `importlib.metadata.version` doesn't work with `awq`
 _auto_awq_available = importlib.util.find_spec("awq") is not None
-_quanto_available = _is_package_available("quanto")
 _is_optimum_quanto_available = False
 try:
     importlib.metadata.version("optimum_quanto")
@@ -203,6 +202,7 @@ _blobfile_available = _is_package_available("blobfile")
 _liger_kernel_available = _is_package_available("liger_kernel")
 _triton_available = _is_package_available("triton")
 _spqr_available = _is_package_available("spqr_quant")
+_rich_available = _is_package_available("rich")
 
 _torch_version = "N/A"
 _torch_available = False
@@ -1300,6 +1300,10 @@ def is_triton_available():
     return _triton_available
 
 
+def is_rich_available():
+    return _rich_available
+
+
 # docstyle-ignore
 AV_IMPORT_ERROR = """
 {0} requires the PyAv library but it was not found in your environment. You can install it with:
@@ -1659,6 +1663,11 @@ JINJA_IMPORT_ERROR = """
 jinja2`. Please note that you may need to restart your runtime after installation.
 """
 
+RICH_IMPORT_ERROR = """
+{0} requires the jinja library but it was not found in your environment. You can install it with pip: `pip install
+rich`. Please note that you may need to restart your runtime after installation.
+"""
+
 BACKENDS_MAPPING = OrderedDict(
     [
         ("av", (is_av_available, AV_IMPORT_ERROR)),
@@ -1705,6 +1714,7 @@ BACKENDS_MAPPING = OrderedDict(
         ("peft", (is_peft_available, PEFT_IMPORT_ERROR)),
         ("jinja", (is_jinja_available, JINJA_IMPORT_ERROR)),
         ("yt_dlp", (is_yt_dlp_available, YT_DLP_IMPORT_ERROR)),
+        ("rich", (is_rich_available, RICH_IMPORT_ERROR)),
     ]
 )
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1664,7 +1664,7 @@ jinja2`. Please note that you may need to restart your runtime after installatio
 """
 
 RICH_IMPORT_ERROR = """
-{0} requires the jinja library but it was not found in your environment. You can install it with pip: `pip install
+{0} requires the rich library but it was not found in your environment. You can install it with pip: `pip install
 rich`. Please note that you may need to restart your runtime after installation.
 """
 


### PR DESCRIPTION
# What does this PR do?

Fixes #36244 

The introduction of `transformers-cli chat` caused ANY cli call to depend on `torch` and `rich`, both optional requirements. This PR adds the appropriate import guards -- tested against a fresh venv with `pip install -e .` (no extras).

@Rocketknight1 we don't have tests for commands 👀 I'm going to defer it for now, as we probably need to review our commands for v5.