### PR TITLE
Sanitize Model Module Names to Follow Python Conventions

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -222,10 +222,10 @@ def get_class_in_module(
     Returns:
         `typing.Type`: The class looked for.
     """
-    name = os.path.normpath(module_path)
+    name = os.path.normpath(module_path).replace("-", "_")
     if name.endswith(".py"):
         name = name[:-3]
-    name = name.replace(os.path.sep, ".")
+    name = ".".join([f"_{x}" if x and x[0].isdigit() else x for x in name.split(os.path.sep)])
     module_file: Path = Path(HF_MODULES_CACHE) / module_path
     with _HF_REMOTE_CODE_LOCK:
         if force_reload:


### PR DESCRIPTION
Correctly sanitize dynamically-loaded module names to follow standard python conventions. See the associated issue for the full background / details.

Resolves https://github.com/huggingface/transformers/issues/35570