### PR TITLE
Allow OOV Image Token for LLaVa Next Variants

### DIFF
--- a/src/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/transformers/models/llava_next/modeling_llava_next.py
@@ -620,7 +620,16 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
             )
 
         if inputs_embeds is None:
-            inputs_embeds = self.get_input_embeddings()(input_ids)
+            if self.config.image_token_index >= self.language_model.get_input_embeddings().num_embeddings:
+                # There is no embedding corresponding to the image token
+                is_image_idx = input_ids == self.config.image_token_index
+                # Create a copy and set the llm inputs corresponding to the out of range image
+                # embeddings to a throwaway value, which will later be clobbered by image features
+                llm_input_ids = input_ids.clone()
+                llm_input_ids[is_image_idx] = 0
+            else:
+                llm_input_ids = input_ids
+            inputs_embeds = self.get_input_embeddings()(llm_input_ids)
 
         if pixel_values is not None and pixel_values.size(0) > 0:
             image_features = self.get_image_features(

--- a/tests/models/llava_next/test_modeling_llava_next.py
+++ b/tests/models/llava_next/test_modeling_llava_next.py
@@ -347,6 +347,24 @@ class LlavaNextForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
             assert model.multi_modal_projector.linear_1.in_features == expected_features
             model(**input_dict)
 
+    def test_out_of_vocab_llm_image_token(self):
+        """
+        Test that we can run inference without crashing if the image token is not
+        in range for the LLM's embedding.
+        """
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            # The new image token is out of bounds for the LLM embedding
+            old_image_token = config.image_token_index
+            config.image_token_index = config.text_config.vocab_size
+            model = model_class(config).to(torch_device)
+            is_image_token = input_dict["input_ids"] == old_image_token
+            input_dict["input_ids"][is_image_token] = config.image_token_index
+
+            with torch.no_grad():
+                model(**input_dict)
+
     @unittest.skip(
         reason="This architecure seem to not compute gradients properly when using GC, check: https://github.com/huggingface/transformers/pull/27124"
     )


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/35683

Allows image tokens for LLaVa Next models that aren't defined in the LLM embedding; if the image token is out of range, the input IDs are copied, and set to idx 0 when embedded with the LLM (value does not matter since the image features will be scattered into the indices of the image token mask).

We could alternatively allocate the embeddings up front with `torch.empty` and mask the text features in, but I thought this is probably cleaner for the way the current model is written.

Can be verified with:
```python
from transformers import LlavaNextProcessor, LlavaNextForConditionalGeneration, AutoConfig
MODEL_NAME = "llava-hf/llava-v1.6-mistral-7b-hf"

device = "cuda"
cfg = AutoConfig.from_pretrained(MODEL_NAME)
# Define a new image token out of the llm vocab size
OLD_IMAGE_TOKEN = cfg.image_token_index
OOV_IMAGE_TOKEN = cfg.vocab_size + 1

# Load a processor, and process inputs normal
url = "https://github.com/haotian-liu/LLaVA/blob/1a91fc274d7c35a9b50b3cb29c4247ae5837ce39/images/llava_v1_5_radar.jpg?raw=true"
conversation = [
    {
        "role": "user",
        "content": [
            {"type": "image", "url": url},
            {"type": "text", "text": "What is shown in this image?"},
        ],
    },
]

processor = LlavaNextProcessor.from_pretrained(MODEL_NAME)
inputs = processor.apply_chat_template(
    conversation,
    add_generation_prompt=True,
    tokenize=True,
    return_dict=True,
    return_tensors="pt"
).to(device)
# Replace the actual image token with the new out of range one
inputs["input_ids"][inputs["input_ids"] == OLD_IMAGE_TOKEN] = OOV_IMAGE_TOKEN

# Load the model and update the image token to match the out of range value
model = LlavaNextForConditionalGeneration.from_pretrained(MODEL_NAME).to(device)
model.config.image_token_index = OOV_IMAGE_TOKEN

# See if it explodes!
output = model.generate(**inputs, max_new_tokens=1)
```

Will blow up with `RuntimeError: CUDA error: device-side assert triggered` (on CUDA devices) `or IndexError: index out of range in self` (on CPU devices) on `main`, but will work on this branch.



<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @ylacombe, @eustlb
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1
 -->
@zucchini-nlp @ArthurZucker - sorry for the delay in opening the PR here 🙂 