### PR TITLE
fix: prevent model access error during Optuna hyperparameter tuning

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2180,7 +2180,12 @@ class Trainer:
 
         # do_train is not a reliable argument, as it might not be set and .train() still called, so
         # the following is a workaround:
-        if (args.fp16_full_eval or args.bf16_full_eval) and not args.do_train and not self.is_model_parallel:
+        if (
+            (args.fp16_full_eval or args.bf16_full_eval)
+            and not args.do_train
+            and not self.is_model_parallel
+            and self.model is not None  # might be None after hp search trial
+        ):
             self._move_model_to_device(self.model, args.device)
 
         if "model_path" in kwargs:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2184,7 +2184,7 @@ class Trainer:
             (args.fp16_full_eval or args.bf16_full_eval)
             and not args.do_train
             and not self.is_model_parallel
-            and self.model is not None  # might be None after hp search trial
+            and self.model_init is None
         ):
             self._move_model_to_device(self.model, args.device)
 


### PR DESCRIPTION
# What does this PR do?

The `transformers.integrations.integration_utils.run_hp_search_optuna` function releases model memory and sets trainer.model to None after each trial. This causes an AttributeError when  subsequent Trainer.train calls attempt to access the model before reinitialization. This is only an issue when `fp16_full_eval` or `bf16_full_eval` flags are enabled.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@SunMarc