### PR TITLE
Lazy import libraries in `src/transformers/image_utils.py`

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -599,6 +599,7 @@ def read_video_opencv(
     """
     # Lazy import cv2
     import cv2
+
     video = cv2.VideoCapture(video_path)
     total_num_frames = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
     video_fps = video.get(cv2.CAP_PROP_FPS)
@@ -654,6 +655,7 @@ def read_video_decord(
     """
     # Lazy import from decord
     from decord import VideoReader, cpu
+
     vr = VideoReader(uri=video_path, ctx=cpu(0))  # decord has problems with gpu
     video_fps = vr.get_avg_fps()
     total_num_frames = len(vr)
@@ -695,6 +697,7 @@ def read_video_pyav(
     """
     # Lazy import av
     import av
+
     container = av.open(video_path)
     total_num_frames = container.streams.video[0].frames
     video_fps = container.streams.video[0].average_rate  # should we better use `av_guess_frame_rate`?
@@ -831,6 +834,7 @@ def load_video(
             raise ImportError("To load a video from YouTube url you have  to install `yt_dlp` first.")
         # Lazy import from yt_dlp
         from yt_dlp import YoutubeDL
+
         buffer = BytesIO()
         with redirect_stdout(buffer), YoutubeDL() as f:
             f.download([video])

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -598,6 +598,7 @@ def read_video_opencv(
             - `VideoMetadata` object.
     """
     # Lazy import cv2
+    requires_backends(read_video_opencv, ["cv2"])
     import cv2
 
     video = cv2.VideoCapture(video_path)
@@ -654,6 +655,7 @@ def read_video_decord(
             - `VideoMetadata` object.
     """
     # Lazy import from decord
+    requires_backends(read_video_decord, ["decord"])
     from decord import VideoReader, cpu
 
     vr = VideoReader(uri=video_path, ctx=cpu(0))  # decord has problems with gpu
@@ -696,6 +698,7 @@ def read_video_pyav(
             - `VideoMetadata` object.
     """
     # Lazy import av
+    requires_backends(read_video_pyav, ["av"])
     import av
 
     container = av.open(video_path)
@@ -833,6 +836,7 @@ def load_video(
         if not is_yt_dlp_available():
             raise ImportError("To load a video from YouTube url you have  to install `yt_dlp` first.")
         # Lazy import from yt_dlp
+        requires_backends(load_video, ["yt_dlp"])
         from yt_dlp import YoutubeDL
 
         buffer = BytesIO()

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -74,17 +74,6 @@ if is_vision_available():
             PILImageResampling.LANCZOS: InterpolationMode.LANCZOS,
         }
 
-if is_decord_available():
-    from decord import VideoReader, cpu
-
-if is_av_available():
-    import av
-
-if is_cv2_available():
-    import cv2
-
-if is_yt_dlp_available():
-    from yt_dlp import YoutubeDL
 
 if TYPE_CHECKING:
     if is_torch_available():
@@ -608,6 +597,8 @@ def read_video_opencv(
             - Numpy array of frames in RGB (shape: [num_frames, height, width, 3]).
             - `VideoMetadata` object.
     """
+    # Lazy import cv2
+    import cv2
     video = cv2.VideoCapture(video_path)
     total_num_frames = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
     video_fps = video.get(cv2.CAP_PROP_FPS)
@@ -661,6 +652,8 @@ def read_video_decord(
             - Numpy array of frames in RGB (shape: [num_frames, height, width, 3]).
             - `VideoMetadata` object.
     """
+    # Lazy import from decord
+    from decord import VideoReader, cpu
     vr = VideoReader(uri=video_path, ctx=cpu(0))  # decord has problems with gpu
     video_fps = vr.get_avg_fps()
     total_num_frames = len(vr)
@@ -700,6 +693,8 @@ def read_video_pyav(
             - Numpy array of frames in RGB (shape: [num_frames, height, width, 3]).
             - `VideoMetadata` object.
     """
+    # Lazy import av
+    import av
     container = av.open(video_path)
     total_num_frames = container.streams.video[0].frames
     video_fps = container.streams.video[0].average_rate  # should we better use `av_guess_frame_rate`?
@@ -834,6 +829,8 @@ def load_video(
     if video.startswith("https://www.youtube.com") or video.startswith("http://www.youtube.com"):
         if not is_yt_dlp_available():
             raise ImportError("To load a video from YouTube url you have  to install `yt_dlp` first.")
+        # Lazy import from yt_dlp
+        from yt_dlp import YoutubeDL
         buffer = BytesIO()
         with redirect_stdout(buffer), YoutubeDL() as f:
             f.download([video])


### PR DESCRIPTION
Lazy import the imports added by #34275.

Enables https://github.com/vllm-project/vllm/pull/13905 (which strictly enforces that `cv2` is lazily imported).