### PR TITLE
Load models much faster on accelerator devices!!

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4838,7 +4838,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             offload_index = {
                 p[len(start_prefix) :]: {"safetensors_file": f, "weight_name": p, "dtype": str_dtype}
                 for p, f in weight_map.items()
-                if p.startswith(start_prefix) and expanded_device_map[p[len(start_prefix) :]] == "disk"
+                if p.startswith(start_prefix) and param_device_map[p[len(start_prefix) :]] == "disk"
             }
         else:
             offload_index = None


### PR DESCRIPTION
# What does this PR do?

Cut model loading time by a large margin (7x factor for an 8B model, 6x for a 32B 🚀🚀)
CudaMalloc was in fact the bottleneck in our current loading pipeline. We can pre-allocate tensor of the expected size to warm-up the caching allocator, which makes much fewer calls to CudaMalloc and cuts loading time accordingly.

The following snippet:

```py
import time
t_ini = time.time()
import torch
from transformers import AutoModelForCausalLM
print(f"Time for the imports: {time.time() - t_ini:.2f} s")

model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
# model_id = "codellama/CodeLlama-34b-Instruct-hf"
device = torch.device(f"cuda:2")


t0 = time.time()
torch.cuda.synchronize(device)
print(f"Time for cuda warmup before loading model: {time.time() - t0:.2f} s")
t0 = time.time()
model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16, device_map=device)
torch.cuda.synchronize(device)
dt = time.time() - t0
print(f"time to load the model: {dt:.2f}")

max_mem = torch.cuda.max_memory_allocated(device) / 1024**3
current_mem = torch.cuda.memory_allocated(device) / 1024**3
print(f"Max: {max_mem:.2f} GiB")
print(f"Current: {current_mem:.2f} GiB")
print(f"Full time: {time.time() - t_ini:.2f} s")
```

returns:

```
Time for the imports: 4.38 s
Time for cuda warmup before loading model: 16.18 s
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:04<00:00,  1.21s/it]
time to load the model: 5.92
Max: 14.96 GiB
Current: 14.96 GiB
Full time: 26.49 s
```

and before:

```
Time for the imports: 4.54 s
Time for cuda warmup before loading model: 15.23 s
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:42<00:00, 10.51s/it]
time to load the model: 42.54
Max: 14.96 GiB
Current: 14.96 GiB
Full time: 62.32 s
```

SO we basically cut loading time by 4x for an 8B model.

Note that in both cases, there is basically 15s overhead for cuda before loading the model.
