### PR TITLE
Fix edge case for continue_final_message

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1712,7 +1712,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                                 "continue_final_message is set but we could not find any text to continue"
                                 "in the final message!"
                             )
-                if final_message not in rendered_chat:
+                if final_message.strip() not in rendered_chat:
                     raise ValueError(
                         "continue_final_message is set but the final message does not appear in the chat after "
                         "applying the chat template! This can happen if the chat template deletes portions of "

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1713,9 +1713,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                                 "in the final message!"
                             )
                 final_msg_loc = rendered_chat.rindex(final_message.strip())
-                if rendered_chat[final_msg_loc : final_msg_loc + len(final_message)] == final_message:
+                if rendered_chat[final_msg_loc : final_msg_loc + len(final_message.lstrip())] == final_message:
                     # The template preserves spacing or the message doesn't have trailing spacing, so things are simple
-                    rendered_chat = rendered_chat[: final_msg_loc + len(final_message)]
+                    rendered_chat = rendered_chat[: final_msg_loc + len(final_message.lstrip())]
                 else:
                     # The message has trailing spacing that was trimmed, so we must be more cautious
                     rendered_chat = rendered_chat[: final_msg_loc + len(final_message.strip())]

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1707,11 +1707,11 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             # Pick the last text block in the message (the first one we hit while iterating in reverse)
                             final_message = content_block["text"]
                             break
-                        else:
-                            raise ValueError(
-                                "continue_final_message is set but we could not find any text to continue"
-                                "in the final message!"
-                            )
+                    else:
+                        raise ValueError(
+                            "continue_final_message is set but we could not find any text to continue"
+                            "in the final message!"
+                        )
                 if final_message.strip() not in rendered_chat:
                     raise ValueError(
                         "continue_final_message is set but the final message does not appear in the chat after "

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1712,6 +1712,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                                 "continue_final_message is set but we could not find any text to continue"
                                 "in the final message!"
                             )
+                if final_message not in rendered_chat:
+                    raise ValueError(
+                        "continue_final_message is set but the final message does not appear in the chat after "
+                        "applying the chat template! This can happen if the chat template deletes portions of "
+                        "the final message. Please verify the chat template and final message in your chat to "
+                        "ensure they are compatible."
+                    )
                 final_msg_loc = rendered_chat.rindex(final_message.strip())
                 if rendered_chat[final_msg_loc : final_msg_loc + len(final_message.lstrip())] == final_message:
                     # The template preserves spacing or the message doesn't have trailing spacing, so things are simple

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1566,6 +1566,33 @@ class TokenizerTesterMixin:
                 )
 
     @require_jinja
+    def test_continue_final_message_with_decoy_earlier_message(self):
+        """Regression test for chat templates where an earlier message has similar content to the final message
+        https://github.com/huggingface/transformers/issues/35433"""
+
+        dummy_template = """
+        {%- for message in messages %}
+            {{- "<|im_start|>" + message['role'] + "\n" + message['content'] | trim + "<|im_end|>" + "\n"}}
+        {%- endfor %}"""
+        dummy_conversation = [
+            {"role": "user", "content": "hi 0"},
+            {"role": "assistant", "content": "bye: 0"},
+            {"role": "user", "content": "hi 1"},
+            {"role": "assistant", "content": "bye: "},
+        ]
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                prefill_output = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template=dummy_template, tokenize=False, continue_final_message=True
+                )
+                # Assert that the final message is unterminated
+                self.assertEqual(
+                    prefill_output,
+                    "<|im_start|>user\nhi 0<|im_end|>\n<|im_start|>assistant\nbye: 0<|im_end|>\n<|im_start|>user\nhi 1<|im_end|>\n<|im_start|>assistant\nbye:",
+                )
+
+    @require_jinja
     def test_chat_template_dict(self):
         dummy_template_1 = "{{'a'}}"
         dummy_template_2 = "{{'b'}}"


### PR DESCRIPTION
The code for `continue_final_message` in `apply_chat_template` fails in the following edge case:

- The chat template trims trailing spaces from messages
- The chat template adds its own spacing after messages
- The unstripped content of the final message is identical to the stripped content of a previous message plus the template's built-in spacing

This causes the template to incorrectly identify the previous message as the final message and strip off a big chunk of the conversation after this point. This is a fairly uncommon edge case, but it's worth fixing nonetheless! cc @TK-21st

This PR handles things more elegantly without a try-except block, and also improves handling when assistant messages contain text/image blocks (which is rare right now, but will probably become more common in future)

Fixes #35433 
Fixes #36440