### PR TITLE
add recommendations for NPU using flash_attn

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import collections
 import copy
 import functools
@@ -1750,9 +1748,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
             if importlib.util.find_spec("flash_attn") is None:
                 if is_torch_npu_available():
-                    recommend_message_npu = (
-                        "Ascend NPU recommends using flash attention by setting attn_implementation='sdpa'."
-                    )
+                    recommend_message_npu = "You should use attn_implementation='sdpa' instead when using NPU. "
                     raise ImportError(
                         f"{preface} the package flash_attn is not supported on Ascend NPU. {recommend_message_npu}"
                     )

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
 import collections
 import copy
 import functools
@@ -97,6 +99,7 @@ from .utils import (
     is_safetensors_available,
     is_torch_flex_attn_available,
     is_torch_greater_or_equal,
+    is_torch_npu_available,
     is_torch_sdpa_available,
     is_torch_xla_available,
     logging,
@@ -1746,7 +1749,15 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             install_message = "Please refer to the documentation of https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2 to install Flash Attention 2."
 
             if importlib.util.find_spec("flash_attn") is None:
-                raise ImportError(f"{preface} the package flash_attn seems to be not installed. {install_message}")
+                if is_torch_npu_available():
+                    recommend_message_npu = (
+                        "Ascend NPU recommends using flash attention by setting attn_implementation='sdpa'."
+                    )
+                    raise ImportError(
+                        f"{preface} the package flash_attn is not supported on Ascend NPU. {recommend_message_npu}"
+                    )
+                else:
+                    raise ImportError(f"{preface} the package flash_attn seems to be not installed. {install_message}")
 
             flash_attention_version = version.parse(importlib.metadata.version("flash_attn"))
             if torch.version.cuda:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -958,6 +958,11 @@ def is_flash_attn_2_available():
     if not (torch.cuda.is_available() or is_torch_mlu_available()):
         return False
 
+    # Ascend does not support "flash_attn".
+    # If "flash_attn" is left in the env, is_flash_attn_2_available() should return False.
+    if is_torch_npu_available():
+        return False
+
     if torch.version.cuda:
         return version.parse(importlib.metadata.version("flash_attn")) >= version.parse("2.1.0")
     elif torch.version.hip:


### PR DESCRIPTION
# What does this PR do?

Currently, Ascend NPU does not support using [flash_attn](https://github.com/Dao-AILab/flash-attention) by setting attn_implementation='flash_attention_2'. 

Refer this [doc](https://www.hiascend.com/document/detail/zh/Pytorch/600/ptmoddevg/trainingmigrguide/performance_tuning_0027.html), NPU's flash attention is integrated in ```torch_npu.npu_fusion_attention``` and ```torch.nn.functional.scaled_dot_product_attention```. So if users want to use flash attention in NPU, they can set attn_implementation='sdpa'.

For NPU, "the package flash_attn seems to be not installed" is not a standard error, so I want to add a note to guide users who want to use flash_attn in NPU so that they can choose the right method.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## notes
NPU needs torch>=2.1 to enable SDPA: https://github.com/huggingface/transformers/pull/35165
