### PR TITLE
Fix model saving bug post training with tensor parallel in Accelerate

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3666,9 +3666,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         gathered_state_dict = {}
         for key, value in state_dict.items():
             if hasattr(value, "_local_tensor"):
-                gathered_state_dict[key] = value.to_local()
+                gathered_state_dict[key] = value.to_local().cpu()
             else:
-                gathered_state_dict[key] = value
+                gathered_state_dict[key] = value.cpu()
 
         del state_dict
         state_dict = gathered_state_dict

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3667,7 +3667,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         for key, value in state_dict.items():
             if hasattr(value, "_local_tensor"):
                 gathered_state_dict[key] = value.to_local()
-            gathered_state_dict[key] = value
+            else:
+                gathered_state_dict[key] = value
 
         del state_dict
         state_dict = gathered_state_dict

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3666,7 +3666,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         gathered_state_dict = {}
         for key, value in state_dict.items():
             if hasattr(value, "_local_tensor"):
-                gathered_state_dict[key] = value.full_tensor()
+                gathered_state_dict[key] = value.to_local()
             gathered_state_dict[key] = value
 
         del state_dict


### PR DESCRIPTION
# What does this PR do?

Currently, attempting to save model after training with tensor parallel in Accelerate gives the `RuntimeError: Attempted to access the data pointer on an invalid python storage`, this is due to the state dict not properly gathered from the sharded tensors beforehand. This PR fixes the error, allowing for successful model saving.

Big thank you to @SalmanMohammadi for the discussion!

![tp_save_error](https://github.com/user-attachments/assets/e27bb497-f5c2-4832-a5c9-da0421f8183c)




<!-- Remove if not applicable -->

Fixes # (issue)
https://github.com/huggingface/transformers/pull/34194#issuecomment-2672474840
https://github.com/huggingface/transformers/issues/36436

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
