### PR TITLE
Fix dtype when loading to meta model

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -904,8 +904,8 @@ def _load_state_dict_into_meta_model(
                         param = param[:].to(param_casting_dtype)
                     module.load_state_dict(
                         {param_type: param[:].to(param_device)},
-                        False,
-                        False,
+                        strict=False,
+                        assign=False,
                     )
                 else:
                     hf_quantizer.create_quantized_param(
@@ -3744,7 +3744,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
-            print('load config', config_path, trust_remote_code)
             config, model_kwargs = cls.config_class.from_pretrained(
                 config_path,
                 cache_dir=cache_dir,
@@ -3758,7 +3757,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 subfolder=subfolder,
                 _from_auto=from_auto_class,
                 _from_pipeline=from_pipeline,
-                trust_remote_code=trust_remote_code,
                 **kwargs,
             )
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -905,7 +905,7 @@ def _load_state_dict_into_meta_model(
                     module.load_state_dict(
                         {param_type: param[:].to(param_device)},
                         False,
-                        True,
+                        False,
                     )
                 else:
                     hf_quantizer.create_quantized_param(
@@ -3744,6 +3744,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
             config_path = config if config is not None else pretrained_model_name_or_path
+            print('load config', config_path, trust_remote_code)
             config, model_kwargs = cls.config_class.from_pretrained(
                 config_path,
                 cache_dir=cache_dir,
@@ -3757,6 +3758,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 subfolder=subfolder,
                 _from_auto=from_auto_class,
                 _from_pipeline=from_pipeline,
+                trust_remote_code=trust_remote_code,
                 **kwargs,
             )
         else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -900,12 +900,10 @@ def _load_state_dict_into_meta_model(
                     if is_fsdp_enabled():
                         param_device = "cpu" if is_local_dist_rank_0() else "meta"
                     module = model.get_submodule(layer)
-                    if param_casting_dtype is not None and param_casting_dtype != empty_param.dtype:
-                        param = param[:].to(param_casting_dtype)
                     module.load_state_dict(
                         {param_type: param[:].to(param_device)},
                         strict=False,
-                        assign=False,
+                        assign=True,
                     )
                 else:
                     hf_quantizer.create_quantized_param(
@@ -4243,14 +4241,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
             else:
                 loaded_state_dict_keys = list(state_dict.keys())
-            if (
-                gguf_path is None
-                and (low_cpu_mem_usage or (use_keep_in_fp32_modules and is_accelerate_available()))
-                and pretrained_model_name_or_path is not None
-            ):
-                # In case some weights need to be kept in float32 and accelerate is not installed,
-                # we later on want to take the path where state_dict is not None, that is the one
-                # that do not require accelerate.
+
+            if gguf_path is None and low_cpu_mem_usage and pretrained_model_name_or_path is not None:
                 state_dict = None
 
         config.name_or_path = pretrained_model_name_or_path

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -900,6 +900,8 @@ def _load_state_dict_into_meta_model(
                     if is_fsdp_enabled():
                         param_device = "cpu" if is_local_dist_rank_0() else "meta"
                     module = model.get_submodule(layer)
+                    if param_casting_dtype is not None and param_casting_dtype != empty_param.dtype:
+                        param = param[:].to(param_casting_dtype)
                     module.load_state_dict(
                         {param_type: param[:].to(param_device)},
                         strict=False,

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -525,13 +525,12 @@ class ModelUtilsTest(TestCasePlus):
         self.assertEqual(model.vision_tower.dtype, torch.bfloat16)
         self.assertEqual(model.multi_modal_projector.linear_1.weight.dtype, torch.float16)
 
-        # TODO @ARTHURZUCKER FIX THIS
         # but if the model has `_keep_in_fp32_modules` then those modules should be in fp32 no matter what
-        # LlavaForConditionalGeneration._keep_in_fp32_modules = ["multi_modal_projector"]
-        # model = LlavaForConditionalGeneration.from_pretrained(TINY_LLAVA, config=config, torch_dtype="auto")
-        # self.assertEqual(model.language_model.dtype, torch.float32)
-        # self.assertEqual(model.vision_tower.dtype, torch.bfloat16)
-        # self.assertEqual(model.multi_modal_projector.linear_1.weight.dtype, torch.float32)
+        LlavaForConditionalGeneration._keep_in_fp32_modules = ["multi_modal_projector"]
+        model = LlavaForConditionalGeneration.from_pretrained(TINY_LLAVA, config=config, torch_dtype="auto")
+        self.assertEqual(model.language_model.dtype, torch.float32)
+        self.assertEqual(model.vision_tower.dtype, torch.bfloat16)
+        self.assertEqual(model.multi_modal_projector.linear_1.weight.dtype, torch.float32)
 
         # torch.set_default_dtype() supports only float dtypes, so will fail with non-float type
         with self.assertRaises(ValueError):


### PR DESCRIPTION
# What does this PR do?

Before https://github.com/huggingface/transformers/pull/36335, when loading the weights to meta model we kept the `dtype` of the module params. This PR fixes it by setting `assign=True`. I am not sure though, why `strict=False`, should I change it to `True`?

Before (no `dtype` is passed to accelerate):
`set_module_tensor_to_device(model, param_name, param_device, **set_module_kwargs)`

After:
`module.load_state_dict({param_type: param[:].to(param_device)}, False, True)`