### PR TITLE
Fix pipeline+peft interaction

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -446,7 +446,6 @@ class _BaseAutoModelClass:
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
-        breakpoint()
         config = kwargs.pop("config", None)
         trust_remote_code = kwargs.pop("trust_remote_code", None)
         kwargs["_from_auto"] = True

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -446,6 +446,7 @@ class _BaseAutoModelClass:
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+        breakpoint()
         config = kwargs.pop("config", None)
         trust_remote_code = kwargs.pop("trust_remote_code", None)
         kwargs["_from_auto"] = True

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -845,8 +845,8 @@ def pipeline(
             if maybe_adapter_path is not None:
                 with open(maybe_adapter_path, "r", encoding="utf-8") as f:
                     adapter_config = json.load(f)
+                    adapter_path = model
                     model = adapter_config["base_model_name_or_path"]
-                    adapter_path = maybe_adapter_path
                     if framework not in (None, "pt"):
                         raise ValueError(
                             f"Adapter files are only supported for PyTorch models. You passed framework={framework}."

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -950,7 +950,6 @@ def pipeline(
             config=config,
             framework=framework,
             task=task,
-            adapter_path=adapter_path,
             **hub_kwargs,
             **model_kwargs,
         )

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -847,11 +847,6 @@ def pipeline(
                     adapter_config = json.load(f)
                     adapter_path = model
                     model = adapter_config["base_model_name_or_path"]
-                    if framework not in (None, "pt"):
-                        raise ValueError(
-                            f"Adapter files are only supported for PyTorch models. You passed framework={framework}."
-                        )
-                    framework = "pt"
 
         config = AutoConfig.from_pretrained(
             model, _from_pipeline=task, code_revision=code_revision, **hub_kwargs, **model_kwargs

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -526,9 +526,14 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
         """
         from transformers import pipeline
 
-        for model_id in self.peft_test_model_ids:
-            pipe = pipeline("text-generation", model_id)
-            _ = pipe("Hello")
+        for adapter_id, base_model_id in zip(self.peft_test_model_ids, self.transformers_test_model_ids):
+            peft_pipe = pipeline("text-generation", adapter_id)
+            base_pipe = pipeline("text-generation", base_model_id)
+            peft_params = list(peft_pipe.model.parameters())
+            base_params = list(base_pipe.model.parameters())
+            self.assertNotEqual(peft_params, base_params)  # Assert we actually loaded the adapter too
+            _ = peft_pipe("Hello")
+
 
     def test_peft_add_adapter_with_state_dict(self):
         """

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -534,7 +534,6 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
             self.assertNotEqual(peft_params, base_params)  # Assert we actually loaded the adapter too
             _ = peft_pipe("Hello")
 
-
     def test_peft_add_adapter_with_state_dict(self):
         """
         Simple test that tests the basic usage of PEFT model through `from_pretrained`. This test tests if

--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -531,7 +531,7 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
             base_pipe = pipeline("text-generation", base_model_id)
             peft_params = list(peft_pipe.model.parameters())
             base_params = list(base_pipe.model.parameters())
-            self.assertNotEqual(peft_params, base_params)  # Assert we actually loaded the adapter too
+            self.assertNotEqual(len(peft_params), len(base_params))  # Assert we actually loaded the adapter too
             _ = peft_pipe("Hello")
 
     def test_peft_add_adapter_with_state_dict(self):


### PR DESCRIPTION
When you pass a PEFT adapter checkpoint to `pipeline()`, it actually loads the base model without the adapter. The reason is a bug in the `pipeline()` code, which has to look up the base model repo to get the config/architecture for the model, but accidentally totally clobbers the adapter path when it does.

Fixes #36473