### PR TITLE
torch compiled flex attention

### DIFF
--- a/src/transformers/integrations/flex_attention.py
+++ b/src/transformers/integrations/flex_attention.py
@@ -7,6 +7,8 @@ from ..utils import is_torch_flex_attn_available
 
 if is_torch_flex_attn_available():
     from torch.nn.attention.flex_attention import flex_attention
+    flex_attention = torch.compile(flex_attention, dynamic=False)
+
 
 
 def flex_attention_forward(


### PR DESCRIPTION
# fix flex attention implementation

I encounter terrible performance when training Llama 8b transformer with flex_attention. Got 15% mfu on a workload where I usually have 45%. Switching to flash_attention_2 fixed the issue. 

```python
config_model = LlamaConfig.from_pretrained("meta-llama/Meta-Llama-3-8B", attn_implementation="flex_attention")
model = LlamaForCausalLM.from_pretrained(pretrained_model_name_or_path="meta-llama/Meta-Llama-3-8B", config=config_model)
```

It seems that the flex_attention implementation is wrong. It does not compile the flex_attention function from pytorch, which is necessary to reach fa2/3 performance. Even when using torch compile on the model itself I saw low mfu (15%) which suggested that torch compile break before reaching flex_attn call

This PR fixes it by adding a torch compile on the flex attention. Mfu increase to 42%.

![Screenshot from 2025-02-28 18-33-39](https://github.com/user-attachments/assets/38c6d64d-9230-4744-8a37-9fb9ab49ce52)


The flex attention [blog](https://pytorch.org/blog/flexattention/) post explains that the speed up is mainly coming from the use of torch compile, and other reference 

It seems that the llama transformers implementation is still underperforming compared to flex_attn on the torch titan codebase (reach 45% mfu that I cannot reach when using transformers llama).

IMO, it would be nice to be able to reach good performance on transformers llama as it is the default implementation of a lot of codebases. I think that there are a lot of graphs that break when using torch compile, probably because of some parameters that are not used during LLM training (attention_mask, etc).

PS the code that I used for benchmark is on this pr : https://github.com/PrimeIntellect-ai/prime/pull/224


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?


## Who can review?


Models:

- text models: @ArthurZucker




